### PR TITLE
Presto's from_unixtime with TSwTZ can be 1 millisecond off in Velox compared to Presto Java

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -70,10 +70,10 @@ struct FromUnixtimeFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<TimestampWithTimezone>& result,
       const arg_type<double>& unixtime,
-      const arg_type<Varchar>& timezone) {
-    int16_t timezoneId =
-        tzID_.value_or(tz::getTimeZoneID((std::string_view)timezone));
-    result = pack(fromUnixtime(unixtime).toMillis(), timezoneId);
+      const arg_type<Varchar>& timeZone) {
+    int16_t timeZoneId =
+        tzID_.value_or(tz::getTimeZoneID((std::string_view)timeZone));
+    result = fromUnixtime(unixtime, timeZoneId);
   }
 
   // (double, bigint, bigint) -> timestamp with time zone

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -300,6 +300,11 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
   // Nan.
   static const double kNan = std::numeric_limits<double>::quiet_NaN();
   EXPECT_EQ(fromUnixtime(kNan, "-04:36"), TimestampWithTimezone(0, "-04:36"));
+
+  // Check rounding behavior.
+  EXPECT_EQ(
+      fromUnixtime(1.7300479933495E9, "America/Costa_Rica"),
+      TimestampWithTimezone(1730047993350, "America/Costa_Rica"));
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtimeTzOffset) {


### PR DESCRIPTION
Summary:
from_unixtime with TSwTZ was written to reuse the logic used to implement the function for 
Timestamps. That is to say, it takes subtracts the seconds from the unixtime, multiplies the 
remainder by 1000, and rounds to get the integer number of milliseconds. The seconds and
milliseconds are later recombined to form the unix timestamp portion of the TSwTZ.

In Presto Java, for TSwTZ they simply multiply the unix timestamp by 1000 and round to get the unix
timestamp portion of the TSwTZ.  Due to the quirks of floating points, this means Presto Java and
Velox can get slightly different answers.

I modified Velox to reproduce the Presto Java logic for TSwTZ and confirmed this gives consistent
results.

Differential Revision: D65434542


