### PR TITLE
Fix the bug that RowIndex column type cannot be serialized

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -25,7 +25,7 @@ columnTypeNames() {
       {HiveColumnHandle::ColumnType::kPartitionKey, "PartitionKey"},
       {HiveColumnHandle::ColumnType::kRegular, "Regular"},
       {HiveColumnHandle::ColumnType::kSynthesized, "Synthesized"},
-  };
+      {HiveColumnHandle::ColumnType::kRowIndex, "RowIndex"}};
 }
 
 template <typename K, typename V>


### PR DESCRIPTION
Summary:
I came across a bug when I tried to serialize a TableScanNode with special row index column. 

### The isssue
`folly::dynamic HiveColumnHandle::serialize()` uses `columnTypeNames` to serialize the TableScanNode. However, RowIndex is missing in `columnTypeNames`. serialize method would raise a std::out_of_range error because of this.

### The fix
The fix is simple -- just add row index column to the map.

Differential Revision: D64088125


