### PR TITLE
Remove usage of GTest Throws in dwrf::ColumnWriterTest.cpp

### DIFF
--- a/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
+++ b/velox/dwio/common/tests/OnDemandUnitLoaderTests.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 #include "velox/dwio/common/UnitLoaderTools.h"
 #include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
@@ -137,11 +138,9 @@ TEST(OnDemandUnitLoaderTests, SeekOutOfRangeReaderError) {
 
   readerMock.seek(60);
 
-  EXPECT_THAT(
-      [&]() { readerMock.seek(61); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Can't seek to possition 61 in file. Must be up to 60."))));
+  VELOX_ASSERT_THROW(
+      readerMock.seek(61),
+      "Can't seek to possition 61 in file. Must be up to 60.");
 }
 
 TEST(OnDemandUnitLoaderTests, SeekOutOfRange) {
@@ -154,11 +153,7 @@ TEST(OnDemandUnitLoaderTests, SeekOutOfRange) {
 
   unitLoader->onSeek(0, 10);
 
-  EXPECT_THAT(
-      [&]() { unitLoader->onSeek(0, 11); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Row out of range"))));
+  VELOX_ASSERT_THROW(unitLoader->onSeek(0, 11), "Row out of range");
 }
 
 TEST(OnDemandUnitLoaderTests, UnitOutOfRange) {
@@ -169,11 +164,8 @@ TEST(OnDemandUnitLoaderTests, UnitOutOfRange) {
 
   auto unitLoader = factory.create(std::move(units), 0);
   unitLoader->getLoadedUnit(0);
-  EXPECT_THAT(
-      [&]() { unitLoader->getLoadedUnit(1); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Unit out of range"))));
+
+  VELOX_ASSERT_THROW(unitLoader->getLoadedUnit(1), "Unit out of range");
 }
 
 TEST(OnDemandUnitLoaderTests, CanRequestUnitMultipleTimes) {
@@ -209,16 +201,12 @@ TEST(OnDemandUnitLoaderTests, InitialSkip) {
   EXPECT_NO_THROW(getFactoryWithSkip(31));
   EXPECT_NO_THROW(getFactoryWithSkip(59));
   EXPECT_NO_THROW(getFactoryWithSkip(60));
-  EXPECT_THAT(
-      [&]() { getFactoryWithSkip(61); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Can only skip up to the past-the-end row of the file."))));
-  EXPECT_THAT(
-      [&]() { getFactoryWithSkip(100); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Can only skip up to the past-the-end row of the file."))));
+  VELOX_ASSERT_THROW(
+      getFactoryWithSkip(61),
+      "Can only skip up to the past-the-end row of the file.");
+  VELOX_ASSERT_THROW(
+      getFactoryWithSkip(100),
+      "Can only skip up to the past-the-end row of the file.");
 }
 
 TEST(OnDemandUnitLoaderTests, NoUnitButSkip) {
@@ -228,9 +216,7 @@ TEST(OnDemandUnitLoaderTests, NoUnitButSkip) {
   EXPECT_NO_THROW(factory.create(std::move(units), 0));
 
   std::vector<std::unique_ptr<LoadUnit>> units2;
-  EXPECT_THAT(
-      [&]() { factory.create(std::move(units2), 1); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr("Can only skip up to the past-the-end row of the file."))));
+  VELOX_ASSERT_THROW(
+      factory.create(std::move(units2), 1),
+      "Can only skip up to the past-the-end row of the file.");
 }

--- a/velox/dwio/common/tests/UnitLoaderToolsTests.cpp
+++ b/velox/dwio/common/tests/UnitLoaderToolsTests.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/UnitLoaderTools.h"
 
 using namespace ::testing;
@@ -158,26 +159,14 @@ TEST(UnitLoaderToolsTests, HowMuchToSkip) {
 
   // Test cases
   EXPECT_EQ(testSkip(0, {}), result(0, 0));
-  EXPECT_THAT(
-      [&]() { testSkip(1, {}); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr(kErrorMessage))));
+  VELOX_ASSERT_THROW(testSkip(1, {}), kErrorMessage);
 
   EXPECT_EQ(testSkip(0, {0}), result(1, 0));
-  EXPECT_THAT(
-      [&]() { testSkip(1, {0}); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr(kErrorMessage))));
+  VELOX_ASSERT_THROW(testSkip(1, {0}), kErrorMessage);
 
   EXPECT_EQ(testSkip(0, {1}), result(0, 0));
   EXPECT_EQ(testSkip(1, {1}), result(1, 0));
-  EXPECT_THAT(
-      [&]() { testSkip(2, {1}); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr(kErrorMessage))));
+  VELOX_ASSERT_THROW(testSkip(2, {1}), kErrorMessage);
 
   std::vector<uint64_t> rowCount = {2, 1, 2};
   EXPECT_EQ(testSkip(0, rowCount), result(0, 0));
@@ -186,9 +175,5 @@ TEST(UnitLoaderToolsTests, HowMuchToSkip) {
   EXPECT_EQ(testSkip(3, rowCount), result(2, 0));
   EXPECT_EQ(testSkip(4, rowCount), result(2, 1));
   EXPECT_EQ(testSkip(5, rowCount), result(3, 0));
-  EXPECT_THAT(
-      [&]() { testSkip(6, rowCount); },
-      Throws<facebook::velox::VeloxRuntimeError>(Property(
-          &facebook::velox::VeloxRuntimeError::message,
-          HasSubstr(kErrorMessage))));
+  VELOX_ASSERT_THROW(testSkip(6, rowCount), kErrorMessage);
 }

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1267,12 +1267,10 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedInt64Key) {
   auto batch = b::create(
       *pool, {typename b::row{typename b::pair{5, 3}, typename b::pair{5, 4}}});
 
-  EXPECT_THAT(
-      ([&]() { testMapWriter<T, T>(*pool, batch, /* useFlatMap */ true); }),
-      Throws<
-          facebook::velox::dwio::common::exception::LoggedException>(Property(
-          &facebook::velox::dwio::common::exception::LoggedException::message,
-          HasSubstr("Duplicated key in map: 5"))));
+  VELOX_ASSERT_THROW_IMPL(
+      facebook::velox::dwio::common::exception::LoggedException,
+      (testMapWriter<T, T>(*pool, batch, /* useFlatMap */ true)),
+      "Duplicated key in map: 5");
 }
 
 TEST_F(ColumnWriterTest, TestMapWriterInt32Key) {
@@ -1320,14 +1318,10 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedStringKey) {
       *pool_,
       {b::row{b::pair{"2", "5"}, b::pair{"2", "8"}}}); // Duplicated key: 2
 
-  EXPECT_THAT(
-      ([&]() {
-        testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ true);
-      }),
-      Throws<
-          facebook::velox::dwio::common::exception::LoggedException>(Property(
-          &facebook::velox::dwio::common::exception::LoggedException::message,
-          HasSubstr("Duplicated key in map: 2"))));
+  VELOX_ASSERT_THROW_IMPL(
+      facebook::velox::dwio::common::exception::LoggedException,
+      (testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ true)),
+      "Duplicated key in map: 2");
 }
 
 TEST_F(ColumnWriterTest, TestMapWriterDifferentNumericKeyValue) {

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1267,8 +1267,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedInt64Key) {
   auto batch = b::create(
       *pool, {typename b::row{typename b::pair{5, 3}, typename b::pair{5, 4}}});
 
-  VELOX_ASSERT_THROW_IMPL(
-      facebook::velox::dwio::common::exception::LoggedException,
+  VELOX_ASSERT_THROW(
       (testMapWriter<T, T>(*pool, batch, /* useFlatMap */ true)),
       "Duplicated key in map: 5");
 }
@@ -1318,8 +1317,7 @@ TEST_F(ColumnWriterTest, TestMapWriterDuplicatedStringKey) {
       *pool_,
       {b::row{b::pair{"2", "5"}, b::pair{"2", "8"}}}); // Duplicated key: 2
 
-  VELOX_ASSERT_THROW_IMPL(
-      facebook::velox::dwio::common::exception::LoggedException,
+  VELOX_ASSERT_THROW(
       (testMapWriter<keyType, valueType>(*pool_, batch, /* useFlatMap */ true)),
       "Duplicated key in map: 2");
 }

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
@@ -126,11 +127,5 @@ TEST_F(StripeLoadKeysTest, ThirdStripeHasKey) {
 }
 
 TEST_F(StripeLoadKeysTest, KeyMismatch) {
-  EXPECT_THAT(
-      [&]() { runTest(3); },
-      Throws<facebook::velox::dwio::common::exception::LoggedException>(
-          Property(
-              &facebook::velox::dwio::common::exception::LoggedException::
-                  failingExpression,
-              HasSubstr("keys.size() == providers_.size()"))));
+  VELOX_ASSERT_THROW(runTest(3), "keys.size() == providers_.size()");
 }

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -17,7 +17,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 #include "velox/dwio/dwrf/utils/ProtoUtils.h"
@@ -127,5 +126,12 @@ TEST_F(StripeLoadKeysTest, ThirdStripeHasKey) {
 }
 
 TEST_F(StripeLoadKeysTest, KeyMismatch) {
-  VELOX_ASSERT_THROW(runTest(3), "keys.size() == providers_.size()");
+  try {
+    static_cast<void>(runTest(3));
+    FAIL() << "Expected an exception";
+  } catch (const facebook::velox::VeloxException& e) {
+    ASSERT_TRUE(
+        e.failingExpression().find("keys.size() == providers_.size()") !=
+        std::string::npos);
+  }
 }


### PR DESCRIPTION
Gtest feature Throws is available in GTest 1.11 while system default in Ubuntu 20.04 is GTest 1.10
Remove usage instead of enforcing a GTest minimum version.