### PR TITLE
selective reader deduplicated array type

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -52,7 +52,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   readLengths(int32_t* lengths, int32_t numLengths, const uint64_t* nulls) = 0;
 
   /// Create row set for child columns based on the row set of parent column.
-  void makeNestedRowSet(const RowSet& rows, int32_t maxRow);
+  virtual void makeNestedRowSet(const RowSet& rows, int32_t maxRow);
 
   /// Compute the offsets and lengths based on the current filtered rows passed
   /// in.
@@ -96,8 +96,10 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
 
   uint64_t skip(uint64_t numValues) override;
 
-  void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
-      override;
+  virtual void read(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* incomingNulls) override;
 
   void getValues(const RowSet& rows, VectorPtr* result) override;
 

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -322,6 +322,16 @@ class E2EFilterTestBase : public testing::Test {
       int32_t numCombinations,
       bool withRecursiveNulls = true);
 
+  void testRunLengthDictionaryScenario(
+      const std::string& columns,
+      std::function<void()> customize,
+      bool wrapInStruct,
+      const std::vector<std::string>& filterable,
+      int32_t numCombinations,
+      int32_t maxRunLength,
+      bool withRecursiveNulls = true,
+      int64_t seed = time(nullptr));
+
  private:
   void testMetadataFilterImpl(
       const std::vector<RowVectorPtr>& batches,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/100

Extend the selective reader for the deduplicated array type. The deduplicated array streams have an internal dictionary semantics, and this brings some noteworthy differences:

1) The offset stream represents indices, matching the cardinality of the rows in the read range. However, the lengths stream has the cardinality of the unique runs.
2) Read ranges can easily be in the middle of the dictionary runs. Hence, we need to manage states to help us either cache and copy the loaded last run/alphabet entry values, or to include them in the current read if previously skipped.
3) Instead of managing states with indices semantics, we manage states with the dictionary semantic to save significant amount of memory. e.g. instead of translating states by maintaining the array indices per row, we record the start of the runs and iterate through them with the sorted row set.
4) Some read ranges are no-op on the dictionary states.

Differential Revision: D64754886


