### PR TITLE
update slice funtion to take BIGINT

### DIFF
--- a/velox/functions/lib/Slice.cpp
+++ b/velox/functions/lib/Slice.cpp
@@ -127,9 +127,7 @@ class SliceFunction : public exec::VectorFunction {
         rawOffsets[row] = start;
         rawSizes[row] = adjustLength(
             start,
-            // Indices are always 32-bit integers, template arguments are used
-            // to accommodate more data types.
-            static_cast<vector_size_t>(decodedLength->valueAt<T>(row)),
+            decodedLength->valueAt<T>(row),
             row,
             baseRawSizes,
             baseRawOffsets,
@@ -198,7 +196,7 @@ class SliceFunction : public exec::VectorFunction {
 
   vector_size_t adjustLength(
       vector_size_t start,
-      vector_size_t length,
+      int64_t length,
       vector_size_t row,
       const vector_size_t* rawSizes,
       const vector_size_t* rawOffsets,
@@ -207,8 +205,8 @@ class SliceFunction : public exec::VectorFunction {
       VELOX_USER_FAIL(
           "The value of length argument of slice() function should not be negative");
     }
-    auto endIndex = rawOffsets[indices[row]] + rawSizes[indices[row]];
-    return std::min(endIndex - start, length);
+    int64_t endIndex = rawOffsets[indices[row]] + rawSizes[indices[row]];
+    return static_cast<vector_size_t>(std::min(endIndex - start, length));
   }
 };
 

--- a/velox/functions/prestosql/tests/SliceTest.cpp
+++ b/velox/functions/prestosql/tests/SliceTest.cpp
@@ -61,11 +61,11 @@ TEST_F(SliceTest, constantInputArray) {
     testSlice("slice(C0, -2, 2)", {arrayVector}, expectedArrayVector);
   }
 
-  // Allow length extends beyond boundary.
+  // Allow length to extend beyond boundary and be a BIGINT.
   {
     auto expectedArrayVector = makeArrayVector<int64_t>(
         {{1, 2, 3, 4, 5, 6, 7}, {1, 2, 7}, {1, 2, 3, 5, 6, 7}});
-    testSlice("slice(C0, 1, 7)", {arrayVector}, expectedArrayVector);
+    testSlice("slice(C0, 1, 2147483648)", {arrayVector}, expectedArrayVector);
   }
 
   // Throw invalid argument when start index = 0.


### PR DESCRIPTION
Summary:
The following difference in output occurs when the length argument is a bigint:

Query: select slice(c0, 2, c1) from (values (array[1, 2, 3], 2147483648)) t(c0, c1);
Presto-0.289: Returns [2, 3]
Velox: Throws an exception "The value of length argument of slice() function should not be negative"

This diff will allow velox to handle BIGINT

Differential Revision: D63429175
