### PR TITLE
Global memory arbitration optimization

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -371,6 +371,24 @@ void registerVeloxMetrics() {
       kMetricArbitratorGlobalArbitrationCount,
       facebook::velox::StatType::COUNT);
 
+  // The number of victims distribution of a global arbitration run [0, 32] with
+  // 32 buckets. It is configured to report the number of victims at P50, P90,
+  // P99, and P100 percentiles.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricArbitratorGlobalArbitrationNumReclaimVictims,
+      1,
+      0,
+      32,
+      50,
+      90,
+      99,
+      100);
+
+  // The number of victim query memory pool having nothing to spill.
+  DEFINE_METRIC(
+      kMetricArbitratorGlobalArbitrationFailedVictimCount,
+      facebook::velox::StatType::COUNT);
+
   // The time distribution of a global arbitration run [0, 600s] with 20
   // buckets. It is configured to report the latency at P50, P90, P99, and P100
   // percentiles.

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -56,7 +56,7 @@ constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeoutCount{
     "velox.task_memory_reclaim_wait_timeout_count"};
 
 constexpr folly::StringPiece kMetricOpMemoryReclaimTimeMs{
-    "velox.op_memory_reclaim_ms"};
+    "velox.op_memory_reclaim_time_ms"};
 
 constexpr folly::StringPiece kMetricOpMemoryReclaimedBytes{
     "velox.op_memory_reclaim_bytes"};
@@ -87,6 +87,14 @@ constexpr folly::StringPiece kMetricArbitratorLocalArbitrationCount{
 
 constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationCount{
     "velox.arbitrator_global_arbitration_count"};
+
+constexpr folly::StringPiece
+    kMetricArbitratorGlobalArbitrationNumReclaimVictims{
+        "velox.arbitrator_global_arbitration_num_reclaim_victims"};
+
+constexpr folly::StringPiece
+    kMetricArbitratorGlobalArbitrationFailedVictimCount{
+        "velox.arbitrator_global_arbitration_failed_victim_count"};
 
 constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationBytes{
     "velox.arbitrator_global_arbitration_bytes"};

--- a/velox/common/base/SuccinctPrinter.cpp
+++ b/velox/common/base/SuccinctPrinter.cpp
@@ -40,7 +40,7 @@ namespace {
 /// Possible units are days(d), hours(h), minutes(m), seconds(s).
 std::string succinctSeconds(uint64_t seconds) {
   std::stringstream out;
-  int days = seconds / kSecondsInDay;
+  const uint64_t days = seconds / kSecondsInDay;
   bool isFirstUnit = true;
   if (days) {
     out << days << "d";
@@ -48,7 +48,7 @@ std::string succinctSeconds(uint64_t seconds) {
   }
   seconds -= days * kSecondsInDay;
 
-  int hours = seconds / kSecondsInHour;
+  const uint64_t hours = seconds / kSecondsInHour;
   if (days || hours) {
     if (!isFirstUnit) {
       out << " ";
@@ -58,11 +58,12 @@ std::string succinctSeconds(uint64_t seconds) {
   }
   seconds -= hours * kSecondsInHour;
 
-  int minutes = seconds / kSecondsInMinute;
+  const uint64_t minutes = seconds / kSecondsInMinute;
   if (days || hours || minutes) {
     if (!isFirstUnit) {
       out << " ";
     }
+
     out << minutes << "m";
     isFirstUnit = false;
   }
@@ -109,6 +110,7 @@ std::string succinctDuration(uint64_t duration, int unitOffset, int precision) {
         std::round((duration * 1.0) / kTimeUnitsInSecond[unitOffset]);
     return succinctSeconds(seconds);
   }
+
   return succinctPrint(
       duration,
       &kTimeUnits[0],

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -40,80 +40,83 @@ namespace velox {
 namespace error_source {
 using namespace folly::string_literals;
 
-// Errors where the root cause of the problem is either because of bad input
-// or an unsupported pattern of use are classified with source USER. Examples
-// of errors in this category include syntax errors, unavailable names or
-// objects.
+/// Errors where the root cause of the problem is either because of bad input
+/// or an unsupported pattern of use are classified with source USER. Examples
+/// of errors in this category include syntax errors, unavailable names or
+/// objects.
 inline constexpr auto kErrorSourceUser = "USER"_fs;
 
-// Errors where the root cause of the problem is an unexpected internal state in
-// the system.
+/// Errors where the root cause of the problem is an unexpected internal state
+/// in the system.
 inline constexpr auto kErrorSourceRuntime = "RUNTIME"_fs;
 
-// Errors where the root cause of the problem is some unreliable aspect of the
-// system are classified with source SYSTEM.
+/// Errors where the root cause of the problem is some unreliable aspect of the
+/// system are classified with source SYSTEM.
 inline constexpr auto kErrorSourceSystem = "SYSTEM"_fs;
 } // namespace error_source
 
 namespace error_code {
 using namespace folly::string_literals;
 
-//====================== User Error Codes ======================:
+///====================== User Error Codes ======================:
 
-// A generic user error code
+/// A generic user error code
 inline constexpr auto kGenericUserError = "GENERIC_USER_ERROR"_fs;
 
-// An error raised when an argument verification fails
+/// An error raised when an argument verification fails
 inline constexpr auto kInvalidArgument = "INVALID_ARGUMENT"_fs;
 
-// An error raised when a requested operation is not supported.
+/// An error raised when a requested operation is not supported.
 inline constexpr auto kUnsupported = "UNSUPPORTED"_fs;
 
-// Arithmetic errors - underflow, overflow, divide by zero etc.
+/// Arithmetic errors - underflow, overflow, divide by zero etc.
 inline constexpr auto kArithmeticError = "ARITHMETIC_ERROR"_fs;
 
-// Arithmetic errors - underflow, overflow, divide by zero etc.
+/// Arithmetic errors - underflow, overflow, divide by zero etc.
 inline constexpr auto kSchemaMismatch = "SCHEMA_MISMATCH"_fs;
 
-//====================== Runtime Error Codes ======================:
+///====================== Runtime Error Codes ======================:
 
-// An error raised when the current state of a component is invalid.
+/// An error raised when the current state of a component is invalid.
 inline constexpr auto kInvalidState = "INVALID_STATE"_fs;
 
-// An error raised when unreachable code point was executed.
+/// An error raised when unreachable code point was executed.
 inline constexpr auto kUnreachableCode = "UNREACHABLE_CODE"_fs;
 
-// An error raised when a requested operation is not yet supported.
+/// An error raised when a requested operation is not yet supported.
 inline constexpr auto kNotImplemented = "NOT_IMPLEMENTED"_fs;
 
-// An error raised when memory pool exceeds limits.
+/// An error raised when memory pool exceeds limits.
 inline constexpr auto kMemCapExceeded = "MEM_CAP_EXCEEDED"_fs;
 
-// An error raised when memory pool is aborted.
+/// An error raised when memory pool is aborted.
 inline constexpr auto kMemAborted = "MEM_ABORTED"_fs;
 
-// Error caused by memory allocation failure (inclusive of allocator memory cap
-// exceeded).
+/// An error raised when memory arbitration is timed out.
+inline constexpr auto kMemArbitrationTimeout = "MEM_ARBITRATION_TIMEOUT"_fs;
+
+/// Error caused by memory allocation failure (inclusive of allocator memory cap
+/// exceeded).
 inline constexpr auto kMemAllocError = "MEM_ALLOC_ERROR"_fs;
 
-// Error caused by failing to allocate cache buffer space for IO.
+/// Error caused by failing to allocate cache buffer space for IO.
 inline constexpr auto kNoCacheSpace = "NO_CACHE_SPACE"_fs;
 
-// An error raised when spill bytes exceeds limits.
+/// An error raised when spill bytes exceeds limits.
 inline constexpr auto kSpillLimitExceeded = "SPILL_LIMIT_EXCEEDED"_fs;
 
-// Errors indicating file read corruptions.
+/// Errors indicating file read corruptions.
 inline constexpr auto kFileCorruption = "FILE_CORRUPTION"_fs;
 
-// Errors indicating file not found.
+/// Errors indicating file not found.
 inline constexpr auto kFileNotFound = "FILE_NOT_FOUND"_fs;
 
-// We do not know how to classify it yet.
+/// We do not know how to classify it yet.
 inline constexpr auto kUnknown = "UNKNOWN"_fs;
 
-// VeloxRuntimeErrors due to unsupported input values such as unicode input to
-// cast-varchar-to-integer and timestamps beyond the year 2037 to datetime
-// functions. This kind of errors is allowed in expression fuzzer.
+/// VeloxRuntimeErrors due to unsupported input values such as unicode input to
+/// cast-varchar-to-integer and timestamps beyond the year 2037 to datetime
+/// functions. This kind of errors is allowed in expression fuzzer.
 inline constexpr auto kUnsupportedInputUncatchable =
     "UNSUPPORTED_INPUT_UNCATCHABLE"_fs;
 } // namespace error_code
@@ -160,12 +163,12 @@ class VeloxException : public std::exception {
             exceptionType,
             exceptionName) {}
 
-  // Inherited
+  /// Inherited
   const char* what() const noexcept override {
     return state_->what();
   }
 
-  // Introduced nonvirtuals
+  /// Introduced nonvirtuals
   const process::StackTrace* stackTrace() const {
     return state_->stackTrace.get();
   }

--- a/velox/common/base/tests/SuccinctPrinterTest.cpp
+++ b/velox/common/base/tests/SuccinctPrinterTest.cpp
@@ -37,6 +37,9 @@ TEST(SuccinctPrinterTest, testSuccinctNanos) {
   EXPECT_EQ(succinctNanos(86'399'499'000'000), "23h 59m 59s");
   EXPECT_EQ(succinctNanos(86'400'123'000'000), "1d 0h 0m 0s");
   EXPECT_EQ(succinctNanos(867'661'789'000'000), "10d 1h 1m 2s");
+  EXPECT_EQ(
+      succinctNanos(std::numeric_limits<uint64_t>::max()),
+      "213503d 23h 34m 34s");
 }
 
 TEST(SuccinctPrinterTest, testSuccinctMicros) {
@@ -51,6 +54,9 @@ TEST(SuccinctPrinterTest, testSuccinctMicros) {
   EXPECT_EQ(succinctMicros(86'399'498), "1m 26s");
   EXPECT_EQ(succinctMicros(86'400'123), "1m 26s");
   EXPECT_EQ(succinctMicros(867'661'789), "14m 28s");
+  EXPECT_EQ(
+      succinctMicros(std::numeric_limits<uint64_t>::max()),
+      "213503982d 8h 1m 50s");
 }
 
 TEST(SuccinctPrinterTest, testSuccinctMillis) {
@@ -65,6 +71,9 @@ TEST(SuccinctPrinterTest, testSuccinctMillis) {
   EXPECT_EQ(succinctMillis(86'399'498), "23h 59m 59s");
   EXPECT_EQ(succinctMillis(86'400'123), "1d 0h 0m 0s");
   EXPECT_EQ(succinctMillis(867'661'789), "10d 1h 1m 2s");
+  EXPECT_EQ(
+      succinctMillis(std::numeric_limits<uint64_t>::max()),
+      "213503982334d 14h 25m 52s");
 }
 
 TEST(SuccinctPrinterTest, testSuccinctBytes) {
@@ -77,6 +86,8 @@ TEST(SuccinctPrinterTest, testSuccinctBytes) {
   EXPECT_EQ(succinctBytes(1'234'567'890), "1.15GB");
   EXPECT_EQ(succinctBytes(1'099'511'627'776), "1.00TB");
   EXPECT_EQ(succinctBytes(1234'099'511'627'776), "1122.41TB");
+  EXPECT_EQ(
+      succinctBytes(std::numeric_limits<uint64_t>::max()), "16777216.00TB");
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/ArbitrationOperation.h
+++ b/velox/common/memory/ArbitrationOperation.h
@@ -105,7 +105,7 @@ class ArbitrationOperation {
 
   /// Invoked to mark the start of global arbitration. This is used to measure
   /// how much time spent in waiting for global arbitration.
-  void startGlobalArbitration() {
+  void recordGlobalArbitrationStartTime() {
     VELOX_CHECK_EQ(globalArbitrationStartTimeMs_, 0);
     VELOX_CHECK_EQ(state_, State::kRunning);
     globalArbitrationStartTimeMs_ = getCurrentTimeMs();

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -19,6 +19,8 @@ velox_add_library(
   velox_memory
   Allocation.cpp
   AllocationPool.cpp
+  ArbitrationOperation.cpp
+  ArbitrationParticipant.cpp
   ByteStream.cpp
   HashStringAllocator.cpp
   MallocAllocator.cpp

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -541,6 +541,13 @@ ScopedReclaimedBytesRecorder::~ScopedReclaimedBytesRecorder() {
     return;
   }
   const int64_t reservedBytesAfterReclaim = pool_->reservedBytes();
+  if (reservedBytesAfterReclaim > reservedBytesBeforeReclaim_) {
+    LOG(ERROR) << "Unexpected reserved bytes growth from " << pool_->name()
+               << " after memory reclaim from "
+               << succinctBytes(reservedBytesBeforeReclaim_) << " to "
+               << succinctBytes(reservedBytesAfterReclaim) << ", current usage "
+               << succinctBytes(pool_->usedBytes());
+  }
   *reclaimedBytes_ = reservedBytesBeforeReclaim_ - reservedBytesAfterReclaim;
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -264,7 +264,7 @@ class MemoryReclaimer {
     /// due to reclaiming at non-reclaimable stage.
     uint64_t numNonReclaimableAttempts{0};
 
-    /// The total execution time to do the reclaim in microseconds.
+    /// The total time to do the reclaim in microseconds.
     uint64_t reclaimExecTimeUs{0};
 
     /// The total reclaimed memory bytes.

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1119,10 +1119,10 @@ void MemoryPoolImpl::abort(const std::exception_ptr& error) {
     parent_->abort(error);
     return;
   }
-  if (reclaimer() == nullptr) {
-    VELOX_FAIL("Can't abort the memory pool {} without reclaimer", name_);
-  }
   setAbortError(error);
+  if (reclaimer() == nullptr) {
+    return;
+  }
   reclaimer()->abort(this, error);
 }
 

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "velox/common/memory/SharedArbitrator.h"
+#include <folly/system/ThreadName.h>
+#include <pthread.h>
 #include <mutex>
-
+#include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/config/Config.h"
@@ -31,38 +33,21 @@ namespace facebook::velox::memory {
 using namespace facebook::velox::memory;
 
 namespace {
-
-// Returns the max capacity to grow of memory 'pool'. The calculation is based
-// on a memory pool's max capacity and its current capacity.
-uint64_t maxGrowCapacity(const MemoryPool& pool) {
-  return pool.maxCapacity() - pool.capacity();
-}
-
-// Returns the capacity of the memory pool with the specified growth target.
-uint64_t capacityAfterGrowth(const MemoryPool& pool, uint64_t targetBytes) {
-  return pool.capacity() + targetBytes;
-}
-
-std::string memoryPoolAbortMessage(
-    MemoryPool* victim,
-    MemoryPool* requestor,
-    size_t growBytes) {
-  std::stringstream out;
-  VELOX_CHECK(victim->isRoot());
-  VELOX_CHECK(requestor->isRoot());
-  if (requestor == victim) {
-    out << "\nFailed memory pool '" << victim->name()
-        << "' aborted by itself when tried to grow " << succinctBytes(growBytes)
-        << "\n";
-  } else {
-    out << "\nFailed memory pool '" << victim->name()
-        << "' aborted when requestor '" << requestor->name()
-        << "' tried to grow " << succinctBytes(growBytes) << "\n";
+#define RETURN_IF_TRUE(func) \
+  {                          \
+    const bool ret = func;   \
+    if (ret) {               \
+      return ret;            \
+    }                        \
   }
-  out << "Memory usage of the failed memory pool:\n"
-      << victim->treeMemoryUsage();
-  return out.str();
-}
+
+#define CHECKED_GROW(pool, growBytes, reservationBytes) \
+  try {                                                 \
+    checkedGrow(pool, growBytes, reservationBytes);     \
+  } catch (const VeloxRuntimeError& e) {                \
+    freeCapacity(growBytes);                            \
+    throw;                                              \
+  }
 
 template <typename T>
 T getConfig(
@@ -79,6 +64,15 @@ T getConfig(
   }
   return defaultValue;
 }
+
+#define VELOX_MEM_ARBITRATION_TIMEOUT(errorMessage)                  \
+  _VELOX_THROW(                                                      \
+      ::facebook::velox::VeloxRuntimeError,                          \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(),  \
+      ::facebook::velox::error_code::kMemArbitrationTimeout.c_str(), \
+      /* isRetriable */ true,                                        \
+      "{}",                                                          \
+      errorMessage);
 } // namespace
 
 int64_t SharedArbitrator::ExtraConfig::reservedCapacity(
@@ -137,6 +131,26 @@ double SharedArbitrator::ExtraConfig::memoryPoolMinFreeCapacityPct(
       kDefaultMemoryPoolMinFreeCapacityPct);
 }
 
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolMinReclaimBytes(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return config::toCapacity(
+      getConfig<std::string>(
+          configs,
+          kMemoryPoolMinReclaimBytes,
+          std::string(kDefaultMemoryPoolMinReclaimBytes)),
+      config::CapacityUnit::BYTE);
+}
+
+uint64_t SharedArbitrator::ExtraConfig::memoryPoolAbortCapacityLimit(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return config::toCapacity(
+      getConfig<std::string>(
+          configs,
+          kMemoryPoolAbortCapacityLimit,
+          std::string(kDefaultMemoryPoolAbortCapacityLimit)),
+      config::CapacityUnit::BYTE);
+}
+
 bool SharedArbitrator::ExtraConfig::globalArbitrationEnabled(
     const std::unordered_map<std::string, std::string>& configs) {
   return getConfig<bool>(
@@ -164,62 +178,157 @@ double SharedArbitrator::ExtraConfig::slowCapacityGrowPct(
       configs, kSlowCapacityGrowPct, kDefaultSlowCapacityGrowPct);
 }
 
+double SharedArbitrator::ExtraConfig::memoryReclaimThreadsHwMultiplier(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return getConfig<double>(
+      configs,
+      kMemoryReclaimThreadsHwMultiplier,
+      kDefaultMemoryReclaimThreadsHwMultiplier);
+}
+
+uint32_t SharedArbitrator::ExtraConfig::globalArbitrationMemoryReclaimPct(
+    const std::unordered_map<std::string, std::string>& configs) {
+  return getConfig<uint32_t>(
+      configs,
+      kGlobalArbitrationMemoryReclaimPct,
+      kDefaultGlobalMemoryArbitrationReclaimPct);
+}
+
 SharedArbitrator::SharedArbitrator(const Config& config)
     : MemoryArbitrator(config),
       reservedCapacity_(ExtraConfig::reservedCapacity(config.extraConfigs)),
-      memoryPoolInitialCapacity_(
-          ExtraConfig::memoryPoolInitialCapacity(config.extraConfigs)),
-      memoryPoolReservedCapacity_(
-          ExtraConfig::memoryPoolReservedCapacity(config.extraConfigs)),
-      memoryReclaimWaitMs_(
+      checkUsageLeak_(ExtraConfig::checkUsageLeak(config.extraConfigs)),
+      maxArbitrationTimeMs_(
           ExtraConfig::memoryReclaimMaxWaitTimeMs(config.extraConfigs)),
+      participantConfig_(
+          ExtraConfig::memoryPoolInitialCapacity(config.extraConfigs),
+          ExtraConfig::memoryPoolReservedCapacity(config.extraConfigs),
+          ExtraConfig::fastExponentialGrowthCapacityLimitBytes(
+              config.extraConfigs),
+          ExtraConfig::slowCapacityGrowPct(config.extraConfigs),
+          ExtraConfig::memoryPoolMinFreeCapacity(config.extraConfigs),
+          ExtraConfig::memoryPoolMinFreeCapacityPct(config.extraConfigs),
+          ExtraConfig::memoryPoolMinReclaimBytes(config.extraConfigs),
+          ExtraConfig::memoryPoolAbortCapacityLimit(config.extraConfigs)),
+      memoryReclaimThreadsHwMultiplier_(
+          ExtraConfig::memoryReclaimThreadsHwMultiplier(config.extraConfigs)),
       globalArbitrationEnabled_(
           ExtraConfig::globalArbitrationEnabled(config.extraConfigs)),
-      checkUsageLeak_(ExtraConfig::checkUsageLeak(config.extraConfigs)),
-      fastExponentialGrowthCapacityLimit_(
-          ExtraConfig::fastExponentialGrowthCapacityLimitBytes(
-              config.extraConfigs)),
-      slowCapacityGrowPct_(
-          ExtraConfig::slowCapacityGrowPct(config.extraConfigs)),
-      memoryPoolMinFreeCapacity_(
-          ExtraConfig::memoryPoolMinFreeCapacity(config.extraConfigs)),
-      memoryPoolMinFreeCapacityPct_(
-          ExtraConfig::memoryPoolMinFreeCapacityPct(config.extraConfigs)),
+      globalArbitrationMemoryReclaimPct_(
+          ExtraConfig::globalArbitrationMemoryReclaimPct(config.extraConfigs)),
       freeReservedCapacity_(reservedCapacity_),
       freeNonReservedCapacity_(capacity_ - freeReservedCapacity_) {
   VELOX_CHECK_EQ(kind_, config.kind);
   VELOX_CHECK_LE(reservedCapacity_, capacity_);
-  VELOX_CHECK_GE(slowCapacityGrowPct_, 0);
-  VELOX_CHECK_GE(memoryPoolMinFreeCapacityPct_, 0);
-  VELOX_CHECK_LE(memoryPoolMinFreeCapacityPct_, 1);
-  VELOX_CHECK_EQ(
-      fastExponentialGrowthCapacityLimit_ == 0,
-      slowCapacityGrowPct_ == 0,
-      "fastExponentialGrowthCapacityLimit_ {} and slowCapacityGrowPct_ {} "
-      "both need to be set (non-zero) at the same time to enable growth capacity "
-      "adjustment.",
-      fastExponentialGrowthCapacityLimit_,
-      slowCapacityGrowPct_);
-  VELOX_CHECK_EQ(
-      memoryPoolMinFreeCapacity_ == 0,
-      memoryPoolMinFreeCapacityPct_ == 0,
-      "memoryPoolMinFreeCapacity_ {} and memoryPoolMinFreeCapacityPct_ {} both "
-      "need to be set (non-zero) at the same time to enable shrink capacity "
-      "adjustment.",
-      memoryPoolMinFreeCapacity_,
-      memoryPoolMinFreeCapacityPct_);
+  VELOX_CHECK_GT(
+      maxArbitrationTimeMs_, 0, "maxArbitrationTimeMs can't be zero");
+
+  VELOX_CHECK_LE(
+      globalArbitrationMemoryReclaimPct_,
+      100,
+      "Invalid globalArbitrationMemoryReclaimPct");
+
+  VELOX_CHECK_GT(
+      memoryReclaimThreadsHwMultiplier_,
+      0.0,
+      "memoryReclaimThreadsHwMultiplier_ needs to be positive");
+
+  const uint64_t numReclaimThreads = std::max<size_t>(
+      1,
+      std::thread::hardware_concurrency() * memoryReclaimThreadsHwMultiplier_);
+  memoryReclaimExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
+      numReclaimThreads,
+      std::make_shared<folly::NamedThreadFactory>("MeomryReclaim"));
+  VELOX_MEM_LOG(INFO) << "Start memory reclaim executor with "
+                      << numReclaimThreads << " threads";
+
+  setupGlobalArbitration();
+
+  VELOX_MEM_LOG(INFO) << "Shared arbitrator created with "
+                      << succinctBytes(capacity_) << " capacity, "
+                      << succinctBytes(reservedCapacity_)
+                      << " reserved capacity";
+  if (globalArbitrationEnabled_) {
+    VELOX_MEM_LOG(INFO) << "Arbitration config: max arbitration time "
+                        << succinctMillis(maxArbitrationTimeMs_)
+                        << ", global memory reclaim percentage "
+                        << globalArbitrationMemoryReclaimPct_;
+  }
+  VELOX_MEM_LOG(INFO) << "Memory pool participant config: "
+                      << participantConfig_.toString();
 }
 
-std::string SharedArbitrator::Candidate::toString() const {
-  return fmt::format(
-      "CANDIDATE[{}] RECLAIMABLE_BYTES[{}] FREE_BYTES[{}]]",
-      pool->name(),
-      succinctBytes(reclaimableBytes),
-      succinctBytes(freeBytes));
+void SharedArbitrator::setupGlobalArbitration() {
+  if (!globalArbitrationEnabled_) {
+    return;
+  }
+  VELOX_CHECK_NULL(globalArbitrationController_);
+
+  const uint64_t minAbortCapacity = 32 << 20;
+  for (auto abortLimit = participantConfig_.abortCapacityLimit; abortLimit >=
+       std::max<uint64_t>(minAbortCapacity,
+                          folly::nextPowTwo(participantConfig_.minCapacity));
+       abortLimit /= 2) {
+    globalArbitrationAbortCapacityLimits_.push_back(abortLimit);
+  }
+  globalArbitrationAbortCapacityLimits_.push_back(0);
+
+  VELOX_MEM_LOG(INFO) << "Global arbitration abort capacity limits: "
+                      << folly::join(
+                             ",", globalArbitrationAbortCapacityLimits_);
+
+  globalArbitrationController_ = std::make_unique<std::thread>([&]() {
+    folly::setThreadName("GlobalArbitrationController");
+    globalArbitrationMain();
+  });
+}
+
+void SharedArbitrator::shutdownGlobalArbitration() {
+  if (!globalArbitrationEnabled_) {
+    VELOX_CHECK_NULL(globalArbitrationController_);
+    return;
+  }
+
+  VELOX_CHECK(!globalArbitrationAbortCapacityLimits_.empty());
+  VELOX_CHECK_NOT_NULL(globalArbitrationController_);
+  {
+    std::lock_guard<std::mutex> l(stateLock_);
+    // We only expect stop global arbitration once during velox runtime
+    // shutdown.
+    VELOX_CHECK(!globalArbitrationStop_);
+    VELOX_CHECK(globalArbitrationWaiters_.empty());
+    globalArbitrationStop_ = true;
+  }
+
+  VELOX_MEM_LOG(INFO) << "Stopping global arbitration controller";
+  globalArbitrationThreadCv_.notify_one();
+  globalArbitrationController_->join();
+  globalArbitrationController_.reset();
+  VELOX_MEM_LOG(INFO) << "Global arbitration controller stopped";
+}
+
+void SharedArbitrator::wakeupGlobalArbitrationThread() {
+  VELOX_CHECK(globalArbitrationEnabled_);
+  VELOX_CHECK_NOT_NULL(globalArbitrationController_);
+  incrementGlobalArbitrationWaitCount();
+  globalArbitrationThreadCv_.notify_one();
 }
 
 SharedArbitrator::~SharedArbitrator() {
-  VELOX_CHECK(candidates_.empty());
+  shutdownGlobalArbitration();
+
+  VELOX_MEM_LOG(INFO) << "Stopping memory reclaim executor '"
+                      << memoryReclaimExecutor_->getName() << "': threads: "
+                      << memoryReclaimExecutor_->numActiveThreads() << "/"
+                      << memoryReclaimExecutor_->numThreads()
+                      << ", task queue: "
+                      << memoryReclaimExecutor_->getTaskQueueSize();
+  memoryReclaimExecutor_.reset();
+  VELOX_MEM_LOG(INFO) << "Memory reclaim executor stopped";
+
+  VELOX_CHECK_EQ(
+      participants_.size(), 0, "Unexpected alive participants on destruction");
+
   if (freeNonReservedCapacity_ + freeReservedCapacity_ != capacity_) {
     const std::string errMsg = fmt::format(
         "Unexpected free capacity leak in arbitrator: freeNonReservedCapacity_[{}] + freeReservedCapacity_[{}] != capacity_[{}])\\n{}",
@@ -235,82 +344,146 @@ SharedArbitrator::~SharedArbitrator() {
   }
 }
 
-void SharedArbitrator::addPool(const std::shared_ptr<MemoryPool>& pool) {
-  VELOX_CHECK_EQ(pool->capacity(), 0);
-  {
-    std::unique_lock guard{poolLock_};
-    VELOX_CHECK_EQ(candidates_.count(pool.get()), 0);
-    candidates_.emplace(pool.get(), pool);
+void SharedArbitrator::startArbitration(ArbitrationOperation* op) {
+  updateArbitrationRequestStats();
+  ++numRunning_;
+  op->start();
+}
+
+void SharedArbitrator::finishArbitration(ArbitrationOperation* op) {
+  VELOX_CHECK_GT(numRunning_, 0);
+  --numRunning_;
+  op->finish();
+
+  const auto stats = op->stats();
+  if (stats.executionTimeMs != 0) {
+    RECORD_HISTOGRAM_METRIC_VALUE(
+        kMetricArbitratorOpExecTimeMs, stats.executionTimeMs);
+    addThreadLocalRuntimeStat(
+        kMemoryArbitrationWallNanos,
+        RuntimeCounter(
+            stats.executionTimeMs * 1'000 * 1'000,
+            RuntimeCounter::Unit::kNanos));
   }
 
-  std::lock_guard<std::mutex> l(stateLock_);
-  const uint64_t maxBytesToReserve =
-      std::min(maxGrowCapacity(*pool), memoryPoolInitialCapacity_);
-  const uint64_t minBytesToReserve = minGrowCapacity(*pool);
-  const uint64_t reservedBytes =
-      decrementFreeCapacityLocked(maxBytesToReserve, minBytesToReserve);
-  try {
-    checkedGrow(pool.get(), reservedBytes, 0);
-  } catch (const VeloxRuntimeError&) {
-    incrementFreeCapacityLocked(reservedBytes);
+  if (stats.localArbitrationWaitTimeMs != 0) {
+    addThreadLocalRuntimeStat(
+        kLocalArbitrationWaitWallNanos,
+        RuntimeCounter(
+            stats.localArbitrationWaitTimeMs * 1'000 * 1'000,
+            RuntimeCounter::Unit::kNanos));
+  }
+  if (stats.localArbitrationExecTimeMs != 0) {
+    addThreadLocalRuntimeStat(
+        kLocalArbitrationExecutionWallNanos,
+        RuntimeCounter(
+            stats.localArbitrationExecTimeMs * 1'000 * 1'000,
+            RuntimeCounter::Unit::kNanos));
+  }
+  if (stats.globalArbitrationWaitTimeMs != 0) {
+    addThreadLocalRuntimeStat(
+        kGlobalArbitrationWaitWallNanos,
+        RuntimeCounter(
+            stats.globalArbitrationWaitTimeMs * 1'000 * 1'000,
+            RuntimeCounter::Unit::kNanos));
+    RECORD_HISTOGRAM_METRIC_VALUE(
+        kMetricArbitratorGlobalArbitrationWaitTimeMs,
+        stats.globalArbitrationWaitTimeMs);
+  }
+}
+
+void SharedArbitrator::addPool(const std::shared_ptr<MemoryPool>& pool) {
+  VELOX_CHECK_EQ(pool->capacity(), 0);
+
+  auto newParticipant = ArbitrationParticipant::create(
+      nextParticipantId_++, pool, &participantConfig_);
+  {
+    std::unique_lock guard{participantLock_};
+    VELOX_CHECK_EQ(
+        participants_.count(pool->name()),
+        0,
+        "Memory pool {} already exists",
+        pool->name());
+    participants_.emplace(newParticipant->name(), newParticipant);
+  }
+
+  auto scopedParticipant = newParticipant->lock().value();
+  std::vector<ContinuePromise> arbitrationWaiters;
+  {
+    std::lock_guard<std::mutex> l(stateLock_);
+    const uint64_t minBytesToReserve = std::min(
+        scopedParticipant->maxCapacity(), scopedParticipant->minCapacity());
+    const uint64_t maxBytesToReserve = std::max(
+        minBytesToReserve,
+        std::min(
+            scopedParticipant->maxCapacity(), participantConfig_.initCapacity));
+    const uint64_t allocatedBytes = allocateCapacityLocked(
+        scopedParticipant->id(), 0, maxBytesToReserve, minBytesToReserve);
+    if (allocatedBytes > 0) {
+      VELOX_CHECK_LE(allocatedBytes, maxBytesToReserve);
+      try {
+        checkedGrow(scopedParticipant, allocatedBytes, 0);
+      } catch (const VeloxRuntimeError& e) {
+        VELOX_MEM_LOG(ERROR)
+            << "Failed to allocate initial capacity "
+            << succinctBytes(allocatedBytes)
+            << " for memory pool: " << scopedParticipant->name() << "\n"
+            << e.what();
+        freeCapacityLocked(allocatedBytes, arbitrationWaiters);
+      }
+    }
+  }
+  for (auto& waiter : arbitrationWaiters) {
+    waiter.setValue();
   }
 }
 
 void SharedArbitrator::removePool(MemoryPool* pool) {
   VELOX_CHECK_EQ(pool->reservedBytes(), 0);
-  shrinkCapacity(pool);
+  const uint64_t freedBytes = shrinkPool(pool, 0);
+  VELOX_CHECK_EQ(pool->capacity(), 0);
+  freeCapacity(freedBytes);
 
-  std::unique_lock guard{poolLock_};
-  const auto ret = candidates_.erase(pool);
+  std::unique_lock guard{participantLock_};
+  const auto ret = participants_.erase(pool->name());
   VELOX_CHECK_EQ(ret, 1);
 }
 
-void SharedArbitrator::getCandidates(
-    ArbitrationOperation* op,
+std::vector<ArbitrationCandidate> SharedArbitrator::getCandidates(
     bool freeCapacityOnly) {
-  op->candidates.clear();
-
-  std::shared_lock guard{poolLock_};
-  op->candidates.reserve(candidates_.size());
-  for (const auto& candidate : candidates_) {
-    const bool selfCandidate = op->requestPool == candidate.first;
-    std::shared_ptr<MemoryPool> pool = candidate.second.lock();
-    if (pool == nullptr) {
-      VELOX_CHECK(!selfCandidate);
+  std::vector<ArbitrationCandidate> candidates;
+  std::shared_lock guard{participantLock_};
+  candidates.reserve(participants_.size());
+  for (const auto& entry : participants_) {
+    auto candidate = entry.second->lock();
+    if (!candidate.has_value()) {
       continue;
     }
-    op->candidates.push_back(
-        {pool,
-         freeCapacityOnly ? 0 : reclaimableUsedCapacity(*pool, selfCandidate),
-         reclaimableFreeCapacity(*pool, selfCandidate),
-         pool->reservedBytes()});
+    candidates.push_back({std::move(candidate.value()), freeCapacityOnly});
   }
-  VELOX_CHECK(!op->candidates.empty());
+  return candidates;
 }
 
 void SharedArbitrator::sortCandidatesByReclaimableFreeCapacity(
-    std::vector<Candidate>& candidates) {
+    std::vector<ArbitrationCandidate>& candidates) {
   std::sort(
       candidates.begin(),
       candidates.end(),
-      [&](const SharedArbitrator::Candidate& lhs,
-          const SharedArbitrator::Candidate& rhs) {
-        return lhs.freeBytes > rhs.freeBytes;
+      [&](const ArbitrationCandidate& lhs, const ArbitrationCandidate& rhs) {
+        return lhs.reclaimableFreeCapacity > rhs.reclaimableFreeCapacity;
       });
-
   TestValue::adjust(
       "facebook::velox::memory::SharedArbitrator::sortCandidatesByReclaimableFreeCapacity",
       &candidates);
 }
 
 void SharedArbitrator::sortCandidatesByReclaimableUsedCapacity(
-    std::vector<Candidate>& candidates) {
+    std::vector<ArbitrationCandidate>& candidates) {
   std::sort(
       candidates.begin(),
       candidates.end(),
-      [](const SharedArbitrator::Candidate& lhs,
-         const SharedArbitrator::Candidate& rhs) {
-        return lhs.reclaimableBytes > rhs.reclaimableBytes;
+      [](const ArbitrationCandidate& lhs, const ArbitrationCandidate& rhs) {
+        return lhs.reclaimableUsedCapacity > rhs.reclaimableUsedCapacity;
       });
 
   TestValue::adjust(
@@ -318,51 +491,60 @@ void SharedArbitrator::sortCandidatesByReclaimableUsedCapacity(
       &candidates);
 }
 
-void SharedArbitrator::sortCandidatesByUsage(
-    std::vector<Candidate>& candidates) {
-  std::sort(
-      candidates.begin(),
-      candidates.end(),
-      [](const SharedArbitrator::Candidate& lhs,
-         const SharedArbitrator::Candidate& rhs) {
-        return lhs.reservedBytes > rhs.reservedBytes;
-      });
-}
+std::optional<ArbitrationCandidate> SharedArbitrator::findAbortCandidate(
+    bool force) {
+  const auto candidates = getCandidates();
+  if (candidates.empty()) {
+    return std::nullopt;
+  }
 
-const SharedArbitrator::Candidate&
-SharedArbitrator::findCandidateWithLargestCapacity(
-    MemoryPool* requestor,
-    uint64_t targetBytes,
-    const std::vector<SharedArbitrator::Candidate>& candidates) {
-  VELOX_CHECK(!candidates.empty());
+  for (uint64_t capacityLimit : globalArbitrationAbortCapacityLimits_) {
+    int32_t candidateIdx{-1};
+    for (int32_t i = 0; i < candidates.size(); ++i) {
+      if (candidates[i].participant->aborted()) {
+        continue;
+      }
+      if (candidates[i].currentCapacity < capacityLimit ||
+          candidates[i].currentCapacity == 0) {
+        continue;
+      }
+      if (candidateIdx == -1) {
+        candidateIdx = i;
+        continue;
+      }
+      // With the same capacity size bucket, we favor the old participant to let
+      // long running query proceed first.
+      if (candidates[candidateIdx].participant->id() <
+          candidates[i].participant->id()) {
+        candidateIdx = i;
+      }
+    }
+    if (candidateIdx != -1) {
+      return candidates[candidateIdx];
+    }
+  }
+
+  if (!force) {
+    VELOX_MEM_LOG(WARNING) << "Can't find an eligible abort victim";
+    return std::nullopt;
+  }
+
+  // Can't find an eligible abort candidate and then return the youngest
+  // candidate which has the largest participant id.
   int32_t candidateIdx{-1};
-  uint64_t maxCapacity{0};
-  for (int32_t i = 0; i < candidates.size(); ++i) {
-    const bool isCandidate = candidates[i].pool.get() == requestor;
-    // For capacity comparison, the requestor's capacity should include both its
-    // current capacity and the capacity growth.
-    const uint64_t capacity =
-        candidates[i].pool->capacity() + (isCandidate ? targetBytes : 0);
-    if (i == 0) {
-      candidateIdx = 0;
-      maxCapacity = capacity;
-      continue;
-    }
-    if (capacity < maxCapacity) {
-      continue;
-    }
-    if (capacity > maxCapacity) {
+  for (auto i = 0; i < candidates.size(); ++i) {
+    if (candidateIdx == -1) {
       candidateIdx = i;
-      maxCapacity = capacity;
-      continue;
-    }
-    // With the same amount of capacity, we prefer to kill the requestor itself
-    // without affecting the other query.
-    if (isCandidate) {
+    } else if (
+        candidates[i].participant->id() >
+        candidates[candidateIdx].participant->id()) {
       candidateIdx = i;
     }
   }
   VELOX_CHECK_NE(candidateIdx, -1);
+  VELOX_MEM_LOG(WARNING)
+      << "Can't find an eligible abort victim and force to abort the youngest participant "
+      << candidates[candidateIdx].participant->name();
   return candidates[candidateIdx];
 }
 
@@ -376,631 +558,717 @@ void SharedArbitrator::updateArbitrationFailureStats() {
   ++numFailures_;
 }
 
-int64_t SharedArbitrator::maxReclaimableCapacity(
-    const MemoryPool& pool,
-    bool isSelfReclaim) const {
-  // Checks if a query memory pool has likely finished processing. It is likely
-  // this pool has finished when it has 0 current usage and non-0 past usage. If
-  // there is a high chance this pool finished, then we don't have to respect
-  // the memory pool reserved capacity limit check.
-  //
-  // NOTE: for query system like Prestissimo, it holds a finished query state in
-  // minutes for query stats fetch request from the Presto coordinator.
-  if (isSelfReclaim || (pool.reservedBytes() == 0 && pool.peakBytes() != 0)) {
-    return pool.capacity();
-  }
-  return std::max<int64_t>(0, pool.capacity() - memoryPoolReservedCapacity_);
+uint64_t SharedArbitrator::allocateCapacity(
+    uint64_t participantId,
+    uint64_t requestBytes,
+    uint64_t maxAllocateBytes,
+    uint64_t minAllocateBytes) {
+  std::lock_guard<std::mutex> l(stateLock_);
+  return allocateCapacityLocked(
+      participantId, requestBytes, maxAllocateBytes, minAllocateBytes);
 }
 
-int64_t SharedArbitrator::reclaimableFreeCapacity(
-    const MemoryPool& pool,
-    bool isSelfReclaim) const {
-  const auto freeBytes = pool.freeBytes();
-  if (freeBytes == 0) {
+uint64_t SharedArbitrator::allocateCapacityLocked(
+    uint64_t participantId,
+    uint64_t requestBytes,
+    uint64_t maxAllocateBytes,
+    uint64_t minAllocateBytes) {
+  VELOX_CHECK_LE(requestBytes, maxAllocateBytes);
+
+  if (FOLLY_UNLIKELY(!globalArbitrationWaiters_.empty())) {
+    if ((participantId > globalArbitrationWaiters_.begin()->first) &&
+        (requestBytes > minAllocateBytes)) {
+      return 0;
+    }
+    maxAllocateBytes = std::max(requestBytes, minAllocateBytes);
+  }
+
+  const uint64_t nonReservedBytes =
+      std::min<uint64_t>(freeNonReservedCapacity_, maxAllocateBytes);
+  if (nonReservedBytes >= maxAllocateBytes) {
+    freeNonReservedCapacity_ -= nonReservedBytes;
+    return nonReservedBytes;
+  }
+
+  uint64_t reservedBytes{0};
+  if (nonReservedBytes < minAllocateBytes) {
+    const uint64_t freeReservedCapacity = freeReservedCapacity_;
+    reservedBytes =
+        std::min(minAllocateBytes - nonReservedBytes, freeReservedCapacity);
+  }
+  if (FOLLY_UNLIKELY(nonReservedBytes + reservedBytes < requestBytes)) {
     return 0;
   }
-  return std::min<int64_t>(
-      isSelfReclaim ? freeBytes : getCapacityShrinkTarget(pool, freeBytes),
-      maxReclaimableCapacity(pool, isSelfReclaim));
-}
 
-int64_t SharedArbitrator::reclaimableUsedCapacity(
-    const MemoryPool& pool,
-    bool isSelfReclaim) const {
-  const auto maxReclaimableBytes = maxReclaimableCapacity(pool, isSelfReclaim);
-  const auto reclaimableBytes = pool.reclaimableBytes();
-  return std::min<int64_t>(maxReclaimableBytes, reclaimableBytes.value_or(0));
-}
-
-int64_t SharedArbitrator::minGrowCapacity(const MemoryPool& pool) const {
-  return std::max<int64_t>(
-      0,
-      std::min<int64_t>(pool.maxCapacity(), memoryPoolReservedCapacity_) -
-          pool.capacity());
-}
-
-uint64_t SharedArbitrator::decrementFreeCapacity(
-    uint64_t maxBytesToReserve,
-    uint64_t minBytesToReserve) {
-  uint64_t reservedBytes{0};
-  {
-    std::lock_guard<std::mutex> l(stateLock_);
-    reservedBytes =
-        decrementFreeCapacityLocked(maxBytesToReserve, minBytesToReserve);
-  }
-  return reservedBytes;
-}
-
-uint64_t SharedArbitrator::decrementFreeCapacityLocked(
-    uint64_t maxBytesToReserve,
-    uint64_t minBytesToReserve) {
-  uint64_t allocatedBytes =
-      std::min<uint64_t>(freeNonReservedCapacity_, maxBytesToReserve);
-  freeNonReservedCapacity_ -= allocatedBytes;
-  if (allocatedBytes < minBytesToReserve) {
-    const uint64_t reservedBytes = std::min<uint64_t>(
-        minBytesToReserve - allocatedBytes, freeReservedCapacity_);
-    freeReservedCapacity_ -= reservedBytes;
-    allocatedBytes += reservedBytes;
-  }
-  return allocatedBytes;
-}
-
-uint64_t SharedArbitrator::getCapacityShrinkTarget(
-    const MemoryPool& pool,
-    uint64_t requestBytes) const {
-  VELOX_CHECK_NE(requestBytes, 0);
-  auto targetBytes = requestBytes;
-  if (memoryPoolMinFreeCapacity_ != 0) {
-    const auto minFreeBytes = std::min(
-        static_cast<uint64_t>(pool.capacity() * memoryPoolMinFreeCapacityPct_),
-        memoryPoolMinFreeCapacity_);
-    const auto maxShrinkBytes = std::max<int64_t>(
-        0LL, pool.freeBytes() - static_cast<int64_t>(minFreeBytes));
-    targetBytes = std::min(targetBytes, static_cast<uint64_t>(maxShrinkBytes));
-  }
-  return targetBytes;
+  freeNonReservedCapacity_ -= nonReservedBytes;
+  freeReservedCapacity_ -= reservedBytes;
+  return nonReservedBytes + reservedBytes;
 }
 
 uint64_t SharedArbitrator::shrinkCapacity(
     MemoryPool* pool,
-    uint64_t requestBytes) {
-  std::lock_guard<std::mutex> l(stateLock_);
-  const uint64_t freedBytes = shrinkPool(
-      pool,
-      requestBytes == 0 ? 0 : getCapacityShrinkTarget(*pool, requestBytes));
-  incrementFreeCapacityLocked(freedBytes);
-  return freedBytes;
+    uint64_t /*unused*/) {
+  VELOX_CHECK(pool->isRoot());
+  auto participant = getParticipant(pool->name());
+  VELOX_CHECK(participant.has_value());
+  return shrink(participant.value(), /*reclaimAll=*/true);
 }
 
 uint64_t SharedArbitrator::shrinkCapacity(
     uint64_t requestBytes,
     bool allowSpill,
     bool allowAbort) {
-  incrementGlobalArbitrationCount();
   const uint64_t targetBytes = requestBytes == 0 ? capacity_ : requestBytes;
-  ArbitrationOperation op(targetBytes);
-  ScopedArbitration scopedArbitration(this, &op);
+  ScopedMemoryArbitrationContext abitrationCtx{};
+  const uint64_t startTimeMs = getCurrentTimeMs();
 
-  std::lock_guard<std::shared_mutex> exclusiveLock(arbitrationLock_);
-  getCandidates(&op);
-
-  uint64_t reclaimedBytes{0};
+  uint64_t totalReclaimedBytes{0};
   if (allowSpill) {
-    uint64_t freedBytes{0};
-    reclaimUsedMemoryFromCandidatesBySpill(&op, freedBytes);
-    reclaimedBytes += freedBytes;
-    if (freedBytes > 0) {
-      incrementFreeCapacity(freedBytes);
-    }
-    if (reclaimedBytes >= op.requestBytes) {
-      return reclaimedBytes;
-    }
-    if (allowAbort) {
-      // Candidate stats may change after spilling.
-      getCandidates(&op);
+    totalReclaimedBytes += reclaimUsedMemoryBySpill(targetBytes);
+  }
+
+  if ((totalReclaimedBytes < targetBytes) && allowAbort) {
+    for (;;) {
+      const uint64_t reclaimedBytes = reclaimUsedMemoryByAbort(/*force=*/false);
+      if (reclaimedBytes == 0) {
+        break;
+      }
+      totalReclaimedBytes += reclaimedBytes;
+      if (totalReclaimedBytes >= targetBytes) {
+        break;
+      }
     }
   }
 
-  if (allowAbort) {
-    uint64_t freedBytes{0};
-    reclaimUsedMemoryFromCandidatesByAbort(&op, freedBytes);
-    reclaimedBytes += freedBytes;
-    if (freedBytes > 0) {
-      incrementFreeCapacity(freedBytes);
-    }
-  }
-  return reclaimedBytes;
+  const uint64_t reclaimTimeMs = getCurrentTimeMs() - startTimeMs;
+  VELOX_MEM_LOG(INFO) << "External shrink reclaimed "
+                      << succinctBytes(totalReclaimedBytes) << ", spent "
+                      << succinctMillis(reclaimTimeMs) << ", spill "
+                      << (allowSpill ? "allowed" : "not allowed") << ", abort "
+                      << (allowSpill ? "allowed" : "not allowed");
+  updateGlobalArbitrationStats(reclaimTimeMs, totalReclaimedBytes);
+  return totalReclaimedBytes;
 }
 
-void SharedArbitrator::testingFreeCapacity(uint64_t capacity) {
-  std::lock_guard<std::mutex> l(stateLock_);
-  incrementFreeCapacityLocked(capacity);
-}
+ArbitrationOperation SharedArbitrator::createArbitrationOperation(
+    MemoryPool* pool,
+    uint64_t requestBytes) {
+  VELOX_CHECK_NOT_NULL(pool);
+  VELOX_CHECK(pool->isRoot());
 
-uint64_t SharedArbitrator::testingNumRequests() const {
-  return numRequests_;
-}
-
-uint64_t SharedArbitrator::getCapacityGrowthTarget(
-    const MemoryPool& pool,
-    uint64_t requestBytes) const {
-  if (fastExponentialGrowthCapacityLimit_ == 0 && slowCapacityGrowPct_ == 0) {
-    return requestBytes;
-  }
-  uint64_t targetBytes{0};
-  const auto capacity = pool.capacity();
-  if (capacity * 2 <= fastExponentialGrowthCapacityLimit_) {
-    targetBytes = capacity;
-  } else {
-    targetBytes = capacity * slowCapacityGrowPct_;
-  }
-  return std::max(requestBytes, targetBytes);
+  auto participant = getParticipant(pool->name());
+  VELOX_CHECK(participant.has_value());
+  return ArbitrationOperation(
+      std::move(participant.value()), requestBytes, maxArbitrationTimeMs_);
 }
 
 bool SharedArbitrator::growCapacity(MemoryPool* pool, uint64_t requestBytes) {
-  // NOTE: we shouldn't trigger the recursive memory capacity growth under
-  // memory arbitration context.
-  VELOX_CHECK(!underMemoryArbitration());
-
-  ArbitrationOperation op(
-      pool, requestBytes, getCapacityGrowthTarget(*pool, requestBytes));
+  VELOX_CHECK(pool->isRoot());
+  auto op = createArbitrationOperation(pool, requestBytes);
   ScopedArbitration scopedArbitration(this, &op);
 
-  bool needGlobalArbitration{false};
-  if (!runLocalArbitration(&op, needGlobalArbitration)) {
-    return false;
+  try {
+    const bool ret = growCapacity(op);
+    if (!ret) {
+      updateArbitrationFailureStats();
+    }
+    return ret;
+  } catch (const std::exception&) {
+    updateArbitrationFailureStats();
+    std::rethrow_exception(std::current_exception());
   }
-  if (!needGlobalArbitration) {
-    return true;
-  }
-  if (!globalArbitrationEnabled_) {
-    return false;
-  }
-  return runGlobalArbitration(&op);
 }
 
-bool SharedArbitrator::runLocalArbitration(
-    ArbitrationOperation* op,
-    bool& needGlobalArbitration) {
-  needGlobalArbitration = false;
-  const std::chrono::steady_clock::time_point localArbitrationStartTime =
-      std::chrono::steady_clock::now();
-  std::shared_lock<std::shared_mutex> sharedLock(arbitrationLock_);
+bool SharedArbitrator::growCapacity(ArbitrationOperation& op) {
   TestValue::adjust(
-      "facebook::velox::memory::SharedArbitrator::runLocalArbitration", this);
-  op->localArbitrationLockWaitTimeUs =
-      std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - localArbitrationStartTime)
-          .count();
-
+      "facebook::velox::memory::SharedArbitrator::growCapacity", this);
   checkIfAborted(op);
+  checkIfTimeout(op);
 
-  if (maybeGrowFromSelf(op)) {
-    return true;
-  }
+  RETURN_IF_TRUE(maybeGrowFromSelf(op));
 
   if (!ensureCapacity(op)) {
-    updateArbitrationFailureStats();
-    VELOX_MEM_LOG(ERROR) << "Can't grow " << op->requestPool->name()
-                         << " capacity to "
-                         << succinctBytes(
-                                op->requestPool->capacity() + op->requestBytes)
+    VELOX_MEM_LOG(ERROR) << "Can't grow " << op.participant()->name()
+                         << " capacity with "
+                         << succinctBytes(op.requestBytes())
                          << " which exceeds its max capacity "
-                         << succinctBytes(op->requestPool->maxCapacity())
+                         << succinctBytes(op.participant()->maxCapacity())
                          << ", current capacity "
-                         << succinctBytes(op->requestPool->capacity())
-                         << ", request " << succinctBytes(op->requestBytes);
+                         << succinctBytes(op.participant()->capacity());
     return false;
   }
-  VELOX_CHECK(!op->requestPool->aborted());
-
-  if (maybeGrowFromSelf(op)) {
-    return true;
-  }
-
-  uint64_t maxGrowTarget{0};
-  uint64_t minGrowTarget{0};
-  getGrowTargets(op, maxGrowTarget, minGrowTarget);
-
-  uint64_t freedBytes = decrementFreeCapacity(maxGrowTarget, minGrowTarget);
-  auto freeGuard = folly::makeGuard([&]() {
-    // Returns the unused freed memory capacity back to the arbitrator.
-    if (freedBytes > 0) {
-      incrementFreeCapacity(freedBytes);
-    }
-  });
-  if (freedBytes >= op->requestBytes) {
-    checkedGrow(op->requestPool, freedBytes, op->requestBytes);
-    freedBytes = 0;
-    return true;
-  }
-  VELOX_CHECK_LT(freedBytes, maxGrowTarget);
-
-  getCandidates(op, /*freeCapacityOnly=*/true);
-  freedBytes +=
-      reclaimFreeMemoryFromCandidates(op, maxGrowTarget - freedBytes, true);
-  if (freedBytes >= op->requestBytes) {
-    const uint64_t bytesToGrow = std::min(maxGrowTarget, freedBytes);
-    checkedGrow(op->requestPool, bytesToGrow, op->requestBytes);
-    freedBytes -= bytesToGrow;
-    return true;
-  }
-  VELOX_CHECK_LT(freedBytes, maxGrowTarget);
-
-  if (!globalArbitrationEnabled_) {
-    freedBytes += reclaim(op->requestPool, maxGrowTarget - freedBytes, true);
-  }
   checkIfAborted(op);
+  checkIfTimeout(op);
 
-  if (freedBytes >= op->requestBytes) {
-    const uint64_t bytesToGrow = std::min(maxGrowTarget, freedBytes);
-    checkedGrow(op->requestPool, bytesToGrow, op->requestBytes);
-    freedBytes -= bytesToGrow;
-    return true;
+  RETURN_IF_TRUE(maybeGrowFromSelf(op));
+
+  op.setGrowTargets();
+  RETURN_IF_TRUE(growWithFreeCapacity(op));
+
+  reclaimUnusedCapacity();
+  RETURN_IF_TRUE(growWithFreeCapacity(op));
+
+  if (!globalArbitrationEnabled_ &&
+      op.participant()->reclaimableUsedCapacity() >=
+          participantConfig_.minReclaimBytes) {
+    // NOTE: if global memory arbitration is not enabled, we will try to reclaim
+    // from the participant itself before failing this operation.
+    reclaim(
+        op.participant(),
+        op.requestBytes(),
+        op.timeoutMs(),
+        /*localArbitration=*/true);
+    checkIfAborted(op);
+    RETURN_IF_TRUE(maybeGrowFromSelf(op));
+    return growWithFreeCapacity(op);
+  }
+  return startAndWaitGlobalArbitration(op);
+}
+
+bool SharedArbitrator::startAndWaitGlobalArbitration(ArbitrationOperation& op) {
+  VELOX_CHECK(globalArbitrationEnabled_);
+  checkIfTimeout(op);
+
+  std::unique_ptr<ArbitrationWait> arbitrationWait;
+  ContinueFuture arbitrationWaitFuture{ContinueFuture::makeEmpty()};
+  uint64_t allocatedBytes{0};
+  {
+    std::lock_guard<std::mutex> l(stateLock_);
+    allocatedBytes = allocateCapacityLocked(
+        op.participant()->id(),
+        op.requestBytes(),
+        op.maxGrowBytes(),
+        op.minGrowBytes());
+    if (allocatedBytes > 0) {
+      VELOX_CHECK_GE(allocatedBytes, op.requestBytes());
+    } else {
+      arbitrationWait = std::make_unique<ArbitrationWait>(
+          &op,
+          ContinuePromise{fmt::format(
+              "{} wait for memory arbitration with {} request bytes",
+              op.participant()->name(),
+              succinctBytes(op.requestBytes()))});
+      arbitrationWaitFuture = arbitrationWait->resumePromise.getSemiFuture();
+      globalArbitrationWaiters_.emplace(
+          op.participant()->id(), arbitrationWait.get());
+    }
   }
 
-  needGlobalArbitration = true;
+  TestValue::adjust(
+      "facebook::velox::memory::SharedArbitrator::startAndWaitGlobalArbitration",
+      this);
+
+  if (arbitrationWaitFuture.valid()) {
+    VELOX_CHECK_NOT_NULL(arbitrationWait);
+    op.recordGlobalArbitrationStartTime();
+    wakeupGlobalArbitrationThread();
+
+    const bool timeout = !std::move(arbitrationWaitFuture)
+                              .wait(std::chrono::milliseconds(op.timeoutMs()));
+    if (timeout) {
+      VELOX_MEM_LOG(ERROR)
+          << op.participant()->name()
+          << " wait for memory arbitration timed out after running "
+          << succinctMillis(op.executionTimeMs());
+      removeGlobalArbitrationWaiter(op.participant()->id());
+    }
+
+    allocatedBytes = arbitrationWait->allocatedBytes;
+    if (allocatedBytes == 0) {
+      checkIfAborted(op);
+      checkIfTimeout(op);
+      return false;
+    }
+  }
+  VELOX_CHECK_GE(allocatedBytes, op.requestBytes());
+  CHECKED_GROW(op.participant(), allocatedBytes, op.requestBytes());
   return true;
 }
 
-bool SharedArbitrator::runGlobalArbitration(ArbitrationOperation* op) {
-  incrementGlobalArbitrationCount();
-  const std::chrono::steady_clock::time_point globalArbitrationStartTime =
-      std::chrono::steady_clock::now();
-  std::lock_guard<std::shared_mutex> exclusiveLock(arbitrationLock_);
+void SharedArbitrator::updateGlobalArbitrationStats(
+    uint64_t arbitrationTimeMs,
+    uint64_t arbitrationBytes) {
+  globalArbitrationTimeMs_ += arbitrationTimeMs;
+  ++globalArbitrationRuns_;
+  globalArbitrationBytes_ += arbitrationBytes;
+  RECORD_METRIC_VALUE(kMetricArbitratorGlobalArbitrationCount);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricArbitratorGlobalArbitrationBytes, arbitrationBytes);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricArbitratorGlobalArbitrationTimeMs, arbitrationTimeMs);
+}
+
+void SharedArbitrator::globalArbitrationMain() {
+  VELOX_MEM_LOG(INFO) << "Global arbitration controller started";
+  while (true) {
+    {
+      std::unique_lock l(stateLock_);
+      globalArbitrationThreadCv_.wait(l, [&] {
+        return globalArbitrationStop_ || !globalArbitrationWaiters_.empty();
+      });
+      if (globalArbitrationStop_) {
+        VELOX_CHECK(globalArbitrationWaiters_.empty());
+        break;
+      }
+    }
+    GlobalArbitrationSection section{this};
+    runGlobalArbitration();
+  }
+  VELOX_MEM_LOG(INFO) << "Global arbitration controller stopped";
+}
+
+void SharedArbitrator::runGlobalArbitration() {
   TestValue::adjust(
       "facebook::velox::memory::SharedArbitrator::runGlobalArbitration", this);
-  op->globalArbitrationLockWaitTimeUs =
-      std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - globalArbitrationStartTime)
-          .count();
-  checkIfAborted(op);
 
-  if (maybeGrowFromSelf(op)) {
-    return true;
-  }
+  const uint64_t startTimeMs = getCurrentTimeMs();
+  uint64_t totalReclaimedBytes{0};
+  bool reclaimByAbort{false};
+  uint64_t reclaimedBytes{0};
+  std::unordered_set<uint64_t> reclaimedParticipants;
+  std::unordered_set<uint64_t> failedParticipants;
+  bool allParticipantsReclaimed{false};
 
-  int32_t attempts = 0;
-  for (;; ++attempts) {
-    if (arbitrateMemory(op)) {
-      return true;
+  size_t round{0};
+  for (;; ++round) {
+    uint64_t arbitrationTimeUs{0};
+    {
+      MicrosecondTimer timer(&arbitrationTimeUs);
+      const uint64_t targetBytes = getGlobalArbitrationTarget();
+      if (targetBytes == 0) {
+        break;
+      }
+
+      // Check if we need to abort participant to reclaim used memory to
+      // accelerate global arbitration.
+      //
+      // TODO: make the time based condition check configurable.
+      reclaimByAbort =
+          (getCurrentTimeMs() - startTimeMs) < maxArbitrationTimeMs_ / 2 &&
+          (reclaimByAbort || (allParticipantsReclaimed && reclaimedBytes == 0));
+      if (!reclaimByAbort) {
+        reclaimedBytes = reclaimUsedMemoryBySpill(
+            targetBytes,
+            reclaimedParticipants,
+            failedParticipants,
+            allParticipantsReclaimed);
+      } else {
+        reclaimedBytes = reclaimUsedMemoryByAbort(/*force=*/true);
+      }
+      totalReclaimedBytes += reclaimedBytes;
+      reclaimUnusedCapacity();
     }
-    if (attempts > 0) {
-      break;
-    }
-    VELOX_CHECK(!op->requestPool->aborted());
-    if (!handleOOM(op)) {
-      break;
-    }
+
+    updateGlobalArbitrationStats(arbitrationTimeUs / 1'000, reclaimedBytes);
   }
-  VELOX_MEM_LOG(ERROR)
-      << "Failed to arbitrate sufficient memory for memory pool "
-      << op->requestPool->name() << ", request "
-      << succinctBytes(op->requestBytes) << " after " << attempts
-      << " attempts, Arbitrator state: " << toString();
-  updateArbitrationFailureStats();
-  return false;
+  VELOX_MEM_LOG(INFO) << "Global arbitration reclaimed "
+                      << succinctBytes(totalReclaimedBytes) << " "
+                      << reclaimedParticipants.size() << " victims, spent "
+                      << succinctMillis(getCurrentTimeMs() - startTimeMs)
+                      << " with " << round << " rounds";
+}
+
+uint64_t SharedArbitrator::getGlobalArbitrationTarget() {
+  uint64_t targetBytes{0};
+  std::lock_guard<std::mutex> l(stateLock_);
+  for (const auto& waiter : globalArbitrationWaiters_) {
+    targetBytes += waiter.second->op->maxGrowBytes();
+  }
+  if (targetBytes == 0) {
+    return 0;
+  }
+  return std::max<uint64_t>(
+      capacity_ * globalArbitrationMemoryReclaimPct_ / 100, targetBytes);
 }
 
 void SharedArbitrator::getGrowTargets(
-    ArbitrationOperation* op,
+    ArbitrationOperation& op,
     uint64_t& maxGrowTarget,
     uint64_t& minGrowTarget) {
-  VELOX_CHECK(op->targetBytes.has_value());
-  maxGrowTarget =
-      std::min(maxGrowCapacity(*op->requestPool), op->targetBytes.value());
-  minGrowTarget = minGrowCapacity(*op->requestPool);
+  op.participant()->getGrowTargets(
+      op.requestBytes(), maxGrowTarget, minGrowTarget);
 }
 
-void SharedArbitrator::checkIfAborted(ArbitrationOperation* op) {
-  if (op->requestPool->aborted()) {
-    updateArbitrationFailureStats();
-    VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted");
+void SharedArbitrator::checkIfAborted(ArbitrationOperation& op) {
+  if (op.participant()->aborted()) {
+    VELOX_MEM_POOL_ABORTED(
+        fmt::format("Memory pool {} aborted", op.participant()->name()));
   }
 }
 
-bool SharedArbitrator::maybeGrowFromSelf(ArbitrationOperation* op) {
-  if (op->requestPool->freeBytes() >= op->requestBytes) {
-    if (growPool(op->requestPool, 0, op->requestBytes)) {
-      return true;
-    }
+void SharedArbitrator::checkIfTimeout(ArbitrationOperation& op) {
+  if (FOLLY_UNLIKELY(op.hasTimeout())) {
+    VELOX_MEM_ARBITRATION_TIMEOUT(fmt::format(
+        "Memory arbitration timed out on memory pool: {} after running {}",
+        op.participant()->name(),
+        succinctMillis(op.executionTimeMs())));
+  }
+}
+
+bool SharedArbitrator::maybeGrowFromSelf(ArbitrationOperation& op) {
+  return op.participant()->grow(0, op.requestBytes());
+}
+
+bool SharedArbitrator::growWithFreeCapacity(ArbitrationOperation& op) {
+  const uint64_t allocatedBytes = allocateCapacity(
+      op.participant()->id(),
+      op.requestBytes(),
+      op.maxGrowBytes(),
+      op.minGrowBytes());
+  if (allocatedBytes > 0) {
+    VELOX_CHECK_GE(allocatedBytes, op.requestBytes());
+    CHECKED_GROW(op.participant(), allocatedBytes, op.requestBytes());
+    return true;
   }
   return false;
 }
 
-bool SharedArbitrator::checkCapacityGrowth(ArbitrationOperation* op) const {
-  return (maxGrowCapacity(*op->requestPool) >= op->requestBytes) &&
-      (capacityAfterGrowth(*op->requestPool, op->requestBytes) <= capacity_);
+std::optional<ScopedArbitrationParticipant> SharedArbitrator::getParticipant(
+    const std::string& name) const {
+  std::shared_lock guard{participantLock_};
+  auto it = participants_.find(name);
+  VELOX_CHECK(it != participants_.end(), "Arbitration pool {} not found", name);
+  return it->second->lock();
 }
 
-bool SharedArbitrator::ensureCapacity(ArbitrationOperation* op) {
-  if ((op->requestBytes > capacity_) ||
-      (op->requestBytes > op->requestPool->maxCapacity())) {
+bool SharedArbitrator::checkCapacityGrowth(ArbitrationOperation& op) const {
+  if (!op.participant()->checkCapacityGrowth(op.requestBytes())) {
     return false;
   }
-  if (checkCapacityGrowth(op)) {
-    return true;
+  return (op.participant()->capacity() + op.requestBytes()) <= capacity_;
+}
+
+bool SharedArbitrator::ensureCapacity(ArbitrationOperation& op) {
+  if ((op.requestBytes() > capacity_) ||
+      (op.requestBytes() > op.participant()->maxCapacity())) {
+    return false;
   }
 
-  const uint64_t reclaimedBytes =
-      reclaim(op->requestPool, op->requestBytes, true);
-  // NOTE: return the reclaimed bytes back to the arbitrator and let the memory
-  // arbitration process to grow the requestor's memory capacity accordingly.
-  incrementFreeCapacity(reclaimedBytes);
-  // Check if the requestor has been aborted in reclaim operation above.
-  if (op->requestPool->aborted()) {
-    updateArbitrationFailureStats();
-    VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted");
-  }
+  RETURN_IF_TRUE(checkCapacityGrowth(op));
+
+  shrink(op.participant(), /*reclaimAll=*/true);
+
+  RETURN_IF_TRUE(checkCapacityGrowth(op));
+
+  reclaim(
+      op.participant(),
+      op.requestBytes(),
+      op.timeoutMs(),
+      /*localArbitration=*/true);
+  // Checks if the requestor has been aborted in reclaim above.
+  checkIfAborted(op);
+
+  RETURN_IF_TRUE(checkCapacityGrowth(op));
+
+  shrink(op.participant(), /*reclaimAll=*/true);
   return checkCapacityGrowth(op);
 }
 
-bool SharedArbitrator::handleOOM(ArbitrationOperation* op) {
-  MemoryPool* victim = findCandidateWithLargestCapacity(
-                           op->requestPool, op->requestBytes, op->candidates)
-                           .pool.get();
-  if (op->requestPool == victim) {
-    VELOX_MEM_LOG(ERROR)
-        << "Requestor memory pool " << op->requestPool->name()
-        << " is selected as victim memory pool so fail the memory arbitration";
-    return false;
-  }
-  VELOX_MEM_LOG(WARNING) << "Aborting victim memory pool " << victim->name()
-                         << " to free up memory for requestor "
-                         << op->requestPool->name();
-  try {
-    if (victim == op->requestPool) {
-      VELOX_MEM_POOL_CAP_EXCEEDED(
-          memoryPoolAbortMessage(victim, op->requestPool, op->requestBytes));
-    } else {
-      VELOX_MEM_POOL_ABORTED(
-          memoryPoolAbortMessage(victim, op->requestPool, op->requestBytes));
-    }
-  } catch (VeloxRuntimeError&) {
-    abort(victim, std::current_exception());
-  }
-  // Free up all the unused capacity from the aborted memory pool and gives back
-  // to the arbitrator.
-  incrementFreeCapacity(shrinkPool(victim, 0));
-  return true;
-}
-
 void SharedArbitrator::checkedGrow(
-    MemoryPool* pool,
+    const ScopedArbitrationParticipant& participant,
     uint64_t growBytes,
     uint64_t reservationBytes) {
-  const auto ret = growPool(pool, growBytes, reservationBytes);
-  VELOX_CHECK(
-      ret,
-      "Failed to grow pool {} with {} and commit {} used reservation",
-      pool->name(),
-      succinctBytes(growBytes),
-      succinctBytes(reservationBytes));
+  const auto ret = participant->grow(growBytes, reservationBytes);
+  if (!ret) {
+    VELOX_FAIL(
+        "Failed to grow memory pool {} with {} and commit {} used reservation, memory pool stats:\n{}\n{}",
+        participant->name(),
+        succinctBytes(growBytes),
+        succinctBytes(reservationBytes),
+        participant->pool()->toString(),
+        participant->pool()->treeMemoryUsage());
+  }
 }
 
-bool SharedArbitrator::arbitrateMemory(ArbitrationOperation* op) {
-  VELOX_CHECK(!op->requestPool->aborted());
-  uint64_t maxGrowTarget{0};
-  uint64_t minGrowTarget{0};
-  getGrowTargets(op, maxGrowTarget, minGrowTarget);
-
-  uint64_t freedBytes = decrementFreeCapacity(maxGrowTarget, minGrowTarget);
-  auto freeGuard = folly::makeGuard([&]() {
-    // Returns the unused freed memory capacity back to the arbitrator.
-    if (freedBytes > 0) {
-      incrementFreeCapacity(freedBytes);
-    }
-  });
-  if (freedBytes >= op->requestBytes) {
-    checkedGrow(op->requestPool, freedBytes, op->requestBytes);
-    freedBytes = 0;
-    return true;
-  }
-  VELOX_CHECK_LT(freedBytes, maxGrowTarget);
-
-  // Get refreshed stats before the global memory arbitration run.
-  getCandidates(op);
-
-  freedBytes +=
-      reclaimFreeMemoryFromCandidates(op, maxGrowTarget - freedBytes, false);
-  if (freedBytes >= op->requestBytes) {
-    const uint64_t bytesToGrow = std::min(maxGrowTarget, freedBytes);
-    checkedGrow(op->requestPool, bytesToGrow, op->requestBytes);
-    freedBytes -= bytesToGrow;
-    return true;
-  }
-  VELOX_CHECK_LT(freedBytes, maxGrowTarget);
-
-  reclaimUsedMemoryFromCandidatesBySpill(op, freedBytes);
-  checkIfAborted(op);
-
-  if (freedBytes < op->requestBytes) {
-    VELOX_MEM_LOG(WARNING)
-        << "Failed to arbitrate sufficient memory for memory pool "
-        << op->requestPool->name() << ", request "
-        << succinctBytes(op->requestBytes) << ", only "
-        << succinctBytes(freedBytes)
-        << " has been freed, Arbitrator state: " << toString();
-    return false;
-  }
-
-  const uint64_t bytesToGrow = std::min(freedBytes, maxGrowTarget);
-  checkedGrow(op->requestPool, bytesToGrow, op->requestBytes);
-  freedBytes -= bytesToGrow;
-  return true;
-}
-
-uint64_t SharedArbitrator::reclaimFreeMemoryFromCandidates(
-    ArbitrationOperation* op,
-    uint64_t reclaimTargetBytes,
-    bool isLocalArbitration) {
-  // Sort candidate memory pools based on their reclaimable free capacity.
-  sortCandidatesByReclaimableFreeCapacity(op->candidates);
-
-  std::lock_guard<std::mutex> l(stateLock_);
+uint64_t SharedArbitrator::reclaimUnusedCapacity() {
+  std::vector<ArbitrationCandidate> candidates =
+      getCandidates(/*freeCapacityOnly=*/true);
   uint64_t reclaimedBytes{0};
-  for (const auto& candidate : op->candidates) {
-    VELOX_CHECK_LT(reclaimedBytes, reclaimTargetBytes);
-    if (candidate.freeBytes == 0) {
-      break;
-    }
-    if (isLocalArbitration && (candidate.pool.get() != op->requestPool) &&
-        isUnderArbitrationLocked(candidate.pool.get())) {
-      // If the reclamation is for local arbitration and the candidate pool is
-      // also under arbitration processing, then we can't reclaim from the
-      // candidate pool as it might cause concurrent changes to the candidate
-      // pool's capacity.
+  SCOPE_EXIT {
+    freeCapacity(reclaimedBytes);
+  };
+  for (const auto& candidate : candidates) {
+    if (candidate.reclaimableFreeCapacity == 0) {
       continue;
     }
-    const int64_t bytesToReclaim = std::min<int64_t>(
-        reclaimTargetBytes - reclaimedBytes,
-        reclaimableFreeCapacity(
-            *candidate.pool, candidate.pool.get() == op->requestPool));
-    if (bytesToReclaim <= 0) {
-      continue;
-    }
-    reclaimedBytes += shrinkPool(candidate.pool.get(), bytesToReclaim);
-    if (reclaimedBytes >= reclaimTargetBytes) {
-      break;
-    }
+    reclaimedBytes += candidate.participant->shrink(/*reclaimAll=*/false);
   }
   reclaimedFreeBytes_ += reclaimedBytes;
   return reclaimedBytes;
 }
 
-void SharedArbitrator::reclaimUsedMemoryFromCandidatesBySpill(
-    ArbitrationOperation* op,
-    uint64_t& freedBytes) {
-  // Sort candidate memory pools based on their reclaimable used capacity.
-  sortCandidatesByReclaimableUsedCapacity(op->candidates);
+uint64_t SharedArbitrator::reclaimUsedMemoryBySpill(uint64_t targetBytes) {
+  std::unordered_set<uint64_t> unusedReclaimedParticipants;
+  std::unordered_set<uint64_t> failedParticipants;
+  bool unusedAllParticipantsReclaimed;
+  return reclaimUsedMemoryBySpill(
+      targetBytes,
+      unusedReclaimedParticipants,
+      failedParticipants,
+      unusedAllParticipantsReclaimed);
+}
 
-  for (const auto& candidate : op->candidates) {
-    VELOX_CHECK_LT(freedBytes, op->requestBytes);
-    if (candidate.reclaimableBytes == 0) {
+uint64_t SharedArbitrator::reclaimUsedMemoryBySpill(
+    uint64_t targetBytes,
+    std::unordered_set<uint64_t>& reclaimedParticipants,
+    std::unordered_set<uint64_t>& failedParticipants,
+    bool& allParticipantsReclaimed) {
+  TestValue::adjust(
+      "facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryBySpill",
+      this);
+
+  allParticipantsReclaimed = true;
+  const uint64_t prevReclaimedBytes = reclaimedUsedBytes_;
+  auto candidates = getCandidates();
+  sortCandidatesByReclaimableUsedCapacity(candidates);
+
+  std::vector<ArbitrationCandidate> victims;
+  victims.reserve(candidates.size());
+  uint64_t bytesToReclaim{0};
+  for (auto& candidate : candidates) {
+    if (candidate.reclaimableUsedCapacity <
+        participantConfig_.minReclaimBytes) {
       break;
     }
-    freedBytes +=
-        reclaim(candidate.pool.get(), op->requestBytes - freedBytes, false);
-    if ((freedBytes >= op->requestBytes) ||
-        (op->requestPool != nullptr && op->requestPool->aborted())) {
-      break;
+    if (failedParticipants.count(candidate.participant->id()) != 0) {
+      VELOX_CHECK_EQ(
+          reclaimedParticipants.count(candidate.participant->id()), 1);
+      continue;
     }
+    if (bytesToReclaim >= targetBytes) {
+      if (reclaimedParticipants.count(candidate.participant->id()) == 0) {
+        allParticipantsReclaimed = false;
+      }
+      continue;
+    }
+    bytesToReclaim += candidate.reclaimableUsedCapacity;
+    reclaimedParticipants.insert(candidate.participant->id());
+    victims.push_back(std::move(candidate));
+  }
+  if (victims.empty()) {
+    FB_LOG_EVERY_MS(WARNING, 1'000)
+        << "No spill victim participant found with global arbitration target: "
+        << succinctBytes(targetBytes);
+    return 0;
+  }
+
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricArbitratorGlobalArbitrationNumReclaimVictims, victims.size());
+
+  struct ReclaimResult {
+    uint64_t participantId{0};
+    uint64_t reclaimedBytes{0};
+
+    explicit ReclaimResult(uint64_t _participantId, uint64_t _reclaimedBytes)
+        : participantId(_participantId), reclaimedBytes(_reclaimedBytes) {}
+  };
+  std::vector<std::shared_ptr<AsyncSource<ReclaimResult>>> reclaimTasks;
+  for (auto& victim : victims) {
+    reclaimTasks.push_back(
+        memory::createAsyncMemoryReclaimTask<ReclaimResult>([this, victim]() {
+          const auto participant = victim.participant;
+          const uint64_t reclaimedBytes = reclaim(
+              participant,
+              victim.reclaimableUsedCapacity,
+              maxArbitrationTimeMs_,
+              /*localArbitration=*/false);
+          return std::make_unique<ReclaimResult>(
+              participant->id(), reclaimedBytes);
+        }));
+    if (reclaimTasks.size() > 1) {
+      memoryReclaimExecutor_->add(
+          [source = reclaimTasks.back()]() { source->prepare(); });
+    }
+  }
+
+  // NOTE: reclaim task can never fail.
+  uint64_t reclaimedBytes{0};
+  for (auto& reclaimTask : reclaimTasks) {
+    const auto reclaimResult = reclaimTask->move();
+    if (reclaimResult->reclaimedBytes == 0) {
+      RECORD_METRIC_VALUE(kMetricArbitratorGlobalArbitrationFailedVictimCount);
+      VELOX_CHECK_EQ(failedParticipants.count(reclaimResult->participantId), 0);
+      failedParticipants.insert(reclaimResult->participantId);
+    }
+    reclaimedBytes += reclaimResult->reclaimedBytes;
+  }
+  VELOX_CHECK_LE(prevReclaimedBytes, reclaimedUsedBytes_);
+  // NOTE: there might be concurrent local spill or spill triggered by
+  // external shrink.
+  return std::max(reclaimedBytes, reclaimedUsedBytes_ - prevReclaimedBytes);
+}
+
+uint64_t SharedArbitrator::reclaimUsedMemoryByAbort(bool force) {
+  TestValue::adjust(
+      "facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryByAbort",
+      this);
+  const auto victimOpt = findAbortCandidate(force);
+  if (!victimOpt.has_value()) {
+    return 0;
+  }
+  const auto& victim = victimOpt.value();
+  try {
+    VELOX_MEM_POOL_ABORTED(fmt::format(
+        "Memory pool aborted to reclaim used memory, current capacity {}, "
+        "memory pool stats:\n{}\n{}",
+        succinctBytes(victim.participant->pool()->capacity()),
+        victim.participant->pool()->toString(),
+        victim.participant->pool()->treeMemoryUsage()));
+  } catch (VeloxRuntimeError&) {
+    return abort(victim.participant, std::current_exception());
   }
 }
 
-void SharedArbitrator::reclaimUsedMemoryFromCandidatesByAbort(
-    ArbitrationOperation* op,
-    uint64_t& freedBytes) {
-  sortCandidatesByUsage(op->candidates);
-
-  for (const auto& candidate : op->candidates) {
-    VELOX_CHECK_LT(freedBytes, op->requestBytes);
-    if (candidate.pool->capacity() == 0) {
-      break;
-    }
-    try {
-      VELOX_MEM_POOL_ABORTED(fmt::format(
-          "Memory pool aborted to reclaim used memory, current usage {}, "
-          "memory pool details:\n{}\n{}",
-          succinctBytes(candidate.reservedBytes),
-          candidate.pool->toString(),
-          candidate.pool->treeMemoryUsage()));
-    } catch (VeloxRuntimeError&) {
-      abort(candidate.pool.get(), std::current_exception());
-    }
-    freedBytes += shrinkPool(candidate.pool.get(), 0);
-    if (freedBytes >= op->requestBytes) {
-      break;
-    }
-  }
+uint64_t SharedArbitrator::shrink(
+    const ScopedArbitrationParticipant& participant,
+    bool reclaimAll) {
+  const uint64_t freedBytes = participant->shrink(reclaimAll);
+  freeCapacity(freedBytes);
+  reclaimedFreeBytes_ += freedBytes;
+  return freedBytes;
 }
 
 uint64_t SharedArbitrator::reclaim(
-    MemoryPool* pool,
+    const ScopedArbitrationParticipant& participant,
     uint64_t targetBytes,
-    bool isLocalArbitration) noexcept {
-  int64_t bytesToReclaim =
-      std::min<uint64_t>(targetBytes, maxReclaimableCapacity(*pool, true));
-  if (bytesToReclaim == 0) {
-    return 0;
-  }
-  uint64_t reclaimDurationUs{0};
-  uint64_t reclaimedUsedBytes{0};
-  uint64_t reclaimedFreeBytes{0};
-  MemoryReclaimer::Stats reclaimerStats;
+    uint64_t timeoutMs,
+    bool localArbitration) noexcept {
+  uint64_t reclaimTimeUs{0};
+  uint64_t reclaimedBytes{0};
+  MemoryReclaimer::Stats stats;
   {
-    MicrosecondTimer reclaimTimer(&reclaimDurationUs);
-    try {
-      reclaimedFreeBytes = shrinkPool(pool, bytesToReclaim);
-      bytesToReclaim -= reclaimedFreeBytes;
-      VELOX_CHECK_GE(bytesToReclaim, 0);
-      if (bytesToReclaim > 0) {
-        if (isLocalArbitration) {
-          incrementLocalArbitrationCount();
-        }
-        pool->reclaim(bytesToReclaim, memoryReclaimWaitMs_, reclaimerStats);
-      }
-    } catch (const std::exception& e) {
-      VELOX_MEM_LOG(ERROR) << "Failed to reclaim from memory pool "
-                           << pool->name() << ", aborting it: " << e.what();
-      abort(pool, std::current_exception());
-      reclaimedUsedBytes = shrinkPool(pool, 0);
-    }
-    reclaimedUsedBytes += shrinkPool(pool, bytesToReclaim);
+    MicrosecondTimer reclaimTimer(&reclaimTimeUs);
+    reclaimedBytes = participant->reclaim(targetBytes, timeoutMs, stats);
   }
-  reclaimedUsedBytes_ += reclaimedUsedBytes;
-  reclaimedFreeBytes_ += reclaimedFreeBytes;
-  numNonReclaimableAttempts_ += reclaimerStats.numNonReclaimableAttempts;
-  VELOX_MEM_LOG(INFO) << "Reclaimed from memory pool " << pool->name()
+  // NOTE: if memory reclaim fails, then the participant is also aborted. If
+  // it happens, we shall first fail the arbitration operation from the
+  // aborted participant before returning the freed capacity.
+  if (participant->aborted()) {
+    removeGlobalArbitrationWaiter(participant->id());
+  }
+  freeCapacity(reclaimedBytes);
+
+  updateMemoryReclaimStats(
+      reclaimedBytes, reclaimTimeUs / 1'000, localArbitration, stats);
+  VELOX_MEM_LOG(INFO) << "Reclaimed from memory pool " << participant->name()
                       << " with target of " << succinctBytes(targetBytes)
-                      << ", actually reclaimed "
-                      << succinctBytes(reclaimedFreeBytes)
-                      << " free memory and "
-                      << succinctBytes(reclaimedUsedBytes)
-                      << " used memory, spent "
-                      << succinctMicros(reclaimDurationUs)
-                      << ", isLocalArbitration: " << isLocalArbitration;
-  return reclaimedUsedBytes + reclaimedFreeBytes;
+                      << ", reclaimed " << succinctBytes(reclaimedBytes)
+                      << ", spent " << succinctMicros(reclaimTimeUs)
+                      << ", local arbitration: " << localArbitration
+                      << " stats " << succinctBytes(stats.reclaimedBytes)
+                      << " numNonReclaimableAttempts "
+                      << stats.numNonReclaimableAttempts;
+  if (reclaimedBytes == 0) {
+    FB_LOG_EVERY_MS(WARNING, 1'000) << fmt::format(
+        "Nothing reclaimed from memory pool {} with reclaim target {},  memory pool stats:\n{}\n{}",
+        participant->name(),
+        succinctBytes(targetBytes),
+        participant->pool()->toString(),
+        participant->pool()->treeMemoryUsage());
+  }
+  return reclaimedBytes;
 }
 
-void SharedArbitrator::abort(
-    MemoryPool* pool,
+void SharedArbitrator::updateMemoryReclaimStats(
+    uint64_t reclaimedBytes,
+    uint64_t reclaimTimeMs,
+    bool localArbitration,
+    const MemoryReclaimer::Stats& stats) {
+  if (localArbitration) {
+    incrementLocalArbitrationCount();
+  }
+  reclaimedUsedBytes_ += reclaimedBytes;
+  numNonReclaimableAttempts_ += stats.numNonReclaimableAttempts;
+  RECORD_METRIC_VALUE(kMetricQueryMemoryReclaimCount);
+  RECORD_HISTOGRAM_METRIC_VALUE(kMetricQueryMemoryReclaimTimeMs, reclaimTimeMs);
+  RECORD_HISTOGRAM_METRIC_VALUE(
+      kMetricQueryMemoryReclaimedBytes, reclaimedBytes);
+}
+
+uint64_t SharedArbitrator::abort(
+    const ScopedArbitrationParticipant& participant,
     const std::exception_ptr& error) {
   RECORD_METRIC_VALUE(kMetricArbitratorAbortedCount);
   ++numAborted_;
-  try {
-    pool->abort(error);
-  } catch (const std::exception& e) {
-    VELOX_MEM_LOG(WARNING) << "Failed to abort memory pool " << pool->toString()
-                           << ", error: " << e.what();
+  const uint64_t freedBytes = participant->abort(error);
+  // NOTE: no matter memory pool abort throws or not, it should have been
+  // marked as aborted to prevent any new memory arbitration triggered from
+  // the aborted memory pool.
+  VELOX_CHECK(participant->aborted());
+  reclaimedUsedBytes_ += freedBytes;
+  removeGlobalArbitrationWaiter(participant->id());
+  freeCapacity(freedBytes);
+  return freedBytes;
+}
+
+void SharedArbitrator::freeCapacity(uint64_t bytes) {
+  if (FOLLY_UNLIKELY(bytes == 0)) {
+    return;
   }
-  // NOTE: no matter memory pool abort throws or not, it should have been marked
-  // as aborted to prevent any new memory arbitration triggered from the aborted
-  // memory pool.
-  VELOX_CHECK(pool->aborted());
+  std::vector<ContinuePromise> resumes;
+  {
+    std::lock_guard<std::mutex> l(stateLock_);
+    freeCapacityLocked(bytes, resumes);
+  }
+  for (auto& resume : resumes) {
+    resume.setValue();
+  }
 }
 
-void SharedArbitrator::incrementFreeCapacity(uint64_t bytes) {
-  std::lock_guard<std::mutex> l(stateLock_);
-  incrementFreeCapacityLocked(bytes);
-}
-
-void SharedArbitrator::incrementFreeCapacityLocked(uint64_t bytes) {
-  incrementFreeReservedCapacityLocked(bytes);
+void SharedArbitrator::freeCapacityLocked(
+    uint64_t bytes,
+    std::vector<ContinuePromise>& resumes) {
+  freeReservedCapacityLocked(bytes);
   freeNonReservedCapacity_ += bytes;
   if (FOLLY_UNLIKELY(
           freeNonReservedCapacity_ + freeReservedCapacity_ > capacity_)) {
     VELOX_FAIL(
-        "The free capacity {}/{} is larger than the max capacity {}, {}",
+        "Free capacity {}/{} is larger than the max capacity {}, {}",
         succinctBytes(freeNonReservedCapacity_),
         succinctBytes(freeReservedCapacity_),
-        succinctBytes(capacity_),
-        toStringLocked());
+        succinctBytes(capacity_));
+  }
+  resumeGlobalArbitrationWaitersLocked(resumes);
+}
+
+void SharedArbitrator::resumeGlobalArbitrationWaitersLocked(
+    std::vector<ContinuePromise>& resumes) {
+  auto it = globalArbitrationWaiters_.begin();
+  while (it != globalArbitrationWaiters_.end()) {
+    auto* op = it->second->op;
+    const uint64_t allocatedBytes = allocateCapacityLocked(
+        op->participant()->id(),
+        op->requestBytes(),
+        op->maxGrowBytes(),
+        op->minGrowBytes());
+    if (allocatedBytes == 0) {
+      break;
+    }
+    VELOX_CHECK_GE(allocatedBytes, op->requestBytes());
+    VELOX_CHECK_EQ(it->second->allocatedBytes, 0);
+    it->second->allocatedBytes = allocatedBytes;
+    resumes.push_back(std::move(it->second->resumePromise));
+    it = globalArbitrationWaiters_.erase(it);
   }
 }
 
-void SharedArbitrator::incrementFreeReservedCapacityLocked(uint64_t& bytes) {
+void SharedArbitrator::removeGlobalArbitrationWaiter(uint64_t id) {
+  ContinuePromise resume = ContinuePromise::makeEmpty();
+  {
+    std::lock_guard<std::mutex> l(stateLock_);
+    auto it = globalArbitrationWaiters_.find(id);
+    if (it != globalArbitrationWaiters_.end()) {
+      VELOX_CHECK_EQ(it->second->allocatedBytes, 0);
+      resume = std::move(it->second->resumePromise);
+      globalArbitrationWaiters_.erase(it);
+    }
+  }
+  if (resume.valid()) {
+    resume.setValue();
+  }
+}
+
+void SharedArbitrator::freeReservedCapacityLocked(uint64_t& bytes) {
   VELOX_CHECK_LE(freeReservedCapacity_, reservedCapacity_);
   const uint64_t freedBytes =
       std::min(bytes, reservedCapacity_ - freeReservedCapacity_);
@@ -1016,7 +1284,7 @@ MemoryArbitrator::Stats SharedArbitrator::stats() const {
 MemoryArbitrator::Stats SharedArbitrator::statsLocked() const {
   Stats stats;
   stats.numRequests = numRequests_;
-  stats.numRunning = numPending_;
+  stats.numRunning = numRunning_;
   stats.numAborted = numAborted_;
   stats.numFailures = numFailures_;
   stats.reclaimedFreeBytes = reclaimedFreeBytes_;
@@ -1030,134 +1298,44 @@ MemoryArbitrator::Stats SharedArbitrator::statsLocked() const {
 
 std::string SharedArbitrator::toString() const {
   std::lock_guard<std::mutex> l(stateLock_);
-  return toStringLocked();
-}
-
-std::string SharedArbitrator::toStringLocked() const {
   return fmt::format(
-      "ARBITRATOR[{} CAPACITY[{}] PENDING[{}] {}]",
+      "ARBITRATOR[{} CAPACITY[{}] {}]",
       kind_,
       succinctBytes(capacity_),
-      numPending_,
       statsLocked().toString());
 }
 
 SharedArbitrator::ScopedArbitration::ScopedArbitration(
     SharedArbitrator* arbitrator,
     ArbitrationOperation* operation)
-    : operation_(operation),
-      arbitrator_(arbitrator),
-      arbitrationCtx_(
-          operation->requestPool == nullptr
-              ? std::make_unique<ScopedMemoryArbitrationContext>()
-              : std::make_unique<ScopedMemoryArbitrationContext>(
-                    operation->requestPool)),
+    : arbitrator_(arbitrator),
+      operation_(operation),
+      arbitrationCtx_(operation->participant()->pool()),
       startTime_(std::chrono::steady_clock::now()) {
   VELOX_CHECK_NOT_NULL(arbitrator_);
   VELOX_CHECK_NOT_NULL(operation_);
-  if (arbitrator_->arbitrationStateCheckCb_ != nullptr &&
-      operation_->requestPool != nullptr) {
-    arbitrator_->arbitrationStateCheckCb_(*operation_->requestPool);
+  if (arbitrator_->arbitrationStateCheckCb_ != nullptr) {
+    arbitrator_->arbitrationStateCheckCb_(*operation_->participant()->pool());
   }
   arbitrator_->startArbitration(operation_);
 }
 
 SharedArbitrator::ScopedArbitration::~ScopedArbitration() {
   arbitrator_->finishArbitration(operation_);
-
-  // Report arbitration operation stats.
-  const auto arbitrationTimeUs =
-      std::chrono::duration_cast<std::chrono::microseconds>(
-          std::chrono::steady_clock::now() - operation_->startTime)
-          .count();
-  RECORD_HISTOGRAM_METRIC_VALUE(
-      kMetricArbitratorOpExecTimeMs, arbitrationTimeUs / 1'000);
-  addThreadLocalRuntimeStat(
-      kMemoryArbitrationWallNanos,
-      RuntimeCounter(arbitrationTimeUs * 1'000, RuntimeCounter::Unit::kNanos));
-  if (operation_->localArbitrationQueueTimeUs != 0) {
-    addThreadLocalRuntimeStat(
-        kLocalArbitrationQueueWallNanos,
-        RuntimeCounter(
-            operation_->localArbitrationQueueTimeUs * 1'000,
-            RuntimeCounter::Unit::kNanos));
-  }
-  if (operation_->localArbitrationLockWaitTimeUs != 0) {
-    addThreadLocalRuntimeStat(
-        kLocalArbitrationLockWaitWallNanos,
-        RuntimeCounter(
-            operation_->localArbitrationLockWaitTimeUs * 1'000,
-            RuntimeCounter::Unit::kNanos));
-  }
-  if (operation_->globalArbitrationLockWaitTimeUs != 0) {
-    addThreadLocalRuntimeStat(
-        kGlobalArbitrationLockWaitWallNanos,
-        RuntimeCounter(
-            operation_->globalArbitrationLockWaitTimeUs * 1'000,
-            RuntimeCounter::Unit::kNanos));
-  }
 }
 
-void SharedArbitrator::startArbitration(ArbitrationOperation* op) {
-  updateArbitrationRequestStats();
-  ContinueFuture waitPromise{ContinueFuture::makeEmpty()};
-  {
-    std::lock_guard<std::mutex> l(stateLock_);
-    ++numPending_;
-    if (op->requestPool != nullptr) {
-      auto it = arbitrationQueues_.find(op->requestPool);
-      if (it != arbitrationQueues_.end()) {
-        it->second->waitPromises.emplace_back(
-            fmt::format("Wait for arbitration {}", op->requestPool->name()));
-        waitPromise = it->second->waitPromises.back().getSemiFuture();
-      } else {
-        arbitrationQueues_.emplace(
-            op->requestPool, std::make_unique<ArbitrationQueue>(op));
-      }
-    }
-  }
-
-  TestValue::adjust(
-      "facebook::velox::memory::SharedArbitrator::startArbitration", this);
-
-  if (waitPromise.valid()) {
-    uint64_t waitTimeUs{0};
-    {
-      MicrosecondTimer timer(&waitTimeUs);
-      waitPromise.wait();
-    }
-    op->localArbitrationQueueTimeUs += waitTimeUs;
-  }
+SharedArbitrator::GlobalArbitrationSection::GlobalArbitrationSection(
+    SharedArbitrator* arbitrator)
+    : arbitrator_(arbitrator) {
+  VELOX_CHECK_NOT_NULL(arbitrator_);
+  VELOX_CHECK(!arbitrator_->globalArbitrationRunning_);
+  arbitrator_->globalArbitrationRunning_ = true;
 }
 
-void SharedArbitrator::finishArbitration(ArbitrationOperation* op) {
-  ContinuePromise resumePromise{ContinuePromise::makeEmpty()};
-  {
-    std::lock_guard<std::mutex> l(stateLock_);
-    VELOX_CHECK_GT(numPending_, 0);
-    --numPending_;
-    if (op->requestPool != nullptr) {
-      auto it = arbitrationQueues_.find(op->requestPool);
-      VELOX_CHECK(
-          it != arbitrationQueues_.end(),
-          "{} not found",
-          op->requestPool->name());
-      auto* runningArbitration = it->second.get();
-      if (runningArbitration->waitPromises.empty()) {
-        arbitrationQueues_.erase(it);
-      } else {
-        resumePromise = std::move(runningArbitration->waitPromises.back());
-        runningArbitration->waitPromises.pop_back();
-      }
-    }
-  }
-  if (resumePromise.valid()) {
-    resumePromise.setValue();
-  }
-}
-
-bool SharedArbitrator::isUnderArbitrationLocked(MemoryPool* pool) const {
-  return arbitrationQueues_.count(pool) != 0;
+SharedArbitrator::GlobalArbitrationSection::~GlobalArbitrationSection() {
+  VELOX_CHECK(arbitrator_->globalArbitrationRunning_);
+  arbitrator_->globalArbitrationRunning_ = false;
+  ;
 }
 
 std::string SharedArbitrator::kind() const {
@@ -1175,10 +1353,11 @@ void SharedArbitrator::unregisterFactory() {
   MemoryArbitrator::unregisterFactory(kind_);
 }
 
-void SharedArbitrator::incrementGlobalArbitrationCount() {
-  RECORD_METRIC_VALUE(kMetricArbitratorGlobalArbitrationCount);
+void SharedArbitrator::incrementGlobalArbitrationWaitCount() {
+  RECORD_METRIC_VALUE(kMetricArbitratorGlobalArbitrationWaitCount);
   addThreadLocalRuntimeStat(
-      kGlobalArbitrationCount, RuntimeCounter(1, RuntimeCounter::Unit::kNone));
+      kGlobalArbitrationWaitCount,
+      RuntimeCounter(1, RuntimeCounter::Unit::kNone));
 }
 
 void SharedArbitrator::incrementLocalArbitrationCount() {

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -18,23 +18,38 @@
 
 #include <shared_mutex>
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/future/VeloxPromise.h"
+#include "velox/common/memory/ArbitrationOperation.h"
+#include "velox/common/memory/ArbitrationParticipant.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 
 namespace facebook::velox::memory {
+namespace test {
+class SharedArbitratorTestHelper;
+}
 
-/// Used to achieve dynamic memory sharing among running queries. When a
+/// Used to achieve dynamic memory sharing among running queries. When a query
 /// memory pool exceeds its current memory capacity, the arbitrator tries to
-/// grow its capacity by reclaim the overused memory from the query with
-/// more memory usage. We can configure memory arbitrator the way to reclaim
-/// memory. For Prestissimo, we can configure it to reclaim memory by
-/// aborting a query. For Prestissimo-on-Spark, we can configure it to
-/// reclaim from a running query through techniques such as disk-spilling,
-/// partial aggregation or persistent shuffle data flushes.
+/// grow its capacity through memory arbitration. If the query memory pool
+/// exceeds its max memory capacity, then the arbitrator reclaims used memory
+/// from the the query itself which is the local arbitration. If not, the
+/// arbitrator tries to grow its capacity with the free unused capacity or
+/// reclaim the unused memory from other running queries. If there is still
+/// not enough free capacity, the arbitrator kicks off the global arbitration
+/// running at the background to reclaim used memory from other running queries.
+/// The request query memory pool waits until the global arbitration reclaims
+/// enough memory to grow its capacity or fails if exceeds the max arbitration
+/// time limit. The background global arbitration runs by a single thread while
+/// the actual memory reclaim is executed by a thread pool to parallelize the
+/// memory reclamation from multiple running queries at the same time. The
+/// global arbitration first tries to reclaim memory by disk spilling and if it
+/// can't quickly reclaim enough memory, it then switchs to abort the younger
+/// queries which also have more memory usage.
 class SharedArbitrator : public memory::MemoryArbitrator {
  public:
   struct ExtraConfig {
@@ -68,7 +83,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     /// timeout.
     static constexpr std::string_view kMemoryReclaimMaxWaitTime{
         "memory-reclaim-max-wait-time"};
-    static constexpr std::string_view kDefaultMemoryReclaimMaxWaitTime{"0ms"};
+    static constexpr std::string_view kDefaultMemoryReclaimMaxWaitTime{"5m"};
     static uint64_t memoryReclaimMaxWaitTimeMs(
         const std::unordered_map<std::string, std::string>& configs);
 
@@ -99,12 +114,33 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static double memoryPoolMinFreeCapacityPct(
         const std::unordered_map<std::string, std::string>& configs);
 
-    /// If true, it allows memory arbitrator to reclaim used memory cross query
-    /// memory pools.
-    static constexpr std::string_view kGlobalArbitrationEnabled{
-        "global-arbitration-enabled"};
-    static constexpr bool kDefaultGlobalArbitrationEnabled{false};
-    static bool globalArbitrationEnabled(
+    /// Specifies the minimum bytes to reclaim from a participant at a time. The
+    /// global arbitration also avoids to reclaim from a participant if its
+    /// reclaimable used capacity is less than this threshold. This is to
+    /// prevent inefficient memory reclaim operations on a participant with
+    /// small reclaimable used capacity which could causes a large number of
+    /// small spilled file on disk.
+    static constexpr std::string_view kMemoryPoolMinReclaimBytes{
+        "memory-pool-min-reclaim-bytes"};
+    static constexpr std::string_view kDefaultMemoryPoolMinReclaimBytes{
+        "128MB"};
+    static uint64_t memoryPoolMinReclaimBytes(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    /// Specifies the starting memory capacity limit for global arbitration to
+    /// search for victim participant to reclaim used memory by abort. For
+    /// participants with capacity larger than the limit, the global arbitration
+    /// choose to abort the youngest participant which has the largest
+    /// participant id. This helps to let the old queries to run to completion.
+    /// The abort capacity limit is reduced by half if could not find a victim
+    /// participant until this reaches to zero.
+    ///
+    /// NOTE: the limit must be zero or a power of 2.
+    static constexpr std::string_view kMemoryPoolAbortCapacityLimit{
+        "memory-pool-abort-capacity-limit"};
+    static constexpr std::string_view kDefaultMemoryPoolAbortCapacityLimit{
+        "1GB"};
+    static uint64_t memoryPoolAbortCapacityLimit(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// When growing capacity, the growth bytes will be adjusted in the
@@ -138,6 +174,31 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static double slowCapacityGrowPct(
         const std::unordered_map<std::string, std::string>& configs);
 
+    /// Floating point number used in calculating how many threads we would use
+    /// for memory reclaim execution: hw_concurrency x multiplier. 0.5 is
+    /// default.
+    static constexpr std::string_view kMemoryReclaimThreadsHwMultiplier{
+        "memory-reclaim-threads-hw-multiplier"};
+    static constexpr double kDefaultMemoryReclaimThreadsHwMultiplier{0.5};
+    static double memoryReclaimThreadsHwMultiplier(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    /// If true, allows memory arbitrator to reclaim used memory cross query
+    /// memory pools.
+    static constexpr std::string_view kGlobalArbitrationEnabled{
+        "global-arbitration-enabled"};
+    static constexpr bool kDefaultGlobalArbitrationEnabled{false};
+    static bool globalArbitrationEnabled(
+        const std::unordered_map<std::string, std::string>& configs);
+
+    /// If not zero, specifies the minimum amount of memory to reclaim by global
+    /// memory arbitration as percentage of total arbitrator memory capacity.
+    static constexpr std::string_view kGlobalArbitrationMemoryReclaimPct{
+        "global-arbitration-memory-reclaim-pct"};
+    static constexpr uint32_t kDefaultGlobalMemoryArbitrationReclaimPct{10};
+    static uint32_t globalArbitrationMemoryReclaimPct(
+        const std::unordered_map<std::string, std::string>& configs);
+
     /// If true, do sanity check on the arbitrator state on destruction.
     ///
     /// TODO: deprecate this flag after all the existing memory leak use cases
@@ -162,7 +223,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   bool growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
-  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes = 0) final;
+  /// NOTE: only support shrinking away all the unused free capacity for now.
+  uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   uint64_t shrinkCapacity(
       uint64_t requestBytes,
@@ -175,144 +237,89 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   std::string toString() const final;
 
-  /// Returns 'freeCapacity' back to the arbitrator for testing.
-  void testingFreeCapacity(uint64_t freeCapacity);
-
-  uint64_t testingNumRequests() const;
-
-  /// Enables/disables global arbitration accordingly.
-  void testingSetGlobalArbitration(bool enableGlobalArbitration) {
-    *const_cast<bool*>(&globalArbitrationEnabled_) = enableGlobalArbitration;
-  }
-
-  /// Operator level runtime stats that are reported during a shared arbitration
-  /// attempt.
+  /// Operator level runtime stats reported for an arbitration operation
+  /// execution.
   static inline const std::string kMemoryArbitrationWallNanos{
       "memoryArbitrationWallNanos"};
-  static inline const std::string kGlobalArbitrationCount{
-      "globalArbitrationCount"};
   static inline const std::string kLocalArbitrationCount{
       "localArbitrationCount"};
-  static inline const std::string kLocalArbitrationQueueWallNanos{
-      "localArbitrationQueueWallNanos"};
-  static inline const std::string kLocalArbitrationLockWaitWallNanos{
-      "localArbitrationLockWaitWallNanos"};
-  static inline const std::string kGlobalArbitrationLockWaitWallNanos{
-      "globalArbitrationLockWaitWallNanos"};
-
-  /// The candidate memory pool stats used by arbitration.
-  struct Candidate {
-    std::shared_ptr<MemoryPool> pool;
-    int64_t reclaimableBytes{0};
-    int64_t freeBytes{0};
-    int64_t reservedBytes{0};
-
-    std::string toString() const;
-  };
+  static inline const std::string kLocalArbitrationWaitWallNanos{
+      "localArbitrationWaitWallNanos"};
+  static inline const std::string kLocalArbitrationExecutionWallNanos{
+      "localArbitrationExecutionWallNanos"};
+  static inline const std::string kGlobalArbitrationWaitCount{
+      "globalArbitrationWaitCount"};
+  static inline const std::string kGlobalArbitrationWaitWallNanos{
+      "globalArbitrationWaitWallNanos"};
 
  private:
   // The kind string of shared arbitrator.
   inline static const std::string kind_{"SHARED"};
 
-  // Contains the execution state of an arbitration operation.
-  struct ArbitrationOperation {
-    MemoryPool* const requestPool;
-    const uint64_t requestBytes;
-
-    // The adjusted grow bytes based on 'requestBytes'. This 'targetBytes' is a
-    // best effort target, and hence will not be guaranteed. The adjustment is
-    // based on 'SharedArbitrator::fastExponentialGrowthCapacityLimit_'
-    // 'SharedArbitrator::slowCapacityGrowPct_'
-    const std::optional<uint64_t> targetBytes;
-
-    // The start time of this arbitration operation.
-    const std::chrono::steady_clock::time_point startTime;
-
-    // The candidate memory pools.
-    std::vector<Candidate> candidates;
-
-    // The time that waits in local arbitration queue.
-    uint64_t localArbitrationQueueTimeUs{0};
-
-    // The time that waits to acquire the local arbitration lock.
-    uint64_t localArbitrationLockWaitTimeUs{0};
-
-    // The time that waits to acquire the global arbitration lock.
-    uint64_t globalArbitrationLockWaitTimeUs{0};
-
-    explicit ArbitrationOperation(uint64_t requestBytes)
-        : ArbitrationOperation(nullptr, requestBytes, std::nullopt) {}
-
-    ArbitrationOperation(
-        MemoryPool* _requestor,
-        uint64_t _requestBytes,
-        std::optional<uint64_t> _targetBytes)
-        : requestPool(_requestor),
-          requestBytes(_requestBytes),
-          targetBytes(_targetBytes),
-          startTime(std::chrono::steady_clock::now()) {
-      VELOX_CHECK(requestPool == nullptr || requestPool->isRoot());
-    }
-
-    uint64_t waitTimeUs() const {
-      return localArbitrationQueueTimeUs + localArbitrationLockWaitTimeUs +
-          globalArbitrationLockWaitTimeUs;
-    }
-  };
-
-  // Used to start and finish an arbitration operation initiated from a memory
-  // pool or memory capacity shrink request sent through shrinkPools() API.
+  // Used to manage an arbitration operation execution. It starts 'op' execution
+  // in ctor and finishes its exection in dtor.
   class ScopedArbitration {
    public:
-    ScopedArbitration(SharedArbitrator* arbitrator, ArbitrationOperation* op);
+    explicit ScopedArbitration(
+        SharedArbitrator* arbitrator,
+        ArbitrationOperation* op);
 
     ~ScopedArbitration();
 
    private:
-    ArbitrationOperation* const operation_{nullptr};
     SharedArbitrator* const arbitrator_;
-    const std::unique_ptr<ScopedMemoryArbitrationContext> arbitrationCtx_;
+    ArbitrationOperation* const operation_;
+    const ScopedMemoryArbitrationContext arbitrationCtx_;
     const std::chrono::steady_clock::time_point startTime_;
   };
 
-  // The arbitration running queue for arbitration requests from the same query
-  // pool.
-  struct ArbitrationQueue {
-    // Points to the current running arbitration.
-    ArbitrationOperation* current;
+  class GlobalArbitrationSection {
+   public:
+    explicit GlobalArbitrationSection(SharedArbitrator* arbitrator);
+    ~GlobalArbitrationSection();
 
-    // The promises of the arbitration requests from the same query pool waiting
-    // for the serial execution.
-    std::vector<ContinuePromise> waitPromises;
-
-    explicit ArbitrationQueue(ArbitrationOperation* op) : current(op) {
-      VELOX_CHECK_NOT_NULL(current);
-    }
+   private:
+    SharedArbitrator* const arbitrator_;
+    const memory::ScopedMemoryArbitrationContext arbitrationCtx_{};
   };
 
-  // Invoked to check if the memory growth will exceed the memory pool's max
-  // capacity limit or the arbitrator's node capacity limit.
-  bool checkCapacityGrowth(ArbitrationOperation* op) const;
+  // Invoked to get the arbitration participant by 'name'. The function returns
+  // std::nullopt if the underlying query memory pool is destroyed.
+  std::optional<ScopedArbitrationParticipant> getParticipant(
+      const std::string& name) const;
 
-  // Invoked to ensure the memory growth request won't exceed the request memory
-  // pool's max capacity as well as the arbitrator's node capacity. If it does,
-  // then we first need to reclaim the used memory from the request memory pool
-  // itself to ensure the memory growth won't exceed the capacity limit, and
-  // then proceed with the memory arbitration process across queries.
-  bool ensureCapacity(ArbitrationOperation* op);
+  // Invoked to create an operation for an arbitration request from given query
+  // memory 'pool'.
+  ArbitrationOperation createArbitrationOperation(
+      MemoryPool* pool,
+      uint64_t requestBytes);
 
-  // Invoked to reclaim the memory from the other query memory pools to grow the
-  // request memory pool's capacity.
-  bool arbitrateMemory(ArbitrationOperation* op);
+  // Run arbitration to grow capacity for 'op'. The function returns true on
+  // success.
+  bool growCapacity(ArbitrationOperation& op);
 
-  // Invoked to start next memory arbitration request, and it will wait for
-  // the serialized execution if there is a running or other waiting
-  // arbitration requests.
+  // Gets the mim/max memory capacity growth targets for 'op' once after it
+  // starts to run.
+  void getGrowTargets(
+      ArbitrationOperation& op,
+      uint64_t& maxGrowTarget,
+      uint64_t& minGrowTarget);
+
+  // Invoked to start execution of 'op'. It waits for the serialized execution
+  // on the same arbitration participant and returns when 'op' is ready to run.
   void startArbitration(ArbitrationOperation* op);
 
-  // Invoked by a finished memory arbitration request to kick off the next
-  // arbitration request execution if there are any ones waiting.
+  // Invoked when 'op' has finished. The function kicks off the next arbitration
+  // operation waiting on the same participant to run if there is one.
   void finishArbitration(ArbitrationOperation* op);
+
+  // Invoked to check if the capacity growth exceeds the participant's max
+  // capacity limit or the arbitrator's capacity limit.
+  bool checkCapacityGrowth(ArbitrationOperation& op) const;
+
+  // Invoked to ensure the capacity growth won't exceed the participant's max
+  // capacity limit by reclaiming used memory from the participant itself.
+  bool ensureCapacity(ArbitrationOperation& op);
 
   // Invoked to run local arbitration on the request memory pool. It first
   // ensures the memory growth is within both memory pool and arbitrator
@@ -326,218 +333,275 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // returns false on failure. Otherwise, it needs to further check if
   // 'needGlobalArbitration' is true or not. If true, needs to proceed with the
   // global arbitration run.
-  bool runLocalArbitration(
-      ArbitrationOperation* op,
-      bool& needGlobalArbitration);
+
+  // Invoked to initialize the global arbitration on arbitrator start-up. It
+  // starts the background threads to used memory from running queries
+  // on-demand.
+  void setupGlobalArbitration();
+
+  // Invoked to stop the global arbitration threads on shut-down.
+  void shutdownGlobalArbitration();
+
+  // The main function of the global arbitration control thread.
+  void globalArbitrationMain();
+
+  // Invoked by arbitration operation to wake up the global arbitration control
+  // thread to reclaim used memory when there is no free capacity in the system.
+  void wakeupGlobalArbitrationThread();
+
+  // Invoked by global arbitration control thread to run global arbitration.
+  void runGlobalArbitration();
+
+  // Invoked to get the global arbitration target in bytes.
+  uint64_t getGlobalArbitrationTarget();
 
   // Invoked to run global arbitration to reclaim free or used memory from the
   // other queries. The global arbitration run is protected by the exclusive
   // lock of 'arbitrationLock_' for serial execution mode. The function returns
   // true on success, false on failure.
-  bool runGlobalArbitration(ArbitrationOperation* op);
+  bool startAndWaitGlobalArbitration(ArbitrationOperation& op);
 
-  // Gets the mim/max memory capacity growth targets for 'op'. The min and max
-  // targets are calculated based on memoryPoolReservedCapacity_ requirements
-  // and the pool's max capacity.
-  void getGrowTargets(
-      ArbitrationOperation* op,
-      uint64_t& maxGrowTarget,
-      uint64_t& minGrowTarget);
+  // Invoked to get stats of candidate participants for arbitration. If
+  // 'freeCapacityOnly' is true, then we only get reclaimable free capacity from
+  // each participant.
+  std::vector<ArbitrationCandidate> getCandidates(
+      bool freeCapacityOnly = false);
 
-  // Invoked to get or refresh the candidate memory pools for arbitration. If
-  // 'freeCapacityOnly' is true, then we only get free capacity stats for each
-  // candidate memory pool.
-  void getCandidates(ArbitrationOperation* op, bool freeCapacityOnly = false);
+  // Invoked to reclaim unused memory capacity from participants without
+  // actually freeing used memory. The function returns the actually reclaimed
+  // free capacity in bytes.
+  uint64_t reclaimUnusedCapacity();
 
   // Sorts 'candidates' based on reclaimable free capacity in descending order.
   static void sortCandidatesByReclaimableFreeCapacity(
-      std::vector<Candidate>& candidates);
+      std::vector<ArbitrationCandidate>& candidates);
+
+  // Invoked to reclaim the specified used memory capacity from one or more
+  // participants in parallel by spilling. 'reclaimedParticipants' tracks the
+  // participants that have been reclaimed by spill across multiple global
+  // arbitration runs. 'failedParticipants' tracks the participants that have
+  // failed to reclaim any memory by spill. This could happen if there is some
+  // unknown bug or limitation in specific spillable operator implementation.
+  // Correspondingly, the global arbitration shall skip reclaiming from those
+  // participants in next arbitration round. 'allParticipantsReclaimed'
+  // indicates if all participants have been reclaimed by spill so far. It is
+  // used by gllobal arbitration to decide if need to switch to abort to reclaim
+  // used memory in the next arbitration round. The function returns the
+  // actually reclaimed used capacity in bytes.
+  //
+  // NOTE: the function sort participants based on their reclaimable used memory
+  // capacity, and reclaim from participants with larger reclaimable used memory
+  // first.
+  uint64_t reclaimUsedMemoryBySpill(
+      uint64_t targetBytes,
+      std::unordered_set<uint64_t>& reclaimedParticipants,
+      std::unordered_set<uint64_t>& failedParticipants,
+      bool& allParticipantsReclaimed);
+
+  uint64_t reclaimUsedMemoryBySpill(uint64_t targetBytes);
 
   // Sorts 'candidates' based on reclaimable used capacity in descending order.
   static void sortCandidatesByReclaimableUsedCapacity(
-      std::vector<Candidate>& candidates);
+      std::vector<ArbitrationCandidate>& candidates);
 
-  // Sorts 'candidates' based on actual used memory in descending order.
-  static void sortCandidatesByUsage(std::vector<Candidate>& candidates);
+  // Invoked to reclaim the used memory capacity to abort the participant with
+  // the largest capacity to free up memory. The function returns the actually
+  // reclaimed capacity in bytes. The function returns zero if there is no
+  // eligible participant to abort. If 'force' is true, it picks up the youngest
+  // participant which has largest participant id to abort if there is no
+  // eligible one.
+  uint64_t reclaimUsedMemoryByAbort(bool force);
 
-  // Finds the candidate with the largest capacity. For 'requestor', the
-  // capacity for comparison including its current capacity and the capacity to
-  // grow.
-  static const SharedArbitrator::Candidate& findCandidateWithLargestCapacity(
-      MemoryPool* requestor,
-      uint64_t targetBytes,
-      const std::vector<Candidate>& candidates);
+  // Finds the participant victim to abort to free used memory based on the
+  // participant's memory capacity and age. The function returns std::nullopt if
+  // there is no eligible candidate. If 'force' is true, it picks up the
+  // youngest participant to abort if there is no eligible one.
+  std::optional<ArbitrationCandidate> findAbortCandidate(bool force);
 
-  // Invoked to reclaim free memory capacity from 'candidates' without
-  // actually freeing used memory.
-  //
-  // NOTE: the function might sort 'candidates' based on each candidate's free
-  // capacity internally.
-  uint64_t reclaimFreeMemoryFromCandidates(
-      ArbitrationOperation* op,
-      uint64_t reclaimTargetBytes,
-      bool isLocalArbitration);
+  // Invoked to use free capacity from arbitrator to grow participant's
+  // capacity.
+  bool growWithFreeCapacity(ArbitrationOperation& op);
 
-  // Invoked to reclaim used memory capacity from 'candidates' by spilling.
-  //
-  // NOTE: the function might sort 'candidates' based on each candidate's
-  // reclaimable memory internally.
-  void reclaimUsedMemoryFromCandidatesBySpill(
-      ArbitrationOperation* op,
-      uint64_t& freedBytes);
+  // Checks if the operation has been aborted or not. The function throws if
+  // aborted.
+  void checkIfAborted(ArbitrationOperation& op);
 
-  // Invoked to reclaim used memory capacity from 'candidates' by aborting the
-  // top memory users' queries.
-  void reclaimUsedMemoryFromCandidatesByAbort(
-      ArbitrationOperation* op,
-      uint64_t& freedBytes);
+  // Checks if the operation has timed out or not. The function throws if timed
+  // out.
+  void checkIfTimeout(ArbitrationOperation& op);
 
-  // Checks if request pool has been aborted or not.
-  void checkIfAborted(ArbitrationOperation* op);
+  // Checks if the request participant already has enough free capacity for the
+  // growth. This could happen if there are multiple arbitration operations from
+  // the same participant. When the first served operation succeeds, it might
+  // have reserved enough capacity for the followup operations.
+  bool maybeGrowFromSelf(ArbitrationOperation& op);
 
-  // Checks if the request pool already has enough free capacity for the growth.
-  // This could happen if there are multiple arbitration operations from the
-  // same query. When the first served operation succeeds, it might have
-  // reserved enough capacity for the followup operations.
-  bool maybeGrowFromSelf(ArbitrationOperation* op);
+  // Invoked to grow 'participant' capacity by 'growBytes' and commit used
+  // reservation by 'reservationBytes'. The function throws if the growth fails.
+  void checkedGrow(
+      const ScopedArbitrationParticipant& participant,
+      uint64_t growBytes,
+      uint64_t reservationBytes);
 
-  // Invoked to grow 'pool' capacity by 'growBytes' and commit used reservation
-  // by 'reservationBytes'. The function throws if the growth fails.
-  void
-  checkedGrow(MemoryPool* pool, uint64_t growBytes, uint64_t reservationBytes);
-
-  // Invoked to reclaim used memory from 'targetPool' with specified
+  // Invoked to reclaim used memory from 'participant' with specified
   // 'targetBytes'. The function returns the actually freed capacity.
-  // 'isLocalArbitration' is true when the reclaim attempt is within a local
+  // 'localArbitration' is true when the reclaim attempt is for a local
   // arbitration.
   uint64_t reclaim(
-      MemoryPool* targetPool,
+      const ScopedArbitrationParticipant& participant,
       uint64_t targetBytes,
-      bool isLocalArbitration) noexcept;
+      uint64_t timeoutMs,
+      bool localArbitration) noexcept;
 
-  // Invoked to abort memory 'pool'.
-  void abort(MemoryPool* pool, const std::exception_ptr& error);
+  uint64_t shrink(
+      const ScopedArbitrationParticipant& participant,
+      bool reclaimAll);
 
-  // Invoked to handle the memory arbitration failure to abort the memory pool
-  // with the largest capacity to free up memory. The function returns true on
-  // success and false if the requestor itself has been selected as the
-  // victim. We don't abort the requestor itself but just fails the
-  // arbitration to let the user decide to either proceed with the query or
-  // fail it.
-  bool handleOOM(ArbitrationOperation* op);
+  // Invoked to abort 'participant' with 'error'.
+  uint64_t abort(
+      const ScopedArbitrationParticipant& participant,
+      const std::exception_ptr& error);
 
-  // Decrements free capacity from the arbitrator with up to
-  // 'maxBytesToReserve'. The arbitrator might have less free available
-  // capacity. The function returns the actual decremented free capacity
-  // bytes. If 'minBytesToReserve' is not zero and there is less than
-  // 'minBytes' available in non-reserved capacity, then the arbitrator tries
-  // to decrement up to 'minBytes' from the reserved capacity.
-  uint64_t decrementFreeCapacity(
-      uint64_t maxBytesToReserve,
-      uint64_t minBytesToReserve);
-  uint64_t decrementFreeCapacityLocked(
-      uint64_t maxBytesToReserve,
-      uint64_t minBytesToReserve);
+  // Allocates capacity for a given participant with 'requestBytes'. The
+  // arbitrator might allocate up to 'maxAllocateBytes'. If there is not enough
+  // capacity in non-reserved free capacity pool, then the arbitrator tries to
+  // allocate up to 'minAllocateBytes' from the reserved capacity pool. The
+  // function returns the allocated bytes. It is set to a value no less than
+  // 'requestBytes' on success and zero on failure.
+  uint64_t allocateCapacity(
+      uint64_t participantId,
+      uint64_t requestBytes,
+      uint64_t maxAllocateBytes,
+      uint64_t minAllocateBytes);
 
-  // Increment free capacity by 'bytes'.
-  void incrementFreeCapacity(uint64_t bytes);
-  void incrementFreeCapacityLocked(uint64_t bytes);
-  // Increments the free reserved capacity up to 'bytes' until reaches to the
-  // reserved capacity limit. 'bytes' is updated accordingly.
-  void incrementFreeReservedCapacityLocked(uint64_t& bytes);
+  uint64_t allocateCapacityLocked(
+      uint64_t participantId,
+      uint64_t requestBytes,
+      uint64_t maxAllocateBytes,
+      uint64_t minAllocateBytes);
 
-  void incrementGlobalArbitrationCount();
+  // Invoked to free capacity back to the arbitrator, and wake up the global
+  // arbitration waiters if there is sufficient free capacity.
+  void freeCapacity(uint64_t bytes);
+
+  // 'resumes' contains the global arbitration waiters to resume.
+  void freeCapacityLocked(
+      uint64_t bytes,
+      std::vector<ContinuePromise>& resumes);
+
+  // Frees reserved capacity up to 'bytes' until reaches to the reserved
+  // capacity limit. 'bytes' is updated accordingly.
+  void freeReservedCapacityLocked(uint64_t& bytes);
+
+  // Invoked by freeCapacity() to resume a set of oldest global arbitration
+  // waiters that could be fulfilled their global arbitration requests from
+  // current available free capacity.
+  void resumeGlobalArbitrationWaitersLocked(
+      std::vector<ContinuePromise>& resumes);
+
+  // Removes the arbitration operation with 'id' from the global arbitration
+  // wait list. It is invoked by participant abort or global arbitration wait
+  // time out.
+  void removeGlobalArbitrationWaiter(uint64_t id);
+
+  // Increments the global arbitration wait count in both arbitrator and the
+  // corresponding operator's runtime stats.
+  void incrementGlobalArbitrationWaitCount();
+
+  // Increments the local arbitration count in both arbitrator and the
+  // corresponding operator's runtime stats.
   void incrementLocalArbitrationCount();
 
-  std::string toStringLocked() const;
+  size_t numParticipants() const {
+    std::shared_lock<folly::SharedMutex> l(participantLock_);
+    return participants_.size();
+  }
 
   Stats statsLocked() const;
 
-  // Returns the max reclaimable capacity from 'pool' which includes both used
-  // and free capacities. If 'isSelfReclaim' true, we reclaim memory from the
-  // request pool itself so that we can bypass the reserved free capacity
-  // reclaim restriction.
-  int64_t maxReclaimableCapacity(const MemoryPool& pool, bool isSelfReclaim)
-      const;
-
-  // Returns the free memory capacity that can be reclaimed from 'pool' by
-  // shrink. If 'isSelfReclaim' true, we reclaim memory from the request pool
-  // itself so that we can bypass the reserved free capacity reclaim
-  // restriction.
-  int64_t reclaimableFreeCapacity(const MemoryPool& pool, bool isSelfReclaim)
-      const;
-
-  // Returns the used memory capacity that can be reclaimed from 'pool' by
-  // disk spill. If 'isSelfReclaim' true, we reclaim memory from the request
-  // pool itself so that we can bypass the reserved free capacity reclaim
-  // restriction.
-  int64_t reclaimableUsedCapacity(const MemoryPool& pool, bool isSelfReclaim)
-      const;
-
-  // Returns the minimal amount of memory capacity to grow for 'pool' to have
-  // the reserved capacity as specified by 'memoryPoolReservedCapacity_'.
-  int64_t minGrowCapacity(const MemoryPool& pool) const;
-
-  // The capacity growth target is set to have a coarser granularity. It can
-  // help to reduce the number of future grow calls, and hence reducing the
-  // number of unnecessary memory arbitration requests.
-  uint64_t getCapacityGrowthTarget(
-      const MemoryPool& pool,
-      uint64_t requestBytes) const;
-
-  // The capacity shrink target is adjusted from request shrink bytes to give
-  // the memory pool more headroom free capacity after shrink. It can help to
-  // reduce the number of future grow calls, and hence reducing the number of
-  // unnecessary memory arbitration requests.
-  uint64_t getCapacityShrinkTarget(
-      const MemoryPool& pool,
-      uint64_t requestBytes) const;
-
-  // Returns true if 'pool' is under memory arbitration.
-  bool isUnderArbitrationLocked(MemoryPool* pool) const;
+  void updateMemoryReclaimStats(
+      uint64_t reclaimedBytes,
+      uint64_t reclaimTimeMs,
+      bool localArbitration,
+      const MemoryReclaimer::Stats& stats);
 
   void updateArbitrationRequestStats();
 
   void updateArbitrationFailureStats();
 
+  void updateGlobalArbitrationStats(
+      uint64_t arbitrationTimeMs,
+      uint64_t arbitrationBytes);
+
   const uint64_t reservedCapacity_;
-  const uint64_t memoryPoolInitialCapacity_;
-  const uint64_t memoryPoolReservedCapacity_;
-  const uint64_t memoryReclaimWaitMs_;
-  const bool globalArbitrationEnabled_;
   const bool checkUsageLeak_;
+  const uint64_t maxArbitrationTimeMs_;
+  const ArbitrationParticipant::Config participantConfig_;
+  const double memoryReclaimThreadsHwMultiplier_;
+  const bool globalArbitrationEnabled_;
+  const uint32_t globalArbitrationMemoryReclaimPct_;
 
-  const uint64_t fastExponentialGrowthCapacityLimit_;
-  const double slowCapacityGrowPct_;
-  const uint64_t memoryPoolMinFreeCapacity_;
-  const double memoryPoolMinFreeCapacityPct_;
+  // The executor used to reclaim memory from multiple participants in parallel
+  // at the background for global arbitration or external memory reclamation.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> memoryReclaimExecutor_;
 
-  mutable folly::SharedMutex poolLock_;
-  std::unordered_map<MemoryPool*, std::weak_ptr<MemoryPool>> candidates_;
+  std::atomic_uint64_t nextParticipantId_{0};
+  mutable folly::SharedMutex participantLock_;
+  std::unordered_map<std::string, std::shared_ptr<ArbitrationParticipant>>
+      participants_;
 
-  // Lock used to protect the arbitrator state.
+  // Lock used to protect the arbitrator internal state.
   mutable std::mutex stateLock_;
+
   tsan_atomic<uint64_t> freeReservedCapacity_{0};
   tsan_atomic<uint64_t> freeNonReservedCapacity_{0};
 
-  // Contains the arbitration running queues with one per each query memory
-  // pool.
-  std::unordered_map<MemoryPool*, std::unique_ptr<ArbitrationQueue>>
-      arbitrationQueues_;
+  bool globalArbitrationStop_{false};
+  // Indicates if the global arbitration is currently running or not.
+  tsan_atomic<bool> globalArbitrationRunning_{false};
 
-  // R/W lock used to control local and global arbitration runs. A local
-  // arbitration run needs to hold a shared lock while the latter needs to hold
-  // an exclusive lock. Hence, multiple local arbitration runs from different
-  // query memory pools can run in parallel but the global ones has to run with
-  // one at a time.
-  mutable std::shared_mutex arbitrationLock_;
+  // The abort capacity limits listed in descending order. It is used by global
+  // arbitration to choose the victim to abort. It starts with the largest limit
+  // and abort the youngest participant whose capacity is larger than the limit.
+  // If there is no such participant, it goes to the next limit and so on.
+  std::vector<uint64_t> globalArbitrationAbortCapacityLimits_;
+  // The global arbitration control thread which runs the global arbitration at
+  // the background, and dispatch the actual memory reclaim work on different
+  // participants to 'globalArbitrationExecutor_' and collects the results back.
+  std::unique_ptr<std::thread> globalArbitrationController_;
+  // Signal used to wakeup 'globalArbitrationController_' to run global
+  // arbitration on-demand.
+  std::condition_variable globalArbitrationThreadCv_;
+
+  // Records an arbitration operation waiting for global memory arbitration.
+  struct ArbitrationWait {
+    ArbitrationOperation* op;
+    ContinuePromise resumePromise;
+    uint64_t allocatedBytes{0};
+
+    ArbitrationWait(ArbitrationOperation* _op, ContinuePromise&& _resumePromise)
+        : op(_op), resumePromise(std::move(_resumePromise)) {}
+  };
+
+  // The map of global arbitration waiters. The key is the arbitration operation
+  // id which is set to id the of the corresponding arbitration participant.
+  // This ensures to satisfy the arbitration request in the order of the age of
+  // arbitration participants with old participants being served first.
+  std::map<uint64_t, ArbitrationWait*> globalArbitrationWaiters_;
+
+  tsan_atomic<uint64_t> globalArbitrationRuns_{0};
+  tsan_atomic<uint64_t> globalArbitrationTimeMs_{0};
+  tsan_atomic<uint64_t> globalArbitrationBytes_{0};
 
   std::atomic_uint64_t numRequests_{0};
-  std::atomic_uint32_t numPending_{0};
-  tsan_atomic<uint64_t> numAborted_{0};
+  std::atomic_uint32_t numRunning_{0};
+  std::atomic_uint64_t numAborted_{0};
   std::atomic_uint64_t numFailures_{0};
-  tsan_atomic<uint64_t> reclaimedFreeBytes_{0};
-  tsan_atomic<uint64_t> reclaimedUsedBytes_{0};
-  tsan_atomic<uint64_t> numNonReclaimableAttempts_{0};
+  std::atomic_uint64_t reclaimedFreeBytes_{0};
+  std::atomic_uint64_t reclaimedUsedBytes_{0};
+  std::atomic_uint64_t numNonReclaimableAttempts_{0};
+
+  friend class GlobalArbitrationSection;
+  friend class test::SharedArbitratorTestHelper;
 };
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   velox_memory_test
   AllocationPoolTest.cpp
   AllocationTest.cpp
+  ArbitrationParticipantTest.cpp
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -148,18 +148,14 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
         "arbitration. Requestor pool name 'leaf-1.0', request size 7.00MB, "
         "memory pool capacity 4.00MB, memory pool max capacity 8.00MB");
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 0);
-    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 0);
-    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 1), 0);
+    VELOX_ASSERT_THROW(
+        manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), "");
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 1), 0);
     ASSERT_EQ(rootPool->capacity(), 4 << 20);
     static_cast<MemoryPoolImpl*>(rootPool.get())->testingSetReservation(0);
     ASSERT_EQ(
-        manager.arbitrator()->shrinkCapacity(leafPool.get(), 1 << 20), 1 << 20);
-    ASSERT_EQ(
-        manager.arbitrator()->shrinkCapacity(rootPool.get(), 1 << 20), 1 << 20);
-    ASSERT_EQ(rootPool->capacity(), 2 << 20);
-    ASSERT_EQ(leafPool->capacity(), 2 << 20);
-    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), 2 << 20);
+        manager.arbitrator()->shrinkCapacity(rootPool.get(), 1 << 20), 4 << 20);
+    ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 1 << 20), 0);
     ASSERT_EQ(rootPool->capacity(), 0);
     ASSERT_EQ(leafPool->capacity(), 0);
   }

--- a/velox/common/memory/tests/SharedArbitratorTestUtil.h
+++ b/velox/common/memory/tests/SharedArbitratorTestUtil.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/ArbitrationParticipant.h"
+#include "velox/common/memory/SharedArbitrator.h"
+
+namespace facebook::velox::memory::test {
+
+class SharedArbitratorTestHelper {
+ public:
+  explicit SharedArbitratorTestHelper(SharedArbitrator* arbitrator)
+      : arbitrator_(arbitrator) {}
+
+  void freeCapacity(uint64_t targetBytes) {
+    arbitrator_->freeCapacity(targetBytes);
+  }
+
+  size_t numParticipants() {
+    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    return arbitrator_->participants_.size();
+  }
+
+  ScopedArbitrationParticipant getParticipant(const std::string& name) const {
+    return arbitrator_->getParticipant(name).value();
+  }
+
+  size_t numGlobalArbitrationWaiters() const {
+    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    return arbitrator_->globalArbitrationWaiters_.size();
+  }
+
+  bool globalArbitrationRunning() const {
+    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    return arbitrator_->globalArbitrationRunning_;
+  }
+
+  void waitForGlobalArbitrationToFinish() const {
+    while (globalArbitrationRunning()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+    }
+  }
+
+  uint64_t maxArbitrationTimeMs() const {
+    return arbitrator_->maxArbitrationTimeMs_;
+  }
+
+  folly::CPUThreadPoolExecutor* memoryReclaimExecutor() const {
+    return arbitrator_->memoryReclaimExecutor_.get();
+  }
+
+  std::thread* globalArbitrationController() const {
+    return arbitrator_->globalArbitrationController_.get();
+  }
+
+ private:
+  SharedArbitrator* const arbitrator_;
+};
+
+class ArbitrationParticipantTestHelper {
+ public:
+  explicit ArbitrationParticipantTestHelper(ArbitrationParticipant* participant)
+      : participant_(participant) {}
+
+  size_t numOps() const {
+    std::lock_guard<std::mutex> l(participant_->stateLock_);
+    return !!(participant_->runningOp_ != nullptr) +
+        participant_->waitOps_.size();
+  }
+
+  ArbitrationOperation* runningOp() const {
+    std::lock_guard<std::mutex> l(participant_->stateLock_);
+    return participant_->runningOp_;
+  }
+
+  std::vector<ArbitrationOperation*> waitingOps() const {
+    std::vector<ArbitrationOperation*> ops;
+    std::lock_guard<std::mutex> l(participant_->stateLock_);
+    ops.reserve(participant_->waitOps_.size());
+    for (const auto& waitOp : participant_->waitOps_) {
+      ops.push_back(waitOp.op);
+    }
+    return ops;
+  }
+
+ private:
+  ArbitrationParticipant* const participant_;
+};
+} // namespace facebook::velox::memory::test

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1276,7 +1276,7 @@ class PartitionedOutputNode : public PlanNode {
         partitionFunctionSpec_(std::move(partitionFunctionSpec)),
         outputType_(std::move(outputType)) {
     VELOX_USER_CHECK_GT(numPartitions, 0);
-    if (numPartitions == 1) {
+    if (numPartitions_ == 1) {
       VELOX_USER_CHECK(
           keys_.empty(),
           "Non-empty partitioning keys require more than one partition");

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -156,6 +156,14 @@ Memory Management
        initiate the memory arbitration request. This indicates the velox runtime doesn't have
        enough memory to run all the queries at their peak memory usage. We have to trigger
        spilling to let them run through completion.
+   * - arbitrator_global_arbitration_num_reclaim_victims
+     - Histogram
+     - The distribution of the number of query memory pools selected to reclaim memory by one
+       global memory arbitration round in range of [0, 32] with 32 buckets. It is configured to
+       report latency at P50, P90, P99, and P100 percentiles.
+   * - arbitrator_global_arbitration_failed_victim_count
+     - Count
+     - The number of victim query memory pool having nothing to spill.
    * - arbitrator_aborted_count
      - Count
      - The number of times a query level memory pool is aborted as a result of
@@ -549,5 +557,3 @@ Hive Connector
      - The distribution of hive sort writer finish processing time slice in range
        of[0, 120s] with 60 buckets. It is configured to report latency at P50,
        P90, P99, and P100 percentiles.
-
-

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1675,7 +1675,7 @@ int Task::getOutputPipelineId() const {
     }
   }
 
-  VELOX_FAIL("Output pipeline not found");
+  VELOX_FAIL("Output pipeline not found for task {}", taskId_);
 }
 
 void Task::setAllOutputConsumed() {

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -329,7 +329,10 @@ TypePtr sanitizeTryResolveType(
       integerVariablesBindings));
 }
 
-void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity) {
+void setupMemory(
+    int64_t allocatorCapacity,
+    int64_t arbitratorCapacity,
+    bool enableGlobalArbitration) {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
   FLAGS_velox_memory_leak_check_enabled = true;
   facebook::velox::memory::SharedArbitrator::registerFactory();
@@ -339,6 +342,13 @@ void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity) {
   options.arbitratorKind = "SHARED";
   options.checkUsageLeak = true;
   options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
+  options.extraArbitratorConfigs = {
+      {std::string(velox::memory::SharedArbitrator::ExtraConfig::
+                       kGlobalArbitrationEnabled),
+       enableGlobalArbitration ? "true" : "false"},
+      {std::string(velox::memory::SharedArbitrator::ExtraConfig::
+                       kMemoryPoolMinReclaimBytes),
+       "0B"}};
   facebook::velox::memory::MemoryManager::initialize(options);
 }
 

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -114,7 +114,10 @@ TypePtr sanitizeTryResolveType(
     std::unordered_map<std::string, int>& integerVariablesBindings);
 
 // Invoked to set up memory system with arbitration.
-void setupMemory(int64_t allocatorCapacity, int64_t arbitratorCapacity);
+void setupMemory(
+    int64_t allocatorCapacity,
+    int64_t arbitratorCapacity,
+    bool enableGlobalArbitration = true);
 
 /// Registers hive connector with configs. It should be called in the
 /// constructor of fuzzers that test plans with TableScan or uses

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -7516,8 +7516,9 @@ DEBUG_ONLY_TEST_F(HashJoinTest, taskWaitTimeout) {
   const auto expectedResult =
       runHashJoinTask(vectors, nullptr, false, numDrivers, pool(), false).data;
 
-  for (uint64_t timeoutMs : {0, 1'000, 30'000}) {
+  for (uint64_t timeoutMs : {1'000, 30'000}) {
     SCOPED_TRACE(fmt::format("timeout {}", succinctMillis(timeoutMs)));
+    LOG(ERROR) << "timeout " << succinctMillis(timeoutMs);
     auto memoryManager = createMemoryManager(512 << 20, 0, timeoutMs);
     auto queryCtx =
         newQueryCtx(memoryManager.get(), executor_.get(), queryMemoryCapacity);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/exec/OutputBufferManager.h"
@@ -2015,7 +2016,8 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
   auto* arbitrator = dynamic_cast<memory::SharedArbitrator*>(
       memory::memoryManager()->arbitrator());
   if (arbitrator != nullptr) {
-    arbitrator->testingFreeCapacity(reclaimedQueryCapacity);
+    memory::test::SharedArbitratorTestHelper arbitratorHelper(arbitrator);
+    arbitratorHelper.freeCapacity(reclaimedQueryCapacity);
   }
 
   auto taskStats = task->taskStats();

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -94,7 +94,7 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
 std::unique_ptr<memory::MemoryManager> createMemoryManager(
     int64_t arbitratorCapacity = kMemoryCapacity,
     uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
-    uint64_t maxReclaimWaitMs = 0,
+    uint64_t maxReclaimWaitMs = 5 * 60 * 1'000,
     uint64_t fastExponentialGrowthCapacityLimit = 0,
     double slowCapacityGrowPct = 0);
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -82,7 +82,9 @@ void OperatorTestBase::setupMemory(
     int64_t arbitratorCapacity,
     int64_t arbitratorReservedCapacity,
     int64_t memoryPoolInitCapacity,
-    int64_t memoryPoolReservedCapacity) {
+    int64_t memoryPoolReservedCapacity,
+    int64_t memoryPoolMinReclaimBytes,
+    int64_t memoryPoolAbortCapacityLimit) {
   if (asyncDataCache_ != nullptr) {
     asyncDataCache_->clear();
     asyncDataCache_.reset();
@@ -102,6 +104,10 @@ void OperatorTestBase::setupMemory(
        folly::to<std::string>(memoryPoolInitCapacity) + "B"},
       {std::string(ExtraConfig::kMemoryPoolReservedCapacity),
        folly::to<std::string>(memoryPoolReservedCapacity) + "B"},
+      {std::string(ExtraConfig::kMemoryPoolMinReclaimBytes),
+       folly::to<std::string>(memoryPoolMinReclaimBytes) + "B"},
+      {std::string(ExtraConfig::kMemoryPoolAbortCapacityLimit),
+       folly::to<std::string>(memoryPoolAbortCapacityLimit) + "B"},
       {std::string(ExtraConfig::kGlobalArbitrationEnabled), "true"},
   };
 
@@ -112,7 +118,7 @@ void OperatorTestBase::setupMemory(
 }
 
 void OperatorTestBase::resetMemory() {
-  OperatorTestBase::setupMemory(8L << 30, 6L << 30, 0, 512 << 20, 0);
+  OperatorTestBase::setupMemory(8L << 30, 6L << 30, 0, 512 << 20, 0, 0, 0);
 }
 
 void OperatorTestBase::SetUp() {

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -49,7 +49,9 @@ class OperatorTestBase : public testing::Test,
       int64_t arbitratorCapacity,
       int64_t arbitratorReservedCapacity,
       int64_t memoryPoolInitCapacity,
-      int64_t memoryPoolReservedCapacity);
+      int64_t memoryPoolReservedCapacity,
+      int64_t memoryPoolMinReclaimBytes,
+      int64_t memoryPoolAbortCapacityLimit);
 
   static void resetMemory();
 


### PR DESCRIPTION
Summary:
This PR adds global memory arbitration optimization which decouples the frontend memory arbitration request
and the backend slow memory arbitration processing. This enables to (1) remove the global locking inside the
arbitrator for slow memory arbitration processing; (2) respect e2e memory arbitration time to avoid the
potential node level deadlock that has happened in the production in the past; (3) backend optimization
such as query level memory reclamation parallelism; (4) more advanced memory arbitration policy
such as respect older query than younger when abort to allow the old slow query having a chance to run
through and also make a more consistent abort choice across nodes in a distributed execution environment
like Prestissimo instead of just relying on a query's current capacity.
Will update existing memory design doc reflect the internal change in followup.

Shadowed this in Prestissimo batch shadow and LBM stress test for reliability (for LBM stress test, the
memory checker gets pushback signal from the jemalloc earlier).

For performance measure by taking a spilled heavy query from Prestissimo batch production and
running 25 of them in parallel, the landing time (the time of the first query to the end of the last query)
has been reduced from 22mins down to 14 mins. The averaged execution time is reduced by half.
The speedup is mostly from query level spill parallelism as well as the global locking reduction. The
memory arbitration time has been reduced form 40k mins to 17k mins, and the driver queue time
has been reduced from 19k mins to 7k mins. This stress test has flakiness but the reduction in
memory arbitration wall-time is consistent across runs. Also the total amount of data to spill are also
consistent across runs at around 22TB


The followup needs to fix the issues on spilling execution path exposed by the stress test.

Differential Revision: D63902323


