### PR TITLE
Support custom comparison in Map Aggregations

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 using facebook::velox::duckdb::duckdbTimestampToVelox;
@@ -530,6 +531,12 @@ variant variantAt(const VectorPtr& vector, vector_size_t row) {
 
   if (typeKind == TypeKind::MAP) {
     return mapVariantAt(vector, row);
+  }
+
+  if (isTimestampWithTimeZoneType(vector->type())) {
+    return variant::typeWithCustomComparison<TypeKind::BIGINT>(
+        vector->as<SimpleVector<int64_t>>()->valueAt(row),
+        TIMESTAMP_WITH_TIME_ZONE());
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(variantAt, typeKind, vector, row);

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -22,12 +22,10 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-template <typename K>
+template <typename K, typename AccumulatorType>
 class MapAggregateBase : public exec::Aggregate {
  public:
   explicit MapAggregateBase(TypePtr resultType) : Aggregate(resultType) {}
-
-  using AccumulatorType = MapAccumulator<K>;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(AccumulatorType);
@@ -202,7 +200,8 @@ class MapAggregateBase : public exec::Aggregate {
   DecodedVector decodedMaps_;
 };
 
-template <template <typename K> class TAggregate>
+template <template <typename K, typename Accumulator = MapAccumulator<K>>
+          class TAggregate>
 std::unique_ptr<exec::Aggregate> createMapAggregate(const TypePtr& resultType) {
   auto typeKind = resultType->childAt(0)->kind();
   switch (typeKind) {

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -545,6 +546,86 @@ TEST_F(MapAggTest, nans) {
                {makeFlatVector<double>({1, 2, kNaN, 3, kNaN}),
                 makeFlatVector<int32_t>({1, 4, 2, 5, 2})}),
            makeFlatVector<int32_t>({1, 4, 2, 5, 6})),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+}
+
+TEST_F(MapAggTest, timestampWithTimeZone) {
+  // Global Aggregation, Primitive type
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE()),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  auto expectedResult = makeRowVector({makeMapVector<int64_t, int32_t>(
+      {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}, {pack(3, 3), 8}}},
+      MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER()))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Primitive type
+  expectedResult = makeRowVector(
+      {makeMapVector<int64_t, int32_t>(
+           {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}},
+            {{pack(3, 3), 8}, {pack(1, 2), 6}, {pack(2, 2), 7}}},
+           MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER())),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+
+  // Global Aggregation, Complex type(Row)
+  data = makeRowVector(
+      {makeRowVector({makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE())}),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  expectedResult = makeRowVector({makeMapVector(
+      {0},
+      makeRowVector({makeFlatVector<int64_t>(
+          {pack(0, 0), pack(1, 0), pack(2, 0), pack(3, 3)},
+          TIMESTAMP_WITH_TIME_ZONE())}),
+      makeFlatVector<int32_t>({1, 2, 3, 8}))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Complex type(Row)
+  expectedResult = makeRowVector(
+      {makeMapVector(
+           {0, 3},
+           makeRowVector({makeFlatVector<int64_t>(
+               {pack(0, 0),
+                pack(1, 0),
+                pack(2, 0),
+                pack(3, 3),
+                pack(1, 2),
+                pack(2, 2)},
+               TIMESTAMP_WITH_TIME_ZONE())}),
+           makeFlatVector<int32_t>({1, 2, 3, 8, 6, 7})),
        makeFlatVector<int32_t>({1, 2})});
 
   testAggregations(

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -53,6 +53,7 @@ struct VariantEquality {
     if (a.isNull() || b.isNull()) {
       return evaluateNullEquality<NullEqualsNull>(a, b);
     }
+
     return a.value<KIND>() == b.value<KIND>();
   }
 };
@@ -670,39 +671,59 @@ variant variant::create(const folly::dynamic& variantobj) {
 }
 
 template <TypeKind KIND>
-bool variant::lessThan(const variant& a, const variant& b) const {
+bool variant::lessThan(const variant& other) const {
   using namespace facebook::velox::util::floating_point;
-  if (a.isNull() && !b.isNull()) {
+  if (isNull() && !other.isNull()) {
     return true;
   }
-  if (a.isNull() || b.isNull()) {
+  if (isNull() || other.isNull()) {
     return false;
   }
+
   using T = typename TypeTraits<KIND>::NativeType;
-  if constexpr (std::is_floating_point_v<T>) {
-    return NaNAwareLessThan<T>{}(a.value<KIND>(), b.value<KIND>());
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+                 ->compare(value<KIND>(), other.value<KIND>()) < 0;
+    }
   }
-  return a.value<KIND>() < b.value<KIND>();
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareLessThan<T>{}(value<KIND>(), other.value<KIND>());
+  }
+  return value<KIND>() < other.value<KIND>();
 }
 
 bool variant::operator<(const variant& other) const {
   if (other.kind_ != this->kind_) {
     return other.kind_ < this->kind_;
   }
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, *this, other);
+
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, other);
 }
 
 template <TypeKind KIND>
-bool variant::equals(const variant& a, const variant& b) const {
+bool variant::equals(const variant& other) const {
   using namespace facebook::velox::util::floating_point;
-  if (a.isNull() || b.isNull()) {
+  if (isNull() || other.isNull()) {
     return false;
   }
   using T = typename TypeTraits<KIND>::NativeType;
-  if constexpr (std::is_floating_point_v<T>) {
-    return NaNAwareEquals<T>{}(a.value<KIND>(), b.value<KIND>());
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+                 ->compare(value<KIND>(), other.value<KIND>()) == 0;
+    }
   }
-  return a.value<KIND>() == b.value<KIND>();
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareEquals<T>{}(value<KIND>(), other.value<KIND>());
+  }
+  return value<KIND>() == other.value<KIND>();
 }
 
 bool variant::equals(const variant& other) const {
@@ -712,80 +733,89 @@ bool variant::equals(const variant& other) const {
   if (other.isNull()) {
     return this->isNull();
   }
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, *this, other);
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, other);
+}
+
+template <TypeKind KIND>
+uint64_t variant::hash() const {
+  using namespace facebook::velox::util::floating_point;
+  using T = typename TypeTraits<KIND>::NativeType;
+
+  if constexpr (kindCanProvideCustomComparison<KIND>::value) {
+    if (typeWithCustomComparison_ != nullptr) {
+      return static_cast<const CanProvideCustomComparisonType<KIND>*>(
+                 typeWithCustomComparison_.get())
+          ->hash(value<KIND>());
+    }
+  }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    return NaNAwareHash<T>{}(value<KIND>());
+  }
+
+  return folly::Hash{}(value<KIND>());
+}
+
+template <>
+uint64_t variant::hash<TypeKind::ARRAY>() const {
+  auto& arrayVariant = value<TypeKind::ARRAY>();
+  auto hasher = folly::Hash{};
+  uint64_t hash = 0;
+  for (int32_t i = 0; i < arrayVariant.size(); i++) {
+    hash =
+        folly::hash::hash_combine_generic(hasher, hash, arrayVariant[i].hash());
+  }
+  return hash;
+}
+
+template <>
+uint64_t variant::hash<TypeKind::ROW>() const {
+  auto hasher = folly::Hash{};
+  uint64_t hash = 0;
+  auto& rowVariant = value<TypeKind::ROW>();
+  for (int32_t i = 0; i < rowVariant.size(); i++) {
+    hash =
+        folly::hash::hash_combine_generic(hasher, hash, rowVariant[i].hash());
+  }
+  return hash;
+}
+
+template <>
+uint64_t variant::hash<TypeKind::TIMESTAMP>() const {
+  auto timestampValue = value<TypeKind::TIMESTAMP>();
+  return folly::Hash{}(timestampValue.getSeconds(), timestampValue.getNanos());
+}
+
+template <>
+uint64_t variant::hash<TypeKind::MAP>() const {
+  auto hasher = folly::Hash{};
+  auto& mapVariant = value<TypeKind::MAP>();
+  uint64_t combinedKeyHash = 0, combinedValueHash = 0;
+  uint64_t singleKeyHash = 0, singleValueHash = 0;
+  for (auto it = mapVariant.begin(); it != mapVariant.end(); ++it) {
+    singleKeyHash = it->first.hash();
+    singleValueHash = it->second.hash();
+    combinedKeyHash = folly::hash::commutative_hash_combine_value_generic(
+        combinedKeyHash, hasher, singleKeyHash);
+    combinedValueHash = folly::hash::commutative_hash_combine_value_generic(
+        combinedValueHash, hasher, singleValueHash);
+  }
+
+  return folly::hash::hash_combine_generic(
+      folly::Hash{}, combinedKeyHash, combinedValueHash);
+}
+
+template <>
+uint64_t variant::hash<TypeKind::OPAQUE>() const {
+  VELOX_NYI();
 }
 
 uint64_t variant::hash() const {
-  using namespace facebook::velox::util::floating_point;
-  uint64_t hash = 0;
   if (isNull()) {
     return folly::Hash{}(static_cast<int32_t>(kind_));
   }
 
-  switch (kind_) {
-    case TypeKind::BIGINT:
-      return folly::Hash{}(value<TypeKind::BIGINT>());
-    case TypeKind::HUGEINT:
-      return folly::Hash{}(value<TypeKind::HUGEINT>());
-    case TypeKind::INTEGER:
-      return folly::Hash{}(value<TypeKind::INTEGER>());
-    case TypeKind::SMALLINT:
-      return folly::Hash{}(value<TypeKind::SMALLINT>());
-    case TypeKind::TINYINT:
-      return folly::Hash{}(value<TypeKind::TINYINT>());
-    case TypeKind::BOOLEAN:
-      return folly::Hash{}(value<TypeKind::BOOLEAN>());
-    case TypeKind::REAL:
-      return NaNAwareHash<float>{}(value<TypeKind::REAL>());
-    case TypeKind::DOUBLE:
-      return NaNAwareHash<double>{}(value<TypeKind::DOUBLE>());
-    case TypeKind::VARBINARY:
-      return folly::Hash{}(value<TypeKind::VARBINARY>());
-    case TypeKind::VARCHAR:
-      return folly::Hash{}(value<TypeKind::VARCHAR>());
-    case TypeKind::ARRAY: {
-      auto& arrayVariant = value<TypeKind::ARRAY>();
-      auto hasher = folly::Hash{};
-      for (int32_t i = 0; i < arrayVariant.size(); i++) {
-        hash = folly::hash::hash_combine_generic(
-            hasher, hash, arrayVariant[i].hash());
-      }
-      return hash;
-    }
-    case TypeKind::ROW: {
-      auto hasher = folly::Hash{};
-      auto& rowVariant = value<TypeKind::ROW>();
-      for (int32_t i = 0; i < rowVariant.size(); i++) {
-        hash = folly::hash::hash_combine_generic(
-            hasher, hash, rowVariant[i].hash());
-      }
-      return hash;
-    }
-    case TypeKind::TIMESTAMP: {
-      auto timestampValue = value<TypeKind::TIMESTAMP>();
-      return folly::Hash{}(
-          timestampValue.getSeconds(), timestampValue.getNanos());
-    }
-    case TypeKind::MAP: {
-      auto hasher = folly::Hash{};
-      auto& mapVariant = value<TypeKind::MAP>();
-      uint64_t combinedKeyHash = 0, combinedValueHash = 0;
-      uint64_t singleKeyHash = 0, singleValueHash = 0;
-      for (auto it = mapVariant.begin(); it != mapVariant.end(); ++it) {
-        singleKeyHash = it->first.hash();
-        singleValueHash = it->second.hash();
-        combinedKeyHash = folly::hash::commutative_hash_combine_value_generic(
-            combinedKeyHash, hasher, singleKeyHash);
-        combinedValueHash = folly::hash::commutative_hash_combine_value_generic(
-            combinedValueHash, hasher, singleValueHash);
-      }
-
-      return folly::hash::hash_combine_generic(
-          folly::Hash{}, combinedKeyHash, combinedValueHash);
-    }
-    default:
-      VELOX_NYI();
-  }
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(hash, kind_);
 }
 
 namespace {
@@ -853,7 +883,7 @@ bool variant::lessThanWithEpsilon(const variant& other) const {
     return *this < other;
   }
 
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, *this, other);
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(lessThan, kind_, other);
 }
 
 namespace {
@@ -918,7 +948,7 @@ bool variant::equalsWithEpsilon(const variant& other) const {
     case TypeKind::ROW:
       return compareComplexTypeWithEpsilon<TypeKind::ROW>(*this, other);
     default:
-      return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, *this, other);
+      return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(equals, kind_, other);
   }
 }
 


### PR DESCRIPTION
Summary:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support
for custom comparison functions provided by custom types in the map aggregations
map_agg and map_union.

Note that I did not add support in map_union_sum because it currently only supports
Maps with a fixed set of key types, and none of those provide custom comparisons.

Differential Revision: D63570186
