### PR TITLE
Fix spill related issues in TopNRowNumber operator

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1120,7 +1120,7 @@ void HashBuild::reclaim(
         memory::createAsyncMemoryReclaimTask<SpillResult>([buildOp]() {
           try {
             buildOp->spiller_->spill();
-            buildOp->table_->clear();
+            buildOp->table_->clear(true);
             // Release the minimum reserved memory.
             buildOp->pool()->release();
             return std::make_unique<SpillResult>(nullptr);

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -289,7 +289,7 @@ class BaseHashTable {
 
   /// Deletes any content of 'this'. If 'freeTable' is false, then hash table is
   /// not freed which can be used for flushing a partial group by, for example.
-  virtual void clear(bool freeTable = false) = 0;
+  virtual void clear(bool freeTable) = 0;
 
   /// Returns the capacity of the internal hash table which is number of rows
   /// it can stores in a group by or hash join build.
@@ -529,7 +529,7 @@ class HashTable : public BaseHashTable {
       int32_t maxRows,
       char** rows) override;
 
-  void clear(bool freeTable = false) override;
+  void clear(bool freeTable) override;
 
   int64_t allocatedBytes() const override {
     // For each row: sizeof(char*) per table entry + memory


### PR DESCRIPTION
Summary:
This change fix two spilling related issues in TopNRowNumber:
(1) close method for TopNRowNumber is not reenterable if the operator fails in the middle of
processing as the close methods does in-place destruction to free up memory back to the HSA. This
can cause problem in query abort code path as the aborted operator's close method could
be called twice even through there is no-concurrency problem there.
This PR fixes the issue by clearing
the used hash table, row container and HSA on the first close. This is verified with unit test and failed LBM
query. Note this is found in LBM stress test.
(2) free the hash table after spill to clear more memory to make spill more efficient and verified with unit test
by checking the operator's memory usage goes zero after spill.

Differential Revision: D64654069


