### PR TITLE
Avoid unnecessary memory reservation in hash probe to prevent query oom

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -88,6 +88,10 @@ class HashBuild final : public Operator {
 
   void close() override;
 
+  bool testingExceededMaxSpillLevelLimit() const {
+    return exceededMaxSpillLevelLimit_;
+  }
+
  private:
   void setState(State state);
   void checkStateTransition(State state);

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -72,6 +72,10 @@ class HashProbe : public Operator {
     return inputSpiller_ != nullptr;
   }
 
+  bool testingExceededMaxSpillLevelLimit() const {
+    return exceededMaxSpillLevelLimit_;
+  }
+
  private:
   // Indicates if the join type includes misses from the left side in the
   // output.


### PR DESCRIPTION
Summary:
Hash probe will always reserve memory based on the preferred output buffer size even when build side is building table.
This can cause unnecessary spill or unused memory reservation. We shall only reserve memory when it has output to produce.
Unit test is added.

Differential Revision: D63789365


