### PR TITLE
Install boost on MacOS setup script

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -44,7 +44,7 @@ MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4
 MACOS_BUILD_DEPS="ninja cmake"
 FB_OS_VERSION="v2024.05.20.00"
 FMT_VERSION="10.1.1"
-FAST_FLOAT_VERSION="v6.1.6"
+BOOST_VERSION="boost-1.84.0"
 STEMMER_VERSION="2.2.0"
 
 function update_brew {
@@ -97,6 +97,15 @@ function install_velox_deps_from_brew {
   do
     install_from_brew ${pkg}
   done
+}
+
+function install_boost {
+  wget_and_untar https://github.com/boostorg/boost/releases/download/${BOOST_VERSION}/${BOOST_VERSION}.tar.gz boost
+  (
+    cd ${DEPENDENCY_DIR}/boost
+    ./bootstrap.sh --prefix=${INSTALL_PREFIX}
+    ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+  )
 }
 
 function install_fmt {
@@ -168,6 +177,7 @@ function install_velox_deps {
   run_and_time install_ranges_v3
   run_and_time install_double_conversion
   run_and_time install_re2
+  run_and_time install_boost
   run_and_time install_fmt
   run_and_time install_folly
   run_and_time install_fizz


### PR DESCRIPTION
Boost install was removed from brew list here https://github.com/facebookincubator/velox/pull/10920/files#diff-49efb0acd7ee0e6a2d6f57f2e48b90bd170a41a7c46d2ef757a6c078b543d28c
We must install a specific version since brew versions evolve.