### PR TITLE
Fix test timeout under debug mode only

### DIFF
--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2405,7 +2405,7 @@ TEST_F(MockSharedArbitrationTest, memoryPoolAbortCapacityLimit) {
   }
 }
 
-TEST_F(
+DEBUG_ONLY_TEST_F(
     MockSharedArbitrationTest,
     globalArbitrationWaitReturnEarlyWithFreeCapacity) {
   uint64_t memoryCapacity = 256 * MB;


### PR DESCRIPTION
Summary: This test depends on testvalue which only run on debug build

Differential Revision: D64705822


