### PR TITLE
Support custom comparison in Variants

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 using facebook::velox::duckdb::duckdbTimestampToVelox;
@@ -530,6 +531,12 @@ variant variantAt(const VectorPtr& vector, vector_size_t row) {
 
   if (typeKind == TypeKind::MAP) {
     return mapVariantAt(vector, row);
+  }
+
+  if (isTimestampWithTimeZoneType(vector->type())) {
+    return variant::typeWithCustomComparison<TypeKind::BIGINT>(
+        vector->as<SimpleVector<int64_t>>()->valueAt(row),
+        TIMESTAMP_WITH_TIME_ZONE());
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(variantAt, typeKind, vector, row);

--- a/velox/functions/lib/aggregates/SetBaseAggregate.h
+++ b/velox/functions/lib/aggregates/SetBaseAggregate.h
@@ -24,13 +24,15 @@ namespace facebook::velox::functions::aggregate {
 /// @tparam ignoreNulls Whether null inputs are ignored.
 /// @tparam nullForEmpty When true, nulls are returned for empty groups.
 /// Otherwise, empty arrays.
-template <typename T, bool ignoreNulls = false, bool nullForEmpty = true>
+template <
+    typename T,
+    bool ignoreNulls = false,
+    bool nullForEmpty = true,
+    typename AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>>
 class SetBaseAggregate : public exec::Aggregate {
  public:
   explicit SetBaseAggregate(const TypePtr& resultType)
       : exec::Aggregate(resultType) {}
-
-  using AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(AccumulatorType);
@@ -216,16 +218,20 @@ class SetBaseAggregate : public exec::Aggregate {
   DecodedVector decodedElements_;
 };
 
-template <typename T, bool ignoreNulls = false, bool nullForEmpty = true>
-class SetAggAggregate : public SetBaseAggregate<T, ignoreNulls, nullForEmpty> {
+template <
+    typename T,
+    bool ignoreNulls = false,
+    bool nullForEmpty = true,
+    typename AccumulatorType = velox::aggregate::prestosql::SetAccumulator<T>>
+class SetAggAggregate
+    : public SetBaseAggregate<T, ignoreNulls, nullForEmpty, AccumulatorType> {
  public:
+  using Base = SetBaseAggregate<T, ignoreNulls, nullForEmpty, AccumulatorType>;
+
   explicit SetAggAggregate(
       const TypePtr& resultType,
       const bool throwOnNestedNulls = false)
-      : SetBaseAggregate<T, ignoreNulls, nullForEmpty>(resultType),
-        throwOnNestedNulls_(throwOnNestedNulls) {}
-
-  using Base = SetBaseAggregate<T, ignoreNulls, nullForEmpty>;
+      : Base(resultType), throwOnNestedNulls_(throwOnNestedNulls) {}
 
   bool supportsToIntermediate() const override {
     return true;

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -22,13 +22,13 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-template <typename T>
-class SetUnionAggregate : public SetBaseAggregate<T> {
+template <typename T, typename AccumulatorType = SetAccumulator<T>>
+class SetUnionAggregate
+    : public SetBaseAggregate<T, false, true, AccumulatorType> {
  public:
-  explicit SetUnionAggregate(const TypePtr& resultType)
-      : SetBaseAggregate<T>(resultType) {}
+  using Base = SetBaseAggregate<T, false, true, AccumulatorType>;
 
-  using Base = SetBaseAggregate<T>;
+  explicit SetUnionAggregate(const TypePtr& resultType) : Base(resultType) {}
 
   bool supportsToIntermediate() const override {
     return true;
@@ -61,7 +61,7 @@ class SetUnionAggregate : public SetBaseAggregate<T> {
     if (rows.isAllSelected()) {
       result = arrayInput;
     } else {
-      auto* pool = SetBaseAggregate<T>::allocator_->pool();
+      auto* pool = Base::allocator_->pool();
       const auto numRows = rows.size();
 
       // Set nulls for rows not present in 'rows'.
@@ -102,16 +102,16 @@ class SetUnionAggregate : public SetBaseAggregate<T> {
 
 /// Returns the number of distinct non-null values in a group. This is an
 /// internal function only used for testing.
-template <typename T>
-class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
+template <typename T, typename AccumulatorType = SetAccumulator<T>>
+class CountDistinctAggregate
+    : public SetAggAggregate<T, true, false, AccumulatorType> {
  public:
+  using Base = SetAggAggregate<T, true, false, AccumulatorType>;
+
   explicit CountDistinctAggregate(
       const TypePtr& resultType,
       const TypePtr& inputType)
-      : SetAggAggregate<T, true, false>(resultType, false),
-        inputType_{inputType} {}
-
-  using Base = SetAggAggregate<T, true, false>;
+      : Base(resultType, false), inputType_{inputType} {}
 
   bool supportsToIntermediate() const override {
     return false;
@@ -123,7 +123,7 @@ class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
     exec::Aggregate::setAllNulls(groups, indices);
     for (auto i : indices) {
       new (groups[i] + Base::offset_)
-          SetAccumulator<T>(inputType_, Base::allocator_);
+          AccumulatorType(inputType_, Base::allocator_);
     }
   }
 
@@ -156,10 +156,26 @@ class CountDistinctAggregate : public SetAggAggregate<T, true, false> {
   TypePtr inputType_;
 };
 
-template <template <typename T> class Aggregate>
+template <
+    template <typename T, typename AccumulatorType>
+    class Aggregate,
+    TypeKind Kind>
+std::unique_ptr<exec::Aggregate> create(const TypePtr& resultType) {
+  return std::make_unique<Aggregate<
+      typename TypeTraits<Kind>::NativeType,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(resultType);
+}
+
+template <template <typename T, typename AcumulatorType = SetAccumulator<T>>
+          class Aggregate>
 std::unique_ptr<exec::Aggregate> create(
     const TypePtr& inputType,
     const TypePtr& resultType) {
+  if (inputType->providesCustomComparison()) {
+    return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+        create, Aggregate, inputType->kind(), resultType);
+  }
+
   switch (inputType->kind()) {
     case TypeKind::BOOLEAN:
       return std::make_unique<Aggregate<bool>>(resultType);
@@ -198,6 +214,26 @@ std::unique_ptr<exec::Aggregate> create(
   }
 }
 
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> creatSetAggAggregate(
+    const TypePtr& resultType) {
+  return std::make_unique<SetAggAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      false,
+      true,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(resultType);
+}
+
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> createCountDistinctAggregate(
+    const TypePtr& resultType,
+    const TypePtr& inputType) {
+  return std::make_unique<CountDistinctAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      aggregate::prestosql::CustomComparisonSetAccumulator<Kind>>>(
+      resultType, inputType);
+}
+
 } // namespace
 
 void registerSetAggAggregate(
@@ -229,6 +265,11 @@ void registerSetAggAggregate(
             isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
         const TypeKind typeKind = inputType->kind();
         const bool throwOnNestedNulls = isRawInput;
+
+        if (inputType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              creatSetAggAggregate, inputType->kind(), resultType);
+        }
 
         switch (typeKind) {
           case TypeKind::BOOLEAN:
@@ -326,8 +367,17 @@ void registerCountDistinctAggregate(
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
         const bool isRawInput = exec::isRawInput(step);
-        const TypeKind typeKind =
-            isRawInput ? argTypes[0]->kind() : argTypes[0]->childAt(0)->kind();
+        const TypePtr& inputType =
+            isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
+        const TypeKind typeKind = inputType->kind();
+
+        if (inputType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              createCountDistinctAggregate,
+              inputType->kind(),
+              resultType,
+              inputType);
+        }
 
         switch (typeKind) {
           case TypeKind::BOOLEAN:

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -25,8 +25,8 @@ namespace {
 /// Returns compare result align with Spark's specific behavior,
 /// which returns true if the value in 'index' row of 'newComparisons' is
 /// greater than/equal or less than/equal the value in the 'accumulator'.
-template <bool sparkGreaterThan, typename T, typename TAccumulator>
 struct SparkComparator {
+  template <bool sparkGreaterThan, typename T, typename TAccumulator>
   static bool compare(
       TAccumulator* accumulator,
       const DecodedVector& newComparisons,
@@ -78,12 +78,7 @@ std::string toString(const std::vector<TypePtr>& types) {
 }
 
 template <
-    template <
-        typename U,
-        typename V,
-        bool B1,
-        template <bool B2, typename C1, typename C2>
-        class C>
+    template <typename U, typename V, bool B1, class C, bool B2>
     class Aggregate,
     bool isMaxFunc>
 exec::AggregateRegistrationResult registerMinMaxBy(

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -53,6 +53,7 @@ struct VariantEquality {
     if (a.isNull() || b.isNull()) {
       return evaluateNullEquality<NullEqualsNull>(a, b);
     }
+
     return a.value<KIND>() == b.value<KIND>();
   }
 };
@@ -670,39 +671,59 @@ variant variant::create(const folly::dynamic& variantobj) {
 }
 
 template <TypeKind KIND>
-bool variant::lessThan(const variant& a, const variant& b) const {
+bool variant::lessThan(const variant& other) const {
   using namespace facebook::velox::util::floating_point;
-  if (a.isNull() && !b.isNull()) {
+  if (isNull() && !other.isNull()) {
     return true;
   }
-  if (a.isNull() || b.isNull()) {
+  if (isNull() || other.isNull()) {
     return false;
   }
+
   using T = typename TypeTraits<KIND>::NativeType;
-  if constexpr (std::is_floating_point_v<T>) {
-    return NaNAwareLessThan<T>{}(a.value<KIND>(), b.value<KIND>());
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+                 ->compare(value<KIND>(), other.value<KIND>()) < 0;
+    }
   }
-  return a.value<KIND>() < b.value<KIND>();
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareLessThan<T>{}(value<KIND>(), other.value<KIND>());
+  }
+  return value<KIND>() < other.value<KIND>();
 }
 
 bool variant::operator<(const variant& other) const {
   if (other.kind_ != this->kind_) {
     return other.kind_ < this->kind_;
   }
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, *this, other);
+
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, other);
 }
 
 template <TypeKind KIND>
-bool variant::equals(const variant& a, const variant& b) const {
+bool variant::equals(const variant& other) const {
   using namespace facebook::velox::util::floating_point;
-  if (a.isNull() || b.isNull()) {
+  if (isNull() || other.isNull()) {
     return false;
   }
   using T = typename TypeTraits<KIND>::NativeType;
-  if constexpr (std::is_floating_point_v<T>) {
-    return NaNAwareEquals<T>{}(a.value<KIND>(), b.value<KIND>());
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+                 ->compare(value<KIND>(), other.value<KIND>()) == 0;
+    }
   }
-  return a.value<KIND>() == b.value<KIND>();
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareEquals<T>{}(value<KIND>(), other.value<KIND>());
+  }
+  return value<KIND>() == other.value<KIND>();
 }
 
 bool variant::equals(const variant& other) const {
@@ -712,80 +733,89 @@ bool variant::equals(const variant& other) const {
   if (other.isNull()) {
     return this->isNull();
   }
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, *this, other);
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, other);
+}
+
+template <TypeKind KIND>
+uint64_t variant::hash() const {
+  using namespace facebook::velox::util::floating_point;
+  using T = typename TypeTraits<KIND>::NativeType;
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+          ->hash(value<KIND>());
+    }
+  }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareHash<T>{}(value<KIND>());
+  }
+
+  return folly::Hash{}(value<KIND>());
+}
+
+template <>
+uint64_t variant::hash<TypeKind::ARRAY>() const {
+  auto& arrayVariant = value<TypeKind::ARRAY>();
+  auto hasher = folly::Hash{};
+  uint64_t hash = 0;
+  for (int32_t i = 0; i < arrayVariant.size(); i++) {
+    hash =
+        folly::hash::hash_combine_generic(hasher, hash, arrayVariant[i].hash());
+  }
+  return hash;
+}
+
+template <>
+uint64_t variant::hash<TypeKind::ROW>() const {
+  auto hasher = folly::Hash{};
+  uint64_t hash = 0;
+  auto& rowVariant = value<TypeKind::ROW>();
+  for (int32_t i = 0; i < rowVariant.size(); i++) {
+    hash =
+        folly::hash::hash_combine_generic(hasher, hash, rowVariant[i].hash());
+  }
+  return hash;
+}
+
+template <>
+uint64_t variant::hash<TypeKind::TIMESTAMP>() const {
+  auto timestampValue = value<TypeKind::TIMESTAMP>();
+  return folly::Hash{}(timestampValue.getSeconds(), timestampValue.getNanos());
+}
+
+template <>
+uint64_t variant::hash<TypeKind::MAP>() const {
+  auto hasher = folly::Hash{};
+  auto& mapVariant = value<TypeKind::MAP>();
+  uint64_t combinedKeyHash = 0, combinedValueHash = 0;
+  uint64_t singleKeyHash = 0, singleValueHash = 0;
+  for (auto it = mapVariant.begin(); it != mapVariant.end(); ++it) {
+    singleKeyHash = it->first.hash();
+    singleValueHash = it->second.hash();
+    combinedKeyHash = folly::hash::commutative_hash_combine_value_generic(
+        combinedKeyHash, hasher, singleKeyHash);
+    combinedValueHash = folly::hash::commutative_hash_combine_value_generic(
+        combinedValueHash, hasher, singleValueHash);
+  }
+
+  return folly::hash::hash_combine_generic(
+      folly::Hash{}, combinedKeyHash, combinedValueHash);
+}
+
+template <>
+uint64_t variant::hash<TypeKind::OPAQUE>() const {
+  VELOX_NYI();
 }
 
 uint64_t variant::hash() const {
-  using namespace facebook::velox::util::floating_point;
-  uint64_t hash = 0;
   if (isNull()) {
     return folly::Hash{}(static_cast<int32_t>(kind_));
   }
 
-  switch (kind_) {
-    case TypeKind::BIGINT:
-      return folly::Hash{}(value<TypeKind::BIGINT>());
-    case TypeKind::HUGEINT:
-      return folly::Hash{}(value<TypeKind::HUGEINT>());
-    case TypeKind::INTEGER:
-      return folly::Hash{}(value<TypeKind::INTEGER>());
-    case TypeKind::SMALLINT:
-      return folly::Hash{}(value<TypeKind::SMALLINT>());
-    case TypeKind::TINYINT:
-      return folly::Hash{}(value<TypeKind::TINYINT>());
-    case TypeKind::BOOLEAN:
-      return folly::Hash{}(value<TypeKind::BOOLEAN>());
-    case TypeKind::REAL:
-      return NaNAwareHash<float>{}(value<TypeKind::REAL>());
-    case TypeKind::DOUBLE:
-      return NaNAwareHash<double>{}(value<TypeKind::DOUBLE>());
-    case TypeKind::VARBINARY:
-      return folly::Hash{}(value<TypeKind::VARBINARY>());
-    case TypeKind::VARCHAR:
-      return folly::Hash{}(value<TypeKind::VARCHAR>());
-    case TypeKind::ARRAY: {
-      auto& arrayVariant = value<TypeKind::ARRAY>();
-      auto hasher = folly::Hash{};
-      for (int32_t i = 0; i < arrayVariant.size(); i++) {
-        hash = folly::hash::hash_combine_generic(
-            hasher, hash, arrayVariant[i].hash());
-      }
-      return hash;
-    }
-    case TypeKind::ROW: {
-      auto hasher = folly::Hash{};
-      auto& rowVariant = value<TypeKind::ROW>();
-      for (int32_t i = 0; i < rowVariant.size(); i++) {
-        hash = folly::hash::hash_combine_generic(
-            hasher, hash, rowVariant[i].hash());
-      }
-      return hash;
-    }
-    case TypeKind::TIMESTAMP: {
-      auto timestampValue = value<TypeKind::TIMESTAMP>();
-      return folly::Hash{}(
-          timestampValue.getSeconds(), timestampValue.getNanos());
-    }
-    case TypeKind::MAP: {
-      auto hasher = folly::Hash{};
-      auto& mapVariant = value<TypeKind::MAP>();
-      uint64_t combinedKeyHash = 0, combinedValueHash = 0;
-      uint64_t singleKeyHash = 0, singleValueHash = 0;
-      for (auto it = mapVariant.begin(); it != mapVariant.end(); ++it) {
-        singleKeyHash = it->first.hash();
-        singleValueHash = it->second.hash();
-        combinedKeyHash = folly::hash::commutative_hash_combine_value_generic(
-            combinedKeyHash, hasher, singleKeyHash);
-        combinedValueHash = folly::hash::commutative_hash_combine_value_generic(
-            combinedValueHash, hasher, singleValueHash);
-      }
-
-      return folly::hash::hash_combine_generic(
-          folly::Hash{}, combinedKeyHash, combinedValueHash);
-    }
-    default:
-      VELOX_NYI();
-  }
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(hash, kind_);
 }
 
 namespace {
@@ -853,7 +883,7 @@ bool variant::lessThanWithEpsilon(const variant& other) const {
     return *this < other;
   }
 
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, *this, other);
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, other);
 }
 
 namespace {
@@ -918,7 +948,7 @@ bool variant::equalsWithEpsilon(const variant& other) const {
     case TypeKind::ROW:
       return compareComplexTypeWithEpsilon<TypeKind::ROW>(*this, other);
     default:
-      return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, *this, other);
+      return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, other);
   }
 }
 


### PR DESCRIPTION
Summary:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support
for custom comparison functions provided by custom types to be used in Variants.

This is primarily needed for testing in QueryAssertions.cpp where we convert Vectors
to variants before comparing them.  For example, when a function may choose one of
a set of equivalent values depending on the order of the input (e.g. the representative
value chosen by the Histogram aggregation).

Differential Revision: D63554289
