### PR TITLE
Add custom comparator to IPAddressType

### DIFF
--- a/velox/functions/prestosql/GreatestLeast.h
+++ b/velox/functions/prestosql/GreatestLeast.h
@@ -66,8 +66,9 @@ struct ExtremeValueFunction {
     return wrapper;
   }
 
-  int64_t extractValue(
-      const exec::CustomTypeWithCustomComparisonView<int64_t>& wrapper) const {
+  template <typename U>
+  U extractValue(
+      const exec::CustomTypeWithCustomComparisonView<U>& wrapper) const {
     return *wrapper;
   }
 

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Comparisons.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Type.h"
 
@@ -30,6 +31,7 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
   registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
       aliases);
+  registerFunction<T, TReturn, IPAddress, IPAddress>(aliases);
 }
 } // namespace
 
@@ -37,6 +39,7 @@ void registerComparisonFunctions(const std::string& prefix) {
   // Comparison functions also need TimestampWithTimezoneType,
   // independent of DateTimeFunctions
   registerTimestampWithTimeZoneType();
+  registerIPAddressType();
 
   registerNonSimdizableScalar<EqFunction, bool>({prefix + "eq"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, prefix + "eq");
@@ -116,6 +119,8 @@ void registerComparisonFunctions(const std::string& prefix) {
       TimestampWithTimezone,
       TimestampWithTimezone,
       TimestampWithTimezone>({prefix + "between"});
+  registerFunction<BetweenFunction, bool, IPAddress, IPAddress, IPAddress>(
+      {prefix + "between"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
 #include "velox/functions/prestosql/Reduce.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::functions {
@@ -57,6 +58,7 @@ void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<Date>(prefix);
   registerGreatestLeastFunction<Timestamp>(prefix);
   registerGreatestLeastFunction<TimestampWithTimezone>(prefix);
+  registerGreatestLeastFunction<IPAddress>(prefix);
 }
 } // namespace
 

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -286,6 +286,46 @@ TEST_F(GreatestLeastTest, leastDate) {
       DATE());
 }
 
+TEST_F(GreatestLeastTest, greatestLeastIpAddress) {
+  auto greatest = [&](const std::optional<std::string>& a,
+                      const std::optional<std::string>& b,
+                      const std::optional<std::string>& c) {
+    return evaluateOnce<std::string>(
+        "cast(greatest(cast(c0 as ipaddress), cast(c1 as ipaddress), cast(c2 as ipaddress)) as varchar)",
+        a,
+        b,
+        c);
+  };
+
+  auto least = [&](const std::optional<std::string>& a,
+                   const std::optional<std::string>& b,
+                   const std::optional<std::string>& c) {
+    return evaluateOnce<std::string>(
+        "cast(least(cast(c0 as ipaddress), cast(c1 as ipaddress), cast(c2 as ipaddress)) as varchar)",
+        a,
+        b,
+        c);
+  };
+
+  auto greatestValue = greatest(
+      "1.1.1.1", "255.255.255.255", "2001:0db8:0000:0000:0000:ff00:0042:832");
+  EXPECT_EQ("2001:db8::ff00:42:832", greatestValue.value());
+
+  auto leastValue = least(
+      "1.1.1.1", "255.255.255.255", "2001:0db8:0000:0000:0000:ff00:0042:832");
+  EXPECT_EQ("1.1.1.1", leastValue.value());
+
+  auto greatestValueWithNulls =
+      greatest("1.1.1.1", "255.255.255.255", std::nullopt);
+  EXPECT_FALSE(greatestValueWithNulls.has_value());
+
+  auto leastValueWithNulls = least(
+      std::nullopt,
+      "255.255.255.255",
+      "2001:0db8:0000:0000:0000:ff00:0042:832");
+  EXPECT_FALSE(leastValueWithNulls.has_value());
+}
+
 TEST_F(GreatestLeastTest, stringBuffersMoved) {
   runTest<StringView>(
       "least(c0, c1)",

--- a/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
@@ -23,6 +23,11 @@ class IPAddressTypeTest : public testing::Test, public TypeTestBase {
   IPAddressTypeTest() {
     registerIPAddressType();
   }
+
+  int128_t getIPv6asInt128FromStringUnchecked(const std::string& ipAddr) {
+    auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
+    return ret.value();
+  }
 };
 
 TEST_F(IPAddressTypeTest, basic) {
@@ -37,5 +42,84 @@ TEST_F(IPAddressTypeTest, basic) {
 
 TEST_F(IPAddressTypeTest, serde) {
   testTypeSerde(IPADDRESS());
+}
+
+TEST_F(IPAddressTypeTest, compare) {
+  auto ipAddr = IPADDRESS();
+  // Baisc IPv4 test
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.1.1.1"),
+          getIPv6asInt128FromStringUnchecked("1.1.1.1")));
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("255.255.255.255"),
+          getIPv6asInt128FromStringUnchecked("255.255.255.255")));
+  ASSERT_GT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.2.3.4"),
+          getIPv6asInt128FromStringUnchecked("1.1.1.1")),
+      0);
+  ASSERT_GT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.1.1.2"),
+          getIPv6asInt128FromStringUnchecked("1.1.1.1")),
+      0);
+  ASSERT_GT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.1.2.1"),
+          getIPv6asInt128FromStringUnchecked("1.1.1.2")),
+      0);
+  ASSERT_LT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.1.1.1"),
+          getIPv6asInt128FromStringUnchecked("1.1.2.1")),
+      0);
+  ASSERT_LT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("1.1.1.1"),
+          getIPv6asInt128FromStringUnchecked("255.1.1.1")),
+      0);
+
+  // Basic IPv6 test
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::1"),
+          getIPv6asInt128FromStringUnchecked("::1")));
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked(
+              "2001:0db8:0000:0000:0000:ff00:0042:8329"),
+          getIPv6asInt128FromStringUnchecked("2001:db8::ff00:42:8329")));
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::ffff:1.2.3.4"),
+          getIPv6asInt128FromStringUnchecked("1.2.3.4")));
+  ASSERT_LT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::ffff:0.1.1.1"),
+          getIPv6asInt128FromStringUnchecked("::ffff:1.1.1.0")),
+      0);
+
+  ASSERT_GT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::FFFF:FFFF:FFFF"),
+          getIPv6asInt128FromStringUnchecked("::0001:255.255.255.255")),
+      0);
+  ASSERT_LT(
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::0001:255.255.255.255"),
+          getIPv6asInt128FromStringUnchecked("255.255.255.255")),
+      0);
+  ASSERT_EQ(
+      0,
+      ipAddr->compare(
+          getIPv6asInt128FromStringUnchecked("::ffff:ffff:ffff"),
+          getIPv6asInt128FromStringUnchecked("255.255.255.255")));
 }
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
We need a comparator for IPAddressType.

- Provide  providesCustomComparison = true to constructor to support custom comparison
- Compare by converting the int128_t/BIGINT to a byteArray, and reversing the byte order. We then use memcmp
- support between for IPAddressType

Differential Revision: D64880148


