### PR TITLE
fix: Add supports time zone adjustment when reading and writing Timestamp data

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -56,7 +56,13 @@ VectorPtr newConstantFromString(
                       VELOX_USER_FAIL("{}", status.message());
                     });
     if constexpr (kind == TypeKind::TIMESTAMP) {
-      copy.toGMT(Timestamp::defaultTimezone());
+      const tz::TimeZone* timezone;
+      if (sessionTimezone.empty()) {
+        timezone = &Timestamp::defaultTimezone();
+      } else {
+        timezone = tz::locateZone(sessionTimezone);
+      }
+      copy.toGMT(*timezone);
     }
     return std::make_shared<ConstantVector<T>>(
         pool, size, false, type, std::move(copy));

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -192,7 +192,9 @@ void fillTimestamps(
     const uint64_t* nulls,
     const int64_t* seconds,
     const uint64_t* nanos,
-    vector_size_t numValues);
+    vector_size_t numValues,
+    const tz::TimeZone* sessionTimezone,
+    const bool adjustTimestampToTimezone);
 
 } // namespace detail
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -59,6 +59,9 @@ class SelectiveTimestampColumnReader
   // Values from copied from 'seconds_'. Nanos are in 'values_'.
   BufferPtr secondsValues_;
   RleVersion version_;
+
+  const tz::TimeZone* sessionTimezone_{nullptr};
+  bool adjustTimestampToTimezone_{false};
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -142,6 +142,8 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
       std::move(sink),
       type,
       config,
+      /*sessionTimezone=*/nullptr,
+      /*adjustTimestampToTimezone=*/false,
       E2EWriterTestUtil::simpleFlushPolicyFactory(true));
 
   auto seed = folly::Random::secureRand32();

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -2093,6 +2093,8 @@ createWriterReader(
       asRowType(batches[0]->type()),
       batches,
       config,
+      /*sessionTimezone=*/nullptr,
+      /*adjustTimestampToTimezone=*/false,
       std::move(flushPolicy));
   std::string data(sinkPtr->data(), sinkPtr->size());
   auto input = std::make_unique<BufferedInput>(

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -83,10 +83,13 @@ void testWriterDefaultFlushPolicy(
       numStripesLower,
       numStripesUpper,
       config,
+      /*sessionTimezoneName=*/"",
+      /*useSelectiveColumnReader=*/false,
+      /*adjustTimestampToTimezone=*/false,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
-      memoryBudget,
-      false);
+      /*writerMemoryCap=*/memoryBudget,
+      /*verifyContent=*/false);
 }
 
 class E2EWriterTest : public testing::Test {

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
@@ -23,71 +23,75 @@ namespace facebook::velox::dwrf {
 
 class E2EWriterTestUtil {
  public:
-  /**
-   * Creates and returns the writer so that the caller can control
-   * its life cycle. The writer is constructed with the supplied parameters.
-   *    sink                    the container for writer output, could be
-   *                            in-memory or on-disk.
-   *    type                    schema of the output data
-   *    config                  ORC configs
-   *    flushPolicyFactory      supplies the policy writer use to determine
-   *                            when to flush the current stripe and start a
-   *                            new one
-   *    layoutPlannerFactory    supplies the layout planner and determine how
-   *                            order of the data streams prior to flush
-   *    writerMemoryCap         total memory budget for the writer
-   */
+  /// Creates and returns the writer so that the caller can control
+  /// its life cycle. The writer is constructed with the supplied parameters.
+  ///    sink                        the container for writer output, could be
+  ///                                in-memory or on-disk.
+  ///    type                        schema of the output data
+  ///    config                      ORC configs
+  ///    sessionTimezone             Session timezone used for writing Timestamp
+  ///    adjustTimestampToTimezone   Whether to adjust Timestamp to the timeZone
+  ///                                obtained through sessionTimezone
+  ///    flushPolicyFactory          supplies the policy writer use to determine
+  ///                                when to flush the current stripe and start
+  ///                                a new one
+  ///    layoutPlannerFactory        supplies the layout planner and determine
+  ///                                how order of the data streams prior to
+  ///                                flush
+  ///    writerMemoryCap             total memory budget for the writer
   static std::unique_ptr<Writer> createWriter(
       std::unique_ptr<dwio::common::FileSink> sink,
       const std::shared_ptr<const Type>& type,
       const std::shared_ptr<Config>& config,
+      const tz::TimeZone* sessionTimezone,
+      bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
       std::function<std::unique_ptr<LayoutPlanner>(
           const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
 
-  /**
-   * Writes data and returns the same writer so that the caller can control
-   * its life cycle. Parameters:
-   *    writer                  the writer to write data into
-   *    batches                 generated data
-   */
+  /// Writes data and returns the same writer so that the caller can control
+  /// its life cycle. Parameters:
+  ///    writer                  the writer to write data into
+  ///    batches                 generated data
   static std::unique_ptr<Writer> writeData(
       std::unique_ptr<Writer> writer,
       const std::vector<VectorPtr>& batches);
 
-  /*
-   * Combines createWriter and writeData.
-   * The writer is constructed with the supplied parameters.
-   *    sink                    the container for writer output, could be
-   *                            in-memory or on-disk.
-   *    type                    schema of the output data
-   *    batches                 generated data
-   *    config                  ORC configs
-   *    flushPolicyFactory      supplies the policy writer use to determine
-   *                            when to flush the current stripe and start a
-   *                            new one
-   *    layoutPlannerFactory    supplies the layout planner and determine how
-   *                            order of the data streams prior to flush
-   *    writerMemoryCap         total memory budget for the writer
-   */
+  /// Combines createWriter and writeData.
+  /// The writer is constructed with the supplied parameters.
+  ///    sink                        the container for writer output, could be
+  ///                                in-memory or on-disk.
+  ///    type                        schema of the output data
+  ///    batches                     generated data
+  ///    config                      ORC configs
+  ///    sessionTimezone             Session timezone used for writing Timestamp
+  ///    adjustTimestampToTimezone   Whether to adjust Timestamp to the timeZone
+  ///                                obtained through sessionTimezone
+  ///    flushPolicyFactory          supplies the policy writer use to determine
+  ///                                when to flush the current stripe and start
+  ///                                a new one
+  ///    layoutPlannerFactory        supplies the layout planner and determine
+  ///                                how order of the data streams prior to
+  ///                                flush
+  ///    writerMemoryCap             total memory budget for the writer
   static std::unique_ptr<Writer> writeData(
       std::unique_ptr<dwio::common::FileSink> sink,
       const std::shared_ptr<const Type>& type,
       const std::vector<VectorPtr>& batches,
       const std::shared_ptr<Config>& config,
+      const tz::TimeZone* sessionTimezone = nullptr,
+      bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
       std::function<std::unique_ptr<LayoutPlanner>(
           const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
 
-  /**
-   * Creates a writer with the supplied configuration and check the IO
-   * characteristics and the content of its output. Uses writeData to perform
-   * the data write and pass through most of the parameters.
-   */
+  /// Creates a writer with the supplied configuration and check the IO
+  /// characteristics and the content of its output. Uses writeData to perform
+  /// the data write and pass through most of the parameters.
   static void testWriter(
       memory::MemoryPool& pool,
       const std::shared_ptr<const Type>& type,
@@ -97,6 +101,9 @@ class E2EWriterTestUtil {
       size_t numStripesLower,
       size_t numStripesUpper,
       const std::shared_ptr<Config>& config,
+      const std::string& sessionTimezoneName = "",
+      bool useSelectiveColumnReader = false,
+      bool adjustTimestampToTimezone = false,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
       std::function<std::unique_ptr<LayoutPlanner>(

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -42,8 +42,6 @@ struct WriterOptions : public dwio::common::WriterOptions {
       WriterContext& context,
       const velox::dwio::common::TypeWithId& type)>
       columnWriterFactory;
-  const tz::TimeZone* sessionTimezone{nullptr};
-  bool adjustTimestampToTimezone{false};
 };
 
 class Writer : public dwio::common::Writer {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -117,10 +117,10 @@ struct Timestamp {
   /// and the number of nanoseconds.
   static Timestamp fromDaysAndNanos(int32_t days, int64_t nanos);
 
-  // date is the number of days since unix epoch.
+  /// date is the number of days since unix epoch.
   static Timestamp fromDate(int32_t date);
 
-  // Returns the current unix timestamp (ms precision).
+  /// Returns the current unix timestamp (ms precision).
   static Timestamp now();
 
   static Timestamp create(const folly::dynamic& obj) {
@@ -137,7 +137,7 @@ struct Timestamp {
     return nanos_;
   }
 
-  // Keep it in header for getting inlined.
+  /// Keep it in header for getting inlined.
   int64_t toNanos() const {
     // int64 can store around 292 years in nanos ~ till 2262-04-12.
     // When an integer overflow occurs in the calculation,
@@ -173,7 +173,7 @@ struct Timestamp {
     return result;
   }
 
-  // Keep it in header for getting inlined.
+  /// Keep it in header for getting inlined.
   int64_t toMillisAllowOverflow() const {
     // Similar to the above toMillis() except that overflowed integer is allowed
     // as result.
@@ -340,12 +340,12 @@ struct Timestamp {
       const TimestampToStringOptions& options,
       char* const startPosition);
 
-  // Assuming the timestamp represents a time at zone, converts it to the GMT
-  // time at the same moment. For example:
-  //
-  //  Timestamp ts{0, 0};
-  //  ts.Timezone("America/Los_Angeles");
-  //  ts.toString(); // returns January 1, 1970 08:00:00
+  /// Assuming the timestamp represents a time at zone, converts it to the GMT
+  /// time at the same moment. For example:
+  ///
+  ///  Timestamp ts{0, 0};
+  ///  ts.Timezone("America/Los_Angeles");
+  ///  ts.toString(); // returns January 1, 1970 08:00:00
   void toGMT(const tz::TimeZone& zone);
 
   /// Assuming the timestamp represents a GMT time, converts it to the time at
@@ -413,7 +413,7 @@ struct Timestamp {
     VELOX_USER_FAIL("Timestamp nanos out of range");
   }
 
-  // Needed for serialization of FlatVector<Timestamp>
+  /// Needed for serialization of FlatVector<Timestamp>
   operator StringView() const {
     return StringView("TODO: Implement");
   }
@@ -446,7 +446,7 @@ struct Timestamp {
     return obj;
   }
 
-  // Pretty printer for gtest.
+  /// Pretty printer for gtest.
   friend void PrintTo(const Timestamp& timestamp, std::ostream* os) {
     *os << "sec: " << timestamp.seconds_ << ", ns: " << timestamp.nanos_;
   }


### PR DESCRIPTION
Part of https://github.com/facebookincubator/velox/pull/10372.

After https://github.com/facebookincubator/velox/pull/10895 we can get `sessionTimezone` and `adjustTimestampToTimezone` in DRWF's `ColumnWriter` and `ColumnReader`. This PR base on https://github.com/facebookincubator/velox/pull/10895 and performs relevant time zone adjustments when reading and writing Timestamp according to the values ​​of `sessionTimezone` and `adjustTimestampToTimezone`.


CC: @Yuhta 