### PR TITLE
Support custom comparison in Variants (attempt 2)

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 using facebook::velox::duckdb::duckdbTimestampToVelox;
@@ -530,6 +531,12 @@ variant variantAt(const VectorPtr& vector, vector_size_t row) {
 
   if (typeKind == TypeKind::MAP) {
     return mapVariantAt(vector, row);
+  }
+
+  if (isTimestampWithTimeZoneType(vector->type())) {
+    return variant::typeWithCustomComparison<TypeKind::BIGINT>(
+        vector->as<SimpleVector<int64_t>>()->valueAt(row),
+        TIMESTAMP_WITH_TIME_ZONE());
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(variantAt, typeKind, vector, row);


### PR DESCRIPTION
Summary:
This is a second attempt to land the changes in
https://github.com/facebookincubator/velox/pull/11119

The original description:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support
for custom comparison functions provided by custom types to be used in Variants.

This is primarily needed for testing in QueryAssertions.cpp where we convert Vectors
to variants before comparing them.  For example, when a function may choose one of
a set of equivalent values depending on the order of the input (e.g. the representative
value chosen by the Histogram aggregation).

New context:
Apparently there are use cases that heavily use variants, so much so that the addition
of the extra shared_ptr for the Type in the Variant object caused a significant memory
regression.

This new approach packs the TypePtr inside the "stored_type" referred to by ptr_ only
if the type of the value being stored in the variant needs custom comparison.  So we
only need to store a boolean inside the Variant to indicate whether or not it needs
custom comparison, i.e. whether other not the TypePtr is present.

Since these use cases are not currently using types that need custom comparison (as
I haven't finished adding support for them) this would at most regress memory by 1
byte per Variant object, and likely be a wash if the compiler is writing objects 8 byte
aligned (given Variant is 9 bytes prior to this change).

Differential Revision: D63784840


