### PR TITLE
Replace nproc in macOS setup script

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -104,7 +104,7 @@ function install_boost {
   (
     cd ${DEPENDENCY_DIR}/boost
     ./bootstrap.sh --prefix=${INSTALL_PREFIX}
-    ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+    ${SUDO} ./b2 "-j${NPROC}" -d0 install threading=multi --without-python
   )
 }
 


### PR DESCRIPTION
nproc may not be found on macOS causing boost not to install. Instead, switch to use existing NPROC to determine the number of logical CPU that nproc would have returned.