### PR TITLE
Make PlanNode enum to string conversions code consistent

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1974,17 +1974,6 @@ PlanNodePtr LocalPartitionNode::create(
       deserializeSources(obj, context));
 }
 
-// static
-const char* LocalPartitionNode::typeName(Type type) {
-  switch (type) {
-    case Type::kGather:
-      return "GATHER";
-    case Type::kRepartition:
-      return "REPARTITION";
-  }
-  VELOX_UNREACHABLE();
-}
-
 namespace {
 std::unordered_map<LocalPartitionNode::Type, std::string>
 localPartitionTypeNames() {
@@ -1994,6 +1983,12 @@ localPartitionTypeNames() {
   };
 }
 } // namespace
+
+// static
+const char* LocalPartitionNode::typeName(Type type) {
+  static const auto kLocalPartitionTypeNames = localPartitionTypeNames();
+  return kLocalPartitionTypeNames.at(type).c_str();
+}
 
 // static
 LocalPartitionNode::Type LocalPartitionNode::typeFromName(
@@ -2019,32 +2014,29 @@ PlanNodePtr EnforceSingleRowNode::create(
       deserializePlanNodeId(obj), deserializeSingleSource(obj, context));
 }
 
+namespace {
+std::unordered_map<PartitionedOutputNode::Kind, std::string>
+partitionKindNames() {
+  return {
+      {PartitionedOutputNode::Kind::kPartitioned, "PARTITIONED"},
+      {PartitionedOutputNode::Kind::kBroadcast, "BROADCAST"},
+      {PartitionedOutputNode::Kind::kArbitrary, "ARBITRARY"},
+  };
+}
+
+} // namespace
+
 // static
 std::string PartitionedOutputNode::kindString(Kind kind) {
-  switch (kind) {
-    case Kind::kPartitioned:
-      return "PARTITIONED";
-    case Kind::kBroadcast:
-      return "BROADCAST";
-    case Kind::kArbitrary:
-      return "ARBITRARY";
-    default:
-      return fmt::format("INVALID OUTPUT KIND {}", static_cast<int>(kind));
-  }
+  static const auto kPartitionNames = partitionKindNames();
+  return kPartitionNames.at(kind);
 }
 
 // static
 PartitionedOutputNode::Kind PartitionedOutputNode::stringToKind(
-    std::string str) {
-  if (str == "PARTITIONED") {
-    return Kind::kPartitioned;
-  } else if (str == "BROADCAST") {
-    return Kind::kBroadcast;
-  } else if (str == "ARBITRARY") {
-    return Kind::kArbitrary;
-  } else {
-    VELOX_FAIL("Unknown output buffer type: {}", str);
-  }
+    const std::string& name) {
+  static const auto kPartitionKinds = invertMap(partitionKindNames());
+  return kPartitionKinds.at(name);
 }
 
 void PartitionedOutputNode::addDetails(std::stringstream& stream) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1232,7 +1232,7 @@ class PartitionedOutputNode : public PlanNode {
     kArbitrary,
   };
   static std::string kindString(Kind kind);
-  static Kind stringToKind(std::string str);
+  static Kind stringToKind(const std::string& str);
 
   PartitionedOutputNode(
       const PlanNodeId& id,

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -535,10 +535,10 @@ TEST_F(OutputBufferManagerTest, outputType) {
       PartitionedOutputNode::kindString(
           PartitionedOutputNode::Kind::kBroadcast),
       "BROADCAST");
-  ASSERT_EQ(
+  EXPECT_THROW(
       PartitionedOutputNode::kindString(
           static_cast<PartitionedOutputNode::Kind>(100)),
-      "INVALID OUTPUT KIND 100");
+      std::out_of_range);
 }
 
 TEST_F(OutputBufferManagerTest, destinationBuffer) {


### PR DESCRIPTION
PartitionedOutputNode and LocalPartitionNode enum to string conversions were not consistent with how the enum to string conversions are done for rest of the PlanNodes enum fields.