### PR TITLE
Remove config property hive.gcs.scheme

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -139,10 +139,6 @@ std::string HiveConfig::gcsEndpoint() const {
   return config_->get<std::string>(kGCSEndpoint, std::string(""));
 }
 
-std::string HiveConfig::gcsScheme() const {
-  return config_->get<std::string>(kGCSScheme, std::string("https"));
-}
-
 std::string HiveConfig::gcsCredentialsPath() const {
   return config_->get<std::string>(kGCSCredentialsPath, std::string(""));
 }

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -136,7 +136,8 @@ std::optional<std::string> HiveConfig::s3RetryMode() const {
 }
 
 std::string HiveConfig::gcsEndpoint() const {
-  return config_->get<std::string>(kGCSEndpoint, std::string(""));
+  return config_->get<std::string>(
+      kGCSEndpoint, std::string("https://storage.googleapis.com"));
 }
 
 std::string HiveConfig::gcsCredentialsPath() const {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -107,9 +107,6 @@ class HiveConfig {
   /// The GCS storage endpoint server.
   static constexpr const char* kGCSEndpoint = "hive.gcs.endpoint";
 
-  /// The GCS storage scheme, https for default credentials.
-  static constexpr const char* kGCSScheme = "hive.gcs.scheme";
-
   /// The GCS service account configuration JSON key file.
   static constexpr const char* kGCSCredentialsPath =
       "hive.gcs.json-key-file-path";
@@ -295,8 +292,6 @@ class HiveConfig {
   std::optional<std::string> s3RetryMode() const;
 
   std::string gcsEndpoint() const;
-
-  std::string gcsScheme() const;
 
   std::string gcsCredentialsPath() const;
 

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -269,7 +269,7 @@ class GCSFileSystem::Impl {
     constexpr std::string_view kHttpsScheme{"https://"};
     auto options = gc::Options{};
     auto endpointOverride = hiveConfig_->gcsEndpoint();
-    // Use insecure credentials by default.
+    // Use secure credentials by default.
     if (!endpointOverride.empty()) {
       options.set<gcs::RestEndpointOption>(endpointOverride);
       // Use Google default credentials if endpoint has https scheme.
@@ -281,7 +281,8 @@ class GCSFileSystem::Impl {
             gc::MakeInsecureCredentials());
       }
     } else {
-      options.set<gc::UnifiedCredentialsOption>(gc::MakeInsecureCredentials());
+      options.set<gc::UnifiedCredentialsOption>(
+          gc::MakeGoogleDefaultCredentials());
     }
     options.set<gcs::UploadBufferSizeOption>(kUploadBufferSize);
 

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -43,7 +43,6 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
-  ASSERT_EQ(hiveConfig.gcsScheme(), "https");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
   ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), false);
   ASSERT_EQ(
@@ -96,7 +95,6 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kS3IamRole, "hello"},
       {HiveConfig::kS3IamRoleSessionName, "velox"},
       {HiveConfig::kGCSEndpoint, "hey"},
-      {HiveConfig::kGCSScheme, "http"},
       {HiveConfig::kGCSCredentialsPath, "hey"},
       {HiveConfig::kOrcUseColumnNames, "true"},
       {HiveConfig::kFileColumnNamesReadAsLowerCase, "true"},
@@ -136,7 +134,6 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.s3IAMRole(), std::optional("hello"));
   ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox");
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "hey");
-  ASSERT_EQ(hiveConfig.gcsScheme(), "http");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "hey");
   ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), true);
   ASSERT_EQ(
@@ -211,7 +208,6 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
-  ASSERT_EQ(hiveConfig.gcsScheme(), "https");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
   ASSERT_EQ(hiveConfig.isOrcUseColumnNames(session.get()), true);
   ASSERT_EQ(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()), true);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -42,7 +42,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.s3SecretKey(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
-  ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
+  ASSERT_EQ(hiveConfig.gcsEndpoint(), "https://storage.googleapis.com");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
   ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), false);
   ASSERT_EQ(
@@ -207,7 +207,7 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.s3SecretKey(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRole(), std::nullopt);
   ASSERT_EQ(hiveConfig.s3IAMRoleSessionName(), "velox-session");
-  ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
+  ASSERT_EQ(hiveConfig.gcsEndpoint(), "https://storage.googleapis.com");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
   ASSERT_EQ(hiveConfig.isOrcUseColumnNames(session.get()), true);
   ASSERT_EQ(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()), true);

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -638,10 +638,6 @@ Each query can override the config by setting corresponding query session proper
      - string
      -
      - The GCS storage endpoint server.
-   * - hive.gcs.scheme
-     - string
-     -
-     - The GCS storage scheme, https for default credentials.
    * - hive.gcs.json-key-file-path
      - string
      -

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -636,8 +636,8 @@ Each query can override the config by setting corresponding query session proper
      - Description
    * - hive.gcs.endpoint
      - string
-     -
-     - The GCS storage endpoint server.
+     - https://storage.googleapis.com
+     - The GCS storage URI.
    * - hive.gcs.json-key-file-path
      - string
      -


### PR DESCRIPTION
The GCS adapter expects two configs `hive.gcs.scheme` value for the scheme and `hive.gcs.endpoint` value without the scheme.
However, in practice, the endpoint value contains the scheme. We can remove `hive.gcs.scheme` to be consistent.
See Trino for example https://trino.io/docs/current/admin/fault-tolerant-execution.html#google-cloud-storage