### PR TITLE
Fix local file sink to use velox fs as well as fail on exist file

### DIFF
--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/common/FileSink.h"
 
 #include "velox/common/base/Fs.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 #include <fcntl.h>
@@ -96,7 +97,7 @@ bool FileSink::registerFactory(const FileSink::Factory& factory) {
 std::unique_ptr<FileSink> FileSink::create(
     const std::string& filePath,
     const Options& options) {
-  DWIO_ENSURE_NOT_NULL(options.metricLogger);
+  VELOX_CHECK_NOT_NULL(options.metricLogger);
   for (auto& factory : factories()) {
     auto result = factory(filePath, options);
     if (result) {
@@ -115,7 +116,7 @@ WriteFileSink::WriteFileSink(
           std::move(name),
           {.metricLogger = std::move(metricLogger), .stats = stats}),
       writeFile_{std::move(writeFile)} {
-  DWIO_ENSURE_NOT_NULL(writeFile_);
+  VELOX_CHECK_NOT_NULL(writeFile_);
 }
 
 void WriteFileSink::write(std::vector<DataBuffer<char>>& buffers) {
@@ -135,52 +136,27 @@ void WriteFileSink::doClose() {
 }
 
 LocalFileSink::LocalFileSink(const std::string& name, const Options& options)
-    : FileSink{name, options} {
+    : FileSink{name, options}, writeFile_() {
   const auto dir = fs::path(name_).parent_path();
   if (!fs::exists(dir)) {
-    DWIO_ENSURE(velox::common::generateFileDirectory(dir.c_str()));
+    VELOX_CHECK(velox::common::generateFileDirectory(dir.c_str()));
   }
-  fd_ = ::open(name_.c_str(), O_CREAT | O_WRONLY | O_TRUNC, S_IRUSR | S_IWUSR);
-  if (fd_ == -1) {
-    markClosed();
-    DWIO_RAISE(
-        "Can't open ", name_, " ErrorNo ", errno, ": ", folly::errnoStr(errno));
+  auto fs = filesystems::getFileSystem(name_, nullptr);
+  writeFile_ = fs->openFileForWrite(name_);
+}
+
+void LocalFileSink::doClose() {
+  LOG(INFO) << "closing file: " << name()
+            << ",  total size: " << succinctBytes(size_);
+  if (writeFile_ != nullptr) {
+    writeFile_->close();
   }
 }
 
 void LocalFileSink::write(std::vector<DataBuffer<char>>& buffers) {
   writeImpl(buffers, [&](auto& buffer) {
-    const size_t size = buffer.size();
-    size_t offset = 0;
-    while (offset < size) {
-      // Write system call can write fewer bytes than requested.
-      const auto bytesWritten =
-          ::write(fd_, buffer.data() + offset, size - offset);
-
-      // errno should only be accessed when the return value is -1.
-      DWIO_ENSURE_NE(
-          bytesWritten,
-          -1,
-          "Bad write of ",
-          name_,
-          " ErrorNo ",
-          errno,
-          " Remaining ",
-          size - offset);
-
-      // ensure the file is making some forward progress in each loop.
-      DWIO_ENSURE_GT(
-          bytesWritten,
-          0,
-          "No bytes transferred ",
-          name_,
-          " Size: ",
-          size,
-          " Offset: ",
-          offset);
-
-      offset += bytesWritten;
-    }
+    const uint64_t size = buffer.size();
+    writeFile_->append({buffer.data(), size});
     return size;
   });
 }

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -166,13 +166,10 @@ class LocalFileSink : public FileSink {
   static void registerFactory();
 
  protected:
-  void doClose() override {
-    ::close(fd_);
-  }
+  void doClose() override;
 
  private:
-  // The local open file handle.
-  int fd_;
+  std::unique_ptr<WriteFile> writeFile_;
 };
 
 class MemorySink : public FileSink {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -42,6 +42,7 @@ class ParquetWriterTest : public ParquetTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
     testutil::TestValue::enable();
+    filesystems::registerLocalFileSystem();
     connector::registerConnectorFactory(
         std::make_shared<connector::hive::HiveConnectorFactory>());
     auto hiveConnector =

--- a/velox/dwio/parquet/tests/writer/SinkTests.cpp
+++ b/velox/dwio/parquet/tests/writer/SinkTests.cpp
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
+#include "velox/common/file/FileSystems.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::parquet;
 
-class SinkTest : public ParquetTestBase {};
+class SinkTest : public ParquetTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+    facebook::velox::filesystems::registerLocalFileSystem();
+  }
+};
 
 TEST_F(SinkTest, close) {
   auto rowType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});


### PR DESCRIPTION
Summary:
Currently local file sink open file through posix API directly. Also realized that it open the existing
file for write with no error in table write debugging this is not desired behavior.
This PR changes to use velox fs to access file which fix both issues.

Differential Revision: D64676012


