### PR TITLE
Avoid local shuffle and global shuffle use the same hash value to avoid data skew

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -129,7 +129,8 @@ class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {
             std::move(constValues)) {}
 
   std::unique_ptr<core::PartitionFunction> create(
-      int numPartitions) const override;
+      int numPartitions,
+      bool localExchange) const override;
 
   std::string toString() const override;
 

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -44,6 +44,10 @@ class HivePartitionFunction : public core::PartitionFunction {
       const RowVector& input,
       std::vector<uint32_t>& partitions) override;
 
+  const std::vector<int>& testingBucketToPartition() const {
+    return bucketToPartition_;
+  }
+
  private:
   // Precompute single value hive hash for a constant partition key.
   void precompute(const BaseVector& value, size_t column_index_t);

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1131,8 +1131,11 @@ class PartitionFunction {
 /// Factory class for creating PartitionFunction instances.
 class PartitionFunctionSpec : public ISerializable {
  public:
+  /// If 'localExchange' is true, the partition function is used for local
+  /// exchange within a velox task.
   virtual std::unique_ptr<PartitionFunction> create(
-      int numPartitions) const = 0;
+      int numPartitions,
+      bool localExchange = false) const = 0;
 
   virtual ~PartitionFunctionSpec() = default;
 
@@ -1144,7 +1147,8 @@ using PartitionFunctionSpecPtr = std::shared_ptr<const PartitionFunctionSpec>;
 class GatherPartitionFunctionSpec : public PartitionFunctionSpec {
  public:
   std::unique_ptr<PartitionFunction> create(
-      int /* numPartitions */) const override {
+      int /*numPartitions*/,
+      bool /*localExchange*/) const override {
     VELOX_UNREACHABLE();
   }
 

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -30,6 +30,7 @@ namespace facebook::velox::exec {
 class HashPartitionFunction : public core::PartitionFunction {
  public:
   HashPartitionFunction(
+      bool localExchange,
       int numPartitions,
       const RowTypePtr& inputType,
       const std::vector<column_index_t>& keyChannels,
@@ -57,6 +58,7 @@ class HashPartitionFunction : public core::PartitionFunction {
       const std::vector<column_index_t>& keyChannels,
       const std::vector<VectorPtr>& constValues);
 
+  const bool localExchange_;
   const int numPartitions_;
   const std::optional<HashBitRange> hashBitRange_ = std::nullopt;
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
@@ -82,7 +84,8 @@ class HashPartitionFunctionSpec : public core::PartitionFunctionSpec {
         constValues_{std::move(constValues)} {}
 
   std::unique_ptr<core::PartitionFunction> create(
-      int numPartitions) const override;
+      int numPartitions,
+      bool localExchange) const override;
 
   std::string toString() const override;
 

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -247,9 +247,10 @@ LocalPartition::LocalPartition(
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
       numPartitions_{queues_.size()},
       partitionFunction_(
-          numPartitions_ == 1
-              ? nullptr
-              : planNode->partitionFunctionSpec().create(numPartitions_)) {
+          numPartitions_ == 1 ? nullptr
+                              : planNode->partitionFunctionSpec().create(
+                                    numPartitions_,
+                                    /*localExchange=*/true)) {
   VELOX_CHECK(numPartitions_ == 1 || partitionFunction_ != nullptr);
 
   for (auto& queue : queues_) {

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -139,9 +139,10 @@ PartitionedOutput::PartitionedOutput(
       numDestinations_(planNode->numPartitions()),
       replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),
       partitionFunction_(
-          numDestinations_ == 1
-              ? nullptr
-              : planNode->partitionFunctionSpec().create(numDestinations_)),
+          numDestinations_ == 1 ? nullptr
+                                : planNode->partitionFunctionSpec().create(
+                                      numDestinations_,
+                                      /*localExchange=*/false)),
       outputChannels_(calculateOutputChannels(
           planNode->inputType(),
           planNode->outputType(),

--- a/velox/exec/RoundRobinPartitionFunction.h
+++ b/velox/exec/RoundRobinPartitionFunction.h
@@ -42,7 +42,8 @@ class RoundRobinPartitionFunction : public core::PartitionFunction {
 class RoundRobinPartitionFunctionSpec : public core::PartitionFunctionSpec {
  public:
   std::unique_ptr<core::PartitionFunction> create(
-      int numPartitions) const override {
+      int numPartitions,
+      bool /*localExchange*/) const override {
     return std::make_unique<velox::exec::RoundRobinPartitionFunction>(
         numPartitions);
   }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1721,7 +1721,7 @@ bool Task::checkIfFinishedLocked() {
   }
 
   if (allFinished) {
-    if ((not hasPartitionedOutput()) || partitionedOutputConsumed_) {
+    if (!hasPartitionedOutput() || partitionedOutputConsumed_) {
       taskStats_.endTimeMs = getCurrentTimeMs();
       return true;
     }
@@ -2350,7 +2350,8 @@ ContinueFuture Task::taskDeletionFuture() {
 std::string Task::toString() const {
   std::lock_guard<std::timed_mutex> l(mutex_);
   std::stringstream out;
-  out << "{Task " << shortId(taskId_) << " (" << taskId_ << ")" << std::endl;
+  out << "{Task " << shortId(taskId_) << " (" << taskId_ << ") "
+      << taskStateString(state_) << std::endl;
 
   if (exception_) {
     out << "Error: " << errorMessageLocked() << std::endl;

--- a/velox/exec/tests/HashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/HashPartitionFunctionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
@@ -38,7 +39,7 @@ TEST_F(HashPartitionFunctionTest, function) {
   // The test case the two hash partition functions having the same config.
   {
     std::vector<uint32_t> partitionsWithoutBits(numRows);
-    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    HashPartitionFunction functionWithoutBits(false, 4, rowType, {0});
     functionWithoutBits.partition(*vector, partitionsWithoutBits);
     EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
@@ -49,10 +50,25 @@ TEST_F(HashPartitionFunctionTest, function) {
     EXPECT_EQ(4, functionWithBits.numPartitions());
   }
 
+  // The test case the local and remote hash functions have different
+  // partitions.
+  {
+    std::vector<uint32_t> partitionsWithoutBits(numRows);
+    HashPartitionFunction functionWithoutBits(true, 4, rowType, {0});
+    functionWithoutBits.partition(*vector, partitionsWithoutBits);
+    EXPECT_EQ(4, functionWithoutBits.numPartitions());
+
+    std::vector<uint32_t> partitionsWithBits(numRows);
+    HashPartitionFunction functionWithBits(HashBitRange{0, 2}, rowType, {0});
+    functionWithBits.partition(*vector, partitionsWithBits);
+    EXPECT_NE(partitionsWithoutBits, partitionsWithBits);
+    EXPECT_EQ(4, functionWithBits.numPartitions());
+  }
+
   // The test case the two hash partition functions with different configs.
   {
     std::vector<uint32_t> partitionsWithoutBits(numRows);
-    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    HashPartitionFunction functionWithoutBits(false, 4, rowType, {0});
     functionWithoutBits.partition(*vector, partitionsWithoutBits);
     EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
@@ -66,7 +82,7 @@ TEST_F(HashPartitionFunctionTest, function) {
   // The test case the two hash partition functions with different configs.
   {
     std::vector<uint32_t> partitionsWithoutBits(numRows);
-    HashPartitionFunction functionWithoutBits(4, rowType, {0});
+    HashPartitionFunction functionWithoutBits(true, 4, rowType, {0});
     functionWithoutBits.partition(*vector, partitionsWithoutBits);
     EXPECT_EQ(4, functionWithoutBits.numPartitions());
 
@@ -120,6 +136,80 @@ TEST_F(HashPartitionFunctionTest, function) {
   }
 }
 
+TEST_F(HashPartitionFunctionTest, skew) {
+  const int numRows = 10'000;
+  auto input = makeRowVector(
+      {makeFlatVector<int32_t>(numRows, [](auto row) { return row; })});
+  auto rowType = asRowType(input->type());
+
+  const auto hashSpec = std::make_unique<exec::HashPartitionFunctionSpec>(
+      rowType, std::vector<column_index_t>{0});
+  const int numRemotePartitions{8};
+  auto remoteHashFunction =
+      hashSpec->create(numRemotePartitions, /*localExchange=*/false);
+  std::vector<uint32_t> remotePartitions(numRows);
+  remoteHashFunction->partition(*input, remotePartitions);
+
+  std::vector<BufferPtr> partitionIndicesVector(numRemotePartitions);
+  std::vector<vector_size_t*> rawPartitionIndicesVector(numRemotePartitions);
+  std::vector<vector_size_t> partitionSizeVectors(numRemotePartitions, 0);
+  for (int i = 0; i < numRemotePartitions; ++i) {
+    partitionIndicesVector[i] =
+        AlignedBuffer::allocate<vector_size_t>(numRows, pool_.get());
+    rawPartitionIndicesVector[i] =
+        partitionIndicesVector[i]->asMutable<vector_size_t>();
+  }
+  for (int row = 0; row < numRows; ++row) {
+    ASSERT_LT(remotePartitions[row], numRemotePartitions);
+    const int partition = remotePartitions[row];
+    rawPartitionIndicesVector[partition][partitionSizeVectors[partition]++] =
+        row;
+  }
+  std::vector<VectorPtr> partitionedInputs;
+  for (int partition = 0; partition < numRemotePartitions; ++partition) {
+    partitionedInputs.push_back(wrap(
+        partitionSizeVectors[partition],
+        partitionIndicesVector[partition],
+        input));
+  }
+
+  // Checks that the bad hash partition function (using remote hash function
+  // with local hash partition count) map all the local input rows to one local
+  // partition.
+  const int numLocalPartitions{4};
+  auto badLocalHashFunction =
+      hashSpec->create(numLocalPartitions, /*localExchange=*/false);
+  for (int partition = 0; partition < numRemotePartitions; ++partition) {
+    const auto localPartitionSize = partitionSizeVectors[partition];
+    std::vector<uint32_t> localPartitions(localPartitionSize);
+    badLocalHashFunction->partition(
+        *static_cast<RowVector*>(partitionedInputs[partition].get()),
+        localPartitions);
+    std::unordered_set<int> localPartitionSet;
+    for (int row = 1; row < localPartitionSize; ++row) {
+      localPartitionSet.insert(localPartitions[row]);
+    }
+    ASSERT_EQ(localPartitionSet.size(), 1) << partition;
+  }
+
+  // Verifies that the local hash partition function evenly distributes the
+  // local input rows.
+  auto localHashFunction =
+      hashSpec->create(numLocalPartitions, /*localExchange=*/true);
+  for (int partition = 0; partition < numRemotePartitions; ++partition) {
+    const auto localPartitionSize = partitionSizeVectors[partition];
+    std::vector<uint32_t> localPartitions(localPartitionSize);
+    localHashFunction->partition(
+        *static_cast<RowVector*>(partitionedInputs[partition].get()),
+        localPartitions);
+    std::unordered_set<int> localPartitionSet;
+    for (int row = 1; row < localPartitionSize; ++row) {
+      localPartitionSet.insert(localPartitions[row]);
+    }
+    ASSERT_EQ(localPartitionSet.size(), numLocalPartitions) << partition;
+  }
+}
+
 TEST_F(HashPartitionFunctionTest, spec) {
   Type::registerSerDe();
   core::ITypedExpr::registerSerDe();
@@ -160,13 +250,16 @@ TEST_F(HashPartitionFunctionTest, spec) {
 }
 
 TEST_F(HashPartitionFunctionTest, noKeyAndBitRange) {
-  auto vector = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6})});
-  auto rowType = asRowType(vector->type());
-  const auto numRows{vector->size()};
-  HashPartitionFunction function(4, rowType, {}, {});
+  for (bool localExchange : {false, true}) {
+    SCOPED_TRACE(fmt::format("localExchange: {}", localExchange));
+    auto vector = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6})});
+    auto rowType = asRowType(vector->type());
+    const auto numRows{vector->size()};
+    HashPartitionFunction function(localExchange, 4, rowType, {}, {});
 
-  std::vector<uint32_t> partitions(numRows);
-  const auto singlePartition = function.partition(*vector, partitions);
-  ASSERT_TRUE(singlePartition.has_value());
-  EXPECT_EQ(singlePartition.value(), 0u);
+    std::vector<uint32_t> partitions(numRows);
+    const auto singlePartition = function.partition(*vector, partitions);
+    ASSERT_TRUE(singlePartition.has_value());
+    EXPECT_EQ(singlePartition.value(), 0u);
+  }
 }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -526,7 +526,7 @@ TEST_F(TaskTest, toJson) {
 
   ASSERT_EQ(
       task->toString(),
-      "{Task task-1 (task-1)\n"
+      "{Task task-1 (task-1) Running\n"
       "Plan:\n"
       "-- Project[1][expressions: (p0:INTEGER, multiply(ROW[\"a\"],ROW[\"a\"])), (p1:DOUBLE, plus(ROW[\"b\"],ROW[\"b\"]))] -> p0:INTEGER, p1:DOUBLE\n"
       "  -- TableScan[0][table: hive_table] -> a:INTEGER, b:DOUBLE\n"

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -829,6 +829,13 @@ class PlanBuilder {
   /// current plan node).
   PlanBuilder& localPartition(const std::vector<std::string>& keys);
 
+  /// A convenience method to add a LocalPartitionNode with hive partition
+  /// function.
+  PlanBuilder& localPartition(
+      int numBuckets,
+      const std::vector<column_index_t>& channels,
+      const std::vector<VectorPtr>& constValues);
+
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node) and hive bucket property.
   PlanBuilder& localPartitionByBucket(


### PR DESCRIPTION
Summary:
There is data skew problem in Velox partitioning handling for local and remote shuffle used by Prestissimo.
If the number of workers for remote shuffle is multiple of the number of threads in local shuffle. Then all
the input on a worker could goes to the same thread. For system hash partitioning, it causes overall slow in
query execution time. For hive partitioning used by table writer, it could also cause exceeded open file
errors as the limit is per table writer thread. We shall use a different hash for the local shuffle. For hash
partition, we apply a second hash function on the computed hash number for the local shuffle while
for the hive partition, we shuffle the bucket to partition map.

Verified in shadow testing, this can prevent exceeded open file errors for hive partition use case. And
significantly improve the query execution time with the default hash partition setting in Prestissimo.

Differential Revision: D64777771
