### PR TITLE
Use 'if constexpr' for Buffer::is_pod_like_v<T>

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -394,7 +394,7 @@ class AlignedBuffer : public Buffer {
       return;
     }
     velox::memory::MemoryPool* pool = old->pool();
-    if (!is_pod_like_v<T>) {
+    if constexpr (!is_pod_like_v<T>) {
       // We always take this code path for non-POD types because
       // pool->reallocate below would move memory around without calling move
       // constructor.

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -347,7 +347,7 @@ void FlatVector<T>::copyRanges(
       const T* sourceValues = flatSource->rawValues();
       applyToEachRange(
           ranges, [&](auto targetIndex, auto sourceIndex, auto count) {
-            if (Buffer::is_pod_like_v<T>) {
+            if constexpr (Buffer::is_pod_like_v<T>) {
               memcpy(
                   &rawValues_[targetIndex],
                   &sourceValues[sourceIndex],

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -169,7 +169,7 @@ class FlatVector final : public SimpleVector<T> {
         } else {
           auto dst = newValues->asMutable<T>();
           auto src = values_->as<T>();
-          if (Buffer::is_pod_like_v<T>) {
+          if constexpr (Buffer::is_pod_like_v<T>) {
             memcpy(dst, src, numCopyBytes);
           } else {
             std::copy(src, src + numCopyBytes / sizeof(T), dst);


### PR DESCRIPTION
`Buffer::is_pod_like_v<T>` is `static constexpr` so we can use  
'if constexpr' to check to ensure that it is evaluated at compile time,  
which might also improve performance a little bit.