### PR TITLE
Add HashJoinReplayer

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -126,6 +126,10 @@ void Operator::maybeSetTracer() {
   }
   tracedOpMap.emplace(operatorId(), operatorType());
 
+  if (!trace::canTrace(operatorType())) {
+    VELOX_UNSUPPORTED("{} does not support tracing", operatorType());
+  }
+
   const auto pipelineId = operatorCtx_->driverCtx()->pipelineId;
   const auto driverId = operatorCtx_->driverCtx()->driverId;
   LOG(INFO) << "Trace input for operator type: " << operatorType()

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -179,4 +179,16 @@ size_t getNumDrivers(
     const std::shared_ptr<filesystems::FileSystem>& fs) {
   return listDriverIds(nodeTraceDir, pipelineId, fs).size();
 }
+
+bool canTrace(const std::string& operatorType) {
+  static const std::unordered_set<std::string> kSupportedOperatorTypes{
+      "FilterProject",
+      "TableWrite",
+      "Aggregation",
+      "PartialAggregation",
+      "PartitionedOutput",
+      "HashBuild",
+      "HashProbe"};
+  return kSupportedOperatorTypes.count(operatorType) > 0;
+}
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/TraceUtil.h
+++ b/velox/exec/TraceUtil.h
@@ -123,4 +123,7 @@ std::vector<std::string> getTaskIds(
 folly::dynamic getTaskMetadata(
     const std::string& taskMetaFilePath,
     const std::shared_ptr<filesystems::FileSystem>& fs);
+
+/// Checks whether the operator can be traced.
+bool canTrace(const std::string& operatorType);
 } // namespace facebook::velox::exec::trace

--- a/velox/tool/trace/CMakeLists.txt
+++ b/velox/tool/trace/CMakeLists.txt
@@ -16,6 +16,7 @@ velox_add_library(
   velox_query_trace_replayer_base
   AggregationReplayer.cpp
   FilterProjectReplayer.cpp
+  HashJoinReplayer.cpp
   OperatorReplayerBase.cpp
   PartitionedOutputReplayer.cpp
   TableWriterReplayer.cpp

--- a/velox/tool/trace/HashJoinReplayer.cpp
+++ b/velox/tool/trace/HashJoinReplayer.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/tool/trace/HashJoinReplayer.h"
+#include "velox/exec/TraceUtil.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::tool::trace {
+core::PlanNodePtr HashJoinReplayer::createPlanNode(
+    const core::PlanNode* node,
+    const core::PlanNodeId& nodeId,
+    const core::PlanNodePtr& source) const {
+  const auto* hashJoinNode = dynamic_cast<const core::HashJoinNode*>(node);
+  return std::make_shared<core::HashJoinNode>(
+      nodeId,
+      hashJoinNode->joinType(),
+      hashJoinNode->isNullAware(),
+      hashJoinNode->leftKeys(),
+      hashJoinNode->rightKeys(),
+      hashJoinNode->filter(),
+      source,
+      PlanBuilder(planNodeIdGenerator_)
+          .traceScan(
+              nodeTraceDir_,
+              pipelineId_ + 1, // Build side
+              exec::trace::getDataType(planFragment_, nodeId_, 1))
+          .planNode(),
+      hashJoinNode->outputType());
+}
+} // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/HashJoinReplayer.h
+++ b/velox/tool/trace/HashJoinReplayer.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/tool/trace/OperatorReplayerBase.h"
+
+namespace facebook::velox::tool::trace {
+/// The replayer to replay the traced 'HashJoin' operator.
+class HashJoinReplayer final : public OperatorReplayerBase {
+ public:
+  HashJoinReplayer(
+      const std::string& rootDir,
+      const std::string& queryId,
+      const std::string& taskId,
+      const std::string& nodeId,
+      const int32_t pipelineId,
+      const std::string& operatorType)
+      : OperatorReplayerBase(
+            rootDir,
+            queryId,
+            taskId,
+            nodeId,
+            pipelineId,
+            operatorType) {}
+
+ private:
+  core::PlanNodePtr createPlanNode(
+      const core::PlanNode* node,
+      const core::PlanNodeId& nodeId,
+      const core::PlanNodePtr& source) const override;
+};
+} // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -18,7 +18,7 @@
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/PlanNode.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/PlanNodeIdGenerator.h"
 
 namespace facebook::velox::exec {
 class Task;

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -42,6 +42,7 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/tool/trace/AggregationReplayer.h"
 #include "velox/tool/trace/FilterProjectReplayer.h"
+#include "velox/tool/trace/HashJoinReplayer.h"
 #include "velox/tool/trace/OperatorReplayerBase.h"
 #include "velox/tool/trace/PartitionedOutputReplayer.h"
 #include "velox/tool/trace/TableWriterReplayer.h"
@@ -112,6 +113,14 @@ std::unique_ptr<tool::trace::OperatorReplayerBase> createReplayer() {
         FLAGS_operator_type);
   } else if (FLAGS_operator_type == "FilterProject") {
     replayer = std::make_unique<tool::trace::FilterProjectReplayer>(
+        FLAGS_root_dir,
+        FLAGS_query_id,
+        FLAGS_task_id,
+        FLAGS_node_id,
+        FLAGS_pipeline_id,
+        FLAGS_operator_type);
+  } else if (FLAGS_operator_type == "HashJoin") {
+    replayer = std::make_unique<tool::trace::HashJoinReplayer>(
         FLAGS_root_dir,
         FLAGS_query_id,
         FLAGS_task_id,

--- a/velox/tool/trace/tests/CMakeLists.txt
+++ b/velox/tool/trace/tests/CMakeLists.txt
@@ -14,8 +14,11 @@
 
 add_executable(
   velox_tool_trace_test
-  AggregationReplayerTest.cpp PartitionedOutputReplayerTest.cpp
-  TableWriterReplayerTest.cpp FilterProjectReplayerTest.cpp)
+  AggregationReplayerTest.cpp
+  PartitionedOutputReplayerTest.cpp
+  TableWriterReplayerTest.cpp
+  HashJoinReplayerTest.cpp
+  FilterProjectReplayerTest.cpp)
 
 add_test(
   NAME velox_tool_trace_test

--- a/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
+++ b/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
@@ -183,7 +183,7 @@ TEST_F(FilterProjectReplayerTest, filterProject) {
                              task->taskId(),
                              projectNodeId_,
                              0,
-                             "HashJoin")
+                             "FilterProject")
                              .run();
   assertEqualResults({result}, {replayingResult});
 }
@@ -217,7 +217,7 @@ TEST_F(FilterProjectReplayerTest, filterOnly) {
                              task->taskId(),
                              filterNodeId_,
                              0,
-                             "HashJoin")
+                             "FilterProject")
                              .run();
   assertEqualResults({result}, {replayingResult});
 }
@@ -251,7 +251,7 @@ TEST_F(FilterProjectReplayerTest, projectOnly) {
                              task->taskId(),
                              projectNodeId_,
                              0,
-                             "HashJoin")
+                             "FilterProject")
                              .run();
   assertEqualResults({result}, {replayingResult});
 }

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <boost/random/uniform_int_distribution.hpp>
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include <folly/experimental/EventCount.h>
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/hyperloglog/SparseHll.h"
+#include "velox/common/testutil/TestValue.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/PartitionFunction.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/TraceUtil.h"
+#include "velox/exec/tests/utils/ArbitratorTestUtil.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/tool/trace/HashJoinReplayer.h"
+
+#include "velox/common/file/Utils.h"
+#include "velox/exec/PlanNodeStats.h"
+
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::core;
+using namespace facebook::velox::common;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::connector;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::common::hll;
+
+namespace facebook::velox::tool::trace::test {
+class HashJoinReplayerTest : public HiveConnectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+    HiveConnectorTestBase::SetUpTestCase();
+    filesystems::registerLocalFileSystem();
+    if (!isRegisteredVectorSerde()) {
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    connector::hive::HiveTableHandle::registerSerDe();
+    connector::hive::LocationHandle::registerSerDe();
+    connector::hive::HiveColumnHandle::registerSerDe();
+    connector::hive::HiveInsertTableHandle::registerSerDe();
+    connector::hive::HiveConnectorSplit::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    registerPartitionFunctionSerDe();
+  }
+
+  void TearDown() override {
+    probeInput_.clear();
+    buildInput_.clear();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  struct PlanWithSplits {
+    core::PlanNodePtr plan;
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId buildScanId;
+    std::unordered_map<core::PlanNodeId, std::vector<exec::Split>> splits;
+
+    explicit PlanWithSplits(
+        const core::PlanNodePtr& _plan,
+        const core::PlanNodeId& _probeScanId = "",
+        const core::PlanNodeId& _buildScanId = "",
+        const std::unordered_map<
+            core::PlanNodeId,
+            std::vector<velox::exec::Split>>& _splits = {})
+        : plan(_plan),
+          probeScanId(_probeScanId),
+          buildScanId(_buildScanId),
+          splits(_splits) {}
+  };
+
+  RowTypePtr concat(const RowTypePtr& a, const RowTypePtr& b) {
+    std::vector<std::string> names = a->names();
+    std::vector<TypePtr> types = a->children();
+
+    for (auto i = 0; i < b->size(); ++i) {
+      names.push_back(b->nameOf(i));
+      types.push_back(b->childAt(i));
+    }
+
+    return ROW(std::move(names), std::move(types));
+  }
+
+  std::vector<RowVectorPtr>
+  makeVectors(int32_t count, int32_t rowsPerVector, const RowTypePtr& rowType) {
+    return HiveConnectorTestBase::makeVectors(rowType, count, rowsPerVector);
+  }
+
+  std::vector<Split> makeSplits(
+      const std::vector<RowVectorPtr>& inputs,
+      const std::string& path,
+      memory::MemoryPool* writerPool) {
+    std::vector<Split> splits;
+    for (auto i = 0; i < 4; ++i) {
+      const std::string filePath = fmt::format("{}/{}", path, i);
+      writeToFile(filePath, inputs);
+      splits.emplace_back(makeHiveConnectorSplit(filePath));
+    }
+
+    return splits;
+  }
+
+  PlanWithSplits createPlan(
+      const std::string& tableDir,
+      core::JoinType joinType,
+      const std::vector<std::string>& probeKeys,
+      const std::vector<std::string>& buildKeys,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const std::vector<Split> probeSplits =
+        makeSplits(probeInput, fmt::format("{}/probe", tableDir), pool());
+    const std::vector<Split> buildSplits =
+        makeSplits(buildInput, fmt::format("{}/build", tableDir), pool());
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId buildScanId;
+    const auto outputColumns = concat(
+                                   asRowType(probeInput_[0]->type()),
+                                   asRowType(buildInput_[0]->type()))
+                                   ->names();
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(probeType_)
+                    .capturePlanNodeId(probeScanId)
+                    .hashJoin(
+                        probeKeys,
+                        buildKeys,
+                        PlanBuilder(planNodeIdGenerator)
+                            .tableScan(buildType_)
+                            .capturePlanNodeId(buildScanId)
+                            .planNode(),
+                        /*filter=*/"",
+                        outputColumns,
+                        joinType,
+                        false)
+                    .capturePlanNodeId(traceNodeId_)
+                    .planNode();
+    return PlanWithSplits{
+        plan,
+        probeScanId,
+        buildScanId,
+        {{probeScanId, probeSplits}, {buildScanId, buildSplits}}};
+  }
+
+  core::PlanNodeId traceNodeId_;
+  RowTypePtr probeType_{
+      ROW({"t0", "t1", "t2", "t3"}, {BIGINT(), VARCHAR(), SMALLINT(), REAL()})};
+
+  RowTypePtr buildType_{
+      ROW({"u0", "u1", "u2", "u3"},
+          {BIGINT(), INTEGER(), SMALLINT(), VARCHAR()})};
+  std::vector<RowVectorPtr> probeInput_ = makeVectors(5, 100, probeType_);
+  std::vector<RowVectorPtr> buildInput_ = makeVectors(3, 100, buildType_);
+
+  const std::vector<std::string> probeKeys_{"t0"};
+  const std::vector<std::string> buildKeys_{"u0"};
+  const std::shared_ptr<TempDirectoryPath> testDir_ =
+      TempDirectoryPath::create();
+  const std::string tableDir_ =
+      fmt::format("{}/{}", testDir_->getPath(), "table");
+};
+
+TEST_F(HashJoinReplayerTest, basic) {
+  const auto planWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder builder(planWithSplits.plan);
+  for (const auto& [planNodeId, nodeSplits] : planWithSplits.splits) {
+    builder.splits(planNodeId, nodeSplits);
+  }
+  const auto result = builder.copyResults(pool());
+
+  const auto traceRoot =
+      fmt::format("{}/{}/traceRoot/", testDir_->getPath(), "basic");
+  std::shared_ptr<Task> task;
+  auto tracePlanWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder traceBuilder(tracePlanWithSplits.plan);
+  traceBuilder.config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_);
+  for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
+    traceBuilder.splits(planNodeId, nodeSplits);
+  }
+  auto traceResult = traceBuilder.copyResults(pool(), task);
+
+  assertEqualResults({result}, {traceResult});
+
+  const auto taskId = task->taskId();
+  const auto replayingResult = HashJoinReplayer(
+                                   traceRoot,
+                                   task->queryCtx()->queryId(),
+                                   task->taskId(),
+                                   traceNodeId_,
+                                   0,
+                                   "HashJoin")
+                                   .run();
+  assertEqualResults({result}, {replayingResult});
+}
+
+DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashBuildSpill) {
+  const auto planWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder builder(planWithSplits.plan);
+  for (const auto& [planNodeId, nodeSplits] : planWithSplits.splits) {
+    builder.splits(planNodeId, nodeSplits);
+  }
+  const auto result = builder.copyResults(pool());
+
+  const auto traceRoot =
+      fmt::format("{}/{}/traceRoot/", testDir_->getPath(), "hash_build_spill");
+  const auto spillDir =
+      fmt::format("{}/{}/spillDir/", testDir_->getPath(), "hash_build_spill");
+  std::shared_ptr<Task> task;
+  auto tracePlanWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+
+  std::atomic_bool injectSpillOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashBuild::finishHashBuild",
+      std::function<void(Operator*)>([&](Operator* op) {
+        if (!injectSpillOnce.exchange(false)) {
+          return;
+        }
+        Operator::ReclaimableSectionGuard guard(op);
+        testingRunArbitration(op->pool());
+      }));
+
+  AssertQueryBuilder traceBuilder(tracePlanWithSplits.plan);
+  traceBuilder.config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+      .config(core::QueryConfig::kSpillEnabled, true)
+      .config(core::QueryConfig::kJoinSpillEnabled, true)
+      .spillDirectory(spillDir);
+  for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
+    traceBuilder.splits(planNodeId, nodeSplits);
+  }
+
+  auto traceResult = traceBuilder.copyResults(pool(), task);
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  const auto& stats = taskStats.at(traceNodeId_);
+  auto opStats = toOperatorStats(task->taskStats());
+  ASSERT_GT(
+      opStats.at("HashBuild").runtimeStats[Operator::kSpillWrites].sum, 0);
+  ASSERT_GT(stats.spilledBytes, 0);
+  ASSERT_GT(stats.spilledRows, 0);
+  ASSERT_GT(stats.spilledFiles, 0);
+  ASSERT_GT(stats.spilledPartitions, 0);
+
+  assertEqualResults({result}, {traceResult});
+
+  const auto taskId = task->taskId();
+  const auto replayingResult = HashJoinReplayer(
+                                   traceRoot,
+                                   task->queryCtx()->queryId(),
+                                   task->taskId(),
+                                   traceNodeId_,
+                                   0,
+                                   "HashJoin")
+                                   .run();
+  assertEqualResults({result}, {replayingResult});
+}
+
+DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashProbeSpill) {
+  const auto planWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+
+  AssertQueryBuilder builder(planWithSplits.plan);
+  for (const auto& [planNodeId, nodeSplits] : planWithSplits.splits) {
+    builder.splits(planNodeId, nodeSplits);
+  }
+  const auto result = builder.copyResults(pool());
+
+  const auto traceRoot =
+      fmt::format("{}/{}/traceRoot/", testDir_->getPath(), "hash_probe_spill");
+  const auto spillDir =
+      fmt::format("{}/{}/spillDir/", testDir_->getPath(), "hash_probe_spill");
+  std::shared_ptr<Task> task;
+  auto tracePlanWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+
+  std::atomic_bool injectProbeSpillOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Driver::runInternal::getOutput",
+      std::function<void(Operator*)>([&](Operator* op) {
+        if (!isHashProbeMemoryPool(*op->pool())) {
+          return;
+        }
+        if (!injectProbeSpillOnce.exchange(false)) {
+          return;
+        }
+        testingRunArbitration(op->pool());
+      }));
+
+  AssertQueryBuilder traceBuilder(tracePlanWithSplits.plan);
+  traceBuilder.config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+      .config(core::QueryConfig::kSpillEnabled, true)
+      .config(core::QueryConfig::kJoinSpillEnabled, true)
+      .spillDirectory(spillDir);
+  for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
+    traceBuilder.splits(planNodeId, nodeSplits);
+  }
+
+  auto traceResult = traceBuilder.copyResults(pool(), task);
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  const auto& stats = taskStats.at(traceNodeId_);
+  auto opStats = toOperatorStats(task->taskStats());
+  ASSERT_GT(
+      opStats.at("HashProbe").runtimeStats[Operator::kSpillWrites].sum, 0);
+
+  ASSERT_GT(stats.spilledBytes, 0);
+  ASSERT_GT(stats.spilledRows, 0);
+  ASSERT_GT(stats.spilledFiles, 0);
+  ASSERT_GT(stats.spilledPartitions, 0);
+
+  assertEqualResults({result}, {traceResult});
+
+  const auto taskId = task->taskId();
+  const auto replayingResult = HashJoinReplayer(
+                                   traceRoot,
+                                   task->queryCtx()->queryId(),
+                                   task->taskId(),
+                                   traceNodeId_,
+                                   0,
+                                   "HashJoin")
+                                   .run();
+  assertEqualResults({result}, {replayingResult});
+}
+} // namespace facebook::velox::tool::trace::test


### PR DESCRIPTION
Add HashJoinReplayer to support replaying of hash join, and add
a valid list of operator types supporting tracing.

Part of #9668 