### PR TITLE
Throw VeloxRuntimeError in Reduce() on violating kMaxArraySize.

### DIFF
--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -36,15 +36,12 @@ void checkArraySizes(
       return;
     }
     const auto size = rawSizes[indices[row]];
-    try {
-      VELOX_USER_CHECK_LT(
-          size,
-          kMaxArraySize,
-          "reduce lambda function doesn't support arrays with more than {} elements",
-          kMaxArraySize);
-    } catch (VeloxUserError&) {
-      context.setError(row, std::current_exception());
-    }
+    // We do not want this error to be suppressed by TRY(), so we simply throw.
+    VELOX_CHECK_LT(
+        size,
+        kMaxArraySize,
+        "reduce lambda function doesn't support arrays with more than {} elements",
+        kMaxArraySize);
   });
 }
 

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -274,7 +274,7 @@ TEST_F(ReduceTest, limit) {
 
   VELOX_ASSERT_THROW(
       evaluate("reduce(c0, 0, (s, x) -> s + x, s -> 1 * s)", data),
-      "reduce lambda function doesn't support arrays with more than 10000 elements");
+      "reduce lambda function doesn't support arrays with more than");
 
   // Exclude huge arrays.
   SelectivityVector rows(4);
@@ -286,11 +286,10 @@ TEST_F(ReduceTest, limit) {
       makeFlatVector<int64_t>({123 * 1'000, 123 * 9'000, -1, 123 * 10});
   assertEqualVectors(expected, result, rows);
 
-  // Mask errors with TRY.
-  result = evaluate("TRY(reduce(c0, 0, (s, x) -> s + x, s -> 1 * s))", data);
-  expected = makeNullableFlatVector<int64_t>(
-      {123 * 1'000, 123 * 9'000, std::nullopt, 123 * 10, std::nullopt});
-  assertEqualVectors(expected, result);
+  // TRY should not mask errors.
+  VELOX_ASSERT_THROW(
+      evaluate("TRY(reduce(c0, 0, (s, x) -> s + x, s -> 1 * s))", data),
+      "reduce lambda function doesn't support arrays with more than");
 }
 
 TEST_F(ReduceTest, rewrites) {


### PR DESCRIPTION
Summary:
Expression can be wrapped in TRY() and current user error gets caught
and NULL is returned, which causes correctness issue.
Changing the code to throw VeloxRuntimeError to fail the query.

Differential Revision: D64352201


