### PR TITLE
Fix tsan flaky test MockSharedArbitrationTest.concurrentArbitrationWithTransientRoots

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1030,7 +1030,7 @@ class MemoryPoolImpl : public MemoryPool {
   std::unique_ptr<MemoryReclaimer> reclaimer_;
 
   // The memory cap in bytes to enforce.
-  int64_t capacity_;
+  tsan_atomic<int64_t> capacity_;
 
   // The number of reservation bytes.
   tsan_atomic<int64_t> reservationBytes_{0};


### PR DESCRIPTION
Summary:
concurrentArbitrationWithTransientRoots detects a data race when we try to log root pool's capacity
from a leaf pool which doesn't hold the lock on the root but only the leaf. This is mostly for logging and
we don't want to introduce the locking on the root which might cause potential deadlock or performance
issue. Change this to tsan variable to pass the test.

Differential Revision: D65075928


