### PR TITLE
Support unary and binary arithmetic operators in expression fuzzer against Presto

### DIFF
--- a/velox/exec/tests/PrestoQueryRunnerTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTest.cpp
@@ -242,7 +242,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
                .planNode();
     EXPECT_EQ(
         queryRunner->toSql(plan),
-        "SELECT plus(a0, c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM tmp GROUP BY c1)");
+        "SELECT (a0 + c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM tmp GROUP BY c1)");
 
     plan = PlanBuilder()
                .tableScan("tmp", dataType)

--- a/velox/functions/sparksql/fuzzer/tests/SparkQueryRunnerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/tests/SparkQueryRunnerTest.cpp
@@ -129,7 +129,7 @@ TEST_F(SparkQueryRunnerTest, toSql) {
              .planNode();
   EXPECT_EQ(
       queryRunner->toSql(plan),
-      "SELECT divide(a0, c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM tmp GROUP BY c1)");
+      "SELECT (a0 / c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM tmp GROUP BY c1)");
 
   plan = exec::test::PlanBuilder()
              .tableScan("tmp", dataType)


### PR DESCRIPTION
Summary:
Extend PrestoQueryRunner to translate Velox function names to the corresponding unary and 
binary operators supported in Presto SQL. This is needed for testing unary and binary arithmetic 
operators in expression fuzzer wtih PQR.

Differential Revision: D64711683


