### PR TITLE
Fix and optimize read IO pattern for flat map column

### DIFF
--- a/velox/common/caching/ScanTracker.cpp
+++ b/velox/common/caching/ScanTracker.cpp
@@ -32,8 +32,10 @@ void ScanTracker::recordReference(
     fileGroupStats_->recordReference(fileId, groupId, id, bytes);
   }
   std::lock_guard<std::mutex> l(mutex_);
-  data_[id].incrementReference(bytes, loadQuantum_);
-  sum_.incrementReference(bytes, loadQuantum_);
+  auto& data = data_[id];
+  data.referencedBytes += bytes;
+  data.lastReferencedBytes = bytes;
+  sum_.referencedBytes += bytes;
 }
 
 void ScanTracker::recordRead(
@@ -45,18 +47,17 @@ void ScanTracker::recordRead(
     fileGroupStats_->recordRead(fileId, groupId, id, bytes);
   }
   std::lock_guard<std::mutex> l(mutex_);
-  data_[id].incrementRead(bytes);
-  sum_.incrementRead(bytes);
+  auto& data = data_[id];
+  data.readBytes += bytes;
+  sum_.readBytes += bytes;
 }
 
 std::string ScanTracker::toString() const {
   std::stringstream out;
   out << "ScanTracker for " << id_ << std::endl;
-  for (const auto& pair : data_) {
-    const int pct =
-        100 * pair.second.readBytes / (1 + pair.second.referencedBytes);
-    out << pair.first.id() << ": " << pct << "% " << pair.second.readBytes
-        << "/" << pair.second.numReads << std::endl;
+  for (const auto& [id, data] : data_) {
+    out << id.id() << ": " << data.readBytes << "/" << data.referencedBytes
+        << std::endl;
   }
   return out.str();
 }

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -44,8 +44,6 @@ struct CacheRequest {
   cache::CachePin pin;
   cache::SsdPin ssdPin;
 
-  bool processed{false};
-
   /// True if this should be coalesced into a CoalescedLoad with other nearby
   /// requests with a similar load probability. This is false for sparsely
   /// accessed large columns where hitting one piece should not load the

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -36,7 +36,6 @@ struct LoadRequest {
 
   velox::common::Region region;
   cache::TrackingId trackingId;
-  bool processed{false};
 
   const SeekableInputStream* stream;
 
@@ -63,6 +62,10 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
         input_(std::move(input)),
         loadQuantum_(loadQuantum),
         pool_(pool) {
+    VELOX_DCHECK(
+        std::is_sorted(requests.begin(), requests.end(), [](auto* x, auto* y) {
+          return x->region.offset < y->region.offset;
+        }));
     requests_.reserve(requests.size());
     for (auto i = 0; i < requests.size(); ++i) {
       requests_.push_back(std::move(*requests[i]));

--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -166,6 +166,9 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
             stream.has_column() ? stream.column() : dwio::common::MAX_UINT32,
             stream.kind()) {}
 
+  /// Pruned flat map keys are not enqueued thus all flatmap values on same
+  /// column should have similar read percentage, so it is ok for them to share
+  /// the same TrackingData.
   DwrfStreamIdentifier(
       uint32_t node,
       uint32_t sequence,

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -539,7 +539,7 @@ TEST_F(CacheTest, ssd) {
   auto sparseStripeBytes = (ioStats_->rawBytesRead() - bytes) / 10;
   EXPECT_LT(sparseStripeBytes, fullStripeBytes / 4);
   // Expect the dense fraction of columns to have read ahead.
-  EXPECT_LT(1000000, ioStats_->prefetch().sum());
+  EXPECT_LT(400'000, ioStats_->prefetch().sum());
 
   constexpr int32_t kStripesPerFile = 10;
   auto bytesPerFile = fullStripeBytes * kStripesPerFile;


### PR DESCRIPTION
Summary:
1. `numReferences` and `numReads` in `TrackingData` can overflow for large volume of read on flatmap column, which causes the read percentage becomes negative and fail to coalesce.
2. Increase the limit for maximum number of regions for coalesce, reducing the number of IO reads for a typical flatmap column to 1/3.

Differential Revision: D64225777


