### PR TITLE
Fix HiveTypeSerializer.unregisteredOpaque

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2037,6 +2037,16 @@ bool registerOpaqueType(const std::string& alias) {
       getOpaqueAliasByTypeIndex().emplace(typeIndex, alias).second;
 }
 
+/// Unregisters an opaque type. Returns true if the type was unregistered.
+/// Currently, it is only used for testing to provide isolation between tests
+/// when using the same alias.
+template <typename Class>
+bool unregisterOpaqueType(const std::string& alias) {
+  auto typeIndex = std::type_index(typeid(Class));
+  return getTypeIndexByOpaqueAlias().erase(alias) == 1 &&
+      getOpaqueAliasByTypeIndex().erase(typeIndex) == 1;
+}
+
 /// Return true if a custom type with the specified name exists.
 bool customTypeExists(const std::string& name);
 

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -183,6 +183,7 @@ TEST(FbHive, parseOpaque) {
   HiveTypeParser parser;
   auto t = parser.parse("opaque<bar>");
   ASSERT_EQ(t->toString(), "OPAQUE<facebook::velox::type::fbhive::Foo>");
+  unregisterOpaqueType<Foo>("bar");
 }
 
 TEST(FbHive, parseUnregisteredOpaque) {
@@ -192,5 +193,6 @@ TEST(FbHive, parseUnregisteredOpaque) {
   VELOX_ASSERT_THROW(
       parser.parse("opaque<Foo>"),
       "Could not find type 'Foo'. Did you call registerOpaqueType?");
+  unregisterOpaqueType<Foo>("bar");
 }
 } // namespace facebook::velox::type::fbhive

--- a/velox/type/fbhive/tests/HiveTypeSerializerTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeSerializerTests.cpp
@@ -41,6 +41,7 @@ TEST(HiveTypeSerializer, opaque) {
   std::shared_ptr<const Type> type = OPAQUE<Foo>();
   auto result = HiveTypeSerializer::serialize(type);
   EXPECT_EQ(result, "opaque<bar>");
+  unregisterOpaqueType<Foo>("bar");
 }
 
 TEST(HiveTypeSerializer, unregisteredOpaque) {


### PR DESCRIPTION
Summary:
Currently the opaque types are registed into a global static variable that is shared
across the process. If multiple tests within the same Suite use the same alias,
they can interfere with the test's expectations. Therefore, this introduces a way
to unregister the type to allow isolation between tests.

Differential Revision: D65290938


