### PR TITLE
Support custom comparison in Presto Min Max By Aggregates

### DIFF
--- a/velox/functions/lib/aggregates/SetBaseAggregate.h
+++ b/velox/functions/lib/aggregates/SetBaseAggregate.h
@@ -24,13 +24,15 @@ namespace facebook::velox::functions::aggregate {
 /// @tparam ignoreNulls Whether null inputs are ignored.
 /// @tparam nullForEmpty When true, nulls are returned for empty groups.
 /// Otherwise, empty arrays.
-template <typename T, bool ignoreNulls = false, bool nullForEmpty = true>
+template <
+    typename T,
+    bool ignoreNulls = false,
+    bool nullForEmpty = true,
+    typename AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>>
 class SetBaseAggregate : public exec::Aggregate {
  public:
   explicit SetBaseAggregate(const TypePtr& resultType)
       : exec::Aggregate(resultType) {}
-
-  using AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(AccumulatorType);
@@ -216,16 +218,20 @@ class SetBaseAggregate : public exec::Aggregate {
   DecodedVector decodedElements_;
 };
 
-template <typename T, bool ignoreNulls = false, bool nullForEmpty = true>
-class SetAggAggregate : public SetBaseAggregate<T, ignoreNulls, nullForEmpty> {
+template <
+    typename T,
+    bool ignoreNulls = false,
+    bool nullForEmpty = true,
+    typename AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>>
+class SetAggAggregate
+    : public SetBaseAggregate<T, ignoreNulls, nullForEmpty, AccumulatorType> {
  public:
+  using Base = SetBaseAggregate<T, ignoreNulls, nullForEmpty, AccumulatorType>;
+
   explicit SetAggAggregate(
       const TypePtr& resultType,
       const bool throwOnNestedNulls = false)
-      : SetBaseAggregate<T, ignoreNulls, nullForEmpty>(resultType),
-        throwOnNestedNulls_(throwOnNestedNulls) {}
-
-  using Base = SetBaseAggregate<T, ignoreNulls, nullForEmpty>;
+      : Base(resultType), throwOnNestedNulls_(throwOnNestedNulls) {}
 
   bool supportsToIntermediate() const override {
     return true;

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -22,13 +22,13 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-template <typename T>
-class SetUnionAggregate : public SetBaseAggregate<T> {
+template <typename T, typename AccumulatorType = SetAccumulator<T>>
+class SetUnionAggregate
+    : public SetBaseAggregate<T, false, true, AccumulatorType> {
  public:
-  explicit SetUnionAggregate(const TypePtr& resultType)
-      : SetBaseAggregate<T>(resultType) {}
+  using Base = SetBaseAggregate<T, false, true, AccumulatorType>;
 
-  using Base = SetBaseAggregate<T>;
+  explicit SetUnionAggregate(const TypePtr& resultType) : Base(resultType) {}
 
   bool supportsToIntermediate() const override {
     return true;
@@ -61,7 +61,7 @@ class SetUnionAggregate : public SetBaseAggregate<T> {
     if (rows.isAllSelected()) {
       result = arrayInput;
     } else {
-      auto* pool = SetBaseAggregate<T>::allocator_->pool();
+      auto* pool = Base::allocator_->pool();
       const auto numRows = rows.size();
 
       // Set nulls for rows not present in 'rows'.
@@ -102,16 +102,16 @@ class SetUnionAggregate : public SetBaseAggregate<T> {
 
 /// Returns the number of distinct non-null values in a group. This is an
 /// internal function only used for testing.
-template <typename T>
-class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
+template <typename T, typename AccumulatorType = SetAccumulator<T>>
+class CountDistinctAggregate
+    : public SetAggAggregate<T, true, false, AccumulatorType> {
  public:
+  using Base = SetAggAggregate<T, true, false, AccumulatorType>;
+
   explicit CountDistinctAggregate(
       const TypePtr& resultType,
       const TypePtr& inputType)
-      : SetAggAggregate<T, true, false>(resultType, false),
-        inputType_{inputType} {}
-
-  using Base = SetAggAggregate<T, true, false>;
+      : Base(resultType, false), inputType_{inputType} {}
 
   bool supportsToIntermediate() const override {
     return false;
@@ -123,7 +123,7 @@ class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
     exec::Aggregate::setAllNulls(groups, indices);
     for (auto i : indices) {
       new (groups[i] + Base::offset_)
-          SetAccumulator<T>(inputType_, Base::allocator_);
+          AccumulatorType(inputType_, Base::allocator_);
     }
   }
 
@@ -156,10 +156,26 @@ class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
   TypePtr inputType_;
 };
 
-template <template <typename T> class Aggregate>
+template <
+    template <typename T, typename AccumulatorType>
+    class Aggregate,
+    TypeKind Kind>
+std::unique_ptr<exec::Aggregate> create(const TypePtr& resultType) {
+  return std::make_unique<Aggregate<
+      typename TypeTraits<Kind>::NativeType,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(resultType);
+}
+
+template <template <typename T, typename AcumulatorType = SetAccumulator<T>>
+          class Aggregate>
 std::unique_ptr<exec::Aggregate> create(
     const TypePtr& inputType,
     const TypePtr& resultType) {
+  if (inputType->providesCustomComparison()) {
+    return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+        create, Aggregate, inputType->kind(), resultType);
+  }
+
   switch (inputType->kind()) {
     case TypeKind::BOOLEAN:
       return std::make_unique<Aggregate<bool>>(resultType);
@@ -198,6 +214,26 @@ std::unique_ptr<exec::Aggregate> create(
   }
 }
 
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> creatSetAggAggregate(
+    const TypePtr& resultType) {
+  return std::make_unique<SetAggAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      false,
+      true,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(resultType);
+}
+
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> createCountDistinctAggregate(
+    const TypePtr& resultType,
+    const TypePtr& inputType) {
+  return std::make_unique<CountDistinctAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(
+      resultType, inputType);
+}
+
 } // namespace
 
 void registerSetAggAggregate(
@@ -229,6 +265,11 @@ void registerSetAggAggregate(
             isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
         const TypeKind typeKind = inputType->kind();
         const bool throwOnNestedNulls = isRawInput;
+
+        if (inputType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              creatSetAggAggregate, inputType->kind(), resultType);
+        }
 
         switch (typeKind) {
           case TypeKind::BOOLEAN:
@@ -326,8 +367,17 @@ void registerCountDistinctAggregate(
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
         const bool isRawInput = exec::isRawInput(step);
-        const TypeKind typeKind =
-            isRawInput ? argTypes[0]->kind() : argTypes[0]->childAt(0)->kind();
+        const TypePtr& inputType =
+            isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
+        const TypeKind typeKind = inputType->kind();
+
+        if (inputType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              createCountDistinctAggregate,
+              inputType->kind(),
+              resultType,
+              inputType);
+        }
 
         switch (typeKind) {
           case TypeKind::BOOLEAN:

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -25,8 +25,8 @@ namespace {
 /// Returns compare result align with Spark's specific behavior,
 /// which returns true if the value in 'index' row of 'newComparisons' is
 /// greater than/equal or less than/equal the value in the 'accumulator'.
-template <bool sparkGreaterThan, typename T, typename TAccumulator>
 struct SparkComparator {
+  template <bool sparkGreaterThan, typename T, typename TAccumulator>
   static bool compare(
       TAccumulator* accumulator,
       const DecodedVector& newComparisons,
@@ -78,12 +78,7 @@ std::string toString(const std::vector<TypePtr>& types) {
 }
 
 template <
-    template <
-        typename U,
-        typename V,
-        bool B1,
-        template <bool B2, typename C1, typename C2>
-        class C>
+    template <typename U, typename V, bool B1, class C, bool B2>
     class Aggregate,
     bool isMaxFunc>
 exec::AggregateRegistrationResult registerMinMaxBy(


### PR DESCRIPTION
Summary:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support for custom
comparison functions provided by custom types in the min_by and max_by aggregations that take a single argument.

Note that this does not add support for the two argument versions of min_by and max_by because
those only support a specific set of schemas, none of which have types that use custom
comparison.  We'll need to add support as part of expanding the set of supported schemas of these
functions.

Differential Revision: D63475061
