### PR TITLE
Support to clear cache in expr set

### DIFF
--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -67,6 +67,12 @@ class ConjunctExpr : public SpecialForm {
   std::string toSql(
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
+  void clearCache() override {
+    Expr::clearCache();
+    tempValues_.reset();
+    tempNulls_.reset();
+  }
+
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 
@@ -89,8 +95,6 @@ class ConjunctExpr : public SpecialForm {
   // true if conjunction (and), false if disjunction (or).
   const bool isAnd_;
 
-  // Errors encountered before processing the current input.
-  FlatVectorPtr<StringView> errors_;
   // temp space for nulls and values of inputs
   BufferPtr tempValues_;
   BufferPtr tempNulls_;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -890,7 +890,6 @@ void Expr::evaluateSharedSubexpr(
     } else {
       // Otherwise, simply evaluate it and return without caching the results.
       eval(rows, context, result);
-
       return;
     }
   }
@@ -932,7 +931,7 @@ void Expr::evaluateSharedSubexpr(
   // Identify a subset of rows that need to be computed: rows -
   // sharedSubexprRows_.
   LocalSelectivityVector missingRowsHolder(context, rows);
-  auto missingRows = missingRowsHolder.get();
+  auto* missingRows = missingRowsHolder.get();
   missingRows->deselect(*sharedSubexprRows);
   VELOX_DCHECK(missingRows->hasSelections());
 
@@ -940,7 +939,7 @@ void Expr::evaluateSharedSubexpr(
   // Final selection of rows need to include sharedSubexprRows_, missingRows and
   // current final selection of rows if set.
   LocalSelectivityVector newFinalSelectionHolder(context, *sharedSubexprRows);
-  auto newFinalSelection = newFinalSelectionHolder.get();
+  auto* newFinalSelection = newFinalSelectionHolder.get();
   newFinalSelection->select(*missingRows);
   if (!context.isFinalSelection()) {
     newFinalSelection->select(*context.finalSelection());
@@ -1962,6 +1961,12 @@ void ExprSet::clear() {
   }
   distinctFields_.clear();
   multiplyReferencedFields_.clear();
+}
+
+void ExprSet::clearCache() {
+  for (auto& expr : exprs_) {
+    expr->clearCache();
+  }
 }
 
 void ExprSetSimplified::eval(

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -52,6 +52,11 @@ class SwitchExpr : public SpecialForm {
     return true;
   }
 
+  void clearCache() override {
+    Expr::clearCache();
+    tempValues_.reset();
+  }
+
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 


### PR DESCRIPTION
Summary:
Support to clear the internally cached buffers from expr set which are allocated through velox memory pool.
This is used by memory arbitration to reclaim memory from eval expression. Unit test is added to verify.

Differential Revision: D64546974


