### PR TITLE
De-flake DriverTest.pause

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -288,11 +288,11 @@ Task::Task(
     std::function<void(std::exception_ptr)> onError)
     : uuid_{makeUuid()},
       taskId_(taskId),
-      planFragment_(std::move(planFragment)),
       destination_(destination),
-      queryCtx_(std::move(queryCtx)),
-      traceConfig_(maybeMakeTraceConfig()),
       mode_(mode),
+      queryCtx_(std::move(queryCtx)),
+      planFragment_(std::move(planFragment)),
+      traceConfig_(maybeMakeTraceConfig()),
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(std::move(onError)),
       splitsStates_(buildSplitStates(planFragment_.planNode)),
@@ -347,6 +347,7 @@ Task::~Task() {
   CLEAR(childPools_.clear());
   CLEAR(pool_.reset());
   CLEAR(planFragment_ = core::PlanFragment());
+  CLEAR(queryCtx_.reset());
   clearStage = "exiting ~Task()";
 
   // Ful-fill the task deletion promises at the end.

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -992,14 +992,18 @@ class Task : public std::enable_shared_from_this<Task> {
   // Application specific task ID specified at construction time. May not be
   // unique or universally unique.
   const std::string taskId_;
-  core::PlanFragment planFragment_;
+
   const int destination_;
-  const std::shared_ptr<core::QueryCtx> queryCtx_;
-  const std::optional<trace::QueryTraceConfig> traceConfig_;
 
   // The execution mode of the task. It is enforced that a task can only be
   // executed in a single mode throughout its lifetime
   const ExecutionMode mode_;
+
+  std::shared_ptr<core::QueryCtx> queryCtx_;
+
+  core::PlanFragment planFragment_;
+
+  const std::optional<trace::QueryTraceConfig> traceConfig_;
 
   // Hook in the system wide task list.
   TaskListEntry taskListEntry_;


### PR DESCRIPTION
Summary: This diff fixes a rare race between test shutdown and Task shutdowm. Even though Test shutdown waits for Task constructor to finish, Test shutdown was not waiting for all member variables of Task to be cleaned up: for example task.queryCtx_ holds memory pool and if task.queryCtx_ is not freed before test shutdown, we get test failure. This diff fixes queryCtx_ destruction by reseting the pointer in ~Task.

Reviewed By: xiaoxmeng

Differential Revision: D64026457


