### PR TITLE
Change the arrow dependency from private to public in velox_external_hdfs

### DIFF
--- a/velox/external/hdfs/CMakeLists.txt
+++ b/velox/external/hdfs/CMakeLists.txt
@@ -14,6 +14,6 @@ if(${VELOX_ENABLE_HDFS})
   velox_add_library(velox_external_hdfs ArrowHdfsInternal.cpp)
   velox_link_libraries(
         velox_external_hdfs
-        PRIVATE
+        PUBLIC
         arrow)
 endif()


### PR DESCRIPTION
Fix https://github.com/facebookincubator/velox/pull/9835#discussion_r1820046134