### PR TITLE
feat: Add opaque type support to PrestoSerializer

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -712,6 +712,12 @@ std::shared_ptr<const OpaqueType> OpaqueType::deserializeExtra(
   return nullptr;
 }
 
+void OpaqueType::clearSerializationRegistry() {
+  auto& registry = OpaqueSerdeRegistry::get();
+  registry.mapping.clear();
+  registry.reverse.clear();
+}
+
 void OpaqueType::registerSerializationTypeErased(
     const std::shared_ptr<const OpaqueType>& type,
     const std::string& persistentName,

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1206,6 +1206,8 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
         deserializeTypeErased);
   }
 
+  static void clearSerializationRegistry();
+
  protected:
   bool equals(const Type& other) const override;
 


### PR DESCRIPTION
Summary:
The idea of opaque types in Presto serializer is that we'll serialize the underlying opaque type to StringView. This requires a serde callbacks to be registered via

  OpaqueType::registerSerialization();

then inside `PrestoSerializer.cpp` we use these to write and read values of type opaque.

Differential Revision: D64362525


