### PR TITLE
Fix the global arbitration check failure when it is disabled

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -304,6 +304,10 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     return state_ == State::kShutdown;
   }
 
+  FOLLY_ALWAYS_INLINE void checkGlobalArbitrationEnabled() const {
+    VELOX_CHECK(globalArbitrationEnabled_, "Global arbitration is not enabled");
+  }
+
   // Invoked to get the arbitration participant by 'name'. The function returns
   // std::nullopt if the underlying query memory pool is destroyed.
   std::optional<ScopedArbitrationParticipant> getParticipant(


### PR DESCRIPTION
Summary:
Some memory intensive queries run into check failure on global arbitration flag before they
start to wait for global memory arbitration as it is not enabled in those clusters. The issue is because
of a bug that we fall back to global arbitration when query which fails to allocate memory from the system
and within the capacity limit and is not qualified to do memory reclaim from itself.
This PR fixes this with unit test.

Differential Revision: D65073054


