### PR TITLE
Unify and utilize NPROC variable for Linux setup scripts

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -102,7 +102,7 @@ function install_lzo {
   (
     cd ${DEPENDENCY_DIR}/lzo
     ./configure --prefix=${INSTALL_PREFIX} --enable-shared --disable-static --docdir=/usr/share/doc/lzo-2.10
-    make "-j$(nproc)"
+    make "-j${NPROC}"
     make install
   )
 }
@@ -117,10 +117,10 @@ function install_boost {
       # clang of version 15 when toolset clang-15 is used.
       # This reconciles the project-config.jam generation with what the b2 build system allows for customization.
       sed -i 's/using clang-15/using clang : 15/g' project-config.jam
-      ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi toolset=clang-15 --without-python
+      ${SUDO} ./b2 "-j${NPROC}" -d0 install threading=multi toolset=clang-15 --without-python
     else
       ./bootstrap.sh --prefix=${INSTALL_PREFIX}
-      ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+      ${SUDO} ./b2 "-j${NPROC}" -d0 install threading=multi --without-python
     fi
   )
 }

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -128,10 +128,10 @@ function install_boost {
       # clang of version 15 when toolset clang-15 is used.
       # This reconciles the project-config.jam generation with what the b2 build system allows for customization.
       sed -i 's/using clang-15/using clang : 15/g' project-config.jam
-      ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi toolset=clang-15 --without-python
+      ${SUDO} ./b2 "-j${NPROC}" -d0 install threading=multi toolset=clang-15 --without-python
     else
       ./bootstrap.sh --prefix=${INSTALL_PREFIX}
-      ${SUDO} ./b2 "-j$(nproc)" -d0 install threading=multi --without-python
+      ${SUDO} ./b2 "-j${NPROC}" -d0 install threading=multi --without-python
     fi
   )
 }


### PR DESCRIPTION
This PR unifies the usage of the number of parallel build threads by using the defined NPROC variable. This variable is populated by the same mechanisms on macOS and Linux ensuring consistency and sharable functions for the script refactor.