### PR TITLE
Fix format_datetime to used linked TimeZone names

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Make Debug Build
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
+          ICU_SOURCE: SYSTEM
           MAKEFLAGS: "NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3"
           EXTRA_CMAKE_FLAGS: "-DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON"
         run: |

--- a/CMake/resolve_dependency_modules/boost.cmake
+++ b/CMake/resolve_dependency_modules/boost.cmake
@@ -13,30 +13,13 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  if(ON_APPLE_M1)
-    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/icu4c")
-  else()
-    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c")
-  endif()
-endif()
-
-# ICU is only needed with Boost build from source
-set_source(ICU)
-resolve_dependency(
-  ICU
-  COMPONENTS
-  data
-  i18n
-  io
-  uc
-  tu
-  test)
-
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/boost)
-if(${ICU_SOURCE} STREQUAL "BUNDLED")
-  # ensure ICU is built before Boost
-  add_dependencies(boost_regex ICU ICU::i18n)
+
+if(ICU_SOURCE)
+  if(${ICU_SOURCE} STREQUAL "BUNDLED")
+    # ensure ICU is built before Boost
+    add_dependencies(boost_regex ICU ICU::i18n)
+  endif()
 endif()
 
 # This prevents system boost from leaking in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,6 +385,25 @@ endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  if(ON_APPLE_M1)
+    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/icu4c")
+  else()
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c")
+  endif()
+endif()
+
+set_source(ICU)
+resolve_dependency(
+  ICU
+  COMPONENTS
+  data
+  i18n
+  io
+  uc
+  tu
+  test)
+
 set(BOOST_INCLUDE_LIBRARIES
     atomic
     context

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -297,4 +297,3 @@ function install_apt_deps {
     fi
   fi
 )
-

--- a/velox/external/date/patches/0006-add_get_time_zone_names.patch
+++ b/velox/external/date/patches/0006-add_get_time_zone_names.patch
@@ -1,0 +1,30 @@
+diff --git a/velox/external/date/tz.cpp b/velox/external/date/tz.cpp
+--- a/velox/external/date/tz.cpp
++++ b/velox/external/date/tz.cpp
+@@ -3538,6 +3538,14 @@
+     return get_tzdb_list().front();
+ }
+ 
++std::vector<std::string> get_time_zone_names() {
++  std::vector<std::string> result;
++  for (const auto& z : get_tzdb().zones) {
++    result.push_back(z.name());
++  }
++  return result;
++}
++
+ const time_zone*
+ #if HAS_STRING_VIEW
+ tzdb::locate_zone(std::string_view tz_name) const
+diff --git a/velox/external/date/tz.h b/velox/external/date/tz.h
+--- a/velox/external/date/tz.h
++++ b/velox/external/date/tz.h
+@@ -1258,6 +1258,8 @@
+ 
+ DATE_API const tzdb& get_tzdb();
+ 
++std::vector<std::string> get_time_zone_names();
++
+ class tzdb_list
+ {
+     std::atomic<tzdb*> head_{nullptr};

--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -3538,6 +3538,14 @@ get_tzdb()
     return get_tzdb_list().front();
 }
 
+std::vector<std::string> get_time_zone_names() {
+  std::vector<std::string> result;
+  for (const auto& z : get_tzdb().zones) {
+    result.push_back(z.name());
+  }
+  return result;
+}
+
 const time_zone*
 #if HAS_STRING_VIEW
 tzdb::locate_zone(std::string_view tz_name) const

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -1258,6 +1258,8 @@ operator<<(std::ostream& os, const tzdb& db);
 
 DATE_API const tzdb& get_tzdb();
 
+std::vector<std::string> get_time_zone_names();
+
 class tzdb_list
 {
     std::atomic<tzdb*> head_{nullptr};

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -24,7 +24,8 @@ velox_link_libraries(velox_functions_util velox_vector velox_common_base)
 velox_add_library(velox_functions_lib_date_time_formatter DateTimeFormatter.cpp
                   DateTimeFormatterBuilder.cpp)
 
-velox_link_libraries(velox_functions_lib_date_time_formatter velox_type_tz)
+velox_link_libraries(velox_functions_lib_date_time_formatter velox_type_tz
+                     ICU::i18n ICU::uc)
 
 velox_add_library(
   velox_functions_lib

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -828,6 +828,12 @@ int32_t parseFromPattern(
     }
     cur += size;
   } else if (curPattern.specifier == DateTimeFormatSpecifier::TIMEZONE) {
+    // JODA does not support parsing time zone long names, so neither do we for
+    // consistency. The pattern for a time zone long name is 4 or more 'z's.
+    VELOX_USER_CHECK_LT(
+        curPattern.minRepresentDigits,
+        4,
+        "Parsing time zone long names is not supported.");
     auto size = parseTimezone(cur, end, date);
     if (size == -1) {
       return -1;

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1209,10 +1209,10 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
           // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
           size += 5;
         } else {
-          VELOX_NYI(
-              "Date format specifier is not yet implemented: {} ({})",
-              getSpecifierName(token.pattern.specifier),
-              token.pattern.minRepresentDigits);
+          // The longest time zone long name is 40, Australian Central Western
+          // Standard Time.
+          // https://www.timeanddate.com/time/zones/
+          size += 50;
         }
 
         break;
@@ -1468,8 +1468,11 @@ int32_t DateTimeFormatter::format(
             std::memcpy(result, abbrev.data(), abbrev.length());
             result += abbrev.length();
           } else {
-            // TODO: implement full name time zone
-            VELOX_NYI("full time zone name is not yet supported");
+            std::string longName = timezone->getLongName(
+                std::chrono::milliseconds(timestamp.toMillis()),
+                tz::TimeZone::TChoose::kEarliest);
+            std::memcpy(result, longName.data(), longName.length());
+            result += longName.length();
           }
         } break;
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3269,6 +3269,28 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_EQ("+05:30", formatDatetime(parseTimestamp("1970-01-01"), "ZZ"));
   EXPECT_EQ("+0530", formatDatetime(parseTimestamp("1970-01-01"), "Z"));
 
+  EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zzz"));
+  EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zz"));
+  EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "z"));
+
+  // Test daylight savings.
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ("PST", formatDatetime(parseTimestamp("1970-01-01"), "z"));
+  EXPECT_EQ("PDT", formatDatetime(parseTimestamp("1970-10-01"), "z"));
+  EXPECT_EQ("PST", formatDatetime(parseTimestamp("2024-03-10 01:00"), "z"));
+  EXPECT_EQ("PDT", formatDatetime(parseTimestamp("2024-03-10 03:00"), "z"));
+  EXPECT_EQ("PDT", formatDatetime(parseTimestamp("2024-11-03 01:00"), "z"));
+  EXPECT_EQ("PST", formatDatetime(parseTimestamp("2024-11-03 02:00"), "z"));
+
+  // Test a long abbreviation.
+  setQueryTimeZone("Asia/Colombo");
+  EXPECT_EQ("+0530", formatDatetime(parseTimestamp("1970-10-01"), "z"));
+
+  setQueryTimeZone("Asia/Kolkata");
+  // We don't support more than 3 'z's yet.
+  EXPECT_THROW(
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"), VeloxRuntimeError);
+
   // Literal test cases.
   EXPECT_EQ("hello", formatDatetime(parseTimestamp("1970-01-01"), "'hello'"));
   EXPECT_EQ("'", formatDatetime(parseTimestamp("1970-01-01"), "''"));
@@ -3313,15 +3335,14 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
 
-  // System errors for patterns we haven't implemented yet.
+  // Time zone name patterns aren't supported when there isn't a time zone
+  // available.
   EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "z"), VeloxRuntimeError);
+      formatDatetime(parseTimestamp("1970-01-01"), "z"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zz"), VeloxRuntimeError);
+      formatDatetime(parseTimestamp("1970-01-01"), "zz"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zzz"), VeloxRuntimeError);
-  EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"), VeloxRuntimeError);
+      formatDatetime(parseTimestamp("1970-01-01"), "zzz"), VeloxUserError);
 }
 
 TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3214,11 +3214,18 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       "0010",
       formatDatetime(parseTimestamp("2022-01-01 03:30:30.001"), "SSSS"));
 
-  // Time zone test cases - 'z'
+  // Time zone test cases - 'Z'
   setQueryTimeZone("Asia/Kolkata");
   EXPECT_EQ(
-      "Asia/Kolkata", formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
+      "Asia/Kolkata",
+      formatDatetime(
+          parseTimestamp("1970-01-01"), "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"));
+  EXPECT_EQ(
+      "Asia/Kolkata", formatDatetime(parseTimestamp("1970-01-01"), "ZZZZ"));
+  EXPECT_EQ(
+      "Asia/Kolkata", formatDatetime(parseTimestamp("1970-01-01"), "ZZZ"));
   EXPECT_EQ("+05:30", formatDatetime(parseTimestamp("1970-01-01"), "ZZ"));
+  EXPECT_EQ("+0530", formatDatetime(parseTimestamp("1970-01-01"), "Z"));
 
   // Literal test cases.
   EXPECT_EQ("hello", formatDatetime(parseTimestamp("1970-01-01"), "'hello'"));
@@ -3243,12 +3250,12 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       "AD 19 1970 4 Thu 1970 1 1 1 AM 8 8 8 8 3 11 5 Asia/Kolkata",
       formatDatetime(
           parseTimestamp("1970-01-01 02:33:11.5"),
-          "G C Y e E y D M d a K h H k m s S zzzz"));
+          "G C Y e E y D M d a K h H k m s S ZZZ"));
   EXPECT_EQ(
       "AD 19 1970 4 asdfghjklzxcvbnmqwertyuiop Thu ' 1970 1 1 1 AM 8 8 8 8 3 11 5 1234567890\\\"!@#$%^&*()-+`~{}[];:,./ Asia/Kolkata",
       formatDatetime(
           parseTimestamp("1970-01-01 02:33:11.5"),
-          "G C Y e 'asdfghjklzxcvbnmqwertyuiop' E '' y D M d a K h H k m s S 1234567890\\\"!@#$%^&*()-+`~{}[];:,./ zzzz"));
+          "G C Y e 'asdfghjklzxcvbnmqwertyuiop' E '' y D M d a K h H k m s S 1234567890\\\"!@#$%^&*()-+`~{}[];:,./ ZZZ"));
 
   disableAdjustTimestampToTimezone();
   EXPECT_EQ(
@@ -3260,15 +3267,19 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "x"), VeloxUserError);
   EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "z"), VeloxUserError);
-  EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zz"), VeloxUserError);
-  EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zzz"), VeloxUserError);
-  EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "q"), VeloxUserError);
   EXPECT_THROW(
       formatDatetime(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
+
+  // System errors for patterns we haven't implemented yet.
+  EXPECT_THROW(
+      formatDatetime(parseTimestamp("1970-01-01"), "z"), VeloxRuntimeError);
+  EXPECT_THROW(
+      formatDatetime(parseTimestamp("1970-01-01"), "zz"), VeloxRuntimeError);
+  EXPECT_THROW(
+      formatDatetime(parseTimestamp("1970-01-01"), "zzz"), VeloxRuntimeError);
+  EXPECT_THROW(
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"), VeloxRuntimeError);
 }
 
 TEST_F(DateTimeFunctionsTest, formatDateTimeTimezone) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3022,6 +3022,19 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
       parseDatetime(
           "2024-02-25+06:00:99 America/XYZ", "yyyy-MM-dd+HH:mm:99 ZZZ"),
       "Invalid date format: '2024-02-25+06:00:99 America/XYZ'");
+
+  // Test to ensure we do not support parsing time zone long names (to be
+  // consistent with JODA).
+  VELOX_ASSERT_THROW(
+      parseDatetime(
+          "2024-02-25+06:00:99 Pacific Standard Time",
+          "yyyy-MM-dd+HH:mm:99 zzzz"),
+      "Parsing time zone long names is not supported.");
+  VELOX_ASSERT_THROW(
+      parseDatetime(
+          "2024-02-25+06:00:99 Pacific Standard Time",
+          "yyyy-MM-dd+HH:mm:99 zzzzzzzzzz"),
+      "Parsing time zone long names is not supported.");
 }
 
 TEST_F(DateTimeFunctionsTest, formatDateTime) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3272,6 +3272,12 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zzz"));
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zz"));
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "z"));
+  EXPECT_EQ(
+      "India Standard Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
+  EXPECT_EQ(
+      "India Standard Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzzzzzzzzzzzzzzzzzzzz"));
 
   // Test daylight savings.
   setQueryTimeZone("America/Los_Angeles");
@@ -3281,16 +3287,47 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_EQ("PDT", formatDatetime(parseTimestamp("2024-03-10 03:00"), "z"));
   EXPECT_EQ("PDT", formatDatetime(parseTimestamp("2024-11-03 01:00"), "z"));
   EXPECT_EQ("PST", formatDatetime(parseTimestamp("2024-11-03 02:00"), "z"));
+  EXPECT_EQ(
+      "Pacific Standard Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
+  EXPECT_EQ(
+      "Pacific Daylight Time",
+      formatDatetime(parseTimestamp("1970-10-01"), "zzzz"));
+  EXPECT_EQ(
+      "Pacific Standard Time",
+      formatDatetime(parseTimestamp("2024-03-10 01:00"), "zzzz"));
+  EXPECT_EQ(
+      "Pacific Daylight Time",
+      formatDatetime(parseTimestamp("2024-03-10 03:00"), "zzzz"));
+  EXPECT_EQ(
+      "Pacific Daylight Time",
+      formatDatetime(parseTimestamp("2024-11-03 01:00"), "zzzz"));
+  EXPECT_EQ(
+      "Pacific Standard Time",
+      formatDatetime(parseTimestamp("2024-11-03 02:00"), "zzzz"));
+
+  // Test ambiguous time.
+  EXPECT_EQ(
+      "PDT", formatDatetime(parseTimestamp("2024-11-03 01:30:00"), "zzz"));
+  EXPECT_EQ(
+      "Pacific Daylight Time",
+      formatDatetime(parseTimestamp("2024-11-03 01:30:00"), "zzzz"));
 
   // Test a long abbreviation.
   setQueryTimeZone("Asia/Colombo");
   EXPECT_EQ("+0530", formatDatetime(parseTimestamp("1970-10-01"), "z"));
+  EXPECT_EQ(
+      "India Standard Time",
+      formatDatetime(parseTimestamp("1970-10-01"), "zzzz"));
+
+  // Test a long long name.
+  setQueryTimeZone("Australia/Eucla");
+  EXPECT_EQ("+0845", formatDatetime(parseTimestamp("1970-10-01"), "z"));
+  EXPECT_EQ(
+      "Australian Central Western Standard Time",
+      formatDatetime(parseTimestamp("1970-10-01"), "zzzz"));
 
   setQueryTimeZone("Asia/Kolkata");
-  // We don't support more than 3 'z's yet.
-  EXPECT_THROW(
-      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"), VeloxRuntimeError);
-
   // Literal test cases.
   EXPECT_EQ("hello", formatDatetime(parseTimestamp("1970-01-01"), "'hello'"));
   EXPECT_EQ("'", formatDatetime(parseTimestamp("1970-01-01"), "''"));

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3340,6 +3340,17 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       "Australian Central Western Standard Time",
       formatDatetime(parseTimestamp("1970-10-01"), "zzzz"));
 
+  // Test a time zone name that is linked to another (that gets replaced when
+  // converted to a string).
+  setQueryTimeZone("US/Pacific");
+  EXPECT_EQ("PST", formatDatetime(parseTimestamp("1970-01-01"), "zzz"));
+  EXPECT_EQ(
+      "Pacific Standard Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
+  EXPECT_EQ(
+      "America/Los_Angeles",
+      formatDatetime(parseTimestamp("1970-01-01"), "ZZZ"));
+
   setQueryTimeZone("Asia/Kolkata");
   // Literal test cases.
   EXPECT_EQ("hello", formatDatetime(parseTimestamp("1970-01-01"), "'hello'"));

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -125,7 +125,8 @@ TEST_F(TimestampWithTimeZoneCastTest, toVarchar) {
       "1970-01-01 01:11:37.123 America/New_York",
       "1969-12-31 22:11:37.123 America/Los_Angeles",
       "1970-01-01 14:11:37.123 Asia/Shanghai",
-      "1970-01-01 11:41:37.123 Asia/Calcutta",
+      "1970-01-01 11:41:37.123 Asia/Kolkata", // Asia/Calcutta is linked to
+                                              // Asia/Kolkata.
   });
 
   auto result = evaluate("cast(c0 as varchar)", makeRowVector({input}));

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -110,7 +110,7 @@ void castToString(
   const auto* timestamps = input.as<SimpleVector<int64_t>>();
 
   auto expectedFormatter =
-      functions::buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS zzzz");
+      functions::buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS ZZZ");
   VELOX_CHECK(
       !expectedFormatter.hasError(),
       "Default format should always be valid, error: {}",

--- a/velox/type/tz/CMakeLists.txt
+++ b/velox/type/tz/CMakeLists.txt
@@ -23,4 +23,6 @@ velox_link_libraries(
   velox_external_date
   Boost::regex
   fmt::fmt
-  Folly::folly)
+  Folly::folly
+  ICU::i18n
+  ICU::uc)

--- a/velox/type/tz/CMakeLists.txt
+++ b/velox/type/tz/CMakeLists.txt
@@ -14,8 +14,12 @@
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
-velox_add_library(velox_type_tz TimeZoneMap.h TimeZoneDatabase.cpp
-                  TimeZoneMap.cpp)
+velox_add_library(
+  velox_type_tz
+  TimeZoneMap.h
+  TimeZoneDatabase.cpp
+  TimeZoneLinks.cpp
+  TimeZoneMap.cpp)
 
 velox_link_libraries(
   velox_type_tz

--- a/velox/type/tz/TimeZoneLinks.cpp
+++ b/velox/type/tz/TimeZoneLinks.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is generated. Do not modify it manually. To re-generate it, run:
+//
+//  ./velox/type/tz/gen_timezone_links.py -f /tmp/backward \
+//       > velox/type/tz/TimeZoneLinks.cpp
+//
+// The backward file should be the same one used in JODA,
+// The latest is available here :
+// https://github.com/JodaOrg/global-tz/blob/global-tz/backward.
+// Presto Java currently uses the one found here:
+// https://github.com/JodaOrg/global-tz/blob/2024agtz/backward
+// To find the current version in Presto Java, check this file at the version of
+// JODA Presto Java is using:
+// https://github.com/JodaOrg/joda-time/blob/v2.12.7/src/changes/changes.xml
+// @generated
+
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::tz {
+
+const std::unordered_map<std::string, std::string>& getTimeZoneLinks() {
+  static auto* tzLinks = new std::unordered_map<std::string, std::string>([] {
+    // Work around clang compiler bug causing multi-hour compilation
+    // with -fsanitize=fuzzer
+    // https://github.com/llvm/llvm-project/issues/75666
+    return std::unordered_map<std::string, std::string>{
+        {"Australia/ACT", "Australia/Sydney"},
+        {"Australia/LHI", "Australia/Lord_Howe"},
+        {"Australia/NSW", "Australia/Sydney"},
+        {"Australia/North", "Australia/Darwin"},
+        {"Australia/Queensland", "Australia/Brisbane"},
+        {"Australia/South", "Australia/Adelaide"},
+        {"Australia/Tasmania", "Australia/Hobart"},
+        {"Australia/Victoria", "Australia/Melbourne"},
+        {"Australia/West", "Australia/Perth"},
+        {"Australia/Yancowinna", "Australia/Broken_Hill"},
+        {"Brazil/Acre", "America/Rio_Branco"},
+        {"Brazil/DeNoronha", "America/Noronha"},
+        {"Brazil/East", "America/Sao_Paulo"},
+        {"Brazil/West", "America/Manaus"},
+        {"Canada/Atlantic", "America/Halifax"},
+        {"Canada/Central", "America/Winnipeg"},
+        {"Canada/Eastern", "America/Toronto"},
+        {"Canada/Mountain", "America/Edmonton"},
+        {"Canada/Newfoundland", "America/St_Johns"},
+        {"Canada/Pacific", "America/Vancouver"},
+        {"Canada/Saskatchewan", "America/Regina"},
+        {"Canada/Yukon", "America/Whitehorse"},
+        {"Chile/Continental", "America/Santiago"},
+        {"Chile/EasterIsland", "Pacific/Easter"},
+        {"Cuba", "America/Havana"},
+        {"Egypt", "Africa/Cairo"},
+        {"Eire", "Europe/Dublin"},
+        {"Etc/GMT+0", "Etc/GMT"},
+        {"Etc/GMT-0", "Etc/GMT"},
+        {"Etc/GMT0", "Etc/GMT"},
+        {"Etc/Greenwich", "Etc/GMT"},
+        {"Etc/UCT", "Etc/UTC"},
+        {"Etc/Universal", "Etc/UTC"},
+        {"Etc/Zulu", "Etc/UTC"},
+        {"GB", "Europe/London"},
+        {"GB-Eire", "Europe/London"},
+        {"GMT+0", "Etc/GMT"},
+        {"GMT-0", "Etc/GMT"},
+        {"GMT0", "Etc/GMT"},
+        {"Greenwich", "Etc/GMT"},
+        {"Hongkong", "Asia/Hong_Kong"},
+        {"Iceland", "Atlantic/Reykjavik"},
+        {"Iran", "Asia/Tehran"},
+        {"Israel", "Asia/Jerusalem"},
+        {"Jamaica", "America/Jamaica"},
+        {"Japan", "Asia/Tokyo"},
+        {"Kwajalein", "Pacific/Kwajalein"},
+        {"Libya", "Africa/Tripoli"},
+        {"Mexico/BajaNorte", "America/Tijuana"},
+        {"Mexico/BajaSur", "America/Mazatlan"},
+        {"Mexico/General", "America/Mexico_City"},
+        {"NZ", "Pacific/Auckland"},
+        {"NZ-CHAT", "Pacific/Chatham"},
+        {"Navajo", "America/Denver"},
+        {"PRC", "Asia/Shanghai"},
+        {"Poland", "Europe/Warsaw"},
+        {"Portugal", "Europe/Lisbon"},
+        {"ROC", "Asia/Taipei"},
+        {"ROK", "Asia/Seoul"},
+        {"Singapore", "Asia/Singapore"},
+        {"Turkey", "Europe/Istanbul"},
+        {"UCT", "Etc/UTC"},
+        {"US/Alaska", "America/Anchorage"},
+        {"US/Aleutian", "America/Adak"},
+        {"US/Arizona", "America/Phoenix"},
+        {"US/Central", "America/Chicago"},
+        {"US/East-Indiana", "America/Indiana/Indianapolis"},
+        {"US/Eastern", "America/New_York"},
+        {"US/Hawaii", "Pacific/Honolulu"},
+        {"US/Indiana-Starke", "America/Indiana/Knox"},
+        {"US/Michigan", "America/Detroit"},
+        {"US/Mountain", "America/Denver"},
+        {"US/Pacific", "America/Los_Angeles"},
+        {"US/Samoa", "Pacific/Pago_Pago"},
+        {"UTC", "Etc/UTC"},
+        {"Universal", "Etc/UTC"},
+        {"W-SU", "Europe/Moscow"},
+        {"Zulu", "Etc/UTC"},
+        {"America/Buenos_Aires", "America/Argentina/Buenos_Aires"},
+        {"America/Catamarca", "America/Argentina/Catamarca"},
+        {"America/Cordoba", "America/Argentina/Cordoba"},
+        {"America/Indianapolis", "America/Indiana/Indianapolis"},
+        {"America/Jujuy", "America/Argentina/Jujuy"},
+        {"America/Knox_IN", "America/Indiana/Knox"},
+        {"America/Louisville", "America/Kentucky/Louisville"},
+        {"America/Mendoza", "America/Argentina/Mendoza"},
+        {"America/Virgin", "America/St_Thomas"},
+        {"Pacific/Samoa", "Pacific/Pago_Pago"},
+        {"Africa/Timbuktu", "Africa/Bamako"},
+        {"America/Argentina/ComodRivadavia", "America/Argentina/Catamarca"},
+        {"America/Atka", "America/Adak"},
+        {"America/Coral_Harbour", "America/Atikokan"},
+        {"America/Ensenada", "America/Tijuana"},
+        {"America/Fort_Wayne", "America/Indiana/Indianapolis"},
+        {"America/Montreal", "America/Toronto"},
+        {"America/Nipigon", "America/Toronto"},
+        {"America/Pangnirtung", "America/Iqaluit"},
+        {"America/Porto_Acre", "America/Rio_Branco"},
+        {"America/Rainy_River", "America/Winnipeg"},
+        {"America/Rosario", "America/Argentina/Cordoba"},
+        {"America/Santa_Isabel", "America/Tijuana"},
+        {"America/Shiprock", "America/Denver"},
+        {"America/Thunder_Bay", "America/Toronto"},
+        {"America/Yellowknife", "America/Edmonton"},
+        {"Antarctica/South_Pole", "Antarctica/McMurdo"},
+        {"Asia/Chongqing", "Asia/Shanghai"},
+        {"Asia/Harbin", "Asia/Shanghai"},
+        {"Asia/Kashgar", "Asia/Urumqi"},
+        {"Asia/Tel_Aviv", "Asia/Jerusalem"},
+        {"Atlantic/Jan_Mayen", "Europe/Oslo"},
+        {"Australia/Canberra", "Australia/Sydney"},
+        {"Australia/Currie", "Australia/Hobart"},
+        {"Europe/Belfast", "Europe/London"},
+        {"Europe/Tiraspol", "Europe/Chisinau"},
+        {"Europe/Uzhgorod", "Europe/Kyiv"},
+        {"Europe/Zaporozhye", "Europe/Kyiv"},
+        {"Pacific/Enderbury", "Pacific/Kanton"},
+        {"Pacific/Johnston", "Pacific/Honolulu"},
+        {"Pacific/Yap", "Pacific/Chuuk"},
+        {"Africa/Asmera", "Africa/Asmara"},
+        {"America/Godthab", "America/Nuuk"},
+        {"Asia/Ashkhabad", "Asia/Ashgabat"},
+        {"Asia/Calcutta", "Asia/Kolkata"},
+        {"Asia/Chungking", "Asia/Shanghai"},
+        {"Asia/Dacca", "Asia/Dhaka"},
+        {"Asia/Istanbul", "Europe/Istanbul"},
+        {"Asia/Katmandu", "Asia/Kathmandu"},
+        {"Asia/Macao", "Asia/Macau"},
+        {"Asia/Rangoon", "Asia/Yangon"},
+        {"Asia/Saigon", "Asia/Ho_Chi_Minh"},
+        {"Asia/Thimbu", "Asia/Thimphu"},
+        {"Asia/Ujung_Pandang", "Asia/Makassar"},
+        {"Asia/Ulan_Bator", "Asia/Ulaanbaatar"},
+        {"Atlantic/Faeroe", "Atlantic/Faroe"},
+        {"Europe/Kiev", "Europe/Kyiv"},
+        {"Europe/Nicosia", "Asia/Nicosia"},
+        {"Pacific/Ponape", "Pacific/Pohnpei"},
+        {"Pacific/Truk", "Pacific/Chuuk"},
+    };
+  }());
+  return *tzLinks;
+}
+
+} // namespace facebook::velox::tz

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -160,6 +160,14 @@ class TimeZone {
       milliseconds timestamp,
       TChoose choose = TChoose::kFail) const;
 
+  /// Returns the long name of the time zone for the given timestamp, e.g.
+  /// Pacific Standard Time.  Note that the timestamp is needed for time zones
+  /// that support daylight savings time as the long name will change depending
+  /// on the date (e.g. Pacific Standard Time vs Pacific Daylight Time).
+  std::string getLongName(
+      milliseconds timestamp,
+      TChoose choose = TChoose::kFail) const;
+
  private:
   const date::time_zone* tz_{nullptr};
   const std::chrono::minutes offset_{0};

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -113,6 +113,7 @@ class TimeZone {
   }
 
   using seconds = std::chrono::seconds;
+  using milliseconds = std::chrono::milliseconds;
 
   /// Converts a local time (the time as perceived in the user time zone
   /// represented by this object) to a system time (the corresponding time in
@@ -150,6 +151,14 @@ class TimeZone {
   const date::time_zone* tz() const {
     return tz_;
   }
+
+  /// Returns the short name (abbreviation) of the time zone for the given
+  /// timestamp. Note that the timestamp is needed for time zones that support
+  /// daylight savings time as the short name will change depending on the date
+  /// (e.g. PST/PDT).
+  std::string getShortName(
+      milliseconds timestamp,
+      TChoose choose = TChoose::kFail) const;
 
  private:
   const date::time_zone* tz_{nullptr};

--- a/velox/type/tz/gen_timezone_links.py
+++ b/velox/type/tz/gen_timezone_links.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+from string import Template
+
+cpp_template = Template(
+    """\
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file is generated. Do not modify it manually. To re-generate it, run:
+//
+//  ./velox/type/tz/gen_timezone_links.py -f /tmp/backward \\
+//       > velox/type/tz/TimeZoneLinks.cpp
+//
+// The backward file should be the same one used in JODA,
+// The latest is available here :
+// https://github.com/JodaOrg/global-tz/blob/global-tz/backward.
+// Presto Java currently uses the one found here:
+// https://github.com/JodaOrg/global-tz/blob/2024agtz/backward
+// To find the current version in Presto Java, check this file at the version of
+// JODA Presto Java is using:
+// https://github.com/JodaOrg/joda-time/blob/v2.12.7/src/changes/changes.xml
+// @generated
+
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::tz {
+
+const std::unordered_map<std::string, std::string>& getTimeZoneLinks() {
+  static auto* tzLinks = new std::unordered_map<std::string, std::string>([] {
+    // Work around clang compiler bug causing multi-hour compilation
+    // with -fsanitize=fuzzer
+    // https://github.com/llvm/llvm-project/issues/75666
+    return std::unordered_map<std::string, std::string>{
+$entries
+    };
+  }());
+  return *tzLinks;
+}
+
+} // namespace facebook::velox::tz\
+"""
+)
+
+entry_template = Template('        {"$tz_key", "$tz_value"},')
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(
+        description="Reads an input file (specified by -f) containing mappings from "
+        "time zone names to the names that should replace them and prints the "
+        "corresponding `TimeZoneLinks.cpp` file.",
+        epilog="(c) Facebook 2004-present",
+    )
+    parser.add_argument(
+        "-f",
+        "--file-input",
+        required=True,
+        help="Input timezone links file.",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    entries = []
+
+    # Read an input file with links following the format:
+    #
+    # >  Link	Australia/Sydney	Australia/NSW
+    # >  Link	Australia/Darwin	Australia/North
+    # >  Link	Australia/Brisbane	Australia/Queensland
+    # >  ...
+    #
+    # Possible containing comments (everything in a line after # is ignored)
+
+    with open(args.file_input) as file_in:
+        for line in file_in:
+            line = line.strip()
+
+            columns = line.split()
+            if len(columns) == 0:
+                continue
+
+            if columns[0] != "Link":
+                continue
+
+            entries.append(
+                entry_template.substitute(tz_key=columns[2], tz_value=columns[1])
+            )
+
+    print(cpp_template.substitute(entries="\n".join(entries)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -259,5 +259,29 @@ TEST(TimeZoneMapTest, getShortName) {
   EXPECT_EQ("PST", toShortName("America/Los_Angeles", ts));
 }
 
+TEST(TimeZoneMapTest, getLongName) {
+  auto toLongName = [&](std::string_view name, size_t ts) {
+    const auto* tz = locateZone(name);
+    EXPECT_NE(tz, nullptr);
+    return tz->getLongName(milliseconds{ts});
+  };
+
+  // Test an offset that maps to an actual time zone.
+  EXPECT_EQ("Coordinated Universal Time", toLongName("+00:00", 0));
+
+  // Test offsets that do not map to named time zones.
+  EXPECT_EQ("+00:01", toLongName("+00:01", 0));
+  EXPECT_EQ("-00:01", toLongName("-00:01", 0));
+  EXPECT_EQ("+01:00", toLongName("+01:00", 0));
+  EXPECT_EQ("-01:01", toLongName("-01:01", 0));
+
+  // In "2024-07-25", America/Los_Angeles was in daylight savings time (UTC-07).
+  size_t ts = 1721890800000;
+  EXPECT_EQ("Pacific Daylight Time", toLongName("America/Los_Angeles", ts));
+
+  // In "2024-01-01", it was not (UTC-08).
+  ts = 1704096000000;
+  EXPECT_EQ("Pacific Standard Time", toLongName("America/Los_Angeles", ts));
+}
 } // namespace
 } // namespace facebook::velox::tz


### PR DESCRIPTION
Summary:
JODA has this concept of linked Time Zones where given a particular time zone ID, it
will write out a different time zone ID when formatting a timestamp as a string (I
suspect this is for historical reasons).

More information is available about this here https://github.com/JodaOrg/global-tz

This diff adds a script to parse the file JODA uses to get these links and turn it into a
static map. I've done this for the file in the version of JODA Presto Java currently uses
(there have been significant updates in more recent versions).  Note that the file
guarantees there are no transitive links so we don't need to handle that case.

I then updated the format_datetime UDF to use this mapping for the ZZZ (or more)
pattern.  It will use the linked time zone ID in place of the time zone ID if one is
available.

This is also fixes casting TimestampWithTimeZone to Varchar which uses the same
code path.

Differential Revision: D64870014
