### PR TITLE
Support custom comparison in Histogram Aggregation (attempt 2)

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 using facebook::velox::duckdb::duckdbTimestampToVelox;
@@ -530,6 +531,12 @@ variant variantAt(const VectorPtr& vector, vector_size_t row) {
 
   if (typeKind == TypeKind::MAP) {
     return mapVariantAt(vector, row);
+  }
+
+  if (isTimestampWithTimeZoneType(vector->type())) {
+    return variant::typeWithCustomComparison<TypeKind::BIGINT>(
+        vector->as<SimpleVector<int64_t>>()->valueAt(row),
+        TIMESTAMP_WITH_TIME_ZONE());
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(variantAt, typeKind, vector, row);


### PR DESCRIPTION
Summary:
This is a second attempt to land the changes in
https://github.com/facebookincubator/velox/pull/11120

The original description:
Building on https://github.com/facebookincubator/velox/pull/11021 this adds support for custom
comparison functions provided by custom types in the Histogram aggregationt.

New context:
I landed this along with https://github.com/facebookincubator/velox/pull/11119 so it
got reverted along with it.  This particular change did not introduce any issues 
though.

Differential Revision: D63795479


