### PR TITLE
Remove the task from the task list at the end of task destruction

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -308,8 +308,9 @@ Task::Task(
 }
 
 Task::~Task() {
-  removeFromTaskList();
-
+  SCOPE_EXIT {
+    removeFromTaskList();
+  };
   // TODO(spershin): Temporary code designed to reveal what causes SIGABRT in
   // jemalloc when destroying some Tasks.
   std::string clearStage;


### PR DESCRIPTION
Summary:
Previously the running task counter is decremented as part of member destruction.
Recent changes to track the running task in a global list for stats tracking but
we remove it from the list at the entry of the task destructor so there is race
condition between the task destruction thread running at the background and the
test shutdown thread. The fix is to move the task list remove at the end of task
destructor. Also note that we manually destroy class members in task destructor
so it is fine to remove the task list in destructor.

Reviewed By: spershin

Differential Revision: D63546925
