### PR TITLE
Move ApproxPercentile intermediate type index to header file

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h"
 #include "velox/common/base/IOUtils.h"
 #include "velox/common/base/Macros.h"
 #include "velox/common/base/RandomUtil.h"
@@ -167,18 +168,6 @@ struct KllSketchAccumulator {
   KllSketch<T> sketch_;
   std::vector<std::pair<T, int64_t>, StlAllocator<std::pair<T, int64_t>>>
       largeCountValues_;
-};
-
-enum IntermediateTypeChildIndex {
-  kPercentiles = 0,
-  kPercentilesIsArray = 1,
-  kAccuracy = 2,
-  kK = 3,
-  kN = 4,
-  kMinValue = 5,
-  kMaxValue = 6,
-  kItems = 7,
-  kLevels = 8,
 };
 
 void checkWeight(int64_t weight) {

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::aggregate::prestosql {
+
+enum ApproxPercentileIntermediateTypeChildIndex {
+  kPercentiles = 0,
+  kPercentilesIsArray = 1,
+  kAccuracy = 2,
+  kK = 3,
+  kN = 4,
+  kMinValue = 5,
+  kMaxValue = 6,
+  kItems = 7,
+  kLevels = 8,
+};
+
+} // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Summary: Moved the enum `IntermediateTypeChildIndex` of ApproxPercentileAggregate function to header file.

Differential Revision: D64121943


