### PR TITLE
feat: Support timestamp and date types for Spark unix_timestamp function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -248,6 +248,11 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT timestamp_millis(1230219000123); -- '2008-12-25 15:30:00.123'
 
+.. spark:function:: to_unix_timestamp(date) -> integer
+   :noindex:
+
+    Alias for ``unix_timestamp(date) -> integer``.
+
 .. spark:function:: to_unix_timestamp(string) -> integer
 
     Alias for ``unix_timestamp(string) -> integer``.
@@ -256,11 +261,6 @@ These functions support TIMESTAMP and DATE input types.
    :noindex:
 
     Alias for ``unix_timestamp(string, format) -> integer``.
-
-.. spark:function:: to_unix_timestamp(date) -> integer
-   :noindex:
-
-    Alias for ``unix_timestamp(date) -> integer``.
 
 .. spark:function:: to_unix_timestamp(timestamp) -> integer
    :noindex:
@@ -304,6 +304,14 @@ These functions support TIMESTAMP and DATE input types.
 
     Returns the current UNIX timestamp in seconds.
 
+.. spark:function:: unix_timestamp(date) -> integer
+
+    Converts the time represented by ``date`` at the configured session timezone to the GMT time, and extracts the seconds. ::
+
+        SELECT unix_timestamp('1970-01-01'); -- 0
+        SELECT unix_timestamp('2024-10-01'); -- 1727740800
+        SELECT unix_timestamp('-2025-02-18'); -- -126065894400
+
 .. spark:function:: unix_timestamp(string) -> integer
    :noindex:
 
@@ -320,14 +328,6 @@ These functions support TIMESTAMP and DATE input types.
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
     Returns null if ``string`` does not match ``format`` or if ``format``
     is invalid.
-
-.. spark:function:: unix_timestamp(date) -> integer
-
-    Converts the time represented by ``date`` at the configured session timezone to the GMT time, and extracts the seconds. ::
-
-        SELECT unix_timestamp('1970-01-01'); -- 0
-        SELECT unix_timestamp('2024-10-01'); -- 1727740800
-        SELECT unix_timestamp('-2025-02-18'); -- -126065894400
 
 .. spark:function:: unix_timestamp(timestamp) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -323,11 +323,19 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: unix_timestamp(date) -> integer
 
-    Returns the UNIX timestamp of time specified by ``date``.
+    Converts the time represented by ``date`` at the configured session timezone to the GMT time, and extracts the seconds. ::
+
+        SELECT unix_timestamp('1970-01-01'); -- 0
+        SELECT unix_timestamp('2024-10-01'); -- 1727740800
+        SELECT unix_timestamp('-2025-02-18'); -- -126065894400
 
 .. spark:function:: unix_timestamp(timestamp) -> integer
 
-    Returns the UNIX timestamp of time specified by ``timestamp``.
+    Returns the UNIX timestamp of the given ``timestamp`` in seconds. ::
+
+        SELECT unix_timestamp(CAST(0 AS TIMESTAMP)); -- 0
+        SELECT unix_timestamp(CAST(1739933174 AS TIMESTAMP)); -- 1739933174
+        SELECT unix_timestamp(CAST(-1739933174 AS TIMESTAMP)); -- -1739933174
 
 .. function:: week_of_year(x) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -257,15 +257,15 @@ These functions support TIMESTAMP and DATE input types.
 
     Alias for ``unix_timestamp(string, format) -> integer``.
 
-.. spark:function:: to_unix_timestamp(date, format) -> integer
+.. spark:function:: to_unix_timestamp(date) -> integer
    :noindex:
 
-    Alias for ``unix_timestamp(date, format) -> integer``.
+    Alias for ``unix_timestamp(date) -> integer``.
 
-.. spark:function:: to_unix_timestamp(timestamp, format) -> integer
+.. spark:function:: to_unix_timestamp(timestamp) -> integer
    :noindex:
 
-    Alias for ``unix_timestamp(timestamp, format) -> integer``.
+    Alias for ``unix_timestamp(timestamp) -> integer``.
 
 .. spark:function:: to_utc_timestamp(timestamp, string) -> timestamp
 
@@ -321,13 +321,13 @@ These functions support TIMESTAMP and DATE input types.
     Returns null if ``string`` does not match ``format`` or if ``format``
     is invalid.
 
-.. spark:function:: unix_timestamp(date, format) -> integer
+.. spark:function:: unix_timestamp(date) -> integer
 
-    Returns the UNIX timestamp of time specified by ``date``, format will not be used.
+    Returns the UNIX timestamp of time specified by ``date``.
 
-.. spark:function:: unix_timestamp(timestamp, format) -> integer
+.. spark:function:: unix_timestamp(timestamp) -> integer
 
-    Returns the UNIX timestamp of time specified by ``timestamp``, format will not be used.
+    Returns the UNIX timestamp of time specified by ``timestamp``.
 
 .. function:: week_of_year(x) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -257,6 +257,16 @@ These functions support TIMESTAMP and DATE input types.
 
     Alias for ``unix_timestamp(string, format) -> integer``.
 
+.. spark:function:: to_unix_timestamp(date, format) -> integer
+   :noindex:
+
+    Alias for ``unix_timestamp(date, format) -> integer``.
+
+.. spark:function:: to_unix_timestamp(timestamp, format) -> integer
+   :noindex:
+
+    Alias for ``unix_timestamp(timestamp, format) -> integer``.
+
 .. spark:function:: to_utc_timestamp(timestamp, string) -> timestamp
 
     Returns the timestamp value from the given timezone to UTC timezone. ::
@@ -310,6 +320,14 @@ These functions support TIMESTAMP and DATE input types.
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
     Returns null if ``string`` does not match ``format`` or if ``format``
     is invalid.
+
+.. spark:function:: unix_timestamp(date, format) -> integer
+
+    Returns the UNIX timestamp of time specified by ``date``, format will not be used.
+
+.. spark:function:: unix_timestamp(timestamp, format) -> integer
+
+    Returns the UNIX timestamp of time specified by ``timestamp``, format will not be used.
 
 .. function:: week_of_year(x) -> integer
 

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -67,6 +67,9 @@ int main(int argc, char** argv) {
       "replace",
       "might_contain",
       "unix_timestamp",
+      // to_unix_timestamp(date) throws VeloxRuntimeError when the date is out
+      // of the supported range.
+      "to_unix_timestamp(date) -> bigint",
       // from_unixtime throws VeloxRuntimeError when the timestamp is out of the
       // supported range.
       "from_unixtime",

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -67,9 +67,6 @@ int main(int argc, char** argv) {
       "replace",
       "might_contain",
       "unix_timestamp",
-      // to_unix_timestamp(date) throws VeloxRuntimeError when the date is out
-      // of the supported range.
-      "to_unix_timestamp(date) -> bigint",
       // from_unixtime throws VeloxRuntimeError when the timestamp is out of the
       // supported range.
       "from_unixtime",

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -225,8 +225,7 @@ struct UnixTimestampParseWithFormatFunction
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const arg_type<Date>* /*input*/,
-      const arg_type<Varchar>* /*format*/) {
+      const arg_type<Date>* /*input*/) {
     this->setTimezone(config);
   }
 
@@ -262,15 +261,11 @@ struct UnixTimestampParseWithFormatFunction
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
-      const arg_type<Timestamp>& input,
-      const arg_type<Varchar>& /*format*/) {
+      const arg_type<Timestamp>& input) {
     result = input.getSeconds();
   }
 
-  FOLLY_ALWAYS_INLINE void call(
-      int64_t& result,
-      const arg_type<Date>& input,
-      const arg_type<Varchar>& /*format*/) {
+  FOLLY_ALWAYS_INLINE void call(int64_t& result, const arg_type<Date>& input) {
     auto timestamp = Timestamp::fromDate(input);
     timestamp.toGMT(*this->sessionTimeZone_);
     result = timestamp.getSeconds();

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -263,16 +263,15 @@ struct UnixTimestampParseWithFormatFunction
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Timestamp>& input,
-      const arg_type<Varchar>& format) {
+      const arg_type<Varchar>& /*format*/) {
     result = input.getSeconds();
   }
 
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Date>& input,
-      const arg_type<Varchar>& format) {
-    auto seconds = input * kSecondsInDay;
-    Timestamp timestamp{seconds, 0};
+      const arg_type<Varchar>& /*format*/) {
+    auto timestamp = Timestamp::fromDate(input);
     timestamp.toGMT(*this->sessionTimeZone_);
     result = timestamp.getSeconds();
   }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -260,15 +260,14 @@ struct UnixTimestampParseWithFormatFunction
     return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Timestamp>& input,
       const arg_type<Varchar>& format) {
     result = input.getSeconds();
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Date>& input,
       const arg_type<Varchar>& format) {
@@ -276,7 +275,6 @@ struct UnixTimestampParseWithFormatFunction
     Timestamp timestamp{seconds, 0};
     timestamp.toGMT(*this->sessionTimeZone_);
     result = timestamp.getSeconds();
-    return true;
   }
 
  private:

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -222,6 +222,14 @@ struct UnixTimestampParseWithFormatFunction
     this->setTimezone(config);
   }
 
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Date>* /*input*/,
+      const arg_type<Varchar>* /*format*/) {
+    this->setTimezone(config);
+  }
+
   FOLLY_ALWAYS_INLINE bool call(
       int64_t& result,
       const arg_type<Varchar>& input,
@@ -249,6 +257,25 @@ struct UnixTimestampParseWithFormatFunction
     }
     (*dateTimeResult).timestamp.toGMT(*this->getTimeZone(*dateTimeResult));
     result = (*dateTimeResult).timestamp.getSeconds();
+    return true;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Timestamp>& input,
+      const arg_type<Varchar>& format) {
+    result = input.getSeconds();
+    return true;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Date>& input,
+      const arg_type<Varchar>& format) {
+    auto seconds = input * kSecondsInDay;
+    Timestamp timestamp{seconds, 0};
+    timestamp.toGMT(*this->sessionTimeZone_);
+    result = timestamp.getSeconds();
     return true;
   }
 

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -40,6 +40,10 @@ void registerDatetimeFunctions(const std::string& prefix) {
       int64_t,
       Varchar,
       Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<UnixTimestampParseWithFormatFunction, int64_t, Timestamp>(
+      {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<UnixTimestampParseWithFormatFunction, int64_t, Date>(
+      {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
   registerFunction<FromUnixtimeFunction, Varchar, int64_t, Varchar>(
       {prefix + "from_unixtime"});
   registerFunction<MakeDateFunction, Date, int32_t, int32_t, int32_t>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -333,13 +333,18 @@ TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
   EXPECT_EQ(0, unixTimestamp(parseDate("1970-01-01")));
   EXPECT_EQ(1727740800, unixTimestamp(parseDate("2024-10-01")));
   EXPECT_EQ(-126065894400, unixTimestamp(parseDate("-2025-02-18")));
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01")));
+  EXPECT_EQ(-126065866022, unixTimestamp(parseDate("-2025-02-18")));
+
+  // Test invalid inputs.
   VELOX_ASSERT_THROW(
       unixTimestamp(kMax), "Timepoint is outside of supported year range");
   VELOX_ASSERT_THROW(
       unixTimestamp(kMin), "Timepoint is outside of supported year range");
-  setQueryTimeZone("America/Los_Angeles");
-  EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01")));
-  EXPECT_EQ(-126065866022, unixTimestamp(parseDate("-2025-02-18")));
+  VELOX_ASSERT_THROW(
+      unixTimestamp(parseDate("2045-12-31")),
+      "Unable to convert timezone 'America/Los_Angeles' past 2037-11-01 09:00:00");
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -310,6 +310,25 @@ TEST_F(DateTimeFunctionsTest, unixTimestampCustomFormat) {
   EXPECT_EQ(
       std::nullopt,
       unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
+
+  const auto unixTimestamp1 = [&](std::optional<Timestamp> timestamp,
+                                  std::optional<StringView> formatStr) {
+    return evaluateOnce<int64_t>(
+        "unix_timestamp(c0, c1)", timestamp, formatStr);
+  };
+  EXPECT_EQ(0, unixTimestamp1(Timestamp(0, 0), "yyyy-MM-dd"));
+  EXPECT_EQ(1, unixTimestamp1(Timestamp(1, 990), "yyyy-MM-dd"));
+  EXPECT_EQ(61, unixTimestamp1(Timestamp(61, 0), "yyyy-MM-dd"));
+
+  const auto unixTimestamp2 = [&](std::optional<int32_t> date,
+                                  std::optional<StringView> formatStr) {
+    return evaluateOnce<int64_t>(
+        "unix_timestamp(c0, c1)", {DATE(), VARCHAR()}, date, formatStr);
+  };
+  EXPECT_EQ(0, unixTimestamp2(parseDate("1970-01-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(1727740800, unixTimestamp2(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(1727766000, unixTimestamp2(parseDate("2024-10-01"), "yyyy-MM-dd"));
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -319,6 +319,11 @@ TEST_F(DateTimeFunctionsTest, unixTimestampTimestampInput) {
   EXPECT_EQ(0, unixTimestamp(Timestamp(0, 0)));
   EXPECT_EQ(1, unixTimestamp(Timestamp(1, 990)));
   EXPECT_EQ(61, unixTimestamp(Timestamp(61, 0)));
+  EXPECT_EQ(-1, unixTimestamp(Timestamp(-1, 0)));
+  EXPECT_EQ(1739933174, unixTimestamp(Timestamp(1739933174, 0)));
+  EXPECT_EQ(-1739933174, unixTimestamp(Timestamp(-1739933174, 0)));
+  EXPECT_EQ(kMax, unixTimestamp(Timestamp(kMax, 0)));
+  EXPECT_EQ(kMin, unixTimestamp(Timestamp(kMin, 0)));
 }
 
 TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
@@ -327,10 +332,14 @@ TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
   };
   EXPECT_EQ(0, unixTimestamp(parseDate("1970-01-01")));
   EXPECT_EQ(1727740800, unixTimestamp(parseDate("2024-10-01")));
+  EXPECT_EQ(-126065894400, unixTimestamp(parseDate("-2025-02-18")));
   VELOX_ASSERT_THROW(
       unixTimestamp(kMax), "Timepoint is outside of supported year range");
+  VELOX_ASSERT_THROW(
+      unixTimestamp(kMin), "Timepoint is outside of supported year range");
   setQueryTimeZone("America/Los_Angeles");
   EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01")));
+  EXPECT_EQ(-126065866022, unixTimestamp(parseDate("-2025-02-18")));
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -313,29 +313,24 @@ TEST_F(DateTimeFunctionsTest, unixTimestampCustomFormat) {
 }
 
 TEST_F(DateTimeFunctionsTest, unixTimestampTimestampInput) {
-  const auto unixTimestamp = [&](std::optional<Timestamp> timestamp,
-                                 std::optional<StringView> formatStr) {
-    return evaluateOnce<int64_t>(
-        "unix_timestamp(c0, c1)", timestamp, formatStr);
+  const auto unixTimestamp = [&](std::optional<Timestamp> timestamp) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0)", timestamp);
   };
-  EXPECT_EQ(0, unixTimestamp(Timestamp(0, 0), "yyyy-MM-dd"));
-  EXPECT_EQ(1, unixTimestamp(Timestamp(1, 990), "yyyy-MM-dd"));
-  EXPECT_EQ(61, unixTimestamp(Timestamp(61, 0), "yyyy-MM-dd"));
+  EXPECT_EQ(0, unixTimestamp(Timestamp(0, 0)));
+  EXPECT_EQ(1, unixTimestamp(Timestamp(1, 990)));
+  EXPECT_EQ(61, unixTimestamp(Timestamp(61, 0)));
 }
 
 TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
-  const auto unixTimestamp = [&](std::optional<int32_t> date,
-                                 std::optional<StringView> formatStr) {
-    return evaluateOnce<int64_t>(
-        "unix_timestamp(c0, c1)", {DATE(), VARCHAR()}, date, formatStr);
+  const auto unixTimestamp = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0)", {DATE()}, date);
   };
-  EXPECT_EQ(0, unixTimestamp(parseDate("1970-01-01"), "yyyy-MM-dd"));
-  EXPECT_EQ(1727740800, unixTimestamp(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(0, unixTimestamp(parseDate("1970-01-01")));
+  EXPECT_EQ(1727740800, unixTimestamp(parseDate("2024-10-01")));
   VELOX_ASSERT_THROW(
-      unixTimestamp(kMax, "yyyy-MM-dd"),
-      "Timepoint is outside of supported year range");
+      unixTimestamp(kMax), "Timepoint is outside of supported year range");
   setQueryTimeZone("America/Los_Angeles");
-  EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01")));
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -310,25 +310,32 @@ TEST_F(DateTimeFunctionsTest, unixTimestampCustomFormat) {
   EXPECT_EQ(
       std::nullopt,
       unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
+}
 
-  const auto unixTimestamp1 = [&](std::optional<Timestamp> timestamp,
-                                  std::optional<StringView> formatStr) {
+TEST_F(DateTimeFunctionsTest, unixTimestampTimestampFormat) {
+  const auto unixTimestamp = [&](std::optional<Timestamp> timestamp,
+                                 std::optional<StringView> formatStr) {
     return evaluateOnce<int64_t>(
         "unix_timestamp(c0, c1)", timestamp, formatStr);
   };
-  EXPECT_EQ(0, unixTimestamp1(Timestamp(0, 0), "yyyy-MM-dd"));
-  EXPECT_EQ(1, unixTimestamp1(Timestamp(1, 990), "yyyy-MM-dd"));
-  EXPECT_EQ(61, unixTimestamp1(Timestamp(61, 0), "yyyy-MM-dd"));
+  EXPECT_EQ(0, unixTimestamp(Timestamp(0, 0), "yyyy-MM-dd"));
+  EXPECT_EQ(1, unixTimestamp(Timestamp(1, 990), "yyyy-MM-dd"));
+  EXPECT_EQ(61, unixTimestamp(Timestamp(61, 0), "yyyy-MM-dd"));
+}
 
-  const auto unixTimestamp2 = [&](std::optional<int32_t> date,
-                                  std::optional<StringView> formatStr) {
+TEST_F(DateTimeFunctionsTest, unixTimestampDateFormat) {
+  const auto unixTimestamp = [&](std::optional<int32_t> date,
+                                 std::optional<StringView> formatStr) {
     return evaluateOnce<int64_t>(
         "unix_timestamp(c0, c1)", {DATE(), VARCHAR()}, date, formatStr);
   };
-  EXPECT_EQ(0, unixTimestamp2(parseDate("1970-01-01"), "yyyy-MM-dd"));
-  EXPECT_EQ(1727740800, unixTimestamp2(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(0, unixTimestamp(parseDate("1970-01-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(1727740800, unixTimestamp(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  VELOX_ASSERT_THROW(
+      unixTimestamp(kMax, "yyyy-MM-dd"),
+      "Timepoint is outside of supported year range");
   setQueryTimeZone("America/Los_Angeles");
-  EXPECT_EQ(1727766000, unixTimestamp2(parseDate("2024-10-01"), "yyyy-MM-dd"));
+  EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01"), "yyyy-MM-dd"));
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -312,7 +312,7 @@ TEST_F(DateTimeFunctionsTest, unixTimestampCustomFormat) {
       unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
 }
 
-TEST_F(DateTimeFunctionsTest, unixTimestampTimestampFormat) {
+TEST_F(DateTimeFunctionsTest, unixTimestampTimestampInput) {
   const auto unixTimestamp = [&](std::optional<Timestamp> timestamp,
                                  std::optional<StringView> formatStr) {
     return evaluateOnce<int64_t>(
@@ -323,7 +323,7 @@ TEST_F(DateTimeFunctionsTest, unixTimestampTimestampFormat) {
   EXPECT_EQ(61, unixTimestamp(Timestamp(61, 0), "yyyy-MM-dd"));
 }
 
-TEST_F(DateTimeFunctionsTest, unixTimestampDateFormat) {
+TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
   const auto unixTimestamp = [&](std::optional<int32_t> date,
                                  std::optional<StringView> formatStr) {
     return evaluateOnce<int64_t>(

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -66,7 +66,7 @@ void Timestamp::toGMT(const tz::TimeZone& zone) {
     // Invalid argument means we hit a conversion not supported by
     // external/date. Need to throw a RuntimeError so that try() statements do
     // not suppress it.
-    VELOX_FAIL(e.what());
+    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(e.what());
   }
   seconds_ = sysSeconds.count();
 }


### PR DESCRIPTION
Adds timestamp and date support for Spark `unix_timestamp` and `to_unix_timestamp` 
functions.

Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1246-L1247.