### PR TITLE
Throw when null row is passed to multimap_from_entries

### DIFF
--- a/velox/functions/prestosql/MultimapFromEntries.h
+++ b/velox/functions/prestosql/MultimapFromEntries.h
@@ -35,9 +35,10 @@ struct MultimapFromEntriesFunction {
     uniqueKeys_.clear();
     uniqueKeys_.reserve(inputArray.size());
 
-    for (const auto& entry : inputArray.skipNulls()) {
-      const auto& key = entry.template at<0>();
-      const auto& value = entry.template at<1>();
+    for (const auto& entry : inputArray) {
+      VELOX_USER_CHECK(entry.has_value(), "map entry cannot be null");
+      const auto& key = entry.value().template at<0>();
+      const auto& value = entry.value().template at<1>();
 
       VELOX_USER_CHECK(key.has_value(), "map key cannot be null");
 


### PR DESCRIPTION
Summary: Currently velox completely ignores null row entries in the input array whereas Presto throws when one is present. The change makes velox behave like Presto.

Differential Revision: D63870933


