### PR TITLE
Fix flaky test HiveConnectorSerDeTest

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -1031,8 +1031,10 @@ std::string HiveInsertTableHandle::toString() const {
   }
 
   if (serdeParameters_.size() > 0) {
+    std::map<std::string, std::string> sortedSerdeParams(
+        serdeParameters_.begin(), serdeParameters_.end());
     out << ", serdeParameters: ";
-    for (const auto& [key, value] : serdeParameters_) {
+    for (const auto& [key, value] : sortedSerdeParams) {
       out << "[" << key << ", " << value << "] ";
     }
   }


### PR DESCRIPTION
The test compares unordered maps from a direct toString() without ordering, creating flakiness. The fix sorts the map before printing.