### PR TITLE
Fix overflow behavior for spark decimal sum aggregate function

### DIFF
--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -23,6 +23,8 @@ namespace facebook::velox::functions::aggregate::sparksql {
 /// @tparam TInputType The raw input data type.
 /// @tparam TSumType The type of sum in the output of partial aggregation or the
 /// final output type of final aggregation.
+/// @tparam ResultPrecision The precision of the result type, used for checking
+/// overflow.
 template <typename TInputType, typename TSumType, uint8_t ResultPrecision>
 class DecimalSumAggregate {
  public:

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -23,7 +23,7 @@ namespace facebook::velox::functions::aggregate::sparksql {
 /// @tparam TInputType The raw input data type.
 /// @tparam TSumType The type of sum in the output of partial aggregation or the
 /// final output type of final aggregation.
-template <typename TInputType, typename TSumType>
+template <typename TInputType, typename TSumType, uint8_t ResultPrecision>
 class DecimalSumAggregate {
  public:
   using InputType = Row<TInputType>;
@@ -78,11 +78,8 @@ class DecimalSumAggregate {
       }
       auto const adjustedSum =
           DecimalUtil::adjustSumForOverflow(sum.value(), overflow);
-      constexpr uint8_t maxPrecision = std::is_same_v<TSumType, int128_t>
-          ? LongDecimalType::kMaxPrecision
-          : ShortDecimalType::kMaxPrecision;
       if (adjustedSum.has_value() &&
-          DecimalUtil::valueInPrecisionRange(adjustedSum, maxPrecision)) {
+          DecimalUtil::valueInPrecisionRange(adjustedSum, ResultPrecision)) {
         return adjustedSum;
       } else {
         // Found overflow during computing adjusted sum.

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -41,6 +41,64 @@ void checkAccumulatorRowType(const TypePtr& type) {
       type->childAt(0)->isShortDecimal() || type->childAt(0)->isLongDecimal());
   VELOX_CHECK_EQ(type->childAt(1)->kind(), TypeKind::BOOLEAN);
 }
+
+std::unique_ptr<exec::Aggregate> constructDecimalSumAgg(
+    const TypePtr& inputType,
+    const TypePtr& sumType,
+    const TypePtr& resultType) {
+  VELOX_CHECK(sumType->isDecimal());
+  uint8_t precision = 0;
+  if (sumType->isShortDecimal()) {
+    precision = sumType->asShortDecimal().precision();
+  } else {
+    precision = sumType->asLongDecimal().precision();
+  }
+  switch (precision) {
+#define PRECISION_CASE(precision)                                           \
+  case precision:                                                           \
+    if (inputType->isShortDecimal() && sumType->isShortDecimal()) {         \
+      return std::make_unique<exec::SimpleAggregateAdapter<                 \
+          DecimalSumAggregate<int64_t, int64_t, precision>>>(resultType);   \
+    } else if (inputType->isShortDecimal() && sumType->isLongDecimal()) {   \
+      return std::make_unique<exec::SimpleAggregateAdapter<                 \
+          DecimalSumAggregate<int64_t, int128_t, precision>>>(resultType);  \
+    } else {                                                                \
+      return std::make_unique<exec::SimpleAggregateAdapter<                 \
+          DecimalSumAggregate<int128_t, int128_t, precision>>>(resultType); \
+    }
+    PRECISION_CASE(11)
+    PRECISION_CASE(12)
+    PRECISION_CASE(13)
+    PRECISION_CASE(14)
+    PRECISION_CASE(15)
+    PRECISION_CASE(16)
+    PRECISION_CASE(17)
+    PRECISION_CASE(18)
+    PRECISION_CASE(19)
+    PRECISION_CASE(20)
+    PRECISION_CASE(21)
+    PRECISION_CASE(22)
+    PRECISION_CASE(23)
+    PRECISION_CASE(24)
+    PRECISION_CASE(25)
+    PRECISION_CASE(26)
+    PRECISION_CASE(27)
+    PRECISION_CASE(28)
+    PRECISION_CASE(29)
+    PRECISION_CASE(30)
+    PRECISION_CASE(31)
+    PRECISION_CASE(32)
+    PRECISION_CASE(33)
+    PRECISION_CASE(34)
+    PRECISION_CASE(35)
+    PRECISION_CASE(36)
+    PRECISION_CASE(37)
+    PRECISION_CASE(38)
+#undef PRECISION_CASE
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
 } // namespace
 
 exec::AggregateRegistrationResult registerSum(
@@ -100,14 +158,8 @@ exec::AggregateRegistrationResult registerSum(
                 BIGINT());
           case TypeKind::BIGINT: {
             if (inputType->isShortDecimal()) {
-              auto const sumType = getDecimalSumType(resultType);
-              if (sumType->isShortDecimal()) {
-                return std::make_unique<exec::SimpleAggregateAdapter<
-                    DecimalSumAggregate<int64_t, int64_t>>>(resultType);
-              } else if (sumType->isLongDecimal()) {
-                return std::make_unique<exec::SimpleAggregateAdapter<
-                    DecimalSumAggregate<int64_t, int128_t>>>(resultType);
-              }
+              return constructDecimalSumAgg(
+                  inputType, getDecimalSumType(resultType), resultType);
             }
             return std::make_unique<SumAggregate<int64_t, int64_t, int64_t>>(
                 BIGINT());
@@ -116,8 +168,8 @@ exec::AggregateRegistrationResult registerSum(
             VELOX_CHECK(inputType->isLongDecimal());
             // If inputType is long decimal,
             // its output type is always long decimal.
-            return std::make_unique<exec::SimpleAggregateAdapter<
-                DecimalSumAggregate<int128_t, int128_t>>>(resultType);
+            return constructDecimalSumAgg(
+                inputType, getDecimalSumType(resultType), resultType);
           }
           case TypeKind::REAL:
             if (resultType->kind() == TypeKind::REAL) {
@@ -138,13 +190,8 @@ exec::AggregateRegistrationResult registerSum(
             checkAccumulatorRowType(inputType);
             // For the intermediate aggregation step, input intermediate sum
             // type is equal to final result sum type.
-            if (inputType->childAt(0)->isShortDecimal()) {
-              return std::make_unique<exec::SimpleAggregateAdapter<
-                  DecimalSumAggregate<int64_t, int64_t>>>(resultType);
-            } else if (inputType->childAt(0)->isLongDecimal()) {
-              return std::make_unique<exec::SimpleAggregateAdapter<
-                  DecimalSumAggregate<int128_t, int128_t>>>(resultType);
-            }
+            return constructDecimalSumAgg(
+                inputType->childAt(0), inputType->childAt(0), resultType);
           }
             [[fallthrough]];
           default:

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -47,13 +47,10 @@ std::unique_ptr<exec::Aggregate> constructDecimalSumAgg(
     const TypePtr& sumType,
     const TypePtr& resultType) {
   VELOX_CHECK(sumType->isDecimal());
-  uint8_t precision = 0;
-  if (sumType->isShortDecimal()) {
-    precision = sumType->asShortDecimal().precision();
-  } else {
-    precision = sumType->asLongDecimal().precision();
-  }
+  uint8_t precision = getDecimalPrecisionScale(*sumType).first;
   switch (precision) {
+    // The sum precision is calculated from the input precision with the formula
+    // min(p + 10, 38). Therefore, the sum precision must >= 11.
 #define PRECISION_CASE(precision)                                           \
   case precision:                                                           \
     if (inputType->isShortDecimal() && sumType->isShortDecimal()) {         \

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -46,7 +46,6 @@ std::unique_ptr<exec::Aggregate> constructDecimalSumAgg(
     const TypePtr& inputType,
     const TypePtr& sumType,
     const TypePtr& resultType) {
-  VELOX_CHECK(sumType->isDecimal());
   uint8_t precision = getDecimalPrecisionScale(*sumType).first;
   switch (precision) {
     // The sum precision is calculated from the input precision with the formula


### PR DESCRIPTION
The result / intermediate type's precision is min(38, input's precision + 10). 
If it's less than 38, we should check overflow with it not 38 / 18. Now the overflow
check doesn't work as expected.
Below case repro the failure:
```
val df = spark.sql("select sum(if(cast(id % 10000 as decimal(9, 2)) < cast(9999999.00 as decimal(9, 2)), cast(9999999.00 as decimal(9, 2)), cast(id % 10000 as decimal(9, 2)))), count(*) from range(100000000000)")
df.collect
```
Null should be returned, but failure happens.
```
org.apache.spark.SparkRuntimeException: Error while decoding: org.apache.spark.SparkArithmeticException: [DECIMAL_PRECISION_EXCEEDS_MAX_PRECISION] Decimal precision 20 exceeds max precision 19.
createexternalrow(input[0, decimal(19,2), true].toJavaBigDecimal, staticinvoke(class java.lang.Long, ObjectType(class java.lang.Long), valueOf, input[1, bigint, false], true, false, true), StructField(sum((IF((CAST((id % 10000) AS DECIMAL(9,2)) < CAST(9999999.00 AS DECIMAL(9,2))), CAST(9999999.00 AS DECIMAL(9,2)), CAST((id % 10000) AS DECIMAL(9,2))))),DecimalType(19,2),true), StructField(count(1),LongType,false)).
```