### PR TITLE
Use nested namespce definition in "/vector" directory

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -39,8 +39,7 @@
 #include "velox/vector/VectorEncoding.h"
 #include "velox/vector/VectorUtil.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 class SimpleVector;
@@ -1006,8 +1005,7 @@ std::string printIndices(
     const BufferPtr& indices,
     vector_size_t maxIndicesToPrint = 10);
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox
 
 namespace folly {
 

--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -21,8 +21,7 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 /*
  * NOTE - biased vector is stored solely as a standard numeric flat array in
@@ -145,5 +144,4 @@ xsimd::batch<T> BiasVector<T>::loadSIMDValueBufferAt(size_t index) const {
   }
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/BuilderTypeUtils.h
+++ b/velox/vector/BuilderTypeUtils.h
@@ -27,8 +27,7 @@
 // Miscellaneous utilities regarding type, to avoid duplication
 // and improve readability in places that have to reason about types.
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 /**
  * @return true iff the type T can be used in a biased vector
@@ -95,5 +94,4 @@ inline bool deltaAllowsBias<int16_t>(uint64_t delta) {
   return delta <= std::numeric_limits<uint8_t>::max();
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -23,8 +23,7 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/SimpleVector.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 // Up to # of elements to show as debug string for `toString()`.
 constexpr vector_size_t kMaxElementsInToString = 5;
@@ -1716,5 +1715,4 @@ void RowVector::appendNulls(vector_size_t numberOfRows) {
   bits::fillBits(mutableRawNulls(), oldSize, newSize, bits::kNull);
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/ConstantVector-inl.h
+++ b/velox/vector/ConstantVector-inl.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 std::unique_ptr<SimpleVector<uint64_t>> ConstantVector<T>::hashAll() const {
@@ -29,5 +28,4 @@ std::unique_ptr<SimpleVector<uint64_t>> ConstantVector<T>::hashAll() const {
       sizeof(uint64_t) * BaseVector::length_ /* representedBytes */);
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/ConstantVector.cpp
+++ b/velox/vector/ConstantVector.cpp
@@ -16,8 +16,7 @@
 
 #include "velox/vector/ConstantVector.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <>
 void ConstantVector<StringView>::setValue(const std::string& string) {
@@ -42,5 +41,4 @@ void ConstantVector<ComplexType>::setValue(const std::string& /*string*/) {
       "ConstantVectors of ComplexType cannot be initialized from string values.");
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -19,8 +19,7 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 void DictionaryVector<T>::setInternalState() {
@@ -218,5 +217,4 @@ void DictionaryVector<T>::validate(const VectorValidateOptions& options) const {
   dictionaryValues_->validate(options);
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -24,8 +24,7 @@
 #include "velox/vector/SimpleVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 class DictionaryVector : public SimpleVector<T> {
@@ -270,7 +269,6 @@ class DictionaryVector : public SimpleVector<T> {
 template <typename T>
 using DictionaryVectorPtr = std::shared_ptr<DictionaryVector<T>>;
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox
 
 #include "velox/vector/DictionaryVector-inl.h"

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -23,8 +23,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 // Here are some common intel intrsic operations. Please refer to
 // https://software.intel.com/sites/landingpage/IntrinsicsGuide for examples.
@@ -592,5 +591,5 @@ inline void FlatVector<bool>::resizeValues(
   values_ = std::move(newValues);
   rawValues_ = values_->asMutable<bool>();
 }
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -19,8 +19,7 @@
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <>
 const bool* FlatVector<bool>::rawValues() const {
@@ -373,5 +372,4 @@ void FlatVector<StringView>::validate(
   }
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -28,8 +28,7 @@
 #include "velox/common/base/Range.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 // A selectivityVector is used to logically filter / select data in place.
 // The goal here is to be able to pass this vector between filter stages on
@@ -469,5 +468,5 @@ void translateToInnerRows(
     const vector_size_t* indices,
     const uint64_t* nulls,
     SelectivityVector& innerRows);
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -18,8 +18,7 @@
 
 #include "velox/vector/BuilderTypeUtils.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 SequenceVector<T>::SequenceVector(
@@ -196,5 +195,4 @@ static inline vector_size_t offsetOfIndex(
   return *lastIndex;
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/SequenceVector.cpp
+++ b/velox/vector/SequenceVector.cpp
@@ -16,10 +16,8 @@
 
 #include "velox/vector/SequenceVector.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template class SequenceVector<int32_t>;
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -34,8 +34,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/TypeAliases.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 namespace exec {
 class EvalCtx;
@@ -544,5 +543,4 @@ inline uint64_t SimpleVector<ComplexType>::hashValueAt(
 template <typename T>
 using SimpleVectorPtr = std::shared_ptr<SimpleVector<T>>;
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/TypeAliases.h
+++ b/velox/vector/TypeAliases.h
@@ -17,8 +17,7 @@
 #pragma once
 #include <cstdint>
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 /**
  * The reason for centralizing these types is to maintain consistency in the
@@ -34,5 +33,4 @@ using ByteCount = int32_t;
 // involved in storage, and should not be changed.
 using SequenceLength = uint32_t;
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/VectorTypeUtils.h
+++ b/velox/vector/VectorTypeUtils.h
@@ -20,8 +20,7 @@
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 // Maps TypeKind to the corresponding writable vector.
 template <TypeKind K>
@@ -94,5 +93,5 @@ template <typename T, bool comparable, bool orderable>
 struct TypeToFlatVector<Generic<T, comparable, orderable>> {
   using type = BaseVector;
 };
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox

--- a/velox/vector/VectorUtil.h
+++ b/velox/vector/VectorUtil.h
@@ -20,8 +20,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/Type.h"
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 
 template <typename T>
 static inline BufferPtr copyToBuffer(
@@ -45,5 +44,4 @@ static inline BufferPtr copyToBuffer(
   return returnsNullptr ? nullptr : AlignedBuffer::allocate<Value>(0, pool);
 }
 
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox

--- a/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
+++ b/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
@@ -21,9 +21,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/vector/SelectivityVector.h"
 
-namespace facebook {
-namespace velox {
-namespace test {
+namespace facebook::velox::test {
 
 // ctor Tests
 
@@ -300,9 +298,7 @@ BENCHMARK_PARAM(BM_operatorEquals, 1000000);
 BENCHMARK_PARAM(BM_operatorEquals, 10000000);
 BENCHMARK_DRAW_LINE();
 
-} // namespace test
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::test
 
 // To run:
 // buck run @mode/opt-clang-thinlto \

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -24,9 +24,7 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/vector/VectorUtil.h"
 
-namespace facebook {
-namespace velox {
-namespace test {
+namespace facebook::velox::test {
 
 template <typename T>
 class VectorUtilTest : public testing::Test {
@@ -85,6 +83,5 @@ TYPED_TEST(VectorUtilTest, copyToBufferWithEmptyVector) {
 TYPED_TEST(VectorUtilTest, copyToBufferWithEmptyVectorReturnsNullptr) {
   this->runTestWithEmptyVectorAndReturnsNullptr();
 }
-} // namespace test
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
The Velox code specification requires to always use "nested namespace 
definition", but I found that although most of the files in the 
"/vector" directory are already used, there are still some files that 
are not used. This patch fixes this problem.

No functional changes.