### PR TITLE
Add support for nested nulls in map_from_entries keys

### DIFF
--- a/velox/functions/prestosql/MapFromEntries.cpp
+++ b/velox/functions/prestosql/MapFromEntries.cpp
@@ -26,8 +26,6 @@
 namespace facebook::velox::functions {
 namespace {
 static const char* kNullKeyErrorMessage = "map key cannot be null";
-static const char* kIndeterminateKeyErrorMessage =
-    "map key cannot be indeterminate";
 static const char* kErrorMessageEntryNotNull = "map entry cannot be null";
 
 // See documentation at https://prestodb.io/docs/current/functions/map.html
@@ -154,15 +152,6 @@ class MapFromEntriesFunction : public exec::VectorFunction {
           if (keyVector->isNullAt(keyIndex)) {
             resetSize(row);
             VELOX_USER_FAIL(kNullKeyErrorMessage);
-          }
-
-          // Check nested null in keys.
-          if (keyVector->containsNullAt(keyIndex)) {
-            resetSize(row);
-            VELOX_USER_FAIL(fmt::format(
-                "{}: {}",
-                kIndeterminateKeyErrorMessage,
-                keyVector->toString(keyIndex)));
           }
         }
       });


### PR DESCRIPTION
Summary:
Velox throws an exception with there are nested nulls in the keys of map_from_entries. Presto supports nested nulls and provides a valid result.

Query: select map_from_entries(c0) from (values array[row(map(array[1, 2], array[1, null]), 1)]) t(c0);
Presto-0.289: Returns {"{1=1, 2=null}": 1}.
Velox: Throws an exception "map key cannot be indeterminate: 2 elements starting at 0 {1 => 1, 2 => null}".

Differential Revision: D63662252
