### PR TITLE
Fix JSON parser to allow control characters in JSON string input

### DIFF
--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -27,6 +27,8 @@ message(STATUS "Building simdjson from source")
 FetchContent_Declare(
   simdjson
   URL ${VELOX_SIMDJSON_SOURCE_URL}
-  URL_HASH ${VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM})
+  URL_HASH ${VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM}
+  PATCH_COMMAND git init && git apply
+                ${CMAKE_CURRENT_LIST_DIR}/simdjson/fix-control-char.patch)
 
 FetchContent_MakeAvailable(simdjson)

--- a/CMake/resolve_dependency_modules/simdjson/fix-control-char.patch
+++ b/CMake/resolve_dependency_modules/simdjson/fix-control-char.patch
@@ -1,0 +1,24 @@
+diff --git a/src/fallback.cpp b/src/fallback.cpp
+index f8e87be0..1bbbd67a 100644
+--- a/src/fallback.cpp
++++ b/src/fallback.cpp
+@@ -130,7 +130,6 @@ simdjson_inline bool validate_string() {
+     } else if (simdjson_unlikely(buf[idx] & 0x80)) {
+       validate_utf8_character();
+     } else {
+-      if (buf[idx] < 0x20) { error = UNESCAPED_CHARS; }
+       idx++;
+     }
+   }
+diff --git a/src/generic/stage1/json_structural_indexer.h b/src/generic/stage1/json_structural_indexer.h
+index cfdedf01..d7c58816 100644
+--- a/src/generic/stage1/json_structural_indexer.h
++++ b/src/generic/stage1/json_structural_indexer.h
+@@ -243,7 +243,6 @@ simdjson_inline void json_structural_indexer::next(const simd::simd8x64<uint8_t>
+ #endif
+   indexer.write(uint32_t(idx-64), prev_structurals); // Output *last* iteration's structurals to the parser
+   prev_structurals = block.structural_start();
+-  unescaped_chars_error |= block.non_quote_inside_string(unescaped);
+ }
+ 
+ simdjson_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -701,6 +701,9 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   VELOX_ASSERT_THROW(
       jsonExtract(kJson, "concat($..category)"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonExtract(kJson, "$.store.keys()"), "Invalid JSON path");
+
+  // Test json with control character.
+  EXPECT_EQ(jsonExtract("{\"c1\":\"ab\ncd\"}", "$.c1"), "\"ab\ncd\"");
 }
 
 } // namespace


### PR DESCRIPTION
JSON string input can contain control characters, e.g., new line character `\n`. It can be
correctly handled by Presto, but not allowed by simdjson lib. If it exists in input,  simdjson
will return `UNESCAPED_CHARS` error, then Velox will output null. Simdjson only allows literal
`\n` (represented by `\\n`). See its code [link](https://github.com/simdjson/simdjson/blob/v3.9.3/src/fallback.cpp#L133).

Here is a test result with presto.
```sql
SELECT json_extract('{"c1":"ab\ncd"}', '$.c1');
  _col0
----------
 "ab\ncd"
(1 row)
```

Just created one discussion thread in simdjson community: https://github.com/simdjson/simdjson/issues/2287.