### PR TITLE
support to clear cached vectors from vector pool

### DIFF
--- a/velox/vector/VectorPool.cpp
+++ b/velox/vector/VectorPool.cpp
@@ -84,6 +84,12 @@ size_t VectorPool::release(std::vector<VectorPtr>& vectors) {
   return numReleased;
 }
 
+void VectorPool::clear() {
+  for (auto& vectorPool : vectors_) {
+    vectorPool.clear();
+  }
+}
+
 bool VectorPool::TypePool::maybePushBack(VectorPtr& vector) {
   // Check that this is a Flat Vector with an initialized, unique, and mutable
   // values Buffer and an uninitialized or unique and mutable nulls Buffer.
@@ -126,5 +132,10 @@ VectorPtr VectorPool::TypePool::pop(
     return result;
   }
   return BaseVector::create(type, vectorSize, &pool);
+}
+
+void VectorPool::TypePool::clear() {
+  std::fill_n(vectors.begin(), kNumPerType, nullptr);
+  size = 0;
 }
 } // namespace facebook::velox

--- a/velox/vector/VectorPool.h
+++ b/velox/vector/VectorPool.h
@@ -42,6 +42,9 @@ class VectorPool {
 
   size_t release(std::vector<VectorPtr>& vectors);
 
+  /// Clears all the cached vectors.
+  void clear();
+
  private:
   /// Max number of elements for a vector to be recyclable. The larger
   /// the batch the less the win from recycling.
@@ -58,6 +61,9 @@ class VectorPool {
         const TypePtr& type,
         vector_size_t vectorSize,
         memory::MemoryPool& pool);
+
+    /// Clears all the cached vectors.
+    void clear();
   };
 
   memory::MemoryPool* const pool_;

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -151,4 +151,48 @@ TEST_F(VectorPoolTest, customTypes) {
   ASSERT_EQ(1'000, vector->size());
   ASSERT_TRUE(isJsonType(vector->type()));
 }
+
+TEST_F(VectorPoolTest, clear) {
+  const auto statsBefore = pool()->stats();
+
+  VectorPool vectorPool(pool());
+
+  std::vector<VectorPtr> vectors(10);
+  std::vector<std::weak_ptr<BaseVector>> vectorPtrs(10);
+  for (auto i = 0; i < 10; ++i) {
+    vectors[i] = vectorPool.get(BIGINT(), 1'000);
+    ASSERT_NE(vectors[i], nullptr);
+    vectorPtrs[i] = vectors[i];
+  }
+
+  for (auto i = 0; i < 10; ++i) {
+    ASSERT_TRUE(vectorPool.release(vectors[i]));
+    ASSERT_EQ(vectors[i], nullptr);
+  }
+
+  // Fetch recycled vectors from the pool.
+  for (auto i = 9; i >= 0; --i) {
+    vectors[i] = vectorPool.get(BIGINT(), 1'000);
+    ASSERT_NE(vectors[i], nullptr);
+    ASSERT_EQ(vectors[i].get(), vectorPtrs[i].lock().get());
+  }
+
+  for (auto i = 0; i < 10; ++i) {
+    ASSERT_TRUE(vectorPool.release(vectors[i]));
+    ASSERT_EQ(vectors[i], nullptr);
+  }
+
+  vectorPool.clear();
+
+  ASSERT_EQ(statsBefore.usedBytes, pool()->stats().usedBytes);
+  ASSERT_EQ(statsBefore.reservedBytes, pool()->stats().reservedBytes);
+
+  // Try to fetch recycled vectors from the pool after clear, and verify that
+  // they are new.
+  for (auto i = 9; i >= 0; --i) {
+    vectors[i] = vectorPool.get(BIGINT(), 1'000);
+    ASSERT_NE(vectors[i], nullptr);
+    ASSERT_EQ(vectorPtrs[i].lock(), nullptr);
+  }
+}
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Add to support to clear cached vectors from vector pool and will be used by hash probe reclaim
to clear the cached buffers in case the hash probe spill triggered at the first input with filter eval
as the filter eval might do the first allocations for vector pool and sub expression cache things.
The followup is to support sub expression cache clear and the integration hash probe reclaim.
We need to make sure the memory reclamation doesn't increase the memory usage after reclaim.

Differential Revision: D64546029


