### PR TITLE
Improve documentation for hive.gcs.endpoint

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -637,7 +637,7 @@ Each query can override the config by setting corresponding query session proper
    * - hive.gcs.endpoint
      - string
      -
-     - The GCS storage endpoint server.
+     - The GCS storage URI.
    * - hive.gcs.json-key-file-path
      - string
      -


### PR DESCRIPTION
This commit got left out here https://github.com/facebookincubator/velox/pull/11235
I removed the default endpoint value from that PR since it was not required.