### PR TITLE
Support Custom Comparison in Simple Function API

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -365,8 +365,8 @@ struct TypeAnalysis<Row<T...>> {
   }
 };
 
-template <typename T>
-struct TypeAnalysis<CustomType<T>> {
+template <typename T, bool providesCustomComparison>
+struct TypeAnalysis<CustomType<T, providesCustomComparison>> {
   void run(TypeAnalysisResults& results) {
     results.stats.concreteCount++;
     results.out << T::typeName;

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1208,12 +1208,70 @@ class GenericView {
   vector_size_t index_;
 };
 
+template <typename T>
+class CustomTypeWithCustomComparisonView {
+ public:
+  CustomTypeWithCustomComparisonView(
+      const T& value,
+      const std::shared_ptr<
+          const CanProvideCustomComparisonType<SimpleTypeTrait<T>::typeKind>>&
+          type)
+      : value_(value), type_(type) {}
+
+  bool operator!=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) != 0;
+  }
+
+  bool operator==(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) == 0;
+  }
+
+  bool operator<(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) < 0;
+  }
+
+  bool operator>(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) > 0;
+  }
+
+  bool operator<=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) <= 0;
+  }
+
+  bool operator>=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) >= 0;
+  }
+
+  uint64_t hash() const {
+    return type_->hash(value_);
+  }
+
+  T operator*() const {
+    return value_;
+  }
+
+ private:
+  const T value_;
+  const std::shared_ptr<
+      const CanProvideCustomComparisonType<SimpleTypeTrait<T>::typeKind>>
+      type_;
+};
+
 } // namespace facebook::velox::exec
 
 namespace std {
 template <>
 struct hash<facebook::velox::exec::GenericView> {
   size_t operator()(const facebook::velox::exec::GenericView& x) const {
+    return x.hash();
+  }
+};
+
+template <typename T>
+struct hash<facebook::velox::exec::CustomTypeWithCustomComparisonView<T>> {
+  size_t operator()(
+      const facebook::velox::exec::CustomTypeWithCustomComparisonView<T>& x)
+      const {
     return x.hash();
   }
 };

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -88,7 +88,8 @@ class SimpleFunctionAdapter : public VectorFunction {
   template <int32_t POSITION>
   static constexpr bool isArgFlatConstantFastPathEligible =
       SimpleTypeTrait<arg_at<POSITION>>::isPrimitiveType &&
-      SimpleTypeTrait<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN;
+      SimpleTypeTrait<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN &&
+      !providesCustomComparison<arg_at<POSITION>>::value;
 
   constexpr int32_t reuseStringsFromArgValue() const {
     return udf_reuse_strings_from_arg<typename FUNC::udf_struct_t>();
@@ -280,7 +281,8 @@ class SimpleFunctionAdapter : public VectorFunction {
       return nullptr;
     } else if constexpr (
         SimpleTypeTrait<arg_at<POSITION>>::typeKind ==
-        return_type_traits::typeKind) {
+            return_type_traits::typeKind &&
+        !providesCustomComparison<arg_at<POSITION>>::value) {
       using type =
           typename VectorExec::template resolver<arg_at<POSITION>>::in_type;
       if (args[POSITION]->isFlatEncoding() && args[POSITION].unique() &&

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -172,11 +172,18 @@ struct resolver<Generic<T, comparable, orderable>> {
   using out_type = GenericWriter;
 };
 
-template <typename T>
-struct resolver<CustomType<T>> {
-  using in_type = typename resolver<typename T::type>::in_type;
-  using null_free_in_type =
-      typename resolver<typename T::type>::null_free_in_type;
+template <typename T, bool providesCustomComparison>
+struct resolver<CustomType<T, providesCustomComparison>> {
+  using in_type = std::conditional_t<
+      providesCustomComparison,
+      CustomTypeWithCustomComparisonView<
+          typename resolver<typename T::type>::in_type>,
+      typename resolver<typename T::type>::in_type>;
+  using null_free_in_type = std::conditional_t<
+      providesCustomComparison,
+      CustomTypeWithCustomComparisonView<
+          typename resolver<typename T::type>::null_free_in_type>,
+      typename resolver<typename T::type>::null_free_in_type>;
   using out_type = typename resolver<typename T::type>::out_type;
 };
 } // namespace detail

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -765,7 +765,8 @@ struct VectorWriter<DynamicRow, void> : public VectorWriterBase {
   vector_t* rowVector_ = nullptr;
 };
 
-template <typename T>
-struct VectorWriter<CustomType<T>> : public VectorWriter<typename T::type> {};
+template <typename T, bool providesCustomComparison>
+struct VectorWriter<CustomType<T, providesCustomComparison>>
+    : public VectorWriter<typename T::type> {};
 
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -66,22 +66,10 @@ VELOX_GEN_BINARY_EXPR(
     lhs >= rhs,
     util::floating_point::NaNAwareGreaterThanEqual<TInput>{}(lhs, rhs));
 
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    LtFunction,
-    unpackMillisUtc(lhs) < unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    GtFunction,
-    unpackMillisUtc(lhs) > unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    LteFunction,
-    unpackMillisUtc(lhs) <= unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    GteFunction,
-    unpackMillisUtc(lhs) >= unpackMillisUtc(rhs),
-    bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LtFunction, lhs < rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GtFunction, lhs > rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LteFunction, lhs <= rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GteFunction, lhs >= rhs, bool);
 
 #undef VELOX_GEN_BINARY_EXPR
 #undef VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE
@@ -148,7 +136,7 @@ struct EqFunctionTimestampWithTimezone {
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) == unpackMillisUtc(rhs);
+    result = lhs == rhs;
   }
 };
 
@@ -188,7 +176,7 @@ struct NeqFunctionTimestampWithTimezone {
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) != unpackMillisUtc(rhs);
+    result = lhs != rhs;
   }
 };
 
@@ -216,9 +204,7 @@ struct BetweenFunctionTimestampWithTimezone {
       const arg_type<TimestampWithTimezone>& value,
       const arg_type<TimestampWithTimezone>& low,
       const arg_type<TimestampWithTimezone>& high) {
-    const auto millis = unpackMillisUtc(value);
-    result =
-        (millis >= unpackMillisUtc(low)) && (millis <= unpackMillisUtc(high));
+    result = value >= low && value <= high;
   }
 };
 

--- a/velox/functions/prestosql/GreatestLeast.h
+++ b/velox/functions/prestosql/GreatestLeast.h
@@ -100,10 +100,10 @@ struct ExtremeValueFunctionTimestampWithTimezone {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& firstElement,
       const arg_type<Variadic<TimestampWithTimezone>>& remainingElement) {
-    auto currentValue = firstElement;
+    auto currentValue = *firstElement;
 
     for (auto element : remainingElement) {
-      auto candidateValue = element.value();
+      auto candidateValue = *element.value();
 
       if constexpr (isLeast) {
         if (unpackMillisUtc(candidateValue) < unpackMillisUtc(currentValue)) {

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -22,12 +22,10 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-template <typename K>
+template <typename K, typename AccumulatorType>
 class MapAggregateBase : public exec::Aggregate {
  public:
   explicit MapAggregateBase(TypePtr resultType) : Aggregate(resultType) {}
-
-  using AccumulatorType = MapAccumulator<K>;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(AccumulatorType);
@@ -202,7 +200,8 @@ class MapAggregateBase : public exec::Aggregate {
   DecodedVector decodedMaps_;
 };
 
-template <template <typename K> class TAggregate>
+template <template <typename K, typename Accumulator = MapAccumulator<K>>
+          class TAggregate>
 std::unique_ptr<exec::Aggregate> createMapAggregate(const TypePtr& resultType) {
   auto typeKind = resultType->childAt(0)->kind();
   switch (typeKind) {

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -228,6 +228,97 @@ struct ComplexTypeMultiMapAccumulator {
   }
 };
 
+/// A wrapper around MultiMapAccumulator that overrides hash and equal_to
+/// functions to use the custom comparisons provided by a custom type.
+template <TypeKind Kind>
+struct CustomComparisonMultiMapAccumulator {
+  using NativeType = typename TypeTraits<Kind>::NativeType;
+
+  struct Hash {
+    const TypePtr& type;
+
+    size_t operator()(const NativeType& value) const {
+      return static_cast<const CanProvideCustomComparisonType<Kind>*>(
+                 type.get())
+          ->hash(value);
+    }
+  };
+
+  struct EqualTo {
+    const TypePtr& type;
+
+    bool operator()(const NativeType& left, const NativeType& right) const {
+      return static_cast<const CanProvideCustomComparisonType<Kind>*>(
+                 type.get())
+                 ->compare(left, right) == 0;
+    }
+  };
+
+  /// The underlying MultiMapAccumulator to which all operations are
+  /// delegated.
+  MultiMapAccumulator<
+      NativeType,
+      CustomComparisonMultiMapAccumulator::Hash,
+      CustomComparisonMultiMapAccumulator::EqualTo>
+      base;
+
+  CustomComparisonMultiMapAccumulator(
+      const TypePtr& type,
+      HashStringAllocator* allocator)
+      : base{
+            CustomComparisonMultiMapAccumulator::Hash{type},
+            CustomComparisonMultiMapAccumulator::EqualTo{type},
+            allocator} {}
+
+  size_t size() const {
+    return base.size();
+  }
+
+  size_t numValues() const {
+    return base.numValues();
+  }
+
+  /// Adds key-value pair.
+  void insert(
+      const DecodedVector& decodedKeys,
+      const DecodedVector& decodedValues,
+      vector_size_t index,
+      HashStringAllocator& allocator) {
+    base.insert(decodedKeys, decodedValues, index, allocator);
+  }
+
+  /// Adds a key with a list of values.
+  void insertMultiple(
+      const DecodedVector& decodedKeys,
+      vector_size_t keyIndex,
+      const DecodedVector& decodedValues,
+      vector_size_t valueIndex,
+      vector_size_t numValues,
+      HashStringAllocator& allocator) {
+    base.insertMultiple(
+        decodedKeys, keyIndex, decodedValues, valueIndex, numValues, allocator);
+  }
+
+  ValueList& insertKey(
+      const DecodedVector& decodedKeys,
+      vector_size_t index,
+      HashStringAllocator& allocator) {
+    return base.insertKey(decodedKeys, index, allocator);
+  }
+
+  void extract(
+      VectorPtr& mapKeys,
+      ArrayVector& mapValueArrays,
+      vector_size_t& keyOffset,
+      vector_size_t& valueOffset) {
+    base.extract(mapKeys, mapValueArrays, keyOffset, valueOffset);
+  }
+
+  void free(HashStringAllocator& allocator) {
+    base.free(allocator);
+  }
+};
+
 template <typename T>
 struct MultiMapAccumulatorTypeTraits {
   using AccumulatorType = MultiMapAccumulator<T>;
@@ -255,14 +346,14 @@ struct MultiMapAccumulatorTypeTraits<ComplexType> {
   using AccumulatorType = ComplexTypeMultiMapAccumulator;
 };
 
-template <typename K>
+template <
+    typename K,
+    typename AccumulatorType =
+        typename MultiMapAccumulatorTypeTraits<K>::AccumulatorType>
 class MultiMapAggAggregate : public exec::Aggregate {
  public:
   explicit MultiMapAggAggregate(TypePtr resultType)
       : exec::Aggregate(std::move(resultType)) {}
-
-  using AccumulatorType =
-      typename MultiMapAccumulatorTypeTraits<K>::AccumulatorType;
 
   bool isFixedSize() const override {
     return false;
@@ -496,6 +587,14 @@ class MultiMapAggAggregate : public exec::Aggregate {
   DecodedVector decodedValueArrays_;
 };
 
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> createMultiMapAggAggregateWithCustomCompare(
+    const TypePtr& resultType) {
+  return std::make_unique<MultiMapAggAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      CustomComparisonMultiMapAccumulator<Kind>>>(resultType);
+}
+
 } // namespace
 
 void registerMultiMapAggAggregate(
@@ -522,7 +621,16 @@ void registerMultiMapAggAggregate(
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        auto typeKind = resultType->childAt(0)->kind();
+        const auto keyType = resultType->childAt(0);
+        const auto typeKind = keyType->kind();
+
+        if (keyType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              createMultiMapAggAggregateWithCustomCompare,
+              typeKind,
+              resultType);
+        }
+
         switch (typeKind) {
           case TypeKind::BOOLEAN:
             return std::make_unique<MultiMapAggAggregate<bool>>(resultType);

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -545,6 +546,86 @@ TEST_F(MapAggTest, nans) {
                {makeFlatVector<double>({1, 2, kNaN, 3, kNaN}),
                 makeFlatVector<int32_t>({1, 4, 2, 5, 2})}),
            makeFlatVector<int32_t>({1, 4, 2, 5, 6})),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+}
+
+TEST_F(MapAggTest, timestampWithTimeZone) {
+  // Global Aggregation, Primitive type
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE()),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  auto expectedResult = makeRowVector({makeMapVector<int64_t, int32_t>(
+      {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}, {pack(3, 3), 8}}},
+      MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER()))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Primitive type
+  expectedResult = makeRowVector(
+      {makeMapVector<int64_t, int32_t>(
+           {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}},
+            {{pack(3, 3), 8}, {pack(1, 2), 6}, {pack(2, 2), 7}}},
+           MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER())),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+
+  // Global Aggregation, Complex type(Row)
+  data = makeRowVector(
+      {makeRowVector({makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE())}),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  expectedResult = makeRowVector({makeMapVector(
+      {0},
+      makeRowVector({makeFlatVector<int64_t>(
+          {pack(0, 0), pack(1, 0), pack(2, 0), pack(3, 3)},
+          TIMESTAMP_WITH_TIME_ZONE())}),
+      makeFlatVector<int32_t>({1, 2, 3, 8}))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Complex type(Row)
+  expectedResult = makeRowVector(
+      {makeMapVector(
+           {0, 3},
+           makeRowVector({makeFlatVector<int64_t>(
+               {pack(0, 0),
+                pack(1, 0),
+                pack(2, 0),
+                pack(3, 3),
+                pack(1, 2),
+                pack(2, 2)},
+               TIMESTAMP_WITH_TIME_ZONE())}),
+           makeFlatVector<int32_t>({1, 2, 3, 8, 6, 7})),
        makeFlatVector<int32_t>({1, 2})});
 
   testAggregations(

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -147,7 +147,7 @@ struct TimestampWithTimezoneT {
   static constexpr const char* typeName = "timestamp with time zone";
 };
 
-using TimestampWithTimezone = CustomType<TimestampWithTimezoneT>;
+using TimestampWithTimezone = CustomType<TimestampWithTimezoneT, true>;
 
 class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
  public:


### PR DESCRIPTION
Summary:
This change extends CustomType in the Simple Function API, templating it on
providesCustomComparison, with the idea that Custom Types that provide custom
comparison operators will set this value to true when they define their CustomType
template overrides.

In Simple Functions, this allows us to wrap the value in a view, called
CustomTypeWithCustomComparisonView, which overrides the standard comparison
operators and hash function to use the operators provided by the Type.  It also provides a
dereference operator to access the raw underlying value.

The only other piece to this diff is adding a VectorReader that constructs the
CustomTypeWithCustomComparisonView.

This should help address https://github.com/facebookincubator/velox/discussions/8713
so we don't have to create special flavors of UDF just for TimestampWithTimezone.

On a side note, if we extend this so that if a Custom Type does not provide custom
comparison operators we produce a similar view without the custom comparison operators,
that would likely solve the issue with custom types and the simple function interface
entirely.

In the follow up diff, I'll clean up the TimestampWithTimezone UDFs for comparisons and
greatest/least.

Differential Revision: D63670301
