### PR TITLE
Add shutdown support memory arbitrator

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -242,6 +242,8 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
     return "test";
   }
 
+  void shutdown() override {}
+
   void addPool(const std::shared_ptr<memory::MemoryPool>& /*unused*/) override {
   }
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -133,6 +133,8 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
 }
 
 MemoryManager::~MemoryManager() {
+  arbitrator_->shutdown();
+
   if (pools_.size() != 0) {
     const auto errMsg = fmt::format(
         "pools_.size() != 0 ({} vs {}). There are unexpected alive memory "

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -91,6 +91,8 @@ class NoopArbitrator : public MemoryArbitrator {
     return "NOOP";
   }
 
+  void shutdown() override {}
+
   void addPool(const std::shared_ptr<MemoryPool>& pool) override {
     VELOX_CHECK_EQ(pool->capacity(), 0);
     growPool(pool.get(), pool->maxCapacity(), 0);

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -103,6 +103,10 @@ class MemoryArbitrator {
 
   virtual ~MemoryArbitrator() = default;
 
+  /// Invoked by the memory manager to shutdown the memory arbitrator to stop
+  /// serving new memory arbitration requests.
+  virtual void shutdown() = 0;
+
   /// Invoked by the memory manager to add a newly created memory pool. The
   /// memory arbitrator allocates the initial capacity for 'pool' and
   /// dynamically adjusts its capacity based query memory needs through memory

--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -57,6 +57,8 @@ class TestArbitrator : public MemoryArbitrator {
              .capacity = config.capacity,
              .extraConfigs = config.extraConfigs}) {}
 
+  void shutdown() override {}
+
   void addPool(const std::shared_ptr<MemoryPool>& /*unused*/) override {}
 
   void removePool(MemoryPool* /*unused*/) override {}

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -333,6 +333,8 @@ class FakeTestArbitrator : public MemoryArbitrator {
     return "USER";
   }
 
+  void shutdown() override {}
+
   void addPool(const std::shared_ptr<MemoryPool>& /*unused*/) override {}
 
   void removePool(MemoryPool* /*unused*/) override {}

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -114,6 +114,8 @@ class FakeTestArbitrator : public MemoryArbitrator {
              .extraConfigs = config.extraConfigs}),
         injectAddPoolFailure_(injectAddPoolFailure) {}
 
+  void shutdown() override {}
+
   void addPool(const std::shared_ptr<MemoryPool>& /*unused*/) override {
     VELOX_CHECK(!injectAddPoolFailure_, "Failed to add pool");
   }

--- a/velox/common/memory/tests/SharedArbitratorTestUtil.h
+++ b/velox/common/memory/tests/SharedArbitratorTestUtil.h
@@ -65,6 +65,11 @@ class SharedArbitratorTestHelper {
     return arbitrator_->globalArbitrationController_.get();
   }
 
+  bool hasShutdown() const {
+    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    return arbitrator_->hasShutdownLocked();
+  }
+
  private:
   SharedArbitrator* const arbitrator_;
 };


### PR DESCRIPTION
Summary:
There are bunch of flaky mock arbitrator tests which are due to the background global arbitration
which can continue to run after the test finishes.
In general we need the shutdown procedure to handle the shared arbitrator destruction properly.
This PR adds shutdown support in shared arbitrator and is invoked from memory manager. This fixes
plus some test fixes solves all existing flakiness in mock arbitrator tests in Meta.

Differential Revision: D64742451


