### PR TITLE
Make exceededMaxSpillLevelLimit_ in HashBuild tsan_atomic

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -217,7 +217,7 @@ class HashBuild final : public Operator {
 
   std::shared_ptr<HashJoinBridge> joinBridge_;
 
-  bool exceededMaxSpillLevelLimit_{false};
+  tsan_atomic<bool> exceededMaxSpillLevelLimit_{false};
 
   State state_{State::kRunning};
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -620,7 +620,7 @@ class HashProbe : public Operator {
   // Indicates if this hash probe has exceeded max spill limit which is not
   // allowed to spill. This is reset when hash probe operator starts to probe
   // the next previously spilled hash table partition.
-  bool exceededMaxSpillLevelLimit_{false};
+  tsan_atomic<bool> exceededMaxSpillLevelLimit_{false};
 
   // The partition bits used to spill the hash table.
   HashBitRange tableSpillHashBits_;


### PR DESCRIPTION
Summary:
setupSpiller and canReclaim may be called concurrently in HashBuild which leads to 
TSAN errors in our tests as the write to and read from exceededMaxSpillLevelLimit_
respectively.

In practice reclaim checks for the case where exceededMaxSpillLevelLimit_ has been
updated since the last time canReclaim has been called and handles that case, so this
will not cause issues.

Marking exceededMaxSpillLevelLimit_ tsan_atomic to get the tests green.

Differential Revision: D63853455


