### PR TITLE
Allow partial date parsing when simple datetime formatter is used

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -344,8 +344,8 @@ format completely matches the string. If there is any mismatch, exception is thr
 
         SELECT get_timestamp('2015-07-22 10:00:00', 'yyyy-MM-dd'); -- timestamp `2015-07-22` (for Simple date formatter)
         SELECT get_timestamp('2015-07-22 10:00:00', 'yyyy-MM-dd'); -- (throws exception) (for Joda date formatter)
-        SELECT unix_timestamp('2016-04-08', 'yyyy-MM-dd'); -- 1460041200 (for Simple date formatter)
-        SELECT unix_timestamp('2016-04-08', 'yyyy-MM-dd'); -- (throws exception) (for Joda date formatter)
+        SELECT unix_timestamp('2016-04-08 00:00:00', 'yyyy-MM-dd'); -- 1460041200 (for Simple date formatter)
+        SELECT unix_timestamp('2016-04-08 00:00:00', 'yyyy-MM-dd'); -- (throws exception) (for Joda date formatter)
 
 For `from_unixtime` and `get_timestamp`, when `Simple` date formatter is used, null is returned for invalid
 format; otherwise, exception is thrown. ::

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -326,17 +326,18 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT year_of_week('2005-01-02'); -- 2004
 
-Different Behaviors Between Simple And Joda Date Formmaters
---------------------------------
+Different Behaviors Between Simple vs. Joda Date Formatter
+----------------------------------------------------------
 
 To align with Spark, Velox supports both `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_
-and `Joda <https://www.joda.org/joda-time/>`_ date formmater to parse/format timestamp/date strings
-on the functions `from_unixtime`, `unix_timestamp`, `make_date` and `to_unix_timestamp`.
+and `Joda <https://www.joda.org/joda-time/>`_ date formmaters to parse/format timestamp/date strings
+used in functions :spark:func:`from_unixtime`, :spark:func:`unix_timestamp`, :spark:func:`make_date`
+and :spark:func:`to_unix_timestamp`.
 If the configuration setting :doc:`spark.legacy_date_formatter <../../configs>` is true,
 `Simple` date formmater in lenient mode is used; otherwise, `Joda` is used. It is important
 to note that there are some different behaviors between these two formatters.
 
-For `unix_timestamp` and `get_timestamp`, the `Simple` date formatter permits partial date parsing
+For :spark:func:`unix_timestamp` and :spark:func:`get_timestamp`, the `Simple` date formatter permits partial date parsing
 which means that format can match only a part of input string. For example, if input string is
 2015-07-22 10:00:00, it can be parsed using format is yyyy-MM-dd because the parser does not require entire
 input to be consumed. In contrast, the `Joda` date formatter performs strict checks to ensure that the
@@ -347,8 +348,8 @@ format completely matches the string. If there is any mismatch, exception is thr
         SELECT unix_timestamp('2016-04-08 00:00:00', 'yyyy-MM-dd'); -- 1460041200 (for Simple date formatter)
         SELECT unix_timestamp('2016-04-08 00:00:00', 'yyyy-MM-dd'); -- (throws exception) (for Joda date formatter)
 
-For `from_unixtime` and `get_timestamp`, when `Simple` date formatter is used, null is returned for invalid
-format; otherwise, exception is thrown. ::
+For :spark:func:`from_unixtime` and :spark:func:`get_timestamp`, when `Simple` date formatter is used, null is
+returned for invalid format; otherwise, exception is thrown. ::
 
         SELECT from_unixtime(100, '!@#$%^&*'); -- NULL (parsing error) (for Simple date formatter)
         SELECT from_unixtime(100, '!@#$%^&*'); -- throws exception) (for Joda date formatter)

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -117,13 +117,18 @@ These functions support TIMESTAMP and DATE input types.
     date formatter in lenient mode that is align with Spark legacy date parser behavior or
     `Joda <https://www.joda.org/joda-time/>`_ date formatter depends on ``spark.legacy_date_formatter`` configuration.
     Returns NULL for parsing error or NULL input. When `Simple` date formatter is used, null is returned for invalid
-    ``dateFormat``; otherwise, exception is thrown. The `Simple` date formatter also permits partial date parsing;
-    otherwise, exception is thrown. ::
+    ``dateFormat``; otherwise, exception is thrown. The `Simple` date formatter also permits partial date parsing
+    which means that ``dateFormat`` can match only a part of ``string``. For example, if ``string`` is
+    2015-07-22 10:00:00, it can be parsed using ``dateFormat`` is yyyy-MM-dd because the parser does not require entire
+    input to be consumed. In contrast, the `Joda` date formatter performs strict checks to ensure that the
+    ``dateFormat`` completely matches the ``string``. If there is any mismatch, exception is thrown. ::
 
         SELECT get_timestamp('1970-01-01', 'yyyy-MM-dd);  -- timestamp `1970-01-01`
         SELECT get_timestamp('1970-01-01', 'yyyy-MM');  -- NULL (parsing error)
         SELECT get_timestamp('1970-01-01', null);  -- NULL
         SELECT get_timestamp('2020-06-10', 'A');  -- (throws exception)
+        SELECT get_timestamp('2015-07-22 10:00:00', 'yyyy-MM-dd'); -- timestamp `2015-07-22` (for Simple date formatter)
+        SELECT get_timestamp('2015-07-22 10:00:00', 'yyyy-MM-dd'); -- (throws exception) (for Joda date formatter)
 
 .. spark:function:: hour(timestamp) -> integer
 
@@ -312,8 +317,13 @@ These functions support TIMESTAMP and DATE input types.
     `Datetime patterns for formatting and parsing
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
     Returns null if ``string`` does not match ``format`` or if ``format``
-    is invalid. When `Simple` date formatter is used, permit partial date
-    parsing; otherwise, exception is thrown.
+    is invalid. The `Simple` date formatter permits partial date parsing
+    which means that ``format`` can match only a part of ``string``. For example,
+    if ``string`` is 2015-07-22 10:00:00, it can be parsed using ``format`` is
+    yyyy-MM-dd because the parser does not require entire input to be consumed.
+    In contrast, the `Joda` date formatter performs strict checks to ensure that the
+    ``format`` completely matches the ``string``. If there is any mismatch,
+    exception is thrown.
 
 .. function:: week_of_year(x) -> integer
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -354,3 +354,4 @@ format; otherwise, exception is thrown. ::
         SELECT from_unixtime(100, '!@#$%^&*'); -- throws exception) (for Joda date formatter)
         SELECT get_timestamp('1970-01-01', '!@#$%^&*'); -- NULL (parsing error) (for Simple date formatter)
         SELECT get_timestamp('1970-01-01', '!@#$%^&*'); -- throws exception) (for Joda date formatter)
+

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -326,8 +326,8 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT year_of_week('2005-01-02'); -- 2004
 
-Different Behaviors Between Simple vs. Joda Date Formatter
-----------------------------------------------------------
+Simple vs. Joda Date Formatter
+------------------------------
 
 To align with Spark, Velox supports both `Simple <https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html>`_
 and `Joda <https://www.joda.org/joda-time/>`_ date formmaters to parse/format timestamp/date strings

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -117,7 +117,8 @@ These functions support TIMESTAMP and DATE input types.
     date formatter in lenient mode that is align with Spark legacy date parser behavior or
     `Joda <https://www.joda.org/joda-time/>`_ date formatter depends on ``spark.legacy_date_formatter`` configuration.
     Returns NULL for parsing error or NULL input. When `Simple` date formatter is used, null is returned for invalid
-    ``dateFormat``; otherwise, exception is thrown. ::
+    ``dateFormat``; otherwise, exception is thrown. The `Simple` date formatter also permits partial date parsing;
+    otherwise, exception is thrown. ::
 
         SELECT get_timestamp('1970-01-01', 'yyyy-MM-dd);  -- timestamp `1970-01-01`
         SELECT get_timestamp('1970-01-01', 'yyyy-MM');  -- NULL (parsing error)
@@ -311,7 +312,8 @@ These functions support TIMESTAMP and DATE input types.
     `Datetime patterns for formatting and parsing
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
     Returns null if ``string`` does not match ``format`` or if ``format``
-    is invalid.
+    is invalid. When `Simple` date formatter is used, permit partial date
+    parsing; otherwise, exception is thrown.
 
 .. function:: week_of_year(x) -> integer
 

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1588,8 +1588,7 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
     }
   }
 
-  // Ensure all input was consumed if type_ is not LENIENT_SIMPLE or
-  // STRICT_SIMPLE.
+  // Ensure all input was consumed if type_ is not legacy datetime formatter.
   if (type_ != DateTimeFormatterType::LENIENT_SIMPLE &&
       type_ != DateTimeFormatterType::STRICT_SIMPLE && cur < end) {
     return parseFail(input, cur, end);

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1588,8 +1588,10 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
     }
   }
 
-  // Ensure all input was consumed.
-  if (cur < end) {
+  // Ensure all input was consumed if type_ is not LENIENT_SIMPLE or
+  // STRICT_SIMPLE.
+  if (type_ != DateTimeFormatterType::LENIENT_SIMPLE &&
+      type_ != DateTimeFormatterType::STRICT_SIMPLE && cur < end) {
     return parseFail(input, cur, end);
   }
 

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1588,8 +1588,7 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
     }
   }
 
-  // Ensure all input was consumed if type_ is not LENIENT_SIMPLE or
-  // STRICT_SIMPLE datetime formatter.
+  // Ensure all input was consumed if type_ is not simple datetime formatter.
   if (type_ != DateTimeFormatterType::LENIENT_SIMPLE &&
       type_ != DateTimeFormatterType::STRICT_SIMPLE && cur < end) {
     return parseFail(input, cur, end);

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1588,7 +1588,8 @@ Expected<DateTimeResult> DateTimeFormatter::parse(
     }
   }
 
-  // Ensure all input was consumed if type_ is not legacy datetime formatter.
+  // Ensure all input was consumed if type_ is not LENIENT_SIMPLE or
+  // STRICT_SIMPLE datetime formatter.
   if (type_ != DateTimeFormatterType::LENIENT_SIMPLE &&
       type_ != DateTimeFormatterType::STRICT_SIMPLE && cur < end) {
     return parseFail(input, cur, end);

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -2441,4 +2441,12 @@ TEST_F(SimpleDateTimeFormatterTest, formatWeekOfMonth) {
   }
 }
 
+TEST_F(SimpleDateTimeFormatterTest, parseUsingPartialInput) {
+  for (bool lenient : {true, false}) {
+    EXPECT_EQ(
+        fromTimestampString("2024-08-01"),
+        parseSimple("2024 08 01 5", "yyyy MM", lenient).timestamp);
+  }
+}
+
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -2442,11 +2442,12 @@ TEST_F(SimpleDateTimeFormatterTest, formatWeekOfMonth) {
 }
 
 TEST_F(SimpleDateTimeFormatterTest, parseUsingPartialInput) {
-  for (bool lenient : {true, false}) {
-    EXPECT_EQ(
-        fromTimestampString("2024-08-01"),
-        parseSimple("2024 08 01 5", "yyyy MM", lenient).timestamp);
-  }
+  EXPECT_EQ(
+      fromTimestampString("2024-08-01"),
+      parseSimple("2024 08 01 5", "yyyy MM", true).timestamp);
+  EXPECT_EQ(
+      fromTimestampString("2024-08-01"),
+      parseSimple("2024 08 01 5", "yyyy MM", false).timestamp);
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
The Spark legacy datetime formatter allows parsing date from incomplete text, 
seeing [code link](https://github.com/openjdk/jdk8/blob/master/jdk/src/share/classes/java/text/DateFormat.java#L351). This PR enables partial date parsing when the `LENIENT_SIMPLE`
or `STRICT_SIMPLE` datetime formatter is used.

Relates issues: #10354, [gluten#6227](https://github.com/apache/incubator-gluten/issues/6227) 