### PR TITLE
misc: Improve OutputBufferManager initialization

### DIFF
--- a/velox/exec/OutputBufferManager.cpp
+++ b/velox/exec/OutputBufferManager.cpp
@@ -17,21 +17,33 @@
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
-// static
-void OutputBufferManager::initialize(const Options& options) {
-  std::lock_guard<std::mutex> l(initMutex_);
-  VELOX_CHECK(
-      instance_ == nullptr, "May initialize OutputBufferManager only once");
-  instance_ = std::make_shared<OutputBufferManager>(options);
-}
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 
 // static
 std::weak_ptr<OutputBufferManager> OutputBufferManager::getInstance() {
-  std::lock_guard<std::mutex> l(initMutex_);
-  if (!instance_) {
-    instance_ = std::make_shared<OutputBufferManager>(Options());
-  }
-  return instance_;
+  return getInstanceRef(Options());
+}
+
+// static
+void OutputBufferManager::initialize(const Options& options) {
+  getInstanceRef(options);
+}
+
+#endif
+
+// static
+const std::shared_ptr<OutputBufferManager>&
+OutputBufferManager::getInstanceRef() {
+  return getInstanceRef(Options());
+}
+
+// static
+const std::shared_ptr<OutputBufferManager>& OutputBufferManager::getInstanceRef(
+    const Options& options) {
+  static const std::shared_ptr<OutputBufferManager> instance =
+      std::make_shared<OutputBufferManager>(options);
+  return instance;
 }
 
 std::shared_ptr<OutputBuffer> OutputBufferManager::getBuffer(

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -27,7 +27,7 @@ class OutputBufferManager {
   /// agree.
   struct Options {};
 
-  explicit OutputBufferManager(Options /*unused*/) {}
+  explicit OutputBufferManager(Options options) : options_(options) {}
 
   void initializeTask(
       std::shared_ptr<Task> task,
@@ -94,11 +94,18 @@ class OutputBufferManager {
 
   void removeTask(const std::string& taskId);
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   /// Initializes singleton with 'options'. May be called once before
   /// getInstance().
   static void initialize(const Options& options);
 
   static std::weak_ptr<OutputBufferManager> getInstance();
+#endif
+
+  static const std::shared_ptr<OutputBufferManager>& getInstanceRef();
+
+  static const std::shared_ptr<OutputBufferManager>& getInstanceRef(
+      const Options& options);
 
   uint64_t numBuffers() const;
 
@@ -144,7 +151,6 @@ class OutputBufferManager {
   std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory_{
       nullptr};
 
-  inline static std::shared_ptr<OutputBufferManager> instance_;
-  inline static std::mutex initMutex_;
+  Options options_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -191,7 +191,7 @@ PartitionedOutput::PartitionedOutput(
           planNode->inputType(),
           planNode->outputType(),
           planNode->outputType())),
-      bufferManager_(OutputBufferManager::getInstance()),
+      bufferManager_(OutputBufferManager::getInstanceRef()),
       // NOTE: 'bufferReleaseFn_' holds a reference on the associated task to
       // prevent it from deleting while there are output buffers being accessed
       // out of the partitioned output buffer manager such as in Prestissimo,

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -305,7 +305,7 @@ Task::Task(
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(std::move(onError)),
       splitsStates_(buildSplitStates(planFragment_.planNode)),
-      bufferManager_(OutputBufferManager::getInstance()) {
+      bufferManager_(OutputBufferManager::getInstanceRef()) {
   // NOTE: the executor must not be folly::InlineLikeExecutor for parallel
   // execution.
   if (mode_ == Task::ExecutionMode::kParallel) {

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -62,7 +62,7 @@ class ExchangeClientTest
     if (!isRegisteredVectorSerde()) {
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
-    bufferManager_ = OutputBufferManager::getInstance().lock();
+    bufferManager_ = OutputBufferManager::getInstanceRef();
 
     common::testutil::TestValue::enable();
   }

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -287,7 +287,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
 
   // 'Delete results' from output buffer triggers 'set all output consumed',
   // which should finish the task.
-  auto outputBufferManager = exec::OutputBufferManager::getInstance().lock();
+  auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
   outputBufferManager->deleteResults(task->taskId(), 0);
 
   // Task must be finished at this stage.
@@ -471,7 +471,7 @@ DEBUG_ONLY_TEST_F(
 
     // 'Delete results' from output buffer triggers 'set all output consumed',
     // which should finish the task.
-    auto outputBufferManager = exec::OutputBufferManager::getInstance().lock();
+    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     // Task must be finished at this stage.
@@ -627,7 +627,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
 
     // 'Delete results' from output buffer triggers 'set all output consumed',
     // which should finish the task.
-    auto outputBufferManager = exec::OutputBufferManager::getInstance().lock();
+    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     // Task must be finished at this stage.

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -122,7 +122,7 @@ TEST_F(LimitTest, partialLimitEagerFlush) {
     params.planNode = builder.partitionedOutput({}, 1).planNode();
     auto cursor = TaskCursor::create(params);
     ASSERT_FALSE(cursor->moveNext());
-    auto bufferManager = exec::OutputBufferManager::getInstance().lock();
+    auto bufferManager = exec::OutputBufferManager::getInstanceRef();
     auto [numPagesPromise, numPagesFuture] = folly::makePromiseContract<int>();
     ASSERT_TRUE(bufferManager->getData(
         cursor->task()->taskId(),

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -209,7 +209,7 @@ class MultiFragmentTest : public HiveConnectorTestBase,
   std::vector<std::shared_ptr<TempFilePath>> filePaths_;
   std::vector<RowVectorPtr> vectors_;
   std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstance().lock()};
+      OutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(MultiFragmentTest, aggregationSingleKey) {
@@ -2379,7 +2379,7 @@ class DataFetcher {
   folly::EventCount bufferFullOrDoneWait_;
 
   std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstance().lock()};
+      OutputBufferManager::getInstanceRef()};
 };
 
 /// Verify that POBM::getData() honors maxBytes parameter roughly at 1MB

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -62,7 +62,7 @@ class OutputBufferManagerTest : public testing::Test {
 
   void SetUp() override {
     pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
-    bufferManager_ = OutputBufferManager::getInstance().lock();
+    bufferManager_ = OutputBufferManager::getInstanceRef();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -91,7 +91,7 @@ class PartitionedOutputTest
 
  private:
   const std::shared_ptr<OutputBufferManager> bufferManager_{
-      OutputBufferManager::getInstance().lock()};
+      OutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(PartitionedOutputTest, flush) {

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1045,7 +1045,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
                   .project({"c0 % 10"})
                   .partitionedOutputBroadcast({})
                   .planFragment();
-  auto bufferManager = OutputBufferManager::getInstance().lock();
+  auto bufferManager = OutputBufferManager::getInstanceRef();
   {
     auto task = Task::create(
         "t0",

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -52,7 +52,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
 
     promise_ = std::move(promise);
 
-    auto buffers = OutputBufferManager::getInstance().lock();
+    auto buffers = OutputBufferManager::getInstanceRef();
     VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");
     VELOX_CHECK(requestPending_);
     auto requestedSequence = sequence_;
@@ -165,7 +165,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void pause() override {
     common::testutil::TestValue::adjust(
         "facebook::velox::exec::test::LocalExchangeSource::pause", nullptr);
-    auto buffers = OutputBufferManager::getInstance().lock();
+    auto buffers = OutputBufferManager::getInstanceRef();
     VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");
     int64_t ackSequence;
     {
@@ -178,7 +178,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void close() override {
     checkSetRequestPromise();
 
-    auto buffers = OutputBufferManager::getInstance().lock();
+    auto buffers = OutputBufferManager::getInstanceRef();
     buffers->deleteResults(remoteTaskId_, destination_);
   }
 

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -63,7 +63,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
   const core::PartitionedOutputNode* const originalNode_;
   const VectorSerde::Kind serdeKind_;
   const std::shared_ptr<exec::OutputBufferManager> bufferManager_{
-      exec::OutputBufferManager::getInstance().lock()};
+      exec::OutputBufferManager::getInstanceRef()};
   const std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency(),

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -120,7 +120,7 @@ class PartitionedOutputReplayerTest
   }
 
   const std::shared_ptr<OutputBufferManager> bufferManager_{
-      exec::OutputBufferManager::getInstance().lock()};
+      exec::OutputBufferManager::getInstanceRef()};
 };
 
 TEST_P(PartitionedOutputReplayerTest, defaultConsumer) {


### PR DESCRIPTION
Starting from C++11, the C++ standard guarantees that the initialization
    of function-local static variables is thread-safe. This is better than
    using a global mutex, especially for subsequent getInstance() calls. This
    is because the overhead of using a static local variable only needs to do
    a simple check to see if the variable has already been initialized, while
    for the global mutex case, all getInstance() calls need to aquire this
    lock exclusively.