### PR TITLE
Add CMake option for 'ENABLE_ALL_WARNINGS' to match Makefile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,34 +338,36 @@ if("${MAX_LINK_JOBS}")
 endif()
 
 if("${ENABLE_ALL_WARNINGS}")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-        "-Wno-range-loop-analysis \
-         -Wno-mismatched-tags \
-         -Wno-nullability-completeness")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-        "-Wno-implicit-fallthrough \
-         -Wno-class-memaccess \
-         -Wno-comment \
-         -Wno-int-in-bool-context \
-         -Wno-redundant-move \
-         -Wno-array-bounds \
-         -Wno-maybe-uninitialized \
-         -Wno-unused-result \
-         -Wno-format-overflow \
-         -Wno-strict-aliasing")
-  endif()
-
-  set(KNOWN_WARNINGS
-      "-Wno-unused \
-       -Wno-unused-parameter \
-       -Wno-sign-compare \
-       -Wno-ignored-qualifiers \
-       ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ${KNOWN_WARNINGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(KNOWN_COMPILER_SPECIFIC_WARNINGS
+      "-Wno-range-loop-analysis \
+       -Wno-mismatched-tags \
+       -Wno-nullability-completeness")
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(KNOWN_COMPILER_SPECIFIC_WARNINGS
+      "-Wno-implicit-fallthrough \
+       -Wno-class-memaccess \
+       -Wno-comment \
+       -Wno-int-in-bool-context \
+       -Wno-redundant-move \
+       -Wno-array-bounds \
+       -Wno-maybe-uninitialized \
+       -Wno-unused-result \
+       -Wno-format-overflow \
+       -Wno-strict-aliasing")
+endif()
+
+set(KNOWN_WARNINGS
+    "-Wno-unused \
+     -Wno-unused-parameter \
+     -Wno-sign-compare \
+     -Wno-ignored-qualifiers \
+     ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
 
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ option(
    This will override other build options."
   OFF)
 option(VELOX_MONO_LIBRARY "Build single unified library." OFF)
+option(ENABLE_ALL_WARNINGS "Enable -Wall and -Wextra compiler warnings." ON)
 
 # option() always creates a BOOL variable so we have to use a normal cache
 # variable with STRING type for this option.
@@ -337,11 +338,11 @@ if("${MAX_LINK_JOBS}")
   set(CMAKE_JOB_POOL_LINK link_job_pool)
 endif()
 
-if("${ENABLE_ALL_WARNINGS}")
+if(ENABLE_ALL_WARNINGS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # regular Clang or AppleClang
   set(KNOWN_COMPILER_SPECIFIC_WARNINGS
       "-Wno-range-loop-analysis \
        -Wno-mismatched-tags \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,36 +339,34 @@ if("${MAX_LINK_JOBS}")
 endif()
 
 if(ENABLE_ALL_WARNINGS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
+        "-Wno-range-loop-analysis \
+         -Wno-mismatched-tags \
+         -Wno-nullability-completeness")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(KNOWN_COMPILER_SPECIFIC_WARNINGS
+        "-Wno-implicit-fallthrough \
+         -Wno-class-memaccess \
+         -Wno-comment \
+         -Wno-int-in-bool-context \
+         -Wno-redundant-move \
+         -Wno-array-bounds \
+         -Wno-maybe-uninitialized \
+         -Wno-unused-result \
+         -Wno-format-overflow \
+         -Wno-strict-aliasing")
+  endif()
+
+  set(KNOWN_WARNINGS
+      "-Wno-unused \
+       -Wno-unused-parameter \
+       -Wno-sign-compare \
+       -Wno-ignored-qualifiers \
+       ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra ${KNOWN_WARNINGS}")
 endif()
-
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang") # regular Clang or AppleClang
-  set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-      "-Wno-range-loop-analysis \
-       -Wno-mismatched-tags \
-       -Wno-nullability-completeness")
-elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set(KNOWN_COMPILER_SPECIFIC_WARNINGS
-      "-Wno-implicit-fallthrough \
-       -Wno-class-memaccess \
-       -Wno-comment \
-       -Wno-int-in-bool-context \
-       -Wno-redundant-move \
-       -Wno-array-bounds \
-       -Wno-maybe-uninitialized \
-       -Wno-unused-result \
-       -Wno-format-overflow \
-       -Wno-strict-aliasing")
-endif()
-
-set(KNOWN_WARNINGS
-    "-Wno-unused \
-     -Wno-unused-parameter \
-     -Wno-sign-compare \
-     -Wno-ignored-qualifiers \
-     ${KNOWN_COMPILER_SPECIFIC_WARNINGS}")
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${KNOWN_WARNINGS}")
 
 message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
Fixes #11217

### Changelog
1. Add CMake option 'ENABLE_ALL_WARNINGS' to align pure CMake execution with Makefile