### PR TITLE
Add ability to verify expression fuzzer runs on a subset of rows

### DIFF
--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -197,6 +197,7 @@ void ExpressionRunner::run(
       verifier.verify(
           typedExprs,
           inputVector,
+          std::nullopt,
           std::move(resultVector),
           true,
           columnsToWrapInLazy);
@@ -209,6 +210,7 @@ void ExpressionRunner::run(
             fuzzer,
             typedExprs,
             inputVector,
+            std::nullopt,
             columnsToWrapInLazy);
       }
       throw;

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -57,14 +57,17 @@ class ExpressionVerifier {
         options_(options),
         referenceQueryRunner_{referenceQueryRunner} {}
 
-  // Executes expressions both using common path (all evaluation
-  // optimizations) and simplified path. Additionally, a list of column
-  // indices can be passed via 'columnsToWrapInLazy' which specify the
-  // columns/children in the input row vector that should be wrapped in a lazy
-  // layer before running it through the common evaluation path. The list can
-  // contain negative column indices that represent lazy vectors that should be
-  // preloaded before being fed to the evaluator. This list is sorted on the
-  // absolute value of the entries.
+  // Executes expressions using common path (all evaluation
+  // optimizations) and compares the result with either the simplified path or a
+  // reference query runner. An optional selectivity vector 'rowsToVerify' can
+  // be passed which specifies which rows to evaluate and verify. If its not
+  // provided (by passing std::nullopt) then all rows will be verified.
+  // Additionally, a list of column indices can be passed via
+  // 'columnsToWrapInLazy' which specify the columns/children in the input row
+  // vector that should be wrapped in a lazy layer before running it through the
+  // common evaluation path. The list can contain negative column indices that
+  // represent lazy vectors that should be preloaded before being fed to the
+  // evaluator. This list is sorted on the absolute value of the entries.
   // Returns:
   //  - result of evaluating the expressions if both paths succeeded and
   //  returned the exact same vectors.
@@ -74,6 +77,7 @@ class ExpressionVerifier {
   fuzzer::ResultOrError verify(
       const std::vector<core::TypedExprPtr>& plans,
       const RowVectorPtr& rowVector,
+      const std::optional<SelectivityVector>& rowsToVerify,
       VectorPtr&& resultVector,
       bool canThrow,
       std::vector<int> columnsToWarpInLazy = {});
@@ -112,5 +116,6 @@ void computeMinimumSubExpression(
     VectorFuzzer& fuzzer,
     const std::vector<core::TypedExprPtr>& plans,
     const RowVectorPtr& rowVector,
+    const std::optional<SelectivityVector>& rowsToVerify,
     const std::vector<int>& columnsToWrapInLazy);
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Currently, the expression fuzzer has a phase where it re-runs rows
that did not throw an error to ensure evaluation is consistent for
them. To achieve this, it currently wraps the inputs with a dictionary
that only points to the subset of those rows. This results a change in
the encoding of inputs which can cause differences in eval paths taken
between phases. To address this and ensure the same paths are taken
for each evaluation phase, this change introduces the ability for the
expression verifier to only verify a subset of the input rows. The
aforementioned fuzzer run phase can only specify the non error rows
and maintain the original input row.

Follow up: After this change, it would be relevant to also store the
input selectivity vector. A subsequent change will be added that would
add this ability and make corresponding changes to the ExpressionRunner

Differential Revision: D64366745


