### PR TITLE
Remove array_nomralize for int 128_t

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -312,7 +312,6 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayNormalizeFunctions<int16_t>(prefix);
   registerArrayNormalizeFunctions<int32_t>(prefix);
   registerArrayNormalizeFunctions<int64_t>(prefix);
-  registerArrayNormalizeFunctions<int128_t>(prefix);
   registerArrayNormalizeFunctions<float>(prefix);
   registerArrayNormalizeFunctions<double>(prefix);
 }


### PR DESCRIPTION
Summary: Removing registration for 128_t since std::abs does not support it. Details in: https://github.com/facebookincubator/velox/issues/11178

Differential Revision: D63964992


