### PR TITLE
Remove unused-variable in velox/common/memory/MemoryAllocator.cpp

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -483,7 +483,6 @@ void MemoryAllocator::getTracingHooks(
   report = [state, allocator, ioVolume]() -> std::string {
     struct rusage rusage;
     getrusage(RUSAGE_SELF, &rusage);
-    auto newStats = allocator->stats();
     float u = elapsedUsec(rusage.ru_utime, state->rusage.ru_utime);
     float s = elapsedUsec(rusage.ru_stime, state->rusage.ru_stime);
     auto m = allocator->stats() - state->allocatorStats;

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -572,7 +572,6 @@ VectorPtr createStringFlatVectorFromUtf8View(
   BufferPtr stringViews =
       AlignedBuffer::allocate<StringView>(arrowArray.length, pool);
   auto* rawStringViews = stringViews->asMutable<uint64_t>();
-  auto* rawNulls = nulls->as<uint64_t>();
 
   // Full copy for inline strings (length <= 12). For non-inline strings,
   // convert 16-byte Arrow Utf8View [4-byte length, 4-byte prefix, 4-byte


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D64278704


