### PR TITLE
Add tests for array_union and array_remove with TimestampWithTimezone

### DIFF
--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -387,4 +388,98 @@ TEST_F(ArrayIntersectTest, dictionaryEncodedElementsInConstant) {
       expected,
       "array_intersect(c0, testing_dictionary_array_elements(ARRAY [2, 2, 3, 1, 2, 2]))",
       {array});
+}
+
+TEST_F(ArrayIntersectTest, timestampWithTimezone) {
+  auto testArrayIntersect =
+      [this](
+          const std::vector<std::optional<int64_t>>& inputArray1,
+          const std::vector<std::optional<int64_t>>& inputArray2,
+          const std::vector<std::optional<int64_t>>& expectedArrayForward,
+          const std::vector<std::optional<int64_t>>& expectedArrayBackward) {
+        const auto input1 = makeArrayVector(
+            {0},
+            makeNullableFlatVector(inputArray1, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto input2 = makeArrayVector(
+            {0},
+            makeNullableFlatVector(inputArray2, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto expectedForward = makeArrayVector(
+            {0},
+            makeNullableFlatVector(
+                expectedArrayForward, TIMESTAMP_WITH_TIME_ZONE()));
+        const auto expectedBackward = makeArrayVector(
+            {0},
+            makeNullableFlatVector(
+                expectedArrayBackward, TIMESTAMP_WITH_TIME_ZONE()));
+
+        testExpr(expectedForward, "array_intersect(c0, c1)", {input1, input2});
+        testExpr(expectedBackward, "array_intersect(c1, c0)", {input1, input2});
+      };
+
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(-2, 1),
+       pack(3, 2),
+       std::nullopt,
+       pack(4, 3),
+       pack(5, 4),
+       pack(6, 5),
+       std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 1), pack(4, 3)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)});
+  testArrayIntersect(
+      {pack(1, 0), pack(2, 1), pack(-2, 2), pack(1, 3)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 2)},
+      {pack(1, 10), pack(-2, 11)});
+  testArrayIntersect(
+      {pack(3, 0), pack(8, 1), std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {},
+      {});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(1, 1),
+       pack(-2, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(4, 5),
+       pack(8, 6)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      {pack(1, 0), pack(-2, 2), pack(4, 5)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(-2, 1),
+       pack(3, 2),
+       std::nullopt,
+       pack(4, 3),
+       pack(5, 4),
+       pack(6, 5),
+       std::nullopt},
+      {pack(10, 10), pack(-24, 11), pack(43, 12)},
+      {},
+      {});
+  testArrayIntersect(
+      {pack(1, 0), pack(2, 1), pack(-2, 2), pack(1, 3)},
+      {std::nullopt, pack(-2, 10), pack(2, 11)},
+      {pack(2, 1), pack(-2, 2)},
+      {pack(-2, 10), pack(2, 11)});
+  testArrayIntersect(
+      {pack(3, 0), pack(8, 1), std::nullopt},
+      {std::nullopt, std::nullopt, std::nullopt},
+      {std::nullopt},
+      {std::nullopt});
+  testArrayIntersect(
+      {pack(1, 0),
+       pack(1, 1),
+       pack(-2, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(4, 5),
+       pack(8, 6)},
+      {pack(8, 10), pack(1, 11), pack(8, 12), pack(1, 13)},
+      {pack(1, 0), pack(8, 6)},
+      {pack(8, 10), pack(1, 11)});
 }

--- a/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -204,6 +205,56 @@ TEST_F(ArrayRemoveTest, arrayWithNull) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
   const auto expected = makeNullableArrayVector<int64_t>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+TEST_F(ArrayRemoveTest, timestampWithTimeZone) {
+  const auto arrayVector = makeArrayVector(
+      {0, 6, 13, 16},
+      makeNullableFlatVector<int64_t>(
+          {pack(1, 1),
+           std::nullopt,
+           pack(2, 2),
+           pack(3, 3),
+           std::nullopt,
+           pack(4, 4),
+           pack(3, 5),
+           pack(4, 6),
+           pack(5, 7),
+           std::nullopt,
+           pack(3, 8),
+           pack(4, 9),
+           pack(5, 10),
+           pack(7, 11),
+           pack(8, 12),
+           pack(9, 13),
+           pack(10, 14),
+           pack(20, 15),
+           pack(30, 16)},
+          TIMESTAMP_WITH_TIME_ZONE()));
+  const auto elementVector = makeFlatVector<int64_t>(
+      {pack(3, 3), pack(3, 3), pack(33, 1), pack(30, 1)},
+      TIMESTAMP_WITH_TIME_ZONE());
+  const auto expected = makeArrayVector(
+      {0, 5, 10, 13},
+      makeNullableFlatVector<int64_t>(
+          {pack(1, 1),
+           std::nullopt,
+           pack(2, 2),
+           std::nullopt,
+           pack(4, 4),
+           pack(4, 6),
+           pack(5, 7),
+           std::nullopt,
+           pack(4, 9),
+           pack(5, 10),
+           pack(7, 11),
+           pack(8, 12),
+           pack(9, 13),
+           pack(10, 14),
+           pack(20, 15)},
+          TIMESTAMP_WITH_TIME_ZONE()));
   testExpression(
       "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
 }

--- a/velox/functions/prestosql/tests/ArrayUnionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayUnionTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -167,5 +168,81 @@ TEST_F(ArrayUnionTest, complexTypes) {
 TEST_F(ArrayUnionTest, floatingPointType) {
   floatArrayTest<float>();
   floatArrayTest<double>();
+}
+
+TEST_F(ArrayUnionTest, timestampWithTimeZone) {
+  const auto array1 = makeArrayVector(
+      {0, 4, 7, 10},
+      makeFlatVector<int64_t>(
+          {pack(1, 1),
+           pack(2, 2),
+           pack(3, 3),
+           pack(4, 4),
+           pack(3, 5),
+           pack(4, 6),
+           pack(5, 7),
+           pack(7, 8),
+           pack(8, 9),
+           pack(9, 10),
+           pack(10, 11),
+           pack(20, 12),
+           pack(30, 13)},
+          TIMESTAMP_WITH_TIME_ZONE()));
+  const auto array2 = makeArrayVector(
+      {0, 3, 6, 6},
+      makeFlatVector<int64_t>(
+          {pack(2, 10),
+           pack(4, 11),
+           pack(5, 12),
+           pack(3, 13),
+           pack(4, 14),
+           pack(5, 15),
+           pack(40, 16),
+           pack(50, 17)},
+          TIMESTAMP_WITH_TIME_ZONE()));
+
+  VectorPtr expected = makeArrayVector(
+      {0, 5, 8, 11},
+      makeFlatVector<int64_t>(
+          {pack(1, 1),
+           pack(2, 2),
+           pack(3, 3),
+           pack(4, 4),
+           pack(5, 12),
+           pack(3, 5),
+           pack(4, 6),
+           pack(5, 7),
+           pack(7, 8),
+           pack(8, 9),
+           pack(9, 10),
+           pack(10, 11),
+           pack(20, 12),
+           pack(30, 13),
+           pack(40, 16),
+           pack(50, 17)},
+          TIMESTAMP_WITH_TIME_ZONE()));
+  testExpression("array_union(c0, c1)", {array1, array2}, expected);
+
+  expected = makeArrayVector(
+      {0, 5, 8, 11},
+      makeFlatVector<int64_t>(
+          {pack(2, 10),
+           pack(4, 11),
+           pack(5, 12),
+           pack(1, 1),
+           pack(3, 3),
+           pack(3, 13),
+           pack(4, 14),
+           pack(5, 15),
+           pack(7, 8),
+           pack(8, 9),
+           pack(9, 10),
+           pack(40, 16),
+           pack(50, 17),
+           pack(10, 11),
+           pack(20, 12),
+           pack(30, 13)},
+          TIMESTAMP_WITH_TIME_ZONE()));
+  testExpression("array_union(c0, c1)", {array2, array1}, expected);
 }
 } // namespace

--- a/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/ArraysOverlapTest.cpp
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
 
 using namespace facebook::velox;
@@ -312,4 +313,70 @@ TEST_F(ArraysOverlapTest, dictionaryEncodedElementsInConstant) {
       expected,
       "arrays_overlap(testing_dictionary_array_elements(ARRAY [2, 2, 3, 1, 2, 2]), c0)",
       {array});
+}
+
+TEST_F(ArraysOverlapTest, TimestampWithTimezone) {
+  auto testArraysOverlap =
+      [this](
+          const std::vector<std::optional<int64_t>>& array1,
+          const std::vector<std::optional<int64_t>>& array2,
+          std::optional<bool> expected) {
+        auto arrayVector1 = makeArrayVector(
+            {0}, makeNullableFlatVector(array1, TIMESTAMP_WITH_TIME_ZONE()));
+        auto arrayVector2 = makeArrayVector(
+            {0}, makeNullableFlatVector(array2, TIMESTAMP_WITH_TIME_ZONE()));
+        auto expectedVector = makeNullableFlatVector<bool>({expected});
+
+        testExpr(
+            expectedVector,
+            "arrays_overlap(C0, C1)",
+            {arrayVector1, arrayVector2});
+        testExpr(
+            expectedVector,
+            "arrays_overlap(C1, C0)",
+            {arrayVector1, arrayVector2});
+      };
+
+  testArraysOverlap(
+      {pack(1, 1),
+       pack(-2, 2),
+       pack(3, 3),
+       std::nullopt,
+       pack(4, 4),
+       pack(5, 5),
+       pack(6, 6),
+       std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(1, 1), pack(2, 2), pack(-2, 3), pack(1, 4)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(3, 1), pack(8, 2), std::nullopt},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      std::nullopt);
+  testArraysOverlap(
+      {pack(1, 1),
+       pack(1, 2),
+       pack(-2, 3),
+       pack(-2, 4),
+       pack(-2, 5),
+       pack(4, 6),
+       pack(8, 7)},
+      {pack(1, 10), pack(-2, 11), pack(4, 12)},
+      true);
+  testArraysOverlap(
+      {pack(2, 1), pack(-1, 2)},
+      {pack(1, 1), pack(-2, 2), std::nullopt},
+      std::nullopt);
+  testArraysOverlap(
+      {pack(1, 1), pack(2, 2), pack(3, 3)},
+      {pack(5, 1), pack(6, 2), pack(7, 3)},
+      false);
+  testArraysOverlap({std::nullopt}, {std::nullopt}, std::nullopt);
+  testArraysOverlap({}, {1, std::nullopt}, false);
+  testArraysOverlap({std::nullopt}, {}, false);
+  testArraysOverlap({}, {std::nullopt}, false);
+  testArraysOverlap({pack(1, 1), pack(2, 2)}, {}, false);
 }


### PR DESCRIPTION
Summary:
With https://github.com/facebookincubator/velox/pull/11136 array_union and
array_remove just work with TimestampWithTimezone.

Adding unit tests to verify this and ensure it doesn't break in the future.

Differential Revision: D64196032


