### PR TITLE
Remove special casing for TimestampWithTimezone in certain Presto UDFs

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -365,8 +365,8 @@ struct TypeAnalysis<Row<T...>> {
   }
 };
 
-template <typename T>
-struct TypeAnalysis<CustomType<T>> {
+template <typename T, bool providesCustomComparison>
+struct TypeAnalysis<CustomType<T, providesCustomComparison>> {
   void run(TypeAnalysisResults& results) {
     results.stats.concreteCount++;
     results.out << T::typeName;

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1208,12 +1208,70 @@ class GenericView {
   vector_size_t index_;
 };
 
+template <typename T>
+class CustomTypeWithCustomComparisonView {
+ public:
+  CustomTypeWithCustomComparisonView(
+      const T& value,
+      const std::shared_ptr<
+          const CanProvideCustomComparisonType<SimpleTypeTrait<T>::typeKind>>&
+          type)
+      : value_(value), type_(type) {}
+
+  bool operator!=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) != 0;
+  }
+
+  bool operator==(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) == 0;
+  }
+
+  bool operator<(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) < 0;
+  }
+
+  bool operator>(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) > 0;
+  }
+
+  bool operator<=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) <= 0;
+  }
+
+  bool operator>=(const CustomTypeWithCustomComparisonView<T>& other) const {
+    return type_->compare(value_, other.value_) >= 0;
+  }
+
+  uint64_t hash() const {
+    return type_->hash(value_);
+  }
+
+  T operator*() const {
+    return value_;
+  }
+
+ private:
+  const T value_;
+  const std::shared_ptr<
+      const CanProvideCustomComparisonType<SimpleTypeTrait<T>::typeKind>>
+      type_;
+};
+
 } // namespace facebook::velox::exec
 
 namespace std {
 template <>
 struct hash<facebook::velox::exec::GenericView> {
   size_t operator()(const facebook::velox::exec::GenericView& x) const {
+    return x.hash();
+  }
+};
+
+template <typename T>
+struct hash<facebook::velox::exec::CustomTypeWithCustomComparisonView<T>> {
+  size_t operator()(
+      const facebook::velox::exec::CustomTypeWithCustomComparisonView<T>& x)
+      const {
     return x.hash();
   }
 };

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -88,7 +88,8 @@ class SimpleFunctionAdapter : public VectorFunction {
   template <int32_t POSITION>
   static constexpr bool isArgFlatConstantFastPathEligible =
       SimpleTypeTrait<arg_at<POSITION>>::isPrimitiveType &&
-      SimpleTypeTrait<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN;
+      SimpleTypeTrait<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN &&
+      !providesCustomComparison<arg_at<POSITION>>::value;
 
   constexpr int32_t reuseStringsFromArgValue() const {
     return udf_reuse_strings_from_arg<typename FUNC::udf_struct_t>();
@@ -280,7 +281,8 @@ class SimpleFunctionAdapter : public VectorFunction {
       return nullptr;
     } else if constexpr (
         SimpleTypeTrait<arg_at<POSITION>>::typeKind ==
-        return_type_traits::typeKind) {
+            return_type_traits::typeKind &&
+        !providesCustomComparison<arg_at<POSITION>>::value) {
       using type =
           typename VectorExec::template resolver<arg_at<POSITION>>::in_type;
       if (args[POSITION]->isFlatEncoding() && args[POSITION].unique() &&

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -172,11 +172,18 @@ struct resolver<Generic<T, comparable, orderable>> {
   using out_type = GenericWriter;
 };
 
-template <typename T>
-struct resolver<CustomType<T>> {
-  using in_type = typename resolver<typename T::type>::in_type;
-  using null_free_in_type =
-      typename resolver<typename T::type>::null_free_in_type;
+template <typename T, bool providesCustomComparison>
+struct resolver<CustomType<T, providesCustomComparison>> {
+  using in_type = std::conditional_t<
+      providesCustomComparison,
+      CustomTypeWithCustomComparisonView<
+          typename resolver<typename T::type>::in_type>,
+      typename resolver<typename T::type>::in_type>;
+  using null_free_in_type = std::conditional_t<
+      providesCustomComparison,
+      CustomTypeWithCustomComparisonView<
+          typename resolver<typename T::type>::null_free_in_type>,
+      typename resolver<typename T::type>::null_free_in_type>;
   using out_type = typename resolver<typename T::type>::out_type;
 };
 } // namespace detail

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -765,7 +765,8 @@ struct VectorWriter<DynamicRow, void> : public VectorWriterBase {
   vector_t* rowVector_ = nullptr;
 };
 
-template <typename T>
-struct VectorWriter<CustomType<T>> : public VectorWriter<typename T::type> {};
+template <typename T, bool providesCustomComparison>
+struct VectorWriter<CustomType<T, providesCustomComparison>>
+    : public VectorWriter<typename T::type> {};
 
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -17,7 +17,6 @@
 
 #include "velox/common/base/CompareFlags.h"
 #include "velox/functions/Macros.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::functions {
@@ -37,18 +36,6 @@ namespace facebook::velox::functions {
     }                                                          \
   };
 
-#define VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(Name, tsExpr, TResult) \
-  template <typename T>                                                       \
-  struct Name##TimestampWithTimezone {                                        \
-    VELOX_DEFINE_FUNCTION_TYPES(T);                                           \
-    FOLLY_ALWAYS_INLINE void call(                                            \
-        bool& result,                                                         \
-        const arg_type<TimestampWithTimezone>& lhs,                           \
-        const arg_type<TimestampWithTimezone>& rhs) {                         \
-      result = (tsExpr);                                                      \
-    }                                                                         \
-  };
-
 VELOX_GEN_BINARY_EXPR(
     LtFunction,
     lhs < rhs,
@@ -65,11 +52,6 @@ VELOX_GEN_BINARY_EXPR(
     GteFunction,
     lhs >= rhs,
     util::floating_point::NaNAwareGreaterThanEqual<TInput>{}(lhs, rhs));
-
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LtFunction, lhs < rhs, bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GtFunction, lhs > rhs, bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LteFunction, lhs <= rhs, bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GteFunction, lhs >= rhs, bool);
 
 #undef VELOX_GEN_BINARY_EXPR
 #undef VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE
@@ -129,18 +111,6 @@ struct EqFunction {
 };
 
 template <typename T>
-struct EqFunctionTimestampWithTimezone {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  void call(
-      bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = lhs == rhs;
-  }
-};
-
-template <typename T>
 struct NeqFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
@@ -168,18 +138,6 @@ struct NeqFunction {
   }
 };
 
-template <typename T>
-struct NeqFunctionTimestampWithTimezone {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  void call(
-      bool& result,
-      const arg_type<TimestampWithTimezone>& lhs,
-      const arg_type<TimestampWithTimezone>& rhs) {
-    result = lhs != rhs;
-  }
-};
-
 template <typename TExec>
 struct BetweenFunction {
   template <typename T>
@@ -191,19 +149,6 @@ struct BetweenFunction {
           util::floating_point::NaNAwareLessThanEqual<T>{}(value, high);
       return;
     }
-    result = value >= low && value <= high;
-  }
-};
-
-template <typename TExec>
-struct BetweenFunctionTimestampWithTimezone {
-  VELOX_DEFINE_FUNCTION_TYPES(TExec);
-
-  void call(
-      bool& result,
-      const arg_type<TimestampWithTimezone>& value,
-      const arg_type<TimestampWithTimezone>& low,
-      const arg_type<TimestampWithTimezone>& high) {
     result = value >= low && value <= high;
   }
 };

--- a/velox/functions/prestosql/Comparisons.h
+++ b/velox/functions/prestosql/Comparisons.h
@@ -66,22 +66,10 @@ VELOX_GEN_BINARY_EXPR(
     lhs >= rhs,
     util::floating_point::NaNAwareGreaterThanEqual<TInput>{}(lhs, rhs));
 
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    LtFunction,
-    unpackMillisUtc(lhs) < unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    GtFunction,
-    unpackMillisUtc(lhs) > unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    LteFunction,
-    unpackMillisUtc(lhs) <= unpackMillisUtc(rhs),
-    bool);
-VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(
-    GteFunction,
-    unpackMillisUtc(lhs) >= unpackMillisUtc(rhs),
-    bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LtFunction, lhs < rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GtFunction, lhs > rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(LteFunction, lhs <= rhs, bool);
+VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE(GteFunction, lhs >= rhs, bool);
 
 #undef VELOX_GEN_BINARY_EXPR
 #undef VELOX_GEN_BINARY_EXPR_TIMESTAMP_WITH_TIME_ZONE
@@ -148,7 +136,7 @@ struct EqFunctionTimestampWithTimezone {
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) == unpackMillisUtc(rhs);
+    result = lhs == rhs;
   }
 };
 
@@ -188,7 +176,7 @@ struct NeqFunctionTimestampWithTimezone {
       bool& result,
       const arg_type<TimestampWithTimezone>& lhs,
       const arg_type<TimestampWithTimezone>& rhs) {
-    result = unpackMillisUtc(lhs) != unpackMillisUtc(rhs);
+    result = lhs != rhs;
   }
 };
 
@@ -216,9 +204,7 @@ struct BetweenFunctionTimestampWithTimezone {
       const arg_type<TimestampWithTimezone>& value,
       const arg_type<TimestampWithTimezone>& low,
       const arg_type<TimestampWithTimezone>& high) {
-    const auto millis = unpackMillisUtc(value);
-    result =
-        (millis >= unpackMillisUtc(low)) && (millis <= unpackMillisUtc(high));
+    result = value >= low && value <= high;
   }
 };
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <string_view>
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
@@ -39,7 +40,7 @@ struct ToUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void call(
       double& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    const auto milliseconds = unpackMillisUtc(timestampWithTimezone);
+    const auto milliseconds = unpackMillisUtc(*timestampWithTimezone);
     result = (double)milliseconds / kMillisecondsInSecond;
   }
 };
@@ -114,10 +115,10 @@ struct TimestampWithTimezoneSupport {
   Timestamp toTimestamp(
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       bool asGMT = false) {
-    auto timestamp = unpackTimestampUtc(timestampWithTimezone);
+    auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
     if (!asGMT) {
       timestamp.toTimezone(
-          *tz::locateZone(unpackZoneKeyId(timestampWithTimezone)));
+          *tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
     }
 
     return timestamp;
@@ -130,7 +131,8 @@ struct TimestampWithTimezoneSupport {
     Timestamp inputTimeStamp = this->toTimestamp(timestampWithTimezone);
     // Create a copy of inputTimeStamp and convert it to GMT
     auto gmtTimeStamp = inputTimeStamp;
-    gmtTimeStamp.toGMT(*tz::locateZone(unpackZoneKeyId(timestampWithTimezone)));
+    gmtTimeStamp.toGMT(
+        *tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
 
     // Get offset in seconds with GMT and convert to hour
     return (inputTimeStamp.getSeconds() - gmtTimeStamp.getSeconds());
@@ -468,7 +470,7 @@ struct TimestampMinusFunction {
       out_type<IntervalDayTime>& result,
       const arg_type<TimestampWithTimezone>& a,
       const arg_type<TimestampWithTimezone>& b) {
-    result = unpackMillisUtc(a) - unpackMillisUtc(b);
+    result = unpackMillisUtc(*a) - unpackMillisUtc(*b);
   }
 };
 
@@ -512,7 +514,7 @@ struct TimestampPlusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -520,7 +522,7 @@ struct TimestampPlusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMonth, interval);
+        *timestampWithTimezone, DateTimeUnit::kMonth, interval);
   }
 
  private:
@@ -568,7 +570,7 @@ struct IntervalPlusTimestamp {
       const arg_type<IntervalDayTime>& interval,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
+        *timestampWithTimezone, DateTimeUnit::kMillisecond, interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -576,7 +578,7 @@ struct IntervalPlusTimestamp {
       const arg_type<IntervalYearMonth>& interval,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMonth, interval);
+        *timestampWithTimezone, DateTimeUnit::kMonth, interval);
   }
 
  private:
@@ -624,7 +626,7 @@ struct TimestampMinusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalDayTime>& interval) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMillisecond, -interval);
+        *timestampWithTimezone, DateTimeUnit::kMillisecond, -interval);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -632,7 +634,7 @@ struct TimestampMinusInterval {
       const arg_type<TimestampWithTimezone>& timestampWithTimezone,
       const arg_type<IntervalYearMonth>& interval) {
     result = addToTimestampWithTimezone(
-        timestampWithTimezone, DateTimeUnit::kMonth, -interval);
+        *timestampWithTimezone, DateTimeUnit::kMonth, -interval);
   }
 
  private:
@@ -1156,10 +1158,10 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     }
 
     if (unit == DateTimeUnit::kSecond) {
-      auto utcTimestamp = unpackTimestampUtc(timestampWithTimezone);
+      auto utcTimestamp = unpackTimestampUtc(*timestampWithTimezone);
       result = pack(
           utcTimestamp.getSeconds() * 1000,
-          unpackZoneKeyId(timestampWithTimezone));
+          unpackZoneKeyId(*timestampWithTimezone));
       return;
     }
 
@@ -1168,9 +1170,9 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     adjustDateTime(dateTime, unit);
     timestamp =
         Timestamp::fromMillis(Timestamp::calendarUtcToEpoch(dateTime) * 1000);
-    timestamp.toGMT(*tz::locateZone(unpackZoneKeyId(timestampWithTimezone)));
+    timestamp.toGMT(*tz::locateZone(unpackZoneKeyId(*timestampWithTimezone)));
 
-    result = pack(timestamp, unpackZoneKeyId(timestampWithTimezone));
+    result = pack(timestamp, unpackZoneKeyId(*timestampWithTimezone));
   }
 
  private:
@@ -1266,8 +1268,8 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       VELOX_UNSUPPORTED("integer overflow");
     }
 
-    result =
-        addToTimestampWithTimezone(timestampWithTimezone, unit, (int32_t)value);
+    result = addToTimestampWithTimezone(
+        *timestampWithTimezone, unit, (int32_t)value);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -1384,7 +1386,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
     // correct as calculations may cross daylight savings boundaries.
     auto timestamp1 = this->toTimestamp(timestampWithTz1, false);
     auto timestamp2 = this->toTimestamp(timestampWithTz2, true);
-    timestamp2.toTimezone(*tz::locateZone(unpackZoneKeyId(timestampWithTz1)));
+    timestamp2.toTimezone(*tz::locateZone(unpackZoneKeyId(*timestampWithTz1)));
 
     result = diffTimestamp(unit, timestamp1, timestamp2);
   }
@@ -1585,8 +1587,8 @@ struct FormatDateTimeFunction {
       const arg_type<Varchar>& formatString) {
     ensureFormatter(formatString);
 
-    const auto timestamp = unpackTimestampUtc(timestampWithTimezone);
-    const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
+    const auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
+    const auto timeZoneId = unpackZoneKeyId(*timestampWithTimezone);
     auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
 
     const auto maxResultSize = jodaDateTime_->maxResultSize(timezonePtr);
@@ -1753,8 +1755,8 @@ struct ToISO8601Function {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    const auto timestamp = unpackTimestampUtc(timestampWithTimezone);
-    const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
+    const auto timestamp = unpackTimestampUtc(*timestampWithTimezone);
+    const auto timeZoneId = unpackZoneKeyId(*timestampWithTimezone);
     const auto* timeZone = tz::locateZone(tz::getTimeZoneName(timeZoneId));
 
     toIso8601(timestamp, timeZone, result);
@@ -1798,7 +1800,7 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& tsWithTz,
       const arg_type<Varchar>& timezone) {
-    const auto inputMs = unpackMillisUtc(tsWithTz);
+    const auto inputMs = unpackMillisUtc(*tsWithTz);
     const auto targetTimezoneID = targetTimezoneID_.has_value()
         ? targetTimezoneID_.value()
         : tz::getTimeZoneID(std::string_view(timezone.data(), timezone.size()));

--- a/velox/functions/prestosql/GreatestLeast.h
+++ b/velox/functions/prestosql/GreatestLeast.h
@@ -100,10 +100,10 @@ struct ExtremeValueFunctionTimestampWithTimezone {
       out_type<TimestampWithTimezone>& result,
       const arg_type<TimestampWithTimezone>& firstElement,
       const arg_type<Variadic<TimestampWithTimezone>>& remainingElement) {
-    auto currentValue = firstElement;
+    auto currentValue = *firstElement;
 
     for (auto element : remainingElement) {
-      auto candidateValue = element.value();
+      auto candidateValue = *element.value();
 
       if constexpr (isLeast) {
         if (unpackMillisUtc(candidateValue) < unpackMillisUtc(currentValue)) {

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -22,12 +22,10 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-template <typename K>
+template <typename K, typename AccumulatorType>
 class MapAggregateBase : public exec::Aggregate {
  public:
   explicit MapAggregateBase(TypePtr resultType) : Aggregate(resultType) {}
-
-  using AccumulatorType = MapAccumulator<K>;
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(AccumulatorType);
@@ -202,7 +200,8 @@ class MapAggregateBase : public exec::Aggregate {
   DecodedVector decodedMaps_;
 };
 
-template <template <typename K> class TAggregate>
+template <template <typename K, typename Accumulator = MapAccumulator<K>>
+          class TAggregate>
 std::unique_ptr<exec::Aggregate> createMapAggregate(const TypePtr& resultType) {
   auto typeKind = resultType->childAt(0)->kind();
   switch (typeKind) {

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -228,6 +228,97 @@ struct ComplexTypeMultiMapAccumulator {
   }
 };
 
+/// A wrapper around MultiMapAccumulator that overrides hash and equal_to
+/// functions to use the custom comparisons provided by a custom type.
+template <TypeKind Kind>
+struct CustomComparisonMultiMapAccumulator {
+  using NativeType = typename TypeTraits<Kind>::NativeType;
+
+  struct Hash {
+    const TypePtr& type;
+
+    size_t operator()(const NativeType& value) const {
+      return static_cast<const CanProvideCustomComparisonType<Kind>*>(
+                 type.get())
+          ->hash(value);
+    }
+  };
+
+  struct EqualTo {
+    const TypePtr& type;
+
+    bool operator()(const NativeType& left, const NativeType& right) const {
+      return static_cast<const CanProvideCustomComparisonType<Kind>*>(
+                 type.get())
+                 ->compare(left, right) == 0;
+    }
+  };
+
+  /// The underlying MultiMapAccumulator to which all operations are
+  /// delegated.
+  MultiMapAccumulator<
+      NativeType,
+      CustomComparisonMultiMapAccumulator::Hash,
+      CustomComparisonMultiMapAccumulator::EqualTo>
+      base;
+
+  CustomComparisonMultiMapAccumulator(
+      const TypePtr& type,
+      HashStringAllocator* allocator)
+      : base{
+            CustomComparisonMultiMapAccumulator::Hash{type},
+            CustomComparisonMultiMapAccumulator::EqualTo{type},
+            allocator} {}
+
+  size_t size() const {
+    return base.size();
+  }
+
+  size_t numValues() const {
+    return base.numValues();
+  }
+
+  /// Adds key-value pair.
+  void insert(
+      const DecodedVector& decodedKeys,
+      const DecodedVector& decodedValues,
+      vector_size_t index,
+      HashStringAllocator& allocator) {
+    base.insert(decodedKeys, decodedValues, index, allocator);
+  }
+
+  /// Adds a key with a list of values.
+  void insertMultiple(
+      const DecodedVector& decodedKeys,
+      vector_size_t keyIndex,
+      const DecodedVector& decodedValues,
+      vector_size_t valueIndex,
+      vector_size_t numValues,
+      HashStringAllocator& allocator) {
+    base.insertMultiple(
+        decodedKeys, keyIndex, decodedValues, valueIndex, numValues, allocator);
+  }
+
+  ValueList& insertKey(
+      const DecodedVector& decodedKeys,
+      vector_size_t index,
+      HashStringAllocator& allocator) {
+    return base.insertKey(decodedKeys, index, allocator);
+  }
+
+  void extract(
+      VectorPtr& mapKeys,
+      ArrayVector& mapValueArrays,
+      vector_size_t& keyOffset,
+      vector_size_t& valueOffset) {
+    base.extract(mapKeys, mapValueArrays, keyOffset, valueOffset);
+  }
+
+  void free(HashStringAllocator& allocator) {
+    base.free(allocator);
+  }
+};
+
 template <typename T>
 struct MultiMapAccumulatorTypeTraits {
   using AccumulatorType = MultiMapAccumulator<T>;
@@ -255,14 +346,14 @@ struct MultiMapAccumulatorTypeTraits<ComplexType> {
   using AccumulatorType = ComplexTypeMultiMapAccumulator;
 };
 
-template <typename K>
+template <
+    typename K,
+    typename AccumulatorType =
+        typename MultiMapAccumulatorTypeTraits<K>::AccumulatorType>
 class MultiMapAggAggregate : public exec::Aggregate {
  public:
   explicit MultiMapAggAggregate(TypePtr resultType)
       : exec::Aggregate(std::move(resultType)) {}
-
-  using AccumulatorType =
-      typename MultiMapAccumulatorTypeTraits<K>::AccumulatorType;
 
   bool isFixedSize() const override {
     return false;
@@ -496,6 +587,14 @@ class MultiMapAggAggregate : public exec::Aggregate {
   DecodedVector decodedValueArrays_;
 };
 
+template <TypeKind Kind>
+std::unique_ptr<exec::Aggregate> createMultiMapAggAggregateWithCustomCompare(
+    const TypePtr& resultType) {
+  return std::make_unique<MultiMapAggAggregate<
+      typename TypeTraits<Kind>::NativeType,
+      CustomComparisonMultiMapAccumulator<Kind>>>(resultType);
+}
+
 } // namespace
 
 void registerMultiMapAggAggregate(
@@ -522,7 +621,16 @@ void registerMultiMapAggAggregate(
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        auto typeKind = resultType->childAt(0)->kind();
+        const auto keyType = resultType->childAt(0);
+        const auto typeKind = keyType->kind();
+
+        if (keyType->providesCustomComparison()) {
+          return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+              createMultiMapAggAggregateWithCustomCompare,
+              typeKind,
+              resultType);
+        }
+
         switch (typeKind) {
           case TypeKind::BOOLEAN:
             return std::make_unique<MultiMapAggAggregate<bool>>(resultType);

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -545,6 +546,86 @@ TEST_F(MapAggTest, nans) {
                {makeFlatVector<double>({1, 2, kNaN, 3, kNaN}),
                 makeFlatVector<int32_t>({1, 4, 2, 5, 2})}),
            makeFlatVector<int32_t>({1, 4, 2, 5, 6})),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+}
+
+TEST_F(MapAggTest, timestampWithTimeZone) {
+  // Global Aggregation, Primitive type
+  auto data = makeRowVector(
+      {makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE()),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  auto expectedResult = makeRowVector({makeMapVector<int64_t, int32_t>(
+      {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}, {pack(3, 3), 8}}},
+      MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER()))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Primitive type
+  expectedResult = makeRowVector(
+      {makeMapVector<int64_t, int32_t>(
+           {{{pack(0, 0), 1}, {pack(1, 0), 2}, {pack(2, 0), 3}},
+            {{pack(3, 3), 8}, {pack(1, 2), 6}, {pack(2, 2), 7}}},
+           MAP(TIMESTAMP_WITH_TIME_ZONE(), INTEGER())),
+       makeFlatVector<int32_t>({1, 2})});
+
+  testAggregations(
+      {data}, {"c2"}, {"map_agg(c0, c1)"}, {"a0", "c2"}, {expectedResult});
+
+  // Global Aggregation, Complex type(Row)
+  data = makeRowVector(
+      {makeRowVector({makeFlatVector<int64_t>(
+           {pack(0, 0),
+            pack(1, 0),
+            pack(2, 0),
+            pack(0, 1),
+            pack(1, 1),
+            pack(1, 2),
+            pack(2, 2),
+            pack(3, 3),
+            pack(1, 1),
+            pack(3, 0)},
+           TIMESTAMP_WITH_TIME_ZONE())}),
+       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2})});
+
+  expectedResult = makeRowVector({makeMapVector(
+      {0},
+      makeRowVector({makeFlatVector<int64_t>(
+          {pack(0, 0), pack(1, 0), pack(2, 0), pack(3, 3)},
+          TIMESTAMP_WITH_TIME_ZONE())}),
+      makeFlatVector<int32_t>({1, 2, 3, 8}))});
+
+  testAggregations({data}, {}, {"map_agg(c0, c1)"}, {expectedResult});
+
+  // Group by Aggregation, Complex type(Row)
+  expectedResult = makeRowVector(
+      {makeMapVector(
+           {0, 3},
+           makeRowVector({makeFlatVector<int64_t>(
+               {pack(0, 0),
+                pack(1, 0),
+                pack(2, 0),
+                pack(3, 3),
+                pack(1, 2),
+                pack(2, 2)},
+               TIMESTAMP_WITH_TIME_ZONE())}),
+           makeFlatVector<int32_t>({1, 2, 3, 8, 6, 7})),
        makeFlatVector<int32_t>({1, 2})});
 
   testAggregations(

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Comparisons.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions {
@@ -27,6 +28,8 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Varbinary, Varbinary>(aliases);
   registerFunction<T, TReturn, bool, bool>(aliases);
   registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
+  registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
+      aliases);
 }
 } // namespace
 
@@ -38,52 +41,22 @@ void registerComparisonFunctions(const std::string& prefix) {
   registerNonSimdizableScalar<EqFunction, bool>({prefix + "eq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, prefix + "eq");
   registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({prefix + "eq"});
-  registerFunction<
-      EqFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "eq"});
 
   registerNonSimdizableScalar<NeqFunction, bool>({prefix + "neq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_neq, prefix + "neq");
   registerFunction<NeqFunction, bool, Generic<T1>, Generic<T1>>(
       {prefix + "neq"});
-  registerFunction<
-      NeqFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "neq"});
 
   registerNonSimdizableScalar<LtFunction, bool>({prefix + "lt"});
-  registerFunction<
-      LtFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "lt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, prefix + "lt");
 
   registerNonSimdizableScalar<GtFunction, bool>({prefix + "gt"});
-  registerFunction<
-      GtFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "gt"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, prefix + "gt");
 
   registerNonSimdizableScalar<LteFunction, bool>({prefix + "lte"});
-  registerFunction<
-      LteFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "lte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, prefix + "lte");
 
   registerNonSimdizableScalar<GteFunction, bool>({prefix + "gte"});
-  registerFunction<
-      GteFunctionTimestampWithTimezone,
-      bool,
-      TimestampWithTimezone,
-      TimestampWithTimezone>({prefix + "gte"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, prefix + "gte");
 
   registerFunction<DistinctFromFunction, bool, Generic<T1>, Generic<T1>>(
@@ -132,7 +105,7 @@ void registerComparisonFunctions(const std::string& prefix) {
       IntervalYearMonth,
       IntervalYearMonth>({prefix + "between"});
   registerFunction<
-      BetweenFunctionTimestampWithTimezone,
+      BetweenFunction,
       bool,
       TimestampWithTimezone,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
 #include "velox/functions/prestosql/Reduce.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::functions {
 
@@ -55,18 +56,7 @@ void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<ShortDecimal<P1, S1>>(prefix);
   registerGreatestLeastFunction<Date>(prefix);
   registerGreatestLeastFunction<Timestamp>(prefix);
-
-  registerFunction<
-      GreatestFunctionTimestampWithTimezone,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
-      Variadic<TimestampWithTimezone>>({prefix + "greatest"});
-
-  registerFunction<
-      LeastFunctionTimestampWithTimezone,
-      TimestampWithTimezone,
-      TimestampWithTimezone,
-      Variadic<TimestampWithTimezone>>({prefix + "least"});
+  registerGreatestLeastFunction<TimestampWithTimezone>(prefix);
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 #include "velox/type/tz/TimeZoneMap.h"
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -147,7 +147,7 @@ struct TimestampWithTimezoneT {
   static constexpr const char* typeName = "timestamp with time zone";
 };
 
-using TimestampWithTimezone = CustomType<TimestampWithTimezoneT>;
+using TimestampWithTimezone = CustomType<TimestampWithTimezoneT, true>;
 
 class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
  public:


### PR DESCRIPTION
Summary:
With the changes to the Simple Function API introduced in
https://github.com/facebookincubator/velox/pull/11136 we no longer need to register
separate UDFs for TimestampWithTimezone to avoid collisions with int64_t at
function resolution time.  We also don't need to specialize the comparison logic.

Cleaning up the existing special cases in the comparison and greatest/least UDFs.

Differential Revision: D63704263
