### PR TITLE
Fix flakey FilterProjectReplayerTest

### DIFF
--- a/velox/tool/trace/tests/CMakeLists.txt
+++ b/velox/tool/trace/tests/CMakeLists.txt
@@ -15,10 +15,10 @@
 add_executable(
   velox_tool_trace_test
   AggregationReplayerTest.cpp
-  PartitionedOutputReplayerTest.cpp
-  TableWriterReplayerTest.cpp
+  FilterProjectReplayerTest.cpp
   HashJoinReplayerTest.cpp
-  FilterProjectReplayerTest.cpp)
+  PartitionedOutputReplayerTest.cpp
+  TableWriterReplayerTest.cpp)
 
 add_test(
   NAME velox_tool_trace_test


### PR DESCRIPTION
In FilterProjectReplayerTest, some drivers may not be assigned 
splits during execution, the splits are consumed by other drivers,
hence them would create an empty tracing data file causing the
replayed crashed as the `OperatorInputTracerReader` throws if
the trace input data file is empty.

This PR adds a check in `OperatorInputTracerReader` before creating
input stream, and ignore the empty data file reading.


Resolve #11430