### PR TITLE
Add "expression.max_array_size_in_reduce" query config property.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -98,6 +98,11 @@ class QueryConfig {
   static constexpr const char* kCastMatchStructByName =
       "cast_match_struct_by_name";
 
+  /// Reduce() function will throw an error if encountered an array of size
+  /// greater than this.
+  static constexpr const char* kExprMaxArraySizeInReduce =
+      "expression.max_array_size_in_reduce";
+
   /// Used for backpressure to block local exchange producers when the local
   /// exchange buffer reaches or exceeds this size.
   static constexpr const char* kMaxLocalExchangeBufferSize =
@@ -541,6 +546,10 @@ class QueryConfig {
 
   bool isMatchStructByName() const {
     return get<bool>(kCastMatchStructByName, false);
+  }
+
+  uint64_t exprMaxArraySizeInReduce() const {
+    return get<uint64_t>(kExprMaxArraySizeInReduce, 100'000);
   }
 
   bool adjustTimestampToTimezone() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -168,6 +168,10 @@ Expression Evaluation Configuration
      - bool
      - false
      - This flag makes the Row conversion to by applied in a way that the casting row field are matched by name instead of position.
+   * - expression.max_array_size_in_reduce
+     - integer
+     - 100000
+     - ``Reduce`` function will throw an error if encountered an array of size greater than this.
    * - debug_disable_expression_with_peeling
      - bool
      - false
@@ -619,6 +623,7 @@ Each query can override the config by setting corresponding query session proper
        Legacy mode only enables throttled retry for transient errors.
        Standard mode is built on top of legacy mode and has throttled retry enabled for throttling errors apart from transient errors.
        Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate.
+
 ``Google Cloud Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. list-table::

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -29,7 +29,8 @@ void checkArraySizes(
   const auto* indices = decodedArray.indices();
   const auto* rawSizes = decodedArray.base()->as<ArrayVector>()->rawSizes();
 
-  static const vector_size_t kMaxArraySize = 10'000;
+  const auto maxArraySize =
+      context.execCtx()->queryCtx()->queryConfig().exprMaxArraySizeInReduce();
 
   rows.applyToSelected([&](auto row) {
     if (decodedArray.isNullAt(row)) {
@@ -39,9 +40,9 @@ void checkArraySizes(
     // We do not want this error to be suppressed by TRY(), so we simply throw.
     VELOX_CHECK_LT(
         size,
-        kMaxArraySize,
+        maxArraySize,
         "reduce lambda function doesn't support arrays with more than {} elements",
-        kMaxArraySize);
+        maxArraySize);
   });
 }
 

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -269,14 +269,15 @@ TEST_F(ReduceTest, nullArray) {
 // Verify limit on the number of array elements.
 TEST_F(ReduceTest, limit) {
   // Make array vector with huge arrays in rows 2 and 4.
+  // Sizes of vectors in the 5 rows: 1'000, 9'000, 110'000, 10, 879'990.
   auto data = makeRowVector({makeArrayVector(
-      {0, 1'000, 10'000, 100'000, 100'010}, makeConstant(123, 1'000'000))});
+      {0, 1'000, 10'000, 120'000, 120'010}, makeConstant(123, 1'000'000))});
 
   VELOX_ASSERT_THROW(
       evaluate("reduce(c0, 0, (s, x) -> s + x, s -> 1 * s)", data),
       "reduce lambda function doesn't support arrays with more than");
 
-  // Exclude huge arrays.
+  // Exclude huge arrays (at rows 2 and 4).
   SelectivityVector rows(4);
   rows.setValid(2, false);
   rows.updateBounds();


### PR DESCRIPTION
Summary:
Increase max array size in reduce() function from 10K to 100K.
This is to allow users' queries to work.
Seeing queries with size of arrays of 70K+.
Such queries run as fast as in Java.
Adding "expression.max_array_size_in_reduce" query config property to allow per
query controls of it.
Will also add config property for the native worker.

Differential Revision: D64368061


