### PR TITLE
Return null for invalid datetime format when legacy date formatter is used

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -82,12 +82,12 @@ These functions support TIMESTAMP and DATE input types.
 
     Adjusts ``unixTime`` (elapsed seconds since UNIX epoch) to configured session timezone, then
     converts it to a formatted time string according to ``format``. Only supports BIGINT type for
-    ``unixTime``. Using `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`
+    ``unixTime``. Using `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_
     date formatter in lenient mode that is align with Spark legacy date parser behavior or
-    `Joda <https://www.joda.org/joda-time/>` date formatter depends on ``spark.legacy_date_formatter`` configuration.
+    `Joda <https://www.joda.org/joda-time/>`_ date formatter depends on ``spark.legacy_date_formatter`` configuration.
     `Valid patterns for date format
-    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. When `Simple` Date Formatter is used,
-    it returns null for invalid ``format``; if not, it throws exception. This function will convert input to
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. When `Simple` date formatter is used,
+    null is returned for invalid ``format``; otherwise, exception is thrown. This function will convert input to
     milliseconds, and integer overflow is allowed in the conversion, which aligns with Spark. See the below third
     example where INT64_MAX is used, -1000 milliseconds are produced by INT64_MAX * 1000 due to integer overflow. ::
 
@@ -113,11 +113,11 @@ These functions support TIMESTAMP and DATE input types.
     The format follows Spark's
     `Datetime patterns
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
-    Using `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`
+    Using `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_
     date formatter in lenient mode that is align with Spark legacy date parser behavior or
-    `Joda <https://www.joda.org/joda-time/>` date formatter depends on ``spark.legacy_date_formatter`` configuration.
-    Returns NULL for parsing error or NULL input. When `Simple` Date Formatter is used,
-    it returns null for invalid ``dateFormat``; if not, it throws exception. ::
+    `Joda <https://www.joda.org/joda-time/>`_ date formatter depends on ``spark.legacy_date_formatter`` configuration.
+    Returns NULL for parsing error or NULL input. When `Simple` date formatter is used, null is returned for invalid
+    ``dateFormat``; otherwise, exception is thrown. ::
 
         SELECT get_timestamp('1970-01-01', 'yyyy-MM-dd);  -- timestamp `1970-01-01`
         SELECT get_timestamp('1970-01-01', 'yyyy-MM');  -- NULL (parsing error)
@@ -292,8 +292,8 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: unix_timestamp() -> integer
 
     Returns the current UNIX timestamp in seconds. Using
-    `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>` date formatter in lenient mode
-    that is align with Spark legacy date parser behavior or `Joda <https://www.joda.org/joda-time/>` date formatter
+    `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_ date formatter in lenient mode
+    that is align with Spark legacy date parser behavior or `Joda <https://www.joda.org/joda-time/>`_ date formatter
     depends on the ``spark.legacy_date_formatter`` configuration.
 
 .. spark:function:: unix_timestamp(string) -> integer

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -113,7 +113,11 @@ These functions support TIMESTAMP and DATE input types.
     The format follows Spark's
     `Datetime patterns
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
-    Returns NULL for parsing error or NULL input. Throws exception for invalid format. ::
+    Using `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`
+    date formatter in lenient mode that is align with Spark legacy date parser behavior or
+    `Joda <https://www.joda.org/joda-time/>` date formatter depends on ``spark.legacy_date_formatter`` configuration.
+    Returns NULL for parsing error or NULL input. When `Simple` Date Formatter is used,
+    it returns null for invalid ``dateFormat``; if not, it throws exception. ::
 
         SELECT get_timestamp('1970-01-01', 'yyyy-MM-dd);  -- timestamp `1970-01-01`
         SELECT get_timestamp('1970-01-01', 'yyyy-MM');  -- NULL (parsing error)

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -86,10 +86,10 @@ These functions support TIMESTAMP and DATE input types.
     date formatter in lenient mode that is align with Spark legacy date parser behavior or
     `Joda <https://www.joda.org/joda-time/>` date formatter depends on ``spark.legacy_date_formatter`` configuration.
     `Valid patterns for date format
-    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. Throws exception for
-    invalid ``format``. This function will convert input to milliseconds, and integer overflow is
-    allowed in the conversion, which aligns with Spark. See the below third example where INT64_MAX
-    is used, -1000 milliseconds are produced by INT64_MAX * 1000 due to integer overflow. ::
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_. When `Simple` Date Formatter is used,
+    it returns null for invalid ``format``; if not, it throws exception. This function will convert input to
+    milliseconds, and integer overflow is allowed in the conversion, which aligns with Spark. See the below third
+    example where INT64_MAX is used, -1000 milliseconds are produced by INT64_MAX * 1000 due to integer overflow. ::
 
         SELECT from_unixtime(100, 'yyyy-MM-dd HH:mm:ss'); -- '1970-01-01 00:01:40'
         SELECT from_unixtime(3600, 'yyyy'); -- '1970'

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -50,7 +50,7 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
 // @return An optional shared pointer to a DateTimeFormatter. If the formatter
 // initialization fails and the legacy formatter is used, std::nullopt is
 // returned.
-std::optional<std::shared_ptr<DateTimeFormatter>> initializeFormatter(
+std::shared_ptr<DateTimeFormatter> initializeFormatter(
     const std::string_view& format,
     bool legacyFormatter) {
   auto formatter = detail::getDateTimeFormatter(
@@ -61,7 +61,7 @@ std::optional<std::shared_ptr<DateTimeFormatter>> initializeFormatter(
   // throws user error.
   if (formatter.hasError()) {
     if (legacyFormatter) {
-      return std::nullopt;
+      return nullptr;
     }
     VELOX_USER_FAIL(formatter.error().message());
   }
@@ -275,8 +275,8 @@ struct FromUnixtimeFunction {
     if (format != nullptr) {
       auto formatter = detail::initializeFormatter(
           std::string_view(*format), legacyFormatter_);
-      if (formatter.has_value()) {
-        formatter_ = formatter.value();
+      if (formatter) {
+        formatter_ = formatter;
         maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
       } else {
         invalidFormat_ = true;
@@ -295,8 +295,8 @@ struct FromUnixtimeFunction {
     if (!isConstantTimeFormat_) {
       auto formatter = detail::initializeFormatter(
           std::string_view(format), legacyFormatter_);
-      if (formatter.has_value()) {
-        formatter_ = formatter.value();
+      if (formatter) {
+        formatter_ = formatter;
         maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
       } else {
         return false;
@@ -399,8 +399,8 @@ struct GetTimestampFunction {
     if (format != nullptr) {
       auto formatter = detail::initializeFormatter(
           std::string_view(*format), legacyFormatter_);
-      if (formatter.has_value()) {
-        formatter_ = formatter.value();
+      if (formatter) {
+        formatter_ = formatter;
       } else {
         invalidFormat_ = true;
       }
@@ -417,8 +417,8 @@ struct GetTimestampFunction {
     if (!isConstantTimeFormat_) {
       auto formatter = detail::initializeFormatter(
           std::string_view(format), legacyFormatter_);
-      if (formatter.has_value()) {
-        formatter_ = formatter.value();
+      if (formatter) {
+        formatter_ = formatter;
       } else {
         return false;
       }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -48,7 +48,7 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
 // @param legacyFormatter Whether legacy formatter is used.
 // @return A shared pointer to a DateTimeFormatter. If the formatter
 // initialization fails and the legacy formatter is used, nullptr is returned.
-std::shared_ptr<DateTimeFormatter> initializeFormatter(
+inline std::shared_ptr<DateTimeFormatter> initializeFormatter(
     const std::string_view format,
     bool legacyFormatter) {
   auto formatter = detail::getDateTimeFormatter(

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -47,8 +47,9 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
 //
 // @param format The format string to be used for initializing the formatter.
 // @param legacyFormatter Determines formatter type.
-// @return True if the formatter was successfully set; false if using the
-// legacy formatter and an invalid format was provided.
+// @return An optional shared pointer to a DateTimeFormatter. If the formatter
+// initialization fails and the legacy formatter is used, std::nullopt is
+// returned.
 std::optional<std::shared_ptr<DateTimeFormatter>> initializeFormatter(
     const std::string_view& format,
     bool legacyFormatter) {

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -281,11 +281,11 @@ struct FromUnixtimeFunction {
                          : DateTimeFormatterType::JODA);
     // Legacy formatter returns null for invalid format but Joda formatter
     // throws user error.
-    if (!legacyFormatter_ && formatter.hasError()) {
-      VELOX_USER_FAIL(formatter.error().message());
-    }
     if (formatter.hasError()) {
-      return false;
+      if (legacyFormatter_) {
+        return false;
+      }
+      VELOX_USER_FAIL(formatter.error().message());
     }
     formatter_ = formatter.value();
     maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
@@ -383,11 +383,12 @@ struct GetTimestampFunction {
                            : DateTimeFormatterType::JODA);
       // Legacy formatter returns null for invalid format but Joda formatter
       // throws user error.
-      if (!legacyFormatter_ && formatter.hasError()) {
-        VELOX_USER_FAIL(formatter.error().message());
-      }
       if (formatter.hasError()) {
-        invalidFormat_ = true;
+        if (legacyFormatter_) {
+          invalidFormat_ = true;
+        } else {
+          VELOX_USER_FAIL(formatter.error().message());
+        }
       } else {
         formatter_ = formatter.value();
       }
@@ -408,11 +409,11 @@ struct GetTimestampFunction {
                            : DateTimeFormatterType::JODA);
       // Legacy formatter returns null for invalid format but Joda formatter
       // throws user error.
-      if (!legacyFormatter_ && formatter.hasError()) {
-        VELOX_USER_FAIL(formatter.error().message());
-      }
       if (formatter.hasError()) {
-        return false;
+        if (legacyFormatter_) {
+          return false;
+        }
+        VELOX_USER_FAIL(formatter.error().message());
       }
       formatter_ = formatter.value();
     }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -49,7 +49,7 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
 // @return A shared pointer to a DateTimeFormatter. If the formatter
 // initialization fails and the legacy formatter is used, nullptr is returned.
 std::shared_ptr<DateTimeFormatter> initializeFormatter(
-    const std::string_view& format,
+    const std::string_view format,
     bool legacyFormatter) {
   auto formatter = detail::getDateTimeFormatter(
       std::string_view(format),

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -40,16 +40,14 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
   }
 }
 
-// Initialize `formatter_` based on the provided format string. It determines
-// formatter type based on the `legacyFormatter` flag. The legacy formatter
-// returns false for an invalid format, while the Joda formatter throws a
-// Velox user error.
+// Creates datetime formatter based on the provided format string. When legacy
+// formatter is used, returns nullptr for invalid format; otherwise, throws a
+// user error.
 //
 // @param format The format string to be used for initializing the formatter.
-// @param legacyFormatter Determines formatter type.
-// @return An optional shared pointer to a DateTimeFormatter. If the formatter
-// initialization fails and the legacy formatter is used, std::nullopt is
-// returned.
+// @param legacyFormatter Whether legacy formatter is used.
+// @return A shared pointer to a DateTimeFormatter. If the formatter
+// initialization fails and the legacy formatter is used, nullptr is returned.
 std::shared_ptr<DateTimeFormatter> initializeFormatter(
     const std::string_view& format,
     bool legacyFormatter) {
@@ -57,8 +55,8 @@ std::shared_ptr<DateTimeFormatter> initializeFormatter(
       std::string_view(format),
       legacyFormatter ? DateTimeFormatterType::STRICT_SIMPLE
                       : DateTimeFormatterType::JODA);
-  // Legacy formatter returns null for invalid format but Joda formatter
-  // throws user error.
+  // When legacy formatter is used, returns nullptr for invalid format;
+  // otherwise, throws a user error.
   if (formatter.hasError()) {
     if (legacyFormatter) {
       return nullptr;

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -51,6 +51,12 @@ class DateTimeFunctionsTest : public SparkFunctionBaseTest {
     });
   }
 
+  void enableLegacyFormatter() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSparkLegacyDateFormatter, "true"},
+    });
+  }
+
   template <typename TOutput, typename TValue>
   std::optional<TOutput> evaluateDateFuncOnce(
       const std::string& expr,
@@ -260,6 +266,9 @@ TEST_F(DateTimeFunctionsTest, unixTimestamp) {
   EXPECT_EQ(std::nullopt, unixTimestamp(std::nullopt));
   EXPECT_EQ(std::nullopt, unixTimestamp("1970-01-01"));
   EXPECT_EQ(std::nullopt, unixTimestamp("00:00:00"));
+  EXPECT_EQ(std::nullopt, unixTimestamp(""));
+  EXPECT_EQ(std::nullopt, unixTimestamp("malformed input"));
+  enableLegacyFormatter();
   EXPECT_EQ(std::nullopt, unixTimestamp(""));
   EXPECT_EQ(std::nullopt, unixTimestamp("malformed input"));
 }
@@ -803,6 +812,13 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
   VELOX_ASSERT_THROW(
       getTimestamp("2023-07-13 21:34", "yyyy-MM-dd HH:II"),
       "Specifier I is not supported");
+
+  // Invalid format returns null for legacy date formatter.
+  enableLegacyFormatter();
+  // Empty format.
+  EXPECT_EQ(getTimestamp("0", ""), std::nullopt);
+  // Unsupported specifier.
+  EXPECT_EQ(getTimestamp("0", "l"), std::nullopt);
 }
 
 TEST_F(DateTimeFunctionsTest, hour) {
@@ -926,6 +942,13 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
       fromUnixTime(0, "FF/MM/dd"), "Specifier F is not supported");
   VELOX_ASSERT_THROW(
       fromUnixTime(0, "yyyy-MM-dd HH:II"), "Specifier I is not supported");
+
+  // Invalid format returns null for legacy date formatter.
+  enableLegacyFormatter();
+  // Empty format.
+  EXPECT_EQ(fromUnixTime(0, ""), std::nullopt);
+  // Unsupported specifier.
+  EXPECT_EQ(fromUnixTime(0, "l"), std::nullopt);
 }
 
 TEST_F(DateTimeFunctionsTest, makeYMInterval) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -813,7 +813,8 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
       getTimestamp("2023-07-13 21:34", "yyyy-MM-dd HH:II"),
       "Specifier I is not supported");
 
-  // Invalid format returns null for legacy date formatter.
+  // Returns null for invalid datetime format when legacy date formatter is
+  // used.
   enableLegacyFormatter();
   // Empty format.
   EXPECT_EQ(getTimestamp("0", ""), std::nullopt);
@@ -943,7 +944,8 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
   VELOX_ASSERT_THROW(
       fromUnixTime(0, "yyyy-MM-dd HH:II"), "Specifier I is not supported");
 
-  // Invalid format returns null for legacy date formatter.
+  // Returns null for invalid datetime format when legacy date formatter is
+  // used.
   enableLegacyFormatter();
   // Empty format.
   EXPECT_EQ(fromUnixTime(0, ""), std::nullopt);


### PR DESCRIPTION
For Spark functions 'unix_timestamp', 'from_unixtime' and 'get_timestamp', 
returns null for invalid datetime format when legacy date formatter is used.

Relating to #10354.