### PR TITLE
Remove unneeded Exchange::result_ member

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -103,9 +103,6 @@ class Exchange : public SourceOperator {
   /// there are more splits available or no-more-splits signal has arrived.
   ContinueFuture splitFuture_{ContinueFuture::makeEmpty()};
 
-  // Reusable result vector.
-  RowVectorPtr result_;
-
   std::shared_ptr<ExchangeClient> exchangeClient_;
   std::vector<std::unique_ptr<SerializedPage>> currentPages_;
   bool atEnd_{false};


### PR DESCRIPTION
`RowVector` is not reused between multiple calls to `getOutput()`. Each 
time `Exchange::getOutput()` is called, a new `RowVector` object will 
be created.

Therefore, there is no need to save a `result_` member in the Exchange 
operator. Saving this member will also cause its reference count to be 
greater than 1, so that the last obtained RowVector object cannot be 
released in time (currently, it needs to wait until the next call to 
`getOutptu` or `close()` method).