### PR TITLE
Let HashJoinBridge be able to reclaim memory in the middle state

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -768,8 +768,26 @@ bool HashBuild::finishHashBuild() {
       RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
 
   addRuntimeStats();
+
+  // Setup spill function for spilling hash table directly from hash join
+  // bridge after transferring of table ownership.
+  HashJoinTableSpillFunc tableSpillFunc;
+  if (canReclaim()) {
+    VELOX_CHECK_NOT_NULL(spiller_);
+    tableSpillFunc = [hashBitRange = spiller_->hashBits(),
+                      joinNode = joinNode_,
+                      spillConfig = spillConfig(),
+                      spillStats =
+                          &spillStats_](std::shared_ptr<BaseHashTable> table) {
+      return spillHashJoinTable(
+          table, hashBitRange, joinNode, spillConfig, spillStats);
+    };
+  }
   joinBridge_->setHashTable(
-      std::move(table_), std::move(spillPartitions), joinHasNullKeys_);
+      std::move(table_),
+      std::move(spillPartitions),
+      joinHasNullKeys_,
+      std::move(tableSpillFunc));
   if (canSpill()) {
     stateCleared_ = true;
   }

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1772,7 +1772,7 @@ void HashProbe::reclaim(
   table_->clear(true);
   // Sets the spilled hash table in the join bridge.
   if (!spillPartitionIdSet.empty()) {
-    joinBridge_->setSpilledHashTable(std::move(spillPartitionSet));
+    joinBridge_->appendSpilledHashTablePartitions(std::move(spillPartitionSet));
   }
 }
 

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -424,4 +424,15 @@ void projectChildren(
         wrapChild(size, mapping, src[inputChannel]);
   }
 }
+
+std::unique_ptr<Operator> BlockedOperatorFactory::toOperator(
+    DriverCtx* ctx,
+    int32_t id,
+    const core::PlanNodePtr& node) {
+  if (std::dynamic_pointer_cast<const BlockedNode>(node)) {
+    return std::make_unique<BlockedOperator>(
+        ctx, id, node, std::move(blockedCb_));
+  }
+  return nullptr;
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -766,7 +766,8 @@ class Task : public std::enable_shared_from_this<Task> {
   // customized instance for hash join plan node, otherwise creates a default
   // memory reclaimer.
   std::unique_ptr<memory::MemoryReclaimer> createNodeReclaimer(
-      bool isHashJoinNode) const;
+      const std::function<std::unique_ptr<memory::MemoryReclaimer>()>&
+          reclaimerFactory) const;
 
   // Creates a memory reclaimer instance for an exchange client if the task
   // memory pool has set memory reclaimer. We don't support to reclaim memory


### PR DESCRIPTION
Add ability to allow hash join bridge to be able to reclaim directly the transferred table from hash build. This is useful in the condition when build has finished and table has been transferred to bridge, but probe side was blocked by downstream operators from performing any of its initial isBlocked() calls. When this happens, probe does not have the ability to spill because it has no knowledge about the ongoing join, neither does build because the table is transferred to bridge already. So when this happens, we rely on bridge to perform the table spill.