### PR TITLE
Support all patterns for Spark CAST(varchar as timestamp)

### DIFF
--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -54,17 +54,17 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
   // If the parsed string has timezone information, convert the timestamp at
   // GMT at that time. For example, "1970-01-01 00:00:00 -00:01" is 60 seconds
   // at GMT.
-  if (result.second != nullptr) {
-    result.first.toGMT(*result.second);
+  if (result.tz != nullptr) {
+    result.timestamp.toGMT(*result.tz);
 
   }
   // If no timezone information is available in the input string, check if we
   // should understand it as being at the session timezone, and if so, convert
   // to GMT.
   else if (options_.timeZone != nullptr) {
-    result.first.toGMT(*options_.timeZone);
+    result.timestamp.toGMT(*options_.timeZone);
   }
-  return result.first;
+  return result.timestamp;
 }
 
 Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t seconds) const {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1499,7 +1499,8 @@ struct FromIso8601Timestamp {
       return castResult.error();
     }
 
-    auto [ts, timeZone] = castResult.value();
+    auto ts = castResult.value().timestamp;
+    auto timeZone = castResult.value().tz;
     // Input string may not contain a timezone - if so, it is interpreted in
     // session timezone.
     if (!timeZone) {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -88,7 +88,8 @@ void castFromString(
     if (castResult.hasError()) {
       context.setStatus(row, castResult.error());
     } else {
-      auto [ts, timeZone] = castResult.value();
+      auto ts = castResult.value().timestamp;
+      auto timeZone = castResult.value().tz;
       // Input string may not contain a timezone - if so, it is interpreted in
       // session timezone.
       if (timeZone == nullptr) {

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -22,7 +22,7 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<exec::ExprPtr>&& compiledChildren,
     bool trackCpuUsage,
-    const core::QueryConfig& /*config*/) {
+    const core::QueryConfig& config) {
   VELOX_CHECK_EQ(
       compiledChildren.size(),
       1,
@@ -33,14 +33,14 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       false,
-      std::make_shared<SparkCastHooks>());
+      std::make_shared<SparkCastHooks>(config));
 }
 
 exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<exec::ExprPtr>&& compiledChildren,
     bool trackCpuUsage,
-    const core::QueryConfig& /*config*/) {
+    const core::QueryConfig& config) {
   VELOX_CHECK_EQ(
       compiledChildren.size(),
       1,
@@ -51,6 +51,6 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<SparkCastHooks>());
+      std::make_shared<SparkCastHooks>(config));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -16,14 +16,60 @@
 
 #include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
 #include "velox/functions/lib/string/StringImpl.h"
-#include "velox/type/TimestampConversion.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions::sparksql {
 
+SparkCastHooks::SparkCastHooks(const core::QueryConfig& config) : CastHooks() {
+  const auto sessionTzName = config.sessionTimezone();
+  if (!sessionTzName.empty()) {
+    options_.timeZone = tz::locateZone(sessionTzName);
+  }
+}
+
 Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
     const StringView& view) const {
-  return util::fromTimestampString(
+  // Allows all patterns supported by Spark:
+  // `[+-]yyyy*`
+  // `[+-]yyyy*-[m]m`
+  // `[+-]yyyy*-[m]m-[d]d`
+  // `[+-]yyyy*-[m]m-[d]d `
+  // `[+-]yyyy*-[m]m-[d]d [h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+  // `[+-]yyyy*-[m]m-[d]dT[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+  // `[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+  // `T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
+  //
+  // where `zone_id` should have one of the forms:
+  //   1. Z - Zulu time zone UTC+0
+  //   2. +|-[h]h:[m]m
+  //   3. A short id, see
+  //     https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
+  //   4. An id with one of the prefixes UTC+, UTC-, GMT+, GMT-, UT+ or UT-,
+  //   and a suffix in the following formats:
+  //     a. +|-h[h]
+  //     b. +|-hh[:]mm
+  //     c. +|-hh:mm:ss
+  //     d. +|-hhmmss
+  //   5. Region-based zone IDs in the form `area/city`, such as `Europe/Paris`
+  const auto conversionResult = util::fromTimestampWithTimezoneString(
       view.data(), view.size(), util::TimestampParseMode::kSparkCast);
+  if (conversionResult.hasError()) {
+    return folly::makeUnexpected(conversionResult.error());
+  }
+
+  auto result = conversionResult.value();
+
+  if (result.tz != nullptr) {
+    // If the parsed string has timezone information, convert the timestamp at
+    // GMT at that time.
+    result.timestamp.toGMT(*result.tz, result.secondsOffset);
+  } else if (options_.timeZone != nullptr) {
+    // If the input string contains no timezone information, determine whether
+    // it should be interpreted as being in the session timezone and, if so,
+    // convert it to GMT.
+    result.timestamp.toGMT(*options_.timeZone);
+  }
+  return result.timestamp;
 }
 
 Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -17,12 +17,15 @@
 #pragma once
 
 #include "velox/expression/CastHooks.h"
+#include "velox/expression/EvalCtx.h"
 
 namespace facebook::velox::functions::sparksql {
 
 // This class provides cast hooks following Spark semantics.
 class SparkCastHooks : public exec::CastHooks {
  public:
+  explicit SparkCastHooks(const velox::core::QueryConfig& config);
+
   // TODO: Spark hook allows more string patterns than Presto.
   Expected<Timestamp> castStringToTimestamp(
       const StringView& view) const override;
@@ -59,5 +62,8 @@ class SparkCastHooks : public exec::CastHooks {
   }
 
   exec::PolicyType getPolicy() const override;
+
+ private:
+  TimestampToStringOptions options_ = {};
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -71,6 +71,19 @@ void Timestamp::toGMT(const tz::TimeZone& zone) {
   seconds_ = sysSeconds.count();
 }
 
+void Timestamp::toGMT(const tz::TimeZone& zone, int32_t secondsOffset) {
+  toGMT(zone);
+  if (seconds_ + secondsOffset < kMinSeconds ||
+      seconds_ + secondsOffset > kMaxSeconds) {
+    VELOX_USER_FAIL(
+        "The seconds offset in timezone will get invalid timestamp, "
+        "timestamp is {}, seconds offset is {}",
+        toString(),
+        secondsOffset);
+  }
+  seconds_ += secondsOffset;
+}
+
 std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
 Timestamp::toTimePointMs(bool allowOverflow) const {
   using namespace std::chrono;

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -348,6 +348,9 @@ struct Timestamp {
   //  ts.toString(); // returns January 1, 1970 08:00:00
   void toGMT(const tz::TimeZone& zone);
 
+  // Converts the timestamp to the GMT time and add the seconds offset.
+  void toGMT(const tz::TimeZone& zone, int32_t secondsOffset);
+
   /// Assuming the timestamp represents a GMT time, converts it to the time at
   /// the same moment at zone. For example:
   ///

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -26,6 +26,17 @@ class TimeZone;
 
 namespace facebook::velox::util {
 
+struct TimestampConversionResult {
+  Timestamp timestamp;
+  const tz::TimeZone* tz;
+  int32_t secondsOffset{0};
+
+  bool operator==(const TimestampConversionResult& other) const {
+    return (timestamp == other.timestamp) && (tz == other.tz) &&
+        (secondsOffset == other.secondsOffset);
+  }
+};
+
 constexpr const int32_t kHoursPerDay{24};
 constexpr const int32_t kMinsPerHour{60};
 constexpr const int32_t kSecsPerMinute{60};
@@ -239,14 +250,12 @@ inline Expected<Timestamp> fromTimestampString(
 ///
 /// `nullptr` means no timezone information was found. Returns Unexpected with
 /// UserError status in case of parsing errors.
-Expected<std::pair<Timestamp, const tz::TimeZone*>>
-fromTimestampWithTimezoneString(
+Expected<TimestampConversionResult> fromTimestampWithTimezoneString(
     const char* buf,
     size_t len,
     TimestampParseMode parseMode);
 
-inline Expected<std::pair<Timestamp, const tz::TimeZone*>>
-fromTimestampWithTimezoneString(
+inline Expected<TimestampConversionResult> fromTimestampWithTimezoneString(
     const StringView& str,
     TimestampParseMode parseMode) {
   return fromTimestampWithTimezoneString(str.data(), str.size(), parseMode);

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -40,6 +40,7 @@ namespace facebook::velox::tz {
 
 using TTimeZoneDatabase = std::vector<std::unique_ptr<TimeZone>>;
 using TTimeZoneIndex = folly::F14FastMap<std::string, const TimeZone*>;
+using TJavaShortIdIndex = folly::F14FastMap<std::string, std::string>;
 
 // Defined in TimeZoneDatabase.cpp
 extern const std::vector<std::pair<int16_t, std::string>>& getTimeZoneEntries();
@@ -133,6 +134,53 @@ const TTimeZoneIndex& getTimeZoneIndex() {
   static TTimeZoneIndex timeZoneIndex =
       buildTimeZoneIndex(getTimeZoneDatabase());
   return timeZoneIndex;
+}
+
+// Java SHORT_IDS map.
+// See https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
+TJavaShortIdIndex buildJavaShortIdIndex() {
+  static TJavaShortIdIndex javaShortIdMap = {
+      {"EST", "-05:00"},
+      {"HST", "-10:00"},
+      {"MST", "-07:00"},
+      {"ACT", "Australia/Darwin"},
+      {"AET", "Australia/Sydney"},
+      {"AGT", "America/Argentina/Buenos_Aires"},
+      {"ART", "Africa/Cairo"},
+      {"AST", "America/Anchorage"},
+      {"BET", "America/Sao_Paulo"},
+      {"BST", "Asia/Dhaka"},
+      {"CAT", "Africa/Harare"},
+      {"CNT", "America/St_Johns"},
+      {"CST", "America/Chicago"},
+      {"CTT", "Asia/Shanghai"},
+      {"EAT", "Africa/Addis_Ababa"},
+      {"ECT", "Europe/Paris"},
+      {"IET", "America/Indiana/Indianapolis"},
+      {"IST", "Asia/Kolkata"},
+      {"JST", "Asia/Tokyo"},
+      {"MIT", "Pacific/Apia"},
+      {"NET", "Asia/Yerevan"},
+      {"NST", "Pacific/Auckland"},
+      {"PLT", "Asia/Karachi"},
+      {"PNT", "America/Phoenix"},
+      {"PRT", "America/Puerto_Rico"},
+      {"PST", "America/Los_Angeles"},
+      {"SST", "Pacific/Guadalcanal"},
+      {"VST", "Asia/Ho_Chi_Minh"},
+  };
+  TJavaShortIdIndex lower;
+  lower.reserve(javaShortIdMap.size());
+  for (auto& it : javaShortIdMap) {
+    lower[boost::algorithm::to_lower_copy(it.first)] =
+        boost::algorithm::to_lower_copy(it.second);
+  }
+  return lower;
+}
+
+const TJavaShortIdIndex& getJavaShortIdIndex() {
+  static TJavaShortIdIndex shortIdIndex = buildJavaShortIdIndex();
+  return shortIdIndex;
 }
 
 inline bool isDigit(char c) {
@@ -230,6 +278,14 @@ std::string normalizeTimeZone(const std::string& originalZoneId) {
       }
     }
   }
+
+  // Check for Java SHORT_IDS.
+  auto shortIdMap = getJavaShortIdIndex();
+  auto it = shortIdMap.find(originalZoneId);
+  if (it != shortIdMap.end()) {
+    return it->second;
+  }
+
   return originalZoneId;
 }
 


### PR DESCRIPTION
Velox supports casting varchar to timestamp, but Spark supports more varchar to timestamp conversion patterns. This PR completes the conversion patterns needed by Spark.

Allows all patterns supported by Spark:
`[+-]yyyy*`
`[+-]yyyy*-[m]m`
`[+-]yyyy*-[m]m-[d]d`
`[+-]yyyy*-[m]m-[d]d `
`[+-]yyyy*-[m]m-[d]d [h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
`[+-]yyyy*-[m]m-[d]dT[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
`[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
`T[h]h:[m]m:[s]s.[ms][ms][ms][us][us][us][zone_id]`
where `zone_id` should have one of the forms:
  - Z - Zulu time zone UTC+0
  - +|-[h]h:[m]m
  - A short id, see https://docs.oracle.com/javase/8/docs/api/java/time/ZoneId.html#SHORT_IDS
  - An id with one of the prefixes UTC+, UTC-, GMT+, GMT-, UT+ or UT-,
    and a suffix in the formats:
    - +|-h[h]
    - +|-h[h]:m[m]
    - +|-hhmm
    - +|-h[h]:mm:ss
    - +|-hhmmss
 - Region-based zone IDs in the form `area/city`, such as `Europe/Paris`