### PR TITLE
Use Velox filesystem for SSD cache data file

### DIFF
--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
@@ -45,6 +46,7 @@ class SsdFileTest : public testing::Test {
   static constexpr int64_t kMB = 1 << 20;
 
   void SetUp() override {
+    filesystems::registerLocalFileSystem();
     memory::MemoryManager::testingSetInstance({});
   }
 


### PR DESCRIPTION
Summary:
SSD cache currently uses native functions for file operations. This needs to be switched to Velox filesystem, so more advanced testing can be built by leveraging features like fault injections.

Differential Revision: D64008883


