### PR TITLE
Working POC for Impulse velox connector

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -95,6 +95,17 @@ class PlanBuilder {
   explicit PlanBuilder(memory::MemoryPool* pool = nullptr)
       : PlanBuilder(std::make_shared<core::PlanNodeIdGenerator>(), pool) {}
 
+  /// Constructor that allows an initial plane node to be specified for testing
+  /// this is useful when testing additional connectors that do not rely on the
+  /// table scan node supported below.
+  PlanBuilder(
+      core::PlanNodePtr initialPlanNode,
+      std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator,
+      memory::MemoryPool* pool = nullptr)
+      : planNode_(std::move(initialPlanNode)),
+        planNodeIdGenerator_{std::move(planNodeIdGenerator)},
+        pool_{pool} {}
+
   static constexpr const std::string_view kHiveDefaultConnectorId{"test-hive"};
   static constexpr const std::string_view kTpchDefaultConnectorId{"test-tpch"};
 

--- a/velox/vector/BuilderTypeUtils.h
+++ b/velox/vector/BuilderTypeUtils.h
@@ -22,6 +22,7 @@
 #include <type_traits>
 
 #include "velox/type/StringView.h"
+#include "velox/type/Timestamp.h"
 #include "velox/type/Type.h"
 
 // Miscellaneous utilities regarding type, to avoid duplication
@@ -53,8 +54,9 @@ constexpr bool isIntegral() {
  */
 template <typename T>
 constexpr bool admitsDictionary() {
-  return std::is_same_v<T, int64_t> || std::is_same_v<T, double> ||
-      std::is_same_v<T, StringView>;
+  return std::is_same_v<T, int128_t> || std::is_same_v<T, int64_t> ||
+      std::is_same_v<T, double> || std::is_same_v<T, StringView> ||
+      std::is_same_v<T, velox::Timestamp>;
 }
 
 /**

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -137,6 +137,10 @@ class SimpleVector : public BaseVector {
     return stats_;
   }
 
+  void testingSetStats(SimpleVectorStats<T>&& stats) {
+    stats_ = std::move(stats);
+  }
+
   // Concrete Vector types need to implement this themselves.
   // This method does not do bounds checking. When the value is null the return
   // value is technically undefined (currently implemented as default of T)


### PR DESCRIPTION
Summary:
Diff introduces poc for Impulse velox connector.   

See info in test plan notes below

Differential Revision: D63794629


