### PR TITLE
Let arbitrator system use nano second

### DIFF
--- a/velox/common/memory/ArbitrationOperation.h
+++ b/velox/common/memory/ArbitrationOperation.h
@@ -31,7 +31,7 @@ class ArbitrationOperation {
   ArbitrationOperation(
       ScopedArbitrationParticipant&& pool,
       uint64_t requestBytes,
-      uint64_t timeoutMs);
+      uint64_t timeoutNs);
 
   ~ArbitrationOperation();
 
@@ -95,28 +95,28 @@ class ArbitrationOperation {
 
   /// Returns the remaining execution time for this operation before time out.
   /// If the operation has already finished, this returns zero.
-  size_t timeoutMs() const;
+  uint64_t timeoutNs() const;
 
   /// Returns true if this operation has timed out.
   bool hasTimeout() const;
 
   /// Returns the execution time of this arbitration operation since creation.
-  size_t executionTimeMs() const;
+  uint64_t executionTimeNs() const;
 
   /// Invoked to mark the start of global arbitration. This is used to measure
   /// how much time spent in waiting for global arbitration.
   void recordGlobalArbitrationStartTime() {
-    VELOX_CHECK_EQ(globalArbitrationStartTimeMs_, 0);
+    VELOX_CHECK_EQ(globalArbitrationStartTimeNs_, 0);
     VELOX_CHECK_EQ(state_, State::kRunning);
-    globalArbitrationStartTimeMs_ = getCurrentTimeMs();
+    globalArbitrationStartTimeNs_ = getCurrentTimeNano();
   }
 
   /// The execution stats of this arbitration operation after completion.
   struct Stats {
-    uint64_t localArbitrationWaitTimeMs{0};
-    uint64_t localArbitrationExecTimeMs{0};
-    uint64_t globalArbitrationWaitTimeMs{0};
-    uint64_t executionTimeMs{0};
+    uint64_t localArbitrationWaitTimeNs{0};
+    uint64_t localArbitrationExecTimeNs{0};
+    uint64_t globalArbitrationWaitTimeNs{0};
+    uint64_t executionTimeNs{0};
   };
 
   /// NOTE: should only called after this arbitration operation finishes.
@@ -126,22 +126,22 @@ class ArbitrationOperation {
   void setState(State state);
 
   const uint64_t requestBytes_;
-  const uint64_t timeoutMs_;
+  const uint64_t timeoutNs_;
 
   // The start time of this arbitration operation.
-  const uint64_t createTimeMs_;
+  const uint64_t createTimeNs_;
   const ScopedArbitrationParticipant participant_;
 
   State state_{State::kInit};
 
-  uint64_t startTimeMs_{0};
-  uint64_t finishTimeMs_{0};
+  uint64_t startTimeNs_{0};
+  uint64_t finishTimeNs_{0};
 
   uint64_t maxGrowBytes_{0};
   uint64_t minGrowBytes_{0};
 
   // The time that starts global arbitration wait
-  uint64_t globalArbitrationStartTimeMs_{};
+  uint64_t globalArbitrationStartTimeNs_{};
 
   friend class ArbitrationParticipant;
 };

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -144,10 +144,10 @@ class ArbitrationParticipant
   }
 
   /// Returns the duration of this arbitration participant since its creation.
-  uint64_t durationUs() const {
-    const auto now = getCurrentTimeMicro();
-    VELOX_CHECK_GE(now, createTimeUs_);
-    return now - createTimeUs_;
+  uint64_t durationNs() const {
+    const auto now = getCurrentTimeNano();
+    VELOX_CHECK_GE(now, createTimeNs_);
+    return now - createTimeNs_;
   }
 
   /// Invoked to acquire a shared reference to this arbitration participant
@@ -206,11 +206,11 @@ class ArbitrationParticipant
   /// restriction.
   uint64_t shrink(bool reclaimAll = false);
 
-  // Invoked to reclaim used memory from this memory pool with specified
-  // 'targetBytes'. The function returns the actually freed capacity.
+  /// Invoked to reclaim used memory from this memory pool with specified
+  /// 'targetBytes'. The function returns the actually freed capacity.
   uint64_t reclaim(
       uint64_t targetBytes,
-      uint64_t maxWaitTimeMs,
+      uint64_t maxWaitTimeNs,
       MemoryReclaimer::Stats& stats) noexcept;
 
   /// Invoked to abort the query memory pool and returns the reclaimed bytes
@@ -226,7 +226,7 @@ class ArbitrationParticipant
   /// Invoked to wait for the pending memory reclaim or abort operation to
   /// complete within a 'maxWaitTimeMs' time window. The function returns false
   /// if the wait has timed out.
-  bool waitForReclaimOrAbort(uint64_t maxWaitTimeMs) const;
+  bool waitForReclaimOrAbort(uint64_t maxWaitTimeNs) const;
 
   /// Invoked to start arbitration operation 'op'. The operation needs to wait
   /// for the prior arbitration operations to finish first before executing to
@@ -246,7 +246,7 @@ class ArbitrationParticipant
   size_t numWaitingOps() const;
 
   struct Stats {
-    uint64_t durationUs{0};
+    uint64_t durationNs{0};
     uint32_t numRequests{0};
     uint32_t numReclaims{0};
     uint32_t numShrinks{0};
@@ -260,7 +260,7 @@ class ArbitrationParticipant
 
   Stats stats() const {
     Stats stats;
-    stats.durationUs = durationUs();
+    stats.durationNs = durationNs();
     stats.aborted = aborted_;
     stats.numRequests = numRequests_;
     stats.numGrows = numGrows_;
@@ -310,7 +310,7 @@ class ArbitrationParticipant
   MemoryPool* const pool_;
   const Config* const config_;
   const uint64_t maxCapacity_;
-  const size_t createTimeUs_;
+  const uint64_t createTimeNs_;
 
   mutable std::mutex stateLock_;
   bool aborted_{false};

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -84,7 +84,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static constexpr std::string_view kMemoryReclaimMaxWaitTime{
         "memory-reclaim-max-wait-time"};
     static constexpr std::string_view kDefaultMemoryReclaimMaxWaitTime{"5m"};
-    static uint64_t memoryReclaimMaxWaitTimeMs(
+    static uint64_t memoryReclaimMaxWaitTimeNs(
         const std::unordered_map<std::string, std::string>& configs);
 
     /// When shrinking capacity, the shrink bytes will be adjusted in a way such
@@ -400,7 +400,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // iteration of global run should directly reclaim capacity by aborting
   // queries.
   bool globalArbitrationShouldReclaimByAbort(
-      uint64_t globalRunElapsedTimeMs,
+      uint64_t globalRunElapsedTimeNs,
       bool hasReclaimedByAbort,
       bool allParticipantsReclaimed,
       uint64_t lastReclaimedBytes) const;
@@ -503,7 +503,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   uint64_t reclaim(
       const ScopedArbitrationParticipant& participant,
       uint64_t targetBytes,
-      uint64_t timeoutMs,
+      uint64_t timeoutNs,
       bool localArbitration) noexcept;
 
   uint64_t shrink(
@@ -574,7 +574,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   void updateMemoryReclaimStats(
       uint64_t reclaimedBytes,
-      uint64_t reclaimTimeMs,
+      uint64_t reclaimTimeNs,
       bool localArbitration,
       const MemoryReclaimer::Stats& stats);
 
@@ -583,12 +583,12 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   void updateArbitrationFailureStats();
 
   void updateGlobalArbitrationStats(
-      uint64_t arbitrationTimeMs,
+      uint64_t arbitrationTimeNs,
       uint64_t arbitrationBytes);
 
   const uint64_t reservedCapacity_;
   const bool checkUsageLeak_;
-  const uint64_t maxArbitrationTimeMs_;
+  const uint64_t maxArbitrationTimeNs_;
   const ArbitrationParticipant::Config participantConfig_;
   const double memoryReclaimThreadsHwMultiplier_;
   const bool globalArbitrationEnabled_;
@@ -646,7 +646,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   std::map<uint64_t, ArbitrationWait*> globalArbitrationWaiters_;
 
   tsan_atomic<uint64_t> globalArbitrationRuns_{0};
-  tsan_atomic<uint64_t> globalArbitrationTimeMs_{0};
+  tsan_atomic<uint64_t> globalArbitrationTimeNs_{0};
   tsan_atomic<uint64_t> globalArbitrationBytes_{0};
 
   std::atomic_uint64_t numRequests_{0};

--- a/velox/common/memory/tests/SharedArbitratorTestUtil.h
+++ b/velox/common/memory/tests/SharedArbitratorTestUtil.h
@@ -53,8 +53,8 @@ class SharedArbitratorTestHelper {
     }
   }
 
-  uint64_t maxArbitrationTimeMs() const {
-    return arbitrator_->maxArbitrationTimeMs_;
+  uint64_t maxArbitrationTimeNs() const {
+    return arbitrator_->maxArbitrationTimeNs_;
   }
 
   folly::CPUThreadPoolExecutor* memoryReclaimExecutor() const {

--- a/velox/common/testutil/ScopedTestTime.cpp
+++ b/velox/common/testutil/ScopedTestTime.cpp
@@ -20,7 +20,7 @@
 
 namespace facebook::velox::common::testutil {
 bool ScopedTestTime::enabled_ = false;
-std::optional<size_t> ScopedTestTime::testTimeUs_ = {};
+std::optional<uint64_t> ScopedTestTime::testTimeNs_ = {};
 
 ScopedTestTime::ScopedTestTime() {
 #ifndef NDEBUG
@@ -32,32 +32,42 @@ ScopedTestTime::ScopedTestTime() {
 }
 
 ScopedTestTime::~ScopedTestTime() {
-  testTimeUs_.reset();
+  testTimeNs_.reset();
   enabled_ = false;
 }
 
-void ScopedTestTime::setCurrentTestTimeSec(size_t currentTimeSec) {
-  setCurrentTestTimeMicro(currentTimeSec * 1000000);
+void ScopedTestTime::setCurrentTestTimeSec(uint64_t currentTimeSec) {
+  setCurrentTestTimeNano(currentTimeSec * 1'000'000'000UL);
 }
 
-void ScopedTestTime::setCurrentTestTimeMs(size_t currentTimeMs) {
-  setCurrentTestTimeMicro(currentTimeMs * 1000);
+void ScopedTestTime::setCurrentTestTimeMs(uint64_t currentTimeMs) {
+  setCurrentTestTimeNano(currentTimeMs * 1'000'000UL);
 }
 
-void ScopedTestTime::setCurrentTestTimeMicro(size_t currentTimeUs) {
-  testTimeUs_ = currentTimeUs;
+void ScopedTestTime::setCurrentTestTimeMicro(uint64_t currentTimeUs) {
+  setCurrentTestTimeNano(currentTimeUs * 1'000UL);
 }
 
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeSec() {
-  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000000L)
-                                 : testTimeUs_;
-}
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeMs() {
-  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000L)
-                                 : testTimeUs_;
+void ScopedTestTime::setCurrentTestTimeNano(uint64_t currentTimeNs) {
+  testTimeNs_ = currentTimeNs;
 }
 
-std::optional<size_t> ScopedTestTime::getCurrentTestTimeMicro() {
-  return testTimeUs_;
+std::optional<uint64_t> ScopedTestTime::getCurrentTestTimeSec() {
+  return testTimeNs_.has_value()
+      ? std::make_optional(*testTimeNs_ / 1'000'000'000L)
+      : testTimeNs_;
+}
+std::optional<uint64_t> ScopedTestTime::getCurrentTestTimeMs() {
+  return testTimeNs_.has_value() ? std::make_optional(*testTimeNs_ / 1000'000L)
+                                 : testTimeNs_;
+}
+
+std::optional<uint64_t> ScopedTestTime::getCurrentTestTimeMicro() {
+  return testTimeNs_.has_value() ? std::make_optional(*testTimeNs_ / 1000L)
+                                 : testTimeNs_;
+}
+
+std::optional<uint64_t> ScopedTestTime::getCurrentTestTimeNano() {
+  return testTimeNs_;
 }
 } // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/ScopedTestTime.h
+++ b/velox/common/testutil/ScopedTestTime.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 namespace facebook::velox::common::testutil {
@@ -24,18 +25,20 @@ class ScopedTestTime {
   ScopedTestTime();
   ~ScopedTestTime();
 
-  void setCurrentTestTimeSec(size_t currentTimeSec);
-  void setCurrentTestTimeMs(size_t currentTimeMs);
-  void setCurrentTestTimeMicro(size_t currentTimeUs);
+  void setCurrentTestTimeSec(uint64_t currentTimeSec);
+  void setCurrentTestTimeMs(uint64_t currentTimeMs);
+  void setCurrentTestTimeMicro(uint64_t currentTimeUs);
+  void setCurrentTestTimeNano(uint64_t currentTimeNs);
 
-  static std::optional<size_t> getCurrentTestTimeSec();
-  static std::optional<size_t> getCurrentTestTimeMs();
-  static std::optional<size_t> getCurrentTestTimeMicro();
+  static std::optional<uint64_t> getCurrentTestTimeSec();
+  static std::optional<uint64_t> getCurrentTestTimeMs();
+  static std::optional<uint64_t> getCurrentTestTimeMicro();
+  static std::optional<uint64_t> getCurrentTestTimeNano();
 
  private:
   // Used to verify only one instance of ScopedTestTime exists at a time.
   static bool enabled_;
   // The overridden value of current time only.
-  static std::optional<size_t> testTimeUs_;
+  static std::optional<uint64_t> testTimeNs_;
 };
 } // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/tests/TestScopedTestTime.cpp
+++ b/velox/common/testutil/tests/TestScopedTestTime.cpp
@@ -61,6 +61,23 @@ DEBUG_ONLY_TEST(TestScopedTestTime, testSetCurrentTimeMicro) {
   ASSERT_NE(getCurrentTimeMicro(), 2000);
 }
 
+DEBUG_ONLY_TEST(TestScopedTestTime, testSetCurrentTimeNano) {
+  {
+    ScopedTestTime scopedTestTime;
+    scopedTestTime.setCurrentTestTimeNano(1000);
+    ASSERT_EQ(getCurrentTimeMicro(), 1);
+    ASSERT_EQ(getCurrentTimeNano(), 1000);
+    scopedTestTime.setCurrentTestTimeNano(2000);
+    ASSERT_EQ(getCurrentTimeMicro(), 2);
+    ASSERT_EQ(getCurrentTimeNano(), 2000);
+  }
+
+  // This should be the actual time, so we don't know what it is, but it
+  // shouldn't be equal to the overridden value.
+  ASSERT_NE(getCurrentTimeMicro(), 2);
+  ASSERT_NE(getCurrentTimeNano(), 2000);
+}
+
 DEBUG_ONLY_TEST(TestScopedTestTime, multipleScopedTestTimes) {
   {
     ScopedTestTime scopedTestTime;

--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -25,35 +25,46 @@ using common::testutil::ScopedTestTime;
 
 #ifndef NDEBUG
 
-size_t getCurrentTimeSec() {
+uint64_t getCurrentTimeSec() {
   return ScopedTestTime::getCurrentTestTimeSec().value_or(
       duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
 }
 
-size_t getCurrentTimeMs() {
+uint64_t getCurrentTimeMs() {
   return ScopedTestTime::getCurrentTestTimeMs().value_or(
       duration_cast<milliseconds>(system_clock::now().time_since_epoch())
           .count());
 }
 
-size_t getCurrentTimeMicro() {
+uint64_t getCurrentTimeMicro() {
   return ScopedTestTime::getCurrentTestTimeMicro().value_or(
       duration_cast<microseconds>(system_clock::now().time_since_epoch())
           .count());
 }
+
+uint64_t getCurrentTimeNano() {
+  return ScopedTestTime::getCurrentTestTimeNano().value_or(
+      duration_cast<nanoseconds>(system_clock::now().time_since_epoch())
+          .count());
+}
 #else
 
-size_t getCurrentTimeSec() {
+uint64_t getCurrentTimeSec() {
   return duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
 }
 
-size_t getCurrentTimeMs() {
+uint64_t getCurrentTimeMs() {
   return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
       .count();
 }
 
-size_t getCurrentTimeMicro() {
+uint64_t getCurrentTimeMicro() {
   return duration_cast<microseconds>(system_clock::now().time_since_epoch())
+      .count();
+}
+
+uint64_t getCurrentTimeNano() {
+  return duration_cast<nanoseconds>(system_clock::now().time_since_epoch())
       .count();
 }
 #endif

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -88,13 +88,15 @@ class ClockTimer {
   uint64_t start_;
 };
 
-// Returns the current epoch time in seconds.
-size_t getCurrentTimeSec();
+/// Returns the current epoch time in seconds.
+uint64_t getCurrentTimeSec();
 
 /// Returns the current epoch time in milliseconds.
-size_t getCurrentTimeMs();
+uint64_t getCurrentTimeMs();
 
 /// Returns the current epoch time in microseconds.
-size_t getCurrentTimeMicro();
+uint64_t getCurrentTimeMicro();
 
+/// Returns the current epoch time in nanoseconds.
+uint64_t getCurrentTimeNano();
 } // namespace facebook::velox


### PR DESCRIPTION
Use nano seconds in arbitrator system to avoid flakiness in time dependent tests. 