### PR TITLE
Support yield in bucket sort table write getout to prevent stuck driver detection

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -523,6 +523,12 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricFileWriterEarlyFlushedRawBytes, facebook::velox::StatType::SUM);
 
+  // The distribution of the amount of time spent on hive sort writer finish
+  // call in range of [0, 120s] with 60 buckets. It is configured to report the
+  // latency at P50, P90, P99, and P100 percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricHiveSortWriterFinishTimeMs, 2'000, 0, 120'000, 50, 90, 99, 100);
+
   // The current spilling memory usage in bytes.
   DEFINE_METRIC(kMetricSpillMemoryBytes, facebook::velox::StatType::AVG);
 

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -162,6 +162,9 @@ constexpr folly::StringPiece kMetricSpillPeakMemoryBytes{
 constexpr folly::StringPiece kMetricFileWriterEarlyFlushedRawBytes{
     "velox.file_writer_early_flushed_raw_bytes"};
 
+constexpr folly::StringPiece kMetricHiveSortWriterFinishTimeMs{
+    "velox.hive_sort_writer_finish_time_ms"};
+
 constexpr folly::StringPiece kMetricArbitratorRequestsCount{
     "velox.arbitrator_requests_count"};
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -170,8 +170,12 @@ class DataSink {
   /// TODO maybe at some point we want to make it async.
   virtual void appendData(RowVectorPtr input) = 0;
 
-  /// Returns the stats of this data sink.
-  virtual Stats stats() const = 0;
+  /// Called after all data has been added via possibly multiple calls to
+  /// appendData() This function finishes the data procesing like sort all the
+  /// added data and write them to the file writer. The finish might take long
+  /// time so it returns false to yield in the middle of processing. The
+  /// function returns true if it has processed all data. This call is blocking.
+  virtual bool finish() = 0;
 
   /// Called once after all data has been added via possibly multiple calls to
   /// appendData(). The function returns the metadata of written data in string
@@ -181,6 +185,9 @@ class DataSink {
   /// Called to abort this data sink object and we don't expect any appendData()
   /// calls on an aborted data sink object.
   virtual void abort() = 0;
+
+  /// Returns the stats of this data sink.
+  virtual Stats stats() const = 0;
 };
 
 class DataSource {

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -314,6 +314,13 @@ uint64_t HiveConfig::sortWriterMaxOutputBytes(
       config::CapacityUnit::BYTE);
 }
 
+uint64_t HiveConfig::sortWriterFinishTimeSliceLimitMs(
+    const config::ConfigBase* session) const {
+  return session->get<uint64_t>(
+      kSortWriterFinishTimeSliceLimitMsSession,
+      config_->get<uint64_t>(kSortWriterFinishTimeSliceLimitMs, 5'000));
+}
+
 uint64_t HiveConfig::footerEstimatedSize() const {
   return config_->get<uint64_t>(kFooterEstimatedSize, 1UL << 20);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -240,6 +240,13 @@ class HiveConfig {
   static constexpr const char* kSortWriterMaxOutputBytesSession =
       "sort_writer_max_output_bytes";
 
+  /// Sort Writer will exit finish() method after this many milliseconds even if
+  /// it has not completed its work yet. Zero means no time limit.
+  static constexpr const char* kSortWriterFinishTimeSliceLimitMs =
+      "sort-writer_finish_time_slice_limit_ms";
+  static constexpr const char* kSortWriterFinishTimeSliceLimitMsSession =
+      "sort_writer_finish_time_slice_limit_ms";
+
   static constexpr const char* kS3UseProxyFromEnv =
       "hive.s3.use-proxy-from-env";
 
@@ -354,6 +361,9 @@ class HiveConfig {
   uint32_t sortWriterMaxOutputRows(const config::ConfigBase* session) const;
 
   uint64_t sortWriterMaxOutputBytes(const config::ConfigBase* session) const;
+
+  uint64_t sortWriterFinishTimeSliceLimitMs(
+      const config::ConfigBase* session) const;
 
   uint64_t footerEstimatedSize() const;
 

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -69,6 +69,8 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 1024);
   ASSERT_EQ(
       hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
+  ASSERT_EQ(
+      hiveConfig.sortWriterFinishTimeSliceLimitMs(emptySession.get()), 5'000);
   ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(emptySession.get()), true);
   ASSERT_EQ(hiveConfig.allowNullPartitionKeys(emptySession.get()), true);
   ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(emptySession.get()), 1024);
@@ -109,6 +111,7 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kOrcWriterStringDictionaryEncodingEnabled, "false"},
       {HiveConfig::kSortWriterMaxOutputRows, "100"},
       {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
+      {HiveConfig::kSortWriterFinishTimeSliceLimitMs, "400"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
       {HiveConfig::kOrcWriterMinCompressionSize, "512"},
       {HiveConfig::kOrcWriterCompressionLevel, "1"},
@@ -159,6 +162,8 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 100);
   ASSERT_EQ(
       hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 100UL << 20);
+  ASSERT_EQ(
+      hiveConfig.sortWriterFinishTimeSliceLimitMs(emptySession.get()), 400);
   ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(emptySession.get()), 512);
   ASSERT_EQ(hiveConfig.orcWriterCompressionLevel(emptySession.get()), 1);
   ASSERT_EQ(
@@ -180,6 +185,7 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kOrcWriterStringDictionaryEncodingEnabledSession, "false"},
       {HiveConfig::kSortWriterMaxOutputRowsSession, "20"},
       {HiveConfig::kSortWriterMaxOutputBytesSession, "20MB"},
+      {HiveConfig::kSortWriterFinishTimeSliceLimitMsSession, "300"},
       {HiveConfig::kPartitionPathAsLowerCaseSession, "false"},
       {HiveConfig::kAllowNullPartitionKeysSession, "false"},
       {HiveConfig::kIgnoreMissingFilesSession, "true"},
@@ -227,6 +233,7 @@ TEST(HiveConfigTest, overrideSession) {
       false);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputBytes(session.get()), 20UL << 20);
+  ASSERT_EQ(hiveConfig.sortWriterFinishTimeSliceLimitMs(session.get()), 300);
   ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(session.get()), false);
   ASSERT_EQ(hiveConfig.allowNullPartitionKeys(session.get()), false);
   ASSERT_EQ(hiveConfig.ignoreMissingFiles(session.get()), true);

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -544,3 +544,10 @@ Hive Connector
      - The distribution of hive file open latency in range of [0, 100s] with 10
        buckets. It is configured to report latency at P50, P90, P99, and P100
        percentiles.
+   * - hive_sort_writer_finish_time_ms
+     - Histogram
+     - The distribution of hive sort writer finish processing time slice in range
+       of[0, 120s] with 60 buckets. It is configured to report latency at P50,
+       P90, P99, and P100 percentiles.
+
+

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -29,14 +29,17 @@ class SortingWriter : public Writer {
       std::unique_ptr<Writer> writer,
       std::unique_ptr<exec::SortBuffer> sortBuffer,
       vector_size_t maxOutputRowsConfig,
-      uint64_t maxOutputBytesConfig);
+      uint64_t maxOutputBytesConfig,
+      uint64_t outputTimeSliceLimitMs);
 
   ~SortingWriter() override;
 
   void write(const VectorPtr& data) override;
 
+  bool finish() override;
+
   /// No action because we need to accumulate all data and sort before data can
-  /// be flushed
+  /// be flushed.
   void flush() override;
 
   void close() override;
@@ -78,6 +81,7 @@ class SortingWriter : public Writer {
   const std::unique_ptr<Writer> outputWriter_;
   const vector_size_t maxOutputRowsConfig_;
   const uint64_t maxOutputBytesConfig_;
+  const uint64_t finishTimeSliceLimitMs_;
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
 

--- a/velox/dwio/common/tests/WriterTest.cpp
+++ b/velox/dwio/common/tests/WriterTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/dwio/common/Writer.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace ::testing;
 
@@ -25,7 +26,10 @@ TEST(WriterTest, stateString) {
   ASSERT_EQ(Writer::stateString(Writer::State::kInit), "INIT");
   ASSERT_EQ(Writer::stateString(Writer::State::kRunning), "RUNNING");
   ASSERT_EQ(Writer::stateString(Writer::State::kClosed), "CLOSED");
+  ASSERT_EQ(Writer::stateString(Writer::State::kFinishing), "FINISHING");
   ASSERT_EQ(Writer::stateString(Writer::State::kAborted), "ABORTED");
+  VELOX_ASSERT_THROW(
+      Writer::stateString(static_cast<Writer::State>(100)), "BAD STATE: 100");
 }
 } // namespace
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -76,6 +76,10 @@ class Writer : public dwio::common::Writer {
   // Forces the writer to flush, does not close the writer.
   virtual void flush() override;
 
+  virtual bool finish() override {
+    return true;
+  }
+
   virtual void close() override;
 
   virtual void abort() override;

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -150,6 +150,10 @@ class Writer : public dwio::common::Writer {
   // Forces a row group boundary before the data added by next write().
   void newRowGroup(int32_t numRows);
 
+  bool finish() override {
+    return true;
+  }
+
   // Closes 'this', After close, data can no longer be added and the completed
   // Parquet file is flushed into 'sink' provided at construction. 'sink' stays
   // live until destruction of 'this'.

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -1086,7 +1086,10 @@ StopReason Driver::blockDriver(
       future.valid(),
       "The operator {} is blocked but blocking future is not valid",
       op->operatorType());
-
+  VELOX_CHECK_NE(blockingReason_, BlockingReason::kNotBlocked);
+  if (blockingReason_ == BlockingReason::kYield) {
+    recordYieldCount();
+  }
   blockedOperatorId_ = blockedOperatorId;
   blockingState = std::make_shared<BlockingState>(
       self, std::move(future), op, blockingReason_);

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -758,6 +758,16 @@ DriverThreadContext* driverThreadContext();
 } // namespace facebook::velox::exec
 
 template <>
+struct fmt::formatter<facebook::velox::exec::BlockingReason>
+    : formatter<std::string> {
+  auto format(facebook::velox::exec::BlockingReason b, format_context& ctx)
+      const {
+    return formatter<std::string>::format(
+        facebook::velox::exec::blockingReasonToString(b), ctx);
+  }
+};
+
+template <>
 struct fmt::formatter<facebook::velox::exec::StopReason>
     : formatter<std::string> {
   auto format(facebook::velox::exec::StopReason s, format_context& ctx) const {

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -104,9 +104,7 @@ class TableWriter : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
 
-  BlockingReason isBlocked(ContinueFuture* /* future */) override {
-    return BlockingReason::kNotBlocked;
-  }
+  BlockingReason isBlocked(ContinueFuture* future) override;
 
   void initialize() override;
 
@@ -192,6 +190,8 @@ class TableWriter : public Operator {
 
   void createDataSink();
 
+  bool finishDataSink();
+
   std::vector<std::string> closeDataSink();
 
   void abortDataSink();
@@ -214,6 +214,10 @@ class TableWriter : public Operator {
   std::unique_ptr<connector::DataSink> dataSink_;
   std::vector<column_index_t> inputMapping_;
   std::shared_ptr<const RowType> mappedType_;
+
+  // The blocking future might be set when finish data sink.
+  ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
+  BlockingReason blockingReason_{BlockingReason::kNotBlocked};
 
   bool finished_{false};
   bool closed_{false};


### PR DESCRIPTION
Summary:
Support yield in the middle of sort writer get output processing to prevent stuck driver detection as well
as friendly to other concurrent running queries or threads. We found in production that the long running get
output from sort writer can trigger alerts as it does sort, potential read spilled data from remote storage
and, encode and flush to remote storage through file writer. This can take hour in case of a small bucket
table which only has 64 buckets such as only 64 threads in the whole
cluster for running the query.

This PR adds finish API to data sink and file writer for table writer to do incremental sort and flush processing.
The data sink finish API call each file writer's finish API and both check the configured finish time slice limit
which are configured through a hive config. Both API returns false if finish needs continue processing or true
when finishes. Correspondingly, when table writer get output it returns null if finish data sink has more work
to do and set the ready block future and yield reason for driver framework to check and yield.

This PR also changes data sink and file writer interface with a new finish state. A new hive config
added for finish time slice limit. The driver framework adds to report the yield from a operator which
currently only reports the yield metric when the yield is triggered by the driver framework itself. A new
histogram metric is added to track the sort writer finish time distribution to monitoring

Differential Revision: D64159781


