### PR TITLE
Minor change to oom message to reduce confusion

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -848,15 +848,15 @@ bool MemoryPoolImpl::incrementReservationThreadSafe(
   }
   VELOX_MEM_POOL_CAP_EXCEEDED(fmt::format(
       "Exceeded memory pool capacity after attempt to grow capacity "
-      "through arbitration. Requestor pool name '{}', request size {}, memory "
-      "pool capacity {}, memory pool max capacity {}, memory manager capacity "
-      "{}, current usage {}\n{}",
+      "through arbitration. Requestor pool name '{}', request size {}, current "
+      "usage {}, memory pool capacity {}, memory pool max capacity {}, memory "
+      "manager capacity {}\n{}",
       requestor->name(),
       succinctBytes(size),
+      succinctBytes(requestor->usedBytes()),
       capacityToString(capacity()),
       capacityToString(maxCapacity_),
       capacityToString(manager_->capacity()),
-      succinctBytes(requestor->usedBytes()),
       treeMemoryUsage()));
 }
 

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -146,7 +146,8 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
         leafPool->allocate(7L << 20),
         "Exceeded memory pool capacity after attempt to grow capacity through "
         "arbitration. Requestor pool name 'leaf-1.0', request size 7.00MB, "
-        "memory pool capacity 4.00MB, memory pool max capacity 8.00MB");
+        "current usage 0B, memory pool capacity 4.00MB, memory pool max "
+        "capacity 8.00MB");
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 0);
     VELOX_ASSERT_THROW(
         manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), "");

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -70,8 +70,8 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   std::vector<std::string> expectedTexts = {
       "Exceeded memory pool capacity after attempt to grow capacity through "
       "arbitration. Requestor pool name 'op.2.0.0.Aggregation', request size "
-      "2.00MB, memory pool capacity 5.00MB, memory pool max capacity 5.00MB, "
-      "memory manager capacity 8.00GB, current usage 3.70MB"};
+      "2.00MB, current usage 3.70MB, memory pool capacity 5.00MB, memory pool "
+      "max capacity 5.00MB, memory manager capacity 8.00GB"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 12.00KB reserved 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -726,9 +726,9 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
         ASSERT_EQ(
             "Exceeded memory pool capacity after attempt to grow capacity "
             "through arbitration. Requestor pool name 'static_quota', request "
-            "size 136.00MB, memory pool capacity 128.00MB, memory pool max "
-            "capacity 128.00MB, memory manager capacity 128.00MB, current "
-            "usage 0B\nMemoryCapExceptions usage 0B reserved 0B peak 0B\n",
+            "size 136.00MB, current usage 0B, memory pool capacity 128.00MB, "
+            "memory pool max capacity 128.00MB, memory manager capacity "
+            "128.00MB\nMemoryCapExceptions usage 0B reserved 0B peak 0B\n",
             ex.message());
       }
     }


### PR DESCRIPTION
The current usage is confused to be treated as memory manager's current memory usage. Move it closer to requestor text to make the message less confusing.