### PR TITLE
Fix adapters dockerfile classpath script name

### DIFF
--- a/scripts/adapters.dockerfile
+++ b/scripts/adapters.dockerfile
@@ -24,7 +24,7 @@ RUN mkdir build && ( cd build &&  source /opt/rh/gcc-toolset-12/enable && \
 RUN curl -L -o /tmp/miniforge.sh https://github.com/conda-forge/miniforge/releases/download/23.11.0-0/Mambaforge-23.11.0-0-Linux-x86_64.sh && \
     bash /tmp/miniforge.sh -b -p /opt/miniforge && \
     rm /tmp/miniforge.sh
-ENV PATH=/opt/miniforge/condabin:${PATH} 
+ENV PATH=/opt/miniforge/condabin:${PATH}
 
 # install test dependencies
 RUN mamba create -y --name adapters python=3.8
@@ -42,5 +42,5 @@ ENV HADOOP_HOME=/usr/local/hadoop \
     PATH=/usr/lib/jvm/java-1.8.0-openjdk/bin:${PATH}
 
 COPY scripts/setup-classpath.sh /
-ENTRYPOINT ["/bin/bash", "-c", "source /set_classpath.sh && source /opt/rh/gcc-toolset-12/enable && exec \"$@\"", "--"]
+ENTRYPOINT ["/bin/bash", "-c", "source /setup-classpath.sh && source /opt/rh/gcc-toolset-12/enable && exec \"$@\"", "--"]
 CMD ["/bin/bash"]


### PR DESCRIPTION
A new script to setup the classpath was added by PR [10446](https://github.com/facebookincubator/velox/pull/10446) that is called incorrectly on startup of the container.
The name needs to be setup-classpath.sh and not set_classpath.sh.

Error returned on startup
[root@czentgr-foobar velox]# docker run -it 64a9eed9f771 bash Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg. --: line 1: /set_classpath.sh: No such file or directory