### PR TITLE
Add max_local_exchange_partition_count config property

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -108,6 +108,16 @@ class QueryConfig {
   static constexpr const char* kMaxLocalExchangeBufferSize =
       "max_local_exchange_buffer_size";
 
+  /// Limits the number of partitions created by a local exchange.
+  /// Partitioning data too granularly can lead to poor performance.
+  /// This setting allows increasing the task concurrency for all
+  /// pipelines except the ones that require a local partitioning.
+  /// Affects the number of drivers for pipelines containing
+  /// LocalPartitionNode and cannot exceed the maximum number of
+  /// pipeline drivers configured for the task.
+  static constexpr const char* kMaxLocalExchangePartitionCount =
+      "max_local_exchange_partition_count";
+
   /// Maximum size in bytes to accumulate in ExchangeQueue. Enforced
   /// approximately, not strictly.
   static constexpr const char* kMaxExchangeBufferSize =
@@ -488,6 +498,12 @@ class QueryConfig {
   uint64_t maxLocalExchangeBufferSize() const {
     static constexpr uint64_t kDefault = 32UL << 20;
     return get<uint64_t>(kMaxLocalExchangeBufferSize, kDefault);
+  }
+
+  uint32_t maxLocalExchangePartitionCount() const {
+    // defaults to unlimited
+    static constexpr uint32_t kDefault = std::numeric_limits<uint32_t>::max();
+    return get<uint32_t>(kMaxLocalExchangePartitionCount, kDefault);
   }
 
   uint64_t maxExchangeBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -76,6 +76,13 @@ Generic Configuration
      - integer
      - 32MB
      - Used for backpressure to block local exchange producers when the local exchange buffer reaches or exceeds this size.
+  * - max_local_exchange_partition_count
+     - integer
+     - 2^32
+     - Limits the number of partitions created by a local exchange. Partitioning data too granularly can lead to poor performance.
+       This setting allows increasing the task concurrency for all pipelines except the ones that require a local partitioning.
+       Affects the number of drivers for pipelines containing LocalPartitionNode and cannot exceed the maximum number of
+       pipeline drivers configured for the task.
    * - exchange.max_buffer_size
      - integer
      - 32MB

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -213,8 +213,14 @@ uint32_t maxDrivers(
         auto localExchange =
             std::dynamic_pointer_cast<const core::LocalPartitionNode>(node)) {
       // Local gather must run single-threaded.
-      if (localExchange->type() == core::LocalPartitionNode::Type::kGather) {
-        return 1;
+      switch (localExchange->type()) {
+        case core::LocalPartitionNode::Type::kGather:
+          return 1;
+        case core::LocalPartitionNode::Type::kRepartition:
+          count = std::min(queryConfig.maxLocalExchangePartitionCount(), count);
+          break;
+        default:
+          VELOX_UNREACHABLE("Unexpected local exchange type");
       }
     } else if (std::dynamic_pointer_cast<const core::LocalMergeNode>(node)) {
       // Local merge must run single-threaded.


### PR DESCRIPTION
Summary:
Used to limit the number of partitions created by a local exchange.
Partitioning data too granularly can lead to poor performance.
This setting allows increasing the task concurrency for all pipelines except the ones that require a local partitioning.

Differential Revision: D64557900


