### PR TITLE
refactor(exchange): Rename taskId to remoteTaskId

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -60,23 +60,22 @@ class Exchange : public SourceOperator {
   virtual VectorSerde* getSerde();
 
  private:
-  // Invoked to create exchange client for remote tasks.
-  // The function shuffles the source task ids first to randomize the source
-  // tasks we fetch data from. This helps to avoid different tasks fetching from
-  // the same source task in a distributed system.
+  // Invoked to create exchange client for remote tasks. The function shuffles
+  // the source task ids first to randomize the source tasks we fetch data from.
+  // This helps to avoid different tasks fetching from the same source task in a
+  // distributed system.
   void addRemoteTaskIds(std::vector<std::string>& remoteTaskIds);
 
-  /// Fetches splits from the task until there are no more splits or task
-  /// returns a future that will be complete when more splits arrive. Adds
-  /// splits to exchangeClient_. Returns true if received a future from the
-  /// task and sets the 'future' parameter. Returns false if fetched all
-  /// splits or if this operator is not the first operator in the pipeline and
-  /// therefore is not responsible for fetching splits and adding them to the
-  /// exchangeClient_.
+  // Fetches splits from the task until there are no more splits or task returns
+  // a future that will be complete when more splits arrive. Adds splits to
+  // exchangeClient_. Returns true if received a future from the task and sets
+  // the 'future' parameter. Returns false if fetched all splits or if this
+  // operator is not the first operator in the pipeline and therefore is not
+  // responsible for fetching splits and adding them to the exchangeClient_.
   bool getSplits(ContinueFuture* future);
 
-  /// Fetches runtime stats from ExchangeClient and replaces these in this
-  /// operator's stats.
+  // Fetches runtime stats from ExchangeClient and replaces these in this
+  // operator's stats.
   void recordExchangeClientStats();
 
   const uint64_t preferredOutputBatchBytes_;
@@ -95,9 +94,8 @@ class Exchange : public SourceOperator {
 
   std::shared_ptr<ExchangeClient> exchangeClient_;
 
-  /// A future received from Task::getSplitOrFuture(). It will be complete
-  /// when there are more splits available or no-more-splits signal has
-  /// arrived.
+  // A future received from Task::getSplitOrFuture(). It will be complete when
+  // there are more splits available or no-more-splits signal has arrived.
   ContinueFuture splitFuture_{ContinueFuture::makeEmpty()};
 
   // Reusable result vector.

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -27,8 +27,8 @@ namespace facebook::velox::exec {
 struct RemoteConnectorSplit : public connector::ConnectorSplit {
   const std::string taskId;
 
-  explicit RemoteConnectorSplit(const std::string& _taskId)
-      : ConnectorSplit(""), taskId(_taskId) {}
+  explicit RemoteConnectorSplit(const std::string& remoteTaskId)
+      : ConnectorSplit(""), taskId(remoteTaskId) {}
 
   std::string toString() const override {
     return fmt::format("Remote: {}", taskId);
@@ -62,9 +62,9 @@ class Exchange : public SourceOperator {
  private:
   // Invoked to create exchange client for remote tasks.
   // The function shuffles the source task ids first to randomize the source
-  // tasks we fetch data from. This helps to avoid different tasks fetching
-  // from the same source task in a distributed system.
-  void addTaskIds(std::vector<std::string>& taskIds);
+  // tasks we fetch data from. This helps to avoid different tasks fetching from
+  // the same source task in a distributed system.
+  void addRemoteTaskIds(std::vector<std::string>& remoteTaskIds);
 
   /// Fetches splits from the task until there are no more splits or task
   /// returns a future that will be complete when more splits arrive. Adds

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -70,7 +70,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   // upstream task. If 'close' has been called already, creates an exchange
   // source and immediately closes it to notify the upstream task that data is
   // no longer needed. Repeated calls with the same 'taskId' are ignored.
-  void addRemoteTaskId(const std::string& taskId);
+  void addRemoteTaskId(const std::string& remoteTaskId);
 
   void noMoreRemoteTasks();
 

--- a/velox/exec/ExchangeSource.cpp
+++ b/velox/exec/ExchangeSource.cpp
@@ -18,17 +18,17 @@
 namespace facebook::velox::exec {
 
 std::shared_ptr<ExchangeSource> ExchangeSource::create(
-    const std::string& taskId,
+    const std::string& remoteTaskId,
     int destination,
     std::shared_ptr<ExchangeQueue> queue,
     memory::MemoryPool* pool) {
   for (auto& factory : factories()) {
-    auto result = factory(taskId, destination, queue, pool);
+    auto result = factory(remoteTaskId, destination, queue, pool);
     if (result) {
       return result;
     }
   }
-  VELOX_FAIL("No ExchangeSource factory matches {}", taskId);
+  VELOX_FAIL("No ExchangeSource factory matches {}", remoteTaskId);
 }
 
 // static

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -23,11 +23,11 @@ namespace facebook::velox::exec {
 class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
  public:
   ExchangeSource(
-      const std::string& taskId,
+      const std::string& remoteTaskId,
       int destination,
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool)
-      : taskId_(taskId),
+      : remoteTaskId_(remoteTaskId),
         destination_(destination),
         queue_(std::move(queue)),
         pool_(pool->shared_from_this()) {}
@@ -35,13 +35,12 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   virtual ~ExchangeSource() = default;
 
   static std::shared_ptr<ExchangeSource> create(
-      const std::string& taskId,
+      const std::string& remoteTaskId,
       int destination,
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool);
 
-  /// Temporary API to indicate whether 'metrics()' API
-  /// is supported.
+  /// Temporary API to indicate whether 'metrics()' API is supported.
   virtual bool supportsMetrics() const {
     return false;
   }
@@ -121,14 +120,14 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
 
   virtual std::string toString() {
     std::stringstream out;
-    out << "[ExchangeSource " << taskId_ << ":" << destination_
+    out << "[ExchangeSource " << remoteTaskId_ << ":" << destination_
         << (requestPending_ ? " pending " : "") << (atEnd_ ? " at end" : "");
     return out.str();
   }
 
   virtual folly::dynamic toJson() {
     folly::dynamic obj = folly::dynamic::object;
-    obj["taskId"] = taskId_;
+    obj["remoteTaskId"] = remoteTaskId_;
     obj["destination"] = destination_;
     obj["sequence"] = sequence_;
     obj["requestPending"] = requestPending_.load();
@@ -137,7 +136,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   }
 
   using Factory = std::function<std::shared_ptr<ExchangeSource>(
-      const std::string& taskId,
+      const std::string& remoteTaskId,
       int destination,
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool)>;
@@ -154,9 +153,9 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   }
 
  protected:
-  // ID of the task producing data
-  const std::string taskId_;
-  // Destination number of 'this' on producer
+  // ID of the remote task producing data.
+  const std::string remoteTaskId_;
+  // Destination number of 'this' on producer.
   const int destination_;
   const std::shared_ptr<ExchangeQueue> queue_{nullptr};
   // Holds a shared reference on the memory pool as it might be still possible

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -28,6 +28,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool)
       : remoteTaskId_(remoteTaskId),
+        taskId_(remoteTaskId),
         destination_(destination),
         queue_(std::move(queue)),
         pool_(pool->shared_from_this()) {}
@@ -155,6 +156,8 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
  protected:
   // ID of the remote task producing data.
   const std::string remoteTaskId_;
+  // Same with 'remoteTaskId_', will be removed after removing usage in Presto.
+  const std::string taskId_;
   // Destination number of 'this' on producer.
   const int destination_;
   const std::shared_ptr<ExchangeQueue> queue_{nullptr};


### PR DESCRIPTION
Currently 'taskId' in an Exchange related class has two meanings, for
example `ExchangeClient::taskId_` means local task (consumer),
`ExchangeSource::taskId_` indicates a remote task (producer). This can
cause a bit of confusion.

And, in some places current codebase already uses 'remoteTaskId, such as
`ExchangeClient::remoteTaskIds_`. This patch renames the remaining
'task ID's representing the remote to 'remoteTaskId' to make it more
intuitive.

No functional changes.