### PR TITLE
Avoid cross thread access of thread local in parallel join build

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -317,7 +317,7 @@ RowVectorPtr Driver::next(ContinueFuture* future) {
   auto self = shared_from_this();
   facebook::velox::process::ScopedThreadDebugInfo scopedInfo(
       self->driverCtx()->threadDebugInfo);
-  ScopedDriverThreadContext scopedDriverThreadContext(*self->driverCtx());
+  ScopedDriverThreadContext scopedDriverThreadContext(self->driverCtx());
   std::shared_ptr<BlockingState> blockingState;
   RowVectorPtr result;
   const auto stop = runInternal(self, blockingState, result);
@@ -759,7 +759,7 @@ void Driver::run(std::shared_ptr<Driver> self) {
   process::TraceContext trace("Driver::run");
   facebook::velox::process::ScopedThreadDebugInfo scopedInfo(
       self->driverCtx()->threadDebugInfo);
-  ScopedDriverThreadContext scopedDriverThreadContext(*self->driverCtx());
+  ScopedDriverThreadContext scopedDriverThreadContext(self->driverCtx());
   std::shared_ptr<BlockingState> blockingState;
   RowVectorPtr nullResult;
   auto reason = self->runInternal(self, blockingState, nullResult);
@@ -1151,9 +1151,9 @@ DriverThreadContext* driverThreadContext() {
   return driverThreadCtx;
 }
 
-ScopedDriverThreadContext::ScopedDriverThreadContext(const DriverCtx& driverCtx)
+ScopedDriverThreadContext::ScopedDriverThreadContext(const DriverCtx* driverCtx)
     : savedDriverThreadCtx_(driverThreadCtx),
-      currentDriverThreadCtx_(DriverThreadContext(&driverCtx)) {
+      currentDriverThreadCtx_(DriverThreadContext(driverCtx)) {
   driverThreadCtx = &currentDriverThreadCtx_;
 }
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -753,7 +753,7 @@ class DriverThreadContext {
 /// starts/leaves the driver thread.
 class ScopedDriverThreadContext {
  public:
-  explicit ScopedDriverThreadContext(const DriverCtx& driverCtx);
+  explicit ScopedDriverThreadContext(const DriverCtx* driverCtx);
   explicit ScopedDriverThreadContext(
       const DriverThreadContext* _driverThreadCtx);
   ~ScopedDriverThreadContext();

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -71,7 +71,7 @@ TEST_F(MemoryReclaimerTest, enterArbitrationTest) {
     fakeTask_->testingIncrementThreads();
     if (underDriverContext) {
       driver->state().setThread();
-      ScopedDriverThreadContext scopedDriverThreadCtx{*driver->driverCtx()};
+      ScopedDriverThreadContext scopedDriverThreadCtx{driver->driverCtx()};
       reclaimer->enterArbitration();
       ASSERT_TRUE(driver->state().isOnThread());
       ASSERT_TRUE(driver->state().suspended());


### PR DESCRIPTION
parallel building threads in parallel join are accessing the main driver thread's thread local variable. The cross thread access of thread local variable can create undefined behavior. Instead of capturing the thread local, we capture the driver context directly to avoid this. 