### PR TITLE
feat(fuzzer): Constrained input generators for fuzzers

### DIFF
--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -12,14 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_vector_fuzzer GeneratorSpec.cpp Utils.cpp VectorFuzzer.cpp)
+add_library(velox_vector_fuzzer_util Utils.cpp)
 
 target_link_libraries(
-  velox_vector_fuzzer velox_type velox_vector)
+  velox_vector_fuzzer_util velox_vector)
+
+add_library(velox_vector_fuzzer GeneratorSpec.cpp VectorFuzzer.cpp)
+
+target_link_libraries(
+  velox_vector_fuzzer velox_type velox_vector velox_vector_fuzzer_util)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(velox_vector_fuzzer
                          PRIVATE -Wno-deprecated-declarations)
 endif()
+
+add_library(velox_fuzzer_constrained_input_generators
+            ConstrainedGenerators.cpp ConstrainedVectorGenerator.cpp)
+
+target_link_libraries(
+  velox_fuzzer_constrained_input_generators
+  Folly::folly
+  velox_expression
+  velox_type
+  velox_vector_fuzzer_util)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/vector/fuzzer/ConstrainedGenerators.cpp
+++ b/velox/vector/fuzzer/ConstrainedGenerators.cpp
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/fuzzer/ConstrainedGenerators.h"
+
+#include <boost/random/uniform_int_distribution.hpp>
+
+#include "velox/vector/fuzzer/Utils.h"
+
+namespace facebook::velox::fuzzer {
+
+// AbstractInputGenerator
+AbstractInputGenerator::AbstractInputGenerator(
+    size_t seed,
+    const TypePtr& type,
+    std::unique_ptr<AbstractInputGenerator>&& next,
+    double nullRatio)
+    : type_{type}, next_{std::move(next)}, nullRatio_{nullRatio} {
+  rng_.seed(seed);
+}
+
+// NotEqualConstrainedGenerator
+variant NotEqualConstrainedGenerator::generate() {
+  variant value;
+  do {
+    value = next_->generate();
+  } while (value == excludedValue_);
+  return value;
+}
+
+// SetConstrainedGenerator
+variant SetConstrainedGenerator::generate() {
+  const auto index =
+      boost::random::uniform_int_distribution<size_t>(0, set_.size() - 1)(rng_);
+  return set_[index];
+}
+
+// JsonInputGenerator
+folly::json::serialization_opts JsonInputGenerator::getSerializationOptions() {
+  folly::json::serialization_opts opts;
+  opts.allow_non_string_keys = true;
+  opts.allow_nan_inf = true;
+  if (makeRandomVariation_) {
+    opts.convert_int_keys = rand<bool>(rng_);
+    opts.pretty_formatting = rand<bool>(rng_);
+    opts.pretty_formatting_indent_width = rand<uint32_t>(rng_, 0, 4);
+    opts.encode_non_ascii = rand<bool>(rng_);
+    opts.sort_keys = rand<bool>(rng_);
+    opts.skip_invalid_utf8 = rand<bool>(rng_);
+  }
+  return opts;
+}
+
+variant JsonInputGenerator::generate() {
+  if (coinToss(rng_, nullRatio_)) {
+    return variant::null(type_->kind());
+  }
+
+  const auto object = objectGenerator_->generate();
+  const folly::dynamic jsonObject = convertVariantToDynamic(object);
+  const auto jsonString = folly::json::serialize(jsonObject, opts_);
+  if (makeRandomVariation_ && coinToss(rng_, 0.5)) {
+    makeRandomVariation(jsonString);
+  }
+  return variant(jsonString);
+}
+
+folly::dynamic JsonInputGenerator::convertVariantToDynamic(
+    const variant& object) {
+  if (object.isNull()) {
+    return folly::dynamic();
+  }
+
+  switch (object.kind()) {
+    case TypeKind::BOOLEAN:
+      return convertVariantToDynamicPrimitive<TypeKind::BOOLEAN>(object);
+    case TypeKind::TINYINT:
+      return convertVariantToDynamicPrimitive<TypeKind::TINYINT>(object);
+    case TypeKind::SMALLINT:
+      return convertVariantToDynamicPrimitive<TypeKind::SMALLINT>(object);
+    case TypeKind::INTEGER:
+      return convertVariantToDynamicPrimitive<TypeKind::INTEGER>(object);
+    case TypeKind::BIGINT:
+      return convertVariantToDynamicPrimitive<TypeKind::BIGINT>(object);
+    case TypeKind::REAL:
+      return convertVariantToDynamicPrimitive<TypeKind::REAL>(object);
+    case TypeKind::DOUBLE:
+      return convertVariantToDynamicPrimitive<TypeKind::DOUBLE>(object);
+    case TypeKind::VARCHAR:
+      return convertVariantToDynamicPrimitive<TypeKind::VARCHAR>(object);
+    case TypeKind::VARBINARY:
+      return convertVariantToDynamicPrimitive<TypeKind::VARBINARY>(object);
+    case TypeKind::TIMESTAMP:
+      return convertVariantToDynamicPrimitive<TypeKind::TIMESTAMP>(object);
+    case TypeKind::HUGEINT:
+      return convertVariantToDynamicPrimitive<TypeKind::HUGEINT>(object);
+    case TypeKind::ARRAY: {
+      folly::dynamic array = folly::dynamic::array;
+      for (const auto& element : object.value<TypeKind::ARRAY>()) {
+        array.push_back(convertVariantToDynamic(element));
+      }
+      return array;
+    }
+    case TypeKind::MAP: {
+      folly::dynamic map = folly::dynamic::object;
+      for (const auto& [key, value] : object.value<TypeKind::MAP>()) {
+        map[convertVariantToDynamic(key)] = convertVariantToDynamic(value);
+      }
+      return map;
+    }
+    case TypeKind::ROW: {
+      folly::dynamic array = folly::dynamic::array;
+      for (const auto& element : object.value<TypeKind::ROW>()) {
+        array.push_back(convertVariantToDynamic(element));
+      }
+      return array;
+    }
+    default:
+      VELOX_UNREACHABLE("Unsupported type");
+  }
+}
+
+std::vector<std::string> getControlCharacters() {
+  static std::vector<std::string> controlCharacters = {
+      "\x00",   "\x01",   "\x02",   "\x03",   "\x04",   "\x05",   "\x06",
+      "\x07",   "\x08",   "\x09",   "\x0A",   "\x0B",   "\x0C",   "\x0D",
+      "\x0E",   "\x0F",   "\x10",   "\x11",   "\x12",   "\x13",   "\x14",
+      "\x15",   "\x16",   "\x17",   "\x18",   "\x19",   "\x1A",   "\x1B",
+      "\x1C",   "\x1D",   "\x1E",   "\x1F",   "\x20",   "\x7F",   "\u0080",
+      "\u0081", "\u0082", "\u0083", "\u0084", "\u0085", "\u0086", "\u0087",
+      "\u0088", "\u0089", "\u008A", "\u008B", "\u008C", "\u008D", "\u008E",
+      "\u008F", "\u0090", "\u0091", "\u0092", "\u0093", "\u0094", "\u0095",
+      "\u0096", "\u0097", "\u0098", "\u0099", "\u009A", "\u009B", "\u009C",
+      "\u009D", "\u009E", "\u009F"};
+  return controlCharacters;
+};
+
+void JsonInputGenerator::makeRandomVariation(std::string json) {
+  if (coinToss(rng_, 0.1)) {
+    const auto controlCharacters = getControlCharacters();
+    const auto index = rand<uint32_t>(rng_, 0, controlCharacters.size() - 1);
+    const auto& controlCharacter = controlCharacters[index];
+    const auto indexToInsert = rand<uint32_t>(rng_, 0, json.size());
+    json.insert(indexToInsert, controlCharacter);
+  } else if (coinToss(rng_, 0.1)) {
+    const auto size = rand<uint32_t>(rng_, 0, json.size());
+    json.resize(size);
+  }
+}
+
+// Utility functions
+template <bool, TypeKind KIND>
+std::unique_ptr<AbstractInputGenerator> getRandomInputGeneratorPrimitive(
+    size_t seed,
+    const TypePtr& type,
+    double nullRatio) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  std::unique_ptr<AbstractInputGenerator> generator =
+      std::make_unique<RandomInputGenerator<T>>(seed, type, nullRatio);
+  return generator;
+}
+
+std::unique_ptr<AbstractInputGenerator>
+getRandomInputGenerator(size_t seed, const TypePtr& type, double nullRatio) {
+  std::unique_ptr<AbstractInputGenerator> generator;
+  if (type->isPrimitiveType()) {
+    return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+        getRandomInputGeneratorPrimitive,
+        false,
+        type->kind(),
+        seed,
+        type,
+        nullRatio);
+  } else if (type->isArray()) {
+    generator = std::make_unique<RandomInputGenerator<ArrayType>>(
+        seed, type, nullRatio);
+  } else if (type->isMap()) {
+    generator =
+        std::make_unique<RandomInputGenerator<MapType>>(seed, type, nullRatio);
+
+  } else if (type->isRow()) {
+    generator = std::make_unique<RandomInputGenerator<RowType>>(
+        seed,
+        type,
+        std::vector<std::unique_ptr<AbstractInputGenerator>>{},
+        nullRatio);
+  }
+  return generator;
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/vector/fuzzer/ConstrainedGenerators.h
+++ b/velox/vector/fuzzer/ConstrainedGenerators.h
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "folly/json.h"
+
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+#include "velox/vector/fuzzer/Utils.h"
+
+namespace facebook::velox::fuzzer {
+
+using facebook::velox::variant;
+
+class AbstractInputGenerator {
+ public:
+  AbstractInputGenerator(
+      size_t seed,
+      const TypePtr& type,
+      std::unique_ptr<AbstractInputGenerator>&& next,
+      double nullRatio);
+
+  virtual ~AbstractInputGenerator() = default;
+
+  virtual variant generate() = 0;
+
+  TypePtr type() const {
+    return type_;
+  }
+
+ protected:
+  FuzzerGenerator rng_;
+
+  TypePtr type_;
+
+  std::unique_ptr<AbstractInputGenerator> next_;
+
+  double nullRatio_;
+};
+
+std::unique_ptr<AbstractInputGenerator>
+getRandomInputGenerator(size_t seed, const TypePtr& type, double nullRatio);
+
+template <typename T, typename Enabled = void>
+class RandomInputGenerator : public AbstractInputGenerator {
+ public:
+  RandomInputGenerator(size_t seed, const TypePtr& type, double nullRatio)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio) {}
+
+  ~RandomInputGenerator() override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(type_->kind());
+    }
+
+    if (type_->isDate()) {
+      return variant(randDate(rng_));
+    }
+    return variant(rand<T>(rng_));
+  }
+};
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+template <typename T>
+class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>
+    : public AbstractInputGenerator {
+ public:
+  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      size_t maxLength = 20,
+      const std::vector<UTF8CharList>& encodings =
+          {UTF8CharList::ASCII,
+           UTF8CharList::UNICODE_CASE_SENSITIVE,
+           UTF8CharList::EXTENDED_UNICODE,
+           UTF8CharList::MATHEMATICAL_SYMBOLS})
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio),
+        maxLength_{maxLength},
+        encodings_{encodings} {}
+
+  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>()
+      override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(type_->kind());
+    }
+
+    const auto length = rand<size_t>(rng_, 0, maxLength_);
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
+    std::string buf;
+    return variant(randString(rng_, length, encodings_, buf, converter));
+  }
+
+ private:
+  const size_t maxLength_;
+
+  std::vector<UTF8CharList> encodings_;
+};
+#pragma GCC diagnostic pop
+
+template <typename T>
+class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>
+    : public AbstractInputGenerator {
+ public:
+  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      size_t maxLength = 10,
+      std::unique_ptr<AbstractInputGenerator>&& elementGenerator = nullptr,
+      std::optional<size_t> containAtIndex = std::nullopt,
+      std::unique_ptr<AbstractInputGenerator>&& containGenerator = nullptr)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio),
+        maxLength_{maxLength},
+        elementGenerator_{
+            elementGenerator
+                ? std::move(elementGenerator)
+                : getRandomInputGenerator(seed, type->childAt(0), nullRatio)},
+        containAtIndex_{containAtIndex},
+        containGenerator_{std::move(containGenerator)} {}
+
+  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>()
+      override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(TypeKind::ARRAY);
+    }
+
+    const auto length = containAtIndex_.has_value()
+        ? rand<size_t>(rng_, containAtIndex_.value() + 1, maxLength_)
+        : rand<size_t>(rng_, 0, maxLength_);
+    std::vector<variant> elements;
+    elements.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+      if UNLIKELY (containAtIndex_.has_value() && *containAtIndex_ == i) {
+        elements.push_back(containGenerator_->generate());
+      } else {
+        elements.push_back(elementGenerator_->generate());
+      }
+    }
+    return variant::array(elements);
+  }
+
+ private:
+  const size_t maxLength_;
+
+  std::unique_ptr<AbstractInputGenerator> elementGenerator_;
+
+  std::optional<size_t> containAtIndex_;
+
+  std::unique_ptr<AbstractInputGenerator> containGenerator_;
+};
+
+template <typename T>
+class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>
+    : public AbstractInputGenerator {
+ public:
+  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      size_t maxLength = 10,
+      std::unique_ptr<AbstractInputGenerator>&& keyGenerator = nullptr,
+      std::unique_ptr<AbstractInputGenerator>&& valueGenerator = nullptr,
+      std::unique_ptr<AbstractInputGenerator>&& containKeyGenerator = nullptr,
+      std::unique_ptr<AbstractInputGenerator>&& containValueGenerator = nullptr)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio),
+        maxLength_{maxLength},
+        keyGenerator_{
+            keyGenerator
+                ? std::move(keyGenerator)
+                : getRandomInputGenerator(seed, type->childAt(0), 0.0)},
+        valueGenerator_{
+            valueGenerator
+                ? std::move(valueGenerator)
+                : getRandomInputGenerator(seed, type->childAt(1), nullRatio)},
+        containKeyGenerator_{std::move(containKeyGenerator)},
+        containValueGenerator_{std::move(containValueGenerator)} {
+    if (containKeyGenerator_ || containValueGenerator_) {
+      VELOX_CHECK_NOT_NULL(containKeyGenerator_);
+      VELOX_CHECK_NOT_NULL(containValueGenerator_);
+    }
+  }
+
+  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>()
+      override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(TypeKind::MAP);
+    }
+
+    const auto length = rand<size_t>(rng_, 0, maxLength_);
+    int64_t containAtIndex = (length > 0 && containKeyGenerator_ != nullptr)
+        ? rand<size_t>(rng_, 0, length - 1)
+        : -1;
+    std::map<variant, variant> map;
+    for (int64_t i = 0; i < length; ++i) {
+      if UNLIKELY (i == containAtIndex) {
+        map.emplace(
+            containKeyGenerator_->generate(),
+            containValueGenerator_->generate());
+      } else {
+        map.emplace(keyGenerator_->generate(), valueGenerator_->generate());
+      }
+    }
+    return variant::map(map);
+  }
+
+ private:
+  const size_t maxLength_;
+
+  std::unique_ptr<AbstractInputGenerator> keyGenerator_;
+
+  std::unique_ptr<AbstractInputGenerator> valueGenerator_;
+
+  std::unique_ptr<AbstractInputGenerator> containKeyGenerator_;
+
+  std::unique_ptr<AbstractInputGenerator> containValueGenerator_;
+};
+
+template <typename T>
+class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>
+    : public AbstractInputGenerator {
+ public:
+  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>(
+      size_t seed,
+      const TypePtr& type,
+      std::vector<std::unique_ptr<AbstractInputGenerator>> fieldGenerators,
+      double nullRatio)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio) {
+    const auto length = type->size();
+    fieldGenerators_ = std::move(fieldGenerators);
+    for (size_t i = 0; i < length; ++i) {
+      if (fieldGenerators_.size() <= i) {
+        fieldGenerators_.push_back(
+            getRandomInputGenerator(seed, type->childAt(i), nullRatio));
+      } else if (fieldGenerators_[i] == nullptr) {
+        fieldGenerators_[i] =
+            getRandomInputGenerator(seed, type->childAt(i), nullRatio);
+      }
+    }
+  }
+
+  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>()
+      override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(TypeKind::ROW);
+    }
+
+    const auto length = type_->size();
+    std::vector<variant> fields;
+    fields.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+      fields.push_back(fieldGenerators_[i]->generate());
+    }
+    return variant::row(fields);
+  }
+
+ private:
+  std::vector<std::unique_ptr<AbstractInputGenerator>> fieldGenerators_;
+};
+
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+class RangeConstrainedGenerator : public AbstractInputGenerator {
+ public:
+  RangeConstrainedGenerator(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      T min,
+      T max)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio),
+        min_{min},
+        max_{max} {}
+
+  ~RangeConstrainedGenerator() override = default;
+
+  variant generate() override {
+    if (coinToss(rng_, nullRatio_)) {
+      return variant::null(type_->kind());
+    }
+    return variant(rand<T>(rng_, min_, max_));
+  }
+
+ private:
+  T min_;
+  T max_;
+};
+
+class NotEqualConstrainedGenerator : public AbstractInputGenerator {
+ public:
+  // nullRatio doesn't affect the data generation because it is 'next' that
+  // generates data.
+  NotEqualConstrainedGenerator(
+      size_t seed,
+      const TypePtr& type,
+      const variant& excludedValue,
+      std::unique_ptr<AbstractInputGenerator>&& next)
+      : AbstractInputGenerator(seed, type, std::move(next), 0.0),
+        excludedValue_{excludedValue} {}
+
+  ~NotEqualConstrainedGenerator() override = default;
+
+  variant generate() override;
+
+ private:
+  variant excludedValue_;
+};
+
+class SetConstrainedGenerator : public AbstractInputGenerator {
+ public:
+  // nullRatio doesn't affect the data generation because only variants in 'set'
+  // can be generated.
+  SetConstrainedGenerator(
+      size_t seed,
+      const TypePtr& type,
+      const std::vector<variant>& set)
+      : AbstractInputGenerator(seed, type, nullptr, 0.0), set_{set} {}
+
+  ~SetConstrainedGenerator() override = default;
+
+  variant generate() override;
+
+ private:
+  std::vector<variant> set_;
+};
+
+class JsonInputGenerator : public AbstractInputGenerator {
+ public:
+  JsonInputGenerator(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      std::unique_ptr<AbstractInputGenerator>&& objectGenerator,
+      bool makeRandomVariation = false)
+      : AbstractInputGenerator(seed, type, nullptr, nullRatio),
+        objectGenerator_{std::move(objectGenerator)},
+        makeRandomVariation_{makeRandomVariation},
+        opts_{getSerializationOptions()} {}
+
+  ~JsonInputGenerator() override = default;
+
+  variant generate() override;
+
+  const folly::json::serialization_opts& serializationOptions() const {
+    return opts_;
+  }
+
+ private:
+  template <TypeKind KIND>
+  folly::dynamic convertVariantToDynamicPrimitive(const variant& v) {
+    using T = typename TypeTraits<KIND>::DeepCopiedType;
+    VELOX_CHECK(v.isSet());
+    const T value = v.value<T>();
+    return folly::dynamic(value);
+  }
+
+  folly::dynamic convertVariantToDynamic(const variant& object);
+
+  void makeRandomVariation(std::string json);
+
+  folly::json::serialization_opts getSerializationOptions();
+
+  std::unique_ptr<AbstractInputGenerator> objectGenerator_;
+
+  bool makeRandomVariation_;
+
+  folly::json::serialization_opts opts_;
+};
+
+} // namespace facebook::velox::fuzzer

--- a/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
+++ b/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/fuzzer/ConstrainedVectorGenerator.h"
+
+#include "velox/expression/VectorWriters.h"
+
+namespace facebook::velox::fuzzer {
+
+using exec::GenericWriter;
+using exec::VectorWriter;
+
+// static
+VectorPtr ConstrainedVectorGenerator::generateConstant(
+    const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+    vector_size_t size,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(customGenerator);
+  VELOX_CHECK(customGenerator->type()->isPrimitiveType());
+
+  const auto& type = customGenerator->type();
+  const auto variant = customGenerator->generate();
+
+  return BaseVector::createConstant(type, variant, size, pool);
+}
+
+template <TypeKind KIND>
+void writeOne(const variant& v, GenericWriter& writer);
+template <>
+void writeOne<TypeKind::VARCHAR>(const variant& v, GenericWriter& writer);
+template <>
+void writeOne<TypeKind::VARBINARY>(const variant& v, GenericWriter& writer);
+template <>
+void writeOne<TypeKind::ARRAY>(const variant& v, GenericWriter& writer);
+template <>
+void writeOne<TypeKind::MAP>(const variant& v, GenericWriter& writer);
+template <>
+void writeOne<TypeKind::ROW>(const variant& v, GenericWriter& writer);
+
+template <TypeKind KIND>
+void writeOne(const variant& v, GenericWriter& writer) {
+  using T = typename TypeTraits<KIND>::NativeType;
+  writer.template castTo<T>() = v.value<KIND>();
+}
+
+template <>
+void writeOne<TypeKind::VARCHAR>(const variant& v, GenericWriter& writer) {
+  writer.template castTo<Varchar>() = v.value<TypeKind::VARCHAR>();
+}
+
+template <>
+void writeOne<TypeKind::VARBINARY>(const variant& v, GenericWriter& writer) {
+  writer.template castTo<Varbinary>() = v.value<TypeKind::VARBINARY>();
+}
+
+template <>
+void writeOne<TypeKind::ARRAY>(const variant& v, GenericWriter& writer) {
+  auto& writerTyped = writer.template castTo<Array<Any>>();
+  const auto& elements = v.array();
+  for (const auto& element : elements) {
+    if (element.isNull()) {
+      writerTyped.add_null();
+    } else {
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, element.kind(), element, writerTyped.add_item());
+    }
+  }
+}
+
+template <>
+void writeOne<TypeKind::MAP>(const variant& v, GenericWriter& writer) {
+  auto& writerTyped = writer.template castTo<Map<Any, Any>>();
+  const auto& map = v.map();
+  for (const auto& pair : map) {
+    const auto& key = pair.first;
+    const auto& value = pair.second;
+    VELOX_CHECK(!key.isNull());
+    if (value.isNull()) {
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, key.kind(), key, writerTyped.add_null());
+    } else {
+      auto writers = writerTyped.add_item();
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, key.kind(), key, std::get<0>(writers));
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, value.kind(), value, std::get<1>(writers));
+    }
+  }
+}
+
+template <>
+void writeOne<TypeKind::ROW>(const variant& v, GenericWriter& writer) {
+  auto& writerTyped = writer.template castTo<DynamicRow>();
+  const auto& elements = v.row();
+  column_index_t i = 0;
+  for (const auto& element : elements) {
+    if (element.isNull()) {
+      writerTyped.set_null_at(i);
+    } else {
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, element.kind(), element, writerTyped.get_writer_at(i));
+    }
+    i++;
+  }
+}
+
+// static
+VectorPtr ConstrainedVectorGenerator::generateFlat(
+    const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+    vector_size_t size,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(customGenerator);
+
+  VectorPtr result;
+  const auto& type = customGenerator->type();
+  BaseVector::ensureWritable(SelectivityVector(size), type, pool, result);
+  VectorWriter<Any> writer;
+  writer.init(*result);
+
+  for (auto i = 0; i < size; ++i) {
+    writer.setOffset(i);
+    const auto variant = customGenerator->generate();
+    if (variant.isNull()) {
+      writer.commitNull();
+    } else {
+      VELOX_DYNAMIC_TYPE_DISPATCH(
+          writeOne, type->kind(), variant, writer.current());
+      writer.commit(true);
+    }
+  }
+  return result;
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/vector/fuzzer/ConstrainedVectorGenerator.h
+++ b/velox/vector/fuzzer/ConstrainedVectorGenerator.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/fuzzer/ConstrainedGenerators.h"
+
+namespace facebook::velox::fuzzer {
+
+class ConstrainedVectorGenerator {
+ public:
+  ConstrainedVectorGenerator() = delete;
+
+  static VectorPtr generateConstant(
+      const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+      vector_size_t size,
+      memory::MemoryPool* pool);
+
+  static VectorPtr generateFlat(
+      const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+      vector_size_t size,
+      memory::MemoryPool* pool);
+};
+
+} // namespace facebook::velox::fuzzer

--- a/velox/vector/fuzzer/Utils.cpp
+++ b/velox/vector/fuzzer/Utils.cpp
@@ -16,12 +16,128 @@
 
 #include "velox/vector/fuzzer/Utils.h"
 
-namespace facebook::velox::generator_spec_utils {
+namespace facebook::velox {
 
 bool coinToss(FuzzerGenerator& rng, double threshold) {
   static std::uniform_real_distribution<> dist(0.0, 1.0);
   return dist(rng) < threshold;
 }
+
+Timestamp randTimestamp(
+    FuzzerGenerator& rng,
+    FuzzerTimestampPrecision timestampPrecision) {
+  // Generate timestamps only in the valid range to avoid datetime functions,
+  // such as try_cast(varchar as timestamp), throwing VeloxRuntimeError in
+  // fuzzers.
+  constexpr int64_t min = -2'140'671'600;
+  constexpr int64_t max = 2'140'671'600;
+  constexpr int64_t microInSecond = 1'000'000;
+  constexpr int64_t millisInSecond = 1'000;
+  // DWRF requires nano to be in a certain range. Hardcode the value here to
+  // avoid the dependency on DWRF.
+  constexpr int64_t MAX_NANOS = 1'000'000'000;
+
+  switch (timestampPrecision) {
+    case FuzzerTimestampPrecision::kNanoSeconds:
+      return Timestamp(
+          rand<int64_t>(rng, min, max), (rand<int64_t>(rng) % MAX_NANOS));
+    case FuzzerTimestampPrecision::kMicroSeconds:
+      return Timestamp::fromMicros(
+          rand<int64_t>(rng, min, max) * microInSecond +
+          rand<int64_t>(rng, -microInSecond, microInSecond));
+    case FuzzerTimestampPrecision::kMilliSeconds:
+      return Timestamp::fromMillis(
+          rand<int64_t>(rng, min, max) * millisInSecond +
+          rand<int64_t>(rng, -millisInSecond, millisInSecond));
+    case FuzzerTimestampPrecision::kSeconds:
+      return Timestamp(rand<int64_t>(rng, min, max), 0);
+  }
+  return {}; // no-op.
+}
+
+int32_t randDate(FuzzerGenerator& rng) {
+  constexpr int64_t min = -24'450;
+  constexpr int64_t max = 24'450;
+  return rand<int32_t>(rng, min, max);
+}
+
+/// Unicode character ranges. Ensure the vector indexes match the UTF8CharList
+/// enum values.
+///
+/// Source: https://jrgraphix.net/research/unicode_blocks.php
+static const std::vector<std::vector<std::pair<char16_t, char16_t>>>
+    kUTFChatSets{
+        // UTF8CharList::ASCII
+        {
+            {33, 127}, // All ASCII printable chars.
+        },
+        // UTF8CharList::UNICODE_CASE_SENSITIVE
+        {
+            {u'\u0020', u'\u007F'}, // Basic Latin.
+            {u'\u0400', u'\u04FF'}, // Cyrillic.
+        },
+        // UTF8CharList::EXTENDED_UNICODE
+        {
+            {u'\u03F0', u'\u03FF'}, // Greek.
+            {u'\u0100', u'\u017F'}, // Latin Extended A.
+            {u'\u0600', u'\u06FF'}, // Arabic.
+            {u'\u0900', u'\u097F'}, // Devanagari.
+            {u'\u0600', u'\u06FF'}, // Hebrew.
+            {u'\u3040', u'\u309F'}, // Hiragana.
+            {u'\u2000', u'\u206F'}, // Punctuation.
+            {u'\u2070', u'\u209F'}, // Sub/Super Script.
+            {u'\u20A0', u'\u20CF'}, // Currency.
+        },
+        // UTF8CharList::MATHEMATICAL_SYMBOLS
+        {
+            {u'\u2200', u'\u22FF'}, // Math Operators.
+            {u'\u2150', u'\u218F'}, // Number Forms.
+            {u'\u25A0', u'\u25FF'}, // Geometric Shapes.
+            {u'\u27C0', u'\u27EF'}, // Math Symbols.
+            {u'\u2A00', u'\u2AFF'}, // Supplemental.
+        },
+    };
+
+FOLLY_ALWAYS_INLINE char16_t getRandomChar(
+    FuzzerGenerator& rng,
+    const std::vector<std::pair<char16_t, char16_t>>& charSet) {
+  const auto& chars = charSet.size() == 1
+      ? charSet.front()
+      : charSet[rand<uint32_t>(rng) % charSet.size()];
+  auto size = chars.second - chars.first;
+  auto inc = (rand<uint32_t>(rng) % size);
+  char16_t res = chars.first + inc;
+  return res;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+std::string randString(
+    FuzzerGenerator& rng,
+    size_t length,
+    const std::vector<UTF8CharList>& encodings,
+    std::string& buf,
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t>& converter) {
+  buf.clear();
+  std::u16string wbuf;
+  wbuf.resize(length);
+
+  for (size_t i = 0; i < length; ++i) {
+    // First choose a random encoding from the list of input acceptable
+    // encodings.
+    VELOX_CHECK_GE(encodings.size(), 1);
+    const auto& encoding = (encodings.size() == 1)
+        ? encodings.front()
+        : encodings[rand<uint32_t>(rng) % encodings.size()];
+
+    wbuf[i] = getRandomChar(rng, kUTFChatSets[encoding]);
+  }
+  buf.append(converter.to_bytes(wbuf));
+  return buf;
+}
+#pragma GCC diagnostic pop
+
+namespace generator_spec_utils {
 
 vector_size_t getRandomIndex(FuzzerGenerator& rng, vector_size_t maxIndex) {
   std::uniform_int_distribution<vector_size_t> indexGenerator(
@@ -59,4 +175,6 @@ BufferPtr generateIndicesBuffer(
   return indices;
 }
 
-} // namespace facebook::velox::generator_spec_utils
+} // namespace generator_spec_utils
+
+} // namespace facebook::velox

--- a/velox/vector/fuzzer/Utils.h
+++ b/velox/vector/fuzzer/Utils.h
@@ -16,6 +16,13 @@
 
 #pragma once
 
+#include <codecvt>
+#include <random>
+
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int_distribution.hpp>
+#include <boost/random/uniform_real_distribution.hpp>
+
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/NullsBuilder.h"
 
@@ -25,6 +32,20 @@ namespace facebook::velox {
 
 using FuzzerGenerator = folly::detail::DefaultGenerator;
 
+enum UTF8CharList {
+  ASCII = 0, // Ascii character set.
+  UNICODE_CASE_SENSITIVE = 1, // Unicode scripts that support case.
+  EXTENDED_UNICODE = 2, // Extended Unicode: Arabic, Devanagiri etc
+  MATHEMATICAL_SYMBOLS = 3 // Mathematical Symbols.
+};
+
+bool coinToss(FuzzerGenerator& rng, double threshold);
+
+struct DataSpec {
+  bool includeNaN;
+  bool includeInfinity;
+};
+
 enum class FuzzerTimestampPrecision : int8_t {
   kNanoSeconds = 0,
   kMicroSeconds = 1,
@@ -32,9 +53,116 @@ enum class FuzzerTimestampPrecision : int8_t {
   kSeconds = 3,
 };
 
-namespace generator_spec_utils {
+// Generate random values for the different supported types.
+template <typename T>
+inline T rand(
+    FuzzerGenerator& /*rng*/,
+    DataSpec /*dataSpec*/ = {false, false}) {
+  VELOX_NYI();
+}
 
-bool coinToss(FuzzerGenerator& rng, double threshold);
+template <>
+inline int8_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<int8_t>()(rng);
+}
+
+template <>
+inline int16_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<int16_t>()(rng);
+}
+
+template <>
+inline int32_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<int32_t>()(rng);
+}
+
+template <>
+inline int64_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<int64_t>()(rng);
+}
+
+template <>
+inline double rand(FuzzerGenerator& rng, DataSpec dataSpec) {
+  if (dataSpec.includeNaN && coinToss(rng, 0.05)) {
+    return std::nan("");
+  }
+
+  if (dataSpec.includeInfinity && coinToss(rng, 0.05)) {
+    return std::numeric_limits<double>::infinity();
+  }
+
+  return boost::random::uniform_01<double>()(rng);
+}
+
+template <>
+inline float rand(FuzzerGenerator& rng, DataSpec dataSpec) {
+  if (dataSpec.includeNaN && coinToss(rng, 0.05)) {
+    return std::nanf("");
+  }
+
+  if (dataSpec.includeInfinity && coinToss(rng, 0.05)) {
+    return std::numeric_limits<float>::infinity();
+  }
+
+  return boost::random::uniform_01<float>()(rng);
+}
+
+template <>
+inline bool rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<uint32_t>(0, 1)(rng);
+}
+
+template <>
+inline uint32_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<uint32_t>()(rng);
+}
+
+template <>
+inline uint64_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return boost::random::uniform_int_distribution<uint64_t>()(rng);
+}
+
+template <>
+inline int128_t rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  return HugeInt::build(rand<int64_t>(rng), rand<uint64_t>(rng));
+}
+
+Timestamp randTimestamp(
+    FuzzerGenerator& rng,
+    FuzzerTimestampPrecision timestampPrecision);
+
+template <>
+inline Timestamp rand(FuzzerGenerator& rng, DataSpec /*dataSpec*/) {
+  // TODO: support other timestamp precisions.
+  return randTimestamp(rng, FuzzerTimestampPrecision::kMicroSeconds);
+}
+
+int32_t randDate(FuzzerGenerator& rng);
+
+template <
+    typename T,
+    typename std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
+inline T rand(FuzzerGenerator& rng, T min, T max) {
+  if constexpr (std::is_integral_v<T>) {
+    return boost::random::uniform_int_distribution<T>(min, max)(rng);
+  } else {
+    return boost::random::uniform_real_distribution<T>(min, max)(rng);
+  }
+}
+
+/// Generates a random string in buf with characters of encodings. Return buf at
+/// the end.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+std::string randString(
+    FuzzerGenerator& rng,
+    size_t length,
+    const std::vector<UTF8CharList>& encodings,
+    std::string& buf,
+    std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t>& converter);
+#pragma GCC diagnostic pop
+
+namespace generator_spec_utils {
 
 vector_size_t getRandomIndex(FuzzerGenerator& rng, vector_size_t maxIndex);
 

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -26,18 +26,6 @@
 
 namespace facebook::velox {
 
-enum UTF8CharList {
-  ASCII = 0, // Ascii character set.
-  UNICODE_CASE_SENSITIVE = 1, // Unicode scripts that support case.
-  EXTENDED_UNICODE = 2, // Extended Unicode: Arabic, Devanagiri etc
-  MATHEMATICAL_SYMBOLS = 3 // Mathematical Symbols.
-};
-
-struct DataSpec {
-  bool includeNaN;
-  bool includeInfinity;
-};
-
 const std::vector<TypePtr>& defaultScalarTypes();
 
 /// VectorFuzzer is a helper class that generates randomized vectors and their

--- a/velox/vector/fuzzer/tests/CMakeLists.txt
+++ b/velox/vector/fuzzer/tests/CMakeLists.txt
@@ -22,3 +22,21 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
   GTest::gmock)
+
+add_executable(velox_fuzzer_constrained_input_generators_test
+               ConstrainedGeneratorsTest.cpp)
+
+add_test(
+  NAME velox_fuzzer_constrained_input_generators_test
+  COMMAND velox_fuzzer_constrained_input_generators_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(
+  velox_fuzzer_constrained_input_generators_test
+  velox_fuzzer_constrained_input_generators
+  velox_presto_types
+  velox_type
+  velox_vector_test_lib
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)

--- a/velox/vector/fuzzer/tests/ConstrainedGeneratorsTest.cpp
+++ b/velox/vector/fuzzer/tests/ConstrainedGeneratorsTest.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/fuzzer/ConstrainedGenerators.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/type/Variant.h"
+#include "velox/vector/fuzzer/ConstrainedVectorGenerator.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::fuzzer::test {
+
+class ConstrainedGeneratorsTest : public testing::Test,
+                                  public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  template <TypeKind KIND>
+  void testRandomPrimitive(const TypePtr& type, bool testNull) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+    using T = typename TypeTraits<KIND>::NativeType;
+
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RandomInputGenerator<T>>(
+            0, type, testNull ? 1.0 : 0.0);
+    auto value = generator->generate();
+    if (testNull) {
+      EXPECT_FALSE(value.hasValue());
+    } else {
+      EXPECT_TRUE(value.hasValue());
+    }
+    EXPECT_EQ(value.kind(), KIND);
+  }
+
+  template <TypeKind KIND>
+  void testRandomComplex(const TypePtr& type, bool testNull) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+    using T = typename TypeTraits<KIND>::ImplType;
+
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RandomInputGenerator<T>>(
+            0, type, testNull ? 1.0 : 0.0);
+    auto value = generator->generate();
+    EXPECT_EQ(value.kind(), KIND);
+    if (testNull) {
+      EXPECT_FALSE(value.hasValue());
+    } else {
+      EXPECT_TRUE(value.hasValue());
+    }
+  }
+
+  template <typename T>
+  void testRangePrimitive(const TypePtr& type, T min, T max, bool testNull) {
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RangeConstrainedGenerator<T>>(
+            0, type, testNull ? 1.0 : 0.0, min, max);
+
+    const uint32_t kIterations = 1000;
+    const variant lower = variant(min);
+    const variant upper = variant(max);
+    for (uint32_t i = 0; i < kIterations; ++i) {
+      auto value = generator->generate();
+      EXPECT_EQ(value.kind(), type->kind());
+      if (testNull) {
+        EXPECT_FALSE(value.hasValue());
+      } else {
+        EXPECT_TRUE(value.hasValue());
+        EXPECT_TRUE(lower < value || lower == value);
+        EXPECT_TRUE(value < upper || value == upper);
+      }
+    }
+  }
+
+  template <typename T>
+  void testRangeInComplex(const TypePtr& type, T min, T max, bool testNull) {
+    EXPECT_TRUE(type->isArray() && type->childAt(0)->isPrimitiveType());
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RandomInputGenerator<ArrayType>>(
+            0,
+            type,
+            0.0,
+            1000,
+            std::make_unique<RangeConstrainedGenerator<T>>(
+                0, type, testNull ? 1.0 : 0.0, min, max));
+
+    const auto value = generator->generate();
+    EXPECT_EQ(value.kind(), TypeKind::ARRAY);
+    EXPECT_TRUE(value.hasValue());
+
+    const auto elements = value.array();
+    const variant lower = variant(min);
+    const variant upper = variant(max);
+    for (const auto& element : elements) {
+      if (testNull) {
+        EXPECT_FALSE(element.hasValue());
+      } else {
+        EXPECT_TRUE(element.hasValue());
+        EXPECT_TRUE(lower < element || lower == element);
+        EXPECT_TRUE(element < upper || element == upper);
+      }
+    }
+  }
+
+  template <typename T>
+  void testContainInArray(const TypePtr& type, T containedValue) {
+    EXPECT_TRUE(type->isArray() && type->childAt(0)->isPrimitiveType());
+    const auto kMaxLength = 10;
+    const auto kContainAtIndex = 5;
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RandomInputGenerator<ArrayType>>(
+            0,
+            type,
+            0.0,
+            kMaxLength,
+            nullptr,
+            kContainAtIndex,
+            std::make_unique<SetConstrainedGenerator>(
+                0,
+                type->childAt(0),
+                std::vector<variant>{variant(containedValue)}));
+
+    const uint32_t kIterations = 100;
+    for (auto i = 0; i < kIterations; ++i) {
+      const auto value = generator->generate();
+      EXPECT_EQ(value.kind(), TypeKind::ARRAY);
+      EXPECT_TRUE(value.hasValue());
+
+      const auto elements = value.array();
+      EXPECT_EQ(elements[kContainAtIndex], variant(containedValue));
+    }
+  }
+
+  template <typename TKey, typename TValue>
+  void testContainInMap(
+      const TypePtr& type,
+      TKey containedKey,
+      TValue containedValue) {
+    EXPECT_TRUE(
+        type->isMap() && type->childAt(0)->isPrimitiveType() &&
+        type->childAt(1)->isPrimitiveType());
+    const auto kMaxLength = 10;
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<RandomInputGenerator<MapType>>(
+            0,
+            type,
+            0.0,
+            kMaxLength,
+            nullptr,
+            nullptr,
+            std::make_unique<SetConstrainedGenerator>(
+                0,
+                type->childAt(0),
+                std::vector<variant>{variant(containedKey)}),
+            std::make_unique<SetConstrainedGenerator>(
+                0,
+                type->childAt(1),
+                std::vector<variant>{variant(containedValue)}));
+
+    const uint32_t kIterations = 100;
+    for (auto i = 0; i < kIterations; ++i) {
+      const auto value = generator->generate();
+      EXPECT_EQ(value.kind(), TypeKind::MAP);
+      EXPECT_TRUE(value.hasValue());
+
+      const auto pairs = value.map();
+      if (!pairs.empty()) {
+        EXPECT_TRUE(pairs.count(variant{containedKey}) > 0);
+        EXPECT_TRUE(pairs.at(variant{containedKey}) == variant{containedValue});
+      }
+    }
+  }
+
+  template <TypeKind KIND, typename TValue>
+  void testNotEqualPrimitive(
+      const TypePtr& type,
+      const TValue& excludedValue,
+      bool testNull) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+    using T = typename TypeTraits<KIND>::NativeType;
+
+    variant excludedVariant{excludedValue};
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<NotEqualConstrainedGenerator>(
+            0,
+            type,
+            excludedVariant,
+            std::make_unique<RandomInputGenerator<T>>(
+                0, type, testNull ? 1.0 : 0.0));
+
+    const uint32_t kIterations = 1000;
+    for (uint32_t i = 0; i < kIterations; ++i) {
+      auto value = generator->generate();
+      EXPECT_EQ(value.kind(), KIND);
+      if (testNull) {
+        EXPECT_FALSE(value.hasValue());
+      } else {
+        EXPECT_TRUE(value.hasValue());
+        EXPECT_NE(value, excludedVariant);
+      }
+    }
+  }
+
+  template <TypeKind KIND>
+  void testNotEqualComplex(
+      const TypePtr& type,
+      const variant& excludedVariant,
+      bool testNull) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+    using T = typename TypeTraits<KIND>::ImplType;
+
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<NotEqualConstrainedGenerator>(
+            0,
+            type,
+            excludedVariant,
+            std::make_unique<RandomInputGenerator<T>>(
+                0, type, testNull ? 1.0 : 0.0));
+
+    const uint32_t kIterations = 1000;
+    for (uint32_t i = 0; i < kIterations; ++i) {
+      auto value = generator->generate();
+      EXPECT_EQ(value.kind(), KIND);
+      if (testNull) {
+        EXPECT_FALSE(value.hasValue());
+      } else {
+        EXPECT_TRUE(value.hasValue());
+        EXPECT_NE(value, excludedVariant);
+      }
+    }
+  }
+
+  template <TypeKind KIND, typename TSet>
+  void testSetPrimitive(const TypePtr& type, const TSet& setOfRawValues) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+
+    const uint32_t kIterations = 1000;
+    std::vector<variant> variants;
+    for (const auto& value : setOfRawValues) {
+      variants.push_back(variant{value});
+    }
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<SetConstrainedGenerator>(0, type, variants);
+
+    for (uint32_t i = 0; i < kIterations; ++i) {
+      auto value = generator->generate();
+      EXPECT_TRUE(value.hasValue());
+      EXPECT_EQ(value.kind(), KIND);
+      EXPECT_NE(setOfRawValues.count(value.value<KIND>()), 0);
+    }
+  }
+
+  template <TypeKind KIND>
+  void testSetComplex(
+      const TypePtr& type,
+      const std::vector<variant>& variants) {
+    VELOX_CHECK_EQ(type->kind(), KIND);
+
+    std::set<variant> setOfVariants{variants.begin(), variants.end()};
+    std::unique_ptr<AbstractInputGenerator> generator =
+        std::make_unique<SetConstrainedGenerator>(0, type, variants);
+
+    const uint32_t kIterations = 1000;
+    for (uint32_t i = 0; i < kIterations; ++i) {
+      auto value = generator->generate();
+      EXPECT_TRUE(value.hasValue());
+      EXPECT_EQ(value.kind(), KIND);
+      EXPECT_NE(setOfVariants.count(value), 0);
+    }
+  }
+
+  template <TypeKind KIND>
+  void testGenerateVectorsPrimitive(
+      const TypePtr& type,
+      const variant& excludedValue) {
+    using T = typename TypeTraits<KIND>::NativeType;
+    const uint32_t kSize = 1000;
+    std::shared_ptr<AbstractInputGenerator> generator =
+        std::make_shared<NotEqualConstrainedGenerator>(
+            0,
+            type,
+            excludedValue,
+            std::make_unique<RandomInputGenerator<T>>(0, type, 0.5));
+    auto vector =
+        ConstrainedVectorGenerator::generateConstant(generator, kSize, pool());
+    EXPECT_EQ(vector->size(), kSize);
+    EXPECT_EQ(vector->typeKind(), KIND);
+    EXPECT_TRUE(vector->isConstantEncoding());
+    EXPECT_TRUE(
+        vector->isNullAt(0) ||
+        vector->as<ConstantVector<T>>()->valueAt(0) != excludedValue);
+
+    vector = ConstrainedVectorGenerator::generateFlat(generator, kSize, pool());
+    EXPECT_EQ(vector->size(), kSize);
+    EXPECT_EQ(vector->typeKind(), KIND);
+    EXPECT_TRUE(vector->isFlatEncoding());
+    bool hasNull = false;
+    for (auto i = 0; i < kSize; ++i) {
+      if (vector->isNullAt(i)) {
+        hasNull = true;
+      } else {
+        EXPECT_NE(vector->as<FlatVector<T>>()->valueAt(i), excludedValue);
+      }
+    }
+    EXPECT_TRUE(hasNull);
+  }
+
+  template <TypeKind KIND>
+  void testGenerateVectorsComplex(const TypePtr& type) {
+    using T = typename TypeTraits<KIND>::ImplType;
+    const uint32_t kSize = 1000;
+    std::shared_ptr<AbstractInputGenerator> generator =
+        std::make_shared<RandomInputGenerator<T>>(0, type, 0.5);
+    auto vector =
+        ConstrainedVectorGenerator::generateFlat(generator, kSize, pool());
+    EXPECT_EQ(vector->size(), kSize);
+    EXPECT_EQ(vector->type(), type);
+  }
+};
+
+TEST_F(ConstrainedGeneratorsTest, randomPrimitive) {
+  testRandomPrimitive<TypeKind::INTEGER>(INTEGER(), false);
+  testRandomPrimitive<TypeKind::VARCHAR>(VARCHAR(), false);
+
+  testRandomPrimitive<TypeKind::INTEGER>(INTEGER(), true);
+  testRandomPrimitive<TypeKind::VARCHAR>(VARCHAR(), true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, randomComplex) {
+  testRandomComplex<TypeKind::ARRAY>(
+      ARRAY(MAP(VARCHAR(), ROW({BIGINT()}))), false);
+  testRandomComplex<TypeKind::ARRAY>(
+      ARRAY(MAP(VARCHAR(), ROW({BIGINT()}))), true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, rangePrimitive) {
+  testRangePrimitive<int64_t>(BIGINT(), 1, 10, false);
+  testRangePrimitive<int64_t>(BIGINT(), 1, 10, true);
+
+  testRangePrimitive<float>(REAL(), 1.0, 10.0, false);
+  testRangePrimitive<float>(REAL(), 1.0, 10.0, true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, rangeInComplex) {
+  testRangeInComplex<int64_t>(ARRAY(BIGINT()), 1, 10, false);
+  testRangeInComplex<int64_t>(ARRAY(BIGINT()), 1, 10, true);
+
+  testRangeInComplex<float>(ARRAY(REAL()), 1.0, 10.0, false);
+  testRangeInComplex<float>(ARRAY(REAL()), 1.0, 10.0, true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, containInComplex) {
+  testContainInArray<int64_t>(ARRAY(BIGINT()), 999);
+  testContainInMap<std::string, int64_t>(MAP(VARCHAR(), BIGINT()), "key", 999);
+}
+
+TEST_F(ConstrainedGeneratorsTest, notEqPrimitive) {
+  testNotEqualPrimitive<TypeKind::TINYINT>(
+      TINYINT(), static_cast<int8_t>(1), false);
+  testNotEqualPrimitive<TypeKind::VARCHAR>(VARCHAR(), ""_sv, false);
+
+  testNotEqualPrimitive<TypeKind::TINYINT>(
+      TINYINT(), static_cast<int8_t>(1), true);
+  testNotEqualPrimitive<TypeKind::VARCHAR>(VARCHAR(), ""_sv, true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, notEqComplex) {
+  auto excludedVariant = variant::array({variant::map(
+      {{variant{"1"}, variant::row({variant{static_cast<int32_t>(1)}})}})});
+  testNotEqualComplex<TypeKind::ARRAY>(
+      ARRAY(MAP(VARCHAR(), ROW({BIGINT()}))), excludedVariant, false);
+  testNotEqualComplex<TypeKind::ARRAY>(
+      ARRAY(MAP(VARCHAR(), ROW({BIGINT()}))), excludedVariant, true);
+}
+
+TEST_F(ConstrainedGeneratorsTest, setPrimitive) {
+  std::unordered_set<int32_t> integers{{1, 2, 3}};
+  testSetPrimitive<TypeKind::INTEGER>(INTEGER(), integers);
+
+  std::unordered_set<std::string> strings{{"1", "2", "3"}};
+  testSetPrimitive<TypeKind::VARCHAR>(VARCHAR(), strings);
+}
+
+TEST_F(ConstrainedGeneratorsTest, setComplex) {
+  std::vector<variant> variants{
+      variant::array({variant::map(
+          {{variant{"1"}, variant::row({variant{static_cast<int32_t>(1)}})}})}),
+      variant::array({variant::map(
+          {{variant{"2"},
+            variant::row({variant{static_cast<int32_t>(2)}})}})})};
+  testSetComplex<TypeKind::ARRAY>(
+      ARRAY(MAP(VARCHAR(), ROW({BIGINT()}))), variants);
+}
+
+TEST_F(ConstrainedGeneratorsTest, json) {
+  const TypePtr type = ARRAY(MAP(DOUBLE(), ROW({BIGINT()})));
+  std::unique_ptr<JsonInputGenerator> generator =
+      std::make_unique<JsonInputGenerator>(
+          0,
+          JSON(),
+          0.4,
+          std::make_unique<RandomInputGenerator<ArrayType>>(0, type, 0.4));
+
+  const uint32_t kIterations = 1000;
+  const auto& opts = generator->serializationOptions();
+  for (uint32_t i = 0; i < kIterations; ++i) {
+    auto value = generator->generate();
+    EXPECT_EQ(value.kind(), TypeKind::VARCHAR);
+    if (value.hasValue()) {
+      EXPECT_TRUE(value.hasValue());
+      folly::dynamic json;
+      auto jsonString = value.value<TypeKind::VARCHAR>();
+      EXPECT_NO_THROW(
+          json = folly::parseJson(value.value<TypeKind::VARCHAR>(), opts));
+      EXPECT_TRUE(json.isNull() || json.isArray());
+    }
+  }
+}
+
+TEST_F(ConstrainedGeneratorsTest, generateVectors) {
+  testGenerateVectorsPrimitive<TypeKind::BIGINT>(BIGINT(), variant(0));
+  testGenerateVectorsPrimitive<TypeKind::VARCHAR>(VARCHAR(), variant(""));
+
+  testGenerateVectorsComplex<TypeKind::ARRAY>(
+      ARRAY(ROW({MAP(VARCHAR(), BIGINT())})));
+  testGenerateVectorsComplex<TypeKind::MAP>(
+      MAP(ARRAY(BIGINT()), ROW({VARCHAR()})));
+}
+
+} // namespace facebook::velox::fuzzer::test


### PR DESCRIPTION
Summary:
This diff adds the constrained input generators for fuzzers. These generators can be 
used to generate random data satisfying given constraints, needed for fuzzers for testing 
functions that have special requirement on input data, such as json functions and 
timestamp with timezone functions, etc.

Differential Revision: D65101030


