### PR TITLE
Clear expression related cached buffers when hash probe spill finish

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1931,6 +1931,16 @@ void HashProbe::clearBuffers() {
   output_.reset();
   nonSpillInputIndicesBuffer_.reset();
   spillInputIndicesBuffers_.clear();
+  if (filter_ == nullptr) {
+    return;
+  }
+  filterResult_.clear();
+  filterResult_.resize(1);
+  filterTableInput_.reset();
+  filterTableResult_.clear();
+  filterTableResult_.resize(1);
+  operatorCtx_->execCtx()->vectorPool()->clear();
+  filter_->clearCache();
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -76,6 +76,10 @@ class HashProbe : public Operator {
     return exceededMaxSpillLevelLimit_;
   }
 
+  bool testingHasPendingInput() const {
+    return input_ != nullptr;
+  }
+
  private:
   // Indicates if the join type includes misses from the left side in the
   // output.


### PR DESCRIPTION
Differential Revision: D64490457

LBM stress test see some unexpected memory usage growth in hash probe spill which caused the query
failure. The unexpected memory growth comes from the join eval execution which includes both the 
reused result buffer in hash probe operator as well as inside the eval expression.
This PR fixes this by adding to clear those buffers when hash probe spill finish (HashProbe::clearBuffers).
Also verified with the failed LBM query.


