### PR TITLE
Make sure inputFlatNoNulls_ is initialized in ctor

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -46,6 +46,7 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row)
 EvalCtx::EvalCtx(core::ExecCtx* execCtx)
     : execCtx_(execCtx), exprSet_(nullptr), row_(nullptr) {
   VELOX_CHECK_NOT_NULL(execCtx);
+  inputFlatNoNulls_ = false;
 }
 
 void EvalCtx::saveAndReset(ContextSaver& saver, const SelectivityVector& rows) {

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -228,3 +228,8 @@ TEST_F(EvalCtxTest, localSingleRow) {
     }
   }
 }
+
+TEST_F(EvalCtxTest, inputFlatNoNulls) {
+  EvalCtx context(&execCtx_);
+  ASSERT_FALSE(context.inputFlatNoNulls());
+}


### PR DESCRIPTION
Summary:
when `inputFlatNoNulls_` is not initialized, it could result in undefined behavior like one described in https://www.internalfb.com/diff/D63556283?dst_version_fbid=804905691596581&transaction_fbid=550949777494622

This diff initializes inputFlatNoNulls_ as false.

Differential Revision: D63673714
