### PR TITLE
Disable aggregate pushdown for decimal type

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -136,24 +136,11 @@ VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
-    const TypePtr& type,
+    const TypePtr& /*type*/,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
-  // Generate proper bits of random value for ShortDecimalType tests.
-  if (type->isShortDecimal()) {
-    auto [precision, scale] = getDecimalPrecisionScale(*type);
-    // DuckDB's valid decimal range.
-    int64_t min = 1 - int64_t(std::pow(10, precision - scale));
-    int64_t max = int64_t(std::pow(10, precision - scale)) - 1;
-    return createScalar<int64_t>(
-        size,
-        gen,
-        [&gen, &min, &max]() { return Random::rand64(min, max, gen); },
-        pool,
-        isNullAt);
-  }
   return createScalar<int64_t>(
       size, gen, [&gen]() { return Random::rand64(gen); }, pool, isNullAt);
 }

--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -136,11 +136,24 @@ VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
-    const TypePtr& /*type*/,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
+  // Generate proper bits of random value for ShortDecimalType tests.
+  if (type->isShortDecimal()) {
+    auto [precision, scale] = getDecimalPrecisionScale(*type);
+    // DuckDB's valid decimal range.
+    int64_t min = 1 - int64_t(std::pow(10, precision - scale));
+    int64_t max = int64_t(std::pow(10, precision - scale)) - 1;
+    return createScalar<int64_t>(
+        size,
+        gen,
+        [&gen, &min, &max]() { return Random::rand64(min, max, gen); },
+        pool,
+        isNullAt);
+  }
   return createScalar<int64_t>(
       size, gen, [&gen]() { return Random::rand64(gen); }, pool, isNullAt);
 }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3755,29 +3755,6 @@ TEST_F(TableScanTest, aggregationPushdown) {
   EXPECT_EQ(0, loadedToValueHook(task));
 }
 
-TEST_F(TableScanTest, decimalDisableAggregationPushdown) {
-  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DECIMAL(18, 2)});
-  auto vectors = makeVectors(10, 1'000, rowType);
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->getPath(), vectors);
-  createDuckDbTable(vectors);
-  auto op = PlanBuilder()
-                .tableScan(rowType)
-                .singleAggregation({"c0"}, {"min(c1)", "max(c1)", "sum(c1)"})
-                .planNode();
-  auto task = assertQuery(
-      op,
-      {filePath},
-      "SELECT c0, min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
-  EXPECT_EQ(
-      0,
-      task->taskStats()
-          .pipelineStats[0]
-          .operatorStats[1]
-          .runtimeStats.at("loadedToValueHook")
-          .sum);
-}
-
 TEST_F(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3754,32 +3754,34 @@ TEST_F(TableScanTest, aggregationPushdown) {
       "SELECT c5, min(c0 + 1), max(c1 + 2), sum(c2 + 3) FROM tmp GROUP BY 1");
   EXPECT_EQ(0, loadedToValueHook(task));
 }
+
 TEST_F(TableScanTest, decimalDisableAggregationPushdown) {
-vector_size_t size = 1'000;
-auto rowVector = makeRowVector({
-                                   makeFlatVector<int64_t>(size, [](auto row) { return 1; }),
-                                   makeFlatVector<int64_t>(
-                                       size, [](auto row) { return row; }, nullptr, DECIMAL(18, 2)),
-                               });
+  vector_size_t size = 1'000;
+  auto rowVector = makeRowVector({
+      makeFlatVector<int64_t>(size, [](auto row) { return 1; }),
+      makeFlatVector<int64_t>(
+          size, [](auto row) { return row; }, nullptr, DECIMAL(18, 2)),
+  });
 
-auto filePath = TempFilePath::create();
-writeToFile(filePath->getPath(), {rowVector});
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), {rowVector});
 
-createDuckDbTable({rowVector});
+  createDuckDbTable({rowVector});
 
-auto rowType = asRowType(rowVector->type());
-auto op = PlanBuilder()
-    .tableScan(rowType)
-    .singleAggregation({"c0"}, {"min(c1)", "max(c1)", "sum(c1)"})
-    .planNode();
+  auto rowType = asRowType(rowVector->type());
+  auto op = PlanBuilder()
+                .tableScan(rowType)
+                .singleAggregation({"c0"}, {"min(c1)", "max(c1)", "sum(c1)"})
+                .planNode();
 
-auto task = assertQuery(
-    op,
-    {filePath},
-    "SELECT c0, min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
-auto stats = task->taskStats().pipelineStats[0].operatorStats[1].runtimeStats;
-EXPECT_EQ(stats.end(), stats.find("loadedToValueHook"));
+  auto task = assertQuery(
+      op,
+      {filePath},
+      "SELECT c0, min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
+  auto stats = task->taskStats().pipelineStats[0].operatorStats[1].runtimeStats;
+  EXPECT_EQ(stats.end(), stats.find("loadedToValueHook"));
 }
+
 TEST_F(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3754,7 +3754,32 @@ TEST_F(TableScanTest, aggregationPushdown) {
       "SELECT c5, min(c0 + 1), max(c1 + 2), sum(c2 + 3) FROM tmp GROUP BY 1");
   EXPECT_EQ(0, loadedToValueHook(task));
 }
+TEST_F(TableScanTest, decimalDisableAggregationPushdown) {
+vector_size_t size = 1'000;
+auto rowVector = makeRowVector({
+                                   makeFlatVector<int64_t>(size, [](auto row) { return 1; }),
+                                   makeFlatVector<int64_t>(
+                                       size, [](auto row) { return row; }, nullptr, DECIMAL(18, 2)),
+                               });
 
+auto filePath = TempFilePath::create();
+writeToFile(filePath->getPath(), {rowVector});
+
+createDuckDbTable({rowVector});
+
+auto rowType = asRowType(rowVector->type());
+auto op = PlanBuilder()
+    .tableScan(rowType)
+    .singleAggregation({"c0"}, {"min(c1)", "max(c1)", "sum(c1)"})
+    .planNode();
+
+auto task = assertQuery(
+    op,
+    {filePath},
+    "SELECT c0, min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
+auto stats = task->taskStats().pipelineStats[0].operatorStats[1].runtimeStats;
+EXPECT_EQ(stats.end(), stats.find("loadedToValueHook"));
+}
 TEST_F(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3755,6 +3755,29 @@ TEST_F(TableScanTest, aggregationPushdown) {
   EXPECT_EQ(0, loadedToValueHook(task));
 }
 
+TEST_F(TableScanTest, decimalDisableAggregationPushdown) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DECIMAL(18, 2)});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+  auto op = PlanBuilder()
+                .tableScan(rowType)
+                .singleAggregation({"c0"}, {"min(c1)", "max(c1)", "sum(c1)"})
+                .planNode();
+  auto task = assertQuery(
+      op,
+      {filePath},
+      "SELECT c0, min(c1), max(c1), sum(c1) FROM tmp GROUP BY 1");
+  EXPECT_EQ(
+      0,
+      task->taskStats()
+          .pipelineStats[0]
+          .operatorStats[1]
+          .runtimeStats.at("loadedToValueHook")
+          .sum);
+}
+
 TEST_F(TableScanTest, bitwiseAggregationPushdown) {
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -113,10 +113,14 @@ class SimpleNumericMaxAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (mayPushdown && args[0]->isLazy()) {
-        BaseAggregate::template pushdown<
-            velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
-        return;
+      if (!args[0]->type()->isDecimal()) {
+        if (mayPushdown && args[0]->isLazy()) {
+          BaseAggregate::template pushdown<
+              velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
+          return;
+        }
+      } else {
+        mayPushdown = false;
       }
     } else {
       mayPushdown = false;
@@ -210,10 +214,14 @@ class SimpleNumericMinAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (mayPushdown && args[0]->isLazy()) {
-        BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, true>>(
-            groups, rows, args[0]);
-        return;
+      if (!args[0]->type()->isDecimal()) {
+        if (mayPushdown && args[0]->isLazy()) {
+          BaseAggregate::template pushdown<
+              velox::aggregate::MinMaxHook<T, true>>(groups, rows, args[0]);
+          return;
+        }
+      } else {
+        mayPushdown = false;
       }
     } else {
       mayPushdown = false;

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -113,10 +113,14 @@ class SimpleNumericMaxAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (mayPushdown && args[0]->isLazy() && !args[0]->type()->isDecimal()) {
-        BaseAggregate::template pushdown<
-            velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
-        return;
+      if (!args[0]->type()->isDecimal()) {
+        if (mayPushdown && args[0]->isLazy()) {
+          BaseAggregate::template pushdown<
+              velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
+          return;
+        }
+      } else {
+        mayPushdown = false;
       }
     } else {
       mayPushdown = false;
@@ -210,10 +214,14 @@ class SimpleNumericMinAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (mayPushdown && args[0]->isLazy() && !args[0]->type()->isDecimal()) {
-        BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, true>>(
-            groups, rows, args[0]);
-        return;
+      if (!args[0]->type()->isDecimal()) {
+        if (mayPushdown && args[0]->isLazy()) {
+          BaseAggregate::template pushdown<
+              velox::aggregate::MinMaxHook<T, true>>(groups, rows, args[0]);
+          return;
+        }
+      } else {
+        mayPushdown = false;
       }
     } else {
       mayPushdown = false;

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -113,14 +113,10 @@ class SimpleNumericMaxAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (!args[0]->type()->isDecimal()) {
-        if (mayPushdown && args[0]->isLazy()) {
-          BaseAggregate::template pushdown<
-              velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
-          return;
-        }
-      } else {
-        mayPushdown = false;
+      if (mayPushdown && args[0]->isLazy() && !args[0]->type()->isDecimal()) {
+        BaseAggregate::template pushdown<
+            velox::aggregate::MinMaxHook<T, false>>(groups, rows, args[0]);
+        return;
       }
     } else {
       mayPushdown = false;
@@ -214,14 +210,10 @@ class SimpleNumericMinAggregate : public SimpleNumericMinMaxAggregate<T> {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
     if constexpr (BaseAggregate::template kMayPushdown<T>) {
-      if (!args[0]->type()->isDecimal()) {
-        if (mayPushdown && args[0]->isLazy()) {
-          BaseAggregate::template pushdown<
-              velox::aggregate::MinMaxHook<T, true>>(groups, rows, args[0]);
-          return;
-        }
-      } else {
-        mayPushdown = false;
+      if (mayPushdown && args[0]->isLazy() && !args[0]->type()->isDecimal()) {
+        BaseAggregate::template pushdown<velox::aggregate::MinMaxHook<T, true>>(
+            groups, rows, args[0]);
+        return;
       }
     } else {
       mayPushdown = false;

--- a/velox/functions/lib/aggregates/SimpleNumericAggregate.h
+++ b/velox/functions/lib/aggregates/SimpleNumericAggregate.h
@@ -36,7 +36,7 @@ class SimpleNumericAggregate : public exec::Aggregate {
 
  protected:
   template <typename T>
-  static constexpr bool kMayPushdown =
+  static constexpr bool kMayPushdown = !std::is_same_v<T, int128_t> &&
       !std::is_same_v<T, Timestamp> && !std::is_same_v<T, UnknownValue>;
 
   // TData is either TAccumulator or TResult, which in most cases are the same,
@@ -100,21 +100,20 @@ class SimpleNumericAggregate : public exec::Aggregate {
     DecodedVector decoded(*arg, rows, !mayPushdown);
     auto encoding = decoded.base()->encoding();
     if constexpr (kMayPushdown<TData>) {
-      if (!arg->type()->isDecimal()) {
-        if (encoding == VectorEncoding::Simple::LAZY) {
-          velox::aggregate::SimpleCallableHook<TData, UpdateSingleValue> hook(
-              exec::Aggregate::offset_,
-              exec::Aggregate::nullByte_,
-              exec::Aggregate::nullMask_,
-              groups,
-              &this->exec::Aggregate::numNulls_,
-              updateSingleValue);
+      if (encoding == VectorEncoding::Simple::LAZY &&
+          !arg->type()->isDecimal()) {
+        velox::aggregate::SimpleCallableHook<TData, UpdateSingleValue> hook(
+            exec::Aggregate::offset_,
+            exec::Aggregate::nullByte_,
+            exec::Aggregate::nullMask_,
+            groups,
+            &this->exec::Aggregate::numNulls_,
+            updateSingleValue);
 
-          auto indices = decoded.indices();
-          decoded.base()->as<const LazyVector>()->load(
-              RowSet(indices, arg->size()), &hook);
-          return;
-        }
+        auto indices = decoded.indices();
+        decoded.base()->as<const LazyVector>()->load(
+            RowSet(indices, arg->size()), &hook);
+        return;
       }
     }
 


### PR DESCRIPTION
Currently, `int64_t` enables push-down for decimal type. This PR disables aggregate pushdown for decimal type regardless of c++ type.

Fixes #11290