### PR TITLE
feat: Add Spark date_trunc function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -64,7 +64,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: date_trunc(fmt, ts) -> timestamp
 
     Returns timestamp ``ts`` truncated to the unit specified by the format model ``fmt``.
-    Returns null if ``fmt`` is invalid.
+    Returns null if ``fmt`` is invalid, microseconds and abbreviated unit string are allowed.
 
     ``fmt`` is case insensitive and must be one of the following:
         * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``ts`` falls in, the time part will be zero out

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -64,7 +64,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: date_trunc(fmt, ts) -> timestamp
 
     Returns timestamp ``ts`` truncated to the unit specified by the format model ``fmt``.
-    Returns null if ``fmt`` is invalid, microseconds and abbreviated unit string are allowed.
+    Returns NULL if ``fmt`` is invalid. ``fmt`` as "MICROSECOND" and abbreviated unit string are allowed.
 
     ``fmt`` is case insensitive and must be one of the following:
         * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``ts`` falls in, the time part will be zero out
@@ -95,6 +95,8 @@ These functions support TIMESTAMP and DATE input types.
         SELECT date_trunc('SECOND', '2015-03-05T09:32:05.359'); -- 2015-03-05 09:32:05
         SELECT date_trunc('MILLISECOND', '2015-03-05T09:32:05.123456'); -- 2015-03-05 09:32:05.123
         SELECT date_trunc('MICROSECOND', '2015-03-05T09:32:05.123456'); -- 2015-03-05 09:32:05.123456
+        SELECT date_trunc('', '2015-03-05T09:32:05.123456'); -- NULL
+        SELECT date_trunc('Y', '2015-03-05T09:32:05.123456'); -- NULL
 
 .. spark:function:: datediff(endDate, startDate) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -61,6 +61,41 @@ These functions support TIMESTAMP and DATE input types.
     ``num_days`` can be positive or negative.
     Supported types for ``num_days`` are: TINYINT, SMALLINT, INTEGER.
 
+.. spark:function:: date_trunc(fmt, ts) -> timestamp
+
+    Returns timestamp ``ts`` truncated to the unit specified by the format model ``fmt``.
+    Returns null if ``fmt`` is invalid.
+
+    ``fmt`` is case insensitive and must be one of the following:
+        * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``ts`` falls in, the time part will be zero out
+        * "QUARTER" - truncate to the first date of the quarter that the ``ts`` falls in, the time part will be zero out
+        * "MONTH", "MM", "MON" - truncate to the first date of the month that the ``ts`` falls in, the time part will be zero out
+        * "WEEK" - truncate to the Monday of the week that the ``ts`` falls in, the time part will be zero out
+        * "DAY", "DD" - zero out the time part
+        * "HOUR" - zero out the minute and second with fraction part
+        * "MINUTE"- zero out the second with fraction part
+        * "SECOND" - zero out the second fraction part
+        * "MILLISECOND" - zero out the microseconds
+        * "MICROSECOND" - everything remains.
+
+    ::
+
+        SELECT date_trunc('YEAR', '2015-03-05T09:32:05.359'); -- 2015-01-01 00:00:00
+        SELECT date_trunc('YYYY', '2015-03-05T09:32:05.359'); -- 2015-01-01 00:00:00
+        SELECT date_trunc('YY', '2015-03-05T09:32:05.359'); -- 2015-01-01 00:00:00
+        SELECT date_trunc('QUARTER', '2015-03-05T09:32:05.359'); -- 2015-01-01 00:00:00
+        SELECT date_trunc('MONTH', '2015-03-05T09:32:05.359'); -- 2015-03-01 00:00:00
+        SELECT date_trunc('MM', '2015-03-05T09:32:05.359'); -- 2015-03-01 00:00:00
+        SELECT date_trunc('MON', '2015-03-05T09:32:05.359'); -- 2015-03-01 00:00:00
+        SELECT date_trunc('WEEK', '2015-03-05T09:32:05.359'); -- 2015-03-02 00:00:00
+        SELECT date_trunc('DAY', '2015-03-05T09:32:05.359'); -- 2015-03-05 00:00:00
+        SELECT date_trunc('DD', '2015-03-05T09:32:05.359'); -- 2015-03-05 00:00:00
+        SELECT date_trunc('HOUR', '2015-03-05T09:32:05.359'); -- 2015-03-05 09:00:00
+        SELECT date_trunc('MINUTE', '2015-03-05T09:32:05.359'); -- 2015-03-05 09:32:00
+        SELECT date_trunc('SECOND', '2015-03-05T09:32:05.359'); -- 2015-03-05 09:32:05
+        SELECT date_trunc('MILLISECOND', '2015-03-05T09:32:05.123456'); -- 2015-03-05 09:32:05.123
+        SELECT date_trunc('MICROSECOND', '2015-03-05T09:32:05.123456'); -- 2015-03-05 09:32:05.123456
+
 .. spark:function:: datediff(endDate, startDate) -> integer
 
     Returns the number of days from startDate to endDate. Only DATE type is allowed
@@ -295,7 +330,7 @@ These functions support TIMESTAMP and DATE input types.
         SELECT unix_millis('1970-01-01 00:00:01'); -- 1000
 
 .. spark:function:: unix_seconds(timestamp) -> bigint
-    
+
     Returns the number of seconds since 1970-01-01 00:00:00 UTC. ::
 
         SELECT unix_seconds('1970-01-01 00:00:01'); -- 1
@@ -315,7 +350,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: unix_timestamp(string) -> integer
    :noindex:
 
-    Returns the UNIX timestamp of time specified by ``string``. Assumes the 
+    Returns the UNIX timestamp of time specified by ``string``. Assumes the
     format ``yyyy-MM-dd HH:mm:ss``. Returns null if ``string`` does not match
     ``format``.
 

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -118,6 +118,19 @@ enum class DateTimeFormatSpecifier : uint8_t {
   WEEK_OF_MONTH = 24
 };
 
+enum class DateTimeUnit {
+  kMicrosecond,
+  kMillisecond,
+  kSecond,
+  kMinute,
+  kHour,
+  kDay,
+  kWeek,
+  kMonth,
+  kQuarter,
+  kYear
+};
+
 struct FormatPattern {
   DateTimeFormatSpecifier specifier;
 

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -145,4 +145,59 @@ void adjustDateTime(std::tm& dateTime, const DateTimeUnit& unit) {
       VELOX_UNREACHABLE();
   }
 }
+
+Timestamp truncateTimestamp(
+    const Timestamp& timestamp,
+    DateTimeUnit unit,
+    const tz::TimeZone* timeZone) {
+  Timestamp result;
+  switch (unit) {
+    // For seconds ,millisecond, microsecond we just truncate the nanoseconds
+    // part of the timestamp; no timezone conversion required.
+    case DateTimeUnit::kMicrosecond:
+      return Timestamp(
+          timestamp.getSeconds(), timestamp.getNanos() / 1000 * 1000);
+
+    case DateTimeUnit::kMillisecond:
+      return Timestamp(
+          timestamp.getSeconds(), timestamp.getNanos() / 1000000 * 1000000);
+
+    case DateTimeUnit::kSecond:
+      return Timestamp(timestamp.getSeconds(), 0);
+
+    // Same for minutes; timezones and daylight savings time are at least in
+    // the granularity of 30 mins, so we can just truncate the epoch directly.
+    case DateTimeUnit::kMinute:
+      return adjustEpoch(timestamp.getSeconds(), 60);
+
+    // Hour truncation has to handle the corner case of daylight savings time
+    // boundaries. Since conversions from local timezone to UTC may be
+    // ambiguous, we need to be carefull about the roundtrip of converting to
+    // local time and back. So what we do is to calculate the truncation delta
+    // in UTC, then applying it to the input timestamp.
+    case DateTimeUnit::kHour: {
+      auto epochToAdjust = getSeconds(timestamp, timeZone);
+      auto secondsDelta =
+          epochToAdjust - adjustEpoch(epochToAdjust, 60 * 60).getSeconds();
+      return Timestamp(timestamp.getSeconds() - secondsDelta, 0);
+    }
+
+    // For the truncations below, we may first need to convert to the local
+    // timestamp, truncate, then convert back to GMT.
+    case DateTimeUnit::kDay:
+      result = adjustEpoch(getSeconds(timestamp, timeZone), 24 * 60 * 60);
+      break;
+
+    default:
+      auto dateTime = getDateTime(timestamp, timeZone);
+      adjustDateTime(dateTime, unit);
+      result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
+      break;
+  }
+
+  if (timeZone != nullptr) {
+    result.toGMT(*timeZone);
+  }
+  return result;
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -25,4 +25,126 @@ const folly::F14FastMap<std::string, int8_t> kDayOfWeekNames{
     {"tue", 5},      {"wed", 6},    {"thursday", 0}, {"friday", 1},
     {"saturday", 2}, {"sunday", 3}, {"monday", 4},   {"tuesday", 5},
     {"wednesday", 6}};
+
+std::optional<DateTimeUnit> fromDateTimeUnitString(
+    const StringView& unitString,
+    bool throwIfInvalid,
+    bool allowMicro,
+    bool allowAbbreviated) {
+  const auto unit = boost::algorithm::to_lower_copy(unitString.str());
+
+  if (unit == "microsecond" && allowMicro) {
+    return DateTimeUnit::kMicrosecond;
+  }
+  if (unit == "millisecond") {
+    return DateTimeUnit::kMillisecond;
+  }
+  if (unit == "second") {
+    return DateTimeUnit::kSecond;
+  }
+  if (unit == "minute") {
+    return DateTimeUnit::kMinute;
+  }
+  if (unit == "hour") {
+    return DateTimeUnit::kHour;
+  }
+  if (unit == "day") {
+    return DateTimeUnit::kDay;
+  }
+  if (unit == "week") {
+    return DateTimeUnit::kWeek;
+  }
+  if (unit == "month") {
+    return DateTimeUnit::kMonth;
+  }
+  if (unit == "quarter") {
+    return DateTimeUnit::kQuarter;
+  }
+  if (unit == "year") {
+    return DateTimeUnit::kYear;
+  }
+  if (allowAbbreviated) {
+    if (unit == "dd") {
+      return DateTimeUnit::kDay;
+    }
+    if (unit == "mon" || unit == "mm") {
+      return DateTimeUnit::kMonth;
+    }
+    if (unit == "yyyy" || unit == "yy") {
+      return DateTimeUnit::kYear;
+    }
+  }
+  if (throwIfInvalid) {
+    VELOX_UNSUPPORTED("Unsupported datetime unit: {}", unitString);
+  }
+  return std::nullopt;
+}
+
+void adjustDateTime(
+    std::tm& dateTime,
+    const DateTimeUnit& unit) {
+  switch (unit) {
+    case DateTimeUnit::kYear:
+      dateTime.tm_mon = 0;
+      dateTime.tm_yday = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kQuarter:
+      dateTime.tm_mon = dateTime.tm_mon / 3 * 3;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kMonth:
+      dateTime.tm_mday = 1;
+      dateTime.tm_hour = 0;
+      dateTime.tm_min = 0;
+      dateTime.tm_sec = 0;
+      break;
+    case DateTimeUnit::kWeek:
+      // Subtract the truncation.
+      dateTime.tm_mday -= dateTime.tm_wday == 0 ? 6 : dateTime.tm_wday - 1;
+      // Setting the day of the week to Monday.
+      dateTime.tm_wday = 1;
+
+      // If the adjusted day of the month falls in the previous month
+      // Move to the previous month.
+      if (dateTime.tm_mday < 1) {
+        dateTime.tm_mon -= 1;
+
+        // If the adjusted month falls in the previous year
+        // Set to December and Move to the previous year.
+        if (dateTime.tm_mon < 0) {
+          dateTime.tm_mon = 11;
+          dateTime.tm_year -= 1;
+        }
+
+        // Calculate the correct day of the month based on the number of days
+        // in the adjusted month.
+        static const int daysInMonth[] = {
+            31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        int daysInPrevMonth = daysInMonth[dateTime.tm_mon];
+
+        // Adjust for leap year if February.
+        if (dateTime.tm_mon == 1 && (dateTime.tm_year + 1900) % 4 == 0 &&
+            ((dateTime.tm_year + 1900) % 100 != 0 ||
+             (dateTime.tm_year + 1900) % 400 == 0)) {
+          daysInPrevMonth = 29;
+        }
+        // Set to the correct day in the previous month.
+        dateTime.tm_mday += daysInPrevMonth;
+      }
+      dateTime.tm_hour = 0;
+      dateTime.tm_min = 0;
+      dateTime.tm_sec = 0;
+      break;
+    case DateTimeUnit::kDay:
+      dateTime.tm_hour = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kHour:
+      dateTime.tm_min = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kMinute:
+      dateTime.tm_sec = 0;
+      break;
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -27,7 +27,7 @@ const folly::F14FastMap<std::string, int8_t> kDayOfWeekNames{
     {"wednesday", 6}};
 
 std::optional<DateTimeUnit> fromDateTimeUnitString(
-    const StringView& unitString,
+    StringView unitString,
     bool throwIfInvalid,
     bool allowMicro,
     bool allowAbbreviated) {
@@ -147,7 +147,7 @@ void adjustDateTime(std::tm& dateTime, const DateTimeUnit& unit) {
 }
 
 Timestamp truncateTimestamp(
-    const Timestamp& timestamp,
+    Timestamp timestamp,
     DateTimeUnit unit,
     const tz::TimeZone* timeZone) {
   Timestamp result;

--- a/velox/functions/lib/TimeUtils.cpp
+++ b/velox/functions/lib/TimeUtils.cpp
@@ -80,9 +80,7 @@ std::optional<DateTimeUnit> fromDateTimeUnitString(
   return std::nullopt;
 }
 
-void adjustDateTime(
-    std::tm& dateTime,
-    const DateTimeUnit& unit) {
+void adjustDateTime(std::tm& dateTime, const DateTimeUnit& unit) {
   switch (unit) {
     case DateTimeUnit::kYear:
       dateTime.tm_mon = 0;

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -135,7 +135,7 @@ struct InitSessionTimezone {
 /// @param allowMicro Whether to allow microsecond.
 /// @param allowAbbreviated Whether to allow abbreviated unit string.
 std::optional<DateTimeUnit> fromDateTimeUnitString(
-    const StringView& unitString,
+    StringView unitString,
     bool throwIfInvalid,
     bool allowMicro = false,
     bool allowAbbreviated = false);
@@ -159,7 +159,7 @@ adjustEpoch(int64_t seconds, int64_t intervalSeconds) {
 
 // Returns timestamp truncated to the specified unit.
 Timestamp truncateTimestamp(
-    const Timestamp& timestamp,
+    Timestamp timestamp,
     DateTimeUnit unit,
     const tz::TimeZone* timeZone);
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -15,11 +15,14 @@
  */
 #pragma once
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <velox/type/Timestamp.h>
 #include "velox/core/QueryConfig.h"
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/external/date/date.h"
 #include "velox/external/date/iso_week.h"
 #include "velox/functions/Macros.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
@@ -123,4 +126,205 @@ struct InitSessionTimezone {
     timeZone_ = getTimeZoneFromConfig(config);
   }
 };
+
+/// Converts string as date time unit. Throws for invalid input string.
+///
+/// @param unitString The input string to represent date time unit.
+/// @param throwIfInvalid Whether to throw an exception for invalid input
+/// string.
+/// @param allowMicro Whether to allow microsecond.
+/// @param allowAbbreviated Whether to allow abbreviated unit string.
+FOLLY_ALWAYS_INLINE std::optional<DateTimeUnit> fromDateTimeUnitString(
+    const StringView& unitString,
+    bool throwIfInvalid,
+    bool allowMicro = false,
+    bool allowAbbreviated = false) {
+  const auto unit = boost::algorithm::to_lower_copy(unitString.str());
+
+  if (unit == "microsecond" && allowMicro) {
+    return DateTimeUnit::kMicrosecond;
+  }
+  if (unit == "millisecond") {
+    return DateTimeUnit::kMillisecond;
+  }
+  if (unit == "second") {
+    return DateTimeUnit::kSecond;
+  }
+  if (unit == "minute") {
+    return DateTimeUnit::kMinute;
+  }
+  if (unit == "hour") {
+    return DateTimeUnit::kHour;
+  }
+  if (unit == "day") {
+    return DateTimeUnit::kDay;
+  }
+  if (unit == "week") {
+    return DateTimeUnit::kWeek;
+  }
+  if (unit == "month") {
+    return DateTimeUnit::kMonth;
+  }
+  if (unit == "quarter") {
+    return DateTimeUnit::kQuarter;
+  }
+  if (unit == "year") {
+    return DateTimeUnit::kYear;
+  }
+  if (allowAbbreviated) {
+    if (unit == "dd") {
+      return DateTimeUnit::kDay;
+    }
+    if (unit == "mon" || unit == "mm") {
+      return DateTimeUnit::kMonth;
+    }
+    if (unit == "yyyy" || unit == "yy") {
+      return DateTimeUnit::kYear;
+    }
+  }
+  if (throwIfInvalid) {
+    VELOX_UNSUPPORTED("Unsupported datetime unit: {}", unitString);
+  }
+  return std::nullopt;
+}
+
+/// Adjusts the given date time object to the start of the specified date time
+/// unit (e.g., year, quarter, month, week, day, hour, minute).
+FOLLY_ALWAYS_INLINE void adjustDateTime(
+    std::tm& dateTime,
+    const DateTimeUnit& unit) {
+  switch (unit) {
+    case DateTimeUnit::kYear:
+      dateTime.tm_mon = 0;
+      dateTime.tm_yday = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kQuarter:
+      dateTime.tm_mon = dateTime.tm_mon / 3 * 3;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kMonth:
+      dateTime.tm_mday = 1;
+      dateTime.tm_hour = 0;
+      dateTime.tm_min = 0;
+      dateTime.tm_sec = 0;
+      break;
+    case DateTimeUnit::kWeek:
+      // Subtract the truncation.
+      dateTime.tm_mday -= dateTime.tm_wday == 0 ? 6 : dateTime.tm_wday - 1;
+      // Setting the day of the week to Monday.
+      dateTime.tm_wday = 1;
+
+      // If the adjusted day of the month falls in the previous month
+      // Move to the previous month.
+      if (dateTime.tm_mday < 1) {
+        dateTime.tm_mon -= 1;
+
+        // If the adjusted month falls in the previous year
+        // Set to December and Move to the previous year.
+        if (dateTime.tm_mon < 0) {
+          dateTime.tm_mon = 11;
+          dateTime.tm_year -= 1;
+        }
+
+        // Calculate the correct day of the month based on the number of days
+        // in the adjusted month.
+        static const int daysInMonth[] = {
+            31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+        int daysInPrevMonth = daysInMonth[dateTime.tm_mon];
+
+        // Adjust for leap year if February.
+        if (dateTime.tm_mon == 1 && (dateTime.tm_year + 1900) % 4 == 0 &&
+            ((dateTime.tm_year + 1900) % 100 != 0 ||
+             (dateTime.tm_year + 1900) % 400 == 0)) {
+          daysInPrevMonth = 29;
+        }
+        // Set to the correct day in the previous month.
+        dateTime.tm_mday += daysInPrevMonth;
+      }
+      dateTime.tm_hour = 0;
+      dateTime.tm_min = 0;
+      dateTime.tm_sec = 0;
+      break;
+    case DateTimeUnit::kDay:
+      dateTime.tm_hour = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kHour:
+      dateTime.tm_min = 0;
+      FMT_FALLTHROUGH;
+    case DateTimeUnit::kMinute:
+      dateTime.tm_sec = 0;
+      break;
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+/// Returns timestamp with seconds adjusted to the nearest lower multiple of the
+/// specified interval. If the given seconds is negative and not an exact
+/// multiple of the interval, it adjusts further down.
+FOLLY_ALWAYS_INLINE Timestamp
+adjustEpoch(int64_t seconds, int64_t intervalSeconds) {
+  int64_t s = seconds / intervalSeconds;
+  if (seconds < 0 && seconds % intervalSeconds) {
+    s = s - 1;
+  }
+  int64_t truncatedSeconds = s * intervalSeconds;
+  return Timestamp(truncatedSeconds, 0);
+}
+
+// Returns timestamp truncated to the specified unit.
+FOLLY_ALWAYS_INLINE Timestamp truncateTimestamp(
+    const Timestamp& timestamp,
+    DateTimeUnit unit,
+    const tz::TimeZone* timeZone) {
+  Timestamp result;
+  switch (unit) {
+    // For seconds ,millisecond, microsecond we just truncate the nanoseconds
+    // part of the timestamp; no timezone conversion required.
+    case DateTimeUnit::kMicrosecond:
+      return Timestamp(
+          timestamp.getSeconds(), timestamp.getNanos() / 1000 * 1000);
+
+    case DateTimeUnit::kMillisecond:
+      return Timestamp(
+          timestamp.getSeconds(), timestamp.getNanos() / 1000000 * 1000000);
+
+    case DateTimeUnit::kSecond:
+      return Timestamp(timestamp.getSeconds(), 0);
+
+    // Same for minutes; timezones and daylight savings time are at least in
+    // the granularity of 30 mins, so we can just truncate the epoch directly.
+    case DateTimeUnit::kMinute:
+      return adjustEpoch(timestamp.getSeconds(), 60);
+
+    // Hour truncation has to handle the corner case of daylight savings time
+    // boundaries. Since conversions from local timezone to UTC may be
+    // ambiguous, we need to be carefull about the roundtrip of converting to
+    // local time and back. So what we do is to calculate the truncation delta
+    // in UTC, then applying it to the input timestamp.
+    case DateTimeUnit::kHour: {
+      auto epochToAdjust = getSeconds(timestamp, timeZone);
+      auto secondsDelta =
+          epochToAdjust - adjustEpoch(epochToAdjust, 60 * 60).getSeconds();
+      return Timestamp(timestamp.getSeconds() - secondsDelta, 0);
+    }
+
+    // For the truncations below, we may first need to convert to the local
+    // timestamp, truncate, then convert back to GMT.
+    case DateTimeUnit::kDay:
+      result = adjustEpoch(getSeconds(timestamp, timeZone), 24 * 60 * 60);
+      break;
+
+    default:
+      auto dateTime = getDateTime(timestamp, timeZone);
+      adjustDateTime(dateTime, unit);
+      result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
+      break;
+  }
+
+  if (timeZone != nullptr) {
+    result.toGMT(*timeZone);
+  }
+  return result;
+}
+
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -134,7 +134,7 @@ struct InitSessionTimezone {
 /// string.
 /// @param allowMicro Whether to allow microsecond.
 /// @param allowAbbreviated Whether to allow abbreviated unit string.
-FOLLY_ALWAYS_INLINE std::optional<DateTimeUnit> fromDateTimeUnitString(
+std::optional<DateTimeUnit> fromDateTimeUnitString(
     const StringView& unitString,
     bool throwIfInvalid,
     bool allowMicro = false,

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -157,22 +157,6 @@ adjustEpoch(int64_t seconds, int64_t intervalSeconds) {
   return Timestamp(truncatedSeconds, 0);
 }
 
-/// Truncates a timestamp to a specified time unit.
-/// For example:
-///   date_trunc('hour', timestamp '2020-05-26 11:30:00') -> '2020-05-26 11:00:00'
-///   date_trunc('day', timestamp '2020-05-26 11:30:00') -> '2020-05-26 00:00:00'
-///   date_trunc('month', timestamp '2020-05-26 11:30:00') -> '2020-05-01 00:00:00'
-///
-/// @param format The time unit to truncate to. Valid values include:
-///   'microsecond', 'millisecond', 'second', 'minute', 'hour', 'day', 
-///   'week', 'month', 'quarter', 'year'
-/// @param timestamp The timestamp to truncate
-/// @return The truncated timestamp, or null if the format is invalid
-template <typename T>
-struct DateTruncFunction {
-  // ... existing code ...
-};
-
 // Returns timestamp truncated to the specified unit.
 FOLLY_ALWAYS_INLINE Timestamp truncateTimestamp(
     const Timestamp& timestamp,

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   Re2FunctionsTest.cpp
   RepeatTest.cpp
   TDigestTest.cpp
+  TimeUtilsTest.cpp
   Utf8Test.cpp
   ZetaDistributionTest.cpp)
 

--- a/velox/functions/lib/tests/TimeUtilsTest.cpp
+++ b/velox/functions/lib/tests/TimeUtilsTest.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/lib/TimeUtils.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+TEST(TimeUtilsTest, fromDateTimeUnitString) {
+  // Return null when unit string is invalid and throwIfInvalid is false.
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("microsecond", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("dd", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("mon", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("mm", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("yyyy", false));
+  ASSERT_EQ(std::nullopt, fromDateTimeUnitString("yy", false));
+
+  // Throw when unit string is invalid and throwIfInvalid is true.
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("", true), "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("microsecond", true),
+      "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("dd", true), "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("mon", true), "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("mm", true), "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("yyyy", true), "Unsupported datetime unit:");
+  VELOX_ASSERT_THROW(
+      fromDateTimeUnitString("yy", true), "Unsupported datetime unit:");
+
+  ASSERT_EQ(
+      DateTimeUnit::kMillisecond, fromDateTimeUnitString("millisecond", false));
+  ASSERT_EQ(DateTimeUnit::kSecond, fromDateTimeUnitString("second", false));
+  ASSERT_EQ(DateTimeUnit::kMinute, fromDateTimeUnitString("minute", false));
+  ASSERT_EQ(DateTimeUnit::kHour, fromDateTimeUnitString("hour", false));
+  ASSERT_EQ(DateTimeUnit::kDay, fromDateTimeUnitString("day", false));
+  ASSERT_EQ(DateTimeUnit::kWeek, fromDateTimeUnitString("week", false));
+  ASSERT_EQ(DateTimeUnit::kMonth, fromDateTimeUnitString("month", false));
+  ASSERT_EQ(DateTimeUnit::kQuarter, fromDateTimeUnitString("quarter", false));
+  ASSERT_EQ(DateTimeUnit::kYear, fromDateTimeUnitString("year", false));
+
+  ASSERT_EQ(
+      DateTimeUnit::kMicrosecond,
+      fromDateTimeUnitString("microsecond", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kMillisecond,
+      fromDateTimeUnitString("millisecond", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kSecond,
+      fromDateTimeUnitString("second", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kMinute,
+      fromDateTimeUnitString("minute", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kHour, fromDateTimeUnitString("hour", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kDay, fromDateTimeUnitString("day", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kDay, fromDateTimeUnitString("dd", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kWeek, fromDateTimeUnitString("week", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kMonth, fromDateTimeUnitString("month", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kMonth, fromDateTimeUnitString("mon", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kMonth, fromDateTimeUnitString("mm", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kQuarter,
+      fromDateTimeUnitString("quarter", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kYear, fromDateTimeUnitString("year", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kYear, fromDateTimeUnitString("yyyy", false, true, true));
+  ASSERT_EQ(
+      DateTimeUnit::kYear, fromDateTimeUnitString("yy", false, true, true));
+}
+
+TEST(TimeUtilsTest, adjustEpoch) {
+  EXPECT_EQ(Timestamp(998474640, 0), adjustEpoch(998474645, 60));
+  EXPECT_EQ(Timestamp(998474400, 0), adjustEpoch(998474645, 60 * 60));
+  EXPECT_EQ(Timestamp(998438400, 0), adjustEpoch(998474645, 24 * 60 * 60));
+  EXPECT_EQ(Timestamp(-120, 0), adjustEpoch(-61, 60));
+}
+
+TEST(TimeUtilsTest, truncateTimestamp) {
+  auto* timezone = tz::locateZone("GMT");
+
+  EXPECT_EQ(
+      Timestamp(0, 0),
+      truncateTimestamp(Timestamp(0, 0), DateTimeUnit::kSecond, timezone));
+  EXPECT_EQ(
+      Timestamp(0, 0),
+      truncateTimestamp(Timestamp(0, 123), DateTimeUnit::kSecond, timezone));
+  EXPECT_EQ(
+      Timestamp(-1, 0),
+      truncateTimestamp(Timestamp(-1, 0), DateTimeUnit::kSecond, timezone));
+
+  EXPECT_EQ(
+      Timestamp(998474645, 321'001'000),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMicrosecond,
+          timezone));
+  EXPECT_EQ(
+      Timestamp(998474645, 321'000'000),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMillisecond,
+          timezone));
+  EXPECT_EQ(
+      Timestamp(998474645, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kSecond,
+          timezone));
+  EXPECT_EQ(
+      Timestamp(998474640, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMinute,
+          timezone));
+  EXPECT_EQ(
+      Timestamp(998474400, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kHour, timezone));
+  EXPECT_EQ(
+      Timestamp(998438400, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kDay, timezone));
+  EXPECT_EQ(
+      Timestamp(998265600, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kWeek, timezone));
+  EXPECT_EQ(
+      Timestamp(996624000, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kMonth, timezone));
+  EXPECT_EQ(
+      Timestamp(993945600, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kQuarter,
+          timezone));
+  EXPECT_EQ(
+      Timestamp(978307200, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kYear, timezone));
+
+  auto* timezone1 = tz::locateZone("America/Los_Angeles");
+  EXPECT_EQ(
+      Timestamp(0, 0),
+      truncateTimestamp(Timestamp(0, 0), DateTimeUnit::kSecond, timezone1));
+  EXPECT_EQ(
+      Timestamp(0, 0),
+      truncateTimestamp(Timestamp(0, 123), DateTimeUnit::kSecond, timezone1));
+  EXPECT_EQ(
+      Timestamp(-57600, 0),
+      truncateTimestamp(Timestamp(0, 0), DateTimeUnit::kDay, timezone1));
+
+  EXPECT_EQ(
+      Timestamp(998474645, 321'001'000),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMicrosecond,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(998474645, 321'000'000),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMillisecond,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(998474645, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kSecond,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(998474640, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMinute,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(998474400, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kHour, timezone1));
+  EXPECT_EQ(
+      Timestamp(998463600, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kDay, timezone1));
+  EXPECT_EQ(
+      Timestamp(998290800, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kWeek, timezone1));
+  EXPECT_EQ(
+      Timestamp(996649200, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kMonth,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(993970800, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234),
+          DateTimeUnit::kQuarter,
+          timezone1));
+  EXPECT_EQ(
+      Timestamp(978336000, 0),
+      truncateTimestamp(
+          Timestamp(998'474'645, 321'001'234), DateTimeUnit::kYear, timezone1));
+}
+} // namespace
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -909,7 +909,7 @@ inline std::optional<DateTimeUnit> getDateUnit(
 inline std::optional<DateTimeUnit> getTimestampUnit(
     const StringView& unitString) {
   std::optional<DateTimeUnit> unit =
-      fromDateTimeUnitString(unitString, false /*throwIfInvalid*/);
+      fromDateTimeUnitString(unitString, /*throwIfInvalid=*/false);
   VELOX_USER_CHECK(
       !(unit.has_value() && unit.value() == DateTimeUnit::kMillisecond),
       "{} is not a valid TIMESTAMP field",
@@ -1057,7 +1057,7 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>* /*timestamp*/) {
     sessionTimeZone_ = getTimeZoneFromConfig(config);
     if (unitString != nullptr) {
-      unit_ = fromDateTimeUnitString(*unitString, false /*throwIfInvalid*/);
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
   }
 
@@ -1079,7 +1079,7 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>& timestamp) {
     const auto unit = unit_.has_value()
         ? unit_.value()
-        : fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value();
+        : fromDateTimeUnitString(unitString, /*throwIfInvalid=*/true).value();
 
     if (value != (int32_t)value) {
       VELOX_UNSUPPORTED("integer overflow");
@@ -1119,7 +1119,7 @@ struct DateAddFunction : public TimestampWithTimezoneSupport<T> {
       const int64_t value,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     const auto unit = unit_.value_or(
-        fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value());
+        fromDateTimeUnitString(unitString, /*throwIfInvalid=*/true).value());
 
     if (value != (int32_t)value) {
       VELOX_UNSUPPORTED("integer overflow");
@@ -1160,7 +1160,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>* /*timestamp1*/,
       const arg_type<Timestamp>* /*timestamp2*/) {
     if (unitString != nullptr) {
-      unit_ = fromDateTimeUnitString(*unitString, false /*throwIfInvalid*/);
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
 
     sessionTimeZone_ = getTimeZoneFromConfig(config);
@@ -1184,7 +1184,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<TimestampWithTimezone>* /*timestampWithTimezone1*/,
       const arg_type<TimestampWithTimezone>* /*timestampWithTimezone2*/) {
     if (unitString != nullptr) {
-      unit_ = fromDateTimeUnitString(*unitString, false /*throwIfInvalid*/);
+      unit_ = fromDateTimeUnitString(*unitString, /*throwIfInvalid=*/false);
     }
   }
 
@@ -1194,7 +1194,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<Timestamp>& timestamp1,
       const arg_type<Timestamp>& timestamp2) {
     const auto unit = unit_.value_or(
-        fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value());
+        fromDateTimeUnitString(unitString, /*throwIfInvalid=*/true).value());
 
     if (LIKELY(sessionTimeZone_ != nullptr)) {
       // sessionTimeZone not null means that the config
@@ -1236,7 +1236,7 @@ struct DateDiffFunction : public TimestampWithTimezoneSupport<T> {
       const arg_type<TimestampWithTimezone>& timestampWithTz1,
       const arg_type<TimestampWithTimezone>& timestampWithTz2) {
     const auto unit = unit_.value_or(
-        fromDateTimeUnitString(unitString, true /*throwIfInvalid*/).value());
+        fromDateTimeUnitString(unitString, /*throwIfInvalid=*/true).value());
 
     // Presto's behavior is to use the time zone of the first parameter to
     // perform the calculation. Note that always normalizing to UTC is not

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -881,54 +881,6 @@ struct MillisecondFromIntervalFunction {
 };
 
 namespace {
-inline std::optional<DateTimeUnit> fromDateTimeUnitString(
-    const StringView& unitString,
-    bool throwIfInvalid) {
-  static const StringView kMillisecond("millisecond");
-  static const StringView kSecond("second");
-  static const StringView kMinute("minute");
-  static const StringView kHour("hour");
-  static const StringView kDay("day");
-  static const StringView kWeek("week");
-  static const StringView kMonth("month");
-  static const StringView kQuarter("quarter");
-  static const StringView kYear("year");
-
-  const auto unit = boost::algorithm::to_lower_copy(unitString.str());
-
-  if (unit == kMillisecond) {
-    return DateTimeUnit::kMillisecond;
-  }
-  if (unit == kSecond) {
-    return DateTimeUnit::kSecond;
-  }
-  if (unit == kMinute) {
-    return DateTimeUnit::kMinute;
-  }
-  if (unit == kHour) {
-    return DateTimeUnit::kHour;
-  }
-  if (unit == kDay) {
-    return DateTimeUnit::kDay;
-  }
-  if (unit == kWeek) {
-    return DateTimeUnit::kWeek;
-  }
-  if (unit == kMonth) {
-    return DateTimeUnit::kMonth;
-  }
-  if (unit == kQuarter) {
-    return DateTimeUnit::kQuarter;
-  }
-  if (unit == kYear) {
-    return DateTimeUnit::kYear;
-  }
-  if (throwIfInvalid) {
-    VELOX_UNSUPPORTED("Unsupported datetime unit: {}", unitString);
-  }
-  return std::nullopt;
-}
-
 inline bool isTimeUnit(const DateTimeUnit unit) {
   return unit == DateTimeUnit::kMillisecond || unit == DateTimeUnit::kSecond ||
       unit == DateTimeUnit::kMinute || unit == DateTimeUnit::kHour;
@@ -1007,74 +959,6 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     }
   }
 
-  FOLLY_ALWAYS_INLINE void adjustDateTime(
-      std::tm& dateTime,
-      const DateTimeUnit& unit) {
-    switch (unit) {
-      case DateTimeUnit::kYear:
-        dateTime.tm_mon = 0;
-        dateTime.tm_yday = 0;
-        FMT_FALLTHROUGH;
-      case DateTimeUnit::kQuarter:
-        dateTime.tm_mon = dateTime.tm_mon / 3 * 3;
-        FMT_FALLTHROUGH;
-      case DateTimeUnit::kMonth:
-        dateTime.tm_mday = 1;
-        dateTime.tm_hour = 0;
-        dateTime.tm_min = 0;
-        dateTime.tm_sec = 0;
-        break;
-      case DateTimeUnit::kWeek:
-        // Subtract the truncation
-        dateTime.tm_mday -= dateTime.tm_wday == 0 ? 6 : dateTime.tm_wday - 1;
-        // Setting the day of the week to Monday
-        dateTime.tm_wday = 1;
-
-        // If the adjusted day of the month falls in the previous month
-        // Move to the previous month
-        if (dateTime.tm_mday < 1) {
-          dateTime.tm_mon -= 1;
-
-          // If the adjusted month falls in the previous year
-          // Set to December and Move to the previous year
-          if (dateTime.tm_mon < 0) {
-            dateTime.tm_mon = 11;
-            dateTime.tm_year -= 1;
-          }
-
-          // Calculate the correct day of the month based on the number of days
-          // in the adjusted month
-          static const int daysInMonth[] = {
-              31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-          int daysInPrevMonth = daysInMonth[dateTime.tm_mon];
-
-          // Adjust for leap year if February
-          if (dateTime.tm_mon == 1 && (dateTime.tm_year + 1900) % 4 == 0 &&
-              ((dateTime.tm_year + 1900) % 100 != 0 ||
-               (dateTime.tm_year + 1900) % 400 == 0)) {
-            daysInPrevMonth = 29;
-          }
-          // Set to the correct day in the previous month
-          dateTime.tm_mday += daysInPrevMonth;
-        }
-        dateTime.tm_hour = 0;
-        dateTime.tm_min = 0;
-        dateTime.tm_sec = 0;
-        break;
-      case DateTimeUnit::kDay:
-        dateTime.tm_hour = 0;
-        FMT_FALLTHROUGH;
-      case DateTimeUnit::kHour:
-        dateTime.tm_min = 0;
-        FMT_FALLTHROUGH;
-      case DateTimeUnit::kMinute:
-        dateTime.tm_sec = 0;
-        break;
-      default:
-        VELOX_UNREACHABLE();
-    }
-  }
-
   FOLLY_ALWAYS_INLINE void call(
       out_type<Timestamp>& result,
       const arg_type<Varchar>& unitString,
@@ -1085,49 +969,7 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     } else {
       unit = getTimestampUnit(unitString).value();
     }
-
-    switch (unit) {
-      // For seconds, we just truncate the nanoseconds part of the timestamp; no
-      // timezone conversion required.
-      case DateTimeUnit::kSecond:
-        result = Timestamp(timestamp.getSeconds(), 0);
-        return;
-
-      // Same for minutes; timezones and daylight savings time are at least in
-      // the granularity of 30 mins, so we can just truncate the epoch directly.
-      case DateTimeUnit::kMinute:
-        result = adjustEpoch(timestamp.getSeconds(), 60);
-        return;
-
-      // Hour truncation has to handle the corner case of daylight savings time
-      // boundaries. Since conversions from local timezone to UTC may be
-      // ambiguous, we need to be carefull about the roundtrip of converting to
-      // local time and back. So what we do is to calculate the truncation delta
-      // in UTC, then applying it to the input timestamp.
-      case DateTimeUnit::kHour: {
-        auto epochToAdjust = getSeconds(timestamp, timeZone_);
-        auto secondsDelta =
-            epochToAdjust - adjustEpoch(epochToAdjust, 60 * 60).getSeconds();
-        result = Timestamp(timestamp.getSeconds() - secondsDelta, 0);
-        return;
-      }
-
-      // For the truncations below, we may first need to convert to the local
-      // timestamp, truncate, then convert back to GMT.
-      case DateTimeUnit::kDay:
-        result = adjustEpoch(getSeconds(timestamp, timeZone_), 24 * 60 * 60);
-        break;
-
-      default:
-        auto dateTime = getDateTime(timestamp, timeZone_);
-        adjustDateTime(dateTime, unit);
-        result = Timestamp(Timestamp::calendarUtcToEpoch(dateTime), 0);
-        break;
-    }
-
-    if (timeZone_ != nullptr) {
-      result.toGMT(*timeZone_);
-    }
+    result = truncateTimestamp(timestamp, unit, timeZone_);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -1197,20 +1039,6 @@ struct DateTruncFunction : public TimestampWithTimezoneSupport<T> {
     }
 
     result = pack(resultMillis, unpackZoneKeyId(*timestampWithTimezone));
-  }
-
- private:
-  /// For fixed interval like second, minute, hour, day and week
-  /// we can truncate date by a simple arithmetic expression:
-  /// floor(seconds / intervalSeconds) * intervalSeconds.
-  FOLLY_ALWAYS_INLINE Timestamp
-  adjustEpoch(int64_t seconds, int64_t intervalSeconds) {
-    int64_t s = seconds / intervalSeconds;
-    if (seconds < 0 && seconds % intervalSeconds) {
-      s = s - 1;
-    }
-    int64_t truncedSeconds = s * intervalSeconds;
-    return Timestamp(truncedSeconds, 0);
   }
 };
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -20,6 +20,7 @@
 #include <optional>
 #include "velox/common/base/Doubles.h"
 #include "velox/external/date/date.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/TimestampConversion.h"
@@ -90,20 +91,6 @@ FOLLY_ALWAYS_INLINE boost::int64_t fromUnixtime(
 
   return pack(std::llround(unixtime * kMillisecondsInSecond), timeZoneId);
 }
-
-namespace {
-enum class DateTimeUnit {
-  kMillisecond,
-  kSecond,
-  kMinute,
-  kHour,
-  kDay,
-  kWeek,
-  kMonth,
-  kQuarter,
-  kYear
-};
-} // namespace
 
 // Year, quarter or month are not uniformly incremented. Months have different
 // total days, and leap years have more days than the rest. If the new year,

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -543,6 +543,7 @@ struct DateTruncFunction {
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
+      const arg_type<Varchar>* /*format*/,
       const arg_type<Timestamp>* /*timestamp*/) {
     timeZone_ = getTimeZoneFromConfig(config);
   }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -535,10 +535,6 @@ struct DateFromUnixDateFunction {
 };
 
 /// Truncates a timestamp to a specified time unit.
-/// For example:
-///   date_trunc('hour', timestamp '2020-05-26 11:30:00') -> '2020-05-26 11:00:00'
-///   date_trunc('day', timestamp '2020-05-26 11:30:00') -> '2020-05-26 00:00:00'
-///   date_trunc('month', timestamp '2020-05-26 11:30:00') -> '2020-05-01 00:00:00'
 ///
 /// @param format The time unit to truncate to
 /// @param timestamp The timestamp to truncate

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -534,11 +534,8 @@ struct DateFromUnixDateFunction {
   }
 };
 
-/// Truncates a timestamp to a specified time unit.
-///
-/// @param format The time unit to truncate to
-/// @param timestamp The timestamp to truncate
-/// @return The truncated timestamp, or null if the format is invalid
+/// Truncates a timestamp to a specified time unit. Return null if the
+/// format is invalid, microseconds and abbreviated unit string are allowed.
 template <typename T>
 struct DateTruncFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -554,8 +551,11 @@ struct DateTruncFunction {
       out_type<Timestamp>& result,
       const arg_type<Varchar>& format,
       const arg_type<Timestamp>& timestamp) {
-    std::optional<DateTimeUnit> unitOption =
-        fromDateTimeUnitString(format, /*throwIfInvalid=*/false, true, true);
+    std::optional<DateTimeUnit> unitOption = fromDateTimeUnitString(
+        format,
+        /*throwIfInvalid=*/false,
+        /*allowMicro=*/true,
+        /*allowAbbreviated=*/true);
     // Return null if unit is illegal.
     if (!unitOption.has_value()) {
       return false;

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -535,6 +535,35 @@ struct DateFromUnixDateFunction {
 };
 
 template <typename T>
+struct DateTruncFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Timestamp>* /*timestamp*/) {
+    timeZone_ = getTimeZoneFromConfig(config);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& format,
+      const arg_type<Timestamp>& timestamp) {
+    std::optional<DateTimeUnit> unitOption =
+        fromDateTimeUnitString(format, false /*throwIfInvalid*/, true, true);
+    // Return null if unit is illegal.
+    if (!unitOption.has_value()) {
+      return false;
+    }
+    result = truncateTimestamp(timestamp, unitOption.value(), timeZone_);
+    return true;
+  }
+
+ private:
+  const tz::TimeZone* timeZone_ = nullptr;
+};
+
+template <typename T>
 struct DateAddFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -534,8 +534,8 @@ struct DateFromUnixDateFunction {
   }
 };
 
-/// Truncates a timestamp to a specified time unit. Return null if the
-/// format is invalid, microseconds and abbreviated unit string are allowed.
+/// Truncates a timestamp to a specified time unit. Return NULL if the format is
+/// invalid. Format as abbreviated unit string and "microseconds" are allowed.
 template <typename T>
 struct DateTruncFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -534,6 +534,15 @@ struct DateFromUnixDateFunction {
   }
 };
 
+/// Truncates a timestamp to a specified time unit.
+/// For example:
+///   date_trunc('hour', timestamp '2020-05-26 11:30:00') -> '2020-05-26 11:00:00'
+///   date_trunc('day', timestamp '2020-05-26 11:30:00') -> '2020-05-26 00:00:00'
+///   date_trunc('month', timestamp '2020-05-26 11:30:00') -> '2020-05-01 00:00:00'
+///
+/// @param format The time unit to truncate to
+/// @param timestamp The timestamp to truncate
+/// @return The truncated timestamp, or null if the format is invalid
 template <typename T>
 struct DateTruncFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -550,7 +559,7 @@ struct DateTruncFunction {
       const arg_type<Varchar>& format,
       const arg_type<Timestamp>& timestamp) {
     std::optional<DateTimeUnit> unitOption =
-        fromDateTimeUnitString(format, false /*throwIfInvalid*/, true, true);
+        fromDateTimeUnitString(format, /*throwIfInvalid=*/false, true, true);
     // Return null if unit is illegal.
     if (!unitOption.has_value()) {
       return false;

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -92,6 +92,8 @@ void registerDatetimeFunctions(const std::string& prefix) {
       {prefix + "unix_millis"});
   registerUnaryIntegralWithTReturn<MillisToTimestampFunction, Timestamp>(
       {prefix + "timestamp_millis"});
+  registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
+      {prefix + "date_trunc"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1167,5 +1167,65 @@ TEST_F(DateTimeFunctionsTest, timestampToMillis) {
   EXPECT_EQ(timestampToMillis("-292275055-05-16 16:47:04.192"), kMinBigint);
 }
 
+TEST_F(DateTimeFunctionsTest, dateTrunc) {
+  const auto dateTrunc = [&](const std::string& format,
+                             std::optional<Timestamp> timestamp) {
+    return evaluateOnce<Timestamp>(
+        fmt::format("date_trunc('{}', c0)", format), timestamp);
+  };
+
+  EXPECT_EQ(std::nullopt, dateTrunc("second", std::nullopt));
+  EXPECT_EQ(std::nullopt, dateTrunc("", Timestamp(0, 0)));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 0)));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 123)));
+  EXPECT_EQ(Timestamp(-1, 0), dateTrunc("second", Timestamp(-1, 0)));
+  EXPECT_EQ(Timestamp(-1, 0), dateTrunc("second", Timestamp(-1, 123)));
+  EXPECT_EQ(Timestamp(0, 0), dateTrunc("day", Timestamp(0, 123)));
+  EXPECT_EQ(
+      Timestamp(998474645, 321'001'000),
+      dateTrunc("microsecond", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474645, 321'000'000),
+      dateTrunc("millisecond", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474645, 0),
+      dateTrunc("second", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474640, 0),
+      dateTrunc("minute", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998474400, 0),
+      dateTrunc("hour", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998438400, 0),
+      dateTrunc("day", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998438400, 0),
+      dateTrunc("dd", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(998265600, 0),
+      dateTrunc("week", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(996624000, 0),
+      dateTrunc("month", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(996624000, 0),
+      dateTrunc("mon", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(996624000, 0),
+      dateTrunc("mm", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(993945600, 0),
+      dateTrunc("quarter", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(978307200, 0),
+      dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(978307200, 0),
+      dateTrunc("yyyy", Timestamp(998'474'645, 321'001'234)));
+  EXPECT_EQ(
+      Timestamp(978307200, 0),
+      dateTrunc("yy", Timestamp(998'474'645, 321'001'234)));
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1176,6 +1176,7 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
 
   EXPECT_EQ(std::nullopt, dateTrunc("second", std::nullopt));
   EXPECT_EQ(std::nullopt, dateTrunc("", Timestamp(0, 0)));
+  EXPECT_EQ(std::nullopt, dateTrunc("y", Timestamp(0, 0)));
   EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 0)));
   EXPECT_EQ(Timestamp(0, 0), dateTrunc("second", Timestamp(0, 123)));
   EXPECT_EQ(Timestamp(-1, 0), dateTrunc("second", Timestamp(-1, 0)));


### PR DESCRIPTION
Adds Spark date_trunc function. Presto date_trunc function was refactored for reuse:
1. Moves class `DateTimeUnit` to `functions/lib/DateTimeFormatter.h`.
2. Extends function `fromDateTimeUnitString` by adding params `allowMicro` and
`allowAbbreviated` for Spark, and moves to `functions/lib/TimeUtils.h`.
4. Moves `adjustDateTime` and `adjustEpoch` functions to `functions/lib/TimeUtils.h`.
5. Extracts new function `truncateTimestamp` to `functions/lib/TimeUtils.h` .
