### PR TITLE
Add arbitration lock time out to shared arbitrator

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -347,7 +347,6 @@ std::shared_ptr<MemoryPool> deprecatedAddDefaultLeafMemoryPool(
 /// using this method can get a pool that is shared with other threads. The goal
 /// is to minimize lock contention while supporting such use cases.
 ///
-///
 /// TODO: deprecate this API after all the use cases are able to manage the
 /// lifecycle of the allocated memory pools properly.
 MemoryPool& deprecatedSharedLeafPool();

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -449,8 +449,12 @@ bool MemoryArbitrator::Stats::operator<=(const Stats& other) const {
   return !(*this > other);
 }
 
-MemoryArbitrationContext::MemoryArbitrationContext(const MemoryPool* requestor)
-    : type(Type::kLocal), requestorName(requestor->name()) {}
+MemoryArbitrationContext::MemoryArbitrationContext(
+    const MemoryPool* requestor,
+    ArbitrationOperation* _op)
+    : type(Type::kLocal), requestorName(requestor->name()), op(_op) {
+  VELOX_CHECK_NOT_NULL(op);
+}
 
 std::string MemoryArbitrationContext::typeName(
     MemoryArbitrationContext::Type type) {
@@ -465,8 +469,10 @@ std::string MemoryArbitrationContext::typeName(
 }
 
 ScopedMemoryArbitrationContext::ScopedMemoryArbitrationContext(
-    const MemoryPool* requestor)
-    : savedArbitrationCtx_(arbitrationCtx), currentArbitrationCtx_(requestor) {
+    const MemoryPool* requestor,
+    ArbitrationOperation* op)
+    : savedArbitrationCtx_(arbitrationCtx),
+      currentArbitrationCtx_(requestor, op) {
   arbitrationCtx = &currentArbitrationCtx_;
 }
 

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 
 using namespace ::testing;
 
@@ -989,13 +990,19 @@ TEST_F(MemoryReclaimerTest, arbitrationContext) {
   ASSERT_FALSE(isSpillMemoryPool(leafChild2.get()));
   ASSERT_TRUE(memoryArbitrationContext() == nullptr);
   {
-    ScopedMemoryArbitrationContext arbitrationContext(leafChild1.get());
+    auto arbitrationStructs =
+        test::ArbitrationTestStructs::createArbitrationTestStructs(leafChild1);
+    ScopedMemoryArbitrationContext arbitrationContext(
+        leafChild1.get(), arbitrationStructs.operation.get());
     ASSERT_TRUE(memoryArbitrationContext() != nullptr);
     ASSERT_EQ(memoryArbitrationContext()->requestorName, leafChild1->name());
   }
   ASSERT_TRUE(memoryArbitrationContext() == nullptr);
   {
-    ScopedMemoryArbitrationContext arbitrationContext(leafChild2.get());
+    auto arbitrationStructs =
+        test::ArbitrationTestStructs::createArbitrationTestStructs(leafChild2);
+    ScopedMemoryArbitrationContext arbitrationContext(
+        leafChild2.get(), arbitrationStructs.operation.get());
     ASSERT_TRUE(memoryArbitrationContext() != nullptr);
     ASSERT_EQ(memoryArbitrationContext()->requestorName, leafChild2->name());
   }
@@ -1003,13 +1010,21 @@ TEST_F(MemoryReclaimerTest, arbitrationContext) {
   std::thread nonAbitrationThread([&]() {
     ASSERT_TRUE(memoryArbitrationContext() == nullptr);
     {
-      ScopedMemoryArbitrationContext arbitrationContext(leafChild1.get());
+      auto arbitrationStructs =
+          test::ArbitrationTestStructs::createArbitrationTestStructs(
+              leafChild1);
+      ScopedMemoryArbitrationContext arbitrationContext(
+          leafChild1.get(), arbitrationStructs.operation.get());
       ASSERT_TRUE(memoryArbitrationContext() != nullptr);
       ASSERT_EQ(memoryArbitrationContext()->requestorName, leafChild1->name());
     }
     ASSERT_TRUE(memoryArbitrationContext() == nullptr);
     {
-      ScopedMemoryArbitrationContext arbitrationContext(leafChild2.get());
+      auto arbitrationStructs =
+          test::ArbitrationTestStructs::createArbitrationTestStructs(
+              leafChild2);
+      ScopedMemoryArbitrationContext arbitrationContext(
+          leafChild2.get(), arbitrationStructs.operation.get());
       ASSERT_TRUE(memoryArbitrationContext() != nullptr);
       ASSERT_EQ(memoryArbitrationContext()->requestorName, leafChild2->name());
     }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/common/memory/SharedArbitrator.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TestValue.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
@@ -3887,7 +3888,10 @@ TEST_P(MemoryPoolTest, overuseUnderArbitration) {
   ASSERT_FALSE(child->maybeReserve(2 * kMaxSize));
   ASSERT_EQ(child->usedBytes(), 0);
   ASSERT_EQ(child->reservedBytes(), 0);
-  ScopedMemoryArbitrationContext scopedMemoryArbitration(child.get());
+  auto arbitrationTestStructs =
+      test::ArbitrationTestStructs::createArbitrationTestStructs(root);
+  ScopedMemoryArbitrationContext scopedMemoryArbitration(
+      root.get(), arbitrationTestStructs.operation.get());
   ASSERT_TRUE(underMemoryArbitration());
   ASSERT_TRUE(child->maybeReserve(2 * kMaxSize));
   ASSERT_EQ(child->usedBytes(), 0);

--- a/velox/common/memory/tests/SharedArbitratorTestUtil.h
+++ b/velox/common/memory/tests/SharedArbitratorTestUtil.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include "velox/common/memory/ArbitrationParticipant.h"
 #include "velox/common/memory/SharedArbitrator.h"
@@ -29,7 +30,7 @@ class SharedArbitratorTestHelper {
   }
 
   size_t numParticipants() {
-    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    std::lock_guard<std::mutex> l(arbitrator_->stateMutex_);
     return arbitrator_->participants_.size();
   }
 
@@ -38,12 +39,12 @@ class SharedArbitratorTestHelper {
   }
 
   size_t numGlobalArbitrationWaiters() const {
-    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    std::lock_guard<std::mutex> l(arbitrator_->stateMutex_);
     return arbitrator_->globalArbitrationWaiters_.size();
   }
 
   bool globalArbitrationRunning() const {
-    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    std::lock_guard<std::mutex> l(arbitrator_->stateMutex_);
     return arbitrator_->globalArbitrationRunning_;
   }
 
@@ -70,7 +71,7 @@ class SharedArbitratorTestHelper {
   }
 
   bool hasShutdown() const {
-    std::lock_guard<std::mutex> l(arbitrator_->stateLock_);
+    std::lock_guard<std::mutex> l(arbitrator_->stateMutex_);
     return arbitrator_->hasShutdownLocked();
   }
 
@@ -107,4 +108,42 @@ class ArbitrationParticipantTestHelper {
  private:
   ArbitrationParticipant* const participant_;
 };
+
+struct ArbitrationTestStructs {
+  ArbitrationParticipant::Config config;
+  std::shared_ptr<ArbitrationParticipant> participant{nullptr};
+  std::shared_ptr<ArbitrationOperation> operation{nullptr};
+
+  static ArbitrationTestStructs createArbitrationTestStructs(
+      const std::shared_ptr<MemoryPool>& pool,
+      uint64_t initCapacity = 1024,
+      uint64_t minCapacity = 128,
+      uint64_t fastExponentialGrowthCapacityLimit = 0,
+      double slowCapacityGrowRatio = 0,
+      uint64_t minFreeCapacity = 0,
+      double minFreeCapacityRatio = 0,
+      uint64_t minReclaimBytes = 128,
+      uint64_t abortCapacityLimit = 512,
+      uint64_t requestBytes = 128,
+      uint64_t maxArbitrationTimeNs = 1'000'000'000'000UL /* 1'000s */) {
+    ArbitrationTestStructs ret{
+        .config = ArbitrationParticipant::Config(
+            initCapacity,
+            minCapacity,
+            fastExponentialGrowthCapacityLimit,
+            slowCapacityGrowRatio,
+            minFreeCapacity,
+            minFreeCapacityRatio,
+            minReclaimBytes,
+            abortCapacityLimit)};
+    ret.participant = ArbitrationParticipant::create(
+        folly::Random::rand64(), pool, &ret.config);
+    ret.operation = std::make_shared<ArbitrationOperation>(
+        ScopedArbitrationParticipant(ret.participant, pool),
+        requestBytes,
+        maxArbitrationTimeNs);
+    return ret;
+  }
+};
+
 } // namespace facebook::velox::memory::test

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -18,6 +18,7 @@
 #include <random>
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Statistics.h"
@@ -1734,7 +1735,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
     const auto oldReservedBytes = writerPool->reservedBytes();
     const auto oldUsedBytes = writerPool->usedBytes();
     {
-      memory::ScopedMemoryArbitrationContext arbitrationCtx(writerPool.get());
+      auto arbitrationStructs =
+          memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+              writerPool);
+      memory::ScopedMemoryArbitrationContext arbitrationCtx(
+          writerPool.get(), arbitrationStructs.operation.get());
       writerPool->reclaim(1L << 30, 0, stats);
     }
     ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
@@ -1773,7 +1778,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimOnWrite) {
       writer->testingNonReclaimableSection() = false;
       stats.numNonReclaimableAttempts = 0;
       {
-        memory::ScopedMemoryArbitrationContext arbitrationCtx(writerPool.get());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                writerPool);
+        memory::ScopedMemoryArbitrationContext arbitrationCtx(
+            writerPool.get(), arbitrationStructs.operation.get());
         const auto reclaimedBytes = writerPool->reclaim(1L << 30, 0, stats);
         ASSERT_GT(reclaimedBytes, 0);
       }
@@ -2115,7 +2124,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimThreshold) {
           *writerPool, reclaimableBytes));
       ASSERT_GT(reclaimableBytes, 0);
       {
-        memory::ScopedMemoryArbitrationContext arbitrationCtx(writerPool.get());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                writerPool);
+        memory::ScopedMemoryArbitrationContext arbitrationCtx(
+            writerPool.get(), arbitrationStructs.operation.get());
         ASSERT_GT(writerPool->reclaim(1L << 30, 0, stats), 0);
       }
       ASSERT_GT(stats.reclaimExecTimeUs, 0);
@@ -2125,7 +2138,11 @@ DEBUG_ONLY_TEST_F(E2EWriterTest, memoryReclaimThreshold) {
           *writerPool, reclaimableBytes));
       ASSERT_EQ(reclaimableBytes, 0);
       {
-        memory::ScopedMemoryArbitrationContext arbitrationCtx(writerPool.get());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                writerPool);
+        memory::ScopedMemoryArbitrationContext arbitrationCtx(
+            writerPool.get(), arbitrationStructs.operation.get());
         ASSERT_EQ(writerPool->reclaim(1L << 30, 0, stats), 0);
       }
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -20,6 +20,7 @@
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/SharedArbitrator.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/HashBuild.h"
@@ -5783,7 +5784,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
 
     if (testData.expectedReclaimable) {
       {
-        memory::ScopedMemoryArbitrationContext ctx(op->pool());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                op->pool()->shared_from_this());
+        memory::ScopedMemoryArbitrationContext ctx(
+            op->pool(), arbitrationStructs.operation.get());
         op->pool()->reclaim(
             folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
             0,
@@ -5923,7 +5928,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   ASSERT_GT(reclaimableBytes, 0);
 
   {
-    memory::ScopedMemoryArbitrationContext ctx(op->pool());
+    auto arbitrationStructs =
+        memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+            op->pool()->shared_from_this());
+    memory::ScopedMemoryArbitrationContext ctx(
+        op->pool(), arbitrationStructs.operation.get());
     op->pool()->reclaim(
         folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
         0,
@@ -6178,7 +6187,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
       ASSERT_GT(reclaimableBytes, 0);
       const auto usedMemoryBytes = op->pool()->usedBytes();
       {
-        memory::ScopedMemoryArbitrationContext ctx(op->pool());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                op->pool()->shared_from_this());
+        memory::ScopedMemoryArbitrationContext ctx(
+            op->pool(), arbitrationStructs.operation.get());
         op->pool()->reclaim(
             folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
             0,
@@ -6259,7 +6272,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         }
         auto* driver = op->testingOperatorCtx()->driver();
         auto task = driver->task();
-        memory::ScopedMemoryArbitrationContext ctx(op->pool());
+        auto arbitrationStructs =
+            memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+                op->pool()->shared_from_this());
+        memory::ScopedMemoryArbitrationContext ctx(
+            op->pool(), arbitrationStructs.operation.get());
         SuspendedSection suspendedSection(driver);
         auto taskPauseWait = task->requestPause();
         taskPauseWait.wait();
@@ -6326,7 +6343,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   const auto usedMemoryBytes = op->pool()->usedBytes();
   reclaimerStats_.reset();
   {
-    memory::ScopedMemoryArbitrationContext ctx(op->pool());
+    auto arbitrationStructs =
+        memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+            op->pool()->shared_from_this());
+    memory::ScopedMemoryArbitrationContext ctx(
+        op->pool(), arbitrationStructs.operation.get());
     op->pool()->reclaim(
         folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
         0,

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/common/memory/tests/SharedArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -264,7 +265,11 @@ TEST_F(MemoryReclaimerTest, parallelMemoryReclaimer) {
           static_cast<MockMemoryReclaimer*>(leafPools.back()->reclaimer()));
     }
 
-    ScopedMemoryArbitrationContext context(rootPool.get());
+    auto arbitrationStructs =
+        memory::test::ArbitrationTestStructs::createArbitrationTestStructs(
+            rootPool);
+    memory::ScopedMemoryArbitrationContext context(
+        rootPool.get(), arbitrationStructs.operation.get());
     memory::MemoryReclaimer::Stats stats;
     rootPool->reclaim(testData.bytesToReclaim, 0, stats);
     for (int i = 0; i < memoryReclaimers.size(); ++i) {


### PR DESCRIPTION
Current arbitrator lock does not enforce timeout, which might lead to arbitration operation's timeout not strictly enforced if waiting for too long for a lock. It can also prevent deadlock situation from completely hanging the system.