### PR TITLE
support row type for combination function

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -280,6 +280,7 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayCombinationsFunctions<Varchar>(prefix);
   registerArrayCombinationsFunctions<Timestamp>(prefix);
   registerArrayCombinationsFunctions<Date>(prefix);
+  registerArrayCombinationsFunctions<Generic<T1>>(prefix);
 
   registerArrayCumSumFunction<int8_t>(prefix);
   registerArrayCumSumFunction<int16_t>(prefix);


### PR DESCRIPTION
Summary:
Queries are failing because combination on row type are not supported. Example: https://www.internalfb.com/intern/presto/query/?query_id=20240925_063408_57648_krybv

```
Scalar function presto.default.combinations not registered with arguments: (ARRAY<ROW<asset_id:BIGINT,body:VARCHAR,p_engagement:DOUBLE,impression:BIGINT,engagement_count:BIGINT,option_group:VARCHAR,text_source:VARCHAR>>, INTEGER). Found function registered with the following signatures: ((array(date),integer) -> ...
```

Let's add a generic to support rows.

Unit test covers basic combination case, case of when n=0 and when n > # of elements to perform the combination.

Differential Revision: D64638036


