### PR TITLE
Enable prefix sort in spilling

### DIFF
--- a/velox/common/base/PrefixSortConfig.h
+++ b/velox/common/base/PrefixSortConfig.h
@@ -22,16 +22,16 @@ namespace facebook::velox::common {
 
 /// Specifies the config for prefix-sort.
 struct PrefixSortConfig {
-  explicit PrefixSortConfig(
-      int64_t maxNormalizedKeySize,
-      int32_t threshold = 130)
-      : maxNormalizedKeySize(maxNormalizedKeySize), threshold(threshold) {}
+  PrefixSortConfig() = default;
+
+  PrefixSortConfig(int64_t _maxNormalizedKeySize, int32_t _threshold)
+      : maxNormalizedKeySize(_maxNormalizedKeySize), threshold(_threshold) {}
 
   /// Max number of bytes can store normalized keys in prefix-sort buffer per
-  /// entry.
-  const int64_t maxNormalizedKeySize;
+  /// entry. Same with QueryConfig kPrefixSortNormalizedKeyMaxBytes.
+  int64_t maxNormalizedKeySize{128};
 
   /// PrefixSort will have performance regression when the dateset is too small.
-  const int32_t threshold;
+  int32_t threshold{130};
 };
 } // namespace facebook::velox::common

--- a/velox/common/base/SpillConfig.cpp
+++ b/velox/common/base/SpillConfig.cpp
@@ -34,6 +34,7 @@ SpillConfig::SpillConfig(
     uint64_t _maxSpillRunRows,
     uint64_t _writerFlushThresholdSize,
     const std::string& _compressionKind,
+    std::optional<PrefixSortConfig> _prefixSortConfig,
     const std::string& _fileCreateConfig)
     : getSpillDirPathCb(std::move(_getSpillDirPathCb)),
       updateAndCheckSpillLimitCb(std::move(_updateAndCheckSpillLimitCb)),
@@ -52,6 +53,7 @@ SpillConfig::SpillConfig(
       maxSpillRunRows(_maxSpillRunRows),
       writerFlushThresholdSize(_writerFlushThresholdSize),
       compressionKind(common::stringToCompressionKind(_compressionKind)),
+      prefixSortConfig(_prefixSortConfig),
       fileCreateConfig(_fileCreateConfig) {
   VELOX_USER_CHECK_GE(
       spillableReservationGrowthPct,

--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include "velox/common/base/PrefixSortConfig.h"
 #include "velox/common/compression/Compression.h"
 
 namespace facebook::velox::common {
@@ -61,6 +62,7 @@ struct SpillConfig {
       uint64_t _maxSpillRunRows,
       uint64_t _writerFlushThresholdSize,
       const std::string& _compressionKind,
+      std::optional<PrefixSortConfig> _prefixSortConfig = std::nullopt,
       const std::string& _fileCreateConfig = {});
 
   /// Returns the spilling level with given 'startBitOffset' and
@@ -134,6 +136,10 @@ struct SpillConfig {
 
   /// CompressionKind when spilling, CompressionKind_NONE means no compression.
   common::CompressionKind compressionKind;
+
+  /// Prefix sort config when spilling, enable prefix sort when this config is
+  /// set, otherwise, fallback to timsort.
+  std::optional<PrefixSortConfig> prefixSortConfig;
 
   /// Custom options passed to velox::FileSystem to create spill WriteFile.
   std::string fileCreateConfig;

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -254,6 +254,12 @@ class QueryConfig {
   static constexpr const char* kSpillCompressionKind =
       "spill_compression_codec";
 
+  /// Enable the prefix sort or fallback to timsort in spill. The prefix sort is
+  /// faster than timsort but requires the memory to build prefix data, which
+  /// may cause out of memory.
+  static constexpr const char* kSpillEnablePrefixSort =
+      "spill_enable_prefix_sort";
+
   /// Specifies spill write buffer size in bytes. The spiller tries to buffer
   /// serialized spill data up to the specified size before write to storage
   /// underneath for io efficiency. If it is set to zero, then spill write
@@ -654,6 +660,10 @@ class QueryConfig {
 
   std::string spillCompressionKind() const {
     return get<std::string>(kSpillCompressionKind, "none");
+  }
+
+  bool spillEnablePrefixSort() const {
+    return get<bool>(kSpillEnablePrefixSort, false);
   }
 
   uint64_t spillWriteBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -349,6 +349,11 @@ Spilling
      - Specifies the compression algorithm type to compress the spilled data before write to disk to trade CPU for IO
        efficiency. The supported compression codecs are: ZLIB, SNAPPY, LZO, ZSTD, LZ4 and GZIP.
        NONE means no compression.
+   * - spill_enable_prefix_sort
+     - bool
+     - false
+     - Enable the prefix sort or fallback to timsort in spill. The prefix sort is faster than timsort but requires the
+       memory to build prefix data, which might have potential risk of running out of server memory.
    * - spiller_start_partition_bit
      - integer
      - 29

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -141,6 +141,9 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       queryConfig.maxSpillRunRows(),
       queryConfig.writerFlushThresholdBytes(),
       queryConfig.spillCompressionKind(),
+      queryConfig.spillEnablePrefixSort()
+          ? std::optional<common::PrefixSortConfig>(prefixSortConfig())
+          : std::nullopt,
       queryConfig.spillFileCreateConfig());
 }
 

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -23,25 +23,6 @@
 
 namespace facebook::velox::exec {
 
-namespace detail {
-
-FOLLY_ALWAYS_INLINE void stdSort(
-    std::vector<char*, memory::StlAllocator<char*>>& rows,
-    RowContainer* rowContainer,
-    const std::vector<CompareFlags>& compareFlags) {
-  std::sort(
-      rows.begin(), rows.end(), [&](const char* leftRow, const char* rightRow) {
-        for (auto i = 0; i < compareFlags.size(); ++i) {
-          if (auto result = rowContainer->compare(
-                  leftRow, rightRow, i, compareFlags[i])) {
-            return result < 0;
-          }
-        }
-        return false;
-      });
-}
-}; // namespace detail
-
 /// The layout of prefix-sort buffer, a prefix entry includes:
 /// 1. normalized keys
 /// 2. non-normalized data ptr for semi-normalized types such as
@@ -126,16 +107,16 @@ class PrefixSort {
       const std::vector<CompareFlags>& compareFlags,
       const velox::common::PrefixSortConfig& config) {
     if (rowContainer->numRows() < config.threshold) {
-      detail::stdSort(rows, rowContainer, compareFlags);
+      timSort(rows, rowContainer, compareFlags);
       return;
     }
     VELOX_DCHECK_EQ(rowContainer->keyTypes().size(), compareFlags.size());
     const auto sortLayout = PrefixSortLayout::makeSortLayout(
         rowContainer->keyTypes(), compareFlags, config.maxNormalizedKeySize);
     // All keys can not normalize, skip the binary string compare opt.
-    // Putting this outside sort-internal helps with inline std-sort.
+    // Putting this outside sort-internal helps with timsort.
     if (sortLayout.noNormalizedKeys) {
-      detail::stdSort(rows, rowContainer, compareFlags);
+      timSort(rows, rowContainer, compareFlags);
       return;
     }
 
@@ -143,14 +124,22 @@ class PrefixSort {
     prefixSort.sortInternal(rows);
   }
 
-  /// The stdsort won't require bytes while prefixsort may require buffers
+  /// The timsort won't require bytes while prefixsort may require buffers
   /// such as prefix data. The logic is similar to the above function
-  /// PrefixSort::sort but returns the maxmium buffer the sort may need.
+  /// PrefixSort::sort but returns the maximum buffer the sort may need.
   static uint32_t maxRequiredBytes(
-      memory::MemoryPool* pool,
       RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags,
-      const velox::common::PrefixSortConfig& config);
+      const velox::common::PrefixSortConfig& config,
+      memory::MemoryPool* pool);
+
+  /// Fallback to timsort when prefix sort conditions such as config and memory
+  /// are not satified. TimSort provides >2X performance win than stdsort for
+  /// user experienced data.
+  static void timSort(
+      std::vector<char*, memory::StlAllocator<char*>>& rows,
+      RowContainer* rowContainer,
+      const std::vector<CompareFlags>& compareFlags);
 
  private:
   // Estimates the memory required for prefix sort such as prefix buffer and

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -298,7 +298,7 @@ void SortBuffer::ensureSortFits() {
   uint64_t sortBufferToReserve =
       numInputRows_ * sizeof(char*) +
       PrefixSort::maxRequiredBytes(
-          pool_, data_.get(), sortCompareFlags_, prefixSortConfig_);
+          data_.get(), sortCompareFlags_, prefixSortConfig_, pool_);
   {
     memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
     if (pool_->maybeReserve(sortBufferToReserve)) {

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -161,7 +161,7 @@ void SortWindowBuild::ensureSortFits() {
   uint64_t sortBufferToReserve =
       numRows_ * (sizeof(char*) + sizeof(vector_size_t)) +
       PrefixSort::maxRequiredBytes(
-          pool_, data_.get(), compareFlags_, prefixSortConfig_);
+          data_.get(), compareFlags_, prefixSortConfig_, pool_);
   {
     memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
     if (pool_->maybeReserve(sortBufferToReserve)) {

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -343,6 +343,7 @@ class SpillState {
       uint64_t targetFileSize,
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
+      const std::optional<common::PrefixSortConfig>& prefixSortConfig,
       memory::MemoryPool* pool,
       folly::Synchronized<common::SpillStats>* stats,
       const std::string& fileCreateConfig = {});
@@ -367,6 +368,10 @@ class SpillState {
 
   common::CompressionKind compressionKind() const {
     return compressionKind_;
+  }
+
+  const std::optional<common::PrefixSortConfig>& prefixSortConfig() const {
+    return prefixSortConfig_;
   }
 
   const std::vector<CompareFlags>& sortCompareFlags() const {
@@ -439,6 +444,7 @@ class SpillState {
   const uint64_t targetFileSize_;
   const uint64_t writeBufferSize_;
   const common::CompressionKind compressionKind_;
+  const std::optional<common::PrefixSortConfig> prefixSortConfig_;
   const std::string fileCreateConfig_;
   memory::MemoryPool* const pool_;
   folly::Synchronized<common::SpillStats>* const stats_;

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -215,6 +215,7 @@ class Spiller {
       uint64_t targetFileSize,
       uint64_t writeBufferSize,
       common::CompressionKind compressionKind,
+      const std::optional<common::PrefixSortConfig>& prefixSortConfig,
       folly::Executor* executor,
       uint64_t maxSpillRunRows,
       const std::string& fileCreateConfig,

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -91,21 +91,6 @@ class PrefixSortTest : public exec::test::OperatorTestBase {
     }
 
     velox::test::assertEqualVectors(actual, expectedResult);
-    // Test timsort.
-    {
-      RowContainer rowContainer(keyTypes, payloadTypes, pool_.get());
-      auto rows = storeRows(numRows, data, &rowContainer);
-      PrefixSort::timSort(rows, &rowContainer, compareFlags);
-      // Extract data from the RowContainer in order.
-      const RowVectorPtr actual =
-          BaseVector::create<RowVector>(rowType, numRows, pool_.get());
-      for (int column = 0; column < compareFlags.size(); ++column) {
-        rowContainer.extractColumn(
-            rows.data(), numRows, column, actual->childAt(column));
-      }
-
-      velox::test::assertEqualVectors(actual, expectedResult);
-    }
   }
 
  private:

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -67,6 +67,7 @@ class SortBufferTest : public OperatorTestBase,
         spillPrefixSortConfig_);
   }
 
+  const bool enableSpillPrefixSort_{GetParam()};
   const velox::common::PrefixSortConfig prefixSortConfig_ =
       velox::common::PrefixSortConfig{std::numeric_limits<int32_t>::max(), 130};
   const std::optional<common::PrefixSortConfig> spillPrefixSortConfig_ =
@@ -100,7 +101,6 @@ class SortBufferTest : public OperatorTestBase,
 
   tsan_atomic<bool> nonReclaimableSection_{false};
   folly::Random::DefaultGenerator rng_;
-  const bool enableSpillPrefixSort_{GetParam()};
 };
 
 TEST_P(SortBufferTest, singleKey) {

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -32,7 +32,8 @@ using namespace facebook::velox::memory;
 
 namespace facebook::velox::functions::test {
 
-class SortBufferTest : public OperatorTestBase {
+class SortBufferTest : public OperatorTestBase,
+                       public testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
     OperatorTestBase::SetUp();
@@ -62,11 +63,16 @@ class SortBufferTest : public OperatorTestBase {
         0,
         0,
         0,
-        "none");
+        "none",
+        spillPrefixSortConfig_);
   }
 
   const velox::common::PrefixSortConfig prefixSortConfig_ =
       velox::common::PrefixSortConfig{std::numeric_limits<int32_t>::max(), 130};
+  const std::optional<common::PrefixSortConfig> spillPrefixSortConfig_ =
+      enableSpillPrefixSort_
+      ? std::optional<common::PrefixSortConfig>(prefixSortConfig_)
+      : std::nullopt;
 
   const RowTypePtr inputType_ = ROW(
       {{"c0", BIGINT()},
@@ -94,9 +100,10 @@ class SortBufferTest : public OperatorTestBase {
 
   tsan_atomic<bool> nonReclaimableSection_{false};
   folly::Random::DefaultGenerator rng_;
+  const bool enableSpillPrefixSort_{GetParam()};
 };
 
-TEST_F(SortBufferTest, singleKey) {
+TEST_P(SortBufferTest, singleKey) {
   struct {
     std::vector<CompareFlags> sortCompareFlags;
     std::vector<int32_t> expectedResult;
@@ -158,7 +165,7 @@ TEST_F(SortBufferTest, singleKey) {
   }
 }
 
-TEST_F(SortBufferTest, multipleKeys) {
+TEST_P(SortBufferTest, multipleKeys) {
   auto sortBuffer = std::make_unique<SortBuffer>(
       inputType_,
       sortColumnIndices_,
@@ -188,7 +195,7 @@ TEST_F(SortBufferTest, multipleKeys) {
 }
 
 // TODO: enable it later with test utility to compare the sorted result.
-TEST_F(SortBufferTest, DISABLED_randomData) {
+TEST_P(SortBufferTest, DISABLED_randomData) {
   struct {
     RowTypePtr inputType;
     std::vector<column_index_t> sortColumnIndices;
@@ -265,7 +272,7 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
   }
 }
 
-TEST_F(SortBufferTest, batchOutput) {
+TEST_P(SortBufferTest, batchOutput) {
   struct {
     bool triggerSpill;
     std::vector<size_t> numInputRows;
@@ -312,7 +319,8 @@ TEST_F(SortBufferTest, batchOutput) {
         0,
         0,
         0,
-        "none");
+        "none",
+        prefixSortConfig_);
     folly::Synchronized<common::SpillStats> spillStats;
     auto sortBuffer = std::make_unique<SortBuffer>(
         inputType_,
@@ -361,7 +369,7 @@ TEST_F(SortBufferTest, batchOutput) {
   }
 }
 
-TEST_F(SortBufferTest, spill) {
+TEST_P(SortBufferTest, spill) {
   struct {
     bool spillEnabled;
     bool memoryReservationFailure;
@@ -408,7 +416,8 @@ TEST_F(SortBufferTest, spill) {
         0,
         0,
         0,
-        "none");
+        "none",
+        prefixSortConfig_);
     folly::Synchronized<common::SpillStats> spillStats;
     auto sortBuffer = std::make_unique<SortBuffer>(
         inputType_,
@@ -463,7 +472,7 @@ TEST_F(SortBufferTest, spill) {
   }
 }
 
-DEBUG_ONLY_TEST_F(SortBufferTest, spillDuringInput) {
+DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringInput) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   const auto spillConfig = getSpillConfig(spillDirectory->getPath());
   folly::Synchronized<common::SpillStats> spillStats;
@@ -520,7 +529,7 @@ DEBUG_ONLY_TEST_F(SortBufferTest, spillDuringInput) {
   }
 }
 
-DEBUG_ONLY_TEST_F(SortBufferTest, spillDuringOutput) {
+DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringOutput) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   const auto spillConfig = getSpillConfig(spillDirectory->getPath());
   folly::Synchronized<common::SpillStats> spillStats;
@@ -572,7 +581,7 @@ DEBUG_ONLY_TEST_F(SortBufferTest, spillDuringOutput) {
   }
 }
 
-DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySortGetOutput) {
+DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySortGetOutput) {
   for (bool spillEnabled : {false, true}) {
     SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
 
@@ -626,7 +635,7 @@ DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySortGetOutput) {
   }
 }
 
-DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySort) {
+DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySort) {
   struct {
     bool usePrefixSort;
     bool spillEnabled;
@@ -676,7 +685,7 @@ DEBUG_ONLY_TEST_F(SortBufferTest, reserveMemorySort) {
   }
 }
 
-TEST_F(SortBufferTest, emptySpill) {
+TEST_P(SortBufferTest, emptySpill) {
   const std::shared_ptr<memory::MemoryPool> fuzzerPool =
       memory::memoryManager()->addLeafPool("emptySpillSource");
 
@@ -704,4 +713,9 @@ TEST_F(SortBufferTest, emptySpill) {
     ASSERT_TRUE(spillStats.rlock()->empty());
   }
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    SortBufferTest,
+    SortBufferTest,
+    testing::ValuesIn({false, true}));
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
Spill uses timsort which is introduced in https://github.com/facebookincubator/velox/pull/6745.
Use the query config `spill_enable_prefix_sort` default false to control if use prefix sort in spill, prefix sort requires extra memory such as prefix data which timsort not.
Prefix sort fallbacks to stdsort when the condition is not satisfied such as sort type contains string type.
So if enable prefix sort, OOM may occur and string type performance may deteriorate depending on data pattern but sort performance is much better.
The sort performance accelerates 2 times  vs before from 561.38ms to 323.14ms in `velox_spiller_aggregate_benchmark`, total time accelerates 18% from 139.75ms to 114.38ms.
```
/mnt/DP_disk1/code/velox/build/velox/exec/tests# ./velox_spiller_aggregate_benchmark
WARNING: Logging before InitGoogleLogging() is written to STDERR
I1029 16:12:05.584403 1758176 AggregateSpillBenchmarkBase.cpp:81] ======Aggregate AGGREGATE_INPUT spilling statistics======
I1029 16:12:05.584498 1758176 AggregateSpillBenchmarkBase.cpp:83] total execution time: 139.75ms
I1029 16:12:05.584528 1758176 AggregateSpillBenchmarkBase.cpp:84] 10000 vectors each with 100 rows have been processed
I1029 16:12:05.584535 1758176 AggregateSpillBenchmarkBase.cpp:87] peak memory usage[0B] cumulative memory usage[0B]
I1029 16:12:05.584542 1758176 AggregateSpillBenchmarkBase.cpp:90] spillRuns[1] spilledInputBytes[1.49GB] spilledBytes[122.09MB] spilledRows[1000000] spilledPartitions[8] spilledFiles[8] spillFillTimeNanos[20.78ms] spillSortTimeNanos[561.38ms] spillExtractVectorTime[170.30ms] spillSerializationTimeNanos[41.86ms] spillWrites[128] spillFlushTimeNanos[13.78ms] spillWriteTimeNanos[85.34ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
I1029 16:12:05.584635 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-7-0-7 size 15.12MB
I1029 16:12:05.584645 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-4-0-3 size 15.37MB
I1029 16:12:05.584656 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-0-0-0 size 15.30MB
I1029 16:12:05.584664 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-5-0-4 size 15.22MB
I1029 16:12:05.584672 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-2-0-2 size 15.28MB
I1029 16:12:05.584681 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-3-0-6 size 15.23MB
I1029 16:12:05.584689 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-1-0-1 size 15.35MB
I1029 16:12:05.584697 1758176 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_FMUXBc/SpillerBenchmarkTest-spill-6-0-5 size 15.22MB
I1029 16:12:05.584717 1758176 SpillerBenchmarkBase.cpp:143] Remove spill dir: /tmp/velox_test_FMUXBc
I1029 16:12:05.602726 1758176 TempDirectoryPath.cpp:29] TempDirectoryPath:: removing all files from /tmp/velox_test_FMUXBc
/mnt/DP_disk1/code/velox/build/velox/exec/tests# ./velox_spiller_aggregate_benchmark
WARNING: Logging before InitGoogleLogging() is written to STDERR
I1029 16:12:53.025599 1758616 AggregateSpillBenchmarkBase.cpp:81] ======Aggregate AGGREGATE_INPUT spilling statistics======
I1029 16:12:53.025705 1758616 AggregateSpillBenchmarkBase.cpp:83] total execution time: 114.38ms
I1029 16:12:53.025740 1758616 AggregateSpillBenchmarkBase.cpp:84] 10000 vectors each with 100 rows have been processed
I1029 16:12:53.025746 1758616 AggregateSpillBenchmarkBase.cpp:87] peak memory usage[0B] cumulative memory usage[0B]
I1029 16:12:53.025755 1758616 AggregateSpillBenchmarkBase.cpp:90] spillRuns[1] spilledInputBytes[1.49GB] spilledBytes[122.09MB] spilledRows[1000000] spilledPartitions[8] spilledFiles[8] spillFillTimeNanos[21.92ms] spillSortTimeNanos[323.14ms] spillExtractVectorTime[176.32ms] spillSerializationTimeNanos[46.42ms] spillWrites[128] spillFlushTimeNanos[12.87ms] spillWriteTimeNanos[92.95ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
I1029 16:12:53.025866 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-0-0-0 size 15.30MB
I1029 16:12:53.025879 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-5-0-2 size 15.22MB
I1029 16:12:53.025890 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-4-0-4 size 15.37MB
I1029 16:12:53.025902 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-3-0-3 size 15.23MB
I1029 16:12:53.025911 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-2-0-5 size 15.28MB
I1029 16:12:53.025921 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-1-0-1 size 15.35MB
I1029 16:12:53.025933 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-6-0-7 size 15.22MB
I1029 16:12:53.025943 1758616 AggregateSpillBenchmarkBase.cpp:97] spilled file /tmp/velox_test_5tmfHu/SpillerBenchmarkTest-spill-7-0-6 size 15.12MB
I1029 16:12:53.025956 1758616 SpillerBenchmarkBase.cpp:143] Remove spill dir: /tmp/velox_test_5tmfHu
I1029 16:12:53.045596 1758616 TempDirectoryPath.cpp:29] TempDirectoryPath:: removing all files from /tmp/velox_test_5tmfHu
```