### PR TITLE
Free hash table after grouping set/row number spill to release memory plus a hash table fix

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -742,7 +742,7 @@ bool GroupingSet::getOutput(
       : 0;
   if (numGroups == 0) {
     if (table_ != nullptr) {
-      table_->clear();
+      table_->clear(/*freeTable=*/true);
     }
     return false;
   }
@@ -789,9 +789,9 @@ void GroupingSet::extractGroups(
   }
 }
 
-void GroupingSet::resetTable() {
+void GroupingSet::resetTable(bool freeTable) {
   if (table_ != nullptr) {
-    table_->clear();
+    table_->clear(freeTable);
   }
 }
 
@@ -1012,7 +1012,7 @@ void GroupingSet::spill() {
   if (sortedAggregations_) {
     sortedAggregations_->clear();
   }
-  table_->clear();
+  table_->clear(/*freeTable=*/true);
 }
 
 void GroupingSet::spill(const RowContainerIterator& rowIterator) {
@@ -1038,7 +1038,7 @@ void GroupingSet::spill(const RowContainerIterator& rowIterator) {
   // guarantee we don't accidentally enter an unsafe situation.
   rows->stringAllocator().freezeAndExecute(
       [&]() { spiller_->spill(rowIterator); });
-  table_->clear();
+  table_->clear(/*freeTable=*/true);
 }
 
 bool GroupingSet::getOutputWithSpill(

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -78,8 +78,9 @@ class GroupingSet {
 
   /// Resets the hash table inside the grouping set when partial aggregation
   /// is full or reclaims memory from distinct aggregation after it has received
-  /// all the inputs.
-  void resetTable();
+  /// all the inputs. If 'freeTable' is false, then hash table itself is not
+  /// freed but only table content.
+  void resetTable(bool freeTable = false);
 
   /// Returns true if 'this' should start producing partial
   /// aggregation results. Checks the memory consumption against

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -412,7 +412,7 @@ void HashAggregation::reclaim(
     }
     if (isDistinct_) {
       // Since we have seen all the input, we can safely reset the hash table.
-      groupingSet_->resetTable();
+      groupingSet_->resetTable(/*freeTable=*/true);
       // Release the minimum reserved memory.
       pool()->release();
       return;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -728,7 +728,7 @@ void HashTable<ignoreNullKeys>::allocateTables(
       memory::AllocationTraits::numPages(size * tableSlotSize());
   rows_->pool()->allocateContiguous(numPages, tableAllocation_);
   table_ = tableAllocation_.data<char*>();
-  memset(table_, 0, capacity_ * sizeof(char*));
+  ::memset(table_, 0, capacity_ * sizeof(char*));
 }
 
 template <bool ignoreNullKeys>
@@ -743,6 +743,7 @@ void HashTable<ignoreNullKeys>::clear(bool freeTable) {
     } else {
       rows_->pool()->freeContiguous(tableAllocation_);
       table_ = nullptr;
+      capacity_ = 0;
     }
   }
   numDistinct_ = 0;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -643,6 +643,10 @@ class HashTable : public BaseHashTable {
     return rehashSize();
   }
 
+  char** testingTable() const {
+    return table_;
+  }
+
   void extractColumn(
       folly::Range<char* const*> rows,
       int32_t columnIndex,

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -327,7 +327,7 @@ RowVectorPtr RowNumber::getOutput() {
       addInput(std::move(unspilledInput));
     } else {
       spillInputReader_ = nullptr;
-      table_->clear();
+      table_->clear(/*freeTable=*/true);
       restoreNextSpillPartition();
     }
   }
@@ -412,7 +412,7 @@ SpillPartitionNumSet RowNumber::spillHashTable() {
   hashTableSpiller->spill();
   hashTableSpiller->finishSpill(spillHashTablePartitionSet_);
 
-  table_->clear();
+  table_->clear(/*freeTable=*/true);
   pool()->release();
   return hashTableSpiller->state().spilledPartitionSet();
 }
@@ -454,6 +454,10 @@ void RowNumber::spill() {
   if (input_ != nullptr) {
     spillInput(input_, memory::spillMemoryPool());
     input_ = nullptr;
+  }
+  if (generateRowNumber_) {
+    results_.clear();
+    results_.resize(1);
   }
 }
 

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -390,6 +390,8 @@ DEBUG_ONLY_TEST_F(RowNumberTest, spillOnlyDuringInputOrOutput) {
           }
 
           testingRunArbitration(op->pool(), 0);
+          // We expect all the memory to be freed after the spill.
+          ASSERT_EQ(op->pool()->usedBytes(), 0);
         })));
 
     core::PlanNodeId rowNumberPlanNodeId;


### PR DESCRIPTION
Summary:
Found in shadow testing that hash aggregation can use non-trivial amount of memory like a couple hundred MB
after reclaim because the hash table held by grouping set. Currently we only clear the hash table in grouping set
but not free the table inside (only free groups). Similar for row number operator.

This PR change includes
(1) free table after spill for both row number and grouping set to make memory reclamation or arbitration
efficient and see significant improvement in global arbitration shadow testing.
(2) free row number result vector in row number spill to have more strict test check and we assume a single
vector is small and just free 1MB per operator in real workload.
(3) fix free table in hash table which doesn't reset capacity and add unit test to cover

Differential Revision: D63964822


