### PR TITLE
feat: Add support for registering components dynamically

### DIFF
--- a/velox/common/dynamic_registry/CMakeLists.txt
+++ b/velox/common/dynamic_registry/CMakeLists.txt
@@ -11,18 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(base)
-add_subdirectory(caching)
-add_subdirectory(compression)
-add_subdirectory(config)
-add_subdirectory(dynamic_registry)
-add_subdirectory(encode)
-add_subdirectory(file)
-add_subdirectory(hyperloglog)
-add_subdirectory(io)
-add_subdirectory(memory)
-add_subdirectory(process)
-add_subdirectory(serialization)
-add_subdirectory(time)
-add_subdirectory(testutil)
-add_subdirectory(fuzzer)
+
+velox_add_library(velox_dynamic_library_loader DynamicLibraryLoader.cpp)
+
+velox_link_libraries(velox_dynamic_library_loader PRIVATE velox_exception)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/common/dynamic_registry/DynamicLibraryLoader.cpp
+++ b/velox/common/dynamic_registry/DynamicLibraryLoader.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <dlfcn.h>
+#include <iostream>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+static constexpr const char* kSymbolName = "registry";
+
+void loadDynamicLibrary(const std::string& fileName) {
+  // Try to dynamically load the shared library.
+  void* handler = dlopen(fileName.c_str(), RTLD_NOW);
+
+  if (handler == nullptr) {
+    VELOX_USER_FAIL("Error while loading shared library: {}", dlerror());
+  }
+
+  LOG(INFO) << "Loaded library " << fileName << ". Searching registry symbol "
+            << kSymbolName;
+  // Lookup the symbol.
+  void* registrySymbol = dlsym(handler, kSymbolName);
+  auto loadUserLibrary = reinterpret_cast<void (*)()>(registrySymbol);
+  const char* error = dlerror();
+
+  // Check for an error first as a null symbol pointer is not necessarily an
+  // error.
+  if (error != nullptr) {
+    VELOX_USER_FAIL("Couldn't find Velox registry symbol: {}", error);
+  }
+
+  if (loadUserLibrary == nullptr) {
+    VELOX_USER_FAIL(
+        "Symbol '{}' resolved to a nullptr, unable to invoke it.", kSymbolName);
+  }
+
+  // Invoke the registry function.
+  LOG(INFO) << "Found registry function. Invoking it.";
+  loadUserLibrary();
+  LOG(INFO) << "Registration complete.";
+}
+
+} // namespace facebook::velox

--- a/velox/common/dynamic_registry/DynamicLibraryLoader.h
+++ b/velox/common/dynamic_registry/DynamicLibraryLoader.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+/// Dynamically opens and registers functions defined in a shared library.
+///
+/// The library being linked needs to provide a function with the following
+/// signature:
+///
+/// void registry();
+///
+/// The registration function needs to be defined in the global namespace,
+/// and be enclosed by a extern "C" directive to prevent the compiler from
+/// mangling the symbol name.
+
+/// The function uses dlopen to load the shared library.
+/// It then searches for the "void registry()" C function which typically
+/// contains all the registration code for the user-defined Velox components
+/// such as functions defined in library. After locating the function it
+/// executes the registration bringing the user-defined Velox components
+/// such as function in the scope of the Velox runtime.
+///
+/// Loading a library twice can cause a components to be registered twice.
+/// This can fail for certain Velox components.
+void loadDynamicLibrary(const std::string& fileName);
+
+} // namespace facebook::velox

--- a/velox/common/dynamic_registry/DynamicUdf.h
+++ b/velox/common/dynamic_registry/DynamicUdf.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This header must be included in any dynamically loaded user-defined
+// function library. It enforces the correct function declaration with
+// the proper signature.
+#pragma once
+
+#include "velox/functions/Udf.h"
+
+extern "C" {
+// The "registry()" declaration and "check()" function ensure the correct
+// registry signature function is defined by the user.
+void registry();
+void check() {
+  registry();
+}
+}

--- a/velox/common/dynamic_registry/README.md
+++ b/velox/common/dynamic_registry/README.md
@@ -1,0 +1,1 @@
+Read [here](https://facebookincubator.github.io/velox/develop/dynamic-loading.html) on how to use the Dynamic Library Loader.

--- a/velox/common/dynamic_registry/tests/CMakeLists.txt
+++ b/velox/common/dynamic_registry/tests/CMakeLists.txt
@@ -1,0 +1,100 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To test functions being added by dynamically linked libraries, we compile
+# `DynamicFunction.cpp` as a small .so library, and use the
+# VELOX_TEST_DYNAMIC_LIBRARY_PATH macro to locate the .so binary.
+
+add_library(velox_function_dynamic SHARED DynamicFunction.cpp)
+add_library(velox_overwrite_int_function_dynamic SHARED
+            DynamicIntFunctionOverwrite.cpp)
+add_library(velox_overwrite_varchar_function_dynamic SHARED
+            DynamicVarcharFunctionOverwrite.cpp)
+add_library(velox_function_err_dynamic SHARED DynamicErrFunction.cpp)
+add_library(velox_overload_int_function_dynamic SHARED
+            DynamicIntFunctionOverload.cpp)
+add_library(velox_overload_varchar_function_dynamic SHARED
+            DynamicVarcharFunctionOverload.cpp)
+
+set(CMAKE_DYLIB_TEST_LINK_LIBRARIES fmt::fmt Folly::folly glog::glog xsimd)
+
+target_link_libraries(
+  velox_function_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+target_link_libraries(
+  velox_overwrite_int_function_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+target_link_libraries(
+  velox_overwrite_varchar_function_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+target_link_libraries(
+  velox_function_err_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+target_link_libraries(
+  velox_overload_int_function_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+target_link_libraries(
+  velox_overload_varchar_function_dynamic
+  PRIVATE ${CMAKE_DYLIB_TEST_LINK_LIBRARIES})
+
+if(APPLE)
+  set(COMMON_LIBRARY_LINK_OPTIONS "-Wl,-undefined,dynamic_lookup")
+else()
+  # This ensures compatibility during Linux compilation by preventing errors
+  # related to 'is being linked both statically and dynamically into this
+  # executable,' particularly for folly_hazptr_use_executor."
+  set(COMMON_LIBRARY_LINK_OPTIONS "-Wl,--exclude-libs,ALL")
+endif()
+
+target_link_options(velox_function_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+target_link_options(velox_overwrite_int_function_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+target_link_options(velox_overwrite_varchar_function_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+target_link_options(velox_function_err_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+target_link_options(velox_overload_int_function_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+target_link_options(velox_overload_varchar_function_dynamic PRIVATE
+                    ${COMMON_LIBRARY_LINK_OPTIONS})
+
+# Here's the actual test which will dynamically load the library defined above.
+add_executable(velox_function_dynamic_link_test DynamicLinkTest.cpp)
+
+target_link_libraries(
+  velox_function_dynamic_link_test
+  velox_functions_test_lib
+  velox_dynamic_library_loader
+  velox_function_registry
+  xsimd
+  GTest::gmock
+  GTest::gtest
+  GTest::gtest_main)
+
+target_compile_definitions(
+  velox_function_dynamic_link_test
+  PRIVATE VELOX_TEST_DYNAMIC_LIBRARY_PATH="${CMAKE_CURRENT_BINARY_DIR}")
+target_compile_definitions(
+  velox_function_dynamic_link_test
+  PRIVATE
+    VELOX_TEST_DYNAMIC_LIBRARY_PATH_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+add_test(NAME velox_function_dynamic_link_test
+         COMMAND velox_function_dynamic_link_test)

--- a/velox/common/dynamic_registry/tests/DynamicErrFunction.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicErrFunction.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Array<int64_t>>& array) {
+    result = array.size();
+    return true;
+  }
+};
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      int64_t,
+      facebook::velox::Array<int64_t>>({"dynamic_err"});
+}
+}

--- a/velox/common/dynamic_registry/tests/DynamicFunction.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicFunction.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result) {
+    result = 123;
+    return true;
+  }
+};
+
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+// In this case, we assume that facebook::velox::registerFunction
+// will be available and resolve when this library gets loaded.
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      int64_t>({"dynamic"});
+}
+}

--- a/velox/common/dynamic_registry/tests/DynamicIntFunctionOverload.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicIntFunctionOverload.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<int64_t>& in) {
+    result = in;
+    return true;
+  }
+};
+
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      int64_t,
+      int64_t>({"dynamic_overload"});
+}
+}

--- a/velox/common/dynamic_registry/tests/DynamicIntFunctionOverwrite.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicIntFunctionOverwrite.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  FOLLY_ALWAYS_INLINE bool call(int64_t& result) {
+    result = 123;
+    return true;
+  }
+};
+
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      int64_t>({"dynamic_overwrite"});
+}
+}

--- a/velox/common/dynamic_registry/tests/DynamicLinkTest.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicLinkTest.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/dynamic_registry/DynamicLibraryLoader.h"
+#include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/functions/FunctionRegistry.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions::test {
+
+class DynamicLinkTest : public FunctionBaseTest {};
+
+namespace {
+std::string getLibraryPath(const std::string& filename) {
+  return fmt::format(
+      "{}/{}{}",
+      VELOX_TEST_DYNAMIC_LIBRARY_PATH,
+      filename,
+      VELOX_TEST_DYNAMIC_LIBRARY_PATH_SUFFIX);
+}
+} // namespace
+
+TEST_F(DynamicLinkTest, dynamicLoadFunc) {
+  const auto dynamicFunction = [&]() {
+    return evaluateOnce<int64_t>("dynamic()", makeRowVector(ROW({}), 1));
+  };
+
+  const auto dynamicFunctionNestedCall = [&]() {
+    return evaluateOnce<int64_t>(
+        "mod(dynamic(), 10)", makeRowVector(ROW({}), 1));
+  };
+
+  VELOX_ASSERT_THROW(
+      dynamicFunction(), "Scalar function doesn't exist: dynamic.");
+
+  auto signaturesBefore = getFunctionSignatures().size();
+  std::string libraryPath = getLibraryPath("libvelox_function_dynamic");
+  loadDynamicLibrary(libraryPath);
+  auto signaturesAfter = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfter, signaturesBefore + 1);
+  EXPECT_EQ(123, dynamicFunction());
+
+  auto& registry = exec::simpleFunctions();
+  auto resolved = registry.resolveFunction("dynamic", {});
+  EXPECT_EQ(TypeKind::BIGINT, resolved->type()->kind());
+
+  EXPECT_EQ(3, dynamicFunctionNestedCall());
+}
+
+TEST_F(DynamicLinkTest, dynamicLoadSameFuncTwice) {
+  const auto dynamicFunction = [&]() {
+    return evaluateOnce<int64_t>("dynamic()", makeRowVector(ROW({}), 1));
+  };
+  auto& registry = exec::simpleFunctions();
+  std::string libraryPath = getLibraryPath("libvelox_function_dynamic");
+
+  loadDynamicLibrary(libraryPath);
+  auto resolved = registry.resolveFunction("dynamic", {});
+  EXPECT_EQ(TypeKind::BIGINT, resolved->type()->kind());
+
+  auto signaturesBefore = getFunctionSignatures().size();
+
+  loadDynamicLibrary(libraryPath);
+  auto signaturesAfterSecond = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfterSecond, signaturesBefore);
+  auto resolvedAfterSecond = registry.resolveFunction("dynamic", {});
+  EXPECT_EQ(TypeKind::BIGINT, resolvedAfterSecond->type()->kind());
+}
+
+TEST_F(DynamicLinkTest, dynamicLoadOverwriteFunc) {
+  const auto dynamicIntFunction = [&]() {
+    return evaluateOnce<int64_t>(
+        "dynamic_overwrite()", makeRowVector(ROW({}), 1));
+  };
+  const auto dynamicVarcharFunction = [&]() {
+    return evaluateOnce<std::string>(
+        "dynamic_overwrite()", makeRowVector(ROW({}), 1));
+  };
+
+  auto& registry = exec::simpleFunctions();
+  auto signaturesBefore = getFunctionSignatures().size();
+
+  VELOX_ASSERT_THROW(
+      dynamicVarcharFunction(),
+      "Scalar function doesn't exist: dynamic_overwrite.");
+
+  std::string libraryPath =
+      getLibraryPath("libvelox_overwrite_varchar_function_dynamic");
+  loadDynamicLibrary(libraryPath);
+  auto signaturesAfterFirst = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfterFirst, signaturesBefore + 1);
+  EXPECT_EQ("123", dynamicVarcharFunction());
+  auto resolved = registry.resolveFunction("dynamic_overwrite", {});
+  EXPECT_EQ(TypeKind::VARCHAR, resolved->type()->kind());
+
+  VELOX_ASSERT_THROW(
+      dynamicIntFunction(),
+      "Expression evaluation result is not of expected type: dynamic_overwrite() -> CONSTANT vector of type VARCHAR");
+
+  std::string libraryPathInt =
+      getLibraryPath("libvelox_overwrite_int_function_dynamic");
+  loadDynamicLibrary(libraryPathInt);
+
+  // The first function loaded should be overwritten.
+  VELOX_ASSERT_THROW(
+      dynamicVarcharFunction(),
+      "Expression evaluation result is not of expected type: dynamic_overwrite() -> CONSTANT vector of type BIGINT");
+  EXPECT_EQ(123, dynamicIntFunction());
+  auto signaturesAfterSecond = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfterSecond, signaturesAfterFirst);
+  auto resolvedAfterSecond = registry.resolveFunction("dynamic_overwrite", {});
+  EXPECT_EQ(TypeKind::BIGINT, resolvedAfterSecond->type()->kind());
+}
+
+TEST_F(DynamicLinkTest, dynamicLoadErrFunc) {
+  const auto dynamicFunctionFail = [&](const std::optional<int64_t> a,
+                                       std::optional<int64_t> b) {
+    return evaluateOnce<int64_t>("dynamic_err(c0)", a, b);
+  };
+
+  const auto dynamicFunctionSuccess =
+      [&](const facebook::velox::RowVectorPtr& arr) {
+        return evaluateOnce<int64_t>("dynamic_err(c0)", arr);
+      };
+
+  auto signaturesBefore = getFunctionSignatures().size();
+  VELOX_ASSERT_THROW(
+      dynamicFunctionFail(0, 0), "Scalar function doesn't exist: dynamic_err.");
+
+  std::string libraryPath = getLibraryPath("libvelox_function_err_dynamic");
+  loadDynamicLibrary(libraryPath);
+
+  auto signaturesAfter = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfter, signaturesBefore + 1);
+
+  // Expecting a fail because we are not passing in an array.
+  VELOX_ASSERT_THROW(
+      dynamicFunctionFail(0, 0),
+      "Scalar function signature is not supported: dynamic_err(BIGINT). Supported signatures: (array(bigint)) -> bigint.");
+
+  auto check = makeRowVector(
+      {makeNullableArrayVector(std::vector<std::vector<std::optional<int64_t>>>{
+          {0, 1, 3, 4, 5, 6, 7, 8, 9}})});
+
+  // Expecting a success because we are passing in an array.
+  EXPECT_EQ(9, dynamicFunctionSuccess(check));
+}
+
+TEST_F(DynamicLinkTest, dynamicLoadOverloadFunc) {
+  const auto dynamicIntFunction = [&](const std::optional<int64_t> a) {
+    return evaluateOnce<int64_t>("dynamic_overload(c0)", a);
+  };
+  const auto dynamicVarcharFunction = [&](const std::optional<std::string> a) {
+    return evaluateOnce<std::string>("dynamic_overload(c0)", a);
+  };
+
+  auto& registry = exec::simpleFunctions();
+  auto signaturesBefore = getFunctionSignatures().size();
+
+  VELOX_ASSERT_THROW(
+      dynamicVarcharFunction("1"),
+      "Scalar function doesn't exist: dynamic_overload.");
+
+  std::string libraryPath =
+      getLibraryPath("libvelox_overload_varchar_function_dynamic");
+  loadDynamicLibrary(libraryPath);
+  auto signaturesAfterFirst = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfterFirst, signaturesBefore + 1);
+  EXPECT_EQ("1", dynamicVarcharFunction("1"));
+  auto resolved = registry.resolveFunction("dynamic_overload", {VARCHAR()});
+  EXPECT_EQ(TypeKind::VARCHAR, resolved->type()->kind());
+
+  // We expect no dynamic_5 with int arguments yet.
+  VELOX_ASSERT_THROW(
+      dynamicIntFunction(0),
+      "Scalar function signature is not supported: dynamic_overload(BIGINT). Supported signatures: (varchar) -> varchar.");
+
+  std::string libraryPathInt =
+      getLibraryPath("libvelox_overload_int_function_dynamic");
+  loadDynamicLibrary(libraryPathInt);
+
+  // The first function loaded should NOT be overwritten.
+  EXPECT_EQ("0", dynamicVarcharFunction("0"));
+  EXPECT_EQ(0, dynamicIntFunction(0));
+  auto signaturesAfterSecond = getFunctionSignatures().size();
+  EXPECT_EQ(signaturesAfterSecond, signaturesAfterFirst);
+  auto resolvedAfterSecond =
+      registry.resolveFunction("dynamic_overload", {BIGINT()});
+  EXPECT_EQ(TypeKind::BIGINT, resolvedAfterSecond->type()->kind());
+}
+
+} // namespace facebook::velox::functions::test

--- a/velox/common/dynamic_registry/tests/DynamicVarcharFunctionOverload.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicVarcharFunctionOverload.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& in) {
+    result = in;
+    return true;
+  }
+};
+
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      facebook::velox::Varchar,
+      facebook::velox::Varchar>({"dynamic_overload"});
+}
+}

--- a/velox/common/dynamic_registry/tests/DynamicVarcharFunctionOverwrite.cpp
+++ b/velox/common/dynamic_registry/tests/DynamicVarcharFunctionOverwrite.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/dynamic_registry/DynamicUdf.h"
+
+// This file defines a mock function that will be dynamically linked and
+// registered. There are no restrictions as to how the function needs to be
+// defined, but the library (.so) needs to provide a `void registry()` C
+// function in the top-level namespace.
+//
+// (note the extern "C" directive to prevent the compiler from mangling the
+// symbol name).
+
+namespace facebook::velox::common::dynamicRegistry {
+
+template <typename T>
+struct DynamicFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(out_type<Varchar>& result) {
+    result = "123";
+    return true;
+  }
+};
+
+} // namespace facebook::velox::common::dynamicRegistry
+
+extern "C" {
+
+void registry() {
+  facebook::velox::registerFunction<
+      facebook::velox::common::dynamicRegistry::DynamicFunction,
+      facebook::velox::Varchar>({"dynamic_overwrite"});
+}
+}

--- a/velox/docs/develop.rst
+++ b/velox/docs/develop.rst
@@ -32,3 +32,4 @@ This guide is intended for Velox contributors and developers of Velox-based appl
     develop/debugging
     develop/TpchBenchmark
     develop/window
+    develop/dynamic-loading

--- a/velox/docs/develop/dynamic-loading.rst
+++ b/velox/docs/develop/dynamic-loading.rst
@@ -1,0 +1,79 @@
+***********************************
+Dynamic Loading of Velox Extensions
+***********************************
+
+This generic utility adds extensibility features to load User Defined Functions (UDFs) without having to fork and build Velox, through the use of shared libraries. Support for connectors and types will be added in the future.
+
+This mechanism relies on ABI compatibility, meaning it is only guarenteed to work if the shared libraries and the Velox build are based on the same Velox version.
+Using shared libraries built against a different version of Velox may result in undefined behavior or runtime errors due to ABI mismatches.
+
+Getting Started
+===============
+
+1. **Create a C++ file for your dynamic library**
+
+   For dynamically loaded function registration, the format followed mirrors that of built-in function registration with some noted differences. Using `DynamicTestFunction.cpp` as an example, the function uses the `extern "C"` keyword to protect against name mangling. A `registry()` function call is also necessary.
+
+   Make sure to also include the necessary header file:
+
+   .. code-block:: cpp
+
+      #include "velox/common/dynamic_registry/DynamicUdf.h"
+
+   Example template for a function with no arguments returning a BIGINT:
+
+   .. code-block:: cpp
+
+      #include "velox/common/dynamic_registry/DynamicUdf.h"
+
+      namespace example_namespace {
+
+      template <typename T>
+      struct DynamicFunction {
+        FOLLY_ALWAYS_INLINE bool call(int64_t& result) {
+          // Code to calculate result.
+        }
+      };
+      }
+
+      extern "C" {
+      void registry() {
+        facebook::velox::registerFunction<
+            example_namespace::DynamicFunction,
+            int64_t>({"your_function_name"});
+      }
+      }
+
+2. **Register functions dynamically by creating `.dylib` (MacOS) or `.so` (Linux) shared libraries**
+
+   These shared libraries may be created using a CMakeLists file like the following:
+
+   .. code-block:: cmake
+
+      add_library(name_of_dynamic_fn SHARED TestFunction.cpp)
+      target_link_libraries(name_of_dynamic_fn PRIVATE fmt::fmt Folly::folly glog::glog xsimd)
+
+      if(APPLE)
+      set(COMMON_LIBRARY_LINK_OPTIONS "-Wl,-undefined,dynamic_lookup")
+      else()
+      set(COMMON_LIBRARY_LINK_OPTIONS "-Wl,--exclude-libs,ALL")
+      endif()
+
+      target_link_options(name_of_dynamic_fn PRIVATE ${COMMON_LIBRARY_LINK_OPTIONS})
+
+   Additional details:
+
+   - **Required Libraries**:
+      - The `fmt::fmt`, `Folly::folly`, and `xsimd` libraries are required for all necessary symbols to be defined when loading `TestFunction.cpp` dynamically.
+      - The `glog::glog` library is required on macOS but optional on Linux.
+
+   - **Linking Options**:
+      - On **macOS**: The `target_link_options` (`"-Wl,-undefined,dynamic_lookup"`) allow symbols to be resolved at runtime.
+      - On **Linux**: The `target_link_options` (`"-Wl,--exclude-libs,ALL"`) prevent errors related to symbols being linked both statically and dynamically.
+
+Notes
+=====
+
+- In Velox, a function's signature is determined solely by its name and argument types. The return type is not taken into account. As a result, if a function with an identical signature is added but with a different return type, it will overwrite the existing function.
+- Function overloading is supported. Therefore, multiple functions can share the same name as long as they differ in the number or types of arguments.
+


### PR DESCRIPTION
Allow users to dynamically register Velox components. Clients such as Presto can use this feature to dynamically load User Defined Functions, connectors, and types.

Based off:  https://github.com/facebookincubator/velox/pull/1005/files