### PR TITLE
Vendor dbgen symbols to avoid collisions

### DIFF
--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -21,8 +21,9 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::tpch {
-
 namespace {
+
+using namespace dbgen;
 
 // DBGenBackend is a singleton that controls access to the DBGEN C functions,
 // and ensures that the required structures are properly initialized and

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -41,14 +41,14 @@ class DBGenIterator {
   void initCustomer(size_t offset);
 
   // Generate different types of records.
-  void genNation(size_t index, code_t& code);
-  void genRegion(size_t index, code_t& code);
-  void genOrder(size_t index, order_t& order);
-  void genSupplier(size_t index, supplier_t& supplier);
-  void genPart(size_t index, part_t& part);
-  void genCustomer(size_t index, customer_t& customer);
+  void genNation(size_t index, dbgen::code_t& code);
+  void genRegion(size_t index, dbgen::code_t& code);
+  void genOrder(size_t index, dbgen::order_t& order);
+  void genSupplier(size_t index, dbgen::supplier_t& supplier);
+  void genPart(size_t index, dbgen::part_t& part);
+  void genCustomer(size_t index, dbgen::customer_t& customer);
 
-  DBGenContext dbgenCtx_;
+  dbgen::DBGenContext dbgenCtx_;
 };
 
 } // namespace facebook::velox::tpch

--- a/velox/tpch/gen/TpchGen.cpp
+++ b/velox/tpch/gen/TpchGen.cpp
@@ -20,8 +20,9 @@
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::tpch {
-
 namespace {
+
+using namespace dbgen;
 
 // The cardinality of the LINEITEM table is not a strict multiple of SF since
 // the number of lineitems in an order is chosen at random with an average of

--- a/velox/tpch/gen/dbgen/bm_utils.cpp
+++ b/velox/tpch/gen/dbgen/bm_utils.cpp
@@ -103,6 +103,9 @@ static char alpha_num[65] =
 #ifndef WIN32
 char* getenv PROTO((const char* name));
 #endif
+
+namespace facebook::velox::tpch::dbgen {
+
 void usage();
 void permute_dist(distribution* d, seed_t* seed);
 
@@ -218,7 +221,11 @@ long julian(long date) {
   return (result + offset);
 }
 
+} // namespace facebook::velox::tpch::dbgen
+
 #include "dbgen/dists_dss.h" // @manual
+
+namespace facebook::velox::tpch::dbgen {
 
 static char
 read_line_into_buffer(char* buffer, size_t bufsiz, const char** src) {
@@ -444,3 +451,5 @@ set_state(
 
   return (result);
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/build.cpp
+++ b/velox/tpch/gen/dbgen/build.cpp
@@ -22,6 +22,8 @@
 #include <math.h>
 #include "dbgen/rng64.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 #define LEAP_ADJ(yr, mnth) ((LEAP(yr) && (mnth) >= 2) ? 1 : 0)
 #define JDAY_BASE 8035 /* start from 1/1/70 a la unix */
 #define JMNTH_BASE (-70 * 12) /* start from 1/1/70 a la unix */
@@ -363,3 +365,5 @@ int mk_region(DSS_HUGE index, code_t* c, DBGenContext* ctx) {
   c->clen = (int)strlen(c->comment);
   return (0);
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/dbgen_gunk.cpp
+++ b/velox/tpch/gen/dbgen/dbgen_gunk.cpp
@@ -12,6 +12,8 @@
 
 #include "dbgen/dss.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 void load_dists(long textBufferSize, DBGenContext* ctx) {
   read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "p_cntr", &p_cntr_set);
   read_dist(tpch_env_config(DIST_TAG, DIST_DFLT), "colors", &colors);
@@ -83,3 +85,5 @@ void cleanup_dists(void) {
 
   free_text_pool();
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/dbgen_gunk.hpp
+++ b/velox/tpch/gen/dbgen/include/dbgen/dbgen_gunk.hpp
@@ -10,7 +10,11 @@
  */
 #pragma once
 
+namespace facebook::velox::tpch::dbgen {
+
 struct DBGenContext;
 
 void load_dists(long textBufferSize, DBGenContext* ctx);
 void cleanup_dists(void);
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/dists_dss.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dists_dss.h
@@ -8,6 +8,9 @@
  *
  * THE TPC SOFTWARE IS AVAILABLE WITHOUT CHARGE FROM TPC.
  */
+
+namespace facebook::velox::tpch::dbgen {
+
 const char* dists_dss =
     "#\n"
     "# $Id: dists.dss,v 1.2 2005/01/03 20:08:58 jms Exp $\n"
@@ -849,3 +852,5 @@ const char* dists_dss =
     "accounts|40\n"
     "deposits|40\n"
     "END Q13b";
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/dss.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dss.h
@@ -118,6 +118,8 @@
 #define RANDOM(tgt, lower, upper, seed) dss_random(&tgt, lower, upper, seed)
 #define RANDOM64(tgt, lower, upper, seed) dss_random64(&tgt, lower, upper, seed)
 
+namespace facebook::velox::tpch::dbgen {
+
 typedef struct {
   long weight;
   char* text;
@@ -577,5 +579,7 @@ struct DBGenContext {
 
   long scale_factor = 1;
 };
+
+} // namespace facebook::velox::tpch::dbgen
 
 #endif /* DSS_H */

--- a/velox/tpch/gen/dbgen/include/dbgen/dsstypes.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dsstypes.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+namespace facebook::velox::tpch::dbgen {
+
 /*
  * typedefs
  */
@@ -163,3 +165,5 @@ long sd_supp(int child, DSS_HUGE skip_count, DBGenContext* ctx);
 long sd_part(int child, DSS_HUGE skip_count, DBGenContext* ctx);
 long sd_psupp(int child, DSS_HUGE skip_count, DBGenContext* ctx);
 long sd_cust(int child, DSS_HUGE skip_count, DBGenContext* ctx);
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/permute.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/permute.h
@@ -8,6 +8,9 @@
  *
  * THE TPC SOFTWARE IS AVAILABLE WITHOUT CHARGE FROM TPC.
  */
+
+namespace facebook::velox::tpch::dbgen {
+
 long permutation[41][22] = {
     {14, 2,  9, 20, 6,  17, 18, 8,  21, 13, 3,
      22, 16, 4, 11, 15, 1,  10, 19, 5,  7,  12},
@@ -91,3 +94,5 @@ long permutation[41][22] = {
      16, 19, 1,  13, 9, 8, 17, 11, 12, 22, 2},
     {13, 15, 17, 1, 22, 11, 3, 4,  7,  20, 14,
      21, 9,  8,  2, 18, 16, 6, 10, 12, 5,  19}};
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/rnd.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/rnd.h
@@ -15,6 +15,8 @@
 
 #pragma once
 
+namespace facebook::velox::tpch::dbgen {
+
 /* function protypes */
 DSS_HUGE NextRand PROTO((DSS_HUGE));
 DSS_HUGE UnifInt PROTO((DSS_HUGE, DSS_HUGE, long));
@@ -28,3 +30,5 @@ DSS_HUGE UnifInt PROTO((DSS_HUGE, DSS_HUGE, long));
  * preferred solution, but not initializing correctly
  */
 #define VSTR_MAX(len) (long)(len / 5 + (len % 5 == 0) ? 0 : 1 + 1)
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/include/dbgen/rng64.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/rng64.h
@@ -13,6 +13,10 @@
 #include "dbgen/config.h" // @manual
 #include "dbgen/dss.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 DSS_HUGE AdvanceRand64(DSS_HUGE nSeed, DSS_HUGE nCount);
 void dss_random64(DSS_HUGE* tgt, DSS_HUGE nLow, DSS_HUGE nHigh, seed_t* seed);
 DSS_HUGE NextRand64(DSS_HUGE nSeed);
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/permute.cpp
+++ b/velox/tpch/gen/dbgen/permute.cpp
@@ -15,6 +15,8 @@
 #include "dbgen/config.h" // @manual
 #include "dbgen/dss.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 DSS_HUGE NextRand(DSS_HUGE seed);
 void permute(long* set, int cnt, seed_t* seed);
 void permute_dist(distribution* d, seed_t* seed);
@@ -58,3 +60,5 @@ void permute_dist(distribution* d, seed_t* seed) {
 
   return;
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/rnd.cpp
+++ b/velox/tpch/gen/dbgen/rnd.cpp
@@ -27,6 +27,8 @@
 #include "dbgen/dss.h" // @manual
 #include "dbgen/rnd.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 const char* tpch_env_config PROTO((const char* tag, const char* dflt));
 void NthElement(DSS_HUGE, DSS_HUGE*);
 
@@ -151,3 +153,5 @@ UnifInt(DSS_HUGE nLow, DSS_HUGE nHigh, seed_t* seed)
   nTemp = (DSS_HUGE)(((double)seed->value / DBGenContext::dM) * (dRange));
   return (nLow + nTemp);
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/rng64.cpp
+++ b/velox/tpch/gen/dbgen/rng64.cpp
@@ -67,6 +67,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+namespace facebook::velox::tpch::dbgen {
+
 void dss_random64(DSS_HUGE* tgt, DSS_HUGE nLow, DSS_HUGE nHigh, seed_t* seed) {
   DSS_HUGE nTemp;
 
@@ -138,3 +140,5 @@ DSS_HUGE AdvanceRand64(DSS_HUGE nSeed, DSS_HUGE nCount) {
   nSeed = nSeed * Apow + Dsum * c;
   return nSeed;
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/speed_seed.cpp
+++ b/velox/tpch/gen/dbgen/speed_seed.cpp
@@ -15,6 +15,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+namespace facebook::velox::tpch::dbgen {
+
 /*  _tal long RandSeed = "Random^SeedFromTimestamp" (void); */
 
 #define ADVANCE_STREAM(stream, num_calls) advanceStream(stream, num_calls, 0)
@@ -213,3 +215,5 @@ long sd_region(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
 
   return (0L);
 }
+
+} // namespace facebook::velox::tpch::dbgen

--- a/velox/tpch/gen/dbgen/text.cpp
+++ b/velox/tpch/gen/dbgen/text.cpp
@@ -64,6 +64,8 @@
 
 #include "dbgen/dss.h" // @manual
 
+namespace facebook::velox::tpch::dbgen {
+
 static char* gen_text(char* dest, seed_t* seed, distribution* s) {
   long i = 0;
   DSS_HUGE j;
@@ -271,3 +273,5 @@ void dbg_text(char* tgt, int min, int max, seed_t* seed) {
 
   return;
 }
+
+} // namespace facebook::velox::tpch::dbgen


### PR DESCRIPTION
Summary:
Vendoring all dbgen symbols into a Velox-specific namespace to prevent
them from leaking and conflicts with symbols from other projects.

Reviewed By: xiaoxmeng

Differential Revision: D63813447
