### PR TITLE
Fix Sort and Spill std::vector for rows memory not tracked causing OOM

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -215,6 +215,17 @@ void PrefixSort::extractRowToPrefix(char* row, char* prefix) {
   getAddressFromPrefix(prefix) = row;
 }
 
+uint32_t PrefixSort::maxRequiredBytes() {
+  const auto numRows = rowContainer_->numRows();
+  const auto numPages =
+      memory::AllocationTraits::numPages(numRows * sortLayout_.entrySize);
+  // Prefix data size + swap buffer size.
+  return memory::AllocationTraits::pageBytes(numPages) +
+      pool_->preferredSize(checkedPlus<size_t>(
+          sortLayout_.entrySize, AlignedBuffer::kPaddedSize)) +
+      2 * pool_->alignment();
+}
+
 void PrefixSort::sortInternal(
     std::vector<char*, memory::StlAllocator<char*>>& rows) {
   const auto numRows = rows.size();

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -215,7 +215,8 @@ void PrefixSort::extractRowToPrefix(char* row, char* prefix) {
   getAddressFromPrefix(prefix) = row;
 }
 
-void PrefixSort::sortInternal(std::vector<char*>& rows) {
+void PrefixSort::sortInternal(
+    std::vector<char*, memory::StlAllocator<char*>>& rows) {
   const auto numRows = rows.size();
   const auto entrySize = sortLayout_.entrySize;
   memory::ContiguousAllocation prefixAllocation;

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -26,7 +26,7 @@ namespace facebook::velox::exec {
 namespace detail {
 
 FOLLY_ALWAYS_INLINE void stdSort(
-    std::vector<char*>& rows,
+    std::vector<char*, memory::StlAllocator<char*>>& rows,
     RowContainer* rowContainer,
     const std::vector<CompareFlags>& compareFlags) {
   std::sort(
@@ -120,7 +120,7 @@ class PrefixSort {
   /// @param rows The result of RowContainer::listRows(), assuming that the
   /// caller (SortBuffer etc.) has already got the result.
   FOLLY_ALWAYS_INLINE static void sort(
-      std::vector<char*>& rows,
+      std::vector<char*, memory::StlAllocator<char*>>& rows,
       memory::MemoryPool* pool,
       RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags,
@@ -144,7 +144,7 @@ class PrefixSort {
   }
 
  private:
-  void sortInternal(std::vector<char*>& rows);
+  void sortInternal(std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   int compareAllNormalizedKeys(char* left, char* right);
 

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -166,9 +166,10 @@ class PrefixSort {
   }
 
  private:
-  // The bytes to allocate in the prefix sort process such as prefix buffer and
+  // Estimates the memory required for prefix sort such as prefix buffer and
   // swap buffer.
   uint32_t maxRequiredBytes();
+
   void sortInternal(std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   int compareAllNormalizedKeys(char* left, char* right);

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -150,20 +150,7 @@ class PrefixSort {
       memory::MemoryPool* pool,
       RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags,
-      const velox::common::PrefixSortConfig& config) {
-    if (rowContainer->numRows() < config.threshold) {
-      return 0;
-    }
-    VELOX_DCHECK_EQ(rowContainer->keyTypes().size(), compareFlags.size());
-    const auto sortLayout = PrefixSortLayout::makeSortLayout(
-        rowContainer->keyTypes(), compareFlags, config.maxNormalizedKeySize);
-    if (sortLayout.noNormalizedKeys) {
-      return 0;
-    }
-
-    PrefixSort prefixSort(pool, rowContainer, sortLayout);
-    return prefixSort.maxRequiredBytes();
-  }
+      const velox::common::PrefixSortConfig& config);
 
  private:
   // Estimates the memory required for prefix sort such as prefix buffer and

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -290,7 +290,7 @@ void SortBuffer::ensureSortFits() {
     return;
   }
 
-  if (numInputRows_ == 0 || spiller_ == nullptr) {
+  if (numInputRows_ == 0 || spiller_ != nullptr) {
     return;
   }
 

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -306,10 +306,12 @@ void SortBuffer::ensureSortFits() {
     }
   }
 
-  LOG(WARNING) << "Failed to reserve " << succinctBytes(sortBufferToReserve)
-               << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+  LOG(WARNING) << fmt::format(
+      "Failed to reserve {} for memory pool {}, usage: {}, reservation: {}",
+      succinctBytes(sortBufferToReserve),
+      pool_->name(),
+      succinctBytes(pool_->usedBytes()),
+      succinctBytes(pool_->reservedBytes()));
 }
 
 void SortBuffer::updateEstimatedOutputRowSize() {

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -113,7 +113,7 @@ class SortBuffer {
   uint64_t numInputRows_ = 0;
   // Used to store the input data in row format.
   std::unique_ptr<RowContainer> data_;
-  std::vector<char*> sortedRows_;
+  std::vector<char*,  memory::StlAllocator<char*>> sortedRows_;
 
   // The data type of the rows stored in 'data_' and spilled on disk. The
   // sort key columns are stored first then the non-sorted data columns.

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -74,6 +74,9 @@ class SortBuffer {
   // Reserves memory for output processing. If reservation cannot be increased,
   // spills enough to make output fit.
   void ensureOutputFits();
+  // Reserves memory for sort. If reservation cannot be increased,
+  // spills enough to make output fit.
+  void ensureSortFits();
   void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
   void prepareOutput(vector_size_t maxOutputRows);
@@ -113,7 +116,7 @@ class SortBuffer {
   uint64_t numInputRows_ = 0;
   // Used to store the input data in row format.
   std::unique_ptr<RowContainer> data_;
-  std::vector<char*,  memory::StlAllocator<char*>> sortedRows_;
+  std::vector<char*, memory::StlAllocator<char*>> sortedRows_;
 
   // The data type of the rows stored in 'data_' and spilled on disk. The
   // sort key columns are stored first then the non-sorted data columns.

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -51,7 +51,8 @@ SortWindowBuild::SortWindowBuild(
       compareFlags_{makeCompareFlags(numPartitionKeys_, node->sortingOrders())},
       pool_(pool),
       prefixSortConfig_(prefixSortConfig),
-      spillStats_(spillStats) {
+      spillStats_(spillStats),
+      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
   VELOX_CHECK_NOT_NULL(pool_);
   allKeyInfo_.reserve(partitionKeyInfo_.size() + sortKeyInfo_.size());
   allKeyInfo_.insert(
@@ -252,6 +253,7 @@ void SortWindowBuild::noMoreInput() {
 
 void SortWindowBuild::loadNextPartitionFromSpill() {
   sortedRows_.clear();
+  sortedRows_.shrink_to_fit();
   data_->clear();
 
   for (;;) {

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -104,7 +104,7 @@ class SortWindowBuild : public WindowBuild {
   // The rows are sorted by partitionKeys + sortKeys. This total
   // ordering can be used to split partitions (with the correct
   // order by) for the processing.
-  std::vector<char*> sortedRows_;
+  std::vector<char*, memory::StlAllocator<char*>> sortedRows_;
 
   // This is a vector that gives the index of the start row
   // (in sortedRows_) of each partition in the RowContainer data_.

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -581,7 +581,7 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   checkEmptySpillRuns();
 }
 
-void Spiller::spill(std::vector<char*>& rows) {
+void Spiller::spill(std::vector<char*, memory::StlAllocator<char*>>& rows) {
   CHECK_NOT_FINALIZED();
   VELOX_CHECK_EQ(type_, Type::kOrderByOutput);
   VELOX_CHECK(!rows.empty());
@@ -705,7 +705,7 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
   return lastRun;
 }
 
-void Spiller::fillSpillRun(std::vector<char*>& rows) {
+void Spiller::fillSpillRun(std::vector<char*, memory::StlAllocator<char*>>& rows) {
   VELOX_CHECK_EQ(bits_.numPartitions(), 1);
   checkEmptySpillRuns();
   uint64_t execTimeNs{0};

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -581,7 +581,7 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   checkEmptySpillRuns();
 }
 
-void Spiller::spill(std::vector<char*, memory::StlAllocator<char*>>& rows) {
+void Spiller::spill(SpillRows& rows) {
   CHECK_NOT_FINALIZED();
   VELOX_CHECK_EQ(type_, Type::kOrderByOutput);
   VELOX_CHECK(!rows.empty());
@@ -705,7 +705,7 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
   return lastRun;
 }
 
-void Spiller::fillSpillRun(std::vector<char*, memory::StlAllocator<char*>>& rows) {
+void Spiller::fillSpillRun(SpillRows& rows) {
   VELOX_CHECK_EQ(bits_.numPartitions(), 1);
   checkEmptySpillRuns();
   uint64_t execTimeNs{0};

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -127,7 +127,7 @@ class Spiller {
   /// 'kOrderByOutput' spiller type to spill during the order by
   /// output processing. Similarly, the spilled rows still stays in the row
   /// container. The caller needs to erase them from the row container.
-  void spill(std::vector<char*>& rows);
+  void spill(std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now
   /// only used by the spilling operator which doesn't need data sort, such as
@@ -297,7 +297,7 @@ class Spiller {
 
   // Prepares spill run of a single partition for the spillable data from the
   // rows.
-  void fillSpillRun(std::vector<char*>& rows);
+  void fillSpillRun(std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   // Writes out all the rows collected in spillRuns_.
   void runSpill(bool lastRun);

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -127,7 +127,7 @@ class Spiller {
   /// 'kOrderByOutput' spiller type to spill during the order by
   /// output processing. Similarly, the spilled rows still stays in the row
   /// container. The caller needs to erase them from the row container.
-  void spill(std::vector<char*, memory::StlAllocator<char*>>& rows);
+  void spill(SpillRows& rows);
 
   /// Append 'spillVector' into the spill file of given 'partition'. It is now
   /// only used by the spilling operator which doesn't need data sort, such as
@@ -297,7 +297,7 @@ class Spiller {
 
   // Prepares spill run of a single partition for the spillable data from the
   // rows.
-  void fillSpillRun(std::vector<char*, memory::StlAllocator<char*>>& rows);
+  void fillSpillRun(SpillRows& rows);
 
   // Writes out all the rows collected in spillRuns_.
   void runSpill(bool lastRun);

--- a/velox/exec/benchmarks/PrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/PrefixSortBenchmark.cpp
@@ -144,7 +144,8 @@ class PrefixSortBenchmark {
       RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags) {
     // Copy rows to avoid sort rows already sorted.
-    std::vector<char*> sortedRows = rows;
+    auto sortedRows = std::vector<char*, memory::StlAllocator<char*>>(
+        rows.begin(), rows.end(), *pool_);
     PrefixSort::sort(
         sortedRows, pool_, rowContainer, compareFlags, kDefaultSortConfig);
   }
@@ -153,7 +154,8 @@ class PrefixSortBenchmark {
       const std::vector<char*>& rows,
       RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags) {
-    std::vector<char*> sortedRows = rows;
+    auto sortedRows = std::vector<char*, memory::StlAllocator<char*>>(
+        rows.begin(), rows.end(), *pool_);
     PrefixSort::sort(
         sortedRows, pool_, rowContainer, compareFlags, kStdSortConfig);
   }

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -24,7 +24,7 @@ namespace {
 
 class PrefixSortTest : public exec::test::OperatorTestBase {
  protected:
-  std::vector<char*>
+  std::vector<char*, memory::StlAllocator<char*>>
   storeRows(int numRows, const RowVectorPtr& sortedRows, RowContainer* data);
 
   static constexpr CompareFlags kAsc{
@@ -57,7 +57,7 @@ class PrefixSortTest : public exec::test::OperatorTestBase {
         rowType->children().end()};
 
     RowContainer rowContainer(keyTypes, payloadTypes, pool_.get());
-    std::vector<char*> rows = storeRows(numRows, data, &rowContainer);
+    auto rows = storeRows(numRows, data, &rowContainer);
 
     // Use PrefixSort to sort rows.
     PrefixSort::sort(
@@ -89,11 +89,11 @@ class PrefixSortTest : public exec::test::OperatorTestBase {
       const RowVectorPtr& sortedRows);
 };
 
-std::vector<char*> PrefixSortTest::storeRows(
+std::vector<char*, memory::StlAllocator<char*>> PrefixSortTest::storeRows(
     int numRows,
     const RowVectorPtr& sortedRows,
     RowContainer* data) {
-  std::vector<char*> rows;
+  std::vector<char*, memory::StlAllocator<char*>> rows(*pool());
   SelectivityVector allRows(numRows);
   rows.resize(numRows);
   for (int row = 0; row < numRows; ++row) {
@@ -116,7 +116,7 @@ const RowVectorPtr PrefixSortTest::generateExpectedResult(
   const auto rowType = asRowType(sortedRows->type());
   const int numKeys = compareFlags.size();
   RowContainer rowContainer(rowType->children(), pool_.get());
-  std::vector<char*> rows = storeRows(numRows, sortedRows, &rowContainer);
+  auto rows = storeRows(numRows, sortedRows, &rowContainer);
 
   std::sort(
       rows.begin(), rows.end(), [&](const char* leftRow, const char* rightRow) {

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -565,7 +565,7 @@ DEBUG_ONLY_TEST_F(SortBufferTest, spillDuringOutput) {
   }
 }
 
-DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemoryGetOutput) {
+DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySortGetOutput) {
   for (bool spillEnabled : {false, true}) {
     SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
 
@@ -611,7 +611,8 @@ DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemoryGetOutput) {
     // Sets an extreme large value to get output once to avoid test flakiness.
     sortBuffer->getOutput(1'000'000);
     if (spillEnabled) {
-      ASSERT_EQ(numReserves, 1);
+      // Reserve memory for sort and getOutput.
+      ASSERT_EQ(numReserves, 2);
     } else {
       ASSERT_EQ(numReserves, 0);
     }

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -75,6 +75,13 @@ class SortBufferTest : public OperatorTestBase {
        {"c3", REAL()},
        {"c4", DOUBLE()},
        {"c5", VARCHAR()}});
+  const RowTypePtr nonPrefixSortInputType_ = ROW(
+      {{"c0", VARCHAR()},
+       {"c1", VARCHAR()},
+       {"c2", VARCHAR()},
+       {"c3", VARCHAR()},
+       {"c4", VARCHAR()},
+       {"c5", VARCHAR()}});
   // Specifies the sort columns ["c4", "c1"].
   std::vector<column_index_t> sortColumnIndices_{4, 1};
   std::vector<CompareFlags> sortCompareFlags_{
@@ -620,53 +627,50 @@ DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySortGetOutput) {
 }
 
 DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySort) {
-  for (bool usePrefixSort : {false, true}) {
-    for (bool spillEnabled : {false, true}) {
-      SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
-      auto spillDirectory = exec::test::TempDirectoryPath::create();
-      auto spillConfig = getSpillConfig(spillDirectory->getPath());
-      folly::Synchronized<common::SpillStats> spillStats;
-      const RowTypePtr inputType = usePrefixSort ? inputType_
-                                                 : ROW(
-                                                       {{"c0", VARCHAR()},
-                                                        {"c1", VARCHAR()},
-                                                        {"c2", VARCHAR()},
-                                                        {"c3", VARCHAR()},
-                                                        {"c4", VARCHAR()},
-                                                        {"c5", VARCHAR()}});
-      auto sortBuffer = std::make_unique<SortBuffer>(
-          inputType,
-          sortColumnIndices_,
-          sortCompareFlags_,
-          pool_.get(),
-          &nonReclaimableSection_,
-          prefixSortConfig_,
-          spillEnabled ? &spillConfig : nullptr,
-          &spillStats);
+  struct SortTestOption {
+    bool usePrefixSort;
+    bool spillEnabled;
+  };
+  for (const auto [usePrefixSort, spillEnabled] : std::vector<SortTestOption>{
+           {false, true}, {true, false}, {true, true}}) {
+    SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
+    auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto spillConfig = getSpillConfig(spillDirectory->getPath());
+    folly::Synchronized<common::SpillStats> spillStats;
+    const RowTypePtr inputType =
+        usePrefixSort ? inputType_ : nonPrefixSortInputType_;
+    auto sortBuffer = std::make_unique<SortBuffer>(
+        inputType,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        prefixSortConfig_,
+        spillEnabled ? &spillConfig : nullptr,
+        &spillStats);
 
-      const std::shared_ptr<memory::MemoryPool> spillSource =
-          memory::memoryManager()->addLeafPool("spillSource");
-      VectorFuzzer fuzzer({.vectorSize = 100}, spillSource.get());
+    const std::shared_ptr<memory::MemoryPool> spillSource =
+        memory::memoryManager()->addLeafPool("spillSource");
+    VectorFuzzer fuzzer({.vectorSize = 100}, spillSource.get());
 
-      TestScopedSpillInjection scopedSpillInjection(0);
-      sortBuffer->addInput(fuzzer.fuzzRow(inputType));
+    TestScopedSpillInjection scopedSpillInjection(0);
+    sortBuffer->addInput(fuzzer.fuzzRow(inputType));
 
-      std::atomic_bool hasReserveMemory = false;
+    std::atomic_bool hasReserveMemory = false;
+    // Reserve memory for sort.
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
+        std::function<void(memory::MemoryPoolImpl*)>(
+            ([&](memory::MemoryPoolImpl* pool) {
+              hasReserveMemory.store(true);
+            })));
+
+    sortBuffer->noMoreInput();
+    if (spillEnabled) {
       // Reserve memory for sort.
-      SCOPED_TESTVALUE_SET(
-          "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
-          std::function<void(memory::MemoryPoolImpl*)>(
-              ([&](memory::MemoryPoolImpl* pool) {
-                hasReserveMemory.store(true);
-              })));
-
-      sortBuffer->noMoreInput();
-      if (spillEnabled) {
-        // Reserve memory for sort.
-        ASSERT_TRUE(hasReserveMemory);
-      } else {
-        ASSERT_FALSE(hasReserveMemory);
-      }
+      ASSERT_TRUE(hasReserveMemory);
+    } else {
+      ASSERT_FALSE(hasReserveMemory);
     }
   }
 }

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -627,13 +627,14 @@ DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySortGetOutput) {
 }
 
 DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySort) {
-  struct SortTestOption {
+  struct {
     bool usePrefixSort;
     bool spillEnabled;
-  };
-  for (const auto [usePrefixSort, spillEnabled] : std::vector<SortTestOption>{
-           {false, true}, {true, false}, {true, true}}) {
-    SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
+  } testSettings[] = {{false, true}, {true, false}, {true, true}};
+
+  for (const auto [usePrefixSort, spillEnabled] : testSettings) {
+    SCOPED_TRACE(fmt::format(
+        "usePrefixSort: {}, spillEnabled: {}, ", usePrefixSort, spillEnabled));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
     auto spillConfig = getSpillConfig(spillDirectory->getPath());
     folly::Synchronized<common::SpillStats> spillStats;

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1176,7 +1176,7 @@ TEST_P(AllTypes, nonSortedSpillFunctions) {
 
     if (type_ == Spiller::Type::kOrderByOutput) {
       RowContainerIterator rowIter;
-      std::vector<char*> rows(5'000);
+      std::vector<char*, memory::StlAllocator<char*>> rows(5'000, *pool_);
       int numListedRows{0};
       numListedRows = rowContainer_->listRows(&rowIter, 5000, rows.data());
       ASSERT_EQ(numListedRows, 5000);
@@ -1548,11 +1548,11 @@ TEST_P(OrderByOutputOnly, basic) {
           "Unexpected spiller type: ORDER_BY_OUTPUT");
     }
     {
-      std::vector<char*> emptyRows;
+      std::vector<char*, memory::StlAllocator<char*>> emptyRows(*pool_);
       VELOX_ASSERT_THROW(spiller_->spill(emptyRows), "");
     }
-    auto spillRows =
-        std::vector<char*>(rows.begin(), rows.begin() + numListedRows);
+    auto spillRows = std::vector<char*, memory::StlAllocator<char*>>(
+        rows.begin(), rows.begin() + numListedRows, *pool_);
     spiller_->spill(spillRows);
     ASSERT_EQ(rowContainer_->numRows(), numRows);
     rowContainer_->clear();
@@ -1630,7 +1630,7 @@ TEST_P(MaxSpillRunTest, basic) {
         testData.maxSpillRunRows);
     if (type_ == Spiller::Type::kOrderByOutput) {
       RowContainerIterator rowIter;
-      std::vector<char*> rows(numRows);
+      std::vector<char*, memory::StlAllocator<char*>> rows(numRows, *pool_);
       int numListedRows{0};
       numListedRows = rowContainer_->listRows(&rowIter, numRows, rows.data());
       ASSERT_EQ(numListedRows, numRows);

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1548,11 +1548,11 @@ TEST_P(OrderByOutputOnly, basic) {
           "Unexpected spiller type: ORDER_BY_OUTPUT");
     }
     {
-      std::vector<char*, memory::StlAllocator<char*>> emptyRows(*pool_);
+      Spiller::SpillRows emptyRows(*pool_);
       VELOX_ASSERT_THROW(spiller_->spill(emptyRows), "");
     }
-    auto spillRows = std::vector<char*, memory::StlAllocator<char*>>(
-        rows.begin(), rows.begin() + numListedRows, *pool_);
+    auto spillRows =
+        Spiller::SpillRows(rows.begin(), rows.begin() + numListedRows, *pool_);
     spiller_->spill(spillRows);
     ASSERT_EQ(rowContainer_->numRows(), numRows);
     rowContainer_->clear();
@@ -1630,7 +1630,7 @@ TEST_P(MaxSpillRunTest, basic) {
         testData.maxSpillRunRows);
     if (type_ == Spiller::Type::kOrderByOutput) {
       RowContainerIterator rowIter;
-      std::vector<char*, memory::StlAllocator<char*>> rows(numRows, *pool_);
+      Spiller::SpillRows rows(numRows, *pool_);
       int numListedRows{0};
       numListedRows = rowContainer_->listRows(&rowIter, numRows, rows.data());
       ASSERT_EQ(numListedRows, numRows);


### PR DESCRIPTION
Spark query failed by killed by yarn because the memory overhead exceeds the threshold.
std::vector for rows should be tracked by memory pool.
Need to refactor everywhere if the std::vector is allocated by rows, this is a first PR.
Reserve the memory for the std::vector for rows and prefix sort required buffer.