### PR TITLE
Remove the use task_bucketed_writer_count config

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1853,7 +1853,6 @@ folly::dynamic TableWriteNode::serialize() const {
   obj["connectorInsertTableHandle"] =
       insertTableHandle_->connectorInsertTableHandle()->serialize();
   obj["hasPartitioningScheme"] = hasPartitioningScheme_;
-  obj["hasBucketProperty"] = hasBucketProperty_;
   obj["outputType"] = outputType_->serialize();
   obj["commitStrategy"] = connector::commitStrategyToString(commitStrategy_);
   return obj;
@@ -1876,7 +1875,6 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
           ISerializable::deserialize<connector::ConnectorInsertTableHandle>(
               obj["connectorInsertTableHandle"]));
   const bool hasPartitioningScheme = obj["hasPartitioningScheme"].asBool();
-  const bool hasBucketProperty = obj["hasBucketProperty"].asBool();
   auto outputType = deserializeRowType(obj["outputType"]);
   auto commitStrategy =
       connector::stringToCommitStrategy(obj["commitStrategy"].asString());
@@ -1889,7 +1887,6 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       std::make_shared<InsertTableHandle>(
           connectorId, connectorInsertTableHandle),
       hasPartitioningScheme,
-      hasBucketProperty,
       outputType,
       commitStrategy,
       source);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -300,11 +300,6 @@ class QueryConfig {
   static constexpr const char* kTaskPartitionedWriterCount =
       "task_partitioned_writer_count";
 
-  /// The number of local parallel table writer operators per task for
-  /// bucketed writes. If not set, use "task_writer_count".
-  static constexpr const char* kTaskBucketedWriterCount =
-      "task_bucketed_writer_count";
-
   /// If true, finish the hash probe on an empty build table for a specific set
   /// of hash joins.
   static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
@@ -770,10 +765,6 @@ class QueryConfig {
   uint32_t taskPartitionedWriterCount() const {
     return get<uint32_t>(kTaskPartitionedWriterCount)
         .value_or(taskWriterCount());
-  }
-
-  uint32_t taskBucketedWriterCount() const {
-    return get<uint32_t>(kTaskBucketedWriterCount).value_or(taskWriterCount());
   }
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -57,42 +57,27 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
   struct {
     std::optional<int> numWriterCounter;
     std::optional<int> numPartitionedWriterCounter;
-    std::optional<int> numBucketedWriterCounter;
     int expectedWriterCounter;
     int expectedPartitionedWriterCounter;
-    int expectedBucketedWriterCounter;
 
     std::string debugString() const {
       return fmt::format(
-          "numWriterCounter[{}] numPartitionedWriterCounter[{}] numBucketedWriterCounter[{}] expectedPartitionedWriterCounter[{}] expectedBucketedWriterCounter[{}]",
+          "numWriterCounter[{}] numPartitionedWriterCounter[{}] expectedWriterCounter[{}] expectedPartitionedWriterCounter[{}]",
           numWriterCounter.value_or(0),
           numPartitionedWriterCounter.value_or(0),
-          numBucketedWriterCounter.value_or(0),
           expectedWriterCounter,
-          expectedPartitionedWriterCounter,
-          expectedBucketedWriterCounter);
+          expectedPartitionedWriterCounter);
     }
   } testSettings[] = {
-      {std::nullopt, std::nullopt, std::nullopt, 4, 4, 4},
-      {std::nullopt, 1, std::nullopt, 4, 1, 4},
-      {std::nullopt, 6, std::nullopt, 4, 6, 4},
-      {2, 4, std::nullopt, 2, 4, 2},
-      {4, 2, std::nullopt, 4, 2, 4},
-      {4, 6, std::nullopt, 4, 6, 4},
-      {6, 5, std::nullopt, 6, 5, 6},
-      {6, 4, std::nullopt, 6, 4, 6},
-      {6, std::nullopt, 6, 6, 6, 6},
-      {6, std::nullopt, 1, 6, 6, 1},
-      {std::nullopt, std::nullopt, 4, 4, 4, 4},
-      {std::nullopt, std::nullopt, 1, 4, 4, 1},
-      {std::nullopt, 1, 1, 4, 1, 1},
-      {std::nullopt, 1, 2, 4, 1, 2},
-      {std::nullopt, 6, 6, 4, 6, 6},
-      {std::nullopt, 6, 3, 4, 6, 3},
-      {2, 4, 3, 2, 4, 3},
-      {4, 2, 1, 4, 2, 1},
-      {4, 6, 7, 4, 6, 7},
-      {6, std::nullopt, 4, 6, 6, 4}};
+      {std::nullopt, std::nullopt, 4, 4},
+      {std::nullopt, 1, 4, 1},
+      {std::nullopt, 6, 4, 6},
+      {2, 4, 2, 4},
+      {4, 2, 4, 2},
+      {4, 6, 4, 6},
+      {6, 5, 6, 5},
+      {6, 4, 6, 4},
+      {6, std::nullopt, 6, 6}};
   for (const auto& testConfig : testSettings) {
     SCOPED_TRACE(testConfig.debugString());
     std::unordered_map<std::string, std::string> configData;
@@ -106,11 +91,6 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
           QueryConfig::kTaskPartitionedWriterCount,
           std::to_string(testConfig.numPartitionedWriterCounter.value()));
     }
-    if (testConfig.numBucketedWriterCounter.has_value()) {
-      configData.emplace(
-          QueryConfig::kTaskBucketedWriterCount,
-          std::to_string(testConfig.numBucketedWriterCounter.value()));
-    }
     auto queryCtx =
         QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
     const QueryConfig& config = queryCtx->queryConfig();
@@ -118,9 +98,6 @@ TEST_F(QueryConfigTest, taskWriterCountConfig) {
     ASSERT_EQ(
         config.taskPartitionedWriterCount(),
         testConfig.expectedPartitionedWriterCounter);
-    ASSERT_EQ(
-        config.taskBucketedWriterCount(),
-        testConfig.expectedBucketedWriterCounter);
   }
 }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -385,10 +385,6 @@ Table Writer
      - integer
      - task_writer_count
      - The number of parallel table writer threads per task for partitioned table writes. If not set, use 'task_writer_count' as default.
-   * - task_bucketed_writer_count
-     - integer
-     - task_writer_count
-     - The number of parallel table writer threads per task for bucketed table writes. If not set, use 'task_writer_count' as default.
 
 Hive Connector
 --------------

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -238,9 +238,7 @@ uint32_t maxDrivers(
       if (!connectorInsertHandle->supportsMultiThreading()) {
         return 1;
       } else {
-        if (tableWrite->hasBucketProperty()) {
-          return queryConfig.taskBucketedWriterCount();
-        } else if (tableWrite->hasPartitioningScheme()) {
+        if (tableWrite->hasPartitioningScheme()) {
           return queryConfig.taskPartitionedWriterCount();
         } else {
           return queryConfig.taskWriterCount();

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -471,8 +471,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       rowType->names(),
       aggregationNode,
       insertHandle,
-      !partitionBy.empty(),
-      bucketProperty != nullptr,
+      false,
       TableWriteTraits::outputType(aggregationNode),
       connector::CommitStrategy::kNoCommit,
       planNode_);


### PR DESCRIPTION
Summary:
We shall just use task_partitioned_writer_count which corresponds to the shuffle
partitioning scheme used by table write node instead of physical table layout.
We can bump up the number of table writer driver threads even for non-bucketed
partition table which won't cause small files as the partitioning scheme is based
on the table partition columns

Differential Revision: D63578063
