### PR TITLE
refactor: Update Base64 as non-throwing API

### DIFF
--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -18,7 +18,7 @@
 #include <folly/Portability.h>
 #include <folly/container/Foreach.h>
 #include <folly/io/Cursor.h>
-#include <stdint.h>
+#include <cstdint>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -310,8 +310,7 @@ std::string Base64::encode(const folly::IOBuf* inputBuffer) {
 // static
 std::string Base64::decode(folly::StringPiece encodedText) {
   std::string decodedResult;
-  Base64::decode(
-      std::make_pair(encodedText.data(), encodedText.size()), decodedResult);
+  decode(std::make_pair(encodedText.data(), encodedText.size()), decodedResult);
   return decodedResult;
 }
 
@@ -320,39 +319,58 @@ void Base64::decode(
     const std::pair<const char*, int32_t>& payload,
     std::string& decodedOutput) {
   size_t inputSize = payload.second;
-  decodedOutput.resize(calculateDecodedSize(payload.first, inputSize));
-  decode(payload.first, inputSize, decodedOutput.data(), decodedOutput.size());
+  auto decodedSize = calculateDecodedSize(payload.first, inputSize);
+  if (decodedSize.hasError()) {
+    VELOX_USER_FAIL(decodedSize.error().message());
+  }
+  decodedOutput.resize(decodedSize.value());
+  auto status = decode(
+      payload.first, inputSize, decodedOutput.data(), decodedOutput.size());
+  if (!status.ok()) {
+    VELOX_USER_FAIL(status.message());
+  }
 }
 
 // static
-void Base64::decode(const char* input, size_t size, char* output) {
-  size_t expectedOutputSize = size / 4 * 3;
-  Base64::decode(input, size, output, expectedOutputSize);
+void Base64::decode(const char* input, size_t inputSize, char* outputBuffer) {
+  size_t outputSize = inputSize / 4 * 3;
+  auto status = decode(input, inputSize, outputBuffer, outputSize);
+  if (!status.ok()) {
+    VELOX_USER_FAIL(status.message());
+  }
 }
 
 // static
-uint8_t Base64::base64ReverseLookup(
+Expected<uint8_t> Base64::base64ReverseLookup(
     char encodedChar,
-    const Base64::ReverseIndex& reverseIndex) {
+    const ReverseIndex& reverseIndex) {
   auto reverseLookupValue = reverseIndex[static_cast<uint8_t>(encodedChar)];
   if (reverseLookupValue >= 0x40) {
-    VELOX_USER_FAIL("decode() - invalid input string: invalid characters");
+    return folly::makeUnexpected(Status::UserError(
+        "decode() - invalid input string: invalid character '{}'",
+        encodedChar));
   }
   return reverseLookupValue;
 }
 
 // static
-size_t Base64::decode(
+Status Base64::decode(
     const char* input,
     size_t inputSize,
     char* output,
     size_t outputSize) {
-  return decodeImpl(
+  auto decodedSize = decodeImpl(
       input, inputSize, output, outputSize, kBase64ReverseIndexTable);
+  if (decodedSize.hasError()) {
+    return decodedSize.error();
+  }
+  return Status::OK();
 }
 
 // static
-size_t Base64::calculateDecodedSize(const char* input, size_t& inputSize) {
+Expected<size_t> Base64::calculateDecodedSize(
+    const char* input,
+    size_t& inputSize) {
   if (inputSize == 0) {
     return 0;
   }
@@ -362,9 +380,9 @@ size_t Base64::calculateDecodedSize(const char* input, size_t& inputSize) {
     // If padded, ensure that the string length is a multiple of the encoded
     // block size
     if (inputSize % kEncodedBlockByteSize != 0) {
-      VELOX_USER_FAIL(
-          "Base64::decode() - invalid input string: "
-          "string length is not a multiple of 4.");
+      return folly::makeUnexpected(
+          Status::UserError("Base64::decode() - invalid input string: "
+                            "string length is not a multiple of 4."));
     }
 
     auto decodedSize =
@@ -385,9 +403,9 @@ size_t Base64::calculateDecodedSize(const char* input, size_t& inputSize) {
   // Adjust the needed size for extra bytes, if present
   if (extraBytes) {
     if (extraBytes == 1) {
-      VELOX_USER_FAIL(
+      return folly::makeUnexpected(Status::UserError(
           "Base64::decode() - invalid input string: "
-          "string length cannot be 1 more than a multiple of 4.");
+          "string length cannot be 1 more than a multiple of 4."));
     }
     decodedSize += (extraBytes * kBinaryBlockByteSize) / kEncodedBlockByteSize;
   }
@@ -396,54 +414,81 @@ size_t Base64::calculateDecodedSize(const char* input, size_t& inputSize) {
 }
 
 // static
-size_t Base64::decodeImpl(
+Expected<size_t> Base64::decodeImpl(
     const char* input,
     size_t inputSize,
     char* outputBuffer,
     size_t outputSize,
     const ReverseIndex& reverseIndex) {
-  if (!inputSize) {
+  if (inputSize == 0) {
     return 0;
   }
 
   auto decodedSize = calculateDecodedSize(input, inputSize);
-  if (outputSize < decodedSize) {
-    VELOX_USER_FAIL(
-        "Base64::decode() - invalid output string: "
-        "output string is too small.");
+  if (decodedSize.hasError()) {
+    return folly::makeUnexpected(decodedSize.error());
   }
+
+  if (outputSize < decodedSize.value()) {
+    return folly::makeUnexpected(
+        Status::UserError("Base64::decode() - invalid output string: "
+                          "output string is too small."));
+  }
+  outputSize = decodedSize.value();
 
   // Handle full groups of 4 characters
   for (; inputSize > 4; inputSize -= 4, input += 4, outputBuffer += 3) {
     // Each character of the 4 encodes 6 bits of the original, grab each with
     // the appropriate shifts to rebuild the original and then split that back
     // into the original 8-bit bytes.
-    uint32_t decodedBlock =
-        (base64ReverseLookup(input[0], reverseIndex) << 18) |
-        (base64ReverseLookup(input[1], reverseIndex) << 12) |
-        (base64ReverseLookup(input[2], reverseIndex) << 6) |
-        base64ReverseLookup(input[3], reverseIndex);
-    outputBuffer[0] = (decodedBlock >> 16) & 0xff;
-    outputBuffer[1] = (decodedBlock >> 8) & 0xff;
-    outputBuffer[2] = decodedBlock & 0xff;
+    uint32_t decodedBlock = 0;
+    for (int i = 0; i < 4; ++i) {
+      auto reverseLookupValue = base64ReverseLookup(input[i], reverseIndex);
+      if (reverseLookupValue.hasError()) {
+        return folly::makeUnexpected(reverseLookupValue.error());
+      }
+      decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
+    }
+    outputBuffer[0] = static_cast<char>((decodedBlock >> 16) & 0xff);
+    outputBuffer[1] = static_cast<char>((decodedBlock >> 8) & 0xff);
+    outputBuffer[2] = static_cast<char>(decodedBlock & 0xff);
   }
 
   // Handle the last 2-4 characters. This is similar to the above, but the
   // last 2 characters may or may not exist.
-  DCHECK(inputSize >= 2);
-  uint32_t decodedBlock = (base64ReverseLookup(input[0], reverseIndex) << 18) |
-      (base64ReverseLookup(input[1], reverseIndex) << 12);
-  outputBuffer[0] = (decodedBlock >> 16) & 0xff;
-  if (inputSize > 2) {
-    decodedBlock |= base64ReverseLookup(input[2], reverseIndex) << 6;
-    outputBuffer[1] = (decodedBlock >> 8) & 0xff;
-    if (inputSize > 3) {
-      decodedBlock |= base64ReverseLookup(input[3], reverseIndex);
-      outputBuffer[2] = decodedBlock & 0xff;
+  if (inputSize >= 2) {
+    uint32_t decodedBlock = 0;
+
+    // Process the first two characters
+    for (int i = 0; i < 2; ++i) {
+      auto reverseLookupValue = base64ReverseLookup(input[i], reverseIndex);
+      if (reverseLookupValue.hasError()) {
+        return folly::makeUnexpected(reverseLookupValue.error());
+      }
+      decodedBlock |= reverseLookupValue.value() << (18 - 6 * i);
+    }
+    outputBuffer[0] = static_cast<char>((decodedBlock >> 16) & 0xff);
+
+    if (inputSize > 2) {
+      auto reverseLookupValue = base64ReverseLookup(input[2], reverseIndex);
+      if (reverseLookupValue.hasError()) {
+        return folly::makeUnexpected(reverseLookupValue.error());
+      }
+      decodedBlock |= reverseLookupValue.value() << 6;
+      outputBuffer[1] = static_cast<char>((decodedBlock >> 8) & 0xff);
+
+      if (inputSize > 3) {
+        auto reverseLookupValue = base64ReverseLookup(input[3], reverseIndex);
+        if (reverseLookupValue.hasError()) {
+          return folly::makeUnexpected(reverseLookupValue.error());
+        }
+        decodedBlock |= reverseLookupValue.value();
+        outputBuffer[2] = static_cast<char>(decodedBlock & 0xff);
+      }
     }
   }
 
-  return decodedSize;
+  return decodedSize.value();
 }
 
 // static
@@ -462,19 +507,23 @@ std::string Base64::encodeUrl(const folly::IOBuf* inputBuffer) {
 }
 
 // static
-void Base64::decodeUrl(
+Status Base64::decodeUrl(
     const char* input,
     size_t inputSize,
     char* outputBuffer,
     size_t outputSize) {
-  decodeImpl(
+  auto decodedSize = decodeImpl(
       input, inputSize, outputBuffer, outputSize, kBase64UrlReverseIndexTable);
+  if (decodedSize.hasError()) {
+    return decodedSize.error();
+  }
+  return Status::OK();
 }
 
 // static
 std::string Base64::decodeUrl(folly::StringPiece encodedText) {
   std::string decodedOutput;
-  Base64::decodeUrl(
+  decodeUrl(
       std::make_pair(encodedText.data(), encodedText.size()), decodedOutput);
   return decodedOutput;
 }
@@ -483,15 +532,18 @@ std::string Base64::decodeUrl(folly::StringPiece encodedText) {
 void Base64::decodeUrl(
     const std::pair<const char*, int32_t>& payload,
     std::string& decodedOutput) {
-  size_t decodedSize = (payload.second + 3) / 4 * 3;
-  decodedOutput.resize(decodedSize, '\0');
-  decodedSize = Base64::decodeImpl(
+  size_t expectedDecodedSize = (payload.second + 3) / 4 * 3;
+  decodedOutput.resize(expectedDecodedSize, '\0');
+  auto decodedSize = decodeImpl(
       payload.first,
       payload.second,
-      &decodedOutput[0],
-      decodedSize,
+      decodedOutput.data(),
+      expectedDecodedSize,
       kBase64UrlReverseIndexTable);
-  decodedOutput.resize(decodedSize);
+  if (decodedSize.hasError()) {
+    VELOX_USER_FAIL(decodedSize.error().message());
+  }
+  decodedOutput.resize(decodedSize.value());
 }
 
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "velox/common/base/GTestMacros.h"
+#include "velox/common/base/Status.h"
 
 namespace facebook::velox::encoding {
 
@@ -86,7 +87,7 @@ class Base64 {
 
   /// Decodes the specified number of characters from the 'input' and writes the
   /// result to the 'outputBuffer'.
-  static size_t decode(
+  static Status decode(
       const char* input,
       size_t inputSize,
       char* outputBuffer,
@@ -103,7 +104,7 @@ class Base64 {
 
   /// Decodes the specified number of characters from the 'input' using URL
   /// encoding and writes the result to the 'outputBuffer'
-  static void decodeUrl(
+  static Status decodeUrl(
       const char* input,
       size_t inputSize,
       char* outputBuffer,
@@ -112,9 +113,11 @@ class Base64 {
   /// Calculates the encoded size based on input 'inputSize'.
   static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
 
-  /// Returns the actual size of the decoded data. Removes the padding
-  /// length from the input data 'inputSize'.
-  static size_t calculateDecodedSize(const char* input, size_t& inputSize);
+  /// Calculates the decoded size based on encoded input and adjusts the input
+  /// size for padding.
+  static Expected<size_t> calculateDecodedSize(
+      const char* input,
+      size_t& inputSize);
 
  private:
   // Padding character used in encoding.
@@ -137,7 +140,7 @@ class Base64 {
 
   // Reverse lookup helper function to get the original index of a Base64
   // character.
-  static uint8_t base64ReverseLookup(
+  static Expected<uint8_t> base64ReverseLookup(
       char encodedChar,
       const ReverseIndex& reverseIndex);
 
@@ -155,7 +158,7 @@ class Base64 {
       char* outputBuffer);
 
   // Decodes the specified data using the provided reverse lookup table.
-  static size_t decodeImpl(
+  static Expected<size_t> decodeImpl(
       const char* input,
       size_t inputSize,
       char* outputBuffer,

--- a/velox/common/encode/CMakeLists.txt
+++ b/velox/common/encode/CMakeLists.txt
@@ -17,4 +17,4 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 velox_add_library(velox_encode Base64.cpp)
-velox_link_libraries(velox_encode PUBLIC Folly::folly)
+velox_link_libraries(velox_encode PUBLIC velox_status Folly::folly)

--- a/velox/common/encode/tests/Base64Test.cpp
+++ b/velox/common/encode/tests/Base64Test.cpp
@@ -49,44 +49,52 @@ TEST_F(Base64Test, fromBase64) {
 }
 
 TEST_F(Base64Test, calculateDecodedSizeProperSize) {
-  size_t encoded_size{0};
-
-  encoded_size = 20;
+  size_t encodedSize = 20;
   EXPECT_EQ(
-      13, Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ==", encoded_size));
-  EXPECT_EQ(18, encoded_size);
+      13,
+      Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ==", encodedSize)
+          .value());
+  EXPECT_EQ(18, encodedSize);
 
-  encoded_size = 18;
+  encodedSize = 18;
   EXPECT_EQ(
-      13, Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ", encoded_size));
-  EXPECT_EQ(18, encoded_size);
+      13,
+      Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ", encodedSize).value());
+  EXPECT_EQ(18, encodedSize);
 
-  encoded_size = 21;
-  VELOX_ASSERT_THROW(
-      Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ==", encoded_size),
-      "Base64::decode() - invalid input string: string length cannot be 1 more than a multiple of 4.");
-
-  encoded_size = 32;
+  encodedSize = 21;
   EXPECT_EQ(
-      23,
-      Base64::calculateDecodedSize(
-          "QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4=", encoded_size));
-  EXPECT_EQ(31, encoded_size);
+      Status::UserError(
+          "Base64::decode() - invalid input string: string length is not a multiple of 4."),
+      Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ===", encodedSize)
+          .error());
 
-  encoded_size = 31;
+  encodedSize = 32;
   EXPECT_EQ(
       23,
       Base64::calculateDecodedSize(
-          "QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4", encoded_size));
-  EXPECT_EQ(31, encoded_size);
+          "QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4=", encodedSize)
+          .value());
+  EXPECT_EQ(31, encodedSize);
 
-  encoded_size = 16;
-  EXPECT_EQ(10, Base64::calculateDecodedSize("MTIzNDU2Nzg5MA==", encoded_size));
-  EXPECT_EQ(14, encoded_size);
+  encodedSize = 31;
+  EXPECT_EQ(
+      23,
+      Base64::calculateDecodedSize(
+          "QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4", encodedSize)
+          .value());
+  EXPECT_EQ(31, encodedSize);
 
-  encoded_size = 14;
-  EXPECT_EQ(10, Base64::calculateDecodedSize("MTIzNDU2Nzg5MA", encoded_size));
-  EXPECT_EQ(14, encoded_size);
+  encodedSize = 16;
+  EXPECT_EQ(
+      10,
+      Base64::calculateDecodedSize("MTIzNDU2Nzg5MA==", encodedSize).value());
+  EXPECT_EQ(14, encodedSize);
+
+  encodedSize = 14;
+  EXPECT_EQ(
+      10, Base64::calculateDecodedSize("MTIzNDU2Nzg5MA", encodedSize).value());
+  EXPECT_EQ(14, encodedSize);
 }
 
 TEST_F(Base64Test, checksPadding) {

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -17,4 +17,9 @@ add_test(velox_common_encode_test velox_common_encode_test)
 target_link_libraries(
   velox_common_encode_test
   PUBLIC Folly::folly
-  PRIVATE velox_encode velox_exception GTest::gtest GTest::gtest_main)
+  PRIVATE
+    velox_encode
+    velox_exception
+    velox_status
+    GTest::gtest
+    GTest::gtest_main)

--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -8,26 +8,25 @@ Binary Functions
 
 .. function:: from_base64(string) -> varbinary
 
-    Decodes a Base64-encoded ``string`` back into its original binary form. 
-    This function is capable of handling both fully padded and non-padded Base64 encoded strings. 
-    Partially padded Base64 strings are not supported and will result in an error.
+    Decodes a Base64-encoded ``string`` back into its original binary form.
+    This function is capable of handling both fully padded and non-padded Base64 encoded strings.
+    Partially padded Base64 strings are not supported and will result in a "UserError" status being returned.
 
     Examples
     --------
     Query with padded Base64 string:
     ::
         SELECT from_base64('SGVsbG8gV29ybGQ='); -- [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
-
     Query with non-padded Base64 string:
     ::
         SELECT from_base64('SGVsbG8gV29ybGQ'); -- [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100]
 
     Query with partial-padded Base64 string:
     ::
-        SELECT from_base64('SGVsbG8gV29ybGQgZm9yIHZlbG94IQ='); -- Error : Base64::decode() - invalid input string: string length is not a multiple of 4.
+        SELECT from_base64('SGVsbG8gV29ybGQgZm9yIHZlbG94IQ='); -- UserError: Base64::decode() - invalid input string: string length is not a multiple of 4.
 
     In the above examples, both the fully padded and non-padded Base64 strings ('SGVsbG8gV29ybGQ=' and 'SGVsbG8gV29ybGQ') decode to the binary representation of the text 'Hello World'.
-    While, partial-padded Base64 string 'SGVsbG8gV29ybGQgZm9yIHZlbG94IQ=' will lead to an velox error.
+    A partial-padded Base64 string 'SGVsbG8gV29ybGQgZm9yIHZlbG94IQ=' will result in a "UserError" status indicating the Base64 string is invalid.
 
 .. function:: from_base64url(string) -> varbinary
 

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -293,11 +293,15 @@ struct FromBase64Function {
   // T can be either arg_type<Varchar> or arg_type<Varbinary>. These are the
   // same, but hard-coding one of them might be confusing.
   template <typename T>
-  FOLLY_ALWAYS_INLINE void call(out_type<Varbinary>& result, const T& input) {
+  FOLLY_ALWAYS_INLINE Status call(out_type<Varbinary>& result, const T& input) {
     auto inputSize = input.size();
-    result.resize(
-        encoding::Base64::calculateDecodedSize(input.data(), inputSize));
-    encoding::Base64::decode(
+    auto decodedSize =
+        encoding::Base64::calculateDecodedSize(input.data(), inputSize);
+    if (decodedSize.hasError()) {
+      return decodedSize.error();
+    }
+    result.resize(decodedSize.value());
+    return encoding::Base64::decode(
         input.data(), inputSize, result.data(), result.size());
   }
 };
@@ -305,13 +309,16 @@ struct FromBase64Function {
 template <typename T>
 struct FromBase64UrlFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Varbinary>& result,
-      const arg_type<Varchar>& input) {
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<Varbinary>& result, const arg_type<Varchar>& input) {
     auto inputSize = input.size();
-    result.resize(
-        encoding::Base64::calculateDecodedSize(input.data(), inputSize));
-    encoding::Base64::decodeUrl(
+    auto decodedSize =
+        encoding::Base64::calculateDecodedSize(input.data(), inputSize);
+    if (decodedSize.hasError()) {
+      return decodedSize.error();
+    }
+    result.resize(decodedSize.value());
+    return encoding::Base64::decodeUrl(
         input.data(), inputSize, result.data(), result.size());
   }
 };

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -442,6 +442,12 @@ TEST_F(BinaryFunctionsTest, fromBase64) {
   VELOX_ASSERT_USER_THROW(
       fromBase64("YQ==="),
       "Base64::decode() - invalid input string: string length is not a multiple of 4.");
+  VELOX_ASSERT_USER_THROW(
+      fromBase64("aG;"),
+      "decode() - invalid input string: invalid character ';'");
+  VELOX_ASSERT_USER_THROW(
+      fromBase64("YQ?="),
+      "decode() - invalid input string: invalid character '?'");
 
   // Check encoded strings without padding
   EXPECT_EQ("a", fromBase64("YQ"));


### PR DESCRIPTION
Follow-up PR: https://github.com/facebookincubator/velox/pull/10371


This PR introduces the following changes:

 1. Refactored Base64 APIs as Non-Throwing
	- The Base64 APIs have been refactored to be non-throwing, aligning with the performance optimizations discussed in the Velox blog post: ["Further Optimizing TRY_CAST and TRY"](https://velox-lib.io/blog/optimize-try-more/).
	- By eliminating exceptions in these functions, we aim to significantly improve performance, particularly in cases where a high percentage of rows might trigger exceptions.
	- The primary benefit comes from reducing the overhead of exception handling, leading to more efficient query execution.
 2. Scoped Change to `BinaryFunctions.h`
	- The non-throwing behavior is applied only to function calls originating from `BinaryFunctions.h`.
	- Calls from other files will continue using the throwing version, ensuring that functionality remains unchanged elsewhere.

Changing the `char` to `std::string_view` and `std::string` will be done in subsequent PR.