### PR TITLE
Rename variables in Base64.* for readability

### DIFF
--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -13,15 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
 
-#include <array>
-#include <exception>
-#include <map>
-#include <string>
+#pragma once
 
 #include <folly/Range.h>
 #include <folly/io/IOBuf.h>
+
+#include <array>
+#include <string>
 
 #include "velox/common/base/GTestMacros.h"
 
@@ -32,65 +31,69 @@ class Base64 {
   static const size_t kCharsetSize = 64;
   static const size_t kReverseIndexSize = 256;
 
-  /// Character set used for encoding purposes.
+  /// Character set used for Base64 encoding.
   /// Contains specific characters that form the encoding scheme.
   using Charset = std::array<char, kCharsetSize>;
 
-  /// Reverse lookup table for decoding purposes.
+  /// Reverse lookup table for decoding.
   /// Maps each possible encoded character to its corresponding numeric value
   /// within the encoding base.
   using ReverseIndex = std::array<uint8_t, kReverseIndexSize>;
 
-  /// Padding character used in encoding.
-  static const char kPadding = '=';
-
-  /// Encodes the specified number of characters from the 'data'.
-  static std::string encode(const char* data, size_t len);
+  /// Encodes the specified number of characters from the 'input'.
+  static std::string encode(const char* input, size_t inputSize);
 
   /// Encodes the specified text.
   static std::string encode(folly::StringPiece text);
 
   /// Encodes the specified IOBuf data.
-  static std::string encode(const folly::IOBuf* text);
+  static std::string encode(const folly::IOBuf* inputBuffer);
 
-  /// Returns encoded size for the input of the specified size.
-  static size_t calculateEncodedSize(size_t size, bool withPadding = true);
-
-  /// Encodes the specified number of characters from the 'data' and writes the
-  /// result to the 'output'. The output must have enough space, e.g. as
+  /// Encodes the specified number of characters from the 'input' and writes the
+  /// result to the 'outputBuffer'. The output must have enough space as
   /// returned by the calculateEncodedSize().
-  static void encode(const char* data, size_t size, char* output);
+  static void encode(const char* input, size_t inputSize, char* outputBuffer);
 
-  /// Decodes the specified encoded text.
-  static std::string decode(folly::StringPiece encoded);
+  /// Encodes the specified number of characters from the 'input' using URL
+  /// encoding.
+  static std::string encodeUrl(const char* input, size_t inputSize);
 
-  /// Returns the actual size of the decoded data. Will also remove the padding
-  /// length from the input data 'size'.
-  static size_t calculateDecodedSize(const char* data, size_t& size);
+  /// Encodes the specified text using URL encoding.
+  static std::string encodeUrl(folly::StringPiece text);
 
-  /// Decodes the specified number of characters from the 'data' and writes the
-  /// result to the 'output'. The output must have enough space, e.g. as
-  /// returned by the calculateDecodedSize().
-  static void decode(const char* data, size_t size, char* output);
+  /// Encodes the specified IOBuf data using URL encoding.
+  static std::string encodeUrl(const folly::IOBuf* inputBuffer);
 
+  /// Encodes the specified number of characters from the 'input' and writes the
+  /// result to the 'outputBuffer' using URL encoding. The output must have
+  /// enough space as returned by the calculateEncodedSize().
+  static void
+  encodeUrl(const char* input, size_t inputSize, char* outputBuffer);
+
+  /// Decodes the input Base64 encoded string.
+  static std::string decode(folly::StringPiece encodedText);
+
+  /// Decodes the specified encoded payload and writes the result to the
+  /// 'output'.
   static void decode(
       const std::pair<const char*, int32_t>& payload,
       std::string& output);
 
-  /// Encodes the specified number of characters from the 'data' and writes the
-  /// result to the 'output' using URL encoding. The output must have enough
-  /// space as returned by the calculateEncodedSize().
-  static void encodeUrl(const char* data, size_t size, char* output);
+  /// Decodes the specified number of characters from the 'input' and writes the
+  /// result to the 'outputBuffer'. The output must have enough space as
+  /// returned by the calculateDecodedSize().
+  static void decode(const char* input, size_t inputSize, char* outputBuffer);
 
-  /// Encodes the specified number of characters from the 'data' using URL
-  /// encoding.
-  static std::string encodeUrl(const char* data, size_t len);
+  /// Decodes the specified number of characters from the 'input' and writes the
+  /// result to the 'outputBuffer'.
+  static size_t decode(
+      const char* input,
+      size_t inputSize,
+      char* outputBuffer,
+      size_t outputSize);
 
-  /// Encodes the specified IOBuf data using URL encoding.
-  static std::string encodeUrl(const folly::IOBuf* data);
-
-  /// Encodes the specified text using URL encoding.
-  static std::string encodeUrl(folly::StringPiece text);
+  /// Decodes the input Base64 URL encoded string.
+  static std::string decodeUrl(folly::StringPiece encodedText);
 
   /// Decodes the specified URL encoded payload and writes the result to the
   /// 'output'.
@@ -98,59 +101,66 @@ class Base64 {
       const std::pair<const char*, int32_t>& payload,
       std::string& output);
 
-  /// Decodes the specified URL encoded text.
-  static std::string decodeUrl(folly::StringPiece text);
+  /// Decodes the specified number of characters from the 'input' using URL
+  /// encoding and writes the result to the 'outputBuffer'
+  static void decodeUrl(
+      const char* input,
+      size_t inputSize,
+      char* outputBuffer,
+      size_t outputSize);
 
-  /// Decodes the specified number of characters from the 'src' and writes the
-  /// result to the 'dst'.
-  static size_t
-  decode(const char* src, size_t src_len, char* dst, size_t dst_len);
+  /// Calculates the encoded size based on input 'inputSize'.
+  static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
 
-  /// Decodes the specified number of characters from the 'src' using URL
-  /// encoding and writes the result to the 'dst'.
-  static void
-  decodeUrl(const char* src, size_t src_len, char* dst, size_t dst_len);
+  /// Returns the actual size of the decoded data. Removes the padding
+  /// length from the input data 'inputSize'.
+  static size_t calculateDecodedSize(const char* input, size_t& inputSize);
 
  private:
-  /// Checks if there is padding in encoded data.
-  static inline bool isPadded(const char* data, size_t len) {
-    return (len > 0 && data[len - 1] == kPadding);
+  // Padding character used in encoding.
+  static const char kPadding = '=';
+
+  // Checks if the input Base64 string is padded.
+  static inline bool isPadded(const char* input, size_t inputSize) {
+    return (inputSize > 0 && input[inputSize - 1] == kPadding);
   }
 
-  /// Counts the number of padding characters in encoded data.
-  static inline size_t numPadding(const char* src, size_t len) {
+  // Counts the number of padding characters in encoded input.
+  static inline size_t numPadding(const char* input, size_t inputSize) {
     size_t numPadding{0};
-    while (len > 0 && src[len - 1] == kPadding) {
+    while (inputSize > 0 && input[inputSize - 1] == kPadding) {
       numPadding++;
-      len--;
+      inputSize--;
     }
     return numPadding;
   }
 
-  /// Performs a reverse lookup in the reverse index to retrieve the original
-  /// index of a character in the base.
-  static uint8_t base64ReverseLookup(char p, const ReverseIndex& reverseIndex);
+  // Reverse lookup helper function to get the original index of a Base64
+  // character.
+  static uint8_t base64ReverseLookup(
+      char encodedChar,
+      const ReverseIndex& reverseIndex);
 
-  /// Encodes the specified data using the provided charset.
+  // Encodes the specified data using the provided charset.
   template <class T>
   static std::string
-  encodeImpl(const T& data, const Charset& charset, bool include_pad);
+  encodeImpl(const T& input, const Charset& charset, bool includePadding);
 
-  /// Encodes the specified data using the provided charset.
+  // Encodes the specified data using the provided charset.
   template <class T>
   static void encodeImpl(
-      const T& data,
+      const T& input,
       const Charset& charset,
-      bool include_pad,
-      char* out);
+      bool includePadding,
+      char* outputBuffer);
 
-  /// Decodes the specified data using the provided reverse lookup table.
+  // Decodes the specified data using the provided reverse lookup table.
   static size_t decodeImpl(
-      const char* src,
-      size_t src_len,
-      char* dst,
-      size_t dst_len,
-      const ReverseIndex& table);
+      const char* input,
+      size_t inputSize,
+      char* outputBuffer,
+      size_t outputSize,
+      const ReverseIndex& reverseIndex);
 
   VELOX_FRIEND_TEST(Base64Test, checksPadding);
   VELOX_FRIEND_TEST(Base64Test, countsPaddingCorrectly);


### PR DESCRIPTION
Follow-up PR: https://github.com/facebookincubator/velox/pull/10371

The following changes are done in this PR.
- Variable names are updated for better readability.
- Function declarations in Base64.h are reordered for better maintainability.