### PR TITLE
Add support for custom comparison in Presto's arrays intersect/except/overlap UDFs

### DIFF
--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -387,4 +388,98 @@ TEST_F(ArrayIntersectTest, dictionaryEncodedElementsInConstant) {
       expected,
       "array_intersect(c0, testing_dictionary_array_elements(ARRAY [2, 2, 3, 1, 2, 2]))",
       {array});
+}
+
+TEST_F(ArrayIntersectTest, timestampWithTimezone) {
+  auto testArrayIntersect =
+      [this](
+          const std::vector<std::optional<int64_t>>& inputArray1,
+          const std::vector<std::optional<int64_t>>& inputArray2,
+          const std::vector<std::optional<int64_t>>& expectedArrayForward,
+          const std::vector<std::optional<int64_t>>& expectedArrayBackward) {
+        const auto input1 = makeArrayVector(
+            {0},
+            makeNullableFlatVector(inputArray1, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto input2 = makeArrayVector(
+            {0},
+            makeNullableFlatVector(inputArray2, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto expectedForward = makeArrayVector(
+            {0},
+            makeNullableFlatVector(
+                expectedArrayForward, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto expectedBackward = makeArrayVector(
+            {0},
+            makeNullableFlatVector(
+                expectedArrayBackward, TIMESTAMP_WITH_TIME_ZONE()));
+
+        testExpr(expectedForward, "array_intersect(c0, c1)", {input1, input2});
+        testExpr(expectedBackward, "array_intersect(c1, c0)", {input1, input2});
+      };
+
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(-2, 1),
+       pack(3, 2),
+       std::nullopt,
+       pack(4, 3),
+       pack(5, 4),
+       pack(6, 5),
+       std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 1), pack(4, 3)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)});
+  testArrayIntersect(
+      {pack(1, 0), pack(2, 1), pack(-2, 2), pack(1, 3)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 2)},
+      {pack(1, 10), pack(-2, 11)});
+  testArrayIntersect(
+      {pack(3, 0), pack(8, 1), std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {},
+      {});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(1, 1),
+       pack(-2, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(4, 5),
+       pack(8, 6)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 2), pack(4, 5)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(-2, 1),
+       pack(3, 2),
+       std::nullopt,
+       pack(4, 3),
+       pack(5, 4),
+       pack(6, 5),
+       std::nullopt},
+      {pack(10, 10), pack(-24, 11), pack(43, 12)},
+      {},
+      {});
+  testArrayIntersect(
+      {pack(1, 0), pack(2, 1), pack(-2, 2), pack(1, 3)},
+      {std::nullopt, pack(-2, 10), pack(2, 11)},
+      {pack(2, 1), pack(-2, 2)},
+      {pack(-2, 10), pack(2, 11)});
+  testArrayIntersect(
+      {pack(3, 0), pack(8, 1), std::nullopt},
+      {std::nullopt, std::nullopt, std::nullopt},
+      {std::nullopt},
+      {std::nullopt});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(1, 1),
+       pack(-2, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(4, 5),
+       pack(8, 6)},
+      {pack(8, 10), pack(1, 11), pack(8, 12), pack(1, 13)},
+      {pack(1, 0), pack(8, 6)},
+      {pack(8, 10), pack(1, 11)});
 }

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -312,4 +313,70 @@ TEST_F(ArraysOverlapTest, dictionaryEncodedElementsInConstant) {
       expected,
       "arrays_overlap(testing_dictionary_array_elements(ARRAY [2, 2, 3, 1, 2, 2]), c0)",
       {array});
+}
+
+TEST_F(ArraysOverlapTest, TimestampWithTimezone) {
+  auto testArraysOverlap =
+      [this](
+          const std::vector<std::optional<int64_t>>& array1,
+          const std::vector<std::optional<int64_t>>& array2,
+          std::optional<bool> expected) {
+        auto arrayVector1 = makeArrayVector(
+            {0}, makeNullableFlatVector(array1, TIMESTAMP_WITH_TIME_ZONE()));
+        auto arrayVector2 = makeArrayVector(
+            {0}, makeNullableFlatVector(array2, TIMESTAMP_WITH_TIME_ZONE()));
+        auto expectedVector = makeNullableFlatVector<bool>({expected});
+
+        testExpr(
+            expectedVector,
+            "arrays_overlap(C0, C1)",
+            {arrayVector1, arrayVector2});
+        testExpr(
+            expectedVector,
+            "arrays_overlap(C1, C0)",
+            {arrayVector1, arrayVector2});
+      };
+
+  testArraysOverlap(
+      {pack(1, 1),
+       pack(-2, 2),
+       pack(3, 3),
+       std::nullopt,
+       pack(4, 4),
+       pack(5, 5),
+       pack(6, 6),
+       std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(1, 1), pack(2, 2), pack(-2, 3), pack(1, 4)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(3, 1), pack(8, 2), std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      std::nullopt);
+  testArraysOverlap(
+      {pack(1, 1),
+       pack(1, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(-2, 5),
+       pack(4, 6),
+       pack(8, 7)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(2, 1), pack(-1, 2)},
+      {pack(1, 1), pack(-2, 2), std::nullopt},
+      std::nullopt);
+  testArraysOverlap(
+      {pack(1, 1), pack(2, 2), pack(3, 3)},
+      {pack(5, 1), pack(6, 2), pack(7, 3)},
+      false);
+  testArraysOverlap({std::nullopt}, {std::nullopt}, std::nullopt);
+  testArraysOverlap({}, {1, std::nullopt}, false);
+  testArraysOverlap({std::nullopt}, {}, false);
+  testArraysOverlap({}, {std::nullopt}, false);
+  testArraysOverlap({pack(1, 1), pack(2, 2)}, {}, false);
 }


### PR DESCRIPTION
Summary:
Update Presto's array_intersect, array_except, and array_overalp UDFs to work with
types that provide custom comparison.  We can reuse the implementation of ValueSet
for complex types, since that just uses the compare and hash functions provided by
the Vector.  With https://github.com/facebookincubator/velox/pull/11022 these just
invoke the Type's custom implementations of these functions.

Differential Revision: D63851047


