### PR TITLE
Clean up timezoneId from DateTimeFormatter

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -154,7 +154,7 @@ struct DateTimeToken {
 
 struct DateTimeResult {
   Timestamp timestamp;
-  int64_t timezoneId{-1};
+  const tz::TimeZone* timezone = nullptr;
 };
 
 /// A user defined formatter that formats/parses time to/from user provided

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -123,10 +123,10 @@ class DateTimeFormatterTest : public testing::Test {
     auto dateTimeResultExpected =
         getJodaDateTimeFormatter(format)->parse(input);
     auto result = dateTimeResult(dateTimeResultExpected);
-    if (result.timezoneId == 0) {
+    if (result.timezone->id() == 0) {
       return "+00:00";
     }
-    return tz::getTimeZoneName(result.timezoneId);
+    return result.timezone->name();
   }
 
   std::string formatMysqlDateTime(
@@ -1096,17 +1096,17 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Include timezone.
   auto result = parseJoda("2021-11-05+01:00+09:00", "YYYY-MM-dd+HH:mmZZ");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("+09:00", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+09:00", result.timezone->name());
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021-11-05+01:00", "ZZYYYY-MM-dd+HH:mm");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("-07:23", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-07:23", result.timezone->name());
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332022-03-08+13:00", "ZZYYYY-MM-dd+HH:mm");
   EXPECT_EQ(fromTimestampString("2022-03-08 13:00:00"), result.timestamp);
-  EXPECT_EQ("+01:33", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+01:33", result.timezone->name());
 
   // Z in the input means GMT in Joda.
   EXPECT_EQ(
@@ -1117,7 +1117,7 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedYMDFormat) {
   // Timezone in string format.
   result = parseJoda("2021-11-05+01:00 PST", "YYYY-MM-dd+HH:mm zz");
   EXPECT_EQ(fromTimestampString("2021-11-05 01:00:00"), result.timestamp);
-  EXPECT_EQ("America/Los_Angeles", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("America/Los_Angeles", result.timezone->name());
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
@@ -1239,17 +1239,17 @@ TEST_F(JodaDateTimeFormatterTest, parseMixedWeekFormat) {
   auto result =
       parseJoda("2021 22 1 13:29:21.213+09:00", "x w e HH:mm:ss.SSSZZ");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("+09:00", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+09:00", result.timezone->name());
 
   // Timezone offset in -hh:mm format.
   result = parseJoda("-07:232021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("-07:23", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-07:23", result.timezone->name());
 
   // Timezone offset in +hhmm format.
   result = parseJoda("+01332021 22 1 13:29:21.213", "ZZx w e HH:mm:ss.SSS");
   EXPECT_EQ(fromTimestampString("2021-05-31 13:29:21.213"), result.timestamp);
-  EXPECT_EQ("+01:33", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+01:33", result.timezone->name());
 }
 
 TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
@@ -1257,13 +1257,13 @@ TEST_F(JodaDateTimeFormatterTest, parseFractionOfSecond) {
   auto result =
       parseJoda("2022-02-23T12:15:00.364+04:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.364"), result.timestamp);
-  EXPECT_EQ("+04:00", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("+04:00", result.timezone->name());
 
   // Valid milliseconds and timezone with negative offset.
   result =
       parseJoda("2022-02-23T12:15:00.776-14:00", "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
   EXPECT_EQ(fromTimestampString("2022-02-23 12:15:00.776"), result.timestamp);
-  EXPECT_EQ("-14:00", tz::getTimeZoneName(result.timezoneId));
+  EXPECT_EQ("-14:00", result.timezone->name());
 
   // Valid milliseconds.
   EXPECT_EQ(

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1501,7 +1501,7 @@ struct FromIso8601Timestamp {
     auto [ts, timeZone] = castResult.value();
     // Input string may not contain a timezone - if so, it is interpreted in
     // session timezone.
-    if (timeZone == nullptr) {
+    if (!timeZone) {
       timeZone = sessionTimeZone_;
     }
     ts.toGMT(*timeZone);
@@ -1687,9 +1687,8 @@ struct ParseDateTimeFunction {
 
     // If timezone was not parsed, fallback to the session timezone. If there's
     // no session timezone, fallback to 0 (GMT).
-    const auto* timeZone = dateTimeResult->timezoneId != -1
-        ? tz::locateZone(dateTimeResult->timezoneId)
-        : sessionTimeZone_;
+    const auto* timeZone =
+        dateTimeResult->timezone ? dateTimeResult->timezone : sessionTimeZone_;
     dateTimeResult->timestamp.toGMT(*timeZone);
     result = pack(dateTimeResult->timestamp, timeZone->id());
     return Status::OK();
@@ -1819,7 +1818,7 @@ struct AtTimezoneFunction : public TimestampWithTimezoneSupport<T> {
       const core::QueryConfig& config,
       const arg_type<TimestampWithTimezone>* /*tsWithTz*/,
       const arg_type<Varchar>* timezone) {
-    if (timezone != nullptr) {
+    if (timezone) {
       targetTimezoneID_ = tz::getTimeZoneID(
           std::string_view(timezone->data(), timezone->size()));
     }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -159,8 +159,7 @@ struct UnixTimestampParseFunction {
 
   const tz::TimeZone* getTimeZone(const DateTimeResult& result) {
     // If timezone was not parsed, fallback to the session timezone.
-    return result.timezoneId != -1 ? tz::locateZone(result.timezoneId)
-                                   : sessionTimeZone_;
+    return result.timezone ? result.timezone : sessionTimeZone_;
   }
 
   // Default if format is not specified, as per Spark documentation.
@@ -400,8 +399,7 @@ struct GetTimestampFunction {
   const tz::TimeZone* getTimeZone(const DateTimeResult& result) const {
     // If timezone was not parsed, fallback to the session timezone. If there's
     // no session timezone, fallback to 0 (GMT).
-    return result.timezoneId != -1 ? tz::locateZone(result.timezoneId)
-                                   : sessionTimeZone_;
+    return result.timezone ? result.timezone : sessionTimeZone_;
   }
 
   std::shared_ptr<DateTimeFormatter> formatter_{nullptr};

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -739,7 +739,7 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
   const auto getTimestampString =
       [&](const std::optional<StringView>& dateString,
           const std::string& format) {
-        return getTimestamp(dateString, format).value().toString();
+        return getTimestamp(dateString, format)->toString();
       };
 
   EXPECT_EQ(getTimestamp("1970-01-01", "yyyy-MM-dd"), Timestamp(0, 0));


### PR DESCRIPTION
Summary: We want to capture a tz::TimeZone* instead of relying on timezoneId inside dateTimeFormatter. The former is more flexible and provides conversion capabilities.

Differential Revision: D64348245
