### PR TITLE
Fix the flaky arbitrationAbort test

### DIFF
--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2219,10 +2219,9 @@ TEST_F(MockSharedArbitrationTest, ensureNodeMaxCapacity) {
   }
 }
 
-TEST_F(MockSharedArbitrationTest, arbitrationAbort) {
+DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, arbitrationAbort) {
   uint64_t memoryCapacity = 256 * MB;
-  setupMemory(
-      memoryCapacity, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1.0, nullptr, true, 1'000);
+  setupMemory(memoryCapacity);
   std::shared_ptr<MockTask> task1 = addTask(memoryCapacity);
   auto* op1 =
       task1->addMemoryOp(true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {


### PR DESCRIPTION
Summary: The doesn't require timeout setting and also only work for debug build

Differential Revision: D64736824


