### PR TITLE
Refactor buildDateTimeFormatter to return velox::Expected

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1575,10 +1575,14 @@ std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
   return builder.setType(DateTimeFormatterType::MYSQL).build();
 }
 
-std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> buildJodaDateTimeFormatter(
     const std::string_view& format) {
   if (format.empty()) {
-    VELOX_USER_FAIL("Invalid pattern specification");
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    }
+    return folly::makeUnexpected(
+        Status::UserError("Invalid pattern specification"));
   }
 
   DateTimeFormatterBuilder builder(format.size());
@@ -1598,16 +1602,19 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
         // Case 2: find closing single quote
         int64_t count = numLiteralChars(startTokenPtr + 1, end);
         if (count == -1) {
-          VELOX_USER_FAIL("No closing single quote for literal");
-        } else {
-          for (int64_t i = 1; i <= count; i++) {
-            builder.appendLiteral(startTokenPtr + i, 1);
-            if (*(startTokenPtr + i) == '\'') {
-              i += 1;
-            }
+          if (threadSkipErrorDetails()) {
+            return folly::makeUnexpected(Status::UserError());
           }
-          cur += count + 2;
+          return folly::makeUnexpected(
+              Status::UserError("No closing single quote for literal"));
         }
+        for (int64_t i = 1; i <= count; i++) {
+          builder.appendLiteral(startTokenPtr + i, 1);
+          if (*(startTokenPtr + i) == '\'') {
+            i += 1;
+          }
+        }
+        cur += count + 2;
       }
     } else {
       int count = 1;
@@ -1686,7 +1693,11 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
           break;
         default:
           if (isalpha(*startTokenPtr)) {
-            VELOX_UNSUPPORTED("Specifier {} is not supported.", *startTokenPtr);
+            if (threadSkipErrorDetails()) {
+              return folly::makeUnexpected(Status::UserError());
+            }
+            return folly::makeUnexpected(Status::UserError(
+                "Specifier {} is not supported.", *startTokenPtr));
           } else {
             builder.appendLiteral(startTokenPtr, cur - startTokenPtr);
           }
@@ -1697,10 +1708,16 @@ std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
   return builder.setType(DateTimeFormatterType::JODA).build();
 }
 
-std::shared_ptr<DateTimeFormatter> buildSimpleDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> buildSimpleDateTimeFormatter(
     const std::string_view& format,
     bool lenient) {
-  VELOX_USER_CHECK(!format.empty(), "Format pattern should not be empty.");
+  if (format.empty()) {
+    if (threadSkipErrorDetails()) {
+      return folly::makeUnexpected(Status::UserError());
+    }
+    return folly::makeUnexpected(
+        Status::UserError("Format pattern should not be empty"));
+  }
 
   DateTimeFormatterBuilder builder(format.size());
   const char* cur = format.data();
@@ -1721,7 +1738,13 @@ std::shared_ptr<DateTimeFormatter> buildSimpleDateTimeFormatter(
         // Append literal characters from the start until the next closing
         // literal sequence single quote.
         int64_t count = numLiteralChars(startTokenPtr + 1, end);
-        VELOX_USER_CHECK_NE(count, -1, "No closing single quote for literal");
+        if (count == -1) {
+          if (threadSkipErrorDetails()) {
+            return folly::makeUnexpected(Status::UserError());
+          }
+          return folly::makeUnexpected(
+              Status::UserError("No closing single quote for literal"));
+        }
         for (int64_t i = 1; i <= count; i++) {
           builder.appendLiteral(startTokenPtr + i, 1);
           if (*(startTokenPtr + i) == '\'') {
@@ -1809,7 +1832,11 @@ std::shared_ptr<DateTimeFormatter> buildSimpleDateTimeFormatter(
           break;
         default:
           if (isalpha(*startTokenPtr)) {
-            VELOX_UNSUPPORTED("Specifier {} is not supported.", *startTokenPtr);
+            if (threadSkipErrorDetails()) {
+              return folly::makeUnexpected(Status::UserError());
+            }
+            return folly::makeUnexpected(Status::UserError(
+                "Specifier {} is not supported.", *startTokenPtr));
           } else {
             builder.appendLiteral(startTokenPtr, cur - startTokenPtr);
           }

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -215,7 +215,7 @@ class DateTimeFormatter {
   DateTimeFormatterType type_;
 };
 
-std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> buildMysqlDateTimeFormatter(
     const std::string_view& format);
 
 Expected<std::shared_ptr<DateTimeFormatter>> buildJodaDateTimeFormatter(

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -218,10 +218,10 @@ class DateTimeFormatter {
 std::shared_ptr<DateTimeFormatter> buildMysqlDateTimeFormatter(
     const std::string_view& format);
 
-std::shared_ptr<DateTimeFormatter> buildJodaDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> buildJodaDateTimeFormatter(
     const std::string_view& format);
 
-std::shared_ptr<DateTimeFormatter> buildSimpleDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> buildSimpleDateTimeFormatter(
     const std::string_view& format,
     bool lenient);
 

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1430,7 +1430,7 @@ TEST_F(MysqlDateTimeTest, invalidBuild) {
   EXPECT_TRUE(buildMysqlDateTimeFormatter("%w").hasError());
 
   // Empty format string
-  EXPECT_THROW(buildMysqlDateTimeFormatter(""), VeloxUserError);
+  EXPECT_TRUE(buildMysqlDateTimeFormatter("").hasError());
 }
 
 TEST_F(MysqlDateTimeTest, formatYear) {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1782,7 +1782,7 @@ struct ToISO8601Function {
   ToISO8601Function() {
     auto formatter =
         functions::buildJodaDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-    VELOX_CHECK(!formatter.hasError());
+    VELOX_CHECK(!formatter.hasError(), "Default format should always be valid");
     formatter_ = formatter.value();
   }
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1795,8 +1795,8 @@ struct ToISO8601Function {
         functions::buildJodaDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
     VELOX_CHECK(
         !formatter.hasError(),
-        "Default format should always be valid, error: " +
-            formatter.error().message());
+        "Default format should always be valid, error: {}",
+        formatter.error().message());
     formatter_ = formatter.value();
   }
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1793,7 +1793,10 @@ struct ToISO8601Function {
   ToISO8601Function() {
     auto formatter =
         functions::buildJodaDateTimeFormatter("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
-    VELOX_CHECK(!formatter.hasError(), "Default format should always be valid");
+    VELOX_CHECK(
+        !formatter.hasError(),
+        "Default format should always be valid, error: " +
+            formatter.error().message());
     formatter_ = formatter.value();
   }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -113,8 +113,8 @@ void castToString(
       functions::buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS zzzz");
   VELOX_CHECK(
       !expectedFormatter.hasError(),
-      "Default format should always be valid, error: " +
-          expectedFormatter.error().message());
+      "Default format should always be valid, error: {}",
+      expectedFormatter.error().message());
   auto formatter = expectedFormatter.value();
   context.applyToSelectedNoThrow(rows, [&](auto row) {
     const auto timestampWithTimezone = timestamps->valueAt(row);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -176,8 +176,7 @@ struct UnixTimestampParseFunction {
         kDefaultFormat_,
         config.sparkLegacyDateFormatter() ? DateTimeFormatterType::STRICT_SIMPLE
                                           : DateTimeFormatterType::JODA);
-    // Default format should always be valid.
-    VELOX_CHECK(!formatter.hasError());
+    VELOX_CHECK(!formatter.hasError(), "Default format should always be valid");
     format_ = formatter.value();
     setTimezone(config);
   }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -26,7 +26,7 @@
 namespace facebook::velox::functions::sparksql {
 
 namespace detail {
-std::shared_ptr<DateTimeFormatter> getDateTimeFormatter(
+Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
     const std::string_view& format,
     DateTimeFormatterType type) {
   switch (type) {
@@ -172,10 +172,13 @@ struct UnixTimestampParseFunction {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/) {
-    format_ = detail::getDateTimeFormatter(
+    auto formatter = detail::getDateTimeFormatter(
         kDefaultFormat_,
         config.sparkLegacyDateFormatter() ? DateTimeFormatterType::STRICT_SIMPLE
                                           : DateTimeFormatterType::JODA);
+    // Default format should always be valid.
+    VELOX_CHECK(!formatter.hasError());
+    format_ = formatter.value();
     setTimezone(config);
   }
 
@@ -226,13 +229,14 @@ struct UnixTimestampParseWithFormatFunction
       const arg_type<Varchar>* format) {
     legacyFormatter_ = config.sparkLegacyDateFormatter();
     if (format != nullptr) {
-      try {
-        this->format_ = detail::getDateTimeFormatter(
-            std::string_view(format->data(), format->size()),
-            legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
-                             : DateTimeFormatterType::JODA);
-      } catch (const VeloxUserError&) {
+      auto formatter = detail::getDateTimeFormatter(
+          std::string_view(format->data(), format->size()),
+          legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
+                           : DateTimeFormatterType::JODA);
+      if (formatter.hasError()) {
         invalidFormat_ = true;
+      } else {
+        this->format_ = formatter.value();
       }
       isConstFormat_ = true;
     }
@@ -248,15 +252,15 @@ struct UnixTimestampParseWithFormatFunction
     }
 
     // Format error returns null.
-    try {
-      if (!isConstFormat_) {
-        this->format_ = detail::getDateTimeFormatter(
-            std::string_view(format.data(), format.size()),
-            legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
-                             : DateTimeFormatterType::JODA);
+    if (!isConstFormat_) {
+      auto formatter = detail::getDateTimeFormatter(
+          std::string_view(format.data(), format.size()),
+          legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
+                           : DateTimeFormatterType::JODA);
+      if (formatter.hasError()) {
+        return false;
       }
-    } catch (const VeloxUserError&) {
-      return false;
+      this->format_ = formatter.value();
     }
     auto dateTimeResult =
         this->format_->parse(std::string_view(input.data(), input.size()));
@@ -311,9 +315,12 @@ struct FromUnixtimeFunction {
  private:
   FOLLY_ALWAYS_INLINE void setFormatter(const arg_type<Varchar>& format) {
     formatter_ = detail::getDateTimeFormatter(
-        std::string_view(format.data(), format.size()),
-        legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
-                         : DateTimeFormatterType::JODA);
+                     std::string_view(format.data(), format.size()),
+                     legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
+                                      : DateTimeFormatterType::JODA)
+                     .thenOrThrow(folly::identity, [&](const Status& status) {
+                       VELOX_USER_FAIL("{}", status.message());
+                     });
     maxResultSize_ = formatter_->maxResultSize(sessionTimeZone_);
   }
 
@@ -402,9 +409,12 @@ struct GetTimestampFunction {
     }
     if (format != nullptr) {
       formatter_ = detail::getDateTimeFormatter(
-          std::string_view(*format),
-          legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
-                           : DateTimeFormatterType::JODA);
+                       std::string_view(*format),
+                       legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
+                                        : DateTimeFormatterType::JODA)
+                       .thenOrThrow(folly::identity, [&](const Status& status) {
+                         VELOX_USER_FAIL("{}", status.message());
+                       });
       isConstantTimeFormat_ = true;
     }
   }
@@ -415,9 +425,12 @@ struct GetTimestampFunction {
       const arg_type<Varchar>& format) {
     if (!isConstantTimeFormat_) {
       formatter_ = detail::getDateTimeFormatter(
-          std::string_view(format),
-          legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
-                           : DateTimeFormatterType::JODA);
+                       std::string_view(format),
+                       legacyFormatter_ ? DateTimeFormatterType::STRICT_SIMPLE
+                                        : DateTimeFormatterType::JODA)
+                       .thenOrThrow(folly::identity, [&](const Status& status) {
+                         VELOX_USER_FAIL("{}", status.message());
+                       });
     }
     auto dateTimeResult = formatter_->parse(std::string_view(input));
     // Null as result for parsing error.


### PR DESCRIPTION
We have recently introduced velox::Expected (https://github.com/facebookincubator/velox/pull/9858) to use in non-void no-throw APIs. It's more proper to return that.