### PR TITLE
Throw actionable error message (or enable the path with jk) when struct encoding pushdown + side table on non-flatmap columns

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -280,6 +280,19 @@ class RowReaderOptions {
     return flatmapNodeIdAsStruct_;
   }
 
+  const std::string mapColumnIdAsStructToString() const {
+    std::ostringstream ss;
+    ss << "Flatmap columns:";
+    for (const auto& [key, valueVec] : flatmapNodeIdAsStruct_) {
+      ss << "ordinal: " << key << " -> [";
+      for (const auto& value : valueVec) {
+        ss << value << " ";
+      }
+      ss << "]";
+    }
+    return ss.str();
+  }
+
   void setDecodingExecutor(std::shared_ptr<folly::Executor> executor) {
     decodingExecutor_ = executor;
   }


### PR DESCRIPTION
Summary:
This diff aims to address an experimental path: nimble + sideTable + useVeloxEval + project regular map columns.

**TL;DR**: Nimble reader doesn't support the struct encoding pushdown feature for non flatmap columns today.
NOTE: Introduce a justknob: [dwio/nimble:enable_struct_encoding_pushdown](https://www.internalfb.com/intern/justknobs/?name=dwio%2Fnimble).
If it returns true (by default), this experimental feature is enabled. 
If it's set to false, the user will expect an error message, which columns are pushed down as flatmaps.

## How to repro?
Prerequisite:
1. Main table partition is in nimble format.
2. useFlatmapStructEncodingConversion = true
2. Projection pushdown on a non-flatmap column `int_counters`, which is not any of the flatmap columns from the side table schema.

## Why is this bug relevant to side table?
Side table requires base batch and side batch is fully aligned, which will trigger a **batch fill** operation - if there is any batch misalignment, basically the merger will look ahead for the next batch and fill the missing rows in the current batch (see Fill.cpp - `appendVeloxStruct()`: https://fburl.com/code/f2ug33z7).
By moving this Map encoding to Struct encoding conversion to DWIO layer, DWIO can handle side table merging efficiently. This is a feature gap for Nimble reader.

See more context in D33372475

Differential Revision: D63682451


