### PR TITLE
Avoid additional memory allocation during sort output spill

### DIFF
--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -77,6 +77,9 @@ class SortBuffer {
   void updateEstimatedOutputRowSize();
   // Invoked to initialize or reset the reusable output buffer to get output.
   void prepareOutput(vector_size_t maxOutputRows);
+  // Invoked to initialize reader to read the spilled data from storage for
+  // output processing.
+  void prepareOutputWithSpill();
   void getOutputWithoutSpill();
   void getOutputWithSpill();
   // Spill during input stage.
@@ -116,6 +119,7 @@ class SortBuffer {
   // sort key columns are stored first then the non-sorted data columns.
   RowTypePtr spillerStoreType_;
   std::unique_ptr<Spiller> spiller_;
+  SpillPartitionSet spillPartitionSet_;
   // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
   // Records the source rows to copy to 'output_' in order.

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -85,15 +85,13 @@ class MemoryArbitrationFuzzer {
 
   struct Stats {
     size_t successCount{0};
-    size_t failureCount{0};
     size_t oomCount{0};
     size_t abortCount{0};
 
     void print() const {
       std::stringstream ss;
-      ss << "Success count = " << successCount
-         << ", failure count = " << failureCount
-         << ". OOM count  = " << oomCount << " Abort count = " << abortCount;
+      ss << "Success count = " << successCount << ". OOM count  = " << oomCount
+         << " Abort count = " << abortCount;
       LOG(INFO) << ss.str();
     }
   };
@@ -714,7 +712,7 @@ void MemoryArbitrationFuzzer::verify() {
           } else if (e.errorCode() == error_code::kMemAborted.c_str()) {
             ++lockedStats->abortCount;
           } else {
-            ++lockedStats->failureCount;
+            LOG(ERROR) << "Unexpected exception: " << e.what();
             std::rethrow_exception(std::current_exception());
           }
         }


### PR DESCRIPTION
Summary:
Memory arbitration fuzzer is flaky because of the unexpected memory allocation after sort output spill finish.
The reason is that when we finish spill, we setup the merge reader to prepare reading the unspilled data. 
The merge reader might use non-trivial amount of data which cause additional memory consumption. And 
we shall keep the spill critical path as fast as possible. This PR moves the merge reader setup from the spill
path to the first get output with unit tests. Also improve the fuzzer test logging a bit to help debug.

Differential Revision: D64072660


