### PR TITLE
Add IPADDRESS/IPPREFIX functions

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -30,7 +30,7 @@ are supported if the conversion of their element types are supported. In additio
 supported conversions to/from JSON are listed in :doc:`json`.
 
 .. list-table::
-   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
    :header-rows: 1
 
    * -
@@ -49,6 +49,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - interval day to second
      - decimal
      - ipaddress
+     - ipprefix
    * - tinyint
      - Y
      - Y
@@ -65,6 +66,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - smallint
      - Y
      - Y
@@ -81,6 +83,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - integer
      - Y
      - Y
@@ -97,6 +100,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - bigint
      - Y
      - Y
@@ -113,6 +117,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - boolean
      - Y
      - Y
@@ -129,6 +134,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - real
      - Y
      - Y
@@ -145,6 +151,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - double
      - Y
      - Y
@@ -161,6 +168,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
    * - varchar
      - Y
      - Y
@@ -175,6 +183,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      -
+     - Y
      - Y
      - Y
    * - varbinary
@@ -193,6 +202,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - 
      - Y
+     -
    * - timestamp
      -
      -
@@ -209,6 +219,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
+     -
    * - timestamp with time zone
      -
      -
@@ -222,6 +233,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      - Y
+     -
      -
      -
      -
@@ -241,6 +253,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     -
    * - interval day to second
      -
      -
@@ -251,6 +264,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - 
+     -
      -
      -
      -
@@ -273,6 +287,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      -
+     -
    * - ipaddress
      - 
      - 
@@ -288,7 +303,25 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
+     - Y
      - 
+   * - ipprefix
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - 
+     - Y
+     - 
+     -
+     -
+     -
+     -
+     - 
+     - 
+     - Y
 
 Cast to Integral Types
 ----------------------
@@ -667,27 +700,54 @@ is the number of whole days in the interval, HH is then number of hours between 
 From IPADDRESS
 ^^^^^^^^^^^^^^
 
-Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPV4 formatted IPV6 addresses.
-For all other IPV6 addresses it will be formatted in compressed alternate form IPV6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+Casting from IPADDRESS to VARCHAR returns a string formatted as x.x.x.x for IPv4 formatted IPv6 addresses.
+For all other IPv6 addresses it will be formatted in compressed alternate form IPv6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
 
-IPV4:
+IPv4:
 
 ::
 
   SELECT cast(ipaddress '1.2.3.4' as varchar); -- '1.2.3.4'
 
-IPV6:
+IPv6:
 
 ::
 
   SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varchar); -- '2001:db8::ff00:42:8329'
   SELECT cast(ipaddress '0:0:0:0:0:0:13.1.68.3' as varchar); -- '::13.1.68.3'
 
-IPV4 mapped IPV6:
+IPv4 mapped IPv6:
 
 ::
 
   SELECT cast(ipaddress '::ffff:ffff:ffff' as varchar); -- '255.255.255.255'
+
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Casting from IPPREFIX to VARCHAR returns a string formatted as *x.x.x.x/<prefix-length>* for IPv4 formatted IPv6 addresses.
+
+For all other IPv6 addresses it will be formatted in compressed alternate form IPv6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+followed by */<prefix-length>*. [`RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_]
+
+IPv4:
+
+::
+
+  SELECT cast(ipprefix '1.2.0.0/16' as varchar); -- '1.2.0.0/16'
+
+IPv6:
+
+::
+
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/128' as varchar); -- '2001:db8::ff00:42:8329/128'
+  SELECT cast(ipprefix '0:0:0:0:0:0:13.1.68.3/32' as varchar); -- '::/32'
+
+IPv4 mapped IPv6:
+
+::
+
+  SELECT cast(ipaddress '::ffff:ffff:0000/16' as varchar); -- '255.255.0.0/16'
 
 Cast to VARBINARY
 -----------------
@@ -695,24 +755,24 @@ Cast to VARBINARY
 From IPADDRESS
 ^^^^^^^^^^^^^^
 
-Returns the IPV6 address as a 16 byte varbinary string in network byte order.
+Returns the IPv6 address as a 16 byte varbinary string in network byte order.
 
-Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range `(RFC 4291#section-2.5.5.2) <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_.
+Internally, the type is a pure IPv6 address. Support for IPv4 is handled using the IPv4-mapped IPv6 address range. [`RFC 4291#section-2.5.5.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_]
 When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
 
-IPV6:
+IPv6:
 
 ::
 
   SELECT cast(ipaddress '2001:0db8:0000:0000:0000:ff00:0042:8329' as varbinary); -- 0x20010db8000000000000ff0000428329
 
-IPV4:
+IPv4:
 
 ::
 
   SELECT cast('1.2.3.4' as ipaddress); -- 0x00000000000000000000ffff01020304
 
-IPV4 mapped IPV6:
+IPv4 mapped IPv6:
 
 ::
 
@@ -1036,16 +1096,18 @@ Invalid example
 Cast to IPADDRESS
 -----------------
 
+.. _ipaddress-from-varchar:
+
 From VARCHAR
 ^^^^^^^^^^^^
 
 To cast a varchar to IPAddress input string must be in the form of either
-IPV4 or IPV6.
+IPv4 or IPv6.
 
-For IPV4 it must be in the form of:
+For IPv4 it must be in the form of:
 x.x.x.x where each x is an integer value between 0-255.
 
-For IPV6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
+For IPv6 it must follow any of the forms defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_.
 
 Full form:
 
@@ -1087,16 +1149,16 @@ Invalid examples:
 From VARBINARY
 ^^^^^^^^^^^^^^
 
-To cast a varbinary to IPAddress it must be either IPV4(4 Bytes)
-or IPV6(16 Bytes) in network byte order.
+To cast a varbinary to IPAddress it must be either IPv4(4 Bytes)
+or IPv6(16 Bytes) in network byte order.
 
-IPV4:
+IPv4:
 
 ::
 
 [01, 02, 03, 04] -> 1.2.3.4
 
-IPV6:
+IPv6:
 
 ::
 
@@ -1108,7 +1170,7 @@ When creating an IPADDRESS, IPv4 addresses will be mapped into that range.
 When formatting an IPADDRESS, any address within the mapped range will be formatted as an IPv4 address.
 Other addresses will be formatted as IPv6 using the canonical format defined in `RFC 5952 <https://datatracker.ietf.org/doc/html/rfc5952.html>`_.
 
-IPV6 mapped IPV4 address:
+IPv6 mapped IPv4 address:
 
 ::
 
@@ -1127,6 +1189,41 @@ Invalid examples:
 ::
 
   SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
+
+Cast to IPPREFIX
+----------------
+
+From VARCHAR
+^^^^^^^^^^^^
+
+The IPPREFIX string must be in the form of *<ip_address>/<ip_prefix>* as defined in `RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_.
+The IPADDRESS portion of the IPPREFIX follows the same rules as casting
+`IPADDRESS from VARCHAR <#ipaddress-from-varchar>`_.
+
+The prefix portion must be <= 32 if the IP is an IPv4 address or <= 128 for an IPv6 address.
+As with IPADDRESS, any IPv6 address in the form of an IPv4 mapped IPv6 address will be
+interpreted as an IPv4 address. Only the canonical(smallest) IP address will be stored
+in the IPPREFIX.
+
+Examples:
+
+Valid examples:
+
+::
+
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/32' as ipprefix); -- ipprefix '2001:0db8::/32'
+  SELECT cast('1.2.3.4/24' as ipprefix); -- ipprefix '1.2.3.0/24'
+  SELECT cast('::ffff:ffff:ffff/16' as ipprefix); -- ipprefix '255.255.0.0/16'
+
+Invalid examples:
+
+::
+
+  SELECT cast('2001:db8::1::1/1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:db8::1::1/1
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/129' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/129
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/-1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/-1
+  SELECT cast('255.2.3.4/33' as ipprefix); -- Cannot cast value to IPPREFIX: 255.2.3.4/33
+  SELECT cast('::ffff:ffff:ffff/33' as ipprefix); -- Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -304,7 +304,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - 
      - Y
-     - 
+     - Y
    * - ipprefix
      - 
      - 
@@ -320,7 +320,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - 
-     - 
+     - Y
      - Y
 
 Cast to Integral Types
@@ -1190,6 +1190,18 @@ Invalid examples:
 
   SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
 
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Returns the canonical(lowest) IPADDRESS in the subnet range.
+
+Examples:
+
+::
+
+  SELECT cast(ipprefix '1.2.3.4/24' as ipaddress) -- ipaddress '1.2.3.0'
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/64' as ipaddress) -- ipaddress '2001:db8::'
+
 Cast to IPPREFIX
 ----------------
 
@@ -1224,6 +1236,19 @@ Invalid examples:
   SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/-1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/-1
   SELECT cast('255.2.3.4/33' as ipprefix); -- Cannot cast value to IPPREFIX: 255.2.3.4/33
   SELECT cast('::ffff:ffff:ffff/33' as ipprefix); -- Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33
+
+From IPADDRESS
+^^^^^^^^^^^^^^
+
+Returns an IPPREFIX where the prefix length is the length of the entire IP address.
+Prefix length for IPv4 is 32 and for IPv6 it is 128.
+
+Examples:
+
+::
+
+  SELECT cast(ipaddress '1.2.3.4' as ipprefix) -- ipprefix '1.2.3.4/32'
+  SELECT cast(ipaddress '2001:db8::ff00:42:8329' as ipprefix) -- ipprefix '2001:db8::ff00:42:8329/128'
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -1,0 +1,51 @@
+===================
+IP Functions
+===================
+
+.. function:: ip_prefix(ip_address, prefix_bits) -> ipprefix
+
+    Returns the IP prefix of a given ``ip_address`` with subnet size of ``prefix_bits``.
+    ``ip_address`` can be either of type ``VARCHAR`` or type ``IPADDRESS``. ::
+
+        SELECT ip_prefix(CAST('192.168.255.255' AS IPADDRESS), 9); -- {192.128.0.0/9}
+        SELECT ip_prefix('2001:0db8:85a3:0001:0001:8a2e:0370:7334', 48); -- {2001:db8:85a3::/48}
+
+.. function:: ip_subnet_min(ip_prefix) -> ip_address
+
+    Returns the smallest IP address of type ``IPADDRESS`` in the subnet
+    specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_min(IPPREFIX '192.168.255.255/9'); -- {192.128.0.0}
+        SELECT ip_subnet_min(IPPREFIX '2001:0db8:85a3:0001:0001:8a2e:0370:7334/48'); -- {2001:db8:85a3::}
+
+.. function:: ip_subnet_max(ip_prefix) -> ip_address
+
+    Returns the largest IP address of type ``IPADDRESS`` in the subnet
+    specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_max(IPPREFIX '192.64.0.0/9'); -- {192.127.255.255}
+        SELECT ip_subnet_max(IPPREFIX '2001:0db8:85a3:0001:0001:8a2e:0370:7334/48'); -- {2001:db8:85a3:ffff:ffff:ffff:ffff:ffff}
+
+.. function:: ip_subnet_range(ip_prefix) -> array(ip_address)
+
+    Return an array of 2 IP addresses.
+    The array contains the smallest and the largest IP address
+    in the subnet specified by ``ip_prefix``. ::
+
+        SELECT ip_subnet_range(IPPREFIX '1.2.3.160/24'); -- [{1.2.3.0}, {1.2.3.255}]
+        SELECT ip_subnet_range(IPPREFIX '64:ff9b::52f4/120'); -- [{64:ff9b::5200}, {64:ff9b::52ff}]
+
+.. function:: is_subnet_of(ip_prefix, ip_address) -> boolean
+
+    Returns ``true`` if the ``ip_address`` is in the subnet of ``ip_prefix``. ::
+
+        SELECT is_subnet_of(IPPREFIX '1.2.3.128/26', IPADDRESS '1.2.3.129'); -- true
+        SELECT is_subnet_of(IPPREFIX '64:fa9b::17/64', IPADDRESS '64:ffff::17'); -- false
+
+.. function:: is_subnet_of(ip_prefix1, ip_prefix2) -> boolean
+
+    Returns ``true`` if ``ip_prefix2`` is a subnet of ``ip_prefix1``. ::
+
+        SELECT is_subnet_of(IPPREFIX '192.168.3.131/26', IPPREFIX '192.168.3.144/30'); -- true
+        SELECT is_subnet_of(IPPREFIX '64:ff9b::17/64', IPPREFIX '64:ffff::17/64'); -- false
+        SELECT is_subnet_of(IPPREFIX '192.168.3.131/26', IPPREFIX '192.168.3.131/26'); -- true

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -15,14 +15,161 @@
  */
 #pragma once
 
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 
 namespace facebook::velox::functions {
 
+template <typename T>
+struct IPPrefixFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPPrefix>& result,
+      const arg_type<IPAddress>& ip,
+      const arg_type<int64_t> prefixBits) {
+    folly::ByteArray16 addrBytes;
+    folly::ByteArray16 canonicalBytes;
+    int128_t intAddr;
+
+    memcpy(&addrBytes, &ip, kIPAddressBytes);
+    std::reverse(addrBytes.begin(), addrBytes.end());
+    folly::IPAddressV6 v6Addr(addrBytes);
+
+    if (v6Addr.isIPv4Mapped()) {
+      canonicalBytes =
+          v6Addr.createIPv4().mask(prefixBits).createIPv6().toByteArray();
+    } else {
+      canonicalBytes = v6Addr.mask(prefixBits).toByteArray();
+    }
+    std::reverse(canonicalBytes.begin(), canonicalBytes.end());
+    memcpy(&intAddr, &canonicalBytes, kIPAddressBytes);
+    result = std::make_tuple(intAddr, (int8_t)prefixBits);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPPrefix>& result,
+      const arg_type<Varchar>& ip,
+      const arg_type<int64_t> prefixBits) {
+    int128_t intAddr;
+    folly::IPAddress addr(ip);
+    auto addrBytes = folly::IPAddress::createIPv6(addr).toByteArray();
+
+    std::reverse(addrBytes.begin(), addrBytes.end());
+    memcpy(&intAddr, &addrBytes, kIPAddressBytes);
+
+    call(result, intAddr, prefixBits);
+  }
+};
+
+template <typename T>
+struct IPSubnetMinFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPAddress>& result,
+      const arg_type<IPPrefix>& ipPrefix) {
+    // IPPrefix type stores the smallest(canonical) IP already
+    result = *ipPrefix.template at<0>();
+  }
+};
+
+static int128_t getIPSubnetMax(int128_t ip, uint8_t prefix) {
+  uint128_t mask = 1;
+  int128_t result;
+  memcpy(&result, &ip, kIPAddressBytes);
+
+  if (isIPv4(ip)) {
+    result |= (mask << (kIPV4Bits - prefix)) - 1;
+  } else {
+    // Special case: Overflow to all 0 subtracting 1 does not work.
+    if (prefix == 0) {
+      result = -1;
+    } else {
+      result |= (mask << (kIPV6Bits - prefix)) - 1;
+    }
+  }
+  return result;
+}
+
+template <typename T>
+struct IPSubnetMaxFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IPAddress>& result,
+      const arg_type<IPPrefix>& ipPrefix) {
+    result =
+        getIPSubnetMax(*ipPrefix.template at<0>(), *ipPrefix.template at<1>());
+  }
+};
+
+template <typename T>
+struct IPSubnetRangeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Array<IPAddress>>& result,
+      const arg_type<IPPrefix>& ipPrefix) {
+    result.push_back(*ipPrefix.template at<0>());
+    result.push_back(
+        getIPSubnetMax(*ipPrefix.template at<0>(), *ipPrefix.template at<1>()));
+  }
+};
+
+template <typename T>
+struct IPSubnetOfFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<IPPrefix>& ipPrefix,
+      const arg_type<IPAddress>& ip) {
+    uint128_t mask = 1;
+    const uint8_t prefix = *ipPrefix.template at<1>();
+    int128_t checkIP = ip;
+
+    if (isIPv4(*ipPrefix.template at<0>())) {
+      checkIP &= ((mask << (kIPV4Bits - prefix)) - 1) ^ -1;
+    } else {
+      // Special case: Overflow to all 0 subtracting 1 does not work.
+      if (prefix == 0) {
+        checkIP = 0;
+      } else {
+        checkIP &= ((mask << (kIPV6Bits - prefix)) - 1) ^ -1;
+      }
+    }
+    result = (*ipPrefix.template at<0>() == checkIP);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<IPPrefix>& ipPrefix,
+      const arg_type<IPPrefix>& ipPrefix2) {
+    call(result, ipPrefix, *ipPrefix2.template at<0>());
+    result =
+        result && (*ipPrefix2.template at<1>() >= *ipPrefix.template at<1>());
+  }
+};
+
 void registerIPAddressFunctions(const std::string& prefix) {
   registerIPAddressType();
   registerIPPrefixType();
+  registerFunction<IPPrefixFunction, IPPrefix, IPAddress, int64_t>(
+      {prefix + "ip_prefix"});
+  registerFunction<IPPrefixFunction, IPPrefix, Varchar, int64_t>(
+      {prefix + "ip_prefix"});
+  registerFunction<IPSubnetMinFunction, IPAddress, IPPrefix>(
+      {prefix + "ip_subnet_min"});
+  registerFunction<IPSubnetMaxFunction, IPAddress, IPPrefix>(
+      {prefix + "ip_subnet_max"});
+  registerFunction<IPSubnetRangeFunction, Array<IPAddress>, IPPrefix>(
+      {prefix + "ip_subnet_range"});
+  registerFunction<IPSubnetOfFunction, bool, IPPrefix, IPAddress>(
+      {prefix + "is_subnet_of"});
+  registerFunction<IPSubnetOfFunction, bool, IPPrefix, IPPrefix>(
+      {prefix + "is_subnet_of"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -79,8 +79,6 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARBINARY:
       if (isHyperLogLogType(type)) {
         return "HyperLogLog";
-      } else if (isIPPrefixType(type)) {
-        return "ipprefix";
       }
       return "varbinary";
     case TypeKind::TIMESTAMP:
@@ -93,6 +91,9 @@ std::string typeName(const TypePtr& type) {
           typeName(type->childAt(0)),
           typeName(type->childAt(1)));
     case TypeKind::ROW: {
+      if (isIPPrefixType(type)) {
+        return "ipprefix";
+      }
       const auto& rowType = type->asRow();
       std::ostringstream out;
       out << "row(";

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
   IPAddressCastTest.cpp
+  IPPrefixCastTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp
   JsonFunctionsTest.cpp
@@ -105,7 +106,6 @@ add_executable(
   WordStemTest.cpp
   ZipTest.cpp
   ZipWithTest.cpp)
-
 add_test(velox_functions_test velox_functions_test)
 
 target_link_libraries(

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(
   HyperLogLogFunctionsTest.cpp
   InPredicateTest.cpp
   IPAddressCastTest.cpp
+  IPAddressFunctionsTest.cpp
   IPPrefixCastTest.cpp
   JsonCastTest.cpp
   JsonExtractScalarTest.cpp

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class IPAddressFunctionsTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::optional<std::string> ipPrefix(
+      const std::optional<std::string> input,
+      std::optional<int64_t> mask) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_prefix(cast(c0 as ipaddress), c1) as varchar)", input, mask);
+    return result;
+  }
+
+  std::optional<std::string> ipPrefixUsingVarchar(
+      const std::optional<std::string> input,
+      std::optional<int64_t> mask) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_prefix(c0, c1) as varchar)", input, mask);
+    return result;
+  }
+
+  std::optional<std::string> ipSubnetMin(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_min(cast(c0 as ipprefix)) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> ipSubnetMax(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_max(cast(c0 as ipprefix)) as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> ipSubnetRangeMin(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_range(cast(c0 as ipprefix))[1] as varchar)", input);
+    return result;
+  }
+
+  std::optional<std::string> ipSubnetRangeMax(
+      const std::optional<std::string> input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(ip_subnet_range(cast(c0 as ipprefix))[2] as varchar)", input);
+    return result;
+  }
+
+  std::optional<bool> isSubnetOfIP(
+      const std::optional<std::string> prefix,
+      const std::optional<std::string> ip) {
+    auto result = evaluateOnce<bool>(
+        "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipaddress))",
+        prefix,
+        ip);
+    return result;
+  }
+
+  std::optional<bool> isSubnetOfIPPrefix(
+      const std::optional<std::string> prefix,
+      const std::optional<std::string> prefix2) {
+    auto result = evaluateOnce<bool>(
+        "is_subnet_of(cast(c0 as ipprefix), cast(c1 as ipprefix))",
+        prefix,
+        prefix2);
+    return result;
+  }
+};
+
+/*
+TEST_F(IPAddressFunctionsTest, nullTest) {
+  EXPECT_EQ(ipPrefix(std::nullopt, 8), std::nullopt);
+  EXPECT_EQ(ipPrefix(std::nullopt, 8), std::nullopt);
+  EXPECT_EQ(ipPrefixUsingVarchar(std::nullopt, 48), std::nullopt);
+  EXPECT_EQ(ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334",
+std::nullopt), std::nullopt); EXPECT_EQ(ipSubnetMin(std::nullopt),
+std::nullopt); EXPECT_EQ(ipSubnetMax(std::nullopt), std::nullopt);
+  EXPECT_EQ(ipSubnetRangeMin(std::nullopt), std::nullopt);
+  EXPECT_EQ(ipSubnetRangeMax(std::nullopt), std::nullopt);
+  EXPECT_EQ(isSubnetOfIPPrefix(std::nullopt, "64:ff9b::17/32"),
+std::nullopt); EXPECT_EQ(isSubnetOfIPPrefix("64:ffff::17/24", std::nullopt),
+std::nullopt); EXPECT_EQ(isSubnetOfIP(std::nullopt, "1.2.3.129"),
+std::nullopt); EXPECT_EQ(isSubnetOfIP("1.2.3.128/26", std::nullopt),
+std::nullopt);
+}
+
+TEST_F(IPAddressFunctionsTest, IPPrefixv4) {
+  EXPECT_EQ("10.0.0.0/8", ipPrefix("10.135.23.12", 8));
+  EXPECT_EQ("192.128.0.0/9", ipPrefix("192.168.255.255", 9));
+  EXPECT_EQ("192.168.255.255/32", ipPrefix("192.168.255.255", 32));
+  EXPECT_EQ("0.0.0.0/0", ipPrefix("192.168.255.255", 0));
+
+  EXPECT_THROW(ipPrefix("12.483.09.1", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefix("10.135.23.12.12", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefix("10.135.23", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefix("12.135.23.12", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefix("10.135.23.12", 33), VeloxUserError);
+}
+
+
+TEST_F(IPAddressFunctionsTest, IPPrefixv4UsingVarchar) {
+  EXPECT_EQ("10.0.0.0/8", ipPrefixUsingVarchar("10.135.23.12", 8));
+  EXPECT_EQ("192.128.0.0/9", ipPrefixUsingVarchar("192.168.255.255", 9));
+  EXPECT_EQ(
+      "192.168.255.255/32", ipPrefixUsingVarchar("192.168.255.255", 32));
+  EXPECT_EQ("0.0.0.0/0", ipPrefixUsingVarchar("192.168.255.255", 0));
+
+  EXPECT_THROW(ipPrefixUsingVarchar("12.483.09.1", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("10.135.23.12.12", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("10.135.23", 8), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("12.135.23.12", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("10.135.23.12", 33), VeloxUserError);
+}
+
+TEST_F(IPAddressFunctionsTest, IPPrefixv6) {
+  EXPECT_EQ(
+      "2001:db8:85a3::/48",
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 48));
+  EXPECT_EQ(
+      "2001:db8:85a3::/52",
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 52));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334/128",
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 128));
+
+  EXPECT_EQ("::/0", ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 0));
+
+  EXPECT_THROW(
+      ipPrefix("q001:0db8:85a3:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefix("2001:0db8:85a3:542e:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370", 8), VeloxUserError);
+  EXPECT_THROW(
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", -1),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefix("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 140),
+      VeloxUserError);
+}
+
+TEST_F(IPAddressFunctionsTest, IPPrefixv6UsingVarchar) {
+  EXPECT_EQ(
+      "2001:db8:85a3::/48",
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 48));
+  EXPECT_EQ(
+      "2001:db8:85a3::/52",
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 52));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334/128",
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 128));
+  EXPECT_EQ(
+      "::/0",
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 0));
+
+  EXPECT_THROW(
+      ipPrefixUsingVarchar("q001:0db8:85a3:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefixUsingVarchar(
+          "2001:0db8:85a3:542e:0001:0001:8a2e:0370:7334", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370", 8),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", -1),
+      VeloxUserError);
+  EXPECT_THROW(
+      ipPrefixUsingVarchar("2001:0db8:85a3:0001:0001:8a2e:0370:7334", 140),
+      VeloxUserError);
+}
+
+TEST_F(IPAddressFunctionsTest, IPPrefixPrestoTests) {
+  EXPECT_EQ(ipPrefix("1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(ipPrefix("1.2.3.4", 32), "1.2.3.4/32");
+  EXPECT_EQ(ipPrefix("1.2.3.4", 0), "0.0.0.0/0");
+  EXPECT_EQ(ipPrefix("::ffff:1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(ipPrefix("64:ff9b::17", 64), "64:ff9b::/64");
+  EXPECT_EQ(ipPrefix("64:ff9b::17", 127), "64:ff9b::16/127");
+  EXPECT_EQ(ipPrefix("64:ff9b::17", 128), "64:ff9b::17/128");
+  EXPECT_EQ(ipPrefix("64:ff9b::17", 0), "::/0");
+  EXPECT_THROW(ipPrefix("::ffff:1.2.3.4", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefix("::ffff:1.2.3.4", 33), VeloxUserError);
+  EXPECT_THROW(ipPrefix("64:ff9b::10", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefix("64:ff9b::10", 129), VeloxUserError);
+}
+
+TEST_F(IPAddressFunctionsTest, IPPrefixVarcharPrestoTests) {
+  EXPECT_EQ(ipPrefixUsingVarchar("1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(ipPrefixUsingVarchar("1.2.3.4", 32), "1.2.3.4/32");
+  EXPECT_EQ(ipPrefixUsingVarchar("1.2.3.4", 0), "0.0.0.0/0");
+  EXPECT_EQ(ipPrefixUsingVarchar("::ffff:1.2.3.4", 24), "1.2.3.0/24");
+  EXPECT_EQ(ipPrefixUsingVarchar("64:ff9b::17", 64), "64:ff9b::/64");
+  EXPECT_EQ(ipPrefixUsingVarchar("64:ff9b::17", 127), "64:ff9b::16/127");
+  EXPECT_EQ(ipPrefixUsingVarchar("64:ff9b::17", 128), "64:ff9b::17/128");
+  EXPECT_EQ(ipPrefixUsingVarchar("64:ff9b::17", 0), "::/0");
+  EXPECT_THROW(ipPrefixUsingVarchar("::ffff:1.2.3.4", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("::ffff:1.2.3.4", 33), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("64:ff9b::10", -1), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("64:ff9b::10", 129), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("localhost", 24), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("64::ff9b::10", 24), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("64:face:book::10", 24), VeloxUserError);
+  EXPECT_THROW(ipPrefixUsingVarchar("123.456.789.012", 24), VeloxUserError);
+}
+
+TEST_F(IPAddressFunctionsTest, ipSubnetMin) {
+  EXPECT_EQ("192.0.0.0", ipSubnetMin("192.64.1.1/9"));
+  EXPECT_EQ("0.0.0.0", ipSubnetMin("192.64.1.1/0"));
+  EXPECT_EQ("128.0.0.0", ipSubnetMin("192.64.1.1/1"));
+  EXPECT_EQ("192.64.1.0", ipSubnetMin("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", ipSubnetMin("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3::",
+      ipSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ("::", ipSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ("::", ipSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetMinPrestoTests) {
+  EXPECT_EQ(ipSubnetMin("1.2.3.4/24"), "1.2.3.0");
+  EXPECT_EQ(ipSubnetMin("1.2.3.4/32"), "1.2.3.4");
+  EXPECT_EQ(ipSubnetMin("64:ff9b::17/64"), "64:ff9b::");
+  EXPECT_EQ(ipSubnetMin("64:ff9b::17/127"), "64:ff9b::16");
+  EXPECT_EQ(ipSubnetMin("64:ff9b::17/128"), "64:ff9b::17");
+  EXPECT_EQ(ipSubnetMin("64:ff9b::17/0"), "::");
+}
+
+TEST_F(IPAddressFunctionsTest, ipSubnetMax) {
+  EXPECT_EQ("192.127.255.255", ipSubnetMax("192.64.1.1/9"));
+  EXPECT_EQ("255.255.255.255", ipSubnetMax("192.64.1.1/0"));
+  EXPECT_EQ("255.255.255.255", ipSubnetMax("192.64.1.1/1"));
+  EXPECT_EQ("192.64.1.1", ipSubnetMax("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", ipSubnetMax("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ(
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7335",
+      ipSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetMaxPrestoTests) {
+  EXPECT_EQ(ipSubnetMax("1.2.3.128/26"), "1.2.3.191");
+  EXPECT_EQ(ipSubnetMax("192.168.128.4/32"), "192.168.128.4");
+  EXPECT_EQ(ipSubnetMax("10.1.16.3/9"), "10.127.255.255");
+  EXPECT_EQ(ipSubnetMax("2001:db8::16/127"), "2001:db8::17");
+  EXPECT_EQ(ipSubnetMax("2001:db8::16/128"), "2001:db8::16");
+  EXPECT_EQ(ipSubnetMax("64:ff9b::17/64"), "64:ff9b::ffff:ffff:ffff:ffff");
+  EXPECT_EQ(ipSubnetMax("64:ff9b::17/72"), "64:ff9b::ff:ffff:ffff:ffff");
+  EXPECT_EQ(
+      ipSubnetMax("64:ff9b::17/0"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetRange) {
+  EXPECT_EQ("192.0.0.0", ipSubnetRangeMin("192.64.1.1/9"));
+  EXPECT_EQ("192.127.255.255", ipSubnetRangeMax("192.64.1.1/9"));
+
+  EXPECT_EQ("0.0.0.0", ipSubnetRangeMin("192.64.1.1/0"));
+  EXPECT_EQ("255.255.255.255", ipSubnetRangeMax("192.64.1.1/0"));
+
+  EXPECT_EQ("128.0.0.0", ipSubnetRangeMin("192.64.1.1/1"));
+  EXPECT_EQ("255.255.255.255", ipSubnetRangeMax("192.64.1.1/1"));
+
+  EXPECT_EQ("192.64.1.0", ipSubnetRangeMin("192.64.1.1/31"));
+  EXPECT_EQ("192.64.1.1", ipSubnetRangeMax("192.64.1.1/31"));
+
+  EXPECT_EQ("192.64.1.1", ipSubnetRangeMin("192.64.1.1/32"));
+  EXPECT_EQ("192.64.1.1", ipSubnetRangeMax("192.64.1.1/32"));
+
+  EXPECT_EQ(
+      "2001:db8:85a3::",
+      ipSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+  EXPECT_EQ(
+      "2001:db8:85a3:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/48"));
+
+  EXPECT_EQ(
+      "::", ipSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "::", ipSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetRangeMin("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+
+  EXPECT_EQ(
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/0"));
+  EXPECT_EQ(
+      "7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+      ipSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/1"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7335",
+      ipSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/127"));
+  EXPECT_EQ(
+      "2001:db8:85a3:1:1:8a2e:370:7334",
+      ipSubnetRangeMax("2001:0db8:85a3:0001:0001:8a2e:0370:7334/128"));
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetRangePrestoTests) {
+  EXPECT_EQ(ipSubnetRangeMin("1.2.3.160/24"), "1.2.3.0");
+  EXPECT_EQ(ipSubnetRangeMin("1.2.3.128/31"), "1.2.3.128");
+  EXPECT_EQ(ipSubnetRangeMin("10.1.6.46/32"), "10.1.6.46");
+  EXPECT_EQ(ipSubnetRangeMin("10.1.6.46/0"), "0.0.0.0");
+  EXPECT_EQ(ipSubnetRangeMin("64:ff9b::17/64"), "64:ff9b::");
+  EXPECT_EQ(ipSubnetRangeMin("64:ff9b::52f4/120"), "64:ff9b::5200");
+  EXPECT_EQ(ipSubnetRangeMin("64:ff9b::17/128"), "64:ff9b::17");
+
+  EXPECT_EQ(ipSubnetRangeMax("1.2.3.160/24"), "1.2.3.255");
+  EXPECT_EQ(ipSubnetRangeMax("1.2.3.128/31"), "1.2.3.129");
+  EXPECT_EQ(ipSubnetRangeMax("10.1.6.46/32"), "10.1.6.46");
+  EXPECT_EQ(ipSubnetRangeMax("10.1.6.46/0"), "255.255.255.255");
+  EXPECT_EQ(
+      ipSubnetRangeMax("64:ff9b::17/64"), "64:ff9b::ffff:ffff:ffff:ffff");
+  EXPECT_EQ(ipSubnetRangeMax("64:ff9b::52f4/120"), "64:ff9b::52ff");
+  EXPECT_EQ(ipSubnetRangeMax("64:ff9b::17/128"), "64:ff9b::17");
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetOfIPAddress) {
+  EXPECT_EQ(isSubnetOfIP("1.2.3.128/26", "1.2.3.129"), true);
+  EXPECT_EQ(isSubnetOfIP("64:fa9b::17/64", "64:ffff::17"), false);
+}*/
+
+TEST_F(IPAddressFunctionsTest, IPSubnetOfIPPrefix) {
+  EXPECT_EQ(isSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
+  EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/32", "64:ffff::17/24"), false);
+  EXPECT_EQ(isSubnetOfIPPrefix("64:ffff::17/24", "64:ff9b::17/32"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.131/26"), true);
+}
+
+TEST_F(IPAddressFunctionsTest, IPSubnetOfPrestoTests) {
+  EXPECT_EQ(isSubnetOfIP("1.2.3.128/26", "1.2.3.129"), true);
+  EXPECT_EQ(isSubnetOfIP("1.2.3.128/26", "1.2.5.1"), false);
+  EXPECT_EQ(isSubnetOfIP("1.2.3.128/32", "1.2.3.128"), true);
+  EXPECT_EQ(isSubnetOfIP("1.2.3.128/0", "192.168.5.1"), true);
+  EXPECT_EQ(isSubnetOfIP("64:ff9b::17/64", "64:ff9b::ffff:ff"), true);
+  EXPECT_EQ(isSubnetOfIP("64:ff9b::17/64", "64:ffff::17"), false);
+
+  EXPECT_EQ(isSubnetOfIPPrefix("192.168.3.131/26", "192.168.3.144/30"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("1.2.3.128/26", "1.2.5.1/30"), false);
+  EXPECT_EQ(isSubnetOfIPPrefix("1.2.3.128/26", "1.2.3.128/26"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/64", "64:ff9b::ff:25/80"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("64:ff9b::17/64", "64:ffff::17/64"), false);
+  EXPECT_EQ(
+      isSubnetOfIPPrefix("2804:431:b000::/37", "2804:431:b000::/38"), true);
+  EXPECT_EQ(
+      isSubnetOfIPPrefix("2804:431:b000::/38", "2804:431:b000::/37"), false);
+  EXPECT_EQ(isSubnetOfIPPrefix("170.0.52.0/22", "170.0.52.0/24"), true);
+  EXPECT_EQ(isSubnetOfIPPrefix("170.0.52.0/24", "170.0.52.0/22"), false);
+}
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql
+                                                    

--- a/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPPrefixCastTest.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class IPPrefixCastTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::optional<std::string> castToVarchar(
+      const std::optional<std::string>& input) {
+    auto result = evaluateOnce<std::string>(
+        "cast(cast(c0 as ipprefix) as varchar)", input);
+    return result;
+  }
+};
+
+TEST_F(IPPrefixCastTest, varcharCast) {
+  EXPECT_EQ(castToVarchar("::ffff:1.2.3.4/24"), "1.2.3.0/24");
+  EXPECT_EQ(castToVarchar("192.168.0.0/24"), "192.168.0.0/24");
+  EXPECT_EQ(castToVarchar("255.2.3.4/0"), "0.0.0.0/0");
+  EXPECT_EQ(castToVarchar("255.2.3.4/1"), "128.0.0.0/1");
+  EXPECT_EQ(castToVarchar("255.2.3.4/2"), "192.0.0.0/2");
+  EXPECT_EQ(castToVarchar("255.2.3.4/4"), "240.0.0.0/4");
+  EXPECT_EQ(castToVarchar("1.2.3.4/8"), "1.0.0.0/8");
+  EXPECT_EQ(castToVarchar("1.2.3.4/16"), "1.2.0.0/16");
+  EXPECT_EQ(castToVarchar("1.2.3.4/24"), "1.2.3.0/24");
+  EXPECT_EQ(castToVarchar("1.2.3.255/25"), "1.2.3.128/25");
+  EXPECT_EQ(castToVarchar("1.2.3.255/26"), "1.2.3.192/26");
+  EXPECT_EQ(castToVarchar("1.2.3.255/28"), "1.2.3.240/28");
+  EXPECT_EQ(castToVarchar("1.2.3.255/30"), "1.2.3.252/30");
+  EXPECT_EQ(castToVarchar("1.2.3.255/32"), "1.2.3.255/32");
+  EXPECT_EQ(
+      castToVarchar("2001:0db8:0000:0000:0000:ff00:0042:8329/128"),
+      "2001:db8::ff00:42:8329/128");
+  EXPECT_EQ(
+      castToVarchar("2001:db8::ff00:42:8329/128"),
+      "2001:db8::ff00:42:8329/128");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1:0:0:1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(castToVarchar("2001:db8:0:0:1::1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(castToVarchar("2001:db8::1:0:0:1/128"), "2001:db8::1:0:0:1/128");
+  EXPECT_EQ(
+      castToVarchar("2001:DB8::FF00:ABCD:12EF/128"),
+      "2001:db8::ff00:abcd:12ef/128");
+  EXPECT_EQ(castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0"), "::/0");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/1"), "8000::/1");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/2"), "c000::/2");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/4"), "f000::/4");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/8"), "ff00::/8");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/16"), "ffff::/16");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/32"),
+      "ffff:ffff::/32");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/48"),
+      "ffff:ffff:ffff::/48");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/64"),
+      "ffff:ffff:ffff:ffff::/64");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/80"),
+      "ffff:ffff:ffff:ffff:ffff::/80");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/96"),
+      "ffff:ffff:ffff:ffff:ffff:ffff::/96");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/112"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:0/112");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/120"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ff00/120");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/124"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fff0/124");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/126"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffc/126");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/127"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/127");
+  EXPECT_EQ(
+      castToVarchar("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"),
+      "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128");
+  EXPECT_EQ(castToVarchar("10.0.0.0/32"), "10.0.0.0/32");
+  EXPECT_EQ(castToVarchar("64:ff9b::10.0.0.0/128"), "64:ff9b::a00:0/128");
+}
+
+TEST_F(IPPrefixCastTest, invalidIPPrefix) {
+  VELOX_ASSERT_THROW(
+      castToVarchar("facebook.com/32"),
+      "Cannot cast value to IPPREFIX: facebook.com");
+  VELOX_ASSERT_THROW(
+      castToVarchar("localhost/32"),
+      "Cannot cast value to IPPREFIX: localhost");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:db8::1::1/128"),
+      "Cannot cast value to IPPREFIX: 2001:db8::1::1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("2001:zxy::1::1/128"),
+      "Cannot cast value to IPPREFIX: 2001:zxy::1::1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("789.1.1.1/32"),
+      "Cannot cast value to IPPREFIX: 789.1.1.1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1"), "Cannot cast value to IPPREFIX: 192.1.1.1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1/128"),
+      "Cannot cast value to IPPREFIX: 192.1.1.1/128");
+  VELOX_ASSERT_THROW(
+      castToVarchar("192.1.1.1/-1"),
+      "Cannot cast value to IPPREFIX: 192.1.1.1/-1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::ffff:ffff:ffff/33"),
+      "Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::ffff:ffff:ffff/-1"),
+      "Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/-1");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::/129"), "Cannot cast value to IPPREFIX: ::/129");
+  VELOX_ASSERT_THROW(
+      castToVarchar("::/-1"), "Cannot cast value to IPPREFIX: ::/-1");
+}
+
+} // namespace
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -150,7 +150,6 @@ class IPAddressCastOperator : public exec::CastOperator {
       }
       folly::IPAddress addr = maybeIp.value();
       auto addrBytes = folly::IPAddress::createIPv6(addr).toByteArray();
-
       std::reverse(addrBytes.begin(), addrBytes.end());
       memcpy(&intAddr, &addrBytes, kIPAddressBytes);
 

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -21,7 +21,6 @@
 static constexpr int kIPV4AddressBytes = 4;
 static constexpr int kIPV4ToV6FFIndex = 10;
 static constexpr int kIPV4ToV6Index = 12;
-static constexpr int kIPAddressBytes = 16;
 
 namespace facebook::velox {
 

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -15,13 +15,13 @@
  */
 #pragma once
 
+#include <folly/IPAddress.h>
+
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
 static constexpr int kIPAddressBytes = 16;
-static constexpr int kIPV4Bits = 32;
 static constexpr int kIPV6HalfBits = 64;
-static constexpr int kIPV6Bits = 128;
 
 namespace facebook::velox {
 

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -18,6 +18,8 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
+static constexpr int kIPAddressBytes = 16;
+
 namespace facebook::velox {
 
 class IPAddressType : public HugeintType {

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -19,8 +19,18 @@
 #include "velox/type/Type.h"
 
 static constexpr int kIPAddressBytes = 16;
+static constexpr int kIPV4Bits = 32;
+static constexpr int kIPV6HalfBits = 64;
+static constexpr int kIPV6Bits = 128;
 
 namespace facebook::velox {
+
+static inline bool isIPv4(int128_t ip) {
+  int128_t ipV4 = 0x0000FFFF00000000;
+  uint128_t mask = 0xFFFFFFFFFFFFFFFF;
+  mask = (mask << kIPV6HalfBits) | 0xFFFFFFFF00000000;
+  return (ip & mask) == ipV4;
+}
 
 class IPAddressType : public HugeintType {
   IPAddressType() = default;

--- a/velox/functions/prestosql/types/IPPrefixType.cpp
+++ b/velox/functions/prestosql/types/IPPrefixType.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <folly/IPAddress.h>
 #include <folly/small_vector.h>
 
 #include "velox/expression/CastExpr.h"

--- a/velox/functions/prestosql/types/IPPrefixType.h
+++ b/velox/functions/prestosql/types/IPPrefixType.h
@@ -18,6 +18,9 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
+static constexpr int kIPV4Bits = 32;
+static constexpr int kIPV6Bits = 128;
+
 namespace facebook::velox {
 
 class IPPrefixType : public RowType {


### PR DESCRIPTION
Adds the corresponding IPADDRESS/IPPREFIX functions from presto from the presto documentation. 
https://prestodb.io/docs/current/functions/ip.html

Contains the changes from multiple other PRs that must be merged first.

https://github.com/facebookincubator/velox/pull/11209
https://github.com/facebookincubator/velox/pull/11309
https://github.com/facebookincubator/velox/pull/11378

This PRs changes are contained in
https://github.com/facebookincubator/velox/pull/11407/commits/6c496f635698b6480fd073c99251d3c575473e01