### PR TITLE
Centralize join probe/build table spill to join bridge

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -26,15 +26,15 @@
 
 namespace facebook::velox::exec {
 
-// Builds a hash table for use in HashProbe. This is the final
-// Operator in a build side Driver. The build side pipeline has
-// multiple Drivers, each with its own HashBuild. The build finishes
-// when the last Driver of the build pipeline finishes. Hence finishHashBuild()
-// has a barrier where the last one to enter gathers the data
-// accumulated by the other Drivers and makes the join hash
-// table. This table is then passed to the probe side pipeline via
-// JoinBridge. After this, all build side Drivers finish and free
-// their state.
+/// Builds a hash table for use in HashProbe. This is the final
+/// Operator in a build side Driver. The build side pipeline has
+/// multiple Drivers, each with its own HashBuild. The build finishes
+/// when the last Driver of the build pipeline finishes. Hence finishHashBuild()
+/// has a barrier where the last one to enter gathers the data
+/// accumulated by the other Drivers and makes the join hash
+/// table. This table is then passed to the probe side pipeline via
+/// JoinBridge. After this, all build side Drivers finish and free
+/// their state.
 class HashBuild final : public Operator {
  public:
   /// Define the internal execution state for hash build.

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -342,8 +342,8 @@ class BaseHashTable {
       int8_t spillInputStartPartitionBit,
       bool disableRangeArrayHash = false) = 0;
 
-  // Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
-  // and be unique.
+  /// Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
+  /// and be unique.
   virtual void erase(folly::Range<char**> rows) = 0;
 
   /// Returns a brief description for use in debugging.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -486,9 +486,8 @@ column_index_t exprToChannel(
   if (dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
     return kConstantChannel;
   }
-  VELOX_FAIL(
+  VELOX_UNREACHABLE(
       "Expression must be field access or constant, got: {}", expr->toString());
-  return 0; // not reached.
 }
 
 std::vector<column_index_t> calculateOutputChannels(


### PR DESCRIPTION
Consolidates table spill logic from hash probe and hash build to a centralized place, hash join bridge. This effort will reduce duplicate and unnecessary code, as well as making reclaiming from higher level possible (directly from join bridge under some circumstances).