### PR TITLE
Remove unused-variable in velox/buffer/tests/BufferTest.cpp

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -154,7 +154,6 @@ TEST_F(BufferTest, testReallocate) {
   int32_t numInPlace = 0;
   int32_t numMoved = 0;
   for (int32_t i = 0; i < buffers.size(); ++i) {
-    size_t oldSize = buffers[i]->size();
     auto ptr = buffers[i].get();
     if (i % 10 == 0) {
       AlignedBuffer::reallocate<char>(&buffers[i], i + 10000);

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -334,6 +334,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 #define VELOX_DCHECK_NE(e1, e2, ...) VELOX_CHECK_NE(e1, e2, ##__VA_ARGS__)
 #define VELOX_DCHECK_NULL(e, ...) VELOX_CHECK_NULL(e, ##__VA_ARGS__)
 #define VELOX_DCHECK_NOT_NULL(e, ...) VELOX_CHECK_NOT_NULL(e, ##__VA_ARGS__)
+#define VELOX_DEBUG_ONLY
 #else
 #define VELOX_DCHECK(expr, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_GT(e1, e2, ...) VELOX_CHECK(true)
@@ -344,6 +345,7 @@ DECLARE_CHECK_FAIL_TEMPLATES(::facebook::velox::VeloxRuntimeError);
 #define VELOX_DCHECK_NE(e1, e2, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_NULL(e, ...) VELOX_CHECK(true)
 #define VELOX_DCHECK_NOT_NULL(e, ...) VELOX_CHECK(true)
+#define VELOX_DEBUG_ONLY [[maybe_unused]]
 #endif
 
 #define VELOX_FAIL(...)                                             \

--- a/velox/common/process/tests/ProfilerTest.cpp
+++ b/velox/common/process/tests/ProfilerTest.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
     });
 
     int wstatus;
-    int w = waitpid(pid, &wstatus, WUNTRACED | WCONTINUED);
+    waitpid(pid, &wstatus, WUNTRACED | WCONTINUED);
     LOG(INFO) << "Test completed";
     completed = true;
     sleepPromise.setValue(true);

--- a/velox/dwio/common/FlatMapHelper.cpp
+++ b/velox/dwio/common/FlatMapHelper.cpp
@@ -528,7 +528,8 @@ void copyOffsetsFromConstInput(
     const BaseVector& source,
     vector_size_t sourceIndex,
     vector_size_t count) {
-  auto nullCount = copyNulls(target, targetIndex, source, sourceIndex, count);
+  VELOX_DEBUG_ONLY const auto nullCount =
+      copyNulls(target, targetIndex, source, sourceIndex, count);
   VELOX_DCHECK_EQ(nullCount, count, "Expecting constant null vector input");
   // We cannot track the last non-null index efficiently across copy
   // invocations. In order to make it easier for computing child offset, we

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -114,7 +114,6 @@ void EvalCtx::copyError(
     vector_size_t fromIndex,
     EvalErrorsPtr& to,
     vector_size_t toIndex) const {
-  const auto fromSize = from.size();
   if (from.hasErrorAt(fromIndex)) {
     ensureErrorsVectorSize(to, toIndex + 1);
     to->copyError(from, fromIndex, toIndex);

--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -417,8 +417,7 @@ int KllSketch<T, A, C>::findLevelToCompact() const {
 
 template <typename T, typename A, typename C>
 void KllSketch<T, A, C>::addEmptyTopLevelToCompletelyFullSketch() {
-  const uint32_t curTotalCap = levels_.back();
-
+  VELOX_DEBUG_ONLY const uint32_t curTotalCap = levels_.back();
   // Make sure that we are following a certain growth scheme.
   VELOX_DCHECK_EQ(levels_[0], 0);
   VELOX_DCHECK_EQ(items_.size(), curTotalCap);

--- a/velox/functions/sparksql/ArrayInsert.h
+++ b/velox/functions/sparksql/ArrayInsert.h
@@ -65,7 +65,6 @@ struct ArrayInsert {
 
       out.reserve(newArrayLength);
       int32_t posIdx = *pos - 1;
-      int32_t nextIdx = 0;
       for (int32_t i = 0; i < newArrayLength; i++) {
         if (i == posIdx) {
           item ? out.push_back(*item) : out.add_null();

--- a/velox/functions/sparksql/MaskFunction.h
+++ b/velox/functions/sparksql/MaskFunction.h
@@ -209,8 +209,7 @@ struct MaskFunction {
       // it with the length of replacing character. Inequality indicates the
       // replacing character includes more than one unicode characters.
       int size;
-      auto codePoint = utf8proc_codepoint(
-          &maskCharData[0], maskCharData + maskCharSize, size);
+      utf8proc_codepoint(&maskCharData[0], maskCharData + maskCharSize, size);
       VELOX_USER_CHECK_EQ(
           maskCharSize,
           size,

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4245,8 +4245,6 @@ void PrestoVectorSerde::deserializeSingleColumn(
   VELOX_CHECK_EQ(
       prestoOptions.compressionKind,
       common::CompressionKind::CompressionKind_NONE);
-  const bool useLosslessTimestamp = prestoOptions.useLosslessTimestamp;
-
   if (*result && result->unique()) {
     VELOX_CHECK(
         *(*result)->type() == *type,

--- a/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
@@ -31,7 +31,6 @@ int main() {
   constexpr int sampleSize = 100;
   constexpr int32_t lo = 100, hi = 1000;
   constexpr double mu = 5.0, sigma = 2.0;
-  constexpr double p = 0.25;
   constexpr double nullProbability = 0.38;
 
   auto normal = std::normal_distribution<double>(mu, sigma);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: aaronwlma

Differential Revision: D65144811


