### PR TITLE
Modify map_top_n to throw when nested nulls are present

### DIFF
--- a/velox/functions/prestosql/MapTopN.h
+++ b/velox/functions/prestosql/MapTopN.h
@@ -60,11 +60,6 @@ struct MapTopNFunction {
       return;
     }
 
-    if (n >= inputMap.size()) {
-      out.copy_from(inputMap);
-      return;
-    }
-
     using It = typename arg_type<Map<Orderable<T1>, Orderable<T2>>>::Iterator;
 
     Compare<It> comparator;

--- a/velox/functions/prestosql/tests/MapTopNTest.cpp
+++ b/velox/functions/prestosql/tests/MapTopNTest.cpp
@@ -66,6 +66,22 @@ TEST_F(MapTopNTest, basic) {
       "n must be greater than or equal to 0");
 }
 
+TEST_F(MapTopNTest, nestedNullFailure) {
+  auto data = makeMapVector(
+      /*offsets=*/{0},
+      /*keyVector=*/makeFlatVector<int32_t>({1, 2, 3}),
+      /*valueVector=*/
+      makeNullableArrayVector<int32_t>({{std::nullopt}, {2}, {5}}));
+
+  // Nested nulls present inhibit the orderbility of values. Expect an error.
+  VELOX_ASSERT_THROW(
+      evaluate("map_top_n(c0, 1)", makeRowVector({data})), // n < map size
+      "Ordering nulls is not supported");
+  VELOX_ASSERT_THROW(
+      evaluate("map_top_n(c0, 10)", makeRowVector({data})), // n > map size
+      "Ordering nulls is not supported");
+}
+
 // Test to ensure we use keys to break ties if values are
 // equal.
 TEST_F(MapTopNTest, equalValues) {


### PR DESCRIPTION
Summary: Nested nulls present inhibit the orderbility of values. Currently, any check for nested null is bypassed when 'n' is greater than the size of the map. This chanhe removes the bypass. This will now match Presto's behavior.

Differential Revision: D63796842


