### PR TITLE
Fix GTest_SOURCE=BUNDLED not work

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -59,6 +59,7 @@ jobs:
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
+      GTest_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
       xsimd_SOURCE: BUNDLED
       CUDA_VERSION: "12.4"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,7 @@ include_directories(SYSTEM velox/external)
 
 # these were previously vendored in third-party/
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  set(GTest_SOURCE AUTO)
+  set_source(GTest)
   resolve_dependency(GTest)
   set(VELOX_GTEST_INCUDE_DIR
       "${gtest_SOURCE_DIR}/googletest/include"


### PR DESCRIPTION
### Description

I failed to build velox in ubuntu and clang-15, because I have gtest-1.11.0 installed (to successully build we need v1.13.0).
When I try to set `-DGTest_SOURCE=BUNDLED` the cmake output shows that it does not work. 

```
/data1/home/wujianchao/.cache/JetBrains/RemoteDev/dist/1729cdbf0ed8b_CLion-2024.2.2/bin/cmake/linux/x64/bin/cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=/usr/lib/llvm-15/bin/clang -DCMAKE_CXX_COMPILER=/usr/lib/llvm-15/bin/clang++ -DGTest_SOURCE=BUNDLED -DCMAKE_PREFIX_PATH=/data1/home/wujianchao/project/jd/velox/deps-install -G "Unix Makefiles" -S /data1/home/wujianchao/project/jd/velox -B /data1/home/wujianchao/project/jd/velox/cmake-build-debug

....

-- Could NOT find double-conversion (missing: double-conversion_DIR)
-- Found double-conversion: /usr/lib/x86_64-linux-gnu/libdouble-conversion.so (Required is at least version "3.1.5")
-- Found GTest: /usr/local/lib/cmake/GTest/GTestConfig.cmake (found version "1.11.0")
-- Using SYSTEM GTest

````