### PR TITLE
Add support for (UT/UTC/GMT)(+/-)H[H] time zone IDs in from_unixtime and at_timezone Presto UDFs

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -284,6 +284,18 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
   EXPECT_EQ(
       fromUnixtime(1667721600.1, "UTC"),
       TimestampWithTimezone(1667721600100, "UTC"));
+  EXPECT_EQ(
+      fromUnixtime(123, "UTC+1"), TimestampWithTimezone(123000, "+01:00"));
+  EXPECT_EQ(
+      fromUnixtime(123, "GMT-2"), TimestampWithTimezone(123000, "-02:00"));
+  EXPECT_EQ(
+      fromUnixtime(123, "UT+14"), TimestampWithTimezone(123000, "+14:00"));
+  EXPECT_EQ(
+      fromUnixtime(123, "Etc/UTC-8"), TimestampWithTimezone(123000, "-08:00"));
+  EXPECT_EQ(
+      fromUnixtime(123, "Etc/GMT+5"), TimestampWithTimezone(123000, "-05:00"));
+  EXPECT_EQ(
+      fromUnixtime(123, "Etc/UT-14"), TimestampWithTimezone(123000, "-14:00"));
 
   // Nan.
   static const double kNan = std::numeric_limits<double>::quiet_NaN();
@@ -4989,6 +5001,39 @@ TEST_F(DateTimeFunctionsTest, atTimezoneTest) {
           pack(1500321297, tz::getTimeZoneID("Atlantic/Bermuda")),
           "Pacific/Fiji"),
       pack(1500321297, tz::getTimeZoneID("Pacific/Fiji")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")), "UTC+8"),
+      pack(1500321297, tz::getTimeZoneID("+08:00")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")), "GMT-7"),
+      pack(1500321297, tz::getTimeZoneID("-07:00")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")), "UT+6"),
+      pack(1500321297, tz::getTimeZoneID("+06:00")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")),
+          "Etc/UTC-13"),
+      pack(1500321297, tz::getTimeZoneID("-13:00")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")),
+          "Etc/GMT+12"),
+      pack(1500321297, tz::getTimeZoneID("-12:00")));
+
+  EXPECT_EQ(
+      at_timezone(
+          pack(1500321297, tz::getTimeZoneID("America/Los_Angeles")),
+          "Etc/UT-11"),
+      pack(1500321297, tz::getTimeZoneID("-11:00")));
 
   EXPECT_EQ(
       at_timezone(

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -178,6 +178,21 @@ TEST(TimeZoneMapTest, getTimeZoneID) {
   EXPECT_EQ(0, getTimeZoneID("ETC/UCT"));
   EXPECT_EQ(0, getTimeZoneID("ETC/universal"));
   EXPECT_EQ(0, getTimeZoneID("etc/zulu"));
+  EXPECT_EQ(0, getTimeZoneID("UTC+0"));
+  EXPECT_EQ(0, getTimeZoneID("UTC-0"));
+  EXPECT_EQ(0, getTimeZoneID("GMT+0"));
+  EXPECT_EQ(0, getTimeZoneID("GMT-0"));
+  EXPECT_EQ(0, getTimeZoneID("UT+0"));
+  EXPECT_EQ(0, getTimeZoneID("UT-0"));
+  EXPECT_EQ(900, getTimeZoneID("UTC+1"));
+  EXPECT_EQ(721, getTimeZoneID("UTC-2"));
+  EXPECT_EQ(1440, getTimeZoneID("UTC+10"));
+  EXPECT_EQ(1020, getTimeZoneID("GMT+3"));
+  EXPECT_EQ(601, getTimeZoneID("GMT-4"));
+  EXPECT_EQ(241, getTimeZoneID("GMT-10"));
+  EXPECT_EQ(1140, getTimeZoneID("UT+5"));
+  EXPECT_EQ(481, getTimeZoneID("UT-6"));
+  EXPECT_EQ(1500, getTimeZoneID("UT+11"));
 
   // (+/-)XX:MM format.
   EXPECT_EQ(840, getTimeZoneID("-00:01"));
@@ -200,6 +215,16 @@ TEST(TimeZoneMapTest, getTimeZoneID) {
   EXPECT_EQ(1020, getTimeZoneID("etc/GMT-3"));
   EXPECT_EQ(301, getTimeZoneID("etc/GMT+9"));
   EXPECT_EQ(1680, getTimeZoneID("etc/GMT-14"));
+  EXPECT_EQ(0, getTimeZoneID("etc/UTC+0"));
+  EXPECT_EQ(0, getTimeZoneID("etc/UTC-0"));
+  EXPECT_EQ(661, getTimeZoneID("etc/UTC-3"));
+  EXPECT_EQ(1380, getTimeZoneID("etc/UTC+9"));
+  EXPECT_EQ(1, getTimeZoneID("etc/UTC-14"));
+  EXPECT_EQ(0, getTimeZoneID("etc/UT+0"));
+  EXPECT_EQ(0, getTimeZoneID("etc/UT-0"));
+  EXPECT_EQ(301, getTimeZoneID("etc/UT-9"));
+  EXPECT_EQ(1020, getTimeZoneID("etc/UT+3"));
+  EXPECT_EQ(1680, getTimeZoneID("etc/UT+14"));
 
   // Case insensitive.
   EXPECT_EQ(0, getTimeZoneID("utc"));


### PR DESCRIPTION
Summary:
Presto Java and Joda support time zone IDs that look like UT+1, UTC-12, GMT+3, Etc/UT-1, 
Etc/UTC+7, Etc/GMT-2.  Of these Velox only supports the Etc/GMT prefix.  This diff adds support for
all 6.

They all map to the offset number of hours in the suffix (except Etc/GMT which flips the sign
for some reason).  E.g. UT+1 maps to +01:00, while Etc/GMT-2 maps to +02:00.

Differential Revision: D65366170


