### PR TITLE
Fix formating of code block in vectors.rst

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -130,7 +130,9 @@ of rows in the vector.
 
 Vectors are always held by std::shared_ptr using the VectorPtr alias.
 
-using VectorPtr = std::shared_ptr<BaseVector>;
+.. code-block:: c++
+
+    using VectorPtr = std::shared_ptr<BaseVector>;
 
 The “bits” namespace contains a number of convenience functions for working with
 a nulls buffer.


### PR DESCRIPTION
In vectors.rst, there is a block of code that is not properly formatted.