### PR TITLE
Support string type for PrefixSort

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -39,8 +39,15 @@ FOLLY_ALWAYS_INLINE void encodeRowColumn(
   } else {
     value = *(reinterpret_cast<T*>(row + rowColumn.offset()));
   }
-  prefixSortLayout.encoders[index].encode(
-      value, prefix + prefixSortLayout.prefixOffsets[index]);
+  if constexpr (std::is_same_v<T, StringView>) {
+    prefixSortLayout.encoders[index].encode(
+        value,
+        prefix + prefixSortLayout.prefixOffsets[index],
+        prefixSortLayout.encodeSizes[index]);
+  } else {
+    prefixSortLayout.encoders[index].encode(
+        value, prefix + prefixSortLayout.prefixOffsets[index]);
+  }
 }
 
 FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
@@ -73,6 +80,11 @@ FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
     }
     case TypeKind::TIMESTAMP: {
       encodeRowColumn<Timestamp>(
+          prefixSortLayout, index, rowColumn, row, prefix);
+      return;
+    }
+    case TypeKind::VARCHAR: {
+      encodeRowColumn<StringView>(
           prefixSortLayout, index, rowColumn, row, prefix);
       return;
     }
@@ -118,12 +130,14 @@ compareByWord(uint64_t* left, uint64_t* right, int32_t bytes) {
 
 PrefixSortLayout PrefixSortLayout::makeSortLayout(
     const std::vector<TypePtr>& types,
+    const std::vector<int32_t>& maxVarLengths,
     const std::vector<CompareFlags>& compareFlags,
     uint32_t maxNormalizedKeySize) {
   uint32_t normalizedKeySize = 0;
   uint32_t numNormalizedKeys = 0;
   const uint32_t numKeys = types.size();
   std::vector<uint32_t> prefixOffsets;
+  std::vector<uint32_t> encodeSizes;
   std::vector<PrefixSortEncoder> encoders;
 
   // Calculate encoders and prefix-offsets, and stop the loop if a key that
@@ -133,12 +147,13 @@ PrefixSortLayout PrefixSortLayout::makeSortLayout(
       break;
     }
     std::optional<uint32_t> encodedSize =
-        PrefixSortEncoder::encodedSize(types[i]->kind());
+        PrefixSortEncoder::encodedSize(types[i]->kind(), maxVarLengths[i]);
     if (encodedSize.has_value()) {
       prefixOffsets.push_back(normalizedKeySize);
       encoders.push_back(
           {compareFlags[i].ascending, compareFlags[i].nullsFirst});
       normalizedKeySize += encodedSize.value();
+      encodeSizes.push_back(encodedSize.value());
       numNormalizedKeys++;
     } else {
       break;
@@ -155,6 +170,7 @@ PrefixSortLayout PrefixSortLayout::makeSortLayout(
       numNormalizedKeys == 0,
       numNormalizedKeys < numKeys,
       std::move(prefixOffsets),
+      std::move(encodeSizes),
       std::move(encoders),
       padding};
 }

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -76,6 +76,9 @@ struct PrefixSortLayout {
   /// extracting columns
   const std::vector<uint32_t> prefixOffsets;
 
+  /// Sizes of normalized keys.
+  const std::vector<uint32_t> encodeSizes;
+
   /// The encoders for normalized keys.
   const std::vector<prefixsort::PrefixSortEncoder> encoders;
 
@@ -85,6 +88,7 @@ struct PrefixSortLayout {
 
   static PrefixSortLayout makeSortLayout(
       const std::vector<TypePtr>& types,
+      const std::vector<int32_t>& maxVarLength,
       const std::vector<CompareFlags>& compareFlags,
       uint32_t maxNormalizedKeySize);
 };
@@ -131,7 +135,10 @@ class PrefixSort {
     }
     VELOX_DCHECK_EQ(rowContainer->keyTypes().size(), compareFlags.size());
     const auto sortLayout = PrefixSortLayout::makeSortLayout(
-        rowContainer->keyTypes(), compareFlags, config.maxNormalizedKeySize);
+        rowContainer->keyTypes(),
+        rowContainer->varLengthColumnsMaxSize(),
+        compareFlags,
+        config.maxNormalizedKeySize);
     // All keys can not normalize, skip the binary string compare opt.
     // Putting this outside sort-internal helps with inline std-sort.
     if (sortLayout.noNormalizedKeys) {

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -189,6 +189,7 @@ RowContainer::RowContainer(
       ++nullOffset;
     }
     columnHasNulls_.push_back(false);
+    varLengthColumnsMaxSize_.push_back(0);
   }
   // Make offset at least sizeof pointer so that there is space for a
   // free list next pointer below the bit at 'freeFlagOffset_'.
@@ -218,6 +219,7 @@ RowContainer::RowContainer(
     ++nullOffset;
     isVariableWidth |= !type->isFixedWidth();
     columnHasNulls_.push_back(false);
+    varLengthColumnsMaxSize_.push_back(0);
   }
   if (hasProbedFlag) {
     nullOffsets_.push_back(nullOffset);
@@ -506,7 +508,8 @@ void RowContainer::store(
         index,
         isKey,
         row,
-        offsets_[column]);
+        offsets_[column],
+        column);
   } else {
     VELOX_DCHECK(isKey || accumulators_.empty());
     auto rowColumn = rowColumns_[column];
@@ -537,7 +540,8 @@ void RowContainer::store(
         decoded,
         rows,
         isKey,
-        offsets_[column]);
+        offsets_[column],
+        column);
   } else {
     const auto rowColumn = rowColumns_[column];
     VELOX_DYNAMIC_TYPE_DISPATCH_ALL(

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -752,6 +752,14 @@ class RowContainer {
     return columnHasNulls_[columnIndex];
   }
 
+  const auto& varLengthColumnsMaxSize() const {
+    return varLengthColumnsMaxSize_;
+  }
+
+  int32_t varLengthColumnsMaxSize(int32_t index) const {
+    return varLengthColumnsMaxSize_[index];
+  }
+
   const std::vector<Accumulator>& accumulators() const {
     return accumulators_;
   }
@@ -937,7 +945,13 @@ class RowContainer {
     }
     if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
-      stringAllocator_->copyMultipart(decoded.valueAt<T>(index), row, offset);
+      auto str = decoded.valueAt<T>(index);
+      varLengthColumnsMaxSize_[column] =
+          varLengthColumnsMaxSize_[column] < str.size()
+          ? str.size()
+          : varLengthColumnsMaxSize_[column];
+
+      stringAllocator_->copyMultipart(str, row, offset);
     } else {
       *reinterpret_cast<T*>(row + offset) = decoded.valueAt<T>(index);
     }
@@ -949,11 +963,18 @@ class RowContainer {
       vector_size_t index,
       bool isKey,
       char* group,
-      int32_t offset) {
+      int32_t offset,
+      int32_t column) {
     using T = typename TypeTraits<Kind>::NativeType;
     if constexpr (std::is_same_v<T, StringView>) {
       RowSizeTracker tracker(group[rowSizeOffset_], *stringAllocator_);
-      stringAllocator_->copyMultipart(decoded.valueAt<T>(index), group, offset);
+      auto str = decoded.valueAt<T>(index);
+      varLengthColumnsMaxSize_[column] =
+          varLengthColumnsMaxSize_[column] < str.size()
+          ? str.size()
+          : varLengthColumnsMaxSize_[column];
+
+      stringAllocator_->copyMultipart(str, group, offset);
     } else {
       *reinterpret_cast<T*>(group + offset) = decoded.valueAt<T>(index);
     }
@@ -979,9 +1000,10 @@ class RowContainer {
       const DecodedVector& decoded,
       folly::Range<char**> rows,
       bool isKey,
-      int32_t offset) {
+      int32_t offset,
+      int32_t column) {
     for (int32_t i = 0; i < rows.size(); ++i) {
-      storeNoNulls<Kind>(decoded, i, isKey, rows[i], offset);
+      storeNoNulls<Kind>(decoded, i, isKey, rows[i], offset, column);
     }
   }
 
@@ -1415,6 +1437,10 @@ class RowContainer {
   // not applicable.
   int32_t probedFlagOffset_ = 0;
 
+  // Maximum size for each variable-length column. If a column is fixed-size,
+  // the value is 0.
+  std::vector<int32_t> varLengthColumnsMaxSize_;
+
   // Bit position of free bit.
   int32_t freeFlagOffset_ = 0;
   int32_t rowSizeOffset_ = 0;
@@ -1471,7 +1497,8 @@ inline void RowContainer::storeNoNulls<TypeKind::ROW>(
     vector_size_t index,
     bool isKey,
     char* row,
-    int32_t offset) {
+    int32_t offset,
+    int32_t /*column*/) {
   storeComplexType(decoded, index, isKey, row, offset);
 }
 
@@ -1495,7 +1522,8 @@ inline void RowContainer::storeNoNulls<TypeKind::ARRAY>(
     vector_size_t index,
     bool isKey,
     char* row,
-    int32_t offset) {
+    int32_t offset,
+    int32_t /*column*/) {
   storeComplexType(decoded, index, isKey, row, offset);
 }
 
@@ -1519,7 +1547,8 @@ inline void RowContainer::storeNoNulls<TypeKind::MAP>(
     vector_size_t index,
     bool isKey,
     char* row,
-    int32_t offset) {
+    int32_t offset,
+    int32_t /*column*/) {
   storeComplexType(decoded, index, isKey, row, offset);
 }
 
@@ -1548,7 +1577,8 @@ inline void RowContainer::storeNoNulls<TypeKind::HUGEINT>(
     vector_size_t index,
     bool /*isKey*/,
     char* row,
-    int32_t offset) {
+    int32_t offset,
+    int32_t /*column*/) {
   HugeInt::serialize(decoded.valueAt<int128_t>(index), row + offset);
 }
 

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -22,6 +22,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SimdUtil.h"
+#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Type.h"
 
@@ -34,7 +35,7 @@ class PrefixSortEncoder {
       : ascending_(ascending), nullsFirst_(nullsFirst){};
 
   /// Encode native primitive types(such as uint64_t, int64_t, uint32_t,
-  /// int32_t, float, double, Timestamp). TODO: Add support for strings.
+  /// int32_t, float, double, Timestamp).
   /// 1. The first byte of the encoded result is null byte. The value is 0 if
   ///    (nulls first and value is null) or (nulls last and value is not null).
   ///    Otherwise, the value is 1.
@@ -50,6 +51,28 @@ class PrefixSortEncoder {
     } else {
       dest[0] = nullsFirst_ ? 0 : 1;
       simd::memset(dest + 1, 0, sizeof(T));
+    }
+  }
+
+  /// Encode String types.
+  FOLLY_ALWAYS_INLINE void encode(
+      std::optional<StringView> value,
+      char* dest,
+      int32_t encodeSize) const {
+    if (value.has_value()) {
+      dest[0] = nullsFirst_ ? 1 : 0;
+      std::string storage;
+      auto data = HashStringAllocator::contiguousString(value.value(), storage);
+      std::memcpy(dest + 1, data.data(), data.size());
+      std::memset(dest + 1 + data.size(), 0, encodeSize - 1 - data.size());
+      if (!ascending_) {
+        for (auto i = 1; i < encodeSize; ++i) {
+          dest[i] = ~dest[i];
+        }
+      }
+    } else {
+      dest[0] = nullsFirst_ ? 0 : 1;
+      std::memset(dest + 1, 0, encodeSize - 1);
     }
   }
 
@@ -69,7 +92,8 @@ class PrefixSortEncoder {
   /// @return For supported types, returns the encoded size, assume nullable.
   ///         For not supported types, returns 'std::nullopt'.
   FOLLY_ALWAYS_INLINE static std::optional<uint32_t> encodedSize(
-      TypeKind typeKind) {
+      TypeKind typeKind,
+      int32_t varLength) {
     switch ((typeKind)) {
       case ::facebook::velox::TypeKind::SMALLINT: {
         return 3;
@@ -88,6 +112,9 @@ class PrefixSortEncoder {
       }
       case ::facebook::velox::TypeKind::TIMESTAMP: {
         return 17;
+      }
+      case ::facebook::velox::TypeKind::VARCHAR: {
+        return 1 + varLength;
       }
       default:
         return std::nullopt;
@@ -248,6 +275,13 @@ FOLLY_ALWAYS_INLINE void PrefixSortEncoder::encodeNoNulls(
     char* dest) const {
   encodeNoNulls(value.getSeconds(), dest);
   encodeNoNulls(value.getNanos(), dest + 8);
+}
+
+template <>
+FOLLY_ALWAYS_INLINE void PrefixSortEncoder::encodeNoNulls(
+    StringView value,
+    char* dest) const {
+  VELOX_NYI();
 }
 
 } // namespace facebook::velox::exec::prefixsort

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -114,6 +114,43 @@ class PrefixEncoderTest : public testing::Test,
     ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, sizeof(T)), 0);
   }
 
+  void testEncodeString(
+      StringView testValue,
+      char* expectedAsc,
+      char* expectedDesc) {
+    std::optional<StringView> nullValue = std::nullopt;
+    std::optional<StringView> value = testValue;
+    char encoded[13];
+    char nullFirst[13];
+    char nullLast[13];
+    auto encodeSize = testValue.size() + 1;
+    memset(nullFirst, 0, encodeSize);
+    memset(nullLast, 1, 1);
+    memset(nullLast + 1, 0, encodeSize - 1);
+
+    auto compare = [&](char* left, char* right) {
+      return std::memcmp(left, right, encodeSize);
+    };
+
+    ascNullsFirstEncoder_.encode(nullValue, encoded, encodeSize);
+    ASSERT_EQ(compare(nullFirst, encoded), 0);
+    ascNullsLastEncoder_.encode(nullValue, encoded, encodeSize);
+    ASSERT_EQ(compare(nullLast, encoded), 0);
+
+    ascNullsFirstEncoder_.encode(value, encoded, encodeSize);
+    ASSERT_EQ(encoded[0], 1);
+    ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
+    ascNullsLastEncoder_.encode(value, encoded, encodeSize);
+    ASSERT_EQ(encoded[0], 0);
+    ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
+    descNullsFirstEncoder_.encode(value, encoded, encodeSize);
+    ASSERT_EQ(encoded[0], 1);
+    ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
+    descNullsLastEncoder_.encode(value, encoded, encodeSize);
+    ASSERT_EQ(encoded[0], 0);
+    ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
+  }
+
   template <typename T>
   void testEncode(T value, char* expectedAsc, char* expectedDesc) {
     testEncodeNoNull<T>(value, expectedAsc, expectedDesc);
@@ -225,7 +262,9 @@ class PrefixEncoderTest : public testing::Test,
 
     auto test = [&](const PrefixSortEncoder& encoder) {
       TypePtr type = TypeTraits<Kind>::ImplType::create();
-      VectorFuzzer fuzzer({.vectorSize = vectorSize, .nullRatio = 0.1}, pool());
+      VectorFuzzer fuzzer(
+          {.vectorSize = vectorSize, .nullRatio = 0.1, .stringLength = 16},
+          pool());
 
       CompareFlags compareFlag = {
           encoder.isNullsFirst(),
@@ -250,8 +289,13 @@ class PrefixEncoderTest : public testing::Test,
         const auto rightValue = rightVector->isNullAt(i)
             ? std::nullopt
             : std::optional<ValueDataType>(rightVector->valueAt(i));
-        encoder.encode(leftValue, leftEncoded);
-        encoder.encode(rightValue, rightEncoded);
+        if constexpr (Kind == TypeKind::VARCHAR) {
+          encoder.encode(leftValue, leftEncoded, 17);
+          encoder.encode(rightValue, rightEncoded, 17);
+        } else {
+          encoder.encode(leftValue, leftEncoded);
+          encoder.encode(rightValue, rightEncoded);
+        }
 
         const auto result = compare(leftEncoded, rightEncoded);
         const auto expected =
@@ -336,6 +380,16 @@ TEST_F(PrefixEncoderTest, encode) {
     descExpected[1] = 0xbbccddeeffffffff;
     testEncode<Timestamp>(value, (char*)ascExpected, (char*)descExpected);
   }
+
+  {
+    StringView value = StringView("aaaaaabbbbbb");
+    char ascExpected[13] = "aaaaaabbbbbb";
+    char descExpected[13];
+    for (int i = 0; i < 12; ++i) {
+      descExpected[i] = ~ascExpected[i];
+    }
+    testEncodeString(value, ascExpected, descExpected);
+  }
 }
 
 TEST_F(PrefixEncoderTest, compare) {
@@ -372,6 +426,10 @@ TEST_F(PrefixEncoderTest, fuzzyDouble) {
 
 TEST_F(PrefixEncoderTest, fuzzyTimestamp) {
   testFuzz<TypeKind::TIMESTAMP>();
+}
+
+TEST_F(PrefixEncoderTest, fuzzyStringView) {
+  testFuzz<TypeKind::VARCHAR>();
 }
 
 } // namespace facebook::velox::exec::prefixsort::test

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -155,7 +155,8 @@ TEST_F(PrefixSortTest, singleKey) {
            Timestamp(3, 3),
            Timestamp(2, 2),
            Timestamp(1, 1)}),
-      makeFlatVector<std::string_view>({"eee", "ddd", "ccc", "bbb", "aaa"})};
+      makeFlatVector<std::string_view>({"eee", "ddd", "ccc", "bbb", "aaa"}),
+      makeFlatVector<std::string_view>({"e", "dddddd", "ddddd", "bbb", "aaa"})};
   for (int i = 5; i < columnsSize; ++i) {
     const auto data = makeRowVector({testData[i]});
 
@@ -183,7 +184,9 @@ TEST_F(PrefixSortTest, singleKeyWithNulls) {
            Timestamp(2, 2),
            Timestamp(1, 1)}),
       makeNullableFlatVector<std::string_view>(
-          {"eee", "ddd", std::nullopt, "bbb", "aaa"})};
+          {"eee", "ddd", std::nullopt, "bbb", "aaa"}),
+      makeNullableFlatVector<std::string_view>(
+          {"ee", "aaa", std::nullopt, "d", "aaaaaaaaaaaaaa"})};
 
   for (int i = 5; i < columnsSize; ++i) {
     const auto data = makeRowVector({testData[i]});
@@ -210,7 +213,7 @@ TEST_F(PrefixSortTest, multipleKeys) {
     const auto data = makeRowVector({
         makeNullableFlatVector<int64_t>({5, 2, std::nullopt, 2, 1}),
         makeNullableFlatVector<std::string_view>(
-            {"eee", "ddd", std::nullopt, "bbb", "aaa"}),
+            {"eee", "aaa", std::nullopt, "bbb", "aaaa"}),
     });
 
     testPrefixSort({kAsc, kAsc}, data);

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -2290,3 +2290,32 @@ TEST_F(RowContainerTest, customComparisonRow) {
             expectedOrder, BIGINT_TYPE_WITH_CUSTOM_COMPARISON())});
       });
 }
+
+TEST_F(RowContainerTest, varLengthColumnsMaxSize) {
+  const uint64_t kNumRows = 5;
+  auto rowVector = makeRowVector({
+      makeFlatVector<int64_t>(
+          kNumRows, [](auto row) { return row % 3; }, nullEvery(6)),
+      makeFlatVector<std::string>({"a", "ab", "abcdse", "as", "b"}),
+      makeFlatVector<std::string>(
+          kNumRows,
+          [](auto row) { return fmt::format("abcdefg1234_{}", row); },
+          nullEvery(3)),
+  });
+  auto rowContainer =
+      makeRowContainer({BIGINT(), VARCHAR(), VARCHAR()}, {}, false);
+  std::vector<char*> rows;
+  rows.reserve(kNumRows);
+  SelectivityVector allRows(kNumRows);
+  for (size_t i = 0; i < kNumRows; i++) {
+    auto row = rowContainer->newRow();
+    rows.push_back(row);
+  }
+  for (int i = 0; i < rowContainer->columnTypes().size(); ++i) {
+    DecodedVector decoded(*rowVector->childAt(i), allRows);
+    rowContainer->store(decoded, folly::Range(rows.data(), kNumRows), i);
+  }
+  ASSERT_EQ(rowContainer->varLengthColumnsMaxSize(0), 0);
+  ASSERT_EQ(rowContainer->varLengthColumnsMaxSize(1), 6);
+  ASSERT_EQ(rowContainer->varLengthColumnsMaxSize(2), 13);
+}


### PR DESCRIPTION
Support string type for PrefixSort.
Retrieve the maximum length of the string column when inserting data into the row container.
Use the maximum length + 1 as the encoding size for string columns.
Perf result
```
StdSort_no-payloads_1_varchar_1k                          162.73ns     6.15M
PrefixSort                                      450.44%    36.13ns    27.68M
StdSort_no-payloads_2_varchar_1k                          189.12ns     5.29M
PrefixSort                                      203.10%    93.12ns    10.74M
StdSort_no-payloads_3_varchar_1k                          208.78ns     4.79M
PrefixSort                                      159.43%   130.95ns     7.64M
StdSort_no-payloads_4_varchar_1k                          222.15ns     4.50M
PrefixSort                                      136.34%   162.93ns     6.14M
StdSort_no-payloads_1_varchar_10k                         252.45ns     3.96M
PrefixSort                                      367.91%    68.62ns    14.57M
StdSort_no-payloads_2_varchar_10k                         264.94ns     3.77M
PrefixSort                                      225.52%   117.48ns     8.51M
StdSort_no-payloads_3_varchar_10k                         291.35ns     3.43M
PrefixSort                                      245.79%   118.54ns     8.44M
StdSort_no-payloads_4_varchar_10k                         311.60ns     3.21M
PrefixSort                                      199.08%   156.52ns     6.39M
StdSort_no-payloads_1_varchar_100k                        364.70ns     2.74M
PrefixSort                                      451.86%    80.71ns    12.39M
StdSort_no-payloads_2_varchar_100k                        379.81ns     2.63M
PrefixSort                                      270.35%   140.49ns     7.12M
StdSort_no-payloads_3_varchar_100k                        484.50ns     2.06M
PrefixSort                                      329.78%   146.92ns     6.81M
StdSort_no-payloads_4_varchar_100k                        503.42ns     1.99M
PrefixSort                                      245.14%   205.36ns     4.87M
StdSort_no-payloads_1_varchar_1000k                       761.40ns     1.31M
PrefixSort                                      702.57%   108.37ns     9.23M
StdSort_no-payloads_2_varchar_1000k                       977.61ns     1.02M
PrefixSort                                      468.83%   208.52ns     4.80M
StdSort_no-payloads_3_varchar_1000k                         1.10us   909.21K
PrefixSort                                      370.11%   297.17ns     3.37M
StdSort_no-payloads_4_varchar_1000k                         1.17us   853.98K
PrefixSort                                      330.43%   354.39ns     2.82M
```
