### PR TITLE
[MINOR] Fix Typo problem for LastDayFunction

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -446,7 +446,7 @@ struct LastDayFunction {
     auto dateTime = getDateTime(date);
     int32_t year = getYear(dateTime);
     int32_t month = getMonth(dateTime);
-    int32_t day = getMonth(dateTime);
+    int32_t day = getDay(dateTime);
     auto lastDay = util::getMaxDayOfMonth(year, month);
     Expected<int64_t> expected =
         util::daysSinceEpochFromDate(year, month, lastDay);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -446,7 +446,6 @@ struct LastDayFunction {
     auto dateTime = getDateTime(date);
     int32_t year = getYear(dateTime);
     int32_t month = getMonth(dateTime);
-    int32_t day = getDay(dateTime);
     auto lastDay = util::getMaxDayOfMonth(year, month);
     Expected<int64_t> expected =
         util::daysSinceEpochFromDate(year, month, lastDay);
@@ -458,10 +457,8 @@ struct LastDayFunction {
     VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
-        "Integer overflow in last_day({}-{}-{})",
-        year,
-        month,
-        day);
+        "Integer overflow in last_day({})",
+        DATE()->toString(date));
     result = daysSinceEpoch;
   }
 };

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -370,6 +370,8 @@ TEST_F(DateTimeFunctionsTest, lastDay) {
   EXPECT_EQ(lastDay("2015-12-05"), parseDateStr("2015-12-31"));
   EXPECT_EQ(lastDay("2016-01-06"), parseDateStr("2016-01-31"));
   EXPECT_EQ(lastDay("2016-02-07"), parseDateStr("2016-02-29"));
+  VELOX_ASSERT_THROW(
+      lastDay("5881580-07-11"), "Integer overflow in last_day(5881580-07-11)")
   EXPECT_EQ(lastDayFunc(std::nullopt), std::nullopt);
 }
 


### PR DESCRIPTION
It should be `getDay` instead of `getMonth`