### PR TITLE
Register (VARCHAR, INTEGER) to trail

### DIFF
--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -52,7 +52,7 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<EndsWithFunction, bool, Varchar, Varchar>(
       {prefix + "ends_with"});
 
-  registerFunction<TrailFunction, Varchar, Varchar, int64_t>(
+  registerFunction<TrailFunction, Varchar, Varchar, int32_t>(
       {prefix + "trail"});
 
   registerFunction<SubstrFunction, Varchar, Varchar, int64_t>(

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -2254,9 +2254,13 @@ TEST_F(StringFunctionsTest, normalize) {
 
 TEST_F(StringFunctionsTest, trail) {
   auto trail = [&](std::optional<std::string> string,
-                   std::optional<int64_t> N) {
+                   std::optional<int32_t> N) {
     return evaluateOnce<std::string>("trail(c0, c1)", string, N);
   };
+  // Test registered signatures
+  auto signatures = getSignatureStrings("trail");
+  ASSERT_EQ(1, signatures.size());
+  ASSERT_EQ(1, signatures.count("(varchar,integer) -> varchar"));
 
   // Basic Test
   EXPECT_EQ("bar", trail("foobar", 3));


### PR DESCRIPTION
Summary:
Thanks to Zac for getting me this query

```
presto:di> SHOW functions LIKE '%trail%';
 Function | Return Type |  Argument Types  | Function Type | Deterministic |                    Description                     | Variable Arity | Built In | Temporary | Language
----------+-------------+------------------+---------------+---------------+----------------------------------------------------+----------------+----------+-----------+----------
 trail    | varchar     | varchar, integer | scalar        | true          | Returns the last N characters of the input string. | false          | true     | false     | sql
(1 row)
Query 20241022_220057_94835_4guzv, FINISHED, 2 nodes
Splits: 11 total, 11 done (100.00%)
[Latency: client-side: 0:03, server-side: 0:03] [0 rows, 0B] [0 rows/s, 0B/s]
```

Look like trail just has arg type (varchar, integer), let's register this type instead

Differential Revision: D64782906


