### PR TITLE
Add nvrtc to setup scripts.

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -135,7 +135,7 @@ jobs:
         working-directory: _build/release
         run: |
           export CLASSPATH=`/usr/local/hadoop/bin/hdfs classpath --glob`
-          ctest -j 8 --output-on-failure --no-tests=error
+          ctest -j 8 --label-exclude cuda_driver --output-on-failure --no-tests=error
 
   ubuntu-debug:
     runs-on: 8-core-ubuntu

--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -114,7 +114,7 @@ jobs:
             "-DVELOX_ENABLE_GCS=ON"
             "-DVELOX_ENABLE_ABFS=ON"
             "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
-            "-DVELOX_ENABLE_GPU=OFF"
+            "-DVELOX_ENABLE_GPU=ON"
             "-DVELOX_MONO_LIBRARY=ON"
           )
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -220,7 +220,8 @@ function install_arrow {
 function install_cuda {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
-  dnf install -y cuda-nvcc-$(echo $1 | tr '.' '-') cuda-cudart-devel-$(echo $1 | tr '.' '-')
+  local dashed="$(echo $1 | tr '.' '-')"
+  dnf install -y cuda-nvcc-$dashed cuda-cudart-devel-$dashed cuda-nvrtc-devel-$dashed
 }
 
 function install_velox_deps {

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -221,7 +221,7 @@ function install_cuda {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
   local dashed="$(echo $1 | tr '.' '-')"
-  dnf install -y cuda-nvcc-$dashed cuda-cudart-devel-$dashed cuda-nvrtc-devel-$dashed cuda-driver-devel-$dashedcuda-driver-devel-$dashed cuda-driver-devel-$dashed 
+  dnf install -y cuda-nvcc-$dashed cuda-cudart-devel-$dashed cuda-nvrtc-devel-$dashed cuda-driver-devel-$dashed 
 }
 
 function install_velox_deps {

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -221,7 +221,7 @@ function install_cuda {
   # See https://developer.nvidia.com/cuda-downloads
   dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
   local dashed="$(echo $1 | tr '.' '-')"
-  dnf install -y cuda-nvcc-$dashed cuda-cudart-devel-$dashed cuda-nvrtc-devel-$dashed
+  dnf install -y cuda-nvcc-$dashed cuda-cudart-devel-$dashed cuda-nvrtc-devel-$dashed cuda-driver-devel-$dashedcuda-driver-devel-$dashed cuda-driver-devel-$dashed 
 }
 
 function install_velox_deps {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -245,7 +245,7 @@ function install_cuda {
     $SUDO apt update
   fi
   local dashed="$(echo $1 | tr '.' '-')"
-  $SUDO apt install -y cuda-nvcc-$dashed cuda-cudart-dev-$dashed cuda-nvrtc-dev-$dashed
+  $SUDO apt install -y cuda-nvcc-$dashed cuda-cudart-dev-$dashed cuda-nvrtc-dev-$dashed cuda-driver-devel-$dashed
 }
 
 function install_velox_deps {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -244,7 +244,8 @@ function install_cuda {
     rm cuda-keyring_1.1-1_all.deb
     $SUDO apt update
   fi
-  $SUDO apt install -y cuda-nvcc-$(echo $1 | tr '.' '-') cuda-cudart-dev-$(echo $1 | tr '.' '-')
+  local dashed="$(echo $1 | tr '.' '-')"
+  $SUDO apt install -y cuda-nvcc-$dashed cuda-cudart-dev-$dashed cuda-nvrtc-dev-$dashed
 }
 
 function install_velox_deps {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -245,7 +245,7 @@ function install_cuda {
     $SUDO apt update
   fi
   local dashed="$(echo $1 | tr '.' '-')"
-  $SUDO apt install -y cuda-nvcc-$dashed cuda-cudart-dev-$dashed cuda-nvrtc-dev-$dashed cuda-driver-devel-$dashed
+  $SUDO apt install -y cuda-nvcc-$dashed cuda-cudart-dev-$dashed cuda-nvrtc-dev-$dashed cuda-driver-dev-$dashed
 }
 
 function install_velox_deps {

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -28,6 +28,8 @@ velox_link_libraries(
   velox_exception
   velox_common_base
   velox_type
+  CUDA::cuda_driver
+  CUDA::cudart
   CUDA::nvrtc)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(
+add_library(
   velox_wave_common
   GpuArena.cpp
   Buffer.cpp
@@ -23,7 +23,7 @@ velox_add_library(
   Type.cpp
   ResultStaging.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   velox_wave_common
   velox_exception
   velox_common_base

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   HashTestUtil.cpp)
 
 add_test(velox_wave_common_test velox_wave_common_test)
+set_tests_properties(velox_wave_common_test PROPERTIES LABELS cuda_driver)
 
 target_link_libraries(
   velox_wave_common_test

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -28,12 +28,6 @@ add_test(velox_wave_common_test velox_wave_common_test)
 target_link_libraries(
   velox_wave_common_test
   velox_wave_common
-  velox_memory
-  velox_time
-  velox_exception
   GTest::gtest
   GTest::gtest_main
-  gflags::gflags
-  glog::glog
-  Folly::folly
-  CUDA::nvrtc)
+  CUDA::cudart)

--- a/velox/experimental/wave/dwio/decode/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/CMakeLists.txt
@@ -14,6 +14,6 @@
 
 add_subdirectory(tests)
 
-velox_add_library(velox_wave_decode GpuDecoder.cu)
+add_library(velox_wave_decode GpuDecoder.cu)
 
-velox_link_libraries(velox_wave_decode velox_wave_common)
+target_link_libraries(velox_wave_decode velox_wave_common)

--- a/velox/experimental/wave/dwio/decode/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/CMakeLists.txt
@@ -16,4 +16,5 @@ add_subdirectory(tests)
 
 add_library(velox_wave_decode GpuDecoder.cu)
 
-target_link_libraries(velox_wave_decode velox_wave_common)
+target_link_libraries(
+  velox_wave_decode velox_wave_common)

--- a/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
@@ -21,11 +21,7 @@ target_link_libraries(
   velox_wave_decode
   velox_wave_common
   velox_memory
-  velox_time
-  velox_exception
   GTest::gtest
   GTest::gtest_main
-  gflags::gflags
-  glog::glog
   Folly::folly
-  CUDA::nvrtc)
+  fmt::fmt)

--- a/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(velox_wave_decode_test GpuDecoderTest.cu)
 
 add_test(velox_wave_decode_test velox_wave_decode_test)
+set_tests_properties(velox_wave_decode_test PROPERTIES LABELS cuda_driver)
 
 target_link_libraries(
   velox_wave_decode_test

--- a/velox/experimental/wave/exec/CMakeLists.txt
+++ b/velox/experimental/wave/exec/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_wave_stream OperandSet.cpp Wave.cpp)
 
-target_link_libraries(velox_wave_stream Folly::folly fmt::fmt xsimd)
+target_link_libraries(
+  velox_wave_stream Folly::folly fmt::fmt xsimd)
 
 add_library(
   velox_wave_exec

--- a/velox/experimental/wave/exec/CMakeLists.txt
+++ b/velox/experimental/wave/exec/CMakeLists.txt
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_wave_stream OperandSet.cpp Wave.cpp)
+add_library(velox_wave_stream OperandSet.cpp Wave.cpp)
 
-velox_link_libraries(velox_wave_stream Folly::folly fmt::fmt xsimd)
+target_link_libraries(velox_wave_stream Folly::folly fmt::fmt xsimd)
 
-velox_add_library(
+add_library(
   velox_wave_exec
   Aggregation.cpp
   AggregationInstructions.cu
@@ -34,7 +34,7 @@ velox_add_library(
   WaveHiveDataSource.cpp
   WaveSplitReader.cpp)
 
-velox_link_libraries(
+target_link_libraries(
   velox_wave_exec
   velox_wave_vector
   velox_wave_common

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ target_link_libraries(
   CUDA::cudart)
 
 add_test(velox_wave_exec_test velox_wave_exec_test)
+set_tests_properties(velox_wave_exec_test PROPERTIES LABELS cuda_driver)
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_executable(velox_wave_benchmark WaveBenchmark.cpp)

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -40,23 +40,14 @@ target_link_libraries(
   velox_type
   velox_vector
   velox_vector_fuzzer
-  Boost::atomic
-  Boost::context
-  Boost::date_time
-  Boost::filesystem
-  Boost::program_options
-  Boost::regex
-  Boost::thread
-  Boost::system
-  gtest
-  gtest_main
-  gmock
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog
   fmt::fmt
-  ${FILESYSTEM}
-  CUDA::nvrtc)
+  CUDA::cudart)
 
 add_test(velox_wave_exec_test velox_wave_exec_test)
 
@@ -87,22 +78,13 @@ if(${VELOX_ENABLE_BENCHMARKS})
     velox_type
     velox_vector
     velox_vector_fuzzer
-    Boost::atomic
-    Boost::context
-    Boost::date_time
-    Boost::filesystem
-    Boost::program_options
-    Boost::regex
-    Boost::thread
-    Boost::system
-    gtest
-    gtest_main
-    gmock
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
     ${FOLLY_BENCHMARK}
     Folly::folly
     gflags::gflags
     glog::glog
     fmt::fmt
-    ${FILESYSTEM}
-    CUDA::nvrtc)
+    CUDA::cudart)
 endif()

--- a/velox/experimental/wave/vector/tests/CMakeLists.txt
+++ b/velox/experimental/wave/vector/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_executable(velox_wave_vector_test VectorTest.cpp)
 
-add_test(veloxwave__vector_test velox_wave_vector_test)
+add_test(veloxwave_vector_test velox_wave_vector_test)
 
 target_link_libraries(
   velox_wave_vector_test


### PR DESCRIPTION
#11225 requires CUDA's nvrtc library  and the cuda driver stubs (on machines without a gpu) to be available.

* Install nvrct and stubs in centos and ubuntu scripts
* Turn GPU build back on.
* Add missing links and remove some superflous ones
* Turn all targets that link directly or indirectly against CUDA::cuda_driver into standalone targets as the stubbed symbols will throw a dload error on the gpu less runner. This way we keep them out of the mono library and avoid throwing errors in non-gpu tests.
* Exclude tests that use the cuda driver stubs via label 