### PR TITLE
Back out "Add alias for array duplicate functions."

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -49,10 +49,6 @@ Array Functions
         SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
         SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
 
-.. function:: array_dupes(array(E)) -> boolean
-
-    This is an alias for :func:`array_duplicates(array(E))`
-
 .. function:: array_duplicates(array(E)) -> array(E)
 
     Returns a set of elements that occur more than once in array.
@@ -80,10 +76,6 @@ Array Functions
         SELECT array_frequency(ARRAY [1, 1, NULL, NULL, NULL]); -- {1 -> 2}
         SELECT array_frequency(ARRAY ["knock", "knock", "who", "?"]); -- {"knock" -> 2, "who" -> 1, "?" -> 1}
         SELECT array_frequency(ARRAY []); -- {}
-
-.. function:: array_has_dupes(array(E)) -> boolean
-
-    This is an alias for :func:`array_has_duplicates(array(E))`.
 
 .. function:: array_has_duplicates(array(E)) -> boolean
 

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -71,7 +71,7 @@ inline void registerArrayHasDuplicatesFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayHasDuplicatesFunction, T>,
       bool,
-      Array<T>>({prefix + "array_has_duplicates", prefix + "array_has_dupes"});
+      Array<T>>({prefix + "array_has_duplicates"});
 }
 
 template <typename T>
@@ -134,7 +134,6 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, prefix + "array_distinct");
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_duplicates, prefix + "array_duplicates");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_duplicates, prefix + "array_dupes");
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_intersect, prefix + "array_intersect");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "contains");

--- a/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDuplicatesTest.cpp
@@ -36,7 +36,7 @@ class ArrayDuplicatesTest : public FunctionBaseTest {
   }
 
   // Execute test for bigint type.
-  void testBigint(const std::string& funcName) {
+  void testBigint() {
     auto array = makeNullableArrayVector<int64_t>({
         {},
         {1,
@@ -72,123 +72,7 @@ class ArrayDuplicatesTest : public FunctionBaseTest {
         {std::nullopt, 0, 1, std::numeric_limits<int64_t>::max()},
     });
 
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testinlineStringArrays(const std::string& funcName) {
-    using S = StringView;
-
-    auto array = makeNullableArrayVector<StringView>({
-        {},
-        {S("")},
-        {std::nullopt},
-        {S("a"), S("b")},
-        {S("a"), std::nullopt, S("b")},
-        {S("a"), S("a")},
-        {S("b"), S("a"), S("b"), S("a"), S("a")},
-        {std::nullopt, std::nullopt},
-        {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
-    });
-
-    auto expected = makeNullableArrayVector<StringView>({
-        {},
-        {},
-        {},
-        {},
-        {},
-        {S("a")},
-        {S("a"), S("b")},
-        {std::nullopt},
-        {std::nullopt, S("a"), S("b")},
-    });
-
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void teststringArrays(const std::string& funcName) {
-    using S = StringView;
-
-    auto array = makeNullableArrayVector<StringView>({
-        {S("red shiny car ahead"), S("blue clear sky above")},
-        {S("blue clear sky above"),
-         S("yellow rose flowers"),
-         std::nullopt,
-         S("blue clear sky above"),
-         S("orange beautiful sunset")},
-        {
-            S("red shiny car ahead"),
-            std::nullopt,
-            S("purple is an elegant color"),
-            S("red shiny car ahead"),
-            S("green plants make us happy"),
-            S("purple is an elegant color"),
-            std::nullopt,
-            S("purple is an elegant color"),
-        },
-    });
-
-    auto expected = makeNullableArrayVector<StringView>({
-        {},
-        {S("blue clear sky above")},
-        {std::nullopt,
-         S("purple is an elegant color"),
-         S("red shiny car ahead")},
-    });
-
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testNonContiguousRows(const std::string& funcName) {
-    auto c0 = makeFlatVector<int64_t>(4, [](auto row) { return row; });
-    auto c1 = makeArrayVector<int64_t>({
-        {1, 1, 2, 3, 3},
-        {1, 1, 2, 3, 4, 4},
-        {1, 1, 2, 3, 4, 5, 5},
-        {1, 1, 2, 3, 3, 4, 5, 6, 6},
-    });
-
-    auto c2 = makeArrayVector<int64_t>({
-        {0, 0, 1, 1, 2, 3, 3},
-        {0, 0, 1, 1, 2, 3, 4, 4},
-        {0, 0, 1, 1, 2, 3, 4, 5, 5},
-        {0, 0, 1, 1, 2, 3, 4, 5, 6, 6},
-    });
-
-    auto expected = makeArrayVector<int64_t>({
-        {1, 3},
-        {0, 1, 4},
-        {1, 5},
-        {0, 1, 6},
-    });
-
-    auto result = evaluate<ArrayVector>(
-        fmt::format("if(c0 % 2 = 0, {}(c1), {}(c2))", funcName, funcName),
-        makeRowVector({c0, c1, c2}));
-    assertEqualVectors(expected, result);
-  }
-
-  void testConstant(const std::string& funcName) {
-    vector_size_t size = 1'000;
-    auto data =
-        makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 4, 5}, {6, 6, 6, 6}});
-
-    auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
-      return evaluate(
-          fmt::format("{}(c0)", funcName),
-          makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
-    };
-
-    auto result = evaluateConstant(0, data);
-    auto expected = makeConstantArray<int64_t>(size, {});
-    assertEqualVectors(expected, result);
-
-    result = evaluateConstant(1, data);
-    expected = makeConstantArray<int64_t>(size, {4, 5});
-    assertEqualVectors(expected, result);
-
-    result = evaluateConstant(2, data);
-    expected = makeConstantArray<int64_t>(size, {6});
-    assertEqualVectors(expected, result);
+    testExpr(expected, "array_duplicates(C0)", {array});
   }
 };
 
@@ -196,28 +80,120 @@ class ArrayDuplicatesTest : public FunctionBaseTest {
 
 // Test integer arrays.
 TEST_F(ArrayDuplicatesTest, integerArrays) {
-  testBigint("array_duplicates");
-  testBigint("array_dupes");
+  testBigint();
 }
 
 // Test inline (short) strings.
 TEST_F(ArrayDuplicatesTest, inlineStringArrays) {
-  testinlineStringArrays("array_duplicates");
-  testinlineStringArrays("array_dupes");
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {},
+      {S("")},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), std::nullopt, S("b")},
+      {S("a"), S("a")},
+      {S("b"), S("a"), S("b"), S("a"), S("a")},
+      {std::nullopt, std::nullopt},
+      {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {},
+      {},
+      {},
+      {},
+      {},
+      {S("a")},
+      {S("a"), S("b")},
+      {std::nullopt},
+      {std::nullopt, S("a"), S("b")},
+  });
+
+  testExpr(expected, "array_duplicates(C0)", {array});
 }
 
 // Test non-inline (> 12 character length) strings.
 TEST_F(ArrayDuplicatesTest, stringArrays) {
-  teststringArrays("array_duplicates");
-  teststringArrays("array_dupes");
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {S("blue clear sky above"),
+       S("yellow rose flowers"),
+       std::nullopt,
+       S("blue clear sky above"),
+       S("orange beautiful sunset")},
+      {
+          S("red shiny car ahead"),
+          std::nullopt,
+          S("purple is an elegant color"),
+          S("red shiny car ahead"),
+          S("green plants make us happy"),
+          S("purple is an elegant color"),
+          std::nullopt,
+          S("purple is an elegant color"),
+      },
+  });
+
+  auto expected = makeNullableArrayVector<StringView>({
+      {},
+      {S("blue clear sky above")},
+      {std::nullopt, S("purple is an elegant color"), S("red shiny car ahead")},
+  });
+
+  testExpr(expected, "array_duplicates(C0)", {array});
 }
 
 TEST_F(ArrayDuplicatesTest, nonContiguousRows) {
-  testNonContiguousRows("array_duplicates");
-  testNonContiguousRows("array_dupes");
+  auto c0 = makeFlatVector<int64_t>(4, [](auto row) { return row; });
+  auto c1 = makeArrayVector<int64_t>({
+      {1, 1, 2, 3, 3},
+      {1, 1, 2, 3, 4, 4},
+      {1, 1, 2, 3, 4, 5, 5},
+      {1, 1, 2, 3, 3, 4, 5, 6, 6},
+  });
+
+  auto c2 = makeArrayVector<int64_t>({
+      {0, 0, 1, 1, 2, 3, 3},
+      {0, 0, 1, 1, 2, 3, 4, 4},
+      {0, 0, 1, 1, 2, 3, 4, 5, 5},
+      {0, 0, 1, 1, 2, 3, 4, 5, 6, 6},
+  });
+
+  auto expected = makeArrayVector<int64_t>({
+      {1, 3},
+      {0, 1, 4},
+      {1, 5},
+      {0, 1, 6},
+  });
+
+  auto result = evaluate<ArrayVector>(
+      "if(c0 % 2 = 0, array_duplicates(c1), array_duplicates(c2))",
+      makeRowVector({c0, c1, c2}));
+  assertEqualVectors(expected, result);
 }
 
 TEST_F(ArrayDuplicatesTest, constant) {
-  testConstant("array_duplicates");
-  testConstant("array_dupes");
+  vector_size_t size = 1'000;
+  auto data = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 4, 5}, {6, 6, 6, 6}});
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "array_duplicates(c0)",
+        makeRowVector({BaseVector::wrapInConstant(size, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, data);
+  auto expected = makeConstantArray<int64_t>(size, {});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, data);
+  expected = makeConstantArray<int64_t>(size, {4, 5});
+  assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, data);
+  expected = makeConstantArray<int64_t>(size, {6});
+  assertEqualVectors(expected, result);
 }

--- a/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
@@ -34,139 +34,114 @@ class ArrayHasDuplicatesTest : public FunctionBaseTest {
         evaluate<SimpleVector<bool>>(expression, makeRowVector(input));
     assertEqualVectors(expected, result);
   }
-
-  void testBigInts(const std::string& funcName) {
-    auto array = makeNullableArrayVector<int64_t>({
-        {},
-        {1,
-         std::numeric_limits<int64_t>::min(),
-         std::numeric_limits<int64_t>::max()},
-        {std::nullopt},
-        {1, 2, 3},
-        {2, 1, 1, -2},
-        {1, 1, 1},
-        {-1, std::nullopt, -1, -1},
-        {std::nullopt, std::nullopt, std::nullopt},
-        {1, -2, -2, 8, -2, 4, 8, 1},
-        {std::numeric_limits<int64_t>::max(),
-         std::numeric_limits<int64_t>::max(),
-         1,
-         std::nullopt,
-         0,
-         1,
-         std::nullopt,
-         0},
-    });
-
-    auto expected = makeNullableFlatVector<bool>(
-        {false, false, false, false, true, true, true, true, true, true});
-
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testInlineStrings(const std::string& funcName) {
-    using S = StringView;
-
-    auto array = makeNullableArrayVector<StringView>({
-        {},
-        {""_sv},
-        {std::nullopt},
-        {S("a"), S("b")},
-        {S("a"), std::nullopt, S("b")},
-        {S("a"), S("a")},
-        {S("b"), S("a"), S("b"), S("a"), S("a")},
-        {std::nullopt, std::nullopt},
-        {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
-    });
-
-    auto expected = makeFlatVector<bool>(
-        {false, false, false, false, false, true, true, true, true});
-
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testLongStrings(const std::string& funcName) {
-    using S = StringView;
-
-    auto array = makeNullableArrayVector<StringView>({
-        {S("red shiny car ahead"), S("blue clear sky above")},
-        {S("blue clear sky above"),
-         S("yellow rose flowers"),
-         std::nullopt,
-         S("blue clear sky above"),
-         S("orange beautiful sunset")},
-        {
-            S("red shiny car ahead"),
-            std::nullopt,
-            S("purple is an elegant color"),
-            S("red shiny car ahead"),
-            S("green plants make us happy"),
-            S("purple is an elegant color"),
-            std::nullopt,
-            S("purple is an elegant color"),
-        },
-    });
-    auto expected = makeFlatVector<bool>({false, true, true});
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testNullFreeBigints(const std::string& funcName) {
-    auto array = makeArrayVector<int64_t>({
-        {1,
-         std::numeric_limits<int64_t>::min(),
-         std::numeric_limits<int64_t>::max()},
-        {2, 1, 1, -2},
-        {1, 1, 1},
-    });
-
-    auto expected = makeNullableFlatVector<bool>({false, true, true});
-
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
-
-  void testNullFreeStrings(const std::string& funcName) {
-    using S = StringView;
-
-    auto array = makeArrayVector<StringView>(
-        {{S("red shiny car ahead"), S("blue clear sky above")},
-         {S("red shiny car ahead"),
-          S("blue clear sky above"),
-          S("blue clear sky above")},
-         {S("a"), S("b")},
-         {S("a"), S("b"), S("b")}
-
-        });
-    auto expected = makeFlatVector<bool>({false, true, false, true});
-    testExpr(expected, fmt::format("{}(C0)", funcName), {array});
-  }
 };
 
 } // namespace
 
 // Test bigint arrays.
 TEST_F(ArrayHasDuplicatesTest, bigints) {
-  testBigInts("array_has_duplicates");
-  testBigInts("array_has_dupes");
+  auto array = makeNullableArrayVector<int64_t>({
+      {},
+      {1,
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()},
+      {std::nullopt},
+      {1, 2, 3},
+      {2, 1, 1, -2},
+      {1, 1, 1},
+      {-1, std::nullopt, -1, -1},
+      {std::nullopt, std::nullopt, std::nullopt},
+      {1, -2, -2, 8, -2, 4, 8, 1},
+      {std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::max(),
+       1,
+       std::nullopt,
+       0,
+       1,
+       std::nullopt,
+       0},
+  });
+
+  auto expected = makeNullableFlatVector<bool>(
+      {false, false, false, false, true, true, true, true, true, true});
+
+  testExpr(expected, "array_has_duplicates(C0)", {array});
 }
 
 // Test inline (short) strings.
 TEST_F(ArrayHasDuplicatesTest, inlineStrings) {
-  testInlineStrings("array_has_duplicates");
-  testInlineStrings("array_has_dupes");
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {},
+      {""_sv},
+      {std::nullopt},
+      {S("a"), S("b")},
+      {S("a"), std::nullopt, S("b")},
+      {S("a"), S("a")},
+      {S("b"), S("a"), S("b"), S("a"), S("a")},
+      {std::nullopt, std::nullopt},
+      {S("b"), std::nullopt, S("a"), S("a"), std::nullopt, S("b")},
+  });
+
+  auto expected = makeFlatVector<bool>(
+      {false, false, false, false, false, true, true, true, true});
+
+  testExpr(expected, "array_has_duplicates(C0)", {array});
 }
 
 // Test non-inline (> 12 character length) strings.
 TEST_F(ArrayHasDuplicatesTest, longStrings) {
-  testLongStrings("array_has_duplicates");
-  testLongStrings("array_has_dupes");
+  using S = StringView;
+
+  auto array = makeNullableArrayVector<StringView>({
+      {S("red shiny car ahead"), S("blue clear sky above")},
+      {S("blue clear sky above"),
+       S("yellow rose flowers"),
+       std::nullopt,
+       S("blue clear sky above"),
+       S("orange beautiful sunset")},
+      {
+          S("red shiny car ahead"),
+          std::nullopt,
+          S("purple is an elegant color"),
+          S("red shiny car ahead"),
+          S("green plants make us happy"),
+          S("purple is an elegant color"),
+          std::nullopt,
+          S("purple is an elegant color"),
+      },
+  });
+  auto expected = makeFlatVector<bool>({false, true, true});
+  testExpr(expected, "array_has_duplicates(C0)", {array});
 }
 
 TEST_F(ArrayHasDuplicatesTest, nullFreeBigints) {
-  testNullFreeBigints("array_has_duplicates");
-  testNullFreeBigints("array_has_dupes");
+  auto array = makeArrayVector<int64_t>({
+      {1,
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()},
+      {2, 1, 1, -2},
+      {1, 1, 1},
+  });
+
+  auto expected = makeNullableFlatVector<bool>({false, true, true});
+
+  testExpr(expected, "array_has_duplicates(C0)", {array});
 }
 
 TEST_F(ArrayHasDuplicatesTest, nullFreeStrings) {
-  testNullFreeStrings("array_has_duplicates");
-  testNullFreeStrings("array_has_dupes");
+  using S = StringView;
+
+  auto array = makeArrayVector<StringView>(
+      {{S("red shiny car ahead"), S("blue clear sky above")},
+       {S("red shiny car ahead"),
+        S("blue clear sky above"),
+        S("blue clear sky above")},
+       {S("a"), S("b")},
+       {S("a"), S("b"), S("b")}
+
+      });
+  auto expected = makeFlatVector<bool>({false, true, false, true});
+  testExpr(expected, "array_has_duplicates(C0)", {array});
 }


### PR DESCRIPTION
Summary: Removing deprecated function alias for array_duplicates and array_has_duplicates. We have already removed this from Presto https://github.com/prestodb/presto/pull/23762

Differential Revision: D63771171


