### PR TITLE
Add replaceFirst function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -93,6 +93,12 @@ String Functions
         SELECT ltrim('test', 't'); -- est
         SELECT ltrim('tetris', 'te'); -- ris
 
+.. function:: replaceFirst(string, search, replace) -> varchar
+
+    Removes the first instances of ``search`` with ``replace`` in ``string``.
+
+    If ``search`` is an empty string, inserts ``replace`` in front of ``string``.
+
 .. function:: replace(string, search) -> varchar
 
     Removes all instances of ``search`` from ``string``.

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -238,8 +238,11 @@ FOLLY_ALWAYS_INLINE void replace(
     TOutString& outputString,
     const TInString& inputString,
     const TInString& replaced,
-    const TInString& replacement) {
-  if (replaced.size() == 0) {
+    const TInString& replacement,
+    bool replaceFirst = false) {
+  if (replaceFirst) {
+    outputString.reserve(inputString.size() + replacement.size());
+  } else if (replaced.size() == 0) {
     // Add replacement before and after each character.
     outputString.reserve(
         inputString.size() + replacement.size() +
@@ -255,7 +258,8 @@ FOLLY_ALWAYS_INLINE void replace(
       std::string_view(inputString.data(), inputString.size()),
       std::string_view(replaced.data(), replaced.size()),
       std::string_view(replacement.data(), replacement.size()),
-      false);
+      false,
+      replaceFirst);
 
   outputString.resize(outputSize);
 }
@@ -265,7 +269,8 @@ template <typename TInOutString, typename TInString>
 FOLLY_ALWAYS_INLINE void replaceInPlace(
     TInOutString& string,
     const TInString& replaced,
-    const TInString& replacement) {
+    const TInString& replacement,
+    bool replaceFirst = false) {
   assert(replacement.size() <= replaced.size() && "invalid inplace replace");
 
   auto outputSize = stringCore::replace(
@@ -273,7 +278,8 @@ FOLLY_ALWAYS_INLINE void replaceInPlace(
       std::string_view(string.data(), string.size()),
       std::string_view(replaced.data(), replaced.size()),
       std::string_view(replacement.data(), replacement.size()),
-      true);
+      true,
+      replaceFirst);
 
   string.resize(outputSize);
 }

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -153,6 +153,7 @@ void registerStringFunctions(const std::string& prefix) {
   registerSplitToMap(prefix);
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_replaceFirst, prefix + "replaceFirst");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reverse, prefix + "reverse");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, prefix + "to_utf8");


### PR DESCRIPTION
Summary:
ReplaceFirst function will replace the first found instance of the search with the replacement. If the search is empty, replaceFirst will prepend the replacement on the input string.

We simply leverage the existing replace function and pass in a replaceFirst bool flag.
Differential Revision: D64475513


