### PR TITLE
Fix query replayer crash

### DIFF
--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -57,7 +57,7 @@ std::vector<std::unique_ptr<folly::IOBuf>> getData(
         result->setValue(std::move(pages));
       }));
   auto future = std::move(semiFuture).via(executor);
-  future.wait(std::chrono::seconds{10});
+  future.wait();
   VELOX_CHECK(future.isReady());
   return std::move(future).value();
 }

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -63,7 +63,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       std::make_unique<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency(),
           std::make_shared<folly::NamedThreadFactory>("Driver"))};
-  const ConsumerCallBack& consumerCb_;
+  const ConsumerCallBack consumerCb_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> consumerExecutor_;
 };
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/QueryReplayer.cpp
+++ b/velox/tool/trace/QueryReplayer.cpp
@@ -19,6 +19,7 @@
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
@@ -89,6 +90,8 @@ void init() {
   const auto ioExecutor = std::make_unique<folly::IOThreadPoolExecutor>(
       std::thread::hardware_concurrency() *
       FLAGS_hiveConnectorExecutorHwMultiplier);
+  connector::registerConnectorFactory(
+      std::make_shared<connector::hive::HiveConnectorFactory>());
   const auto hiveConnector =
       connector::getConnectorFactory("hive")->newConnector(
           "test-hive",


### PR DESCRIPTION
Issues with current replayer
1) Query replayer does not register hive connector factory.
2) PartitionedOutputReplayer holds non-existent reference on default consumer.

The PR fixes these 2 issues