### PR TITLE
Add support for testing peeling in expression fuzzer

### DIFF
--- a/velox/docs/develop/testing/fuzzer.rst
+++ b/velox/docs/develop/testing/fuzzer.rst
@@ -369,7 +369,7 @@ ExpressionRunner supports the following flags:
 
 * ``--complex_constant_path`` optional path to complex constants that aren't accurately expressable in SQL (Array, Map, Structs, ...). This is used with SQL file to reproduce the exact expression, not needed when the expression doesn't contain complex constants.
 
-* ``--lazy_column_list_path`` optional path for the file stored on-disk which contains a vector of column indices that specify which columns of the input row vector should be wrapped in lazy. This is used when the failing test included input columns that were lazy vector.
+* ``--input_row_metadata_path`` optional path for the file stored on-disk which contains a struct containing input row metadata. This includes columns in the input row vector to be wrapped in a lazy vector and/or dictionary encoded. It may also contain a dictionary peel for columns requiring dictionary encoding. This is used when the failing test included input columns that were lazy vectors and/or had columns wrapped with a common dictionary wrap.
 
 * ``--result_path`` optional path to result vector that was created by the Fuzzer. Result vector is used to reproduce cases where Fuzzer passes dirty vectors to expression evaluation as a result buffer. This ensures that functions are implemented correctly, taking into consideration dirty result buffer.
 

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -65,6 +65,14 @@ DEFINE_double(
     "vector will be selected to be wrapped in lazy encoding "
     "(expressed as double from 0 to 1).");
 
+DEFINE_double(
+    common_dictionary_wraps_generation_ratio,
+    0.0,
+    "Specifies the probability with which columns in the input row "
+    "vector will be selected to be wrapped in a common dictionary wrap "
+    "(expressed as double from 0 to 1). Only columns not already encoded "
+    "will be considered.");
+
 DEFINE_int32(
     max_expression_trees_per_step,
     1,
@@ -207,6 +215,8 @@ ExpressionFuzzerVerifier::Options getExpressionFuzzerVerifierOptions(
   opts.reproPersistPath = FLAGS_repro_persist_path;
   opts.persistAndRunOnce = FLAGS_persist_and_run_once;
   opts.lazyVectorGenerationRatio = FLAGS_lazy_vector_generation_ratio;
+  opts.commonDictionaryWrapRatio =
+      FLAGS_common_dictionary_wraps_generation_ratio;
   opts.maxExpressionTreesPerStep = FLAGS_max_expression_trees_per_step;
   opts.vectorFuzzerOptions = getVectorFuzzerOptions();
   opts.expressionFuzzerOptions = getExpressionFuzzerOptions(

--- a/velox/expression/fuzzer/FuzzerToolkit.cpp
+++ b/velox/expression/fuzzer/FuzzerToolkit.cpp
@@ -14,8 +14,29 @@
  * limitations under the License.
  */
 #include "velox/expression/fuzzer/FuzzerToolkit.h"
+#include "velox/vector/VectorSaver.h"
 
 namespace facebook::velox::fuzzer {
+
+namespace {
+template <typename T>
+void saveStdVector(const std::vector<T>& list, std::ostream& out) {
+  // Size of the vector
+  size_t size = list.size();
+  out.write((char*)&(size), sizeof(size));
+  out.write(
+      reinterpret_cast<const char*>(list.data()), list.size() * sizeof(T));
+}
+
+template <typename T>
+std::vector<T> restoreStdVector(std::istream& in) {
+  size_t size;
+  in.read((char*)&size, sizeof(size));
+  std::vector<T> vec(size);
+  in.read(reinterpret_cast<char*>(vec.data()), size * sizeof(T));
+  return vec;
+}
+} // namespace
 
 std::string CallableSignature::toString() const {
   std::string buf = name;
@@ -135,6 +156,62 @@ void compareVectors(
   });
 
   LOG(INFO) << "Two vectors match.";
+}
+
+RowVectorPtr applyCommonDictionaryLayer(
+    const RowVectorPtr& rowVector,
+    const InputRowMetadata& inputRowMetadata) {
+  if (inputRowMetadata.columnsToWrapInCommonDictionary.empty()) {
+    return rowVector;
+  }
+  auto size = rowVector->size();
+  auto& nulls = inputRowMetadata.commonDictionaryNulls;
+  auto& indices = inputRowMetadata.commonDictionaryIndices;
+  if (nulls) {
+    VELOX_CHECK_LE(bits::nbytes(size), nulls->size());
+  }
+  VELOX_CHECK_LE(size, indices->size() / sizeof(vector_size_t));
+  std::vector<VectorPtr> newInputs;
+  int listIndex = 0;
+  auto& columnsToWrap = inputRowMetadata.columnsToWrapInCommonDictionary;
+  for (int idx = 0; idx < rowVector->childrenSize(); idx++) {
+    auto& child = rowVector->childAt(idx);
+    VELOX_CHECK_NOT_NULL(child);
+    if (listIndex < columnsToWrap.size() && idx == columnsToWrap[listIndex]) {
+      newInputs.push_back(
+          BaseVector::wrapInDictionary(nulls, indices, size, child));
+      listIndex++;
+    } else {
+      newInputs.push_back(child);
+    }
+  }
+  return std::make_shared<RowVector>(
+      rowVector->pool(), rowVector->type(), nullptr, size, newInputs);
+}
+
+void InputRowMetadata::saveToFile(const char* filePath) const {
+  std::ofstream outputFile(filePath, std::ofstream::binary);
+  saveStdVector(columnsToWrapInLazy, outputFile);
+  saveStdVector(columnsToWrapInCommonDictionary, outputFile);
+  writeOptionalBuffer(commonDictionaryIndices, outputFile);
+  writeOptionalBuffer(commonDictionaryNulls, outputFile);
+  outputFile.close();
+}
+
+InputRowMetadata InputRowMetadata::restoreFromFile(
+    const char* filePath,
+    memory::MemoryPool* pool) {
+  InputRowMetadata ret;
+  std::ifstream in(filePath, std::ifstream::binary);
+  ret.columnsToWrapInLazy = restoreStdVector<int>(in);
+  if (in.peek() != EOF) {
+    // this allows reading old files that only saved columnsToWrapInLazy.
+    ret.columnsToWrapInCommonDictionary = restoreStdVector<int>(in);
+    ret.commonDictionaryIndices = readOptionalBuffer(in, pool);
+    ret.commonDictionaryNulls = readOptionalBuffer(in, pool);
+  }
+  in.close();
+  return ret;
 }
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/FuzzerToolkit.h
+++ b/velox/expression/fuzzer/FuzzerToolkit.h
@@ -114,4 +114,35 @@ void compareVectors(
     const std::string& leftName = "left",
     const std::string& rightName = "right",
     const std::optional<SelectivityVector>& rows = std::nullopt);
+
+struct InputRowMetadata {
+  // Column indices to wrap in LazyVector (in a strictly increasing order)
+  std::vector<int> columnsToWrapInLazy;
+
+  // Column indices to wrap in a common dictionary layer (in a strictly
+  // increasing order)
+  std::vector<int> columnsToWrapInCommonDictionary;
+
+  // Dictionary indices and nulls for the common dictionary layer. Buffers are
+  // null if no columns are specified in `columnsToWrapInCommonDictionary`.
+  BufferPtr commonDictionaryIndices;
+  BufferPtr commonDictionaryNulls;
+
+  bool empty() const {
+    return columnsToWrapInLazy.empty() &&
+        columnsToWrapInCommonDictionary.empty();
+  }
+
+  void saveToFile(const char* filePath) const;
+  static InputRowMetadata restoreFromFile(
+      const char* filePath,
+      memory::MemoryPool* pool);
+};
+
+// Wraps the columns in the row vector with a common dictionary layer. The
+// column indices to wrap and the wrap itself is specified in
+// `inputRowMetadata`.
+RowVectorPtr applyCommonDictionaryLayer(
+    const RowVectorPtr& rowVector,
+    const InputRowMetadata& inputRowMetadata);
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/tests/FuzzerToolkitTest.cpp
+++ b/velox/expression/fuzzer/tests/FuzzerToolkitTest.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
+
+#include <gtest/gtest.h>
+#include "velox/exec/tests/utils/TempFilePath.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::fuzzer::test {
+class FuzzerToolKitTest : public testing::Test,
+                          public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  bool compareBuffers(const BufferPtr& lhs, const BufferPtr& rhs) {
+    if (!lhs && !rhs) {
+      return true;
+    }
+    if ((lhs && !rhs) || (!lhs && rhs) || lhs->size() != rhs->size()) {
+      return false;
+    }
+    return memcmp(lhs->as<char>(), rhs->as<char>(), lhs->size()) == 0;
+  }
+
+  bool equals(const InputRowMetadata& lhs, const InputRowMetadata& rhs) {
+    return lhs.columnsToWrapInLazy == rhs.columnsToWrapInLazy &&
+        lhs.columnsToWrapInCommonDictionary ==
+        rhs.columnsToWrapInCommonDictionary &&
+        compareBuffers(
+               lhs.commonDictionaryIndices, rhs.commonDictionaryIndices) &&
+        compareBuffers(lhs.commonDictionaryNulls, rhs.commonDictionaryNulls);
+  }
+};
+
+TEST_F(FuzzerToolKitTest, inputRowMetadataRoundTrip) {
+  InputRowMetadata metadata;
+  metadata.columnsToWrapInLazy = {1, -2, 3, -4, 5};
+  metadata.columnsToWrapInCommonDictionary = {1, 2, 3, 4, 5};
+  metadata.commonDictionaryIndices = makeIndicesInReverse(5);
+  metadata.commonDictionaryNulls = makeNulls({true, false, true, false, true});
+
+  {
+    auto path = exec::test::TempFilePath::create();
+    metadata.saveToFile(path->getPath().c_str());
+    auto copy =
+        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
+    ASSERT_TRUE(equals(metadata, copy));
+  }
+
+  metadata.commonDictionaryNulls = nullptr;
+  {
+    auto path = exec::test::TempFilePath::create();
+    metadata.saveToFile(path->getPath().c_str());
+    auto copy =
+        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
+    ASSERT_TRUE(equals(metadata, copy));
+  }
+
+  metadata.columnsToWrapInCommonDictionary.clear();
+  metadata.commonDictionaryIndices = nullptr;
+  {
+    auto path = exec::test::TempFilePath::create();
+    metadata.saveToFile(path->getPath().c_str());
+    auto copy =
+        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
+    ASSERT_TRUE(equals(metadata, copy));
+  }
+
+  metadata.columnsToWrapInLazy.clear();
+  metadata.commonDictionaryIndices = nullptr;
+  {
+    auto path = exec::test::TempFilePath::create();
+    metadata.saveToFile(path->getPath().c_str());
+    auto copy =
+        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
+    ASSERT_TRUE(equals(metadata, copy));
+  }
+}
+} // namespace facebook::velox::fuzzer::test

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -21,6 +21,7 @@
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
 #include "velox/expression/tests/ExpressionRunner.h"
 #include "velox/expression/tests/ExpressionVerifier.h"
 #include "velox/parse/Expressions.h"
@@ -114,7 +115,7 @@ void ExpressionRunner::run(
     const std::string& mode,
     vector_size_t numRows,
     const std::string& storeResultPath,
-    const std::string& lazyColumnListPath,
+    const std::string& inputRowMetadataPath,
     std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
     bool findMinimalSubExpression,
     bool useSeperatePoolForInput) {
@@ -143,10 +144,10 @@ void ExpressionRunner::run(
     VELOX_CHECK_GT(inputVector->size(), 0, "Input vector must not be empty.");
   }
 
-  std::vector<int> columnsToWrapInLazy;
-  if (!lazyColumnListPath.empty()) {
-    columnsToWrapInLazy =
-        restoreStdVectorFromFile<int>(lazyColumnListPath.c_str());
+  fuzzer::InputRowMetadata inputRowMetadata;
+  if (!inputRowMetadataPath.empty()) {
+    inputRowMetadata = fuzzer::InputRowMetadata::restoreFromFile(
+        inputRowMetadataPath.c_str(), pool.get());
   }
 
   parse::registerTypeResolver();
@@ -200,7 +201,7 @@ void ExpressionRunner::run(
           std::nullopt,
           std::move(resultVector),
           true,
-          columnsToWrapInLazy);
+          inputRowMetadata);
     } catch (const std::exception&) {
       if (findMinimalSubExpression) {
         VectorFuzzer::Options options;
@@ -211,16 +212,15 @@ void ExpressionRunner::run(
             typedExprs,
             inputVector,
             std::nullopt,
-            columnsToWrapInLazy);
+            inputRowMetadata);
       }
       throw;
     }
 
   } else if (mode == "common") {
-    if (!columnsToWrapInLazy.empty()) {
-      inputVector =
-          VectorFuzzer::fuzzRowChildrenToLazy(inputVector, columnsToWrapInLazy);
-    }
+    inputVector = VectorFuzzer::fuzzRowChildrenToLazy(
+        inputVector, inputRowMetadata.columnsToWrapInLazy);
+    inputVector = applyCommonDictionaryLayer(inputVector, inputRowMetadata);
     exec::ExprSet exprSet(typedExprs, &execCtx);
     auto results = evaluateAndPrintResults(exprSet, inputVector, rows, execCtx);
     if (!storeResultPath.empty()) {

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -47,9 +47,9 @@ class ExpressionRunner {
   /// @param storeResultPath The path to a directory on disk where the results
   /// of expression or query evaluation will be stored. If empty, the results
   /// will not be stored.
-  /// @param lazyColumnListPath The path to on-disk vector of column indices
-  /// that specify which columns of the input row vector should be wrapped in
-  /// lazy.
+  /// @param inputRowMetadataPath The path to on-disk serialized struct that
+  ///        contains metadata about the input row vector like the columns
+  ///        to wrap in lazy or dictionary encoding and the dictionary wrap.
   /// @param findMinimalSubExpression Whether to find minimum failing
   ///        subexpression on result mismatch.
   /// @param useSeperatePoolForInput Whether to use separate memory pools for
@@ -70,7 +70,7 @@ class ExpressionRunner {
       const std::string& mode,
       vector_size_t numRows,
       const std::string& storeResultPath,
-      const std::string& lazyColumnListPath,
+      const std::string& inputRowMetadataPath,
       std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
       bool findMinimalSubExpression = false,
       bool useSeperatePoolForInput = true);

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -87,11 +87,12 @@ DEFINE_string(
     "table 't'.");
 
 DEFINE_string(
-    lazy_column_list_path,
+    input_row_metadata_path,
     "",
-    "Path for the file stored on-disk which contains a vector of column "
-    "indices that specify which columns of the input row vector should "
-    "be wrapped in lazy.");
+    "Path for the file stored on-disk which contains a struct containing "
+    "input row metadata. This includes columns in the input row vector to "
+    "be wrapped in a lazy vector and/or dictionary encoded. It may also "
+    "contain a dictionary peel for columns requiring dictionary encoding.");
 
 DEFINE_bool(
     use_seperate_memory_pool_for_input_vector,
@@ -204,11 +205,11 @@ static void checkDirForExpectedFiles() {
       ? checkAndReturnFilePath(
             test::ExpressionVerifier::kExpressionSqlFileName, "sql_path")
       : FLAGS_sql_path;
-  FLAGS_lazy_column_list_path = FLAGS_lazy_column_list_path.empty()
+  FLAGS_input_row_metadata_path = FLAGS_input_row_metadata_path.empty()
       ? checkAndReturnFilePath(
-            test::ExpressionVerifier::kIndicesOfLazyColumnsFileName,
-            "lazy_column_list_path")
-      : FLAGS_lazy_column_list_path;
+            test::ExpressionVerifier::kInputRowMetadataFileName,
+            "input_row_metadata_path")
+      : FLAGS_input_row_metadata_path;
   FLAGS_complex_constant_path = FLAGS_complex_constant_path.empty()
       ? checkAndReturnFilePath(
             test::ExpressionVerifier::kComplexConstantsFileName,
@@ -266,7 +267,7 @@ int main(int argc, char** argv) {
       FLAGS_mode,
       FLAGS_num_rows,
       FLAGS_store_result_path,
-      FLAGS_lazy_column_list_path,
+      FLAGS_input_row_metadata_path,
       referenceQueryRunner,
       FLAGS_find_minimal_subexpression,
       FLAGS_use_seperate_memory_pool_for_input_vector);

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -24,11 +24,13 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
+#include "velox/vector/VectorSaver.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::test {
 
 using exec::test::ReferenceQueryRunner;
+using facebook::velox::fuzzer::InputRowMetadata;
 
 struct ExpressionVerifierOptions {
   bool disableConstantFolding{false};
@@ -41,8 +43,8 @@ class ExpressionVerifier {
   // File names used to persist data required for reproducing a failed test
   // case.
   static constexpr const std::string_view kInputVectorFileName = "input_vector";
-  static constexpr const std::string_view kIndicesOfLazyColumnsFileName =
-      "indices_of_lazy_columns";
+  static constexpr const std::string_view kInputRowMetadataFileName =
+      "input_row_metadata";
   static constexpr const std::string_view kResultVectorFileName =
       "result_vector";
   static constexpr const std::string_view kExpressionSqlFileName = "sql";
@@ -80,14 +82,14 @@ class ExpressionVerifier {
       const std::optional<SelectivityVector>& rowsToVerify,
       VectorPtr&& resultVector,
       bool canThrow,
-      std::vector<int> columnsToWarpInLazy = {});
+      const InputRowMetadata& inputRowMetadata = {});
 
  private:
   // Utility method used to serialize the relevant data required to repro a
   // crash.
   void persistReproInfo(
       const VectorPtr& inputVector,
-      std::vector<int> columnsToWarpInLazy,
+      const InputRowMetadata& inputRowMetadata,
       const VectorPtr& resultVector,
       const std::string& sql,
       const std::vector<VectorPtr>& complexConstants);
@@ -97,7 +99,7 @@ class ExpressionVerifier {
   // otherwise.
   void persistReproInfoIfNeeded(
       const VectorPtr& inputVector,
-      const std::vector<int>& columnsToWarpInLazy,
+      const InputRowMetadata& inputRowMetadata,
       const VectorPtr& resultVector,
       const std::string& sql,
       const std::vector<VectorPtr>& complexConstants);
@@ -117,5 +119,5 @@ void computeMinimumSubExpression(
     const std::vector<core::TypedExprPtr>& plans,
     const RowVectorPtr& rowVector,
     const std::optional<SelectivityVector>& rowsToVerify,
-    const std::vector<int>& columnsToWrapInLazy);
+    const InputRowMetadata& inputRowMetadata);
 } // namespace facebook::velox::test

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -53,15 +53,6 @@ VectorPtr restoreVectorFromFile(const char* filePath, memory::MemoryPool* pool);
 /// Reads a string from a file stored by saveStringToFile() method
 std::string restoreStringFromFile(const char* filePath);
 
-// Write the vector to a file. Contents would include the size of the list
-// followed by all the values.
-template <typename T>
-void saveStdVectorToFile(const std::vector<T>& list, const char* filePath);
-
-// Reads a std::vector from a file stored by saveStdVectorToFile() method.
-template <typename T>
-std::vector<T> restoreStdVectorFromFile(const char* filePath);
-
 /// Serializes a SelectivityVector into binary format and writes it to the
 /// provided output stream.
 void saveSelectivityVector(const SelectivityVector& rows, std::ostream& out);
@@ -69,5 +60,21 @@ void saveSelectivityVector(const SelectivityVector& rows, std::ostream& out);
 /// Deserializes a SelectivityVector serialized by 'saveSelectivityVector' from
 /// the provided input stream.
 SelectivityVector restoreSelectivityVector(std::istream& in);
+
+/// Serializes a BufferPtr into binary format and writes it to the
+/// provided output stream. 'buffer' must be non-null.
+void writeBuffer(const BufferPtr& buffer, std::ostream& out);
+
+/// Serializes a optional BufferPtr into binary format and writes it to the
+/// provided output stream.
+void writeOptionalBuffer(const BufferPtr& buffer, std::ostream& out);
+
+/// Deserializes a BufferPtr serialized by 'writeBuffer' from the provided
+/// input stream.
+BufferPtr readBuffer(std::istream& in, memory::MemoryPool* pool);
+
+/// Deserializes a optional BufferPtr serialized by 'writeOptionalBuffer' from
+/// the provided input stream.
+BufferPtr readOptionalBuffer(std::istream& in, memory::MemoryPool* pool);
 
 } // namespace facebook::velox

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -328,7 +328,7 @@ class VectorFuzzer {
       RowVectorPtr rowVector,
       const std::vector<int>& columnsToWrapInLazy);
 
-  /// Generate a random null buffer.
+  /// Generate a random null buffer. Can return nullptr if no nulls are set.
   BufferPtr fuzzNulls(vector_size_t size);
 
   /// Generate a random indices buffer of 'size' with maximum possible index

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -622,14 +622,6 @@ TEST_F(VectorSaverTest, LazyVector) {
       fuzzer);
 }
 
-TEST_F(VectorSaverTest, stdVector) {
-  std::vector<column_index_t> intVector = {1, 2, 3, 4, 5};
-  auto path = exec::test::TempFilePath::create();
-  saveStdVectorToFile<column_index_t>(intVector, path->getPath().c_str());
-  auto copy = restoreStdVectorFromFile<column_index_t>(path->getPath().c_str());
-  ASSERT_EQ(intVector, copy);
-}
-
 namespace {
 struct VectorSaverInfo {
   // Path to directory where to store the vector.


### PR DESCRIPTION
Summary:
This change allows wrapping input columns with a shared dictionary
layer, to exercise code paths that handle dictionary peeling of
multiple inputs. Previously, only single inputs could be peeled due
to differing dictionary wraps across columns. This allows us to
replicate vectors that are produced by joins or unnest or filters.
It achieves this by first picking columns that are not encoded (as
multiple dictionary layers will soon be phased out), then wrapping
them just before passing them to evaluation. This change also adds
the ability to serialize these common wraps to ensure easy repro
using ExpressionRunnerTest.

'common_dictionary_wraps_generation_ratio' startup flag is used to
enable this feature.

Differential Revision: D64436877
