### PR TITLE
Memory arbitration related code refactor

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -285,18 +285,18 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricArbitratorFailuresCount, facebook::velox::StatType::COUNT);
 
-  // Tracks the memory reclaim count on an operator.
-  DEFINE_METRIC(kMetricMemoryReclaimCount, facebook::velox::StatType::COUNT);
+  // Tracks the op memory reclaim count on an operator.
+  DEFINE_METRIC(kMetricOpMemoryReclaimCount, facebook::velox::StatType::COUNT);
 
   // Tracks op memory reclaim exec time in range of [0, 600s] with 20 buckets
   // and reports P50, P90, P99, and P100.
   DEFINE_HISTOGRAM_METRIC(
-      kMetricMemoryReclaimExecTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
+      kMetricOpMemoryReclaimTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
 
   // Tracks op memory reclaim bytes distribution in range of [0, 4GB] with 64
   // buckets and reports P50, P90, P99, and P100
   DEFINE_HISTOGRAM_METRIC(
-      kMetricMemoryReclaimedBytes,
+      kMetricOpMemoryReclaimedBytes,
       67'108'864,
       0,
       4'294'967'296,
@@ -305,9 +305,30 @@ void registerVeloxMetrics() {
       99,
       100);
 
-  // Tracks the memory reclaim count on an operator.
+  // Tracks the memory reclaim count on a query task.
   DEFINE_METRIC(
       kMetricTaskMemoryReclaimCount, facebook::velox::StatType::COUNT);
+
+  // Tracks query memory reclaim time in range of [0, 600s] with 20 buckets
+  // and reports P50, P90, P99, and P100.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricQueryMemoryReclaimTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
+
+  // Tracks query memory reclaim bytes distribution in range of [0, 4GB] with 64
+  // buckets and reports P50, P90, P99, and P100
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricQueryMemoryReclaimedBytes,
+      67'108'864,
+      0,
+      4'294'967'296,
+      50,
+      90,
+      99,
+      100);
+
+  // Tracks the memory reclaim count on a query.
+  DEFINE_METRIC(
+      kMetricQueryMemoryReclaimCount, facebook::velox::StatType::COUNT);
 
   // Tracks memory reclaim task wait time in range of [0, 60s] with 60 buckets
   // and reports P50, P90, P99, and P100.
@@ -350,25 +371,56 @@ void registerVeloxMetrics() {
       kMetricArbitratorGlobalArbitrationCount,
       facebook::velox::StatType::COUNT);
 
-  // The number of global arbitration that reclaims used memory by slow disk
-  // spilling.
+  // The time distribution of a global arbitration run [0, 600s] with 20
+  // buckets. It is configured to report the latency at P50, P90, P99, and P100
+  // percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricArbitratorGlobalArbitrationTimeMs,
+      30'000,
+      0,
+      600'000,
+      50,
+      90,
+      99,
+      100);
+
+  // The reclaimed bytes distribution of a global arbitration run in range of
+  // [0, 32GB] with 64 buckets. It is configured to report the reclaimed bytes
+  // at P50, P90, P99, and P100 percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricArbitratorGlobalArbitrationBytes,
+      512L << 20,
+      0,
+      32L << 30,
+      50,
+      90,
+      99,
+      100);
+
+  // The number of times that an arbitration operation wait for global
+  // arbitration to free up memory.
   DEFINE_METRIC(
-      kMetricArbitratorSlowGlobalArbitrationCount,
+      kMetricArbitratorGlobalArbitrationWaitCount,
       facebook::velox::StatType::COUNT);
 
-  // The distribution of the amount of time an arbitration operation stays in
-  // arbitration queues and waits the arbitration r/w locks in range of [0,
-  // 600s] with 20 buckets. It is configured to report the latency at P50, P90,
-  // P99, and P100 percentiles.
+  // The time distribution of a global arbitration wait [0, 300s] with 20
+  // buckets. It is configured to report the latency at P50, P90, P99, and P100
+  // percentiles.
   DEFINE_HISTOGRAM_METRIC(
-      kMetricArbitratorWaitTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
+      kMetricArbitratorGlobalArbitrationWaitTimeMs,
+      15'000,
+      0,
+      300'000,
+      50,
+      90,
+      99,
+      100);
 
   // The distribution of the amount of time it takes to complete a single
-  // arbitration request stays queued in range of [0, 600s] with 20
-  // buckets. It is configured to report the latency at P50, P90, P99,
-  // and P100 percentiles.
+  // arbitration operation in range of [0, 600s] with 20 buckets. It is
+  // configured to report the latency at P50, P90, P99, and P100 percentiles.
   DEFINE_HISTOGRAM_METRIC(
-      kMetricArbitratorArbitrationTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
+      kMetricArbitratorOpExecTimeMs, 30'000, 0, 600'000, 50, 90, 99, 100);
 
   // Tracks the average of free memory capacity managed by the arbitrator in
   // bytes.

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -34,14 +34,14 @@ constexpr folly::StringPiece kMetricCacheShrinkTimeMs{"velox.cache_shrink_ms"};
 constexpr folly::StringPiece kMetricMaxSpillLevelExceededCount{
     "velox.spill_max_level_exceeded_count"};
 
-constexpr folly::StringPiece kMetricMemoryReclaimExecTimeMs{
-    "velox.memory_reclaim_exec_ms"};
+constexpr folly::StringPiece kMetricQueryMemoryReclaimTimeMs{
+    "velox.query_memory_reclaim_time_ms"};
 
-constexpr folly::StringPiece kMetricMemoryReclaimedBytes{
-    "velox.memory_reclaim_bytes"};
+constexpr folly::StringPiece kMetricQueryMemoryReclaimedBytes{
+    "velox.query_memory_reclaim_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryReclaimCount{
-    "velox.memory_reclaim_count"};
+constexpr folly::StringPiece kMetricQueryMemoryReclaimCount{
+    "velox.query_memory_reclaim_count"};
 
 constexpr folly::StringPiece kMetricTaskMemoryReclaimCount{
     "velox.task_memory_reclaim_count"};
@@ -54,6 +54,15 @@ constexpr folly::StringPiece kMetricTaskMemoryReclaimExecTimeMs{
 
 constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeoutCount{
     "velox.task_memory_reclaim_wait_timeout_count"};
+
+constexpr folly::StringPiece kMetricOpMemoryReclaimTimeMs{
+    "velox.op_memory_reclaim_ms"};
+
+constexpr folly::StringPiece kMetricOpMemoryReclaimedBytes{
+    "velox.op_memory_reclaim_bytes"};
+
+constexpr folly::StringPiece kMetricOpMemoryReclaimCount{
+    "velox.op_memory_reclaim_count"};
 
 constexpr folly::StringPiece kMetricMemoryNonReclaimableCount{
     "velox.memory_non_reclaimable_count"};
@@ -79,8 +88,17 @@ constexpr folly::StringPiece kMetricArbitratorLocalArbitrationCount{
 constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationCount{
     "velox.arbitrator_global_arbitration_count"};
 
-constexpr folly::StringPiece kMetricArbitratorSlowGlobalArbitrationCount{
-    "velox.arbitrator_slow_global_arbitration_count"};
+constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationBytes{
+    "velox.arbitrator_global_arbitration_bytes"};
+
+constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationTimeMs{
+    "velox.arbitrator_global_arbitration_time_ms"};
+
+constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationWaitCount{
+    "velox.arbitrator_global_arbitration_wait_count"};
+
+constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationWaitTimeMs{
+    "velox.arbitrator_global_arbitration_wait_time_ms"};
 
 constexpr folly::StringPiece kMetricArbitratorAbortedCount{
     "velox.arbitrator_aborted_count"};
@@ -88,11 +106,8 @@ constexpr folly::StringPiece kMetricArbitratorAbortedCount{
 constexpr folly::StringPiece kMetricArbitratorFailuresCount{
     "velox.arbitrator_failures_count"};
 
-constexpr folly::StringPiece kMetricArbitratorArbitrationTimeMs{
-    "velox.arbitrator_arbitration_time_ms"};
-
-constexpr folly::StringPiece kMetricArbitratorWaitTimeMs{
-    "velox.arbitrator_wait_time_ms"};
+constexpr folly::StringPiece kMetricArbitratorOpExecTimeMs{
+    "velox.arbitrator_op_exec_time_ms"};
 
 constexpr folly::StringPiece kMetricArbitratorFreeCapacityBytes{
     "velox.arbitrator_free_capacity_bytes"};

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -541,7 +541,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
        .sumEvictScore = 10,
        .ssdStats = newSsdStats});
   arbitrator.updateStats(memory::MemoryArbitrator::Stats(
-      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
+      10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10));
   std::this_thread::sleep_for(std::chrono::milliseconds(4'000));
 
   // Stop right after sufficient wait to ensure the following reads from main

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -35,6 +35,9 @@ class ArbitrationParticipant
     : public std::enable_shared_from_this<ArbitrationParticipant> {
  public:
   struct Config {
+    /// The initial capacity of a query memory pool.
+    uint64_t initCapacity;
+
     /// The minimum capacity of a query memory pool.
     uint64_t minCapacity;
 
@@ -77,6 +80,7 @@ class ArbitrationParticipant
     double minFreeCapacityRatio;
 
     Config(
+        uint64_t _initCapacity,
         uint64_t _minCapacity,
         uint64_t _fastExponentialGrowthCapacityLimit,
         double _slowCapacityGrowRatio,
@@ -339,6 +343,7 @@ class ScopedArbitrationParticipant {
 /// decisions.
 struct ArbitrationCandidate {
   ScopedArbitrationParticipant participant;
+  int64_t currentCapacity{0};
   int64_t reclaimableUsedCapacity{0};
   int64_t reclaimableFreeCapacity{0};
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -866,7 +866,7 @@ bool MemoryPoolImpl::growCapacity(MemoryPool* requestor, uint64_t size) {
 
   bool success{false};
   {
-    ScopedMemoryPoolArbitrationCtx arbitrationCtx(requestor);
+    MemoryPoolArbitrationSection arbitrationSection(requestor);
     success = arbitrator_->growCapacity(this, size);
   }
   // The memory pool might have been aborted during the time it leaves the

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -563,7 +563,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   friend class MemoryManager;
   friend class MemoryArbitrator;
   friend class velox::memory::TestArbitrator;
-  friend class ScopedMemoryPoolArbitrationCtx;
+  friend class MemoryPoolArbitrationSection;
   friend class ArbitrationParticipant;
 
   VELOX_FRIEND_TEST(MemoryPoolTest, shrinkAndGrowAPIs);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -81,7 +81,7 @@ T getConfig(
 }
 } // namespace
 
-int64_t SharedArbitrator::ExtraConfig::getReservedCapacity(
+int64_t SharedArbitrator::ExtraConfig::reservedCapacity(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(
       getConfig<std::string>(
@@ -89,7 +89,7 @@ int64_t SharedArbitrator::ExtraConfig::getReservedCapacity(
       config::CapacityUnit::BYTE);
 }
 
-uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolInitialCapacity(
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolInitialCapacity(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(
       getConfig<std::string>(
@@ -99,7 +99,7 @@ uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolInitialCapacity(
       config::CapacityUnit::BYTE);
 }
 
-uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolReservedCapacity(
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolReservedCapacity(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(
       getConfig<std::string>(
@@ -109,7 +109,7 @@ uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolReservedCapacity(
       config::CapacityUnit::BYTE);
 }
 
-uint64_t SharedArbitrator::ExtraConfig::getMemoryReclaimMaxWaitTimeMs(
+uint64_t SharedArbitrator::ExtraConfig::memoryReclaimMaxWaitTimeMs(
     const std::unordered_map<std::string, std::string>& configs) {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
              config::toDuration(getConfig<std::string>(
@@ -119,7 +119,7 @@ uint64_t SharedArbitrator::ExtraConfig::getMemoryReclaimMaxWaitTimeMs(
       .count();
 }
 
-uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolMinFreeCapacity(
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolMinFreeCapacity(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(
       getConfig<std::string>(
@@ -129,7 +129,7 @@ uint64_t SharedArbitrator::ExtraConfig::getMemoryPoolMinFreeCapacity(
       config::CapacityUnit::BYTE);
 }
 
-double SharedArbitrator::ExtraConfig::getMemoryPoolMinFreeCapacityPct(
+double SharedArbitrator::ExtraConfig::memoryPoolMinFreeCapacityPct(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<double>(
       configs,
@@ -137,19 +137,18 @@ double SharedArbitrator::ExtraConfig::getMemoryPoolMinFreeCapacityPct(
       kDefaultMemoryPoolMinFreeCapacityPct);
 }
 
-bool SharedArbitrator::ExtraConfig::getGlobalArbitrationEnabled(
+bool SharedArbitrator::ExtraConfig::globalArbitrationEnabled(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<bool>(
       configs, kGlobalArbitrationEnabled, kDefaultGlobalArbitrationEnabled);
 }
 
-bool SharedArbitrator::ExtraConfig::getCheckUsageLeak(
+bool SharedArbitrator::ExtraConfig::checkUsageLeak(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<bool>(configs, kCheckUsageLeak, kDefaultCheckUsageLeak);
 }
 
-uint64_t
-SharedArbitrator::ExtraConfig::getFastExponentialGrowthCapacityLimitBytes(
+uint64_t SharedArbitrator::ExtraConfig::fastExponentialGrowthCapacityLimitBytes(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(
       getConfig<std::string>(
@@ -159,7 +158,7 @@ SharedArbitrator::ExtraConfig::getFastExponentialGrowthCapacityLimitBytes(
       config::CapacityUnit::BYTE);
 }
 
-double SharedArbitrator::ExtraConfig::getSlowCapacityGrowPct(
+double SharedArbitrator::ExtraConfig::slowCapacityGrowPct(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<double>(
       configs, kSlowCapacityGrowPct, kDefaultSlowCapacityGrowPct);
@@ -167,25 +166,25 @@ double SharedArbitrator::ExtraConfig::getSlowCapacityGrowPct(
 
 SharedArbitrator::SharedArbitrator(const Config& config)
     : MemoryArbitrator(config),
-      reservedCapacity_(ExtraConfig::getReservedCapacity(config.extraConfigs)),
+      reservedCapacity_(ExtraConfig::reservedCapacity(config.extraConfigs)),
       memoryPoolInitialCapacity_(
-          ExtraConfig::getMemoryPoolInitialCapacity(config.extraConfigs)),
+          ExtraConfig::memoryPoolInitialCapacity(config.extraConfigs)),
       memoryPoolReservedCapacity_(
-          ExtraConfig::getMemoryPoolReservedCapacity(config.extraConfigs)),
+          ExtraConfig::memoryPoolReservedCapacity(config.extraConfigs)),
       memoryReclaimWaitMs_(
-          ExtraConfig::getMemoryReclaimMaxWaitTimeMs(config.extraConfigs)),
+          ExtraConfig::memoryReclaimMaxWaitTimeMs(config.extraConfigs)),
       globalArbitrationEnabled_(
-          ExtraConfig::getGlobalArbitrationEnabled(config.extraConfigs)),
-      checkUsageLeak_(ExtraConfig::getCheckUsageLeak(config.extraConfigs)),
+          ExtraConfig::globalArbitrationEnabled(config.extraConfigs)),
+      checkUsageLeak_(ExtraConfig::checkUsageLeak(config.extraConfigs)),
       fastExponentialGrowthCapacityLimit_(
-          ExtraConfig::getFastExponentialGrowthCapacityLimitBytes(
+          ExtraConfig::fastExponentialGrowthCapacityLimitBytes(
               config.extraConfigs)),
       slowCapacityGrowPct_(
-          ExtraConfig::getSlowCapacityGrowPct(config.extraConfigs)),
+          ExtraConfig::slowCapacityGrowPct(config.extraConfigs)),
       memoryPoolMinFreeCapacity_(
-          ExtraConfig::getMemoryPoolMinFreeCapacity(config.extraConfigs)),
+          ExtraConfig::memoryPoolMinFreeCapacity(config.extraConfigs)),
       memoryPoolMinFreeCapacityPct_(
-          ExtraConfig::getMemoryPoolMinFreeCapacityPct(config.extraConfigs)),
+          ExtraConfig::memoryPoolMinFreeCapacityPct(config.extraConfigs)),
       freeReservedCapacity_(reservedCapacity_),
       freeNonReservedCapacity_(capacity_ - freeReservedCapacity_) {
   VELOX_CHECK_EQ(kind_, config.kind);
@@ -467,7 +466,6 @@ uint64_t SharedArbitrator::shrinkCapacity(
     MemoryPool* pool,
     uint64_t requestBytes) {
   std::lock_guard<std::mutex> l(stateLock_);
-  ++numShrinks_;
   const uint64_t freedBytes = shrinkPool(
       pool,
       requestBytes == 0 ? 0 : getCapacityShrinkTarget(*pool, requestBytes));
@@ -488,8 +486,6 @@ uint64_t SharedArbitrator::shrinkCapacity(
   getCandidates(&op);
 
   uint64_t reclaimedBytes{0};
-  RECORD_METRIC_VALUE(kMetricArbitratorSlowGlobalArbitrationCount);
-
   if (allowSpill) {
     uint64_t freedBytes{0};
     reclaimUsedMemoryFromCandidatesBySpill(&op, freedBytes);
@@ -816,7 +812,6 @@ bool SharedArbitrator::arbitrateMemory(ArbitrationOperation* op) {
   }
   VELOX_CHECK_LT(freedBytes, maxGrowTarget);
 
-  RECORD_METRIC_VALUE(kMetricArbitratorSlowGlobalArbitrationCount);
   reclaimUsedMemoryFromCandidatesBySpill(op, freedBytes);
   checkIfAborted(op);
 
@@ -956,7 +951,6 @@ uint64_t SharedArbitrator::reclaim(
   }
   reclaimedUsedBytes_ += reclaimedUsedBytes;
   reclaimedFreeBytes_ += reclaimedFreeBytes;
-  reclaimTimeUs_ += reclaimDurationUs;
   numNonReclaimableAttempts_ += reclaimerStats.numNonReclaimableAttempts;
   VELOX_MEM_LOG(INFO) << "Reclaimed from memory pool " << pool->name()
                       << " with target of " << succinctBytes(targetBytes)
@@ -1022,18 +1016,15 @@ MemoryArbitrator::Stats SharedArbitrator::stats() const {
 MemoryArbitrator::Stats SharedArbitrator::statsLocked() const {
   Stats stats;
   stats.numRequests = numRequests_;
+  stats.numRunning = numPending_;
   stats.numAborted = numAborted_;
   stats.numFailures = numFailures_;
-  stats.queueTimeUs = waitTimeUs_;
-  stats.arbitrationTimeUs = arbitrationTimeUs_;
-  stats.numShrunkBytes = reclaimedFreeBytes_;
-  stats.numReclaimedBytes = reclaimedUsedBytes_;
+  stats.reclaimedFreeBytes = reclaimedFreeBytes_;
+  stats.reclaimedUsedBytes = reclaimedUsedBytes_;
   stats.maxCapacityBytes = capacity_;
   stats.freeCapacityBytes = freeNonReservedCapacity_ + freeReservedCapacity_;
   stats.freeReservedCapacityBytes = freeReservedCapacity_;
-  stats.reclaimTimeUs = reclaimTimeUs_;
   stats.numNonReclaimableAttempts = numNonReclaimableAttempts_;
-  stats.numShrinks = numShrinks_;
   return stats;
 }
 
@@ -1056,7 +1047,11 @@ SharedArbitrator::ScopedArbitration::ScopedArbitration(
     ArbitrationOperation* operation)
     : operation_(operation),
       arbitrator_(arbitrator),
-      arbitrationCtx_(operation->requestPool),
+      arbitrationCtx_(
+          operation->requestPool == nullptr
+              ? std::make_unique<ScopedMemoryArbitrationContext>()
+              : std::make_unique<ScopedMemoryArbitrationContext>(
+                    operation->requestPool)),
       startTime_(std::chrono::steady_clock::now()) {
   VELOX_CHECK_NOT_NULL(arbitrator_);
   VELOX_CHECK_NOT_NULL(operation_);
@@ -1076,7 +1071,7 @@ SharedArbitrator::ScopedArbitration::~ScopedArbitration() {
           std::chrono::steady_clock::now() - operation_->startTime)
           .count();
   RECORD_HISTOGRAM_METRIC_VALUE(
-      kMetricArbitratorArbitrationTimeMs, arbitrationTimeUs / 1'000);
+      kMetricArbitratorOpExecTimeMs, arbitrationTimeUs / 1'000);
   addThreadLocalRuntimeStat(
       kMemoryArbitrationWallNanos,
       RuntimeCounter(arbitrationTimeUs * 1'000, RuntimeCounter::Unit::kNanos));
@@ -1100,14 +1095,6 @@ SharedArbitrator::ScopedArbitration::~ScopedArbitration() {
         RuntimeCounter(
             operation_->globalArbitrationLockWaitTimeUs * 1'000,
             RuntimeCounter::Unit::kNanos));
-  }
-  arbitrator_->arbitrationTimeUs_ += arbitrationTimeUs;
-
-  const uint64_t waitTimeUs = operation_->waitTimeUs();
-  if (waitTimeUs != 0) {
-    RECORD_HISTOGRAM_METRIC_VALUE(
-        kMetricArbitratorWaitTimeMs, waitTimeUs / 1'000);
-    arbitrator_->waitTimeUs_ += waitTimeUs;
   }
 }
 

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -42,7 +42,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     /// capacity of 'memoryPoolReservedCapacity' to run.
     static constexpr std::string_view kReservedCapacity{"reserved-capacity"};
     static constexpr std::string_view kDefaultReservedCapacity{"0B"};
-    static int64_t getReservedCapacity(
+    static int64_t reservedCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// The initial memory capacity to reserve for a newly created query memory
@@ -51,14 +51,14 @@ class SharedArbitrator : public memory::MemoryArbitrator {
         "memory-pool-initial-capacity"};
     static constexpr std::string_view kDefaultMemoryPoolInitialCapacity{
         "256MB"};
-    static uint64_t getMemoryPoolInitialCapacity(
+    static uint64_t memoryPoolInitialCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// The minimal amount of memory capacity reserved for each query to run.
     static constexpr std::string_view kMemoryPoolReservedCapacity{
         "memory-pool-reserved-capacity"};
     static constexpr std::string_view kDefaultMemoryPoolReservedCapacity{"0B"};
-    static uint64_t getMemoryPoolReservedCapacity(
+    static uint64_t memoryPoolReservedCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// Specifies the max time to wait for memory reclaim by arbitration. The
@@ -69,7 +69,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static constexpr std::string_view kMemoryReclaimMaxWaitTime{
         "memory-reclaim-max-wait-time"};
     static constexpr std::string_view kDefaultMemoryReclaimMaxWaitTime{"0ms"};
-    static uint64_t getMemoryReclaimMaxWaitTimeMs(
+    static uint64_t memoryReclaimMaxWaitTimeMs(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// When shrinking capacity, the shrink bytes will be adjusted in a way such
@@ -90,13 +90,13 @@ class SharedArbitrator : public memory::MemoryArbitrator {
         "memory-pool-min-free-capacity"};
     static constexpr std::string_view kDefaultMemoryPoolMinFreeCapacity{
         "128MB"};
-    static uint64_t getMemoryPoolMinFreeCapacity(
+    static uint64_t memoryPoolMinFreeCapacity(
         const std::unordered_map<std::string, std::string>& configs);
 
     static constexpr std::string_view kMemoryPoolMinFreeCapacityPct{
         "memory-pool-min-free-capacity-pct"};
     static constexpr double kDefaultMemoryPoolMinFreeCapacityPct{0.25};
-    static double getMemoryPoolMinFreeCapacityPct(
+    static double memoryPoolMinFreeCapacityPct(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// If true, it allows memory arbitrator to reclaim used memory cross query
@@ -104,7 +104,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static constexpr std::string_view kGlobalArbitrationEnabled{
         "global-arbitration-enabled"};
     static constexpr bool kDefaultGlobalArbitrationEnabled{false};
-    static bool getGlobalArbitrationEnabled(
+    static bool globalArbitrationEnabled(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// When growing capacity, the growth bytes will be adjusted in the
@@ -129,13 +129,13 @@ class SharedArbitrator : public memory::MemoryArbitrator {
         "fast-exponential-growth-capacity-limit"};
     static constexpr std::string_view
         kDefaultFastExponentialGrowthCapacityLimit{"512MB"};
-    static uint64_t getFastExponentialGrowthCapacityLimitBytes(
+    static uint64_t fastExponentialGrowthCapacityLimitBytes(
         const std::unordered_map<std::string, std::string>& configs);
 
     static constexpr std::string_view kSlowCapacityGrowPct{
         "slow-capacity-grow-pct"};
     static constexpr double kDefaultSlowCapacityGrowPct{0.25};
-    static double getSlowCapacityGrowPct(
+    static double slowCapacityGrowPct(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// If true, do sanity check on the arbitrator state on destruction.
@@ -144,7 +144,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     /// have been fixed.
     static constexpr std::string_view kCheckUsageLeak{"check-usage-leak"};
     static constexpr bool kDefaultCheckUsageLeak{true};
-    static bool getCheckUsageLeak(
+    static bool checkUsageLeak(
         const std::unordered_map<std::string, std::string>& configs);
   };
 
@@ -269,9 +269,9 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     ~ScopedArbitration();
 
    private:
-    ArbitrationOperation* const operation_;
+    ArbitrationOperation* const operation_{nullptr};
     SharedArbitrator* const arbitrator_;
-    const ScopedMemoryArbitrationContext arbitrationCtx_;
+    const std::unique_ptr<ScopedMemoryArbitrationContext> arbitrationCtx_;
     const std::chrono::steady_clock::time_point startTime_;
   };
 
@@ -536,12 +536,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   std::atomic_uint32_t numPending_{0};
   tsan_atomic<uint64_t> numAborted_{0};
   std::atomic_uint64_t numFailures_{0};
-  std::atomic_uint64_t waitTimeUs_{0};
-  tsan_atomic<uint64_t> arbitrationTimeUs_{0};
   tsan_atomic<uint64_t> reclaimedFreeBytes_{0};
   tsan_atomic<uint64_t> reclaimedUsedBytes_{0};
-  tsan_atomic<uint64_t> reclaimTimeUs_{0};
   tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
-  tsan_atomic<uint64_t> numShrinks_{0};
 };
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -409,6 +409,7 @@ static ArbitrationParticipant::Config arbitrationConfig(
     uint64_t minFreeCapacity = kMemoryPoolMinFreeCapacity,
     double minFreeCapacityRatio = kMemoryPoolMinFreeCapacityRatio) {
   return ArbitrationParticipant::Config{
+      0,
       minCapacity,
       fastExponentialGrowthCapacityLimit,
       slowCapacityGrowRatio,
@@ -418,6 +419,7 @@ static ArbitrationParticipant::Config arbitrationConfig(
 
 TEST_F(ArbitrationParticipantTest, config) {
   struct {
+    uint64_t initCapacity;
     uint64_t minCapacity;
     uint64_t fastExponentialGrowthCapacityLimit;
     double slowCapacityGrowRatio;
@@ -428,7 +430,8 @@ TEST_F(ArbitrationParticipantTest, config) {
 
     std::string debugString() const {
       return fmt::format(
-          "minCapacity {}, fastExponentialGrowthCapacityLimit: {}, slowCapacityGrowRatio: {}, minFreeCapacity: {}, minFreeCapacityRatio: {}, expectedError: {}, expectedToString: {}",
+          "initCapacity {}, minCapacity {}, fastExponentialGrowthCapacityLimit: {}, slowCapacityGrowRatio: {}, minFreeCapacity: {}, minFreeCapacityRatio: {}, expectedError: {}, expectedToString: {}",
+          succinctBytes(initCapacity),
           succinctBytes(minCapacity),
           succinctBytes(fastExponentialGrowthCapacityLimit),
           slowCapacityGrowRatio,
@@ -440,79 +443,89 @@ TEST_F(ArbitrationParticipantTest, config) {
   } testSettings[] = {
       {1,
        1,
+       1,
        0.1,
        1,
        0.1,
        false,
-       "minCapacity 1, fastExponentialGrowthCapacityLimit 1, slowCapacityGrowRatio 0.1, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {0,
+       1,
+       0,
+       0,
+       1,
+       0.1,
+       false,
+       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {0,
+       1,
+       0,
+       0,
+       0,
+       0,
+       false,
+       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0"},
+      {1,
+       1,
+       0,
+       0,
+       1,
+       0.1,
+       false,
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {1,
+       0,
+       1,
+       0.1,
+       1,
+       0.1,
+       false,
+       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
       {1,
        0,
        0,
+       0,
        1,
        0.1,
        false,
-       "minCapacity 1, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
+       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {0,
+       0,
+       0,
+       0,
+       0,
+       0,
+       false,
+       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0"},
+      {0,
+       0,
+       0,
+       0,
+       1,
+       0.1,
+       false,
+       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {0, 1, 0, 0.1, 1, 0.1, true, ""},
+      {0, 1, 1, 0.1, 0, 0.1, true, ""},
+      {0, 1, 1, 0.1, 1, 0, true, ""},
       {1,
-       0,
-       0,
-       0,
-       0,
-       false,
-       "minCapacity 1, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 0, minFreeCapacityRatio 0"},
-      {1,
-       0,
-       0,
        1,
-       0.1,
-       false,
-       "minCapacity 1, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
-      {0,
-       1,
-       0.1,
-       1,
-       0.1,
-       false,
-       "minCapacity 0, fastExponentialGrowthCapacityLimit 1, slowCapacityGrowRatio 0.1, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
-      {0,
-       0,
-       0,
-       1,
-       0.1,
-       false,
-       "minCapacity 0, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
-      {0,
-       0,
-       0,
-       0,
-       0,
-       false,
-       "minCapacity 0, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 0, minFreeCapacityRatio 0"},
-      {0,
-       0,
-       0,
-       1,
-       0.1,
-       false,
-       "minCapacity 0, fastExponentialGrowthCapacityLimit 0, slowCapacityGrowRatio 0, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
-      {1, 0, 0.1, 1, 0.1, true, ""},
-      {1, 1, 0.1, 0, 0.1, true, ""},
-      {1, 1, 0.1, 1, 0, true, ""},
-      {1,
        1,
        2,
        1,
        0.1,
        false,
-       "minCapacity 1, fastExponentialGrowthCapacityLimit 1, slowCapacityGrowRatio 2, minFreeCapacity 1, minFreeCapacityRatio 0.1"},
-      {1, 1, -1, 1, 0.1, true, ""},
-      {1, 1, 0.1, 1, 2, true, ""},
-      {1, 1, 0.1, 1, -1, true, ""}};
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 2, minFreeCapacity 1B, minFreeCapacityRatio 0.1"},
+      {0, 1, 1, -1, 1, 0.1, true, ""},
+      {0, 1, 1, 0.1, 1, 2, true, ""},
+      {0, 1, 1, 0.1, 1, -1, true, ""}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     if (testData.expectedError) {
       VELOX_ASSERT_THROW(
           ArbitrationParticipant::Config(
+              testData.initCapacity,
               testData.minCapacity,
               testData.fastExponentialGrowthCapacityLimit,
               testData.slowCapacityGrowRatio,
@@ -522,11 +535,13 @@ TEST_F(ArbitrationParticipantTest, config) {
       continue;
     }
     const auto config = ArbitrationParticipant::Config(
+        testData.initCapacity,
         testData.minCapacity,
         testData.fastExponentialGrowthCapacityLimit,
         testData.slowCapacityGrowRatio,
         testData.minFreeCapacity,
         testData.minFreeCapacityRatio);
+    ASSERT_EQ(testData.initCapacity, config.initCapacity);
     ASSERT_EQ(testData.minCapacity, config.minCapacity);
     ASSERT_EQ(
         testData.fastExponentialGrowthCapacityLimit,
@@ -881,7 +896,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableUsedCapacityAndReclaim) {
       {128 << 20, 0, 0.0, 128 << 20, 0, 0, 0, 0, 0},
       {128 << 20, 0, 0.0, 128 << 20, 0, 32 << 20, 0, 0, 0},
       {128 << 20, 0, 0.0, 128 << 20, 32 << 20, 0, 0, 0, 32 << 20},
-      {64 << 20, 0, 0.0, 128 << 20, 96 << 20, 0, 64 << 20, 64 << 20, 32 << 20},
+      {64 << 20, 0, 0.0, 128 << 20, 96 << 20, 0, 64 << 20, 96 << 20, 32 << 20},
       {64 << 20, 0, 0.0, 128 << 20, 128 << 20, 0, 64 << 20, 64 << 20, 64 << 20},
       {0, 32 << 20, 0.25, 128 << 20, 0, 0, 0, 0},
       {0, 64 << 20, 0.25, 128 << 20, 0, 0, 0, 0},
@@ -925,7 +940,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableUsedCapacityAndReclaim) {
        64 << 20,
        64 << 20,
        32 << 20,
-       32 << 20,
+       96 << 20,
        32 << 20},
       {32 << 20,
        32 << 20,
@@ -934,7 +949,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableUsedCapacityAndReclaim) {
        256 << 20,
        0,
        224 << 20,
-       192 << 20,
+       224 << 20,
        32 << 20},
       {32 << 20,
        64 << 20,
@@ -943,7 +958,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableUsedCapacityAndReclaim) {
        256 << 20,
        0,
        224 << 20,
-       192 << 20,
+       224 << 20,
        32 << 20}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -1549,34 +1564,30 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperation) {
       participant->lock().value(), requestBytes, opTimeoutMs);
   VELOX_ASSERT_THROW(
       ArbitrationOperation(participant->lock().value(), 0, opTimeoutMs), "");
+  VELOX_ASSERT_THROW(op.stats(), "(init vs. finished)");
   ASSERT_EQ(op.requestBytes(), requestBytes);
   ASSERT_FALSE(op.aborted());
   ASSERT_FALSE(op.hasTimeout());
-  ASSERT_EQ(op.allocatedBytes(), 0);
   ASSERT_LE(op.timeoutMs(), opTimeoutMs);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(1'000)); // NOLINT
-  ASSERT_GE(op.executionTimeMs(), 1'000);
-  ASSERT_LE(op.timeoutMs(), opTimeoutMs - 1'000);
+  std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+  ASSERT_GE(op.executionTimeMs(), 200);
+  ASSERT_LE(op.timeoutMs(), opTimeoutMs - 200);
   ASSERT_EQ(op.maxGrowBytes(), 0);
   ASSERT_EQ(op.minGrowBytes(), 0);
-  ASSERT_EQ(op.localArbitrationWaitTimeUs(), 0);
-  ASSERT_EQ(op.globalArbitrationWaitTimeUs(), 0);
   ASSERT_FALSE(op.hasTimeout());
   VELOX_ASSERT_THROW(op.setGrowTargets(), "");
   ASSERT_EQ(op.requestBytes(), requestBytes);
   ASSERT_EQ(op.maxGrowBytes(), 0);
   ASSERT_EQ(op.minGrowBytes(), 0);
 
-  ASSERT_EQ(op.localArbitrationWaitTimeUs(), 0);
-  ASSERT_EQ(op.globalArbitrationWaitTimeUs(), 0);
-
   ASSERT_EQ(op.state(), ArbitrationOperation::State::kInit);
   ASSERT_FALSE(scopedParticipant->hasRunningOp());
   ASSERT_EQ(scopedParticipant->numWaitingOps(), 0);
-  VELOX_ASSERT_THROW(op.setLocalArbitrationWaitTimeUs(2'000), "");
-  VELOX_ASSERT_THROW(op.setGlobalArbitrationWaitTimeUs(2'000), "");
+  VELOX_ASSERT_THROW(op.finish(), "");
   op.start();
+  ASSERT_EQ(op.state(), ArbitrationOperation::State::kRunning);
+  VELOX_ASSERT_THROW(op.stats(), "(running vs. finished)");
   op.setGrowTargets();
   ASSERT_EQ(op.requestBytes(), requestBytes);
   ASSERT_EQ(op.maxGrowBytes(), requestBytes);
@@ -1590,24 +1601,26 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperation) {
   ASSERT_EQ(scopedParticipant->numWaitingOps(), 0);
   ASSERT_EQ(op.state(), ArbitrationOperation::State::kRunning);
 
-  VELOX_ASSERT_THROW(op.setLocalArbitrationWaitTimeUs(2'000), "");
-  ASSERT_EQ(op.localArbitrationWaitTimeUs(), 0);
-  op.setGlobalArbitrationWaitTimeUs(2'000);
-  ASSERT_EQ(op.globalArbitrationWaitTimeUs(), 2'000);
-  VELOX_ASSERT_THROW(op.setGlobalArbitrationWaitTimeUs(2'000), "");
-  op.allocatedBytes() = op.maxGrowBytes();
+  std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+  op.startGlobalArbitration();
+  VELOX_ASSERT_THROW(op.startGlobalArbitration(), "");
+  VELOX_ASSERT_THROW(op.stats(), "(running vs. finished)");
+  std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
 
   op.finish();
   ASSERT_EQ(op.state(), ArbitrationOperation::State::kFinished);
   ASSERT_FALSE(scopedParticipant->hasRunningOp());
   ASSERT_EQ(scopedParticipant->numWaitingOps(), 0);
-  VELOX_ASSERT_THROW(op.setLocalArbitrationWaitTimeUs(2'000), "");
-  VELOX_ASSERT_THROW(op.setGlobalArbitrationWaitTimeUs(2'000), "");
+  VELOX_ASSERT_THROW(op.startGlobalArbitration(), "");
   ASSERT_FALSE(op.hasTimeout());
   const auto execTimeMs = op.executionTimeMs();
-  std::this_thread::sleep_for(std::chrono::milliseconds(1'000)); // NOLINT
+  std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
   ASSERT_EQ(op.executionTimeMs(), execTimeMs);
   ASSERT_FALSE(op.hasTimeout());
+  ASSERT_GE(op.stats().localArbitrationWaitTimeMs, 200);
+  ASSERT_GE(op.stats().localArbitrationExecTimeMs, 200);
+  ASSERT_GE(op.stats().globalArbitrationWaitTimeMs, 200);
+  ASSERT_GE(op.stats().executionTimeMs, 600);
 
   // Operation timeout.
   {
@@ -1637,6 +1650,56 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperation) {
     ArbitrationOperation abortCheckOp(
         participant->lock().value(), 1 << 20, 100);
     ASSERT_TRUE(abortCheckOp.aborted());
+  }
+}
+
+TEST_F(ArbitrationParticipantTest, arbitrationOperationStats) {
+  auto task = createTask(kMemoryCapacity);
+  const auto config = arbitrationConfig(0, 0, 0.0, 0, 0.0);
+  const int participantId{10};
+  auto participant =
+      ArbitrationParticipant::create(participantId, task->pool(), &config);
+  auto scopedParticipant = participant->lock().value();
+  const int requestBytes = 1 << 20;
+  const int opTimeoutMs = 1'000'000;
+  // Operation stats without global arbitration.
+  {
+    ArbitrationOperation op(
+        participant->lock().value(), requestBytes, opTimeoutMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    op.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    op.finish();
+    const auto stats = op.stats();
+    ASSERT_GE(stats.localArbitrationWaitTimeMs, 200);
+    ASSERT_GE(stats.localArbitrationExecTimeMs, 200);
+    ASSERT_GE(stats.globalArbitrationWaitTimeMs, 0);
+    ASSERT_GE(stats.executionTimeMs, 400);
+  }
+  // Operation stats with global arbitration.
+  {
+    ArbitrationOperation op(
+        participant->lock().value(), requestBytes, opTimeoutMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    op.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    op.startGlobalArbitration();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    op.finish();
+    const auto stats = op.stats();
+    ASSERT_GE(stats.localArbitrationWaitTimeMs, 200);
+    ASSERT_GE(stats.localArbitrationExecTimeMs, 200);
+    ASSERT_GE(stats.globalArbitrationWaitTimeMs, 200);
+    ASSERT_GE(stats.executionTimeMs, 600);
+  }
+
+  // Operation stats not started.
+  {
+    ArbitrationOperation op(
+        participant->lock().value(), requestBytes, opTimeoutMs);
+    std::this_thread::sleep_for(std::chrono::milliseconds(200)); // NOLINT
+    VELOX_ASSERT_THROW(op.finish(), "");
+    VELOX_ASSERT_THROW(op.stats(), "");
   }
 }
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -103,10 +103,8 @@ TEST_F(MemoryManagerTest, ctor) {
         "Memory Allocator[MALLOC capacity 4.00GB allocated bytes 0 "
         "allocated pages 0 mapped pages 0]\n"
         "ARBITRATOR[SHARED CAPACITY[4.00GB] PENDING[0] "
-        "STATS[numRequests 0 numAborted 0 numFailures 0 "
-        "numNonReclaimableAttempts 0 numShrinks 0 queueTime 0us "
-        "arbitrationTime 0us reclaimTime 0us shrunkMemory 0B "
-        "reclaimedMemory 0B maxCapacity 4.00GB freeCapacity 4.00GB freeReservedCapacity 0B]]]");
+        "numRequests 0 numRunning 0 numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 "
+        "reclaimedFreeCapacity 0B reclaimedUsedCapacity 0B maxCapacity 4.00GB freeCapacity 4.00GB freeReservedCapacity 0B]]");
   }
 }
 

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -623,8 +623,8 @@ DEBUG_ONLY_TEST_P(SharedArbitrationTestWithThreadingModes, reclaimToOrderBy) {
     memThread.join();
     waitForAllTasksToBeDeleted();
     const auto newStats = arbitrator_->stats();
-    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
-    ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
+    ASSERT_GT(newStats.reclaimedUsedBytes, oldStats.reclaimedUsedBytes);
+
     ASSERT_GT(orderByQueryCtx->pool()->stats().numCapacityGrowths, 0);
   }
 }
@@ -729,8 +729,7 @@ DEBUG_ONLY_TEST_P(
     waitForAllTasksToBeDeleted();
 
     const auto newStats = arbitrator_->stats();
-    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
-    ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
+    ASSERT_GT(newStats.reclaimedUsedBytes, oldStats.reclaimedUsedBytes);
   }
 }
 
@@ -845,8 +844,7 @@ DEBUG_ONLY_TEST_P(
     waitForAllTasksToBeDeleted();
 
     const auto newStats = arbitrator_->stats();
-    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
-    ASSERT_GT(newStats.reclaimTimeUs, oldStats.reclaimTimeUs);
+    ASSERT_GT(newStats.reclaimedUsedBytes, oldStats.reclaimedUsedBytes);
   }
 }
 
@@ -1428,9 +1426,7 @@ TEST_P(SharedArbitrationTestWithThreadingModes, reserveReleaseCounters) {
       for (auto& queryThread : threads) {
         queryThread.join();
       }
-      ASSERT_EQ(arbitrator_->stats().numShrinks, 0);
     }
-    ASSERT_EQ(arbitrator_->stats().numShrinks, numRootPools);
   }
 }
 

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -767,8 +767,7 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, memoryReclaim) {
       memory::testingRunArbitration();
       memory::MemoryArbitrator::Stats curStats =
           memory::memoryManager()->arbitrator()->stats();
-      ASSERT_GT(curStats.reclaimTimeUs - oldStats.reclaimTimeUs, 0);
-      ASSERT_GT(curStats.numReclaimedBytes - oldStats.numReclaimedBytes, 0);
+      ASSERT_GT(curStats.reclaimedUsedBytes - oldStats.reclaimedUsedBytes, 0);
       // We expect dwrf writer set numNonReclaimableAttempts counter.
       ASSERT_LE(
           curStats.numNonReclaimableAttempts -
@@ -779,8 +778,7 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, memoryReclaim) {
       memory::testingRunArbitration();
       memory::MemoryArbitrator::Stats curStats =
           memory::memoryManager()->arbitrator()->stats();
-      ASSERT_EQ(curStats.reclaimTimeUs - oldStats.reclaimTimeUs, 0);
-      ASSERT_EQ(curStats.numReclaimedBytes - oldStats.numReclaimedBytes, 0);
+      ASSERT_EQ(curStats.reclaimedUsedBytes - oldStats.reclaimedUsedBytes, 0);
     }
     const auto partitions = dataSink->close();
     if (testData.sortWriter && testData.expectedWriterReclaimed) {

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -92,17 +92,29 @@ Memory Management
      - The distribution of cache shrink latency in range of [0, 100s] with 10
        buckets. It is configured to report the latency at P50, P90, P99, and
        P100 percentiles.
-   * - memory_reclaim_count
+   * - op_memory_reclaim_count
      - Count
      - The count of operator memory reclaims.
-   * - memory_reclaim_exec_ms
+   * - op_memory_reclaim_time_ms
      - Histogram
-     - The distribution of memory reclaim execution time in range of [0, 600s]
+     - The distribution of operator memory reclaim execution time in range of
+       [0, 600s] with 20 buckets. It is configured to report latency at P50, P90,
+       P99, and P100 percentiles.
+   * - op_memory_reclaim_bytes
+     - Histogram
+     - The distribution of operator reclaimed bytes in range of [0, 4GB] with 64 buckets
+       and reports P50, P90, P99, and P100.
+   * - query_memory_reclaim_count
+     - Count
+     - The count of query memory reclaims.
+   * - query_memory_reclaim_time_ms
+     - Histogram
+     - The distribution of query memory reclaim execution time in range of [0, 600s]
        with 20 buckets. It is configured to report latency at P50, P90, P99, and
        P100 percentiles.
-   * - memory_reclaim_bytes
+   * - query_memory_reclaim_bytes
      - Histogram
-     - The distribution of reclaimed bytes in range of [0, 4GB] with 64 buckets
+     - The distribution of query reclaimed bytes in range of [0, 4GB] with 64 buckets
        and reports P50, P90, P99, and P100.
    * - task_memory_reclaim_count
      - Count
@@ -144,9 +156,6 @@ Memory Management
        initiate the memory arbitration request. This indicates the velox runtime doesn't have
        enough memory to run all the queries at their peak memory usage. We have to trigger
        spilling to let them run through completion.
-   * - arbitrator_slow_global_arbitration_count
-     - Count
-     - The number of global arbitration that reclaims used memory by slow disk spilling.
    * - arbitrator_aborted_count
      - Count
      - The number of times a query level memory pool is aborted as a result of
@@ -159,18 +168,24 @@ Memory Management
        its request, the arbitration request would surpass the maximum allowed
        capacity for the requester, or the arbitration process couldn't release
        the requested amount of memory.
-   * - arbitrator_wait_time_ms
+   * - arbitrator_global_arbitration_time_ms
      - Histogram
-     - The distribution of the amount of time an arbitration request stays in
-       arbitration queues and waits the arbitration r/w locks in range of [0, 600s]
-       with 20 buckets. It is configured to report the latency at P50, P90, P99,
-       and P100 percentiles.
-   * - arbitrator_arbitration_time_ms
+     - The time distribution of a global arbitration run [0, 600s] with 20 buckets.
+       It is configured to report the latency at P50, P90, P99, and P100 percentiles.
+   * - arbitrator_global_arbitration_wait_count
+     - Count
+     - The number of times that an arbitration operation wait for global
+       arbitration to free up memory.
+   * - arbitrator_global_arbitration_wait_time_ms
+     - Histogram
+     - The time distribution of a global arbitration wait [0, 300s] with 20
+       buckets. It is configured to report the latency at P50, P90, P99, and P100
+       percentiles.
+   * - arbitrator_op_exec_time_ms
      - Histogram
      - The distribution of the amount of time it take to complete a single
-       arbitration request stays queued in range of [0, 600s] with 20
-       buckets. It is configured to report the latency at P50, P90, P99,
-       and P100 percentiles.
+       arbitration operation in range of [0, 600s] with 20 buckets. It is configured
+       to report the latency at P50, P90, P99 and P100 percentiles.
    * - arbitrator_free_capacity_bytes
      - Average
      - The average of total free memory capacity which is managed by the

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -7052,7 +7052,7 @@ TEST_F(HashJoinTest, reclaimFromJoinBuilderWithMultiDrivers) {
   // the scope
   waitForAllTasksToBeDeleted();
   ASSERT_GT(arbitrator->stats().numRequests, 0);
-  ASSERT_GT(arbitrator->stats().numReclaimedBytes, 0);
+  ASSERT_GT(arbitrator->stats().reclaimedUsedBytes, 0);
 }
 
 DEBUG_ONLY_TEST_F(
@@ -7689,7 +7689,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpill) {
 
           const auto* arbitrator = memory::memoryManager()->arbitrator();
           ASSERT_GT(arbitrator->stats().numRequests, 0);
-          ASSERT_GT(arbitrator->stats().numReclaimedBytes, 0);
+          ASSERT_GT(arbitrator->stats().reclaimedUsedBytes, 0);
         })
         .run();
   }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -3714,7 +3714,6 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, writerFlushThreshold) {
     const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
     const int numPrevNonReclaimableAttempts =
         arbitrator->stats().numNonReclaimableAttempts;
-    const int numPrevShrinks = arbitrator->stats().numShrinks;
     auto queryCtx = core::QueryCtx::create(
         executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
     ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
@@ -3792,10 +3791,9 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, writerFlushThreshold) {
     ASSERT_EQ(
         arbitrator->stats().numNonReclaimableAttempts,
         numPrevNonReclaimableAttempts);
-    ASSERT_GE(arbitrator->stats().numReclaimedBytes, testParam.bytesToReserve);
+    ASSERT_GE(arbitrator->stats().reclaimedUsedBytes, testParam.bytesToReserve);
     waitForAllTasksToBeDeleted(3'000'000);
     queryCtx.reset();
-    ASSERT_EQ(arbitrator->stats().numShrinks, numPrevShrinks + 1);
   }
 }
 
@@ -3908,7 +3906,7 @@ DEBUG_ONLY_TEST_F(
   const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
   const int numPrevNonReclaimableAttempts =
       arbitrator->stats().numNonReclaimableAttempts;
-  const int numPrevReclaimedBytes = arbitrator->stats().numReclaimedBytes;
+  const int numPrevReclaimedBytes = arbitrator->stats().reclaimedUsedBytes;
   auto queryCtx = core::QueryCtx::create(
       executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
@@ -3979,7 +3977,7 @@ DEBUG_ONLY_TEST_F(
       arbitrator->stats().numNonReclaimableAttempts,
       numPrevArbitrationFailures);
   ASSERT_EQ(arbitrator->stats().numFailures, numPrevNonReclaimableAttempts);
-  ASSERT_GT(arbitrator->stats().numReclaimedBytes, numPrevReclaimedBytes);
+  ASSERT_GT(arbitrator->stats().reclaimedUsedBytes, numPrevReclaimedBytes);
   waitForAllTasksToBeDeleted();
 }
 


### PR DESCRIPTION
Summary:
Update participant operator methods to better support global arbitration.
Remove stats from existing arbitrator stats which are not used much in production monitoring to simplify code
Add memory arbitration context type to differentiate local arbitration context and global arbitration context. The latter
doesn't have an associated request memory poll as in global arbitration optimization
Rename ScopedMemoryPoolArbitrationContext to MemoryPoolArbitrationSection as we have too many context things
in memory code space
Add metrics used by global arbitration optimization and remove the ones not used much in production monitoring

Differential Revision: D63815963


