### PR TITLE
Reclaim from join table directly from hash join bridge

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -783,6 +783,7 @@ bool HashBuild::finishHashBuild() {
   addRuntimeStats();
   joinBridge_->setHashTable(
       std::move(table_), std::move(spillPartitions), joinHasNullKeys_);
+  joinBridge_->maybeSetSpillStatsRecorder(&spillStats_);
   if (canSpill()) {
     stateCleared_ = true;
   }

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -47,6 +47,10 @@ class HashJoinBridge : public JoinBridge {
   /// HashBuild operators to parallelize the restoring operation.
   void addBuilder();
 
+  bool canReclaim() const;
+
+  uint64_t reclaim();
+
   /// Invoked to spill 'table' and returns spilled partitions. This method
   /// should only be invoked when the 'table' is a ready-to-use one, meaning it
   /// should not be one in the middle of building. Hence it is normally invoked
@@ -148,6 +152,9 @@ class HashJoinBridge : public JoinBridge {
   void maybeSetJoinNode(
       const std::shared_ptr<const core::HashJoinNode>& joinNode);
 
+  void maybeSetSpillStatsRecorder(
+      folly::Synchronized<common::SpillStats>* stats);
+
  private:
   // Spills the row container from one of the sub-table from
   // 'table' to parallelize the table spilling. The function
@@ -194,6 +201,11 @@ class HashJoinBridge : public JoinBridge {
   RowTypePtr tableType_;
   std::shared_ptr<const core::HashJoinNode> joinNode_;
   std::optional<common::SpillConfig> spillConfig_;
+
+  // A flag indicating if any probe operator has poked 'this' join bridge to
+  // attempt to get table. It is reset for each table partition processing.
+  std::atomic_bool probeStarted_;
+  folly::Synchronized<common::SpillStats>* spillStats_{nullptr};
   friend test::HashJoinBridgeTestHelper;
 };
 
@@ -204,9 +216,10 @@ bool isLeftNullAwareJoinWithFilter(
 
 class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
-  static std::unique_ptr<memory::MemoryReclaimer> create() {
+  static std::unique_ptr<memory::MemoryReclaimer> create(
+      std::shared_ptr<HashJoinBridge> joinBridge) {
     return std::unique_ptr<memory::MemoryReclaimer>(
-        new HashJoinMemoryReclaimer());
+        new HashJoinMemoryReclaimer(joinBridge));
   }
 
   uint64_t reclaim(
@@ -216,7 +229,9 @@ class HashJoinMemoryReclaimer final : public MemoryReclaimer {
       memory::MemoryReclaimer::Stats& stats) final;
 
  private:
-  HashJoinMemoryReclaimer() : MemoryReclaimer() {}
+  HashJoinMemoryReclaimer(std::shared_ptr<HashJoinBridge> joinBridge)
+      : MemoryReclaimer(), joinBridge_(joinBridge) {}
+  std::weak_ptr<HashJoinBridge> joinBridge_;
 };
 
 /// Returns true if 'pool' is a hash build operator's memory pool. The check is

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -270,7 +270,7 @@ void HashProbe::maybeSetupInputSpiller(
   // spill input, then we shall just finish the spiller and records the spilled
   // partition set accordingly.
   if (noMoreSpillInput_) {
-    inputSpiller_->finishSpill(spillPartitionSet_);
+    inputSpiller_->finishSpill(inputSpillPartitionSet_);
   }
 }
 
@@ -283,13 +283,13 @@ void HashProbe::maybeSetupSpillInputReader(
   // If 'restoredPartitionId' is not null, then 'table_' is built from the
   // spilled build data. Create an unsorted reader to read the probe inputs from
   // the corresponding spilled probe partition on disk.
-  auto iter = spillPartitionSet_.find(restoredPartitionId.value());
-  VELOX_CHECK(iter != spillPartitionSet_.end());
+  auto iter = inputSpillPartitionSet_.find(restoredPartitionId.value());
+  VELOX_CHECK(iter != inputSpillPartitionSet_.end());
   auto partition = std::move(iter->second);
   VELOX_CHECK_EQ(partition->id(), restoredPartitionId.value());
   spillInputReader_ = partition->createUnorderedReader(
       spillConfig_->readBufferSize, pool(), &spillStats_);
-  spillPartitionSet_.erase(iter);
+  inputSpillPartitionSet_.erase(iter);
 }
 
 void HashProbe::initializeResultIter() {
@@ -337,7 +337,7 @@ void HashProbe::asyncWaitForHashTable() {
       // Null-aware anti join with null keys on the build side without a filter
       // always returns nothing.
       // The flag must be set on the first (and only) built 'table_'.
-      VELOX_CHECK(spillPartitionSet_.empty());
+      VELOX_CHECK(inputSpillPartitionSet_.empty());
       noMoreInput();
       return;
     }
@@ -351,11 +351,11 @@ void HashProbe::asyncWaitForHashTable() {
 
   maybeSetupSpillInputReader(hashBuildResult->restoredPartitionId);
   maybeSetupInputSpiller(hashBuildResult->spillPartitionIds);
-  prepareTableSpill(hashBuildResult->restoredPartitionId);
+  checkMaxSpillLevel(hashBuildResult->restoredPartitionId);
 
   if (table_->numDistinct() == 0) {
     if (skipProbeOnEmptyBuild()) {
-      if (!needSpillInput()) {
+      if (!needToSpillInput()) {
         if (isSpillInput() ||
             operatorCtx_->driverCtx()
                 ->queryConfig()
@@ -467,7 +467,7 @@ void HashProbe::addSpillInput() {
 }
 
 void HashProbe::spillInput(RowVectorPtr& input) {
-  VELOX_CHECK(needSpillInput());
+  VELOX_CHECK(needToSpillInput());
 
   const auto numInput = input->size();
   prepareInputIndicesBuffers(
@@ -622,7 +622,7 @@ void HashProbe::addInput(RowVectorPtr input) {
 
   bool hasDecoded = false;
 
-  if (needSpillInput()) {
+  if (needToSpillInput()) {
     if (isRightSemiProjectJoin(joinType_) && !probeSideHasNullKeys_) {
       decodeAndDetectNonNullKeys();
       hasDecoded = true;
@@ -637,7 +637,7 @@ void HashProbe::addInput(RowVectorPtr input) {
 
   if (table_->numDistinct() == 0) {
     if (skipProbeOnEmptyBuild()) {
-      VELOX_CHECK(needSpillInput());
+      VELOX_CHECK(needToSpillInput());
       input_ = nullptr;
       return;
     }
@@ -882,11 +882,11 @@ bool HashProbe::canSpill() const {
 }
 
 bool HashProbe::hasMoreSpillData() const {
-  VELOX_CHECK(spillPartitionSet_.empty() || canSpill());
-  return !spillPartitionSet_.empty() || needSpillInput();
+  VELOX_CHECK(inputSpillPartitionSet_.empty() || canSpill());
+  return !inputSpillPartitionSet_.empty() || needToSpillInput();
 }
 
-bool HashProbe::needSpillInput() const {
+bool HashProbe::needToSpillInput() const {
   VELOX_CHECK(spillInputPartitionIds_.empty() || canSpill());
   VELOX_CHECK_EQ(spillInputPartitionIds_.empty(), inputSpiller_ == nullptr);
 
@@ -1573,7 +1573,7 @@ void HashProbe::noMoreInputInternal() {
     VELOX_CHECK_EQ(
         spillInputPartitionIds_.size(),
         inputSpiller_->spilledPartitionSet().size());
-    inputSpiller_->finishSpill(spillPartitionSet_);
+    inputSpiller_->finishSpill(inputSpillPartitionSet_);
     VELOX_CHECK_EQ(spillStats_.rlock()->spillSortTimeNanos, 0);
   }
 
@@ -1750,7 +1750,7 @@ void HashProbe::reclaim(
   if (hasMoreProbeInput) {
     // Only spill hash table if any hash probe operators still has input probe
     // data, otherwise we skip this step.
-    spillPartitionSet = spillTable();
+    spillPartitionSet = joinBridge_->spillTable(table_, &spillStats_);
     VELOX_CHECK(!spillPartitionSet.empty());
   }
   const auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
@@ -1881,82 +1881,7 @@ void HashProbe::maybeSetupSpillOutputReader() {
   spillOutputPartitionSet_.clear();
 }
 
-SpillPartitionSet HashProbe::spillTable() {
-  struct SpillResult {
-    std::unique_ptr<Spiller> spiller{nullptr};
-    const std::exception_ptr error{nullptr};
-
-    explicit SpillResult(std::exception_ptr _error) : error(_error) {}
-    explicit SpillResult(std::unique_ptr<Spiller> _spiller)
-        : spiller(std::move(_spiller)) {}
-  };
-
-  const std::vector<RowContainer*> rowContainers = table_->allRows();
-  std::vector<std::shared_ptr<AsyncSource<SpillResult>>> spillTasks;
-  auto* spillExecutor = spillConfig()->executor;
-  for (auto* rowContainer : rowContainers) {
-    if (rowContainer->numRows() == 0) {
-      continue;
-    }
-    spillTasks.push_back(memory::createAsyncMemoryReclaimTask<SpillResult>(
-        [this, rowContainer]() {
-          try {
-            return std::make_unique<SpillResult>(spillTable(rowContainer));
-          } catch (const std::exception& e) {
-            LOG(ERROR) << "Spill sub-table from hash probe pool "
-                       << pool()->name() << " failed: " << e.what();
-            // The exception is captured and thrown by the caller.
-            return std::make_unique<SpillResult>(std::current_exception());
-          }
-        }));
-    if ((spillTasks.size() > 1) && (spillExecutor != nullptr)) {
-      spillExecutor->add([source = spillTasks.back()]() { source->prepare(); });
-    }
-  }
-
-  auto syncGuard = folly::makeGuard([&]() {
-    for (auto& spillTask : spillTasks) {
-      // We consume the result for the pending tasks. This is a cleanup in the
-      // guard and must not throw. The first error is already captured before
-      // this runs.
-      try {
-        spillTask->move();
-      } catch (const std::exception&) {
-      }
-    }
-  });
-
-  SpillPartitionSet spillPartitions;
-  for (auto& spillTask : spillTasks) {
-    const auto result = spillTask->move();
-    if (result->error) {
-      std::rethrow_exception(result->error);
-    }
-    result->spiller->finishSpill(spillPartitions);
-  }
-
-  // Remove the spilled partitions which are empty so as we don't need to
-  // trigger unnecessary spilling at hash probe side.
-  removeEmptyPartitions(spillPartitions);
-  return spillPartitions;
-}
-
-std::unique_ptr<Spiller> HashProbe::spillTable(RowContainer* subTableRows) {
-  VELOX_CHECK_NOT_NULL(tableSpillType_);
-
-  auto tableSpiller = std::make_unique<Spiller>(
-      Spiller::Type::kHashJoinBuild,
-      joinType_,
-      subTableRows,
-      tableSpillType_,
-      std::move(tableSpillHashBits_),
-      spillConfig(),
-      &spillStats_);
-  tableSpiller->spill();
-  return tableSpiller;
-}
-
-void HashProbe::prepareTableSpill(
+void HashProbe::checkMaxSpillLevel(
     const std::optional<SpillPartitionId>& restoredPartitionId) {
   if (!canSpill()) {
     return;
@@ -1980,40 +1905,6 @@ void HashProbe::prepareTableSpill(
     }
   }
   exceededMaxSpillLevelLimit_ = false;
-
-  tableSpillHashBits_ = HashBitRange(
-      startPartitionBit, startPartitionBit + config->numPartitionBits);
-
-  // NOTE: we only need to init 'tableSpillType_' once.
-  if (tableSpillType_ != nullptr) {
-    return;
-  }
-
-  const auto& tableInputType = joinNode_->sources()[1]->outputType();
-  std::vector<std::string> names;
-  names.reserve(tableInputType->size());
-  std::vector<TypePtr> types;
-  types.reserve(tableInputType->size());
-  const auto numKeys = joinNode_->rightKeys().size();
-
-  // Identify the non-key build side columns.
-  folly::F14FastMap<column_index_t, column_index_t> keyChannelMap;
-  for (int i = 0; i < numKeys; ++i) {
-    const auto& key = joinNode_->rightKeys()[i];
-    const auto channel = exprToChannel(key.get(), tableInputType);
-    keyChannelMap[channel] = i;
-    names.emplace_back(tableInputType->nameOf(channel));
-    types.emplace_back(tableInputType->childAt(channel));
-  }
-  const auto numDependents = tableInputType->size() - numKeys;
-  for (auto i = 0; i < tableInputType->size(); ++i) {
-    if (keyChannelMap.find(i) == keyChannelMap.end()) {
-      names.emplace_back(tableInputType->nameOf(i));
-      types.emplace_back(tableInputType->childAt(i));
-    }
-  }
-  tableSpillType_ = hashJoinTableSpillType(
-      ROW(std::move(names), std::move(types)), joinType_);
 }
 
 void HashProbe::close() {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -201,9 +201,9 @@ class HashProbe : public Operator {
   void maybeSetupSpillInputReader(
       const std::optional<SpillPartitionId>& restoredSpillPartitionId);
 
-  // Prepares the table spill by checking the spill level limit, setting spill
-  // partition bits and table spill type.
-  void prepareTableSpill(
+  // Checks the hash table's spill level limit from the restored table. Sets the
+  // 'exceededMaxSpillLevelLimit_' accordingly.
+  void checkMaxSpillLevel(
       const std::optional<SpillPartitionId>& restoredPartitionId);
 
   bool canSpill() const override;
@@ -218,7 +218,7 @@ class HashProbe : public Operator {
   // Indicates if the operator needs to spill probe inputs. It is true if parts
   // of the build-side rows have been spilled. Hence, the probe operator needs
   // to spill the corresponding probe-side rows as well.
-  bool needSpillInput() const;
+  bool needToSpillInput() const;
 
   // This ensures there is sufficient buffer reserved to produce the next output
   // batch. This might trigger memory arbitration underneath and the probe
@@ -251,14 +251,6 @@ class HashProbe : public Operator {
   void spillOutput(const std::vector<HashProbe*>& operators);
   // Produces and spills output from this probe operator.
   void spillOutput();
-
-  // Spills the composed 'table_' from the built side.
-  SpillPartitionSet spillTable();
-  // Spills the row container from one of the sub-table from 'table_' to
-  // parallelize the table spilling. The function spills all the rows from the
-  // row container and returns the spiller for the caller to collect the spilled
-  // partitions and stats.
-  std::unique_ptr<Spiller> spillTable(RowContainer* subTableRows);
 
   // Invoked to spill rows in 'input' to disk directly if the corresponding
   // partitions have been spilled at the build side.
@@ -300,7 +292,7 @@ class HashProbe : public Operator {
   // restore. Also note that the spilled partition at build side must not be
   // empty.
   bool emptyBuildSide() const {
-    return table_->numDistinct() == 0 && spillPartitionSet_.empty() &&
+    return table_->numDistinct() == 0 && inputSpillPartitionSet_.empty() &&
         spillInputPartitionIds_.empty();
   }
 
@@ -373,8 +365,8 @@ class HashProbe : public Operator {
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
 
-  // Table shared between other HashProbes in other Drivers of the same
-  // pipeline.
+  // Current working hash table that is shared between other HashProbes in other
+  // Drivers of the same pipeline.
   std::shared_ptr<BaseHashTable> table_;
 
   // Indicates whether there was no input. Used for right semi join project.
@@ -622,11 +614,6 @@ class HashProbe : public Operator {
   // the next previously spilled hash table partition.
   tsan_atomic<bool> exceededMaxSpillLevelLimit_{false};
 
-  // The partition bits used to spill the hash table.
-  HashBitRange tableSpillHashBits_;
-  // The row type used to spill hash table on disk.
-  RowTypePtr tableSpillType_;
-
   // The spilled output partition set which is cleared after setup
   // 'spillOutputReader_'.
   SpillPartitionSet spillOutputPartitionSet_;
@@ -668,7 +655,7 @@ class HashProbe : public Operator {
   bool noMoreSpillInput_{false};
 
   // The spilled probe partitions remaining to restore.
-  SpillPartitionSet spillPartitionSet_;
+  SpillPartitionSet inputSpillPartitionSet_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, ProbeOperatorState state) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -342,8 +342,8 @@ class BaseHashTable {
       int8_t spillInputStartPartitionBit,
       bool disableRangeArrayHash = false) = 0;
 
-  // Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
-  // and be unique.
+  /// Removes 'rows' from the hash table and its RowContainer. 'rows' must exist
+  /// and be unique.
   virtual void erase(folly::Range<char**> rows) = 0;
 
   /// Returns a brief description for use in debugging.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -486,9 +486,8 @@ column_index_t exprToChannel(
   if (dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
     return kConstantChannel;
   }
-  VELOX_FAIL(
+  VELOX_UNREACHABLE(
       "Expression must be field access or constant, got: {}", expr->toString());
-  return 0; // not reached.
 }
 
 std::vector<column_index_t> calculateOutputChannels(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -483,7 +483,9 @@ velox::memory::MemoryPool* Task::getOrAddNodePool(
     return nodePools_[planNodeId];
   }
   childPools_.push_back(pool_->addAggregateChild(
-      fmt::format("node.{}", planNodeId), createNodeReclaimer(false)));
+      fmt::format("node.{}", planNodeId), createNodeReclaimer([&](){
+        return exec::ParallelMemoryReclaimer::create(queryCtx_->spillExecutor());
+      })));
   auto* nodePool = childPools_.back().get();
   nodePools_[planNodeId] = nodePool;
   return nodePool;
@@ -499,22 +501,24 @@ memory::MemoryPool* Task::getOrAddJoinNodePool(
     return nodePools_[nodeId];
   }
   childPools_.push_back(pool_->addAggregateChild(
-      fmt::format("node.{}", nodeId), createNodeReclaimer(true)));
+      fmt::format("node.{}", nodeId), createNodeReclaimer([&]() {
+        return HashJoinMemoryReclaimer::create(
+            getHashJoinBridgeLocked(splitGroupId, planNodeId));
+      })));
   auto* nodePool = childPools_.back().get();
   nodePools_[nodeId] = nodePool;
   return nodePool;
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createNodeReclaimer(
-    bool isHashJoinNode) const {
+    std::function<std::unique_ptr<memory::MemoryReclaimer>()> reclaimerFactory)
+    const {
   if (pool()->reclaimer() == nullptr) {
     return nullptr;
   }
   // Sets memory reclaimer for the parent node memory pool on the first child
   // operator construction which has set memory reclaimer.
-  return isHashJoinNode
-      ? HashJoinMemoryReclaimer::create()
-      : exec::ParallelMemoryReclaimer::create(queryCtx_->spillExecutor());
+  return reclaimerFactory();
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createExchangeClientReclaimer()

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -766,7 +766,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // customized instance for hash join plan node, otherwise creates a default
   // memory reclaimer.
   std::unique_ptr<memory::MemoryReclaimer> createNodeReclaimer(
-      bool isHashJoinNode) const;
+      std::function<std::unique_ptr<memory::MemoryReclaimer>()>
+          reclaimerFactory) const;
 
   // Creates a memory reclaimer instance for an exchange client if the task
   // memory pool has set memory reclaimer. We don't support to reclaim memory


### PR DESCRIPTION
Add ability to allow hash join bridge to be able to reclaim directly the transferred table from hash build. This is useful in the condition when build has finished and table has been transferred to bridge, but probe side was blocked by downstream operators from performing any of its initial isBlocked() calls. When this happens, probe does not have the ability to spill because it has no knowledge about the ongoing join, neither does build because the table is transferred to bridge already. So when this happens, we rely on bridge to perform the table spill.