### PR TITLE
Fix velox_query_replayer linking error

### DIFF
--- a/velox/tool/trace/CMakeLists.txt
+++ b/velox/tool/trace/CMakeLists.txt
@@ -17,7 +17,8 @@ velox_add_library(
   AggregationReplayer.cpp
   OperatorReplayerBase.cpp
   PartitionedOutputReplayer.cpp
-  TableWriterReplayer.cpp)
+  TableWriterReplayer.cpp
+  TraceReplayRunner.cpp)
 
 velox_link_libraries(
   velox_query_trace_replayer_base


### PR DESCRIPTION
A follow-up fix PR for #11360 to address the linking error:

```cmake
[1432/1435] Linking CXX executable velox/tool/trace/velox_query_replayer
FAILED: velox/tool/trace/velox_query_replayer
...
Undefined symbols for architecture arm64:
  "facebook::velox::tool::trace::TraceReplayRunner::run()", referenced from:
      _main in TraceReplayerMain.cpp.o
  "facebook::velox::tool::trace::TraceReplayRunner::init()", referenced from:
      _main in TraceReplayerMain.cpp.o
  "facebook::velox::tool::trace::TraceReplayRunner::TraceReplayRunner()", referenced from:
      _main in TraceReplayerMain.cpp.o
  "vtable for facebook::velox::tool::trace::TraceReplayRunner", referenced from:
      facebook::velox::tool::trace::TraceReplayRunner::~TraceReplayRunner() in TraceReplayerMain.cpp.o
   NOTE: a missing vtable usually means the first non-inline virtual member function has no definition.
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)

ninja: build stopped: subcommand failed.
make[1]: *** [build] Error 1
make: *** [debug] Error 2
```

CC @xiaoxmeng 