### PR TITLE
Fix nullable bug of Arrow MapVector in Bridge.cpp

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -34,6 +34,10 @@ namespace {
 // and one for offsets (2).
 static constexpr size_t kMaxBuffers{3};
 
+void clearNullableFlag(int64_t& flags) {
+  flags = flags & (~ARROW_FLAG_NULLABLE);
+}
+
 // Structure that will hold the buffers needed by ArrowArray. This is opaquely
 // carried by ArrowArray.private_data
 class VeloxToArrowBridgeHolder {
@@ -1446,6 +1450,10 @@ void exportToArrow(
           maps.getNullCount());
       exportToArrow(rows, *child, options);
       child->name = "entries";
+      // Map data should be a non-nullable struct type.
+      clearNullableFlag(child->flags);
+      // Map data key type should be non-nullable.
+      clearNullableFlag(child->children[0]->flags);
       bridgeHolder->setChildAtIndex(0, std::move(child), arrowSchema);
 
     } else if (type->kind() == TypeKind::ARRAY) {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -87,6 +87,11 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
       EXPECT_STREQ("+m", schema->format);
       ASSERT_EQ(schema->n_children, 1);
       schema = schema->children[0];
+      // Map data should be a non-nullable struct type
+      ASSERT_EQ(schema->flags & ARROW_FLAG_NULLABLE, 0);
+      ASSERT_EQ(schema->n_children, 2);
+      // Map data key type should be a non-nullable
+      ASSERT_EQ(schema->children[0]->flags & ARROW_FLAG_NULLABLE, 0);
     } else if (type->kind() == TypeKind::ROW) {
       EXPECT_STREQ("+s", schema->format);
     }


### PR DESCRIPTION
There is a constraint defined in [arrow/format/Schema.fbs](https://github.com/apache/arrow/blob/a153dcb7ae1f61e705472574a5890b33db8cb76a/format/Schema.fbs#L138), which requires the MapVector itself and the key of MapVector to be not nullable.

> /// Neither the "entries" field nor the "key" field may be nullable.


There are also two not-nullable constraints in the Java implementation of MapVector:
1. Map data should be a non-nullable struct type;
https://github.com/apache/arrow/blob/d4516c5386f84619dfdf2a9f72fed6d7df89704c/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java#L98
2. Map data key type should be a non-nullable;
https://github.com/apache/arrow/blob/d4516c5386f84619dfdf2a9f72fed6d7df89704c/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java#L105

However, When the velox convert the MapVector to Arrow MapVector, velox will set the flag of MapVector to nullable, which violates these constraints: https://github.com/facebookincubator/velox/blob/acd57170b6d98206def1ef02b74c467e3ba18061/velox/vector/arrow/Bridge.cpp#L1388

