### PR TITLE
Skip overflow check for decimal add in agg function

### DIFF
--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -392,8 +392,8 @@ class AverageAggregateBase : public exec::Aggregate {
 template <typename TUnscaledType>
 class DecimalAverageAggregateBase : public DecimalAggregate<TUnscaledType> {
  public:
-  explicit DecimalAverageAggregateBase(TypePtr resultType)
-      : DecimalAggregate<TUnscaledType>(resultType) {}
+  explicit DecimalAverageAggregateBase(TypePtr inputType, TypePtr resultType)
+      : DecimalAggregate<TUnscaledType>(inputType, resultType) {}
 
   virtual TUnscaledType computeFinalValue(
       functions::aggregate::LongDecimalWithOverflowState* accumulator) final {

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -177,8 +177,9 @@ template <typename TInputType>
 class DecimalSumAggregate
     : public functions::aggregate::DecimalAggregate<int128_t, TInputType> {
  public:
-  explicit DecimalSumAggregate(TypePtr resultType)
+  explicit DecimalSumAggregate(TypePtr inputType, TypePtr resultType)
       : functions::aggregate::DecimalAggregate<int128_t, TInputType>(
+            inputType,
             resultType) {}
 
   virtual int128_t computeFinalValue(

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -81,7 +81,7 @@ void registerAverageAggregate(
             case TypeKind::BIGINT: {
               if (inputType->isShortDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               return std::make_unique<
                   AverageAggregateBase<int64_t, double, double>>(resultType);
@@ -89,7 +89,7 @@ void registerAverageAggregate(
             case TypeKind::HUGEINT: {
               if (inputType->isLongDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               VELOX_NYI();
             }
@@ -117,14 +117,14 @@ void registerAverageAggregate(
                   AverageAggregateBase<int64_t, double, double>>(resultType);
             case TypeKind::BIGINT:
               return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                  resultType);
+                  inputType, resultType);
             case TypeKind::HUGEINT:
               return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                  resultType);
+                  inputType, resultType);
             case TypeKind::VARBINARY:
               if (inputType->isLongDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                    inputType, resultType);
               } else if (
                   inputType->isShortDecimal() ||
                   inputType->kind() == TypeKind::VARBINARY) {
@@ -132,7 +132,7 @@ void registerAverageAggregate(
                 // LongDecimalWithOverflowState is used and the template type
                 // does not matter.
                 return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               [[fallthrough]];
             default:

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -76,14 +76,15 @@ exec::AggregateRegistrationResult registerSum(
             return std::make_unique<T<int32_t, int64_t, int64_t>>(BIGINT());
           case TypeKind::BIGINT: {
             if (inputType->isShortDecimal()) {
-              return std::make_unique<DecimalSumAggregate<int64_t>>(resultType);
+              return std::make_unique<DecimalSumAggregate<int64_t>>(
+                  inputType, resultType);
             }
             return std::make_unique<T<int64_t, int64_t, int64_t>>(BIGINT());
           }
           case TypeKind::HUGEINT: {
             if (inputType->isLongDecimal()) {
               return std::make_unique<DecimalSumAggregate<int128_t>>(
-                  resultType);
+                  inputType, resultType);
             }
             VELOX_NYI();
           }
@@ -101,7 +102,8 @@ exec::AggregateRegistrationResult registerSum(
             // Always use int128_t template for Varbinary as the result
             // type is either int128_t or
             // UnscaledLongDecimalWithOverflowState.
-            return std::make_unique<DecimalSumAggregate<int128_t>>(resultType);
+            return std::make_unique<DecimalSumAggregate<int128_t>>(
+                inputType, resultType);
 
           default:
             VELOX_UNREACHABLE(

--- a/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
@@ -58,3 +58,19 @@ target_link_libraries(
   Folly::folly
   ${FOLLY_BENCHMARK}
   gflags::gflags)
+
+add_executable(velox_aggregates_decimal_agg_bm DecimalAgg.cpp)
+
+target_link_libraries(
+  velox_aggregates_decimal_agg_bm
+  velox_aggregates
+  velox_functions_aggregates_test_lib
+  velox_functions_lib
+  velox_exec_test_lib
+  velox_functions_prestosql
+  velox_dwio_common_exception
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  Folly::folly
+  ${FOLLY_BENCHMARK}
+  gflags::gflags)

--- a/velox/functions/prestosql/aggregates/benchmarks/DecimalAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/DecimalAgg.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+static constexpr int32_t kNumVectors = 10;
+static constexpr int32_t kRowsPerVector = 10'000;
+
+namespace {
+
+class DecimalAggBenchmark : public AggregationTestBase {
+ public:
+  void TestBody() override {}
+
+  static inline const std::string kSum = "sum(c0)";
+  static inline const std::string kAvg = "avg(c0)";
+
+  void runSumAndAvg(const TypePtr& decimalType) {
+    run(decimalType);
+  }
+
+ private:
+  void run(const TypePtr& decimalType) {
+    folly::BenchmarkSuspender suspender;
+
+    auto plan = makePlan(decimalType);
+    AssertQueryBuilder assertQueryBuilder(plan);
+    suspender.dismiss();
+
+    vector_size_t numResultRows = 0;
+    auto result = assertQueryBuilder.copyResults(pool());
+    numResultRows += result->size();
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  core::PlanNodePtr makePlan(const TypePtr& decimalType) {
+    auto rowType = ROW({"c0", "c1"}, {decimalType, BOOLEAN()});
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      vectors.emplace_back(fuzzer.fuzzInputRow(rowType));
+    }
+    return PlanBuilder()
+        .values(vectors)
+        .partialAggregation({"c1"}, {kSum, kSum, kAvg, kAvg})
+        .finalAggregation()
+        .planNode();
+  }
+};
+
+std::unique_ptr<DecimalAggBenchmark> benchmark;
+
+BENCHMARK(decimal_5) {
+  benchmark->runSumAndAvg(DECIMAL(5, 2));
+}
+
+BENCHMARK(decimal_10) {
+  benchmark->runSumAndAvg(DECIMAL(10, 2));
+}
+
+BENCHMARK(decimal_20) {
+  benchmark->runSumAndAvg(DECIMAL(20, 2));
+}
+
+BENCHMARK(decimal_30) {
+  benchmark->runSumAndAvg(DECIMAL(30, 2));
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  OperatorTestBase::SetUpTestCase();
+  benchmark = std::make_unique<DecimalAggBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
+  return 0;
+}

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -185,8 +185,8 @@ TEST_F(SumTest, sumDecimalOverflow) {
 
   auto decimalSumOverflow = [this](
                                 const std::vector<int128_t>& input,
-                                const std::vector<int128_t>& output) {
-    const TypePtr type = DECIMAL(38, 0);
+                                const std::vector<int128_t>& output,
+                                const TypePtr& type = DECIMAL(38, 0)) {
     auto in = makeRowVector({makeFlatVector<int128_t>({input}, type)});
     auto expected = makeRowVector({makeFlatVector<int128_t>({output}, type)});
     PlanBuilder builder(pool());
@@ -247,6 +247,14 @@ TEST_F(SumTest, sumDecimalOverflow) {
   VELOX_ASSERT_THROW(
       decimalSumOverflow(longDecimalInput, longDecimalOutput),
       "Value '-100000000000000000000000000000000000000' is not in the range of Decimal Type");
+
+  longDecimalInput.clear();
+  for (int i = 0; i < 100; ++i) {
+    longDecimalInput.push_back(DecimalUtil::kLongDecimalMax / 100 + 1);
+  }
+  VELOX_ASSERT_THROW(
+      decimalSumOverflow(longDecimalInput, longDecimalOutput, DECIMAL(36, 0)),
+      "Decimal overflow");
 
   AggregationTestBase::enableTestIncremental();
 }

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -130,7 +130,7 @@ exec::AggregateRegistrationResult registerAverage(
             case TypeKind::BIGINT: {
               if (inputType->isShortDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               return std::make_unique<
                   AverageAggregate<int64_t, double, double>>(resultType);
@@ -138,7 +138,7 @@ exec::AggregateRegistrationResult registerAverage(
             case TypeKind::HUGEINT: {
               if (inputType->isLongDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               VELOX_NYI();
             }
@@ -166,14 +166,14 @@ exec::AggregateRegistrationResult registerAverage(
                   AverageAggregate<int64_t, double, double>>(resultType);
             case TypeKind::BIGINT:
               return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                  resultType);
+                  inputType, resultType);
             case TypeKind::HUGEINT:
               return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                  resultType);
+                  inputType, resultType);
             case TypeKind::VARBINARY:
               if (inputType->isLongDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                    inputType, resultType);
               } else if (
                   inputType->isShortDecimal() ||
                   inputType->kind() == TypeKind::VARBINARY) {
@@ -181,7 +181,7 @@ exec::AggregateRegistrationResult registerAverage(
                 // LongDecimalWithOverflowState is used and the template type
                 // does not matter.
                 return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                    inputType, resultType);
               }
               [[fallthrough]];
             default:


### PR DESCRIPTION
If the input precision is much less than 38, we don't need to check for overflow 
when adding decimal values if there are not many input rows. For example, if the input type 
is Decimal(7, 2), with a maximum value of 99,999.99, overflow occurs only when 
there are >=10^31 rows. Therefore, we can skip overflow checks for 
the first 10^31 - 1 rows, when adding raw inputs.
We observed  ~12% perf gain in TPCH query1, for details, please check https://github.com/facebookincubator/velox/pull/11126#issuecomment-2449319692