### PR TITLE
Fix casting "Generic" Vectors to FlatVector<UnknownValue>

### DIFF
--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -332,7 +332,7 @@ struct SimpleTypeTrait<IntervalYearMonth> : public SimpleTypeTrait<int32_t> {
 
 template <typename T, bool comparable, bool orderable>
 struct SimpleTypeTrait<Generic<T, comparable, orderable>> {
-  static constexpr TypeKind typeKind = TypeKind::UNKNOWN;
+  static constexpr TypeKind typeKind = TypeKind::INVALID;
   static constexpr bool isPrimitiveType = false;
   static constexpr bool isFixedWidth = false;
 };

--- a/velox/vector/VectorTypeUtils.h
+++ b/velox/vector/VectorTypeUtils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -84,5 +85,9 @@ struct TypeToFlatVector {
   using type = typename KindToFlatVector<SimpleTypeTrait<T>::typeKind>::type;
 };
 
+template <typename T, bool comparable, bool orderable>
+struct TypeToFlatVector<Generic<T, comparable, orderable>> {
+  using type = BaseVector;
+};
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary:
In simple functions and simple aggregations, there's a bunch of places where we use 
TypeToFlatVector to decide how to cast a VectorPtr to its concrete type.  Notably in
the VectorWriters for complex types which we use in simple functions, we use this to
cast the child Vectors of the complex Vectors we'll write to.

Today, if the type is Generic, we cast to a FlatVector<UnknownValue>.  This is wrong
as the Vector could be of any flat-like Vector (FlatVector, ArrayVector, MapVector,
etc.).  Ultimately this just sort of works AFAICT because the GenericWriter ignores
whatever type it was cast to and treats it as a generic BaseVector. It's generally
unsafe though, and UBSan is catching this in our Fuzzer tests.

To fix this, I updated the TypeKind of a Generic in SimpleTypeTrait to be INVALID
rather than UNKNOWN.  UNKNOWN is intended for Vectors of nulls where
the type can't be determined.  In this case the type can be determined in the code
designed to handle Generics, and if you're trying to use the TypeKind of a Generic
in SimpleTypeTrait you're probably doing something wrong, so INVALID seems like a
better fit.  The TypeTraits for INVALID are also not primitive and not fixed width unlike
those for UNKNOWN which matches the other fields in SimpleTypeTrait for Generic.

I also updated TypeToFlatVector to add a template specialization that sets type to
BaseVector, rather than using KindToFlatVector. This is consistent with where these
Vectors are used (e.g. GenericWriter) and makes the casts safe.

Differential Revision: D63905959


