### PR TITLE
Add IPPREFIX to/from IPADDRESS Casting

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -30,7 +30,7 @@ are supported if the conversion of their element types are supported. In additio
 supported conversions to/from JSON are listed in :doc:`json`.
 
 .. list-table::
-   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
    :header-rows: 1
 
    * -
@@ -49,6 +49,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - interval day to second
      - decimal
      - ipaddress
+     - ipprefix
    * - tinyint
      - Y
      - Y
@@ -65,6 +66,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - smallint
      - Y
      - Y
@@ -81,6 +83,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - integer
      - Y
      - Y
@@ -97,6 +100,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - bigint
      - Y
      - Y
@@ -113,6 +117,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - boolean
      - Y
      - Y
@@ -129,6 +134,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - real
      - Y
      - Y
@@ -145,6 +151,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - double
      - Y
      - Y
@@ -161,6 +168,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - varchar
      - Y
      - Y
@@ -175,6 +183,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      -
+     - Y
      - Y
      - Y
    * - varbinary
@@ -193,6 +202,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - 
      - Y
+     -
    * - timestamp
      -
      -
@@ -209,6 +219,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
+     -
    * - timestamp with time zone
      -
      -
@@ -222,6 +233,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      - Y
+     -
      -
      -
      -
@@ -241,6 +253,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     -
    * - interval day to second
      -
      -
@@ -251,6 +264,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
      -
      -
      -
@@ -273,6 +287,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      -
+     -
    * - ipaddress
      - 
      - 
@@ -288,7 +303,25 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
+     - Y
      - 
+   * - ipprefix
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - Y
+     - 
+     -
+     -
+     -
+     -
+     - 
+     - 
+     - Y
 
 Cast to Integral Types
 ----------------------
@@ -667,27 +700,54 @@ is the number of whole days in the interval, HH is then number of hours between 
 From IPADDRESS
 ^^^^^^^^^^^^^^
 
-Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPV4 formatted IPV6 addresses.
-For all other IPV6 addresses it will be formatted in compressed alternate form IPV6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPv4 formatted IPv6 addresses.
+For all other IPv6 addresses it will be formatted in compressed alternate form IPv6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
 
-IPV4:
+IPv4:
 
 ::
 
   SELECT cast(ipaddress '1.2.3.4' as varchar); -- '1.2.3.4'
 
-IPV6:
+IPv6:
 
 ::
 
   SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varchar); -- '2001:db8::ff00:42:8329'
   SELECT cast(ipaddress '0:0:0:0:0:0:13.1.68.3' as varchar); -- '::13.1.68.3'
 
-IPV4 mapped IPV6:
+IPv4 mapped IPv6:
 
 ::
 
   SELECT cast(ipaddress '::ffff:ffff:ffff' as varchar); -- '255.255.255.255'
+
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Casting from IPPREFIX to VARCHAR returns a string formatted as *x.x.x.x/<prefix-length>* for IPv4 formatted IPv6 addresses.
+
+For all other IPv6 addresses it will be formatted in compressed alternate form IPv6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+followed by */<prefix-length>*. [`RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_]
+
+IPv4:
+
+::
+
+  SELECT cast(ipprefix '1.2.0.0/16' as varchar); -- '1.2.0.0/16'
+
+IPv6:
+
+::
+
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/128' as varchar); -- '2001:db8::ff00:42:8329/128'
+  SELECT cast(ipprefix '0:0:0:0:0:0:13.1.68.3/32' as varchar); -- '::/32'
+
+IPv4 mapped IPv6:
+
+::
+
+  SELECT cast(ipaddress '::ffff:ffff:0000/16' as varchar); -- '255.255.0.0/16'
 
 Cast to VARBINARY
 -----------------
@@ -695,24 +755,24 @@ Cast to VARBINARY
 From IPADDRESS
 ^^^^^^^^^^^^^^
 
-Returns the IPV6 address as a 16 byte varbinary string in network byte order.
+Returns the IPv6 address as a 16 byte varbinary string in network byte order.
 
-Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_.
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range. [`RFC 4291#section-2.5.5.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_]
 When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
 
-IPV6:
+IPv6:
 
 ::
 
   SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varbinary); -- 0x20010db8000000000000ff0000428329
 
-IPV4:
+IPv4:
 
 ::
 
   SELECT cast('1.2.3.4' as ipaddress); -- 0x00000000000000000000ffff01020304
 
-IPV4 mapped IPV6:
+IPv4 mapped IPv6:
 
 ::
 
@@ -1036,16 +1096,18 @@ Invalid example
 Cast to IPADDRESS
 -----------------
 
+.. _ipaddress-from-varchar:
+
 From VARCHAR
 ^^^^^^^^^^^^
 
 To cast a varchar to IPAddress input string must be in the form of either
-IPV4 or IPV6.
+IPv4 or IPv6.
 
-For IPV4 it must be in the form of:
+For IPv4 it must be in the form of:
 x.x.x.x where each x is an integer value between 0-255.
 
-For IPV6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
+For IPv6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
 
 Full form:
 
@@ -1087,16 +1149,16 @@ Invalid examples:
 From VARBINARY
 ^^^^^^^^^^^^^^
 
-To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
-or IPV6(16 Bytes) in network byte order.
+To cast a varbinary to IPAddress it must be either IPv4(4 Bytes)
+or IPv6(16 Bytes) in network byte order.
 
-IPV4:
+IPv4:
 
 ::
 
 [01, 02, 03, 04] -> 1.2.3.4
 
-IPV6:
+IPv6:
 
 ::
 
@@ -1108,7 +1170,7 @@ When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
 When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address.
 Other addresses will be formatted as IPv6 using the canonical format defined in `RFC 5952 <https://datatracker.ietf.org/doc/html/rfc5952.html>`_.
 
-IPV6 mapped IPV4 address:
+IPv6 mapped IPv4 address:
 
 ::
 
@@ -1127,6 +1189,41 @@ Invalid examples:
 ::
 
   SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
+
+Cast to IPPREFIX
+----------------
+
+From VARCHAR
+^^^^^^^^^^^^
+
+The IPPREFIX string must be in the form of *<ip_address>/<ip_prefix>* as defined in `RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_.
+The IPADDRESS portion of the IPPREFIX follows the same rules as casting
+`IPADDRESS from VARCHAR <#ipaddress-from-varchar>`_.
+
+The prefix portion must be <= 32 if the IP is an IPv4 address or <= 128 for an IPv6 address.
+As with IPADDRESS, any IPv6 address in the form of an IPv4 mapped IPv6 address will be
+interpreted as an IPv4 address. Only the canonical(smallest) IP address will be stored
+in the IPPREFIX.
+
+Examples:
+
+Valid examples:
+
+::
+
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/32' as ipprefix); -- ipprefix '2001:0db8::/32'
+  SELECT cast('1.2.3.4/24' as ipprefix); -- ipprefix '1.2.3.0/24'
+  SELECT cast('::ffff:ffff:ffff/16' as ipprefix); -- ipprefix '255.255.0.0/16'
+
+Invalid examples:
+
+::
+
+  SELECT cast('2001:db8::1::1/1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:db8::1::1/1
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/129' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/129
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/-1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/-1
+  SELECT cast('255.2.3.4/33' as ipprefix); -- Cannot cast value to IPPREFIX: 255.2.3.4/33
+  SELECT cast('::ffff:ffff:ffff/33' as ipprefix); -- Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -304,7 +304,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - 
      - Y
-     - 
+     - Y
    * - ipprefix
      - 
      - 
@@ -320,7 +320,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
-     - 
+     - Y
      - Y
 
 Cast to Integral Types
@@ -1190,6 +1190,18 @@ Invalid examples:
 
   SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
 
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Returns the canonical(lowest) IPADDRESS in the subnet range.
+
+Examples:
+
+::
+
+  SELECT cast(ipprefix '1.2.3.4/24' as ipaddress) -- ipaddress '1.2.3.0'
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/64' as ipaddress) -- ipaddress '2001:db8::'
+
 Cast to IPPREFIX
 ----------------
 
@@ -1224,6 +1236,19 @@ Invalid examples:
   SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/-1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/-1
   SELECT cast('255.2.3.4/33' as ipprefix); -- Cannot cast value to IPPREFIX: 255.2.3.4/33
   SELECT cast('::ffff:ffff:ffff/33' as ipprefix); -- Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33
+
+From IPADDRESS
+^^^^^^^^^^^^^^
+
+Returns an IPPREFIX where the prefix length is the length of the entire IP address.
+Prefix length for IPv4 is 32 and for IPv6 it is 128.
+
+Examples:
+
+::
+
+  SELECT cast(ipaddress '1.2.3.4' as ipprefix) -- ipprefix '1.2.3.4/32'
+  SELECT cast(ipaddress '2001:db8::ff00:42:8329' as ipprefix) -- ipprefix '2001:db8::ff00:42:8329/128'
 
 Miscellaneous
 -------------

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -79,8 +79,6 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARBINARY:
       if (isHyperLogLogType(type)) {
         return "HyperLogLog";
-      } else if (isIPPrefixType(type)) {
-        return "ipprefix";
       }
       return "varbinary";
     case TypeKind::TIMESTAMP:
@@ -93,6 +91,9 @@ std::string typeName(const TypePtr& type) {
           typeName(type->childAt(0)),
           typeName(type->childAt(1)));
     case TypeKind::ROW: {
+      if (isIPPrefixType(type)) {
+        return "ipprefix";
+      }
       const auto& rowType = type->asRow();
       std::ostringstream out;
       out << "row(";

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
   IPAddressCastTest.cpp
+  IPPrefixCastTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp
   JsonFunctionsTest.cpp
@@ -105,7 +106,6 @@ add_executable(
   WordStemTest.cpp
   ZipTest.cpp
   ZipWithTest.cpp)
-
 add_test(velox_functions_test velox_functions_test)
 
 target_link_libraries(

--- a/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class IPPrefixCastTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::optional<std::string> castToVarchar(
+      const std::optional<std::string>& input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(c0 as ipprefix) as varchar)", input);
+    return result;
+  }
+};
+
+TEST_F(IPPrefixCastTest, varcharCast) {
+  EXPECT_EQ(castToVarchar("::ffff:1.2.3.4/24"), "1.2.3.0/24");
+  EXPECT_EQ(castToVarchar("192.168.0.0/24"), "192.168.0.0/24");
+  EXPECT_EQ(castToVarchar("255.2.3.4/0"), "0.0.0.0/0");
+  EXPECT_EQ(castToVarchar("255.2.3.4/1"), "128.0.0.0/1");
+  EXPECT_EQ(castToVarchar("255.2.3.4/2"), "192.0.0.0/2");
+  EXPECT_EQ(castToVarchar("255.2.3.4/4"), "240.0.0.0/4");
+  EXPECT_EQ(castToVarchar("1.2.3.4/8"), "1.0.0.0/8");
+  EXPECT_EQ(castToVarchar("1.2.3.4/16"), "1.2.0.0/16");
+  EXPECT_EQ(castToVarchar("1.2.3.4/24"), "1.2.3.0/24");
+  EXPECT_EQ(castToVarchar("1.2.3.255/25"), "1.2.3.128/25");
+  EXPECT_EQ(castToVarchar("1.2.3.255/26"), "1.2.3.192/26");
+  EXPECT_EQ(castToVarchar("1.2.3.255/28"), "1.2.3.240/28");
+  EXPECT_EQ(castToVarchar("1.2.3.255/30"), "1.2.3.252/30");
+  EXPECT_EQ(castToVarchar("1.2.3.255/32"), "1.2.3.255/32");
+  EXPECT_EQ(
+      castToVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329/128"),
+      "2001:db8::ff00:42:8329/128");
+  EXPECT_EQ(
+      castToVarchar("2001:db8::ff00:42:8329/128"),
+      "2001:db8::ff00:42:8329/128");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1:0:0:1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1::1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(castToVarchar("2001:db8::1:0:0:1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(
+      castToVarchar("2001:DB8::FF00:ABCD:12EF/128"),
+      "2001:db8::ff00:abcd:12ef/128");
+  EXPECT_EQ(castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0"), "::/0");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/1"), "8000::/1");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/2"), "c000::/2");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/4"), "f000::/4");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/8"), "ff00::/8");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/16"), "ffff::/16");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/32"),
+      "ffff:ffff::/32");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/48"),
+      "ffff:ffff:ffff::/48");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/64"),
+      "ffff:ffff:ffff:ffff::/64");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/80"),
+      "ffff:ffff:ffff:ffff:ffff::/80");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/96"),
+      "ffff:ffff:ffff:ffff:ffff:ffff::/96");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/112"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:0/112");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/120"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00/120");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/124"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff0/124");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/126"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/126");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/127"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/127");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128");
+  EXPECT_EQ(castToVarchar("10.0.0.0/32"), "10.0.0.0/32");
+  EXPECT_EQ(castToVarchar("64:ff9b::10.0.0.0/128"), "64:ff9b::a00:0/128");
+}
+
+TEST_F(IPPrefixCastTest, invalidIPPrefix) {
+  VELOX_ASSERT_THROW(
+      castToVarchar("facebook.com/32"),
+      "Cannot cast value to IPPREFIX: facebook.com");
+  VELOX_ASSERT_THROW(
+      castToVarchar("localhost/32"),
+      "Cannot cast value to IPPREFIX: localhost");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:db8::1::1/128"),
+      "Cannot cast value to IPPREFIX: 2001:db8::1::1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:zxy::1::1/128"),
+      "Cannot cast value to IPPREFIX: 2001:zxy::1::1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("789.1.1.1/32"),
+      "Cannot cast value to IPPREFIX: 789.1.1.1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1"), "Cannot cast value to IPPREFIX: 192.1.1.1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1/128"),
+      "Cannot cast value to IPPREFIX: 192.1.1.1/128");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1/-1"),
+      "Cannot cast value to IPPREFIX: 192.1.1.1/-1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::ffff:ffff:ffff/33"),
+      "Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::ffff:ffff:ffff/-1"),
+      "Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/-1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::/129"), "Cannot cast value to IPPREFIX: ::/129");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::/-1"), "Cannot cast value to IPPREFIX: ::/-1");
+}
+
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -21,7 +21,6 @@
 static constexpr int kIPV4AddressBytes = 4;
 static constexpr int kIPV4ToV6FFIndex = 10;
 static constexpr int kIPV4ToV6Index = 12;
-static constexpr int kIPAddressBytes = 16;
 
 namespace facebook::velox {
 

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -18,6 +18,8 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
+static constexpr int kIPAddressBytes = 16;
+
 namespace facebook::velox {
 
 class IPAddressType : public HugeintType {

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -19,8 +19,18 @@
 #include "velox/type/Type.h"
 
 static constexpr int kIPAddressBytes = 16;
+static constexpr int kIPV4Bits = 32;
+static constexpr int kIPV6HalfBits = 64;
+static constexpr int kIPV6Bits = 128;
 
 namespace facebook::velox {
+
+static inline bool isIPv4(int128_t ip) {
+  int128_t ipV4 = 0x0000FFFF00000000;
+  uint128_t mask = 0xFFFFFFFFFFFFFFFF;
+  mask = (mask << kIPV6HalfBits) | 0xFFFFFFFF00000000;
+  return (ip & mask) == ipV4;
+}
 
 class IPAddressType : public HugeintType {
   IPAddressType() = default;


### PR DESCRIPTION
Add support for IPPREFIX <-> IPADDRESS cast. Relies on changes from https://github.com/facebookincubator/velox/pull/11309.

Only commit "[Add IPPREFIX <-> IPADDRESS cast](https://github.com/facebookincubator/velox/pull/11378/commits/6c496f635698b6480fd073c99251d3c575473e01#diff-8dc58e91e33f91c504fbb2b0d253f9724dd2c1031e200139945b7a61f949755f)" should be reviewed until the above is merged. 