### PR TITLE
Remove unused-variable in velox/buffer/tests/BufferTest.cpp +8

### DIFF
--- a/velox/functions/lib/RowsTranslationUtil.h
+++ b/velox/functions/lib/RowsTranslationUtil.h
@@ -41,9 +41,9 @@ SelectivityVector toElementRows(
   auto rawNulls = arrayBaseVector->rawNulls();
   auto rawSizes = arrayBaseVector->rawSizes();
   auto rawOffsets = arrayBaseVector->rawOffsets();
-  const auto sizeRange =
+  VELOX_DEBUG_ONLY const auto sizeRange =
       arrayBaseVector->sizes()->template asRange<vector_size_t>().end();
-  const auto offsetRange =
+  VELOX_DEBUG_ONLY const auto offsetRange =
       arrayBaseVector->offsets()->template asRange<vector_size_t>().end();
 
   SelectivityVector elementRows(size, false);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D65282800


