### PR TITLE
Merge nest loop join build vectors

### DIFF
--- a/velox/exec/NestedLoopJoinBuild.h
+++ b/velox/exec/NestedLoopJoinBuild.h
@@ -59,6 +59,8 @@ class NestedLoopJoinBuild : public Operator {
   }
 
  private:
+  std::vector<RowVectorPtr> mergeDataVectors() const;
+
   std::vector<RowVectorPtr> dataVectors_;
 
   // Future for synchronizing with other Drivers of the same pipeline. All build


### PR DESCRIPTION
Summary: When build vectors in nested loop join are small, we should merge them to get better performance.  In some extreme case, the performance difference can be more than 100 times.

Differential Revision: D65450017


