### PR TITLE
De-flake DriverTest.pause

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -288,9 +288,9 @@ Task::Task(
     std::function<void(std::exception_ptr)> onError)
     : uuid_{makeUuid()},
       taskId_(taskId),
+      queryCtx_(std::move(queryCtx)),
       planFragment_(std::move(planFragment)),
       destination_(destination),
-      queryCtx_(std::move(queryCtx)),
       traceConfig_(maybeMakeTraceConfig()),
       mode_(mode),
       consumerSupplier_(std::move(consumerSupplier)),
@@ -347,6 +347,7 @@ Task::~Task() {
   CLEAR(childPools_.clear());
   CLEAR(pool_.reset());
   CLEAR(planFragment_ = core::PlanFragment());
+  CLEAR(queryCtx_.reset());
   clearStage = "exiting ~Task()";
 
   // Ful-fill the task deletion promises at the end.

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -992,9 +992,12 @@ class Task : public std::enable_shared_from_this<Task> {
   // Application specific task ID specified at construction time. May not be
   // unique or universally unique.
   const std::string taskId_;
+  // QueryContext should be declared before planFragment as
+  // planFragment may allocate memory in query mempool held by queryContext
+  std::shared_ptr<core::QueryCtx> queryCtx_;
   core::PlanFragment planFragment_;
   const int destination_;
-  const std::shared_ptr<core::QueryCtx> queryCtx_;
+
   const std::optional<trace::QueryTraceConfig> traceConfig_;
 
   // The execution mode of the task. It is enforced that a task can only be


### PR DESCRIPTION
Summary: This diff fixes a rare race between test shutdown and Task shutdowm. Even though Test shutdown waits for Task constructor to finish, Test shutdown was not waiting for all member variables of Task to be cleaned up: for example task.queryCtx_ holds memory pool and if task.queryCtx_ is not freed before test shutdown, we get test failure. This diff fixes queryCtx_ destruction by reseting the pointer in ~Task.

Reviewed By: xiaoxmeng

Differential Revision: D64026457


