### PR TITLE
CMake: Move resolve dependency macros under velox_ prefix

### DIFF
--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -45,10 +45,10 @@ endmacro()
 
 # * Macro to resolve third-party dependencies.
 #
-# Provides the macro velox_resolve_dependency(). This macro will allow us to find the
-# dependency via the usage of find_package or use the custom
-# velox_build_dependency(dependency_name) macro to download and build the third party
-# dependency.
+# Provides the macro velox_resolve_dependency(). This macro will allow us to
+# find the dependency via the usage of find_package or use the custom
+# velox_build_dependency(dependency_name) macro to download and build the third
+# party dependency.
 #
 # velox_resolve_dependency(dependency_name [...] )
 #
@@ -89,7 +89,7 @@ endmacro()
 # By using a macro we don't need to propagate the value into the parent scope.
 macro(velox_set_source dependency_name)
   velox_set_with_default(${dependency_name}_SOURCE ${dependency_name}_SOURCE
-                   ${VELOX_DEPENDENCY_SOURCE})
+                         ${VELOX_DEPENDENCY_SOURCE})
   message(
     STATUS "Setting ${dependency_name} source to ${${dependency_name}_SOURCE}")
 endmacro()
@@ -143,7 +143,7 @@ macro(velox_resolve_dependency_url dependency_name)
           "${VELOX_${dependency_name}_SOURCE_URL}")
   if(DEFINED ENV{VELOX_${dependency_name}_URL})
     velox_set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM
-                     VELOX_${dependency_name}_SHA256 "")
+                           VELOX_${dependency_name}_SHA256 "")
     if(DEFINED ENV{VELOX_${dependency_name}_SHA256})
       string(PREPEND VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM "SHA256=")
     endif()

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -110,27 +110,6 @@ function(velox_set_with_default var_name envvar_name default)
   endif()
 endfunction()
 
-# List subdirectories of ${dir}
-function(velox_list_subdirs var dir)
-  if(NOT IS_DIRECTORY ${dir})
-    message(FATAL_ERROR "${dir} is not a directory!")
-  endif()
-
-  # finds files & dirs
-  file(GLOB children ${dir}/*)
-  set(dirs "")
-
-  foreach(child ${children})
-    if(IS_DIRECTORY ${child})
-      list(APPEND dirs ${child})
-    endif()
-  endforeach()
-
-  set(${var}
-      ${dirs}
-      PARENT_SCOPE)
-endfunction()
-
 # Set custom source url with a optional sha256 checksum.
 macro(velox_resolve_dependency_url dependency_name)
   # Prepend prefix for default checksum.

--- a/CMake/ResolveDependency.cmake
+++ b/CMake/ResolveDependency.cmake
@@ -14,7 +14,7 @@
 
 # MODULE:   ThirdpartyToolchain
 #
-# PROVIDES: resolve_dependency( dependency_name dependencyName [...] )
+# PROVIDES: velox_resolve_dependency( dependency_name dependencyName [...] )
 #
 # Provides the ability to resolve third party dependencies. If the dependency is
 # already available in the system it will be used.
@@ -24,7 +24,7 @@
 # should match find_package() standards.
 #
 # EXAMPLE USAGE: # Download and setup or use already installed dependency.
-# include(ThirdpartyToolchain) resolve_dependency(folly)
+# include(ThirdpartyToolchain) velox_resolve_dependency(folly)
 #
 # ==============================================================================
 
@@ -38,19 +38,19 @@ list(APPEND CMAKE_MODULE_PATH
 # Enable SSL certificate verification for file downloads
 set(CMAKE_TLS_VERIFY true)
 
-macro(build_dependency dependency_name)
+macro(velox_build_dependency dependency_name)
   string(TOLOWER ${dependency_name} dependency_name_lower)
   include(${dependency_name_lower})
 endmacro()
 
 # * Macro to resolve third-party dependencies.
 #
-# Provides the macro resolve_dependency(). This macro will allow us to find the
+# Provides the macro velox_resolve_dependency(). This macro will allow us to find the
 # dependency via the usage of find_package or use the custom
-# build_dependency(dependency_name) macro to download and build the third party
+# velox_build_dependency(dependency_name) macro to download and build the third party
 # dependency.
 #
-# resolve_dependency(dependency_name [...] )
+# velox_resolve_dependency(dependency_name [...] )
 #
 # [...]: the macro will pass all arguments after DEPENDENCY_NAME on to
 # find_package. ${dependency_name}_SOURCE is expected to be set to either AUTO,
@@ -63,7 +63,7 @@ endmacro()
 # In the case of setting ${dependency_name}_SOURCE to SYSTEM if the dependency
 # is not found the build will fail and will not fall back to download and build
 # from source.
-macro(resolve_dependency dependency_name)
+macro(velox_resolve_dependency dependency_name)
   set(find_package_args ${dependency_name} ${ARGN})
   list(REMOVE_ITEM find_package_args REQUIRED QUIET)
   if(${dependency_name}_SOURCE STREQUAL "AUTO")
@@ -72,13 +72,13 @@ macro(resolve_dependency dependency_name)
       set(${dependency_name}_SOURCE "SYSTEM")
     else()
       set(${dependency_name}_SOURCE "BUNDLED")
-      build_dependency(${dependency_name})
+      velox_build_dependency(${dependency_name})
     endif()
     message(STATUS "Using ${${dependency_name}_SOURCE} ${dependency_name}")
   elseif(${dependency_name}_SOURCE STREQUAL "SYSTEM")
     find_package(${find_package_args} REQUIRED)
   elseif(${dependency_name}_SOURCE STREQUAL "BUNDLED")
-    build_dependency(${dependency_name})
+    velox_build_dependency(${dependency_name})
   else()
     message(
       FATAL_ERROR
@@ -87,8 +87,8 @@ macro(resolve_dependency dependency_name)
 endmacro()
 
 # By using a macro we don't need to propagate the value into the parent scope.
-macro(set_source dependency_name)
-  set_with_default(${dependency_name}_SOURCE ${dependency_name}_SOURCE
+macro(velox_set_source dependency_name)
+  velox_set_with_default(${dependency_name}_SOURCE ${dependency_name}_SOURCE
                    ${VELOX_DEPENDENCY_SOURCE})
   message(
     STATUS "Setting ${dependency_name} source to ${${dependency_name}_SOURCE}")
@@ -98,7 +98,7 @@ endmacro()
 # ENV or var_name is defined then set var_name to ${DEFAULT}. If called from
 # within a nested scope the variable will not propagate into outer scopes
 # automatically! Use PARENT_SCOPE.
-function(set_with_default var_name envvar_name default)
+function(velox_set_with_default var_name envvar_name default)
   if(DEFINED ENV{${envvar_name}})
     set(${var_name}
         $ENV{${envvar_name}}
@@ -111,7 +111,7 @@ function(set_with_default var_name envvar_name default)
 endfunction()
 
 # List subdirectories of ${dir}
-function(list_subdirs var dir)
+function(velox_list_subdirs var dir)
   if(NOT IS_DIRECTORY ${dir})
     message(FATAL_ERROR "${dir} is not a directory!")
   endif()
@@ -132,17 +132,17 @@ function(list_subdirs var dir)
 endfunction()
 
 # Set custom source url with a optional sha256 checksum.
-macro(resolve_dependency_url dependency_name)
+macro(velox_resolve_dependency_url dependency_name)
   # Prepend prefix for default checksum.
   string(PREPEND VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM "SHA256=")
 
-  set_with_default(
+  velox_set_with_default(
     VELOX_${dependency_name}_SOURCE_URL VELOX_${dependency_name}_URL
     ${VELOX_${dependency_name}_SOURCE_URL})
   message(VERBOSE "Set VELOX_${dependency_name}_SOURCE_URL to "
           "${VELOX_${dependency_name}_SOURCE_URL}")
   if(DEFINED ENV{VELOX_${dependency_name}_URL})
-    set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM
+    velox_set_with_default(VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM
                      VELOX_${dependency_name}_SHA256 "")
     if(DEFINED ENV{VELOX_${dependency_name}_SHA256})
       string(PREPEND VELOX_${dependency_name}_BUILD_SHA256_CHECKSUM "SHA256=")

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -69,7 +69,7 @@ Ideally all patches should be upstream when possible and removed once merged.
 ## Adding new dependencies
 
 - Copy `template.cmake` and rename it to the name used in `find_package` but all lower-case.
-- Switch `find_package` vs `set_source('package')` `resolve_dependency('package' 'optional args for find_package')` in `CMakeLists.txt`
+- Switch `find_package` vs `velox_set_source('package')` `velox_resolve_dependency('package' 'optional args for find_package')` in `CMakeLists.txt`
 - Update the template with the correct package name and download url/repo etc., set any necessary package options
 - Try to build and make necessary changes
   - Repeat until success :D (Feel free to raise and issue for review & support)

--- a/CMake/resolve_dependency_modules/absl.cmake
+++ b/CMake/resolve_dependency_modules/absl.cmake
@@ -16,9 +16,10 @@ include_guard(GLOBAL)
 set(VELOX_ABSL_BUILD_VERSION 20240116.2)
 set(VELOX_ABSL_BUILD_SHA256_CHECKSUM
     733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc)
-string(CONCAT VELOX_ABSL_SOURCE_URL
-              "https://github.com/abseil/abseil-cpp/archive/refs/tags/"
-              "${VELOX_ABSL_BUILD_VERSION}.tar.gz")
+string(
+  CONCAT VELOX_ABSL_SOURCE_URL
+         "https://github.com/abseil/abseil-cpp/archive/refs/tags/"
+         "${VELOX_ABSL_BUILD_VERSION}.tar.gz")
 
 velox_resolve_dependency_url(ABSL)
 

--- a/CMake/resolve_dependency_modules/absl.cmake
+++ b/CMake/resolve_dependency_modules/absl.cmake
@@ -20,7 +20,7 @@ string(CONCAT VELOX_ABSL_SOURCE_URL
               "https://github.com/abseil/abseil-cpp/archive/refs/tags/"
               "${VELOX_ABSL_BUILD_VERSION}.tar.gz")
 
-resolve_dependency_url(ABSL)
+velox_resolve_dependency_url(ABSL)
 
 message(STATUS "Building Abseil from source")
 

--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -62,7 +62,7 @@ if(VELOX_ENABLE_ARROW)
       "https://archive.apache.org/dist/arrow/arrow-${VELOX_ARROW_BUILD_VERSION}/apache-arrow-${VELOX_ARROW_BUILD_VERSION}.tar.gz"
   )
 
-  resolve_dependency_url(ARROW)
+  velox_resolve_dependency_url(ARROW)
 
   ExternalProject_Add(
     arrow_ep

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -30,7 +30,7 @@ string(
 set(VELOX_BOOST_BUILD_SHA256_CHECKSUM
     4d27e9efed0f6f152dc28db6430b9d3dfb40c0345da7342eaa5a987dde57bd95)
 
-resolve_dependency_url(BOOST)
+velox_resolve_dependency_url(BOOST)
 message(STATUS "Building boost from source")
 
 # required for Boost::thread

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -66,5 +66,7 @@ set(BUILD_SHARED_LIBS OFF)
 FetchContent_MakeAvailable(Boost)
 
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)
-target_link_libraries(boost_headers INTERFACE ${BOOST_HEADER_ONLY})
+target_link_libraries(
+  boost_headers
+  INTERFACE ${BOOST_HEADER_ONLY})
 add_library(Boost::headers ALIAS boost_headers)

--- a/CMake/resolve_dependency_modules/c-ares.cmake
+++ b/CMake/resolve_dependency_modules/c-ares.cmake
@@ -21,7 +21,7 @@ string(
          "https://github.com/c-ares/c-ares/archive/refs/tags/"
          "${VELOX_CARES_BUILD_VERSION}.tar.gz")
 
-resolve_dependency_url(CARES)
+velox_resolve_dependency_url(CARES)
 
 message(STATUS "Building C-ARES from source")
 

--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -23,9 +23,9 @@ set(VELOX_CPR_SOURCE_URL
 # Add the dependency for curl, so that we can define the source URL for curl in
 # curl.cmake. This will override the curl version declared by cpr.
 set(curl_SOURCE BUNDLED)
-resolve_dependency(curl)
+velox_resolve_dependency(curl)
 
-resolve_dependency_url(CPR)
+velox_resolve_dependency_url(CPR)
 
 message(STATUS "Building cpr from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/curl.cmake
+++ b/CMake/resolve_dependency_modules/curl.cmake
@@ -22,7 +22,7 @@ string(
     VELOX_CURL_SOURCE_URL "https://github.com/curl/curl/releases/download/"
     "curl-${VELOX_CURL_VERSION_UNDERSCORES}/curl-${VELOX_CURL_VERSION}.tar.xz")
 
-resolve_dependency_url(CURL)
+velox_resolve_dependency_url(CURL)
 
 FetchContent_Declare(
   curl

--- a/CMake/resolve_dependency_modules/duckdb.cmake
+++ b/CMake/resolve_dependency_modules/duckdb.cmake
@@ -20,7 +20,7 @@ set(VELOX_DUCKDB_SOURCE_URL
     "https://github.com/duckdb/duckdb/archive/refs/tags/v${VELOX_DUCKDB_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(DUCKDB)
+velox_resolve_dependency_url(DUCKDB)
 
 message(STATUS "Building DuckDB from source")
 # We need remove-ccache.patch to remove adding ccache to the build command

--- a/CMake/resolve_dependency_modules/fmt.cmake
+++ b/CMake/resolve_dependency_modules/fmt.cmake
@@ -19,7 +19,7 @@ set(VELOX_FMT_BUILD_SHA256_CHECKSUM
 set(VELOX_FMT_SOURCE_URL
     "https://github.com/fmtlib/fmt/archive/${VELOX_FMT_VERSION}.tar.gz")
 
-resolve_dependency_url(FMT)
+velox_resolve_dependency_url(FMT)
 
 message(STATUS "Building fmt from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -21,7 +21,7 @@ set(VELOX_FOLLY_SOURCE_URL
     "https://github.com/facebook/folly/releases/download/${VELOX_FOLLY_BUILD_VERSION}/folly-${VELOX_FOLLY_BUILD_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(FOLLY)
+velox_resolve_dependency_url(FOLLY)
 
 message(STATUS "Building Folly from source")
 

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -16,9 +16,10 @@ include_guard(GLOBAL)
 set(VELOX_GFLAGS_VERSION 2.2.2)
 set(VELOX_GFLAGS_BUILD_SHA256_CHECKSUM
     34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf)
-string(CONCAT VELOX_GFLAGS_SOURCE_URL
-              "https://github.com/gflags/gflags/archive/refs/tags/"
-              "v${VELOX_GFLAGS_VERSION}.tar.gz")
+string(
+  CONCAT VELOX_GFLAGS_SOURCE_URL
+         "https://github.com/gflags/gflags/archive/refs/tags/"
+         "v${VELOX_GFLAGS_VERSION}.tar.gz")
 
 velox_resolve_dependency_url(GFLAGS)
 

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -20,7 +20,7 @@ string(CONCAT VELOX_GFLAGS_SOURCE_URL
               "https://github.com/gflags/gflags/archive/refs/tags/"
               "v${VELOX_GFLAGS_VERSION}.tar.gz")
 
-resolve_dependency_url(GFLAGS)
+velox_resolve_dependency_url(GFLAGS)
 
 message(STATUS "Building gflags from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/glog.cmake
+++ b/CMake/resolve_dependency_modules/glog.cmake
@@ -20,7 +20,7 @@ set(VELOX_GLOG_SOURCE_URL
     "https://github.com/google/glog/archive/refs/tags/v${VELOX_GLOG_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(GLOG)
+velox_resolve_dependency_url(GLOG)
 
 message(STATUS "Building glog from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/google_cloud_cpp_storage.cmake
+++ b/CMake/resolve_dependency_modules/google_cloud_cpp_storage.cmake
@@ -13,8 +13,8 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set_source(gRPC)
-resolve_dependency(gRPC CONFIG 1.48.1 REQUIRED)
+velox_set_source(gRPC)
+velox_resolve_dependency(gRPC CONFIG 1.48.1 REQUIRED)
 
 set(VELOX_GOOGLE_CLOUD_CPP_BUILD_VERSION 2.22.0)
 set(VELOX_GOOGLE_CLOUD_CPP_BUILD_SHA256_CHECKSUM
@@ -24,7 +24,7 @@ string(
          "https://github.com/googleapis/google-cloud-cpp/archive/refs/tags/"
          "v${VELOX_GOOGLE_CLOUD_CPP_BUILD_VERSION}.tar.gz")
 
-resolve_dependency_url(GOOGLE_CLOUD_CPP)
+velox_resolve_dependency_url(GOOGLE_CLOUD_CPP)
 
 message(STATUS "Building Google Cloud CPP storage from source")
 

--- a/CMake/resolve_dependency_modules/grpc.cmake
+++ b/CMake/resolve_dependency_modules/grpc.cmake
@@ -13,8 +13,8 @@
 # limitations under the License.
 include_guard(GLOBAL)
 
-set_source(absl)
-resolve_dependency(absl CONFIG REQUIRED)
+velox_set_source(absl)
+velox_resolve_dependency(absl CONFIG REQUIRED)
 
 set(VELOX_GRPC_BUILD_VERSION 1.48.1)
 set(VELOX_GRPC_BUILD_SHA256_CHECKSUM
@@ -24,7 +24,7 @@ string(
          "https://github.com/grpc/grpc/archive/refs/tags/"
          "v${VELOX_GRPC_BUILD_VERSION}.tar.gz")
 
-resolve_dependency_url(GRPC)
+velox_resolve_dependency_url(GRPC)
 
 message(STATUS "Building gRPC from source")
 

--- a/CMake/resolve_dependency_modules/gtest.cmake
+++ b/CMake/resolve_dependency_modules/gtest.cmake
@@ -20,7 +20,7 @@ set(VELOX_GTEST_SOURCE_URL
     "https://github.com/google/googletest/archive/refs/tags/v${VELOX_GTEST_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(GTEST)
+velox_resolve_dependency_url(GTEST)
 
 message(STATUS "Building gtest from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/icu.cmake
+++ b/CMake/resolve_dependency_modules/icu.cmake
@@ -22,12 +22,12 @@ string(
          "release-${VELOX_ICU4C_BUILD_VERSION}-1/"
          "icu4c-${VELOX_ICU4C_BUILD_VERSION}_1-src.tgz")
 
-resolve_dependency_url(ICU4C)
+velox_resolve_dependency_url(ICU4C)
 
 message(STATUS "Building ICU4C from source")
 
 ProcessorCount(NUM_JOBS)
-set_with_default(NUM_JOBS NUM_THREADS ${NUM_JOBS})
+velox_set_with_default(NUM_JOBS NUM_THREADS ${NUM_JOBS})
 find_program(MAKE_PROGRAM make REQUIRED)
 
 set(ICU_CFG --disable-tests --disable-samples)

--- a/CMake/resolve_dependency_modules/icu.cmake
+++ b/CMake/resolve_dependency_modules/icu.cmake
@@ -65,12 +65,22 @@ file(MAKE_DIRECTORY ${ICU_INCLUDE_DIRS})
 file(MAKE_DIRECTORY ${ICU_LIBRARIES})
 
 # Create a target for each component
-set(icu_components data i18n io uc tu test)
+set(icu_components
+    data
+    i18n
+    io
+    uc
+    tu
+    test)
 
 foreach(component ${icu_components})
   add_library(ICU::${component} SHARED IMPORTED)
-  string(CONCAT ICU_${component}_LIBRARY ${ICU_LIBRARIES} "/libicu"
-                ${component} ".so")
+  string(
+    CONCAT ICU_${component}_LIBRARY
+           ${ICU_LIBRARIES}
+           "/libicu"
+           ${component}
+           ".so")
   file(TOUCH ${ICU_${component}_LIBRARY})
   set_target_properties(
     ICU::${component}

--- a/CMake/resolve_dependency_modules/protobuf.cmake
+++ b/CMake/resolve_dependency_modules/protobuf.cmake
@@ -24,14 +24,14 @@ if(${VELOX_PROTOBUF_BUILD_VERSION} LESS 22.0)
       "v${VELOX_PROTOBUF_BUILD_VERSION}/protobuf-all-${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz"
   )
 else()
-  set_source(absl)
-  resolve_dependency(absl CONFIG REQUIRED)
+  velox_set_source(absl)
+  velox_resolve_dependency(absl CONFIG REQUIRED)
   string(CONCAT VELOX_PROTOBUF_SOURCE_URL
                 "https://github.com/protocolbuffers/protobuf/archive/"
                 "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz")
 endif()
 
-resolve_dependency_url(PROTOBUF)
+velox_resolve_dependency_url(PROTOBUF)
 
 message(STATUS "Building Protobuf from source")
 

--- a/CMake/resolve_dependency_modules/protobuf.cmake
+++ b/CMake/resolve_dependency_modules/protobuf.cmake
@@ -26,9 +26,10 @@ if(${VELOX_PROTOBUF_BUILD_VERSION} LESS 22.0)
 else()
   velox_set_source(absl)
   velox_resolve_dependency(absl CONFIG REQUIRED)
-  string(CONCAT VELOX_PROTOBUF_SOURCE_URL
-                "https://github.com/protocolbuffers/protobuf/archive/"
-                "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz")
+  string(
+    CONCAT VELOX_PROTOBUF_SOURCE_URL
+           "https://github.com/protocolbuffers/protobuf/archive/"
+           "v${VELOX_PROTOBUF_BUILD_VERSION}.tar.gz")
 endif()
 
 velox_resolve_dependency_url(PROTOBUF)

--- a/CMake/resolve_dependency_modules/pybind11.cmake
+++ b/CMake/resolve_dependency_modules/pybind11.cmake
@@ -16,9 +16,10 @@ include_guard(GLOBAL)
 set(VELOX_PYBIND11_BUILD_VERSION 2.10.0)
 set(VELOX_PYBIND11_BUILD_SHA256_CHECKSUM
     eacf582fa8f696227988d08cfc46121770823839fe9e301a20fbce67e7cd70ec)
-string(CONCAT VELOX_PYBIND11_SOURCE_URL
-              "https://github.com/pybind/pybind11/archive/refs/tags/"
-              "v${VELOX_PYBIND11_BUILD_VERSION}.tar.gz")
+string(
+  CONCAT VELOX_PYBIND11_SOURCE_URL
+         "https://github.com/pybind/pybind11/archive/refs/tags/"
+         "v${VELOX_PYBIND11_BUILD_VERSION}.tar.gz")
 
 velox_resolve_dependency_url(PYBIND11)
 

--- a/CMake/resolve_dependency_modules/pybind11.cmake
+++ b/CMake/resolve_dependency_modules/pybind11.cmake
@@ -20,7 +20,7 @@ string(CONCAT VELOX_PYBIND11_SOURCE_URL
               "https://github.com/pybind/pybind11/archive/refs/tags/"
               "v${VELOX_PYBIND11_BUILD_VERSION}.tar.gz")
 
-resolve_dependency_url(PYBIND11)
+velox_resolve_dependency_url(PYBIND11)
 
 message(STATUS "Building Pybind11 from source")
 

--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -20,7 +20,7 @@ set(VELOX_SIMDJSON_SOURCE_URL
     "https://github.com/simdjson/simdjson/archive/refs/tags/v${VELOX_SIMDJSON_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(SIMDJSON)
+velox_resolve_dependency_url(SIMDJSON)
 
 message(STATUS "Building simdjson from source")
 

--- a/CMake/resolve_dependency_modules/stemmer.cmake
+++ b/CMake/resolve_dependency_modules/stemmer.cmake
@@ -20,7 +20,7 @@ set(VELOX_STEMMER_SOURCE_URL
     "https://snowballstem.org/dist/libstemmer_c-${VELOX_STEMMER_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(STEMMER)
+velox_resolve_dependency_url(STEMMER)
 
 message(STATUS "Building stemmer from source")
 find_program(MAKE_PROGRAM make REQUIRED)

--- a/CMake/resolve_dependency_modules/template.cmake
+++ b/CMake/resolve_dependency_modules/template.cmake
@@ -19,7 +19,7 @@ set(VELOX_<PACKAGE>_BUILD_SHA256_CHECKSUM 123)
 set(VELOX_<PACKAGE>_SOURCE_URL "") # ideally don't use github archive links as
                                    # they are not guranteed to be hash stable
 
-resolve_dependency_url(<PACKAGE>)
+velox_resolve_dependency_url(<PACKAGE>)
 
 message(STATUS "Building <PACKAGE> from source")
 FetchContent_Declare(

--- a/CMake/resolve_dependency_modules/xsimd.cmake
+++ b/CMake/resolve_dependency_modules/xsimd.cmake
@@ -20,7 +20,7 @@ set(VELOX_XSIMD_SOURCE_URL
     "https://github.com/xtensor-stack/xsimd/archive/refs/tags/${VELOX_XSIMD_VERSION}.tar.gz"
 )
 
-resolve_dependency_url(XSIMD)
+velox_resolve_dependency_url(XSIMD)
 
 message(STATUS "Building xsimd from source")
 FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,8 @@ list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
 include(ResolveDependency)
 include(VeloxUtils)
 
-velox_set_with_default(VELOX_DEPENDENCY_SOURCE_DEFAULT VELOX_DEPENDENCY_SOURCE AUTO)
+velox_set_with_default(VELOX_DEPENDENCY_SOURCE_DEFAULT VELOX_DEPENDENCY_SOURCE
+                       AUTO)
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Add all options below

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
 include(ResolveDependency)
 include(VeloxUtils)
 
-set_with_default(VELOX_DEPENDENCY_SOURCE_DEFAULT VELOX_DEPENDENCY_SOURCE AUTO)
+velox_set_with_default(VELOX_DEPENDENCY_SOURCE_DEFAULT VELOX_DEPENDENCY_SOURCE AUTO)
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Add all options below
@@ -171,7 +171,7 @@ endif()
 
 if(VELOX_BUILD_TESTING OR VELOX_BUILD_TEST_UTILS)
   set(cpr_SOURCE BUNDLED)
-  resolve_dependency(cpr)
+  velox_resolve_dependency(cpr)
   set(VELOX_ENABLE_DUCKDB ON)
   set(VELOX_ENABLE_PARSE ON)
 endif()
@@ -191,8 +191,8 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
 endif()
 
 if(${VELOX_ENABLE_DUCKDB})
-  set_source(DuckDB)
-  resolve_dependency(DuckDB)
+  velox_set_source(DuckDB)
+  velox_resolve_dependency(DuckDB)
 endif()
 
 if(DEFINED ENV{INSTALL_PREFIX})
@@ -399,8 +399,8 @@ if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   endif()
 endif()
 
-set_source(ICU)
-resolve_dependency(
+velox_set_source(ICU)
+velox_resolve_dependency(
   ICU
   COMPONENTS
   data
@@ -420,14 +420,14 @@ set(BOOST_INCLUDE_LIBRARIES
     system
     thread)
 
-set_source(Boost)
-resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+velox_set_source(Boost)
+velox_resolve_dependency(Boost 1.77.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)
 
-set_source(gflags)
-resolve_dependency(gflags COMPONENTS ${VELOX_GFLAGS_TYPE})
+velox_set_source(gflags)
+velox_resolve_dependency(gflags COMPONENTS ${VELOX_GFLAGS_TYPE})
 if(NOT TARGET gflags::gflags)
   # This is a bit convoluted, but we want to be able to use gflags::gflags as a
   # target even when velox is built as a subproject which uses
@@ -445,10 +445,10 @@ if(${gflags_SOURCE} STREQUAL "BUNDLED")
 else()
   set(glog_SOURCE SYSTEM)
 endif()
-resolve_dependency(glog)
+velox_resolve_dependency(glog)
 
-set_source(fmt)
-resolve_dependency(fmt 9.0.0)
+velox_set_source(fmt)
+velox_resolve_dependency(fmt 9.0.0)
 
 if(${VELOX_BUILD_MINIMAL_WITH_DWIO} OR ${VELOX_ENABLE_HIVE_CONNECTOR})
   # DWIO needs all sorts of stream compression libraries.
@@ -469,12 +469,12 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO} OR ${VELOX_ENABLE_HIVE_CONNECTOR})
   endif()
 endif()
 
-set_source(re2)
-resolve_dependency(re2)
+velox_set_source(re2)
+velox_resolve_dependency(re2)
 
 if(${VELOX_BUILD_PYTHON_PACKAGE})
-  set_source(pybind11)
-  resolve_dependency(pybind11 2.10.0)
+  velox_set_source(pybind11)
+  velox_resolve_dependency(pybind11 2.10.0)
   add_subdirectory(pyvelox)
 endif()
 
@@ -485,31 +485,31 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO}
    OR VELOX_ENABLE_GCS)
 
   # Locate or build protobuf.
-  set_source(Protobuf)
-  resolve_dependency(Protobuf CONFIG 3.21.7 REQUIRED)
+  velox_set_source(Protobuf)
+  velox_resolve_dependency(Protobuf CONFIG 3.21.7 REQUIRED)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 
-set_source(simdjson)
-resolve_dependency(simdjson 3.9.3)
+velox_set_source(simdjson)
+velox_resolve_dependency(simdjson 3.9.3)
 
 # Locate or build folly.
 add_compile_definitions(FOLLY_HAVE_INT128_T=1)
-set_source(folly)
-resolve_dependency(folly)
+velox_set_source(folly)
+velox_resolve_dependency(folly)
 
 if(${VELOX_BUILD_TESTING})
   # Spark qury runner depends on absl, gRPC.
-  set_source(absl)
-  resolve_dependency(absl)
+  velox_set_source(absl)
+  velox_resolve_dependency(absl)
 
   # 'gRPC_CARES_PROVIDER' is set as 'package', which means c-ares library needs
   # to be installed on the system, instead of being built by gRPC.
-  set_source(c-ares)
-  resolve_dependency(c-ares)
+  velox_set_source(c-ares)
+  velox_resolve_dependency(c-ares)
 
-  set_source(gRPC)
-  resolve_dependency(gRPC)
+  velox_set_source(gRPC)
+  velox_resolve_dependency(gRPC)
 endif()
 
 if(VELOX_ENABLE_REMOTE_FUNCTIONS)
@@ -527,8 +527,8 @@ else()
 endif()
 
 if(VELOX_ENABLE_GCS)
-  set_source(google_cloud_cpp_storage)
-  resolve_dependency(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)
+  velox_set_source(google_cloud_cpp_storage)
+  velox_resolve_dependency(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)
   add_definitions(-DVELOX_ENABLE_GCS)
 endif()
 
@@ -596,18 +596,18 @@ include_directories(SYSTEM velox/external)
 
 # these were previously vendored in third-party/
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  set_source(GTest)
-  resolve_dependency(GTest)
+  velox_set_source(GTest)
+  velox_resolve_dependency(GTest)
   set(VELOX_GTEST_INCUDE_DIR
       "${gtest_SOURCE_DIR}/googletest/include"
       PARENT_SCOPE)
 endif()
 
-set_source(xsimd)
-resolve_dependency(xsimd 10.0.0)
+velox_set_source(xsimd)
+velox_resolve_dependency(xsimd 10.0.0)
 
-set_source(stemmer)
-resolve_dependency(stemmer)
+velox_set_source(stemmer)
+velox_resolve_dependency(stemmer)
 
 if(VELOX_BUILD_TESTING)
   set(BUILD_TESTING ON)
@@ -627,8 +627,8 @@ if("${TREAT_WARNINGS_AS_ERRORS}")
 endif()
 
 if(VELOX_ENABLE_ARROW)
-  set_source(Arrow)
-  resolve_dependency(Arrow)
+  velox_set_source(Arrow)
+  velox_resolve_dependency(Arrow)
 endif()
 
 add_subdirectory(velox)


### PR DESCRIPTION
It is best practice in CMake to use a project prefix for project specific macros, functions and variables. This makes it easier to compose projects in larger builds as well as differentiate general functions from project specific functions.

This moves several macros and it will require some simple migration of any CMake code reusing the resolve dependency macros:

 * build_dependency -> velox_build_dependency
 * list_subdirs -> removed after reviewer suggestion
 * resolve_dependency -> velox_resolve_dependency
 * resolve_dependency_url -> velox_resolve_dependency_url
 * set_source -> velox_set_source
 * set_with_default -> velox_set_with_default

This should be a simple change as the other changes are just to adapt to the changed macro names. 