### PR TITLE
add opaque type support to hive type serde

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -885,6 +885,18 @@ typeFactories() {
 
 } // namespace
 
+std::unordered_map<std::string, std::type_index>& getTypeIndexByOpaqueAlias() {
+  static std::unordered_map<std::string, std::type_index>
+      typeIndexByOpaqueAlias;
+  return typeIndexByOpaqueAlias;
+}
+
+std::unordered_map<std::type_index, std::string>& getOpaqueAliasByTypeIndex() {
+  static std::unordered_map<std::type_index, std::string>
+      opaqueAliasByTypeIndexMap;
+  return opaqueAliasByTypeIndexMap;
+}
+
 bool registerCustomType(
     const std::string& name,
     std::unique_ptr<const CustomTypeFactories> factories) {
@@ -1204,6 +1216,24 @@ TypePtr getType(
   }
 
   return getCustomType(name);
+}
+
+std::type_index getTypeIdForOpaqueTypeAlias(const std::string& name) {
+  auto it = getTypeIndexByOpaqueAlias().find(name);
+  VELOX_CHECK(
+      it != getTypeIndexByOpaqueAlias().end(),
+      "Could not find type '{}'. Did you call registerOpaqueType?",
+      name);
+  return it->second;
+}
+
+std::string getOpaqueAliasForTypeId(std::type_index typeIndex) {
+  auto it = getOpaqueAliasByTypeIndex().find(typeIndex);
+  VELOX_CHECK(
+      it != getOpaqueAliasByTypeIndex().end(),
+      "Could not find type index '{}'. Did you call registerOpaqueType?",
+      typeIndex.name());
+  return it->second;
 }
 
 } // namespace facebook::velox

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -58,6 +58,7 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::Binary, TypeKind::VARBINARY>(
       {"binary", "varbinary"});
   setupMetadata<TokenType::Timestamp, TypeKind::TIMESTAMP>("timestamp");
+  setupMetadata<TokenType::Opaque, TypeKind::OPAQUE>("opaque");
   setupMetadata<TokenType::List, TypeKind::ARRAY>("array");
   setupMetadata<TokenType::Map, TypeKind::MAP>("map");
   setupMetadata<TokenType::Struct, TypeKind::ROW>({"struct", "row"});
@@ -87,7 +88,16 @@ std::shared_ptr<const Type> HiveTypeParser::parse(const std::string& ser) {
 Result HiveTypeParser::parseType() {
   Token nt = nextToken();
   VELOX_CHECK(!nt.isEOS(), "Unexpected end of stream parsing type!!!");
-  if (nt.isValidType() && nt.isPrimitiveType()) {
+
+  if (!nt.isValidType()) {
+    VELOX_FAIL(
+        "Unexpected token {} at {}. typeKind = {}",
+        nt.value.toString(),
+        remaining_.toString(),
+        nt.typeKind());
+  }
+
+  if (nt.isPrimitiveType()) {
     if (nt.metadata->tokenString[0] == "decimal") {
       eatToken(TokenType::LeftRoundBracket);
       Token precision = nextToken();
@@ -118,7 +128,16 @@ Result HiveTypeParser::parseType() {
       eatToken(TokenType::RightRoundBracket);
     }
     return Result{scalarType};
-  } else if (nt.isValidType()) {
+  } else if (nt.isOpaqueType()) {
+    eatToken(TokenType::StartSubType);
+    folly::StringPiece innerTypeName =
+        eatToken(TokenType::Identifier, true).value;
+    eatToken(TokenType::EndSubType);
+
+    auto typeIndex = getTypeIdForOpaqueTypeAlias(innerTypeName.str());
+    auto instance = std::make_shared<const OpaqueType>(typeIndex);
+    return Result{instance};
+  } else {
     ResultList resultList = parseTypeList(TypeKind::ROW == nt.typeKind());
     switch (nt.typeKind()) {
       case velox::TypeKind::ROW:
@@ -138,13 +157,8 @@ Result HiveTypeParser::parseType() {
         return Result{velox::ARRAY(resultList.typelist.at(0))};
       }
       default:
-        VELOX_FAIL("unsupported kind: " + std::to_string((int)nt.typeKind()));
+        VELOX_FAIL("unsupported kind: " + mapTypeKindToName(nt.typeKind()));
     }
-  } else {
-    VELOX_FAIL(fmt::format(
-        "Unexpected token {} at {}",
-        nt.value.toString(),
-        remaining_.toString()));
   }
 }
 
@@ -248,6 +262,10 @@ bool Token::isValidType() const {
 
 bool Token::isEOS() const {
   return metadata->tokenType == TokenType::EndOfStream;
+}
+
+bool Token::isOpaqueType() const {
+  return metadata->tokenType == TokenType::Opaque;
 }
 
 int8_t HiveTypeParser::makeTokenId(TokenType tokenType) const {

--- a/velox/type/fbhive/HiveTypeParser.h
+++ b/velox/type/fbhive/HiveTypeParser.h
@@ -42,6 +42,7 @@ enum class TokenType {
   String,
   Binary,
   Timestamp,
+  Opaque,
   List,
   Map,
   Struct,
@@ -88,6 +89,8 @@ struct Token {
   bool isValidType() const;
 
   bool isEOS() const;
+
+  bool isOpaqueType() const;
 };
 
 struct TokenAndRemaining : public Token {

--- a/velox/type/fbhive/HiveTypeSerializer.cpp
+++ b/velox/type/fbhive/HiveTypeSerializer.cpp
@@ -58,6 +58,10 @@ std::string HiveTypeSerializer::visit(const Type& type) const {
       return "map<" + visitChildren(type.asMap()) + ">";
     case TypeKind::ROW:
       return "struct<" + visitChildren(type.asRow()) + ">";
+    case TypeKind::OPAQUE: {
+      auto typeAlias = getOpaqueAliasForTypeId(type.asOpaque().typeIndex());
+      return "opaque<" + typeAlias + ">";
+    }
     default:
       VELOX_UNSUPPORTED("unsupported type: " + type.toString());
   }

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -176,4 +176,21 @@ TEST(FbHive, parseSpecialChar) {
   ASSERT_EQ(t->toString(), "ROW<\"a$_#\":INTEGER>");
 }
 
+struct Foo {};
+TEST(FbHive, parseOpaque) {
+  // Use a custom name to highlight this is just an alias.
+  registerOpaqueType<Foo>("bar");
+  HiveTypeParser parser;
+  auto t = parser.parse("opaque<bar>");
+  ASSERT_EQ(t->toString(), "OPAQUE<facebook::velox::type::fbhive::Foo>");
+}
+
+TEST(FbHive, parseUnregisteredOpaque) {
+  // Use a custom name to highlight this is just an alias.
+  registerOpaqueType<Foo>("bar");
+  HiveTypeParser parser;
+  VELOX_ASSERT_THROW(
+      parser.parse("opaque<Foo>"),
+      "Could not find type 'Foo'. Did you call registerOpaqueType?");
+}
 } // namespace facebook::velox::type::fbhive


### PR DESCRIPTION
Summary:
My understanding of opaque types in Velox is that Velox doesn't know about the underlying type of it, and treats them as a `shared_ptr<void>`. For serializing data across processes, we need to somewhat break that assumption, because when we need to know how to deserialize this opaque data.

One option is to have the underlying type as part of the serialized type signature, the other is to store this information with the serialized data itself. I'm adopting the first option here.

We also need to introduce a layer of abstraction for opaque type index, by allowing aliasing opaque types. 

The reason we can't use opaque type index is the assumption that they're not stable across processes. So if you serialize a opaque type as string in process A and then deserialize in process B, even if running the same revision there's no guarantee the type ID is the same.

With this change, callers are required to register an alias for opaque types before serializing/deserializing it via `HiveTypeSerializer` and `HiveTypeParser`. I put this registry in `Type.h` but if we want to keep this specific to `HiveTypeSerializer/HiveTypeParser` we could move it elsewhere.

Differential Revision: D64358220


