### PR TITLE
Fix data race in cache eviction path

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -130,8 +130,8 @@ void AsyncDataCacheEntry::initialize(FileCacheKey key) {
       // No memory to cover 'this'.
       release();
       VELOX_CACHE_ERROR(fmt::format(
-          "Failed to allocate {} bytes for cache: {}",
-          size_,
+          "Failed to allocate {} pages for cache: {}",
+          sizePages,
           cache->allocator()->getAndClearFailureMessage()));
     }
   }


### PR DESCRIPTION
Summary:
The cache entry init code path (thread) logs an error message with cache entry size when allocation fails.
This happens after it releases the cache entry which could be race with cache eviction code path which clears
to zero. The fix is to print out the allocated pages instead of bytes in cache error message to prevent.

Differential Revision: D64014938


