### PR TITLE
Supports serializing a range of rows for UnsafeRowFast

### DIFF
--- a/velox/row/UnsafeRowFast.h
+++ b/velox/row/UnsafeRowFast.h
@@ -43,6 +43,18 @@ class UnsafeRowFast {
   /// 'buffer' must have sufficient capacity and set to all zeros.
   int32_t serialize(vector_size_t index, char* buffer) const;
 
+  /// Serializes rows in the range [offset, offset + size) into 'buffer' at
+  /// given 'bufferOffsets'. 'buffer' must have sufficient capacity and set to
+  /// all zeros for null-bits handling. 'bufferOffsets' must be pre-filled with
+  /// the write offsets for each row and must be accessible for 'size' elements.
+  /// The caller must ensure that the space between each offset in
+  /// 'bufferOffsets' is no less than the 'fixedRowSize' or 'rowSize'.
+  void serialize(
+      vector_size_t offset,
+      vector_size_t size,
+      char* buffer,
+      const size_t* bufferOffsets);
+
  protected:
   explicit UnsafeRowFast(const VectorPtr& vector);
 
@@ -110,6 +122,14 @@ class UnsafeRowFast {
   /// Serializes struct value to buffer. Value must not be null.
   int32_t serializeRow(vector_size_t index, char* buffer) const;
 
+  /// Serializes struct values in range [offset, offset + size) to buffer.
+  /// Value must not be null.
+  void serializeRow(
+      vector_size_t offset,
+      vector_size_t size,
+      char* buffer,
+      const size_t* bufferOffsets);
+
   const TypeKind typeKind_;
   DecodedVector decoded_;
 
@@ -129,5 +149,8 @@ class UnsafeRowFast {
 
   // Fixed-width types only. Number of bytes used for a single value.
   size_t valueBytes_;
+
+  // ROW type only. True if children have variable-width type.
+  bool hasVariableWidth_{false};
 };
 } // namespace facebook::velox::row

--- a/velox/row/UnsafeRowFast.h
+++ b/velox/row/UnsafeRowFast.h
@@ -52,8 +52,8 @@ class UnsafeRowFast {
   void serialize(
       vector_size_t offset,
       vector_size_t size,
-      char* buffer,
-      const size_t* bufferOffsets);
+      const size_t* bufferOffsets,
+      char* buffer) const;
 
  protected:
   explicit UnsafeRowFast(const VectorPtr& vector);
@@ -121,14 +121,6 @@ class UnsafeRowFast {
 
   /// Serializes struct value to buffer. Value must not be null.
   int32_t serializeRow(vector_size_t index, char* buffer) const;
-
-  /// Serializes struct values in range [offset, offset + size) to buffer.
-  /// Value must not be null.
-  void serializeRow(
-      vector_size_t offset,
-      vector_size_t size,
-      char* buffer,
-      const size_t* bufferOffsets);
 
   const TypeKind typeKind_;
   DecodedVector decoded_;

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -95,6 +95,8 @@ class UnsafeRowFuzzTests : public ::testing::Test {
 
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();
+
+  BufferPtr buffer_;
 };
 
 TEST_F(UnsafeRowFuzzTests, fast) {
@@ -187,9 +189,39 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       auto rowSize = fast.serialize(i, buffers_[i]);
       VELOX_CHECK_LE(rowSize, kBufferSize);
 
-      EXPECT_EQ(rowSize, fast.rowSize(i)) << i << ", " << data->toString(i);
+    std::vector<size_t> rowSize(numRows);
+    std::vector<size_t> offsets(numRows);
+    size_t totalSize = 0;
+    if (auto fixedRowSize = UnsafeRowFast::fixedRowSize(rowType)) {
+      totalSize = fixedRowSize.value() * numRows;
+      for (auto i = 0; i < numRows; ++i) {
+        rowSize[i] = fixedRowSize.value();
+        offsets[i] = fixedRowSize.value() * i;
+      }
+    } else {
+      for (auto i = 0; i < numRows; ++i) {
+        rowSize[i] = fast.rowSize(i);
+        offsets[i] = totalSize;
+        totalSize += rowSize[i];
+      }
+    }
 
-      serialized.push_back(std::string_view(buffers_[i], rowSize));
+    buffer_ = AlignedBuffer::allocate<char>(totalSize, pool_.get(), 0);
+    auto* rawBuffer = buffer_->asMutable<char>();
+
+    vector_size_t offset = 0;
+    vector_size_t rangeSize = 1;
+    // Serialize with different range size.
+    while (offset < numRows) {
+      auto size = std::min<vector_size_t>(rangeSize, numRows - offset);
+      fast.serialize(offset, size, rawBuffer, offsets.data() + offset);
+      offset += size;
+      rangeSize = checkedMultiply<vector_size_t>(rangeSize, 2);
+    }
+
+    for (auto i = 0; i < numRows; ++i) {
+      serialized.push_back(
+          std::string_view(rawBuffer + offsets[i], rowSize[i]));
     }
     return serialized;
   });

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -93,10 +93,10 @@ class UnsafeRowFuzzTests : public ::testing::Test {
 
   std::array<char[kBufferSize], kNumBuffers> buffers_{};
 
-  BufferPtr buffer_;
-
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::memoryManager()->addLeafPool();
+
+  BufferPtr buffer_;
 };
 
 TEST_F(UnsafeRowFuzzTests, fast) {

--- a/velox/serializers/benchmarks/RowSerializerBenchmark.cpp
+++ b/velox/serializers/benchmarks/RowSerializerBenchmark.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 
 #include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::test {
@@ -27,6 +28,14 @@ class RowSerializerBenchmark {
       const RowTypePtr& rowType,
       vector_size_t rangeSize) {
     serializer::CompactRowVectorSerde::registerVectorSerde();
+    serialize(rowType, rangeSize);
+    deregisterVectorSerde();
+  }
+
+  void unsafeRowVectorSerde(
+      const RowTypePtr& rowType,
+      vector_size_t rangeSize) {
+    serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
     serialize(rowType, rangeSize);
     deregisterVectorSerde();
   }
@@ -72,17 +81,33 @@ class RowSerializerBenchmark {
     RowSerializerBenchmark benchmark;                \
     benchmark.compactRowVectorSerde(rowType, 1);     \
   }                                                  \
+  BENCHMARK(unsafe_serialize_1_##name) {             \
+    RowSerializerBenchmark benchmark;                \
+    benchmark.unsafeRowVectorSerde(rowType, 1);      \
+  }                                                  \
   BENCHMARK(compact_serialize_10_##name) {           \
     RowSerializerBenchmark benchmark;                \
     benchmark.compactRowVectorSerde(rowType, 10);    \
+  }                                                  \
+  BENCHMARK(unsafe_serialize_10_##name) {            \
+    RowSerializerBenchmark benchmark;                \
+    benchmark.unsafeRowVectorSerde(rowType, 10);     \
   }                                                  \
   BENCHMARK(compact_serialize_100_##name) {          \
     RowSerializerBenchmark benchmark;                \
     benchmark.compactRowVectorSerde(rowType, 100);   \
   }                                                  \
+  BENCHMARK(unsafe_serialize_100_##name) {           \
+    RowSerializerBenchmark benchmark;                \
+    benchmark.unsafeRowVectorSerde(rowType, 100);    \
+  }                                                  \
   BENCHMARK(compact_serialize_1000_##name) {         \
     RowSerializerBenchmark benchmark;                \
     benchmark.compactRowVectorSerde(rowType, 1'000); \
+  }                                                  \
+  BENCHMARK(unsafe_serialize_1000_##name) {          \
+    RowSerializerBenchmark benchmark;                \
+    benchmark.unsafeRowVectorSerde(rowType, 1'000);  \
   }
 
 VECTOR_SERDE_BENCHMARKS(

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -50,9 +50,15 @@ class UnsafeRowSerializerTest : public ::testing::Test,
   void serialize(RowVectorPtr rowVector, std::ostream* output) {
     const auto numRows = rowVector->size();
 
-    std::vector<IndexRange> ranges(numRows);
-    for (int i = 0; i < numRows; i++) {
-      ranges[i] = IndexRange{i, 1};
+    // Serialize with different range size.
+    std::vector<IndexRange> ranges;
+    vector_size_t offset = 0;
+    vector_size_t rangeSize = 1;
+    while (offset < numRows) {
+      auto size = std::min<vector_size_t>(rangeSize, numRows - offset);
+      ranges.push_back(IndexRange{offset, size});
+      offset += size;
+      rangeSize = checkedMultiply<vector_size_t>(rangeSize, 2);
     }
 
     std::unique_ptr<row::UnsafeRowFast> unsafeRow;
@@ -79,7 +85,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     } else {
       Scratch scratch;
       serializer->append(
-          rowVector, folly::Range(ranges.data(), numRows), scratch);
+          rowVector, folly::Range(ranges.data(), ranges.size()), scratch);
     }
 
     auto size = serializer->maxSerializedSize();


### PR DESCRIPTION
Adopt similar optimization from https://github.com/facebookincubator/velox/pull/10714

Peformance improvment of benchmark `velox_unsafe_row_serialize_benchmark - unsafe_serialize`

```
| Test Name            | Time (us) - before            | Time (us) - after                   | Improvement (%) |
|----------------------|-------------------------------|-------------------------------------|-----------------|
| fixedWidth5          | 43.86                         | 22.33                               | 49.09           |
| fixedWidth10         | 80.24                         | 40.67                               | 49.31           |
| fixedWidth20         | 156.73                        | 66.24                               | 57.73           |
| strings1             | 30.76                         | 25.12                               | 18.33           |
| strings5             | 89.66                         | 77.42                               | 13.65           |
| arrays               | 43.64                         | 36.72                               | 15.86           |
| nestedArrays         | 251.33                        | 247.79                              | 1.41            |
| maps                 | 109.51                        | 105.94                              | 3.26            |
| structs              | 70.81                         | 67.46                               | 4.73            |

```