### PR TITLE
Remove unused-variable in velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -203,7 +203,6 @@ void SelectiveStringDictionaryColumnReader::read(
     const RowSet& rows,
     const uint64_t* incomingNulls) {
   prepareRead<int32_t>(offset, rows, incomingNulls);
-  bool isDense = rows.back() == rows.size() - 1;
   const auto* nullsPtr =
       nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
   // lazy loading dictionary data when first hit

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -846,7 +846,6 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
   const auto outOfLineBytes =
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const auto outOfLineBytesPerRow = outOfLineBytes / numDistinct;
   const int64_t flatBytes = input->estimateFlatSize();
 
   // Test-only spill path.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -444,8 +444,6 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
   const auto outOfLineBytes =
       rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const auto outOfLineBytesPerRow =
-      std::max<uint64_t>(1, numRows == 0 ? 0 : outOfLineBytes / numRows);
   const auto currentUsage = pool()->usedBytes();
 
   if (numRows != 0) {

--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -291,7 +291,6 @@ struct InverseCauchyCDFFunction {
   FOLLY_ALWAYS_INLINE void
   call(double& result, double median, double scale, double p) {
     static constexpr double kInf = std::numeric_limits<double>::infinity();
-    static constexpr double kDoubleMax = std::numeric_limits<double>::max();
     static constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
 
     VELOX_USER_CHECK(p >= 0 && p <= 1, "p must be in the interval [0, 1]");


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D64279128


