### PR TITLE
Support different vector serialization format for streaming shuffle

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -60,7 +60,7 @@ target_link_libraries(
 
 add_executable(velox_benchmark_feature_normalization FeatureNormalization.cpp)
 target_link_libraries(
-  velox_benchmark_feature_normalization ${velox_benchmark_deps}
+  velox_benchmark_feature_normalization ${velox_benchmark_deps} velox_row_fast
   velox_functions_prestosql)
 
 add_executable(velox_benchmark_basic_preproc Preproc.cpp)
@@ -99,4 +99,5 @@ target_link_libraries(
   ${velox_benchmark_deps}
   velox_vector_test_lib
   velox_functions_spark
-  velox_functions_prestosql)
+  velox_functions_prestosql
+  velox_row_fast)

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -16,17 +16,14 @@
 
 #pragma once
 
-#include <array>
 #include <atomic>
 #include <memory>
 #include <optional>
-#include <queue>
 
 #include <fmt/format.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Portability.h"
-#include "velox/common/future/VeloxPromise.h"
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MemoryArbitrator.h"

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -162,3 +162,20 @@ These stats are reported by operators that support spilling.
    * - spillDeserializationWallNanos
      - nanos
      - The time spent on deserializing rows read from spilled files.
+
+Shuffle
+--------
+These stats are reported by shuffle operators.
+
+.. list-table::
+   :widths: 50 25 50
+   :header-rows: 1
+
+   * - Stats
+     - Unit
+     - Description
+   * - shuffleSerdeKind
+     -
+     - Indicates the vector serde kind used by an operator for shuffle with 1
+       for Presto, 2 for CompactRow, 3 for UnsafeRow. It is reported by Exchange,
+       MergeExchange and PartitionedOutput operators for now.

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_LINK_LIBS
     velox_dwio_dwrf_proto
     velox_dwio_dwrf_reader
     velox_dwio_dwrf_writer
+    velox_row_fast
     gflags::gflags
     GTest::gtest
     GTest::gtest_main
@@ -289,7 +290,11 @@ add_executable(velox_dwio_dwrf_config_test ConfigTests.cpp)
 add_test(velox_dwio_dwrf_config_test velox_dwio_dwrf_config_test)
 
 target_link_libraries(
-  velox_dwio_dwrf_config_test velox_link_libs Folly::folly ${TEST_LINK_LIBS})
+  velox_dwio_dwrf_config_test
+  velox_link_libs
+  velox_row_fast
+  Folly::folly
+  ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_ratio_checker_test RatioTrackerTest.cpp)
 add_test(velox_dwio_dwrf_ratio_checker_test velox_dwio_dwrf_ratio_checker_test)

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -304,7 +304,8 @@ MergeExchange::MergeExchange(
           mergeExchangeNode->sortingKeys(),
           mergeExchangeNode->sortingOrders(),
           mergeExchangeNode->id(),
-          "MergeExchange") {}
+          "MergeExchange"),
+      serde_(getNamedVectorSerde(mergeExchangeNode->serdeKind())) {}
 
 BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   if (operatorCtx_->driverCtx()->driverId != 0) {
@@ -364,4 +365,10 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   }
 }
 
+void MergeExchange::close() {
+  Operator::close();
+  stats_.wlock()->addRuntimeStat(
+      Operator::kShuffleSerdeKind,
+      RuntimeCounter(static_cast<int64_t>(serde_->kind())));
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -191,10 +191,17 @@ class MergeExchange : public Merge {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::MergeExchangeNode>& orderByNode);
 
+  VectorSerde* serde() const {
+    return serde_;
+  }
+
+  void close() override;
+
  protected:
   BlockingReason addMergeSources(ContinueFuture* future) override;
 
  private:
+  VectorSerde* const serde_;
   bool noMoreSplits_ = false;
   // Task Ids from all the splits we took to process so far.
   std::vector<std::string> remoteSourceTaskIds_;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -163,6 +163,7 @@ class MergeExchangeSource : public MergeSource {
           inputStream_.get(),
           mergeExchange_->pool(),
           mergeExchange_->outputType(),
+          mergeExchange_->serde(),
           &data);
 
       auto lockedStats = mergeExchange_->stats().wlock();

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -360,6 +360,10 @@ class Operator : public BaseRuntimeStatWriter {
   static inline const std::string kSpillDeserializationTime{
       "spillDeserializationWallNanos"};
 
+  /// The vector serde kind used by an operator for shuffle. The recorded
+  /// runtime stats value is the corresponding enum value.
+  static inline const std::string kShuffleSerdeKind{"shuffleSerdeKind"};
+
   /// 'operatorId' is the initial index of the 'this' in the Driver's list of
   /// Operators. This is used as in index into OperatorStats arrays in the Task.
   /// 'planNodeId' is a query-level unique identifier of the PlanNode to which

--- a/velox/exec/OperatorTraceReader.cpp
+++ b/velox/exec/OperatorTraceReader.cpp
@@ -30,6 +30,7 @@ OperatorTraceInputReader::OperatorTraceInputReader(
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
       dataType_(std::move(dataType)),
       pool_(pool),
+      serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),
       inputStream_(getInputStream()) {
   VELOX_CHECK_NOT_NULL(dataType_);
 }
@@ -45,7 +46,7 @@ bool OperatorTraceInputReader::read(RowVectorPtr& batch) const {
   }
 
   VectorStreamGroup::read(
-      inputStream_.get(), pool_, dataType_, &batch, &readOptions_);
+      inputStream_.get(), pool_, dataType_, serde_, &batch, &readOptions_);
   return true;
 }
 

--- a/velox/exec/OperatorTraceReader.h
+++ b/velox/exec/OperatorTraceReader.h
@@ -47,6 +47,7 @@ class OperatorTraceInputReader {
   const std::shared_ptr<filesystems::FileSystem> fs_;
   const RowTypePtr dataType_;
   memory::MemoryPool* const pool_;
+  VectorSerde* const serde_;
   const std::unique_ptr<common::FileInputStream> inputStream_;
 };
 

--- a/velox/exec/OperatorTraceWriter.cpp
+++ b/velox/exec/OperatorTraceWriter.cpp
@@ -34,6 +34,7 @@ OperatorTraceWriter::OperatorTraceWriter(
       traceDir_(std::move(traceDir)),
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
       pool_(pool),
+      serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),
       updateAndCheckTraceLimitCB_(std::move(updateAndCheckTraceLimitCB)) {
   traceFile_ = fs_->openFileForWrite(getOpTraceInputFilePath(traceDir_));
   VELOX_CHECK_NOT_NULL(traceFile_);
@@ -48,7 +49,7 @@ void OperatorTraceWriter::write(const RowVectorPtr& rows) {
   }
 
   if (batch_ == nullptr) {
-    batch_ = std::make_unique<VectorStreamGroup>(pool_);
+    batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
     batch_->createStreamTree(
         std::static_pointer_cast<const RowType>(rows->type()),
         1'000,

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -61,6 +61,7 @@ class OperatorTraceWriter {
       /*nullsFirst=*/true};
   const std::shared_ptr<filesystems::FileSystem> fs_;
   memory::MemoryPool* const pool_;
+  VectorSerde* const serde_;
   const UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB_;
 
   std::unique_ptr<WriteFile> traceFile_;

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -189,8 +189,9 @@ class SpillWriter {
 
   // Updates the aggregated spill bytes of this query, and throws if exceeds
   // the max spill bytes limit.
-  common::UpdateAndCheckSpillLimitCB updateAndCheckSpillLimitCb_;
+  const common::UpdateAndCheckSpillLimitCB updateAndCheckSpillLimitCb_;
   memory::MemoryPool* const pool_;
+  VectorSerde* const serde_;
   folly::Synchronized<common::SpillStats>* const stats_;
 
   bool finished_{false};
@@ -200,8 +201,8 @@ class SpillWriter {
   SpillFiles finishedFiles_;
 };
 
-/// Represents a spill file for read which turns the serialized spilled data on
-/// disk back into a sequence of spilled row vectors.
+/// Represents a spill file for read which turns the serialized spilled data
+/// on disk back into a sequence of spilled row vectors.
 ///
 /// NOTE: The class will not delete spill file upon destruction, so the user
 /// needs to remove the unused spill files at some point later. For example, a
@@ -269,6 +270,7 @@ class SpillReadFile {
   const common::CompressionKind compressionKind_;
   const serializer::presto::PrestoVectorSerde::PrestoOptions readOptions_;
   memory::MemoryPool* const pool_;
+  VectorSerde* const serde_;
   folly::Synchronized<common::SpillStats>* const stats_;
 
   std::unique_ptr<common::FileInputStream> input_;

--- a/velox/exec/TaskTraceReader.cpp
+++ b/velox/exec/TaskTraceReader.cpp
@@ -31,7 +31,10 @@ TaskTraceMetadataReader::TaskTraceMetadataReader(
       traceFilePath_(getTaskTraceMetaFilePath(traceDir_)),
       pool_(pool) {
   VELOX_CHECK_NOT_NULL(fs_);
-  VELOX_CHECK(fs_->exists(traceFilePath_));
+  VELOX_CHECK(
+      fs_->exists(traceFilePath_),
+      "Task trace file not found: {}",
+      traceFilePath_);
 }
 
 void TaskTraceMetadataReader::read(

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -132,11 +132,12 @@ class ExchangeBenchmark : public VectorTestBase {
 
     core::PlanNodePtr finalAggPlan;
     std::vector<std::string> finalAggTaskIds;
-    finalAggPlan = exec::test::PlanBuilder()
-                       .exchange(leafPlan->outputType())
-                       .singleAggregation({}, {"count(1)"})
-                       .partitionedOutput({}, 1)
-                       .planNode();
+    finalAggPlan =
+        exec::test::PlanBuilder()
+            .exchange(leafPlan->outputType(), VectorSerde::Kind::kPresto)
+            .singleAggregation({}, {"count(1)"})
+            .partitionedOutput({}, 1)
+            .planNode();
 
     std::vector<exec::Split> finalAggSplits;
     for (int i = 0; i < width; i++) {
@@ -149,10 +150,11 @@ class ExchangeBenchmark : public VectorTestBase {
       addRemoteSplits(task, leafTaskIds);
     }
 
-    auto plan = exec::test::PlanBuilder()
-                    .exchange(finalAggPlan->outputType())
-                    .singleAggregation({}, {"sum(a0)"})
-                    .planNode();
+    auto plan =
+        exec::test::PlanBuilder()
+            .exchange(finalAggPlan->outputType(), VectorSerde::Kind::kPresto)
+            .singleAggregation({}, {"sum(a0)"})
+            .planNode();
 
     auto expected =
         makeRowVector({makeFlatVector<int64_t>(1, [&](auto /*row*/) {

--- a/velox/exec/fuzzer/AggregationFuzzerRunner.h
+++ b/velox/exec/fuzzer/AggregationFuzzerRunner.h
@@ -27,7 +27,9 @@
 #include "velox/exec/fuzzer/AggregationFuzzer.h"
 #include "velox/exec/fuzzer/AggregationFuzzerOptions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::exec::test {
@@ -105,6 +107,15 @@ class AggregationFuzzerRunner {
     facebook::velox::parse::registerTypeResolver();
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerVectorSerde();
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+      serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+      serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+      serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+    }
     facebook::velox::filesystems::registerLocalFileSystem();
 
     auto& aggregationFunctionDataSpecs =

--- a/velox/exec/fuzzer/JoinFuzzerRunner.h
+++ b/velox/exec/fuzzer/JoinFuzzerRunner.h
@@ -24,7 +24,9 @@
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 
 /// Join FuzzerRunner leverages JoinFuzzer and VectorFuzzer to
 /// automatically generate and execute join tests. It works by:
@@ -69,6 +71,15 @@ class JoinFuzzerRunner {
     filesystems::registerLocalFileSystem();
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+      serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+      serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+      serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+    }
     joinFuzzer(seed, std::move(referenceQueryRunner));
     return RUN_ALL_TESTS();
   }

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -26,6 +26,9 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 DEFINE_int32(steps, 10, "Number of plans to generate and test.");
@@ -173,6 +176,16 @@ RowNumberFuzzer::RowNumberFuzzer(
       referenceQueryRunner_{std::move(referenceQueryRunner)} {
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
+
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+  }
 
   // Make sure not to run out of open file descriptors.
   std::unordered_map<std::string, std::string> hiveConfig = {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
   aggregate_companion_functions_test
   velox_exec
   velox_function_registry
+  velox_exec_test_lib
   GTest::gtest
   GTest::gtest_main)
 

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -28,7 +28,9 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/VectorSaver.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -141,7 +143,7 @@ class ExchangeFuzzer : public VectorTestBase {
     }
     auto partialAggPlan =
         exec::test::PlanBuilder()
-            .exchange(leafPlan->outputType())
+            .exchange(leafPlan->outputType(), VectorSerde::Kind::kPresto)
             .partialAggregation({}, makeAggregates(rowType, 1))
             .partitionedOutput({}, 1)
             .planNode();
@@ -156,13 +158,14 @@ class ExchangeFuzzer : public VectorTestBase {
       addRemoteSplits(task, leafTaskIds);
     }
 
-    auto plan = exec::test::PlanBuilder()
-                    .exchange(partialAggPlan->outputType())
-                    .finalAggregation(
-                        {},
-                        makeAggregates(*partialAggPlan->outputType(), 0),
-                        rawInputTypes)
-                    .planNode();
+    auto plan =
+        exec::test::PlanBuilder()
+            .exchange(partialAggPlan->outputType(), VectorSerde::Kind::kPresto)
+            .finalAggregation(
+                {},
+                makeAggregates(*partialAggPlan->outputType(), 0),
+                rawInputTypes)
+            .planNode();
 
     try {
       // Create the Task to do the final aggregation using a TaskCursor so we
@@ -571,6 +574,15 @@ int main(int argc, char** argv) {
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+  }
   exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);
 
   ExchangeFuzzer fuzzer;

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -15,10 +15,8 @@
  */
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/OutputBufferManager.h"
@@ -39,7 +37,18 @@ using facebook::velox::test::BatchMaker;
 namespace facebook::velox::exec {
 namespace {
 
-class MultiFragmentTest : public HiveConnectorTestBase {
+class MultiFragmentTest
+    : public HiveConnectorTestBase,
+      public testing::WithParamInterface<VectorSerde::Kind> {
+ public:
+  static std::vector<VectorSerde::Kind> getTestParams() {
+    const std::vector<VectorSerde::Kind> kinds(
+        {VectorSerde::Kind::kPresto,
+         VectorSerde::Kind::kCompactRow,
+         VectorSerde::Kind::kUnsafeRow});
+    return kinds;
+  }
+
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
@@ -159,7 +168,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       const std::string& taskId,
       int32_t destination,
       const RowVectorPtr& data) {
-    auto page = toSerializedPage(data, bufferManager_, pool());
+    auto page = toSerializedPage(data, GetParam(), bufferManager_, pool());
     const auto pageSize = page->size();
 
     ContinueFuture unused;
@@ -200,20 +209,24 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       OutputBufferManager::getInstance().lock()};
 };
 
-TEST_F(MultiFragmentTest, aggregationSingleKey) {
+TEST_P(MultiFragmentTest, aggregationSingleKey) {
   setupSources(10, 1000);
   std::vector<std::shared_ptr<Task>> tasks;
   auto leafTaskId = makeTaskId("leaf", 0);
   core::PlanNodePtr partialAggPlan;
+  core::PlanNodeId partitionNodeId;
+  std::shared_ptr<Task> leafTask;
   {
-    partialAggPlan = PlanBuilder()
-                         .tableScan(rowType_)
-                         .project({"c0 % 10 AS c0", "c1"})
-                         .partialAggregation({"c0"}, {"sum(c1)"})
-                         .partitionedOutput({"c0"}, 3)
-                         .planNode();
+    partialAggPlan =
+        PlanBuilder()
+            .tableScan(rowType_)
+            .project({"c0 % 10 AS c0", "c1"})
+            .partialAggregation({"c0"}, {"sum(c1)"})
+            .partitionedOutput({"c0"}, 3, /*outputLayout=*/{}, GetParam())
+            .capturePlanNodeId(partitionNodeId)
+            .planNode();
 
-    auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
+    leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
     leafTask->start(4);
     addHiveSplits(leafTask, filePaths_);
@@ -221,21 +234,27 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
 
   core::PlanNodePtr finalAggPlan;
   std::vector<std::string> finalAggTaskIds;
+  core::PlanNodeId exchangeNodeId;
+  std::vector<std::shared_ptr<Task>> finalTasks;
   for (int i = 0; i < 3; i++) {
-    finalAggPlan = PlanBuilder()
-                       .exchange(partialAggPlan->outputType())
-                       .finalAggregation({"c0"}, {"sum(a0)"}, {{BIGINT()}})
-                       .partitionedOutput({}, 1)
-                       .planNode();
+    finalAggPlan =
+        PlanBuilder()
+            .exchange(partialAggPlan->outputType(), GetParam())
+            .capturePlanNodeId(exchangeNodeId)
+            .finalAggregation({"c0"}, {"sum(a0)"}, {{BIGINT()}})
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+            .planNode();
 
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
     auto task = makeTask(finalAggTaskIds.back(), finalAggPlan, i);
     tasks.push_back(task);
+    finalTasks.push_back(task);
     task->start(1);
     addRemoteSplits(task, {leafTaskId});
   }
 
-  auto op = PlanBuilder().exchange(finalAggPlan->outputType()).planNode();
+  auto op =
+      PlanBuilder().exchange(finalAggPlan->outputType(), GetParam()).planNode();
 
   assertQuery(
       op, finalAggTaskIds, "SELECT c0 % 10, sum(c1) FROM tmp GROUP BY 1");
@@ -285,20 +304,38 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
       ASSERT_EQ(numPools, 8);
     }
   }
+  auto leafPlanStats = toPlanStats(leafTask->taskStats());
+  const auto serdeKindRuntimsStats =
+      leafPlanStats.at(partitionNodeId)
+          .customStats.at(Operator::kShuffleSerdeKind);
+  ASSERT_EQ(serdeKindRuntimsStats.count, 4);
+  ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
+  ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
+
+  for (const auto& finalTask : finalTasks) {
+    auto finalPlanStats = toPlanStats(finalTask->taskStats());
+    const auto serdeKindRuntimsStats =
+        finalPlanStats.at(exchangeNodeId)
+            .customStats.at(Operator::kShuffleSerdeKind);
+    ASSERT_EQ(serdeKindRuntimsStats.count, 1);
+    ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
+    ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
+  }
 }
 
-TEST_F(MultiFragmentTest, aggregationMultiKey) {
+TEST_P(MultiFragmentTest, aggregationMultiKey) {
   setupSources(10, 1'000);
   std::vector<std::shared_ptr<Task>> tasks;
   auto leafTaskId = makeTaskId("leaf", 0);
   core::PlanNodePtr partialAggPlan;
   {
-    partialAggPlan = PlanBuilder()
-                         .tableScan(rowType_)
-                         .project({"c0 % 10 AS c0", "c1 % 2 AS c1", "c2"})
-                         .partialAggregation({"c0", "c1"}, {"sum(c2)"})
-                         .partitionedOutput({"c0", "c1"}, 3)
-                         .planNode();
+    partialAggPlan =
+        PlanBuilder()
+            .tableScan(rowType_)
+            .project({"c0 % 10 AS c0", "c1 % 2 AS c1", "c2"})
+            .partialAggregation({"c0", "c1"}, {"sum(c2)"})
+            .partitionedOutput({"c0", "c1"}, 3, /*outputLayout=*/{}, GetParam())
+            .planNode();
 
     auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
@@ -311,9 +348,9 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan =
         PlanBuilder()
-            .exchange(partialAggPlan->outputType())
+            .exchange(partialAggPlan->outputType(), GetParam())
             .finalAggregation({"c0", "c1"}, {"sum(a0)"}, {{BIGINT()}})
-            .partitionedOutput({}, 1)
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
             .planNode();
 
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
@@ -323,7 +360,8 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
     addRemoteSplits(task, {leafTaskId});
   }
 
-  auto op = PlanBuilder().exchange(finalAggPlan->outputType()).planNode();
+  auto op =
+      PlanBuilder().exchange(finalAggPlan->outputType(), GetParam()).planNode();
 
   assertQuery(
       op,
@@ -335,23 +373,25 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
   }
 }
 
-TEST_F(MultiFragmentTest, distributedTableScan) {
+TEST_P(MultiFragmentTest, distributedTableScan) {
   setupSources(10, 1000);
   // Run the table scan several times to test the caching.
   for (int i = 0; i < 3; ++i) {
     auto leafTaskId = makeTaskId("leaf", 0);
 
-    auto leafPlan = PlanBuilder()
-                        .tableScan(rowType_)
-                        .project({"c0 % 10", "c1 % 2", "c2"})
-                        .partitionedOutput({}, 1, {"c2", "p1", "p0"})
-                        .planNode();
+    auto leafPlan =
+        PlanBuilder()
+            .tableScan(rowType_)
+            .project({"c0 % 10", "c1 % 2", "c2"})
+            .partitionedOutput({}, 1, {"c2", "p1", "p0"}, GetParam())
+            .planNode();
 
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
     addHiveSplits(leafTask, filePaths_);
 
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
     auto task =
         assertQuery(op, {leafTaskId}, "SELECT c2, c1 % 2, c0 % 10 FROM tmp");
 
@@ -361,7 +401,7 @@ TEST_F(MultiFragmentTest, distributedTableScan) {
   }
 }
 
-TEST_F(MultiFragmentTest, mergeExchange) {
+TEST_P(MultiFragmentTest, mergeExchange) {
   setupSources(20, 1000);
 
   static const core::SortOrder kAscNullsLast(true, false);
@@ -378,19 +418,22 @@ TEST_F(MultiFragmentTest, mergeExchange) {
   std::vector<std::string> partialSortTaskIds;
   RowTypePtr outputType;
 
+  core::PlanNodeId partitionNodeId;
   for (int i = 0; i < 2; ++i) {
     auto sortTaskId = makeTaskId("orderby", tasks.size());
     partialSortTaskIds.push_back(sortTaskId);
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-    auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
-                               .localMerge(
-                                   {"c0"},
-                                   {PlanBuilder(planNodeIdGenerator)
-                                        .tableScan(rowType_)
-                                        .orderBy({"c0"}, true)
-                                        .planNode()})
-                               .partitionedOutput({}, 1)
-                               .planNode();
+    auto partialSortPlan =
+        PlanBuilder(planNodeIdGenerator)
+            .localMerge(
+                {"c0"},
+                {PlanBuilder(planNodeIdGenerator)
+                     .tableScan(rowType_)
+                     .orderBy({"c0"}, true)
+                     .planNode()})
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+            .capturePlanNodeId(partitionNodeId)
+            .planNode();
 
     auto sortTask = makeTask(sortTaskId, partialSortPlan, tasks.size());
     tasks.push_back(sortTask);
@@ -401,18 +444,19 @@ TEST_F(MultiFragmentTest, mergeExchange) {
 
   auto finalSortTaskId = makeTaskId("orderby", tasks.size());
   core::PlanNodeId mergeExchangeId;
-  auto finalSortPlan = PlanBuilder()
-                           .mergeExchange(outputType, {"c0"})
-                           .capturePlanNodeId(mergeExchangeId)
-                           .partitionedOutput({}, 1)
-                           .planNode();
+  auto finalSortPlan =
+      PlanBuilder()
+          .mergeExchange(outputType, {"c0"}, GetParam())
+          .capturePlanNodeId(mergeExchangeId)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
 
-  auto task = makeTask(finalSortTaskId, finalSortPlan, 0);
-  tasks.push_back(task);
-  task->start(1);
-  addRemoteSplits(task, partialSortTaskIds);
+  auto mergeTask = makeTask(finalSortTaskId, finalSortPlan, 0);
+  tasks.push_back(mergeTask);
+  mergeTask->start(1);
+  addRemoteSplits(mergeTask, partialSortTaskIds);
 
-  auto op = PlanBuilder().exchange(outputType).planNode();
+  auto op = PlanBuilder().exchange(outputType, GetParam()).planNode();
   assertQueryOrdered(
       op, {finalSortTaskId}, "SELECT * FROM tmp ORDER BY 1 NULLS LAST", {0});
 
@@ -420,7 +464,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
     ASSERT_TRUE(waitForTaskCompletion(task.get())) << task->taskId();
   }
 
-  const auto finalSortStats = toPlanStats(task->taskStats());
+  const auto finalSortStats = toPlanStats(mergeTask->taskStats());
   const auto& mergeExchangeStats = finalSortStats.at(mergeExchangeId);
 
   EXPECT_EQ(20'000, mergeExchangeStats.inputRows);
@@ -428,10 +472,16 @@ TEST_F(MultiFragmentTest, mergeExchange) {
 
   EXPECT_LT(0, mergeExchangeStats.inputBytes);
   EXPECT_LT(0, mergeExchangeStats.rawInputBytes);
+
+  const auto serdeKindRuntimsStats =
+      mergeExchangeStats.customStats.at(Operator::kShuffleSerdeKind);
+  ASSERT_EQ(serdeKindRuntimsStats.count, 1);
+  ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
+  ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
 }
 
 // Test reordering and dropping columns in PartitionedOutput operator.
-TEST_F(MultiFragmentTest, partitionedOutput) {
+TEST_P(MultiFragmentTest, partitionedOutput) {
   setupSources(10, 1000);
 
   // Test dropping columns only
@@ -439,11 +489,12 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     auto leafTaskId = makeTaskId("leaf", 0);
     auto leafPlan = PlanBuilder()
                         .values(vectors_)
-                        .partitionedOutput({}, 1, {"c0", "c1"})
+                        .partitionedOutput({}, 1, {"c0", "c1"}, GetParam())
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
     assertQuery(op, {leafTaskId}, "SELECT c0, c1 FROM tmp");
 
@@ -453,13 +504,15 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
   // Test reordering and dropping at the same time
   {
     auto leafTaskId = makeTaskId("leaf", 0);
-    auto leafPlan = PlanBuilder()
-                        .values(vectors_)
-                        .partitionedOutput({}, 1, {"c3", "c0", "c2"})
-                        .planNode();
+    auto leafPlan =
+        PlanBuilder()
+            .values(vectors_)
+            .partitionedOutput({}, 1, {"c3", "c0", "c2"}, GetParam())
+            .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
     assertQuery(op, {leafTaskId}, "SELECT c3, c0, c2 FROM tmp");
 
@@ -473,11 +526,15 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
         PlanBuilder()
             .values(vectors_)
             .partitionedOutput(
-                {}, 1, {"c0", "c1", "c2", "c3", "c4", "c3", "c2", "c1", "c0"})
+                {},
+                1,
+                {"c0", "c1", "c2", "c3", "c4", "c3", "c2", "c1", "c0"},
+                GetParam())
             .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
     assertQuery(
         op, {leafTaskId}, "SELECT c0, c1, c2, c3, c4, c3, c2, c1, c0 FROM tmp");
@@ -489,17 +546,19 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
   {
     constexpr int32_t kFanout = 4;
     auto leafTaskId = makeTaskId("leaf", 0);
-    auto leafPlan = PlanBuilder()
-                        .values(vectors_)
-                        .partitionedOutput({"c5"}, kFanout, {"c2", "c0", "c3"})
-                        .planNode();
+    auto leafPlan =
+        PlanBuilder()
+            .values(vectors_)
+            .partitionedOutput({"c5"}, kFanout, {"c2", "c0", "c3"}, GetParam())
+            .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
 
-    auto intermediatePlan = PlanBuilder()
-                                .exchange(leafPlan->outputType())
-                                .partitionedOutput({}, 1, {"c3", "c0", "c2"})
-                                .planNode();
+    auto intermediatePlan =
+        PlanBuilder()
+            .exchange(leafPlan->outputType(), GetParam())
+            .partitionedOutput({}, 1, {"c3", "c0", "c2"}, GetParam())
+            .planNode();
     std::vector<std::string> intermediateTaskIds;
     for (auto i = 0; i < kFanout; ++i) {
       intermediateTaskIds.push_back(makeTaskId("intermediate", i));
@@ -509,7 +568,9 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
       addRemoteSplits(intermediateTask, {leafTaskId});
     }
 
-    auto op = PlanBuilder().exchange(intermediatePlan->outputType()).planNode();
+    auto op = PlanBuilder()
+                  .exchange(intermediatePlan->outputType(), GetParam())
+                  .planNode();
 
     auto task =
         assertQuery(op, intermediateTaskIds, "SELECT c3, c0, c2 FROM tmp");
@@ -528,14 +589,15 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                             [](std::string nodeId,
                                core::PlanNodePtr source) -> core::PlanNodePtr {
                               return core::PartitionedOutputNode::broadcast(
-                                  nodeId, 1, ROW({}), source);
+                                  nodeId, 1, ROW({}), GetParam(), source);
                             })
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
     leafTask->updateOutputBuffers(1, true);
 
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
     vector_size_t numRows = 0;
     for (const auto& vector : vectors_) {
@@ -556,7 +618,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
     auto leafTaskId = makeTaskId("leaf", 0);
     auto leafPlan = PlanBuilder()
                         .values(vectors_)
-                        .partitionedOutput({}, 1, {"c0", "c1"})
+                        .partitionedOutput({}, 1, {"c0", "c1"}, GetParam())
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(4);
@@ -567,7 +629,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
   }
 }
 
-TEST_F(MultiFragmentTest, noHashPartitionSkew) {
+TEST_P(MultiFragmentTest, noHashPartitionSkew) {
   setupSources(10, 1000);
 
   // Update the key column.
@@ -583,14 +645,14 @@ TEST_F(MultiFragmentTest, noHashPartitionSkew) {
   auto producerPlan =
       PlanBuilder()
           .values(vectors_)
-          .partitionedOutput({"c0"}, numPartitions, {"c0", "c1"})
+          .partitionedOutput({"c0"}, numPartitions, {"c0", "c1"}, GetParam())
           .planNode();
   auto producerTask = makeTask(producerTaskId, producerPlan, 0);
   producerTask->start(1);
 
   core::PlanNodeId partialAggregationNodeId;
   auto consumerPlan = PlanBuilder()
-                          .exchange(producerPlan->outputType())
+                          .exchange(producerPlan->outputType(), GetParam())
                           .localPartition({"c0"})
                           .partialAggregation({"c0"}, {"count(1)"})
                           .capturePlanNodeId(partialAggregationNodeId)
@@ -641,7 +703,7 @@ TEST_F(MultiFragmentTest, noHashPartitionSkew) {
   }
 }
 
-TEST_F(MultiFragmentTest, noHivePartitionSkew) {
+TEST_P(MultiFragmentTest, noHivePartitionSkew) {
   setupSources(10, 1000);
 
   // Update the key column.
@@ -666,14 +728,15 @@ TEST_F(MultiFragmentTest, noHivePartitionSkew) {
                   numBuckets,
                   std::vector<column_index_t>{0},
                   std::vector<VectorPtr>{}),
-              {"c0", "c1"})
+              {"c0", "c1"},
+              GetParam())
           .planNode();
   auto producerTask = makeTask(producerTaskId, producerPlan, 0);
   producerTask->start(1);
 
   core::PlanNodeId partialAggregationNodeId;
   auto consumerPlan = PlanBuilder()
-                          .exchange(producerPlan->outputType())
+                          .exchange(producerPlan->outputType(), GetParam())
                           .localPartition(numBuckets, {0}, {})
                           .partialAggregation({"c0"}, {"count(1)"})
                           .capturePlanNodeId(partialAggregationNodeId)
@@ -721,7 +784,7 @@ TEST_F(MultiFragmentTest, noHivePartitionSkew) {
   }
 }
 
-TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
+TEST_P(MultiFragmentTest, partitionedOutputWithLargeInput) {
   // Verify that partitionedOutput operator is able to split a single input
   // vector if it hits memory or row limits.
   // We create a large vector that hits the row limit (70% - 120% of 10,000).
@@ -731,14 +794,15 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
   // Single Partition
   {
     auto leafTaskId = makeTaskId("leaf", 0);
-    auto leafPlan =
-        PlanBuilder()
-            .values(vectors_)
-            .partitionedOutput({}, 1, {"c0", "c1", "c2", "c3", "c4"})
-            .planNode();
+    auto leafPlan = PlanBuilder()
+                        .values(vectors_)
+                        .partitionedOutput(
+                            {}, 1, {"c0", "c1", "c2", "c3", "c4"}, GetParam())
+                        .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0, nullptr, 4 << 20);
     leafTask->start(1);
-    auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+    auto op =
+        PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
     auto task =
         assertQuery(op, {leafTaskId}, "SELECT c0, c1, c2, c3, c4 FROM tmp");
@@ -760,15 +824,17 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
                 kFanout,
                 false,
                 std::make_shared<exec::RoundRobinPartitionFunctionSpec>(),
-                {"c0", "c1", "c2", "c3", "c4"})
+                {"c0", "c1", "c2", "c3", "c4"},
+                GetParam())
             .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     leafTask->start(1);
 
     auto intermediatePlan =
         PlanBuilder()
-            .exchange(leafPlan->outputType())
-            .partitionedOutput({}, 1, {"c0", "c1", "c2", "c3", "c4"})
+            .exchange(leafPlan->outputType(), GetParam())
+            .partitionedOutput(
+                {}, 1, {"c0", "c1", "c2", "c3", "c4"}, GetParam())
             .planNode();
     std::vector<std::string> intermediateTaskIds;
     for (auto i = 0; i < kFanout; ++i) {
@@ -779,7 +845,9 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
       addRemoteSplits(intermediateTask, {leafTaskId});
     }
 
-    auto op = PlanBuilder().exchange(intermediatePlan->outputType()).planNode();
+    auto op = PlanBuilder()
+                  .exchange(intermediatePlan->outputType(), GetParam())
+                  .planNode();
 
     auto task = assertQuery(
         op, intermediateTaskIds, "SELECT c0, c1, c2, c3, c4 FROM tmp");
@@ -790,7 +858,7 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
   }
 }
 
-TEST_F(MultiFragmentTest, broadcast) {
+TEST_P(MultiFragmentTest, broadcast) {
   auto data = makeRowVector(
       {makeFlatVector<int32_t>(1'000, [](auto row) { return row; })});
 
@@ -798,7 +866,10 @@ TEST_F(MultiFragmentTest, broadcast) {
   std::vector<std::shared_ptr<Task>> tasks;
   auto leafTaskId = makeTaskId("leaf", 0);
   auto leafPlan =
-      PlanBuilder().values({data}).partitionedOutputBroadcast().planNode();
+      PlanBuilder()
+          .values({data})
+          .partitionedOutputBroadcast(/*outputLayout=*/{}, GetParam())
+          .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   tasks.emplace_back(leafTask);
   leafTask->start(1);
@@ -807,11 +878,12 @@ TEST_F(MultiFragmentTest, broadcast) {
   core::PlanNodePtr finalAggPlan;
   std::vector<std::string> finalAggTaskIds;
   for (int i = 0; i < 3; i++) {
-    finalAggPlan = PlanBuilder()
-                       .exchange(leafPlan->outputType())
-                       .singleAggregation({}, {"count(1)"})
-                       .partitionedOutput({}, 1)
-                       .planNode();
+    finalAggPlan =
+        PlanBuilder()
+            .exchange(leafPlan->outputType(), GetParam())
+            .singleAggregation({}, {"count(1)"})
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+            .planNode();
 
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
     auto task = makeTask(finalAggTaskIds.back(), finalAggPlan, i);
@@ -823,7 +895,8 @@ TEST_F(MultiFragmentTest, broadcast) {
   leafTask->updateOutputBuffers(finalAggTaskIds.size(), true);
 
   // Collect results from multiple tasks.
-  auto op = PlanBuilder().exchange(finalAggPlan->outputType()).planNode();
+  auto op =
+      PlanBuilder().exchange(finalAggPlan->outputType(), GetParam()).planNode();
 
   assertQuery(op, finalAggTaskIds, "SELECT UNNEST(array[1000, 1000, 1000])");
 
@@ -836,7 +909,7 @@ TEST_F(MultiFragmentTest, broadcast) {
   leafTask->updateOutputBuffers(finalAggTaskIds.size(), true);
 }
 
-TEST_F(MultiFragmentTest, roundRobinPartition) {
+TEST_P(MultiFragmentTest, roundRobinPartition) {
   auto data = {
       makeRowVector({
           makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
@@ -860,7 +933,9 @@ TEST_F(MultiFragmentTest, roundRobinPartition) {
               {},
               2,
               false,
-              std::make_shared<exec::RoundRobinPartitionFunctionSpec>())
+              std::make_shared<exec::RoundRobinPartitionFunctionSpec>(),
+              /*outputLayout=*/{},
+              GetParam())
           .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
 
@@ -881,8 +956,8 @@ TEST_F(MultiFragmentTest, roundRobinPartition) {
   std::vector<std::string> collectTaskIds;
   for (int i = 0; i < 2; i++) {
     collectPlan = PlanBuilder()
-                      .exchange(leafPlan->outputType())
-                      .partitionedOutput({}, 1)
+                      .exchange(leafPlan->outputType(), GetParam())
+                      .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
                       .planNode();
 
     collectTaskIds.push_back(makeTaskId("collect", i));
@@ -891,7 +966,8 @@ TEST_F(MultiFragmentTest, roundRobinPartition) {
   }
 
   // Collect everything.
-  auto finalPlan = PlanBuilder().exchange(leafPlan->outputType()).planNode();
+  auto finalPlan =
+      PlanBuilder().exchange(leafPlan->outputType(), GetParam()).planNode();
 
   assertQuery(finalPlan, {collectTaskIds}, "SELECT * FROM tmp");
 
@@ -901,7 +977,7 @@ TEST_F(MultiFragmentTest, roundRobinPartition) {
 }
 
 // Test PartitionedOutput operator with constant partitioning keys.
-TEST_F(MultiFragmentTest, constantKeys) {
+TEST_P(MultiFragmentTest, constantKeys) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>(
           1'000, [](auto row) { return row; }, nullEvery(7)),
@@ -919,10 +995,11 @@ TEST_F(MultiFragmentTest, constantKeys) {
 
   // Make leaf task: Values -> Repartitioning (3-way)
   auto leafTaskId = makeTaskId("leaf", 0);
-  auto leafPlan = PlanBuilder()
-                      .values({data})
-                      .partitionedOutput({"c0", "123"}, 3, true, {"c0"})
-                      .planNode();
+  auto leafPlan =
+      PlanBuilder()
+          .values({data})
+          .partitionedOutput({"c0", "123"}, 3, true, {"c0"}, GetParam())
+          .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   addTask(leafTask, {});
 
@@ -932,10 +1009,10 @@ TEST_F(MultiFragmentTest, constantKeys) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan =
         PlanBuilder()
-            .exchange(leafPlan->outputType())
+            .exchange(leafPlan->outputType(), GetParam())
             .project({"c0 is null AS co_is_null"})
             .partialAggregation({}, {"count_if(co_is_null)", "count(1)"})
-            .partitionedOutput({}, 1)
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
             .planNode();
 
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
@@ -946,7 +1023,7 @@ TEST_F(MultiFragmentTest, constantKeys) {
   // Collect results and verify number of nulls is 3 times larger than in the
   // original data.
   auto op = PlanBuilder()
-                .exchange(finalAggPlan->outputType())
+                .exchange(finalAggPlan->outputType(), GetParam())
                 .finalAggregation(
                     {}, {"sum(a0)", "sum(a1)"}, {{BIGINT()}, {BIGINT()}})
                 .planNode();
@@ -961,7 +1038,7 @@ TEST_F(MultiFragmentTest, constantKeys) {
   }
 }
 
-TEST_F(MultiFragmentTest, replicateNullsAndAny) {
+TEST_P(MultiFragmentTest, replicateNullsAndAny) {
   auto data = makeRowVector({makeFlatVector<int32_t>(
       1'000, [](auto row) { return row; }, nullEvery(7))});
 
@@ -977,10 +1054,11 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
 
   // Make leaf task: Values -> Repartitioning (3-way)
   auto leafTaskId = makeTaskId("leaf", 0);
-  auto leafPlan = PlanBuilder()
-                      .values({data})
-                      .partitionedOutput({"c0"}, 3, true)
-                      .planNode();
+  auto leafPlan =
+      PlanBuilder()
+          .values({data})
+          .partitionedOutput({"c0"}, 3, true, /*outputLayout=*/{}, GetParam())
+          .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   addTask(leafTask, {});
 
@@ -990,10 +1068,10 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
   for (int i = 0; i < 3; i++) {
     finalAggPlan =
         PlanBuilder()
-            .exchange(leafPlan->outputType())
+            .exchange(leafPlan->outputType(), GetParam())
             .project({"c0 is null AS co_is_null"})
             .partialAggregation({}, {"count_if(co_is_null)", "count(1)"})
-            .partitionedOutput({}, 1)
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
             .planNode();
 
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
@@ -1004,7 +1082,7 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
   // Collect results and verify number of nulls is 3 times larger than in the
   // original data.
   auto op = PlanBuilder()
-                .exchange(finalAggPlan->outputType())
+                .exchange(finalAggPlan->outputType(), GetParam())
                 .finalAggregation(
                     {}, {"sum(a0)", "sum(a1)"}, {{BIGINT()}, {BIGINT()}})
                 .planNode();
@@ -1020,7 +1098,7 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
 }
 
 // Test query finishing before all splits have been scheduled.
-TEST_F(MultiFragmentTest, limit) {
+TEST_P(MultiFragmentTest, limit) {
   auto data = makeRowVector({makeFlatVector<int32_t>(
       1'000, [](auto row) { return row; }, nullEvery(7))});
 
@@ -1033,7 +1111,7 @@ TEST_F(MultiFragmentTest, limit) {
       PlanBuilder()
           .tableScan(std::dynamic_pointer_cast<const RowType>(data->type()))
           .limit(0, 10, true)
-          .partitionedOutput({}, 1)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
           .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   leafTask->start(1);
@@ -1043,7 +1121,7 @@ TEST_F(MultiFragmentTest, limit) {
 
   // Make final task: Exchange -> FinalLimit(10).
   auto plan = PlanBuilder()
-                  .exchange(leafPlan->outputType())
+                  .exchange(leafPlan->outputType(), GetParam())
                   .localPartition(std::vector<std::string>{})
                   .limit(0, 10, false)
                   .planNode();
@@ -1066,7 +1144,7 @@ TEST_F(MultiFragmentTest, limit) {
   ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
 }
 
-TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
+TEST_P(MultiFragmentTest, mergeExchangeOverEmptySources) {
   std::vector<std::shared_ptr<Task>> tasks;
   std::vector<std::string> leafTaskIds;
 
@@ -1075,8 +1153,10 @@ TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
   for (int i = 0; i < 2; ++i) {
     auto taskId = makeTaskId("leaf-", i);
     leafTaskIds.push_back(taskId);
-    auto plan =
-        PlanBuilder().values({data}).partitionedOutput({}, 1).planNode();
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+                    .planNode();
 
     auto task = makeTask(taskId, plan, tasks.size());
     tasks.push_back(task);
@@ -1085,7 +1165,7 @@ TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
 
   auto exchangeTaskId = makeTaskId("exchange-", 0);
   auto plan = PlanBuilder()
-                  .mergeExchange(rowType_, {"c0"})
+                  .mergeExchange(rowType_, {"c0"}, GetParam())
                   .singleAggregation({"c0"}, {"count(1)"})
                   .planNode();
 
@@ -1099,22 +1179,23 @@ TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
 namespace {
 core::PlanNodePtr makeJoinOverExchangePlan(
     const RowTypePtr& exchangeType,
-    const RowVectorPtr& buildData) {
+    const RowVectorPtr& buildData,
+    VectorSerde::Kind serdeKind) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   return PlanBuilder(planNodeIdGenerator)
-      .exchange(exchangeType)
+      .exchange(exchangeType, serdeKind)
       .hashJoin(
           {"c0"},
           {"u_c0"},
           PlanBuilder(planNodeIdGenerator).values({buildData}).planNode(),
           "",
           {"c0"})
-      .partitionedOutput({}, 1)
+      .partitionedOutput({}, 1, /*outputLayout=*/{}, serdeKind)
       .planNode();
 }
 } // namespace
 
-TEST_F(MultiFragmentTest, earlyCompletion) {
+TEST_P(MultiFragmentTest, earlyCompletion) {
   // Setup a distributed query with 4 tasks:
   // - 1 leaf task with results partitioned 2 ways;
   // - 2 intermediate tasks reading from 2 partitions produced by the leaf task.
@@ -1142,7 +1223,7 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
   auto leafTaskId = makeTaskId("leaf", 0);
   auto plan = PlanBuilder()
                   .values({data, data, data, data})
-                  .partitionedOutput({"c0"}, 2)
+                  .partitionedOutput({"c0"}, 2, /*outputLayout=*/{}, GetParam())
                   .planNode();
 
   auto task = makeTask(leafTaskId, plan, tasks.size());
@@ -1161,8 +1242,8 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
           {"u_c0"}, {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
     }
 
-    auto joinPlan =
-        makeJoinOverExchangePlan(asRowType(data->type()), buildData);
+    auto joinPlan = makeJoinOverExchangePlan(
+        asRowType(data->type()), buildData, GetParam());
 
     joinOutputType = joinPlan->outputType();
 
@@ -1177,7 +1258,8 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
   }
 
   // Create output task.
-  auto outputPlan = PlanBuilder().exchange(joinOutputType).planNode();
+  auto outputPlan =
+      PlanBuilder().exchange(joinOutputType, GetParam()).planNode();
 
   assertQuery(
       outputPlan, joinTaskIds, "SELECT UNNEST([3, 3, 3, 3, 4, 4, 4, 4])");
@@ -1187,7 +1269,7 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
   }
 }
 
-TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
+TEST_P(MultiFragmentTest, earlyCompletionBroadcast) {
   // Same as 'earlyCompletion' test, but broadcasts leaf task results to all
   // intermediate tasks.
 
@@ -1205,7 +1287,7 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
   auto leafTaskId = makeTaskId("leaf", 0);
   auto plan = PlanBuilder()
                   .values({data, data, data, data})
-                  .partitionedOutputBroadcast()
+                  .partitionedOutputBroadcast(/*outputLayout=*/{}, GetParam())
                   .planNode();
 
   auto leafTask = makeTask(leafTaskId, plan, tasks.size());
@@ -1224,8 +1306,8 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
           {"u_c0"}, {makeFlatVector<int64_t>({-7, 10, 12345678})});
     }
 
-    auto joinPlan =
-        makeJoinOverExchangePlan(asRowType(data->type()), buildData);
+    auto joinPlan = makeJoinOverExchangePlan(
+        asRowType(data->type()), buildData, GetParam());
 
     joinOutputType = joinPlan->outputType();
 
@@ -1243,7 +1325,8 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
   leafTask->updateOutputBuffers(joinTaskIds.size(), true);
 
   // Create output task.
-  auto outputPlan = PlanBuilder().exchange(joinOutputType).planNode();
+  auto outputPlan =
+      PlanBuilder().exchange(joinOutputType, GetParam()).planNode();
 
   assertQuery(outputPlan, joinTaskIds, "SELECT UNNEST([10, 10, 10, 10])");
 
@@ -1252,7 +1335,7 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
   }
 }
 
-TEST_F(MultiFragmentTest, earlyCompletionMerge) {
+TEST_P(MultiFragmentTest, earlyCompletionMerge) {
   // Same as 'earlyCompletion' test, but uses MergeExchange instead of Exchange.
 
   std::vector<std::shared_ptr<Task>> tasks;
@@ -1269,7 +1352,7 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
   auto leafTaskId = makeTaskId("leaf", 0);
   auto plan = PlanBuilder()
                   .values({data, data, data, data})
-                  .partitionedOutput({"c0"}, 2)
+                  .partitionedOutput({"c0"}, 2, /*outputLayout=*/{}, GetParam())
                   .planNode();
 
   auto task = makeTask(leafTaskId, plan, tasks.size());
@@ -1291,14 +1374,14 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto joinPlan =
         PlanBuilder(planNodeIdGenerator)
-            .mergeExchange(asRowType(data->type()), {"c0"})
+            .mergeExchange(asRowType(data->type()), {"c0"}, GetParam())
             .hashJoin(
                 {"c0"},
                 {"u_c0"},
                 PlanBuilder(planNodeIdGenerator).values({buildData}).planNode(),
                 "",
                 {"c0"})
-            .partitionedOutput({}, 1)
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
             .planNode();
 
     joinOutputType = joinPlan->outputType();
@@ -1314,7 +1397,8 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
   }
 
   // Create output task.
-  auto outputPlan = PlanBuilder().exchange(joinOutputType).planNode();
+  auto outputPlan =
+      PlanBuilder().exchange(joinOutputType, GetParam()).planNode();
 
   assertQuery(
       outputPlan, joinTaskIds, "SELECT UNNEST([3, 3, 3, 3, 4, 4, 4, 4])");
@@ -1402,7 +1486,7 @@ class SlowOperatorTranslator : public Operator::PlanNodeTranslator {
   }
 };
 
-TEST_F(MultiFragmentTest, exchangeDestruction) {
+TEST_P(MultiFragmentTest, exchangeDestruction) {
   // This unit test tests the proper destruction of ExchangeClient upon
   // task destruction.
   Operator::registerOperator(std::make_unique<SlowOperatorTranslator>());
@@ -1420,7 +1504,7 @@ TEST_F(MultiFragmentTest, exchangeDestruction) {
   leafPlan = PlanBuilder()
                  .tableScan(rowType_)
                  .project({"c0 % 10 AS c0", "c1"})
-                 .partitionedOutput({}, 1)
+                 .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
                  .planNode();
 
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
@@ -1429,11 +1513,11 @@ TEST_F(MultiFragmentTest, exchangeDestruction) {
 
   auto rootPlan =
       PlanBuilder()
-          .exchange(leafPlan->outputType())
+          .exchange(leafPlan->outputType(), GetParam())
           .addNode([&leafPlan](std::string id, core::PlanNodePtr node) {
             return std::make_shared<SlowNode>(id, std::move(node));
           })
-          .partitionedOutput({}, 1)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
           .planNode();
 
   auto rootTask = makeTask("root-task", rootPlan, 0);
@@ -1451,19 +1535,19 @@ TEST_F(MultiFragmentTest, exchangeDestruction) {
   rootTask = nullptr;
 }
 
-TEST_F(MultiFragmentTest, cancelledExchange) {
+TEST_P(MultiFragmentTest, cancelledExchange) {
   // Create a source fragment borrow the output type from it.
   auto planFragment = exec::test::PlanBuilder()
                           .tableScan(rowType_)
                           .filter("c0 % 5 = 1")
-                          .partitionedOutput({}, 1, {"c0", "c1"})
+                          .partitionedOutput({}, 1, {"c0", "c1"}, GetParam())
                           .planFragment();
 
   // Create task with exchange.
   auto planFragmentWithExchange =
       exec::test::PlanBuilder()
-          .exchange(planFragment.planNode->outputType())
-          .partitionedOutput({}, 1)
+          .exchange(planFragment.planNode->outputType(), GetParam())
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
           .planFragment();
   auto exchangeTask =
       makeTask("output.0.0.1", planFragmentWithExchange.planNode, 0);
@@ -1480,11 +1564,18 @@ TEST_F(MultiFragmentTest, cancelledExchange) {
 
 class TestCustomExchangeNode : public core::PlanNode {
  public:
-  TestCustomExchangeNode(const core::PlanNodeId& id, const RowTypePtr type)
-      : PlanNode(id), outputType_(type) {}
+  TestCustomExchangeNode(
+      const core::PlanNodeId& id,
+      const RowTypePtr type,
+      VectorSerde::Kind serdeKind)
+      : PlanNode(id), outputType_(type), serdeKind_(serdeKind) {}
 
   const RowTypePtr& outputType() const override {
     return outputType_;
+  }
+
+  VectorSerde::Kind serdeKind() const {
+    return serdeKind_;
   }
 
   const std::vector<core::PlanNodePtr>& sources() const override {
@@ -1509,7 +1600,8 @@ class TestCustomExchangeNode : public core::PlanNode {
     // Nothing to add
   }
 
-  RowTypePtr outputType_;
+  const RowTypePtr outputType_;
+  const VectorSerde::Kind serdeKind_;
 };
 
 class TestCustomExchange : public exec::Exchange {
@@ -1524,7 +1616,8 @@ class TestCustomExchange : public exec::Exchange {
             ctx,
             std::make_shared<core::ExchangeNode>(
                 customExchangeNode->id(),
-                customExchangeNode->outputType()),
+                customExchangeNode->outputType(),
+                customExchangeNode->serdeKind()),
             std::move(exchangeClient)) {}
 
   RowVectorPtr getOutput() override {
@@ -1549,12 +1642,16 @@ class TestCustomExchangeTranslator : public exec::Operator::PlanNodeTranslator {
   }
 };
 
-TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
+TEST_P(MultiFragmentTest, customPlanNodeWithExchangeClient) {
   setupSources(5, 100);
   Operator::registerOperator(std::make_unique<TestCustomExchangeTranslator>());
   auto leafTaskId = makeTaskId("leaf", 0);
-  auto leafPlan =
-      PlanBuilder().values(vectors_).partitionedOutput({}, 1).planNode();
+  core::PlanNodeId partitionNodeId;
+  auto leafPlan = PlanBuilder()
+                      .values(vectors_)
+                      .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+                      .capturePlanNodeId(partitionNodeId)
+                      .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   leafTask->start(1);
 
@@ -1565,7 +1662,7 @@ TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
       PlanBuilder()
           .addNode([&leafPlan](std::string id, core::PlanNodePtr /* input */) {
             return std::make_shared<TestCustomExchangeNode>(
-                id, leafPlan->outputType());
+                id, leafPlan->outputType(), GetParam());
           })
           .capturePlanNodeId(testNodeId)
           .planNode();
@@ -1584,6 +1681,13 @@ TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
           .at(testNodeId)
           .customStats.count("testCustomExchangeStat"),
       0);
+
+  auto planStats = toPlanStats(leafTask->taskStats());
+  const auto serdeKindRuntimsStats =
+      planStats.at(partitionNodeId).customStats.at(Operator::kShuffleSerdeKind);
+  ASSERT_EQ(serdeKindRuntimsStats.count, 1);
+  ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
+  ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
 }
 
 // This test is to reproduce the race condition between task terminate and no
@@ -1596,16 +1700,17 @@ TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
 //     task is not running.
 // T5: task terminate processes the pending remote splits by accessing the
 //     associated exchange client and run into segment fault.
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     MultiFragmentTest,
     raceBetweenTaskTerminateAndTaskNoMoreSplits) {
   setupSources(10, 1000);
   auto leafTaskId = makeTaskId("leaf", 0);
-  core::PlanNodePtr leafPlan = PlanBuilder()
-                                   .tableScan(rowType_)
-                                   .project({"c0 % 10 AS c0", "c1"})
-                                   .partitionedOutput({}, 1)
-                                   .planNode();
+  core::PlanNodePtr leafPlan =
+      PlanBuilder()
+          .tableScan(rowType_)
+          .project({"c0 % 10 AS c0", "c1"})
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   leafTask->start(1);
   addHiveSplits(leafTask, filePaths_);
@@ -1637,7 +1742,7 @@ DEBUG_ONLY_TEST_F(
         blockTerminate.await([&]() { return readyToTerminate.load(); });
       })));
   auto rootPlan = PlanBuilder()
-                      .exchange(leafPlan->outputType())
+                      .exchange(leafPlan->outputType(), GetParam())
                       .finalAggregation({"c0"}, {"count(c1)"}, {{BIGINT()}})
                       .planNode();
 
@@ -1659,12 +1764,14 @@ DEBUG_ONLY_TEST_F(
   ASSERT_TRUE(waitForTaskFailure(rootTask.get(), 1'000'000'000));
 }
 
-TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
+TEST_P(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   setupSources(8, 1000);
   auto taskId = makeTaskId("task", 0);
   core::PlanNodePtr leafPlan;
-  leafPlan =
-      PlanBuilder().tableScan(rowType_).partitionedOutput({}, 1).planNode();
+  leafPlan = PlanBuilder()
+                 .tableScan(rowType_)
+                 .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+                 .planNode();
 
   auto task = makeTask(taskId, leafPlan, 0);
   task->start(1);
@@ -1725,7 +1832,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   task.reset();
 }
 
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     MultiFragmentTest,
     taskTerminateWithProblematicRemainingRemoteSplits) {
   // Start the task with 2 drivers.
@@ -1739,12 +1846,12 @@ DEBUG_ONLY_TEST_F(
                       {"p_c0"},
                       {"c0"},
                       PlanBuilder(planNodeIdGenerator)
-                          .exchange(rowType_)
+                          .exchange(rowType_, GetParam())
                           .capturePlanNodeId(exchangeNodeId)
                           .planNode(),
                       "",
                       {"c0"})
-                  .partitionedOutput({}, 1)
+                  .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
                   .planNode();
   auto taskId = makeTaskId("final", 0);
   auto task = makeTask(taskId, plan, 0);
@@ -1796,7 +1903,7 @@ DEBUG_ONLY_TEST_F(
   failThread.join();
 }
 
-DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {
+DEBUG_ONLY_TEST_P(MultiFragmentTest, mergeWithEarlyTermination) {
   setupSources(10, 1000);
 
   std::vector<std::shared_ptr<TempFilePath>> filePaths(
@@ -1806,15 +1913,16 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {
   auto sortTaskId = makeTaskId("orderby", 0);
   partialSortTaskIds.push_back(sortTaskId);
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
-                             .localMerge(
-                                 {"c0"},
-                                 {PlanBuilder(planNodeIdGenerator)
-                                      .tableScan(rowType_)
-                                      .orderBy({"c0"}, true)
-                                      .planNode()})
-                             .partitionedOutput({}, 1)
-                             .planNode();
+  auto partialSortPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {PlanBuilder(planNodeIdGenerator)
+                   .tableScan(rowType_)
+                   .orderBy({"c0"}, true)
+                   .planNode()})
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
 
   auto partialSortTask = makeTask(sortTaskId, partialSortPlan, 1);
   partialSortTask->start(1);
@@ -1838,10 +1946,11 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {
       }));
 
   auto finalSortTaskId = makeTaskId("orderby", 1);
-  auto finalSortPlan = PlanBuilder()
-                           .mergeExchange(partialSortPlan->outputType(), {"c0"})
-                           .partitionedOutput({}, 1)
-                           .planNode();
+  auto finalSortPlan =
+      PlanBuilder()
+          .mergeExchange(partialSortPlan->outputType(), {"c0"}, GetParam())
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
   auto finalSortTask = makeTask(finalSortTaskId, finalSortPlan, 0);
   finalSortTask->start(1);
   addRemoteSplits(finalSortTask, partialSortTaskIds);
@@ -1879,6 +1988,14 @@ class DataFetcher {
     /// Average number of bytes per packet.
     int64_t averagePacketBytes() const {
       return numPackets > 0 ? (totalBytes / numPackets) : 0;
+    }
+
+    std::string toString() const {
+      return fmt::format(
+          "numPackets {} numPages {} totalBytes {}",
+          numPackets,
+          numPages,
+          totalBytes);
     }
   };
 
@@ -1947,7 +2064,7 @@ class DataFetcher {
 /// granularity. It can do so only if PartitionedOutput operator limits the size
 /// of individual pages. PartitionedOutput operator is expected to limit page
 /// sizes to no more than 1MB give and take 30%.
-TEST_F(MultiFragmentTest, maxBytes) {
+TEST_P(MultiFragmentTest, maxBytes) {
   std::string s(25, 'x');
   // Keep the row count under 7000 to avoid hitting the row limit in the
   // operator instead.
@@ -1960,7 +2077,7 @@ TEST_F(MultiFragmentTest, maxBytes) {
   core::PlanNodeId outputNodeId;
   auto plan = PlanBuilder()
                   .values({data}, false, 100)
-                  .partitionedOutput({}, 1)
+                  .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
                   .capturePlanNodeId(outputNodeId)
                   .planNode();
 
@@ -1971,6 +2088,7 @@ TEST_F(MultiFragmentTest, maxBytes) {
     const auto taskId = fmt::format("test.{}", testIteration++);
 
     SCOPED_TRACE(taskId);
+    SCOPED_TRACE(fmt::format("maxBytes: {}", maxBytes));
     auto task = makeTask(taskId, plan, 0);
     task->start(1);
     task->updateOutputBuffers(1, true);
@@ -1983,11 +2101,11 @@ TEST_F(MultiFragmentTest, maxBytes) {
 
     ASSERT_TRUE(waitForTaskCompletion(task.get()));
 
-    auto stats = fetcher.stats();
+    const auto stats = fetcher.stats();
     if (testIteration > 1) {
       ASSERT_EQ(prevStats.numPages, stats.numPages);
       ASSERT_EQ(prevStats.totalBytes, stats.totalBytes);
-      ASSERT_GT(prevStats.numPackets, stats.numPackets);
+      ASSERT_GT(prevStats.numPackets, stats.numPackets) << stats.toString();
     }
 
     ASSERT_LT(stats.averagePacketBytes(), maxBytes * 1.5);
@@ -2007,11 +2125,11 @@ TEST_F(MultiFragmentTest, maxBytes) {
   test(5 * kMB);
   test(10 * kMB);
   test(20 * kMB);
-  test(32 * kMB);
+  test(40 * kMB);
 }
 
 // Verifies that ExchangeClient stats are populated even if task fails.
-DEBUG_ONLY_TEST_F(MultiFragmentTest, exchangeStatsOnFailure) {
+DEBUG_ONLY_TEST_P(MultiFragmentTest, exchangeStatsOnFailure) {
   // Triggers a failure after fetching first 10 pages.
   std::atomic_uint64_t expectedReceivedPages{0};
   SCOPED_TESTVALUE_SET(
@@ -2033,17 +2151,19 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, exchangeStatsOnFailure) {
       makeConstant(StringView(s), 10'000),
   });
 
-  auto producerPlan = PlanBuilder()
-                          .values({data}, false, 30)
-                          .partitionedOutput({}, 1)
-                          .planNode();
+  auto producerPlan =
+      PlanBuilder()
+          .values({data}, false, 30)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
 
   auto producerTaskId = makeTaskId("producer", 0);
   auto producerTask = makeTask(producerTaskId, producerPlan, 0);
   producerTask->start(1);
   producerTask->updateOutputBuffers(1, true);
 
-  auto plan = PlanBuilder().exchange(producerPlan->outputType()).planNode();
+  auto plan =
+      PlanBuilder().exchange(producerPlan->outputType(), GetParam()).planNode();
 
   auto task = makeTask("t", plan, 0, noopConsumer());
   task->start(4);
@@ -2064,20 +2184,21 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, exchangeStatsOnFailure) {
   ASSERT_TRUE(waitForTaskCompletion(producerTask.get(), 3'000'000));
 }
 
-TEST_F(MultiFragmentTest, earlyTaskFailure) {
+TEST_P(MultiFragmentTest, earlyTaskFailure) {
   setupSources(1, 10);
 
   const auto partialSortTaskId = makeTaskId("partialSortBy", 0);
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
-                             .localMerge(
-                                 {"c0"},
-                                 {PlanBuilder(planNodeIdGenerator)
-                                      .tableScan(rowType_)
-                                      .orderBy({"c0"}, true)
-                                      .planNode()})
-                             .partitionedOutput({}, 1)
-                             .planNode();
+  auto partialSortPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {PlanBuilder(planNodeIdGenerator)
+                   .tableScan(rowType_)
+                   .orderBy({"c0"}, true)
+                   .planNode()})
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
   for (bool internalFailure : {false, true}) {
     SCOPED_TRACE(fmt::format("internalFailure: {}", internalFailure));
 
@@ -2088,7 +2209,7 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
 
     auto finalSortTaskId = makeTaskId("finalSortBy", 0);
     auto finalSortPlan = PlanBuilder()
-                             .mergeExchange(outputType, {"c0"})
+                             .mergeExchange(outputType, {"c0"}, GetParam())
                              .partitionedOutput({}, 1)
                              .planNode();
 
@@ -2119,17 +2240,21 @@ TEST_F(MultiFragmentTest, earlyTaskFailure) {
   }
 }
 
-TEST_F(MultiFragmentTest, mergeSmallBatchesInExchange) {
+TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
   auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
 
   const int32_t numPartitions = 100;
-  auto producerPlan = test::PlanBuilder()
-                          .values({data})
-                          .partitionedOutput({"c0"}, numPartitions)
-                          .planNode();
+  auto producerPlan =
+      test::PlanBuilder()
+          .values({data})
+          .partitionedOutput(
+              {"c0"}, numPartitions, /*outputLayout=*/{}, GetParam())
+          .planNode();
   const auto producerTaskId = "local://t1";
 
-  auto plan = test::PlanBuilder().exchange(asRowType(data->type())).planNode();
+  auto plan = test::PlanBuilder()
+                  .exchange(asRowType(data->type()), GetParam())
+                  .planNode();
 
   auto expected = makeRowVector({
       makeFlatVector<int32_t>(3'000, [](auto row) { return 1 + row % 3; }),
@@ -2172,13 +2297,29 @@ TEST_F(MultiFragmentTest, mergeSmallBatchesInExchange) {
     ASSERT_EQ(numPages, stats.customStats.at("numReceivedPages").sum);
   };
 
-  test(1, 1'000);
-  test(1'000, 56);
-  test(10'000, 6);
-  test(100'000, 1);
+  if (GetParam() == VectorSerde::Kind::kPresto) {
+    test(1, 1'000);
+    test(1'000, 56);
+    test(10'000, 6);
+    test(100'000, 1);
+  } else if (GetParam() == VectorSerde::Kind::kCompactRow) {
+    test(1, 1'000);
+    test(1'000, 28);
+    test(10'000, 3);
+    test(100'000, 1);
+  } else {
+    test(1, 1'000);
+    test(1'000, 63);
+    test(10'000, 7);
+    test(100'000, 1);
+  }
 }
 
-TEST_F(MultiFragmentTest, compression) {
+TEST_P(MultiFragmentTest, compression) {
+  // NOTE: only presto format supports compression for now
+  if (GetParam() != VectorSerde::Kind::kPresto) {
+    return;
+  }
   bufferManager_->testingSetCompression(
       common::CompressionKind::CompressionKind_LZ4);
   auto guard = folly::makeGuard([&]() {
@@ -2189,13 +2330,14 @@ TEST_F(MultiFragmentTest, compression) {
   constexpr int32_t kNumRepeats = 1'000'000;
   const auto data = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
 
-  const auto producerPlan = test::PlanBuilder()
-                                .values({data}, false, kNumRepeats)
-                                .partitionedOutput({}, 1)
-                                .planNode();
+  const auto producerPlan =
+      test::PlanBuilder()
+          .values({data}, false, kNumRepeats)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam())
+          .planNode();
 
   const auto plan = test::PlanBuilder()
-                        .exchange(asRowType(data->type()))
+                        .exchange(asRowType(data->type()), GetParam())
                         .singleAggregation({}, {"sum(c0)"})
                         .planNode();
 
@@ -2234,6 +2376,11 @@ TEST_F(MultiFragmentTest, compression) {
   test("local://t1", 0.7, false);
   test("local://t2", 0.0000001, true);
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    MultiFragmentTest,
+    MultiFragmentTest,
+    testing::ValuesIn(MultiFragmentTest::getTestParams()));
 
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -21,7 +21,9 @@
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/SerializedPageUtil.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -29,9 +31,26 @@ using namespace facebook::velox::core;
 
 using facebook::velox::test::BatchMaker;
 
+struct TestParam {
+  PartitionedOutputNode::Kind outputKind;
+  VectorSerde::Kind serdeKind;
+
+  TestParam(
+      PartitionedOutputNode::Kind _outputKind,
+      VectorSerde::Kind _serdeKind)
+      : outputKind(_outputKind), serdeKind(_serdeKind) {}
+};
+
 class OutputBufferManagerTest : public testing::Test {
  protected:
-  OutputBufferManagerTest() {
+  OutputBufferManagerTest() : serdeKind_(VectorSerde::Kind::kPresto) {
+    std::vector<std::string> names = {"c0", "c1"};
+    std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
+    rowType_ = ROW(std::move(names), std::move(types));
+  }
+
+  explicit OutputBufferManagerTest(VectorSerde::Kind serdeKind)
+      : serdeKind_(serdeKind) {
     std::vector<std::string> names = {"c0", "c1"};
     std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
     rowType_ = ROW(std::move(names), std::move(types));
@@ -51,6 +70,16 @@ class OutputBufferManagerTest : public testing::Test {
         return std::make_unique<
             serializer::presto::PrestoOutputStreamListener>();
       });
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+      facebook::velox::serializer::presto::PrestoVectorSerde::
+          registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+      serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+      serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
     }
   }
 
@@ -91,7 +120,8 @@ class OutputBufferManagerTest : public testing::Test {
       vector_size_t size) {
     auto vector = std::dynamic_pointer_cast<RowVector>(
         BatchMaker::createBatch(rowType, size, *pool_));
-    return exec::test::toSerializedPage(vector, bufferManager_, pool_.get());
+    return exec::test::toSerializedPage(
+        vector, serdeKind_, bufferManager_, pool_.get());
   }
 
   void enqueue(
@@ -403,6 +433,7 @@ class OutputBufferManagerTest : public testing::Test {
     }
   }
 
+  const VectorSerde::Kind serdeKind_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
@@ -411,29 +442,52 @@ class OutputBufferManagerTest : public testing::Test {
   RowTypePtr rowType_;
 };
 
-struct TestParam {
-  PartitionedOutputNode::Kind kind;
+class OutputBufferManagerWithDifferentSerdeKindsTest
+    : public OutputBufferManagerTest,
+      public testing::WithParamInterface<VectorSerde::Kind> {
+ public:
+  static std::vector<VectorSerde::Kind> getTestParams() {
+    static std::vector<VectorSerde::Kind> params = {
+        VectorSerde::Kind::kPresto,
+        VectorSerde::Kind::kCompactRow,
+        VectorSerde::Kind::kUnsafeRow};
+    return params;
+  }
 };
 
 class AllOutputBufferManagerTest
     : public OutputBufferManagerTest,
-      public testing::WithParamInterface<PartitionedOutputNode::Kind> {
+      public testing::WithParamInterface<TestParam> {
  public:
-  AllOutputBufferManagerTest() : kind_(GetParam()) {}
-
-  static std::vector<PartitionedOutputNode::Kind> getTestParams() {
-    static std::vector<PartitionedOutputNode::Kind> params = {
-        PartitionedOutputNode::Kind::kBroadcast,
-        PartitionedOutputNode::Kind::kPartitioned,
-        PartitionedOutputNode::Kind::kArbitrary};
+  static std::vector<TestParam> getTestParams() {
+    static std::vector<TestParam> params = {
+        {PartitionedOutputNode::Kind::kBroadcast, VectorSerde::Kind::kPresto},
+        {PartitionedOutputNode::Kind::kBroadcast,
+         VectorSerde::Kind::kCompactRow},
+        {PartitionedOutputNode::Kind::kBroadcast,
+         VectorSerde::Kind::kUnsafeRow},
+        {PartitionedOutputNode::Kind::kPartitioned, VectorSerde::Kind::kPresto},
+        {PartitionedOutputNode::Kind::kPartitioned,
+         VectorSerde::Kind::kCompactRow},
+        {PartitionedOutputNode::Kind::kPartitioned,
+         VectorSerde::Kind::kUnsafeRow},
+        {PartitionedOutputNode::Kind::kArbitrary, VectorSerde::Kind::kPresto},
+        {PartitionedOutputNode::Kind::kArbitrary,
+         VectorSerde::Kind::kCompactRow},
+        {PartitionedOutputNode::Kind::kArbitrary,
+         VectorSerde::Kind::kUnsafeRow}};
     return params;
   }
 
+  AllOutputBufferManagerTest()
+      : OutputBufferManagerTest(GetParam().serdeKind),
+        outputKind_(GetParam().outputKind) {}
+
  protected:
-  PartitionedOutputNode::Kind kind_;
+  const PartitionedOutputNode::Kind outputKind_;
 };
 
-TEST_F(OutputBufferManagerTest, arbitrayBuffer) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, arbitrayBuffer) {
   {
     ArbitraryBuffer buffer;
     ASSERT_TRUE(buffer.empty());
@@ -509,6 +563,12 @@ TEST_F(OutputBufferManagerTest, arbitrayBuffer) {
   }
 }
 
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    testing::ValuesIn(
+        OutputBufferManagerWithDifferentSerdeKindsTest::getTestParams()));
+
 TEST_F(OutputBufferManagerTest, outputType) {
   ASSERT_EQ(
       PartitionedOutputNode::kindString(
@@ -528,7 +588,7 @@ TEST_F(OutputBufferManagerTest, outputType) {
       "Invalid Output Kind 100");
 }
 
-TEST_F(OutputBufferManagerTest, destinationBuffer) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, destinationBuffer) {
   {
     ArbitraryBuffer buffer;
     DestinationBuffer destinationBuffer;
@@ -717,7 +777,7 @@ TEST_F(OutputBufferManagerTest, destinationBuffer) {
   }
 }
 
-TEST_F(OutputBufferManagerTest, basicPartitioned) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicPartitioned) {
   vector_size_t size = 100;
   std::string taskId = "t0";
   auto task = initializeTask(
@@ -727,11 +787,12 @@ TEST_F(OutputBufferManagerTest, basicPartitioned) {
   // Duplicateb update buffers with the same settings are allowed and ignored.
   ASSERT_TRUE(bufferManager_->updateOutputBuffers(taskId, 5, true));
   ASSERT_FALSE(bufferManager_->isFinished(taskId));
-  // Partitioned output buffer doesn't allow to update with different number of
-  // output buffers once created.
+  // Partitioned output buffer doesn't allow to update with different number
+  // of output buffers once created.
   VELOX_ASSERT_THROW(
       bufferManager_->updateOutputBuffers(taskId, 5 + 1, true), "");
-  // Partitioned output buffer doesn't expect more output buffers once created.
+  // Partitioned output buffer doesn't expect more output buffers once
+  // created.
   VELOX_ASSERT_THROW(bufferManager_->updateOutputBuffers(taskId, 5, false), "");
   VELOX_ASSERT_THROW(
       bufferManager_->updateOutputBuffers(taskId, 5 - 1, true), "");
@@ -796,7 +857,7 @@ TEST_F(OutputBufferManagerTest, basicPartitioned) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(OutputBufferManagerTest, basicBroadcast) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicBroadcast) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
@@ -867,7 +928,7 @@ TEST_F(OutputBufferManagerTest, basicBroadcast) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(OutputBufferManagerTest, basicArbitrary) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, basicArbitrary) {
   const vector_size_t size = 100;
   int numDestinations = 5;
   const std::string taskId = "t0";
@@ -950,7 +1011,9 @@ TEST_F(OutputBufferManagerTest, basicArbitrary) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(OutputBufferManagerTest, inactiveDestinationBuffer) {
+TEST_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    inactiveDestinationBuffer) {
   const vector_size_t dataSize = 1'000;
   const int maxBytes = 1;
   int numDestinations = 2;
@@ -1040,8 +1103,8 @@ TEST_F(OutputBufferManagerTest, inactiveDestinationBuffer) {
     ASSERT_EQ(stats.buffersStats[i].bytesBuffered, 0);
   }
 
-  // Set the second destination buffer active to load data with notify when data
-  // gets queued.
+  // Set the second destination buffer active to load data with notify when
+  // data gets queued.
   actives[1] = true;
   ASSERT_TRUE(bufferManager_->getData(
       taskId,
@@ -1087,7 +1150,9 @@ TEST_F(OutputBufferManagerTest, inactiveDestinationBuffer) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(OutputBufferManagerTest, broadcastWithDynamicAddedDestination) {
+TEST_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    broadcastWithDynamicAddedDestination) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
@@ -1131,7 +1196,9 @@ TEST_F(OutputBufferManagerTest, broadcastWithDynamicAddedDestination) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(OutputBufferManagerTest, arbitraryWithDynamicAddedDestination) {
+TEST_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    arbitraryWithDynamicAddedDestination) {
   const vector_size_t size = 100;
   int numDestinations = 5;
   const std::string taskId = "t0";
@@ -1190,7 +1257,7 @@ TEST_F(OutputBufferManagerTest, arbitraryWithDynamicAddedDestination) {
 TEST_P(AllOutputBufferManagerTest, maxBytes) {
   const vector_size_t size = 100;
   const std::string taskId = "t0";
-  initializeTask(taskId, rowType_, kind_, 1, 1);
+  initializeTask(taskId, rowType_, outputKind_, 1, 1);
 
   enqueue(taskId, 0, rowType_, size);
   enqueue(taskId, 0, rowType_, size);
@@ -1205,7 +1272,7 @@ TEST_P(AllOutputBufferManagerTest, maxBytes) {
   fetchOneAndAck(taskId, 0, 1);
   fetchOneAndAck(taskId, 0, 2);
 
-  if (kind_ != PartitionedOutputNode::Kind::kPartitioned) {
+  if (outputKind_ != PartitionedOutputNode::Kind::kPartitioned) {
     bufferManager_->updateOutputBuffers(taskId, 0, true);
   }
   noMoreData(taskId);
@@ -1216,9 +1283,10 @@ TEST_P(AllOutputBufferManagerTest, maxBytes) {
 TEST_P(AllOutputBufferManagerTest, outputBufferUtilization) {
   const std::string taskId = std::to_string(rand());
   const auto destination = 0;
-  auto task = initializeTask(taskId, rowType_, kind_, 1, 1);
+  auto task = initializeTask(taskId, rowType_, outputKind_, 1, 1);
   verifyOutputBuffer(task, OutputBufferStatus::kInitiated);
-  if (kind_ == facebook::velox::core::PartitionedOutputNode::Kind::kBroadcast) {
+  if (outputKind_ ==
+      facebook::velox::core::PartitionedOutputNode::Kind::kBroadcast) {
     bufferManager_->updateOutputBuffers(taskId, destination, true);
   }
 
@@ -1259,10 +1327,10 @@ TEST_P(AllOutputBufferManagerTest, outputBufferUtilization) {
 TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
   const vector_size_t vectorSize = 100;
   const std::string taskId = std::to_string(folly::Random::rand32());
-  initializeTask(taskId, rowType_, kind_, 1, 1);
+  initializeTask(taskId, rowType_, outputKind_, 1, 1);
   {
     const auto stats = getStats(taskId);
-    ASSERT_EQ(stats.kind, kind_);
+    ASSERT_EQ(stats.kind, outputKind_);
     ASSERT_FALSE(stats.noMoreData);
     ASSERT_FALSE(stats.finished);
     ASSERT_FALSE(stats.noMoreBuffers);
@@ -1283,13 +1351,13 @@ TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
     totalNumRows += vectorSize;
     // Force ArbitraryBuffer to load data, otherwise the data would
     // not be buffered in DestinationBuffer.
-    if (kind_ == PartitionedOutputNode::Kind::kArbitrary) {
+    if (outputKind_ == PartitionedOutputNode::Kind::kArbitrary) {
       fetchOne(taskId, 0, pageId);
     }
     const auto statsEnqueue = getStats(taskId);
     ASSERT_EQ(statsEnqueue.buffersStats[0].pagesBuffered, 1);
     ASSERT_EQ(statsEnqueue.buffersStats[0].rowsBuffered, vectorSize);
-    if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
+    if (outputKind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
       ASSERT_EQ(statsEnqueue.bufferedPages, pageId + 1);
       ASSERT_EQ(statsEnqueue.bufferedBytes, totalBytes);
     } else {
@@ -1307,7 +1375,7 @@ TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
     ASSERT_EQ(statsAck.buffersStats[0].rowsSent, totalNumRows);
     ASSERT_EQ(statsAck.buffersStats[0].pagesBuffered, 0);
     ASSERT_EQ(statsAck.buffersStats[0].rowsBuffered, 0);
-    if (kind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
+    if (outputKind_ == core::PartitionedOutputNode::Kind::kBroadcast) {
       ASSERT_EQ(statsAck.bufferedPages, pageId + 1);
       ASSERT_EQ(statsAck.bufferedBytes, totalBytes);
     } else {
@@ -1352,7 +1420,7 @@ TEST_P(AllOutputBufferManagerTest, outputBufferStats) {
   ASSERT_FALSE(bufferManager_->stats(taskId).has_value());
 }
 
-TEST_F(OutputBufferManagerTest, outOfOrderAcks) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, outOfOrderAcks) {
   const vector_size_t size = 100;
   const std::string taskId = "t0";
   auto task = initializeTask(
@@ -1394,7 +1462,9 @@ TEST_F(OutputBufferManagerTest, errorInQueue) {
       queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
 }
 
-TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
+TEST_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    setQueueErrorWithPendingPages) {
   const uint64_t kBufferSize = 128;
   auto iobuf = folly::IOBuf::create(kBufferSize);
   const std::string payload("setQueueErrorWithPendingPages");
@@ -1421,10 +1491,10 @@ TEST_F(OutputBufferManagerTest, setQueueErrorWithPendingPages) {
       queue->dequeueLocked(1, &atEnd, &future), "Forced failure");
 }
 
-TEST_F(OutputBufferManagerTest, getDataOnFailedTask) {
+TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, getDataOnFailedTask) {
   // Fetching data on a task which was either never initialized in the buffer
-  // manager or was removed by a parallel thread must return false. The `notify`
-  // callback must not be registered.
+  // manager or was removed by a parallel thread must return false. The
+  // `notify` callback must not be registered.
   ASSERT_FALSE(bufferManager_->getData(
       "test.0.1",
       1,
@@ -1438,7 +1508,9 @@ TEST_F(OutputBufferManagerTest, getDataOnFailedTask) {
   ASSERT_FALSE(bufferManager_->updateNumDrivers("test.0.2", 1));
 }
 
-TEST_F(OutputBufferManagerTest, updateBrodcastBufferOnFailedTask) {
+TEST_P(
+    OutputBufferManagerWithDifferentSerdeKindsTest,
+    updateBrodcastBufferOnFailedTask) {
   // Updating broadcast buffer count in the buffer manager for a given unknown
   // task must not throw exception, instead must return FALSE.
   ASSERT_FALSE(bufferManager_->updateOutputBuffers(
@@ -1459,10 +1531,10 @@ TEST_P(AllOutputBufferManagerTest, multiFetchers) {
     initializeTask(
         taskId,
         rowType_,
-        kind_,
+        outputKind_,
         numPartitions,
         1,
-        kind_ == PartitionedOutputNode::Kind::kBroadcast ? 256 << 20 : 0);
+        outputKind_ == PartitionedOutputNode::Kind::kBroadcast ? 256 << 20 : 0);
 
     std::vector<std::thread> threads;
     std::vector<int64_t> fetchedPages(numPartitions + extendedNumPartitions, 0);
@@ -1477,7 +1549,8 @@ TEST_P(AllOutputBufferManagerTest, multiFetchers) {
     std::vector<int64_t> producedPages(
         numPartitions + extendedNumPartitions, 0);
     for (int i = 0; i < totalPages; ++i) {
-      const int partition = kind_ == PartitionedOutputNode::Kind::kPartitioned
+      const int partition =
+          outputKind_ == PartitionedOutputNode::Kind::kPartitioned
           ? folly::Random().rand32(rng) % numPartitions
           : 0;
       try {
@@ -1491,7 +1564,8 @@ TEST_P(AllOutputBufferManagerTest, multiFetchers) {
       if (folly::Random().oneIn(4)) {
         std::this_thread::sleep_for(std::chrono::microseconds(5)); // NOLINT
       }
-      if (i == 1000 && (kind_ != PartitionedOutputNode::Kind::kPartitioned)) {
+      if (i == 1000 &&
+          (outputKind_ != PartitionedOutputNode::Kind::kPartitioned)) {
         bufferManager_->updateOutputBuffers(
             taskId, numPartitions + extendedNumPartitions, false);
         for (size_t i = numPartitions;
@@ -1512,11 +1586,11 @@ TEST_P(AllOutputBufferManagerTest, multiFetchers) {
     }
 
     if (!earlyTermination) {
-      if (kind_ == PartitionedOutputNode::Kind::kPartitioned) {
+      if (outputKind_ == PartitionedOutputNode::Kind::kPartitioned) {
         for (int i = 0; i < numPartitions; ++i) {
           ASSERT_EQ(fetchedPages[i], producedPages[i]);
         }
-      } else if (kind_ == PartitionedOutputNode::Kind::kBroadcast) {
+      } else if (outputKind_ == PartitionedOutputNode::Kind::kBroadcast) {
         int64_t totalFetchedPages{0};
         for (const auto& pages : fetchedPages) {
           totalFetchedPages += pages;

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -21,17 +21,16 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/exec/OutputBufferManager.h"
-#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
-#include "velox/vector/tests/utils/VectorTestBase.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
@@ -124,6 +123,15 @@ void OperatorTestBase::resetMemory() {
 void OperatorTestBase::SetUp() {
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
   driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);
   ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -333,7 +333,15 @@ class PlanBuilder {
   /// splits.
   ///
   /// @param outputType The type of the data coming in and out of the exchange.
-  PlanBuilder& exchange(const RowTypePtr& outputType);
+  /// @param serdekind The kind of seralized data format.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& exchange(const RowTypePtr& outputType) {
+    return exchange(outputType, VectorSerde::Kind::kPresto);
+  }
+#endif
+  PlanBuilder& exchange(
+      const RowTypePtr& outputType,
+      VectorSerde::Kind serdekind);
 
   /// Add a MergeExchangeNode using specified ORDER BY clauses.
   ///
@@ -343,9 +351,17 @@ class PlanBuilder {
   ///
   /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
   /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   PlanBuilder& mergeExchange(
       const RowTypePtr& outputType,
-      const std::vector<std::string>& keys);
+      const std::vector<std::string>& keys) {
+    return mergeExchange(outputType, keys, VectorSerde::Kind::kPresto);
+  }
+#endif
+  PlanBuilder& mergeExchange(
+      const RowTypePtr& outputType,
+      const std::vector<std::string>& keys,
+      VectorSerde::Kind serdekind);
 
   /// Add a ProjectNode using specified SQL expressions.
   ///
@@ -785,13 +801,15 @@ class PlanBuilder {
       const std::vector<std::string>& keys,
       int numPartitions,
       bool replicateNullsAndAny,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
 
   /// Same as above, but assumes 'replicateNullsAndAny' is false.
   PlanBuilder& partitionedOutput(
       const std::vector<std::string>& keys,
       int numPartitions,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
 
   /// Same as above, but allows to provide custom partition function.
   PlanBuilder& partitionedOutput(
@@ -799,7 +817,8 @@ class PlanBuilder {
       int numPartitions,
       bool replicateNullsAndAny,
       core::PartitionFunctionSpecPtr partitionFunctionSpec,
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
 
   /// Adds a PartitionedOutputNode to broadcast the input data.
   ///
@@ -808,11 +827,13 @@ class PlanBuilder {
   /// some input columns may be missing in the output, some columns may be
   /// duplicated in the output.
   PlanBuilder& partitionedOutputBroadcast(
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
 
   /// Adds a PartitionedOutputNode to put data into arbitrary buffer.
   PlanBuilder& partitionedOutputArbitrary(
-      const std::vector<std::string>& outputLayout = {});
+      const std::vector<std::string>& outputLayout = {},
+      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
 
   /// Adds a LocalPartitionNode to hash-partition the input on the specified
   /// keys using exec::HashPartitionFunction. Number of partitions is determined

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-#include <algorithm>
-#include <array>
-#include <random>
+
 #include "velox/common/file/FileSystems.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/RowContainer.h"
-#include "velox/exec/VectorHasher.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/CompactRowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::exec::test {
@@ -46,6 +45,18 @@ class RowContainerTestBase : public testing::Test,
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+      facebook::velox::serializer::presto::PrestoVectorSerde::
+          registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+      facebook::velox::serializer::CompactRowVectorSerde::
+          registerNamedVectorSerde();
+    }
+    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+      facebook::velox::serializer::spark::UnsafeRowVectorSerde::
+          registerNamedVectorSerde();
     }
     filesystems::registerLocalFileSystem();
   }

--- a/velox/exec/tests/utils/SerializedPageUtil.cpp
+++ b/velox/exec/tests/utils/SerializedPageUtil.cpp
@@ -22,9 +22,11 @@ namespace facebook::velox::exec::test {
 
 std::unique_ptr<SerializedPage> toSerializedPage(
     const RowVectorPtr& vector,
+    VectorSerde::Kind serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,
     memory::MemoryPool* pool) {
-  auto data = std::make_unique<VectorStreamGroup>(pool);
+  auto data =
+      std::make_unique<VectorStreamGroup>(pool, getNamedVectorSerde(serdeKind));
   auto size = vector->size();
   auto range = IndexRange{0, size};
   data->createStreamTree(asRowType(vector->type()), size);

--- a/velox/exec/tests/utils/SerializedPageUtil.h
+++ b/velox/exec/tests/utils/SerializedPageUtil.h
@@ -18,13 +18,14 @@
 #include "velox/exec/ExchangeQueue.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/vector/ComplexVector.h"
-#include "velox/vector/VectorStream.h"
+// #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec::test {
 
 /// Helper function for serializing RowVector to PrestoPage format.
 std::unique_ptr<SerializedPage> toSerializedPage(
     const RowVectorPtr& vector,
+    VectorSerde::Kind serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,
     memory::MemoryPool* pool);
 

--- a/velox/functions/prestosql/coverage/CMakeLists.txt
+++ b/velox/functions/prestosql/coverage/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(
   velox_functions_prestosql
   velox_function_registry
   velox_aggregates
+  velox_row_fast
   velox_window
   velox_coverage_util)

--- a/velox/functions/sparksql/coverage/CMakeLists.txt
+++ b/velox/functions/sparksql/coverage/CMakeLists.txt
@@ -19,4 +19,5 @@ target_link_libraries(
   velox_function_registry
   velox_functions_spark_aggregates
   velox_functions_spark_window
+  velox_row_fast
   velox_coverage_util)

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -25,6 +25,9 @@
 #include "velox/exec/fuzzer/TransformResultVerifier.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 
 DEFINE_int64(
     seed,
@@ -51,6 +54,21 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
 
   facebook::velox::functions::prestosql::registerInternalFunctions();
+  if (!isRegisteredNamedVectorSerde(
+          facebook::velox::VectorSerde::Kind::kPresto)) {
+    facebook::velox::serializer::presto::PrestoVectorSerde::
+        registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(
+          facebook::velox::VectorSerde::Kind::kCompactRow)) {
+    facebook::velox::serializer::CompactRowVectorSerde::
+        registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(
+          facebook::velox::VectorSerde::Kind::kUnsafeRow)) {
+    facebook::velox::serializer::spark::UnsafeRowVectorSerde::
+        registerNamedVectorSerde();
+  }
   facebook::velox::memory::MemoryManager::initialize({});
 
   // TODO: List of the functions that at some point crash or fail and need to

--- a/velox/row/CompactRow.h
+++ b/velox/row/CompactRow.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "velox/common/base/RawVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 
@@ -25,17 +24,24 @@ class CompactRow {
  public:
   explicit CompactRow(const RowVectorPtr& vector);
 
+  /// Returns the serialized sizes of the rows at specified indexes.
+  ///
+  /// TODO: optimizes using columnar serialization size calculation.
+  void serializedRowSizes(
+      const folly::Range<const vector_size_t*>& rows,
+      vector_size_t** sizes) const;
+
   /// Returns row size if all fields are fixed width. Return std::nullopt if
   /// there are variable-width fields.
   static std::optional<int32_t> fixedRowSize(const RowTypePtr& rowType);
 
   /// Returns serialized size of the row at specified index. Use only if
   /// 'fixedRowSize' returned std::nullopt.
-  int32_t rowSize(vector_size_t index);
+  int32_t rowSize(vector_size_t index) const;
 
   /// Serializes row at specified index into 'buffer'.
   /// 'buffer' must have sufficient capacity and set to all zeros.
-  int32_t serialize(vector_size_t index, char* buffer);
+  int32_t serialize(vector_size_t index, char* buffer) const;
 
   /// Serializes rows in the range [offset, offset + size) into 'buffer' at
   /// given 'bufferOffsets'. 'buffer' must have sufficient capacity and set to
@@ -47,7 +53,7 @@ class CompactRow {
       vector_size_t offset,
       vector_size_t size,
       const size_t* bufferOffsets,
-      char* buffer);
+      char* buffer) const;
 
   /// Deserializes multiple rows into a RowVector of specified type. The type
   /// must match the contents of the serialized rows.
@@ -61,7 +67,7 @@ class CompactRow {
 
   void initialize(const TypePtr& type);
 
-  bool isNullAt(vector_size_t);
+  bool isNullAt(vector_size_t) const;
 
   /// Fixed-width types only. Returns number of bytes used by single value.
   int32_t valueBytes() const {
@@ -70,56 +76,59 @@ class CompactRow {
 
   /// Writes fixed-width value at specified index into 'buffer'. Value must not
   /// be null.
-  void serializeFixedWidth(vector_size_t index, char* buffer);
+  void serializeFixedWidth(vector_size_t index, char* buffer) const;
 
   /// Writes range of fixed-width values between 'offset' and 'offset + size'
   /// into 'buffer'. Values can be null.
-  void
-  serializeFixedWidth(vector_size_t offset, vector_size_t size, char* buffer);
+  void serializeFixedWidth(
+      vector_size_t offset,
+      vector_size_t size,
+      char* buffer) const;
 
   /// Returns serialized size of variable-width row.
-  int32_t variableWidthRowSize(vector_size_t index);
+  int32_t variableWidthRowSize(vector_size_t index) const;
 
   /// Writes variable-width value at specified index into 'buffer'. Value must
   /// not be null. Returns number of bytes written to 'buffer'.
-  int32_t serializeVariableWidth(vector_size_t index, char* buffer);
+  int32_t serializeVariableWidth(vector_size_t index, char* buffer) const;
 
  private:
   /// Returns serialized size of array row.
-  int32_t arrayRowSize(vector_size_t index);
+  int32_t arrayRowSize(vector_size_t index) const;
 
   /// Serializes array value to buffer. Value must not be null. Returns number
   /// of bytes written to 'buffer'.
-  int32_t serializeArray(vector_size_t index, char* buffer);
+  int32_t serializeArray(vector_size_t index, char* buffer) const;
 
   /// Returns serialized size of map row.
-  int32_t mapRowSize(vector_size_t index);
+  int32_t mapRowSize(vector_size_t index) const;
 
   /// Serializes map value to buffer. Value must not be null. Returns number of
   /// bytes written to 'buffer'.
-  int32_t serializeMap(vector_size_t index, char* buffer);
+  int32_t serializeMap(vector_size_t index, char* buffer) const;
 
   /// Returns serialized size of a range of values.
   int32_t arrayRowSize(
-      CompactRow& elements,
+      const CompactRow& elements,
       vector_size_t offset,
       vector_size_t size,
-      bool fixedWidth);
+      bool fixedWidth) const;
 
   /// Serializes a range of values into buffer. Returns number of bytes written
   /// to 'buffer'.
   int32_t serializeAsArray(
-      CompactRow& elements,
+      const CompactRow& elements,
       vector_size_t offset,
       vector_size_t size,
       bool fixedWidth,
-      char* buffer);
+      char* buffer) const;
+  ;
 
   /// Returns serialized size of struct value.
-  int32_t rowRowSize(vector_size_t index);
+  int32_t rowRowSize(vector_size_t index) const;
 
   /// Serializes struct value to buffer. Value must not be null.
-  int32_t serializeRow(vector_size_t index, char* buffer);
+  int32_t serializeRow(vector_size_t index, char* buffer) const;
 
   /// Serializes struct values in range [offset, offset + size) to buffer.
   /// Value must not be null.
@@ -127,7 +136,7 @@ class CompactRow {
       vector_size_t offset,
       vector_size_t size,
       char* buffer,
-      const size_t* bufferOffsets);
+      const size_t* bufferOffsets) const;
 
   const TypeKind typeKind_;
   DecodedVector decoded_;

--- a/velox/row/UnsafeRowFast.h
+++ b/velox/row/UnsafeRowFast.h
@@ -24,24 +24,31 @@ class UnsafeRowFast {
  public:
   explicit UnsafeRowFast(const RowVectorPtr& vector);
 
+  /// Returns the serialized sizes of the rows at specified row indexes.
+  ///
+  /// TODO: optimizes using columnar serialization size calculation.
+  void serializedRowSizes(
+      const folly::Range<const vector_size_t*>& rows,
+      vector_size_t** sizes) const;
+
   /// Returns row size if all fields are fixed width. Return std::nullopt if
   /// there are variable-width fields.
   static std::optional<int32_t> fixedRowSize(const RowTypePtr& rowType);
 
   /// Returns serialized size of the row at specified index. Use only if
   /// 'fixedRowSize' returned std::nullopt.
-  int32_t rowSize(vector_size_t index);
+  int32_t rowSize(vector_size_t index) const;
 
   /// Serializes row at specified index into 'buffer'.
   /// 'buffer' must have sufficient capacity and set to all zeros.
-  int32_t serialize(vector_size_t index, char* buffer);
+  int32_t serialize(vector_size_t index, char* buffer) const;
 
  protected:
   explicit UnsafeRowFast(const VectorPtr& vector);
 
   void initialize(const TypePtr& type);
 
-  bool isNullAt(vector_size_t);
+  bool isNullAt(vector_size_t) const;
 
   /// Fixed-width types only. Returns number of bytes used by single value.
   int32_t valueBytes() const {
@@ -50,56 +57,58 @@ class UnsafeRowFast {
 
   /// Writes fixed-width value at specified index into 'buffer'. Value must not
   /// be null.
-  void serializeFixedWidth(vector_size_t index, char* buffer);
+  void serializeFixedWidth(vector_size_t index, char* buffer) const;
 
   /// Writes range of fixed-width values between 'offset' and 'offset + size'
   /// into 'buffer'. Values can be null.
-  void
-  serializeFixedWidth(vector_size_t offset, vector_size_t size, char* buffer);
+  void serializeFixedWidth(
+      vector_size_t offset,
+      vector_size_t size,
+      char* buffer) const;
 
   /// Returns serialized size of variable-width row.
-  int32_t variableWidthRowSize(vector_size_t index);
+  int32_t variableWidthRowSize(vector_size_t index) const;
 
   /// Writes variable-width value at specified index into 'buffer'. Value must
   /// not be null. Returns number of bytes written to 'buffer'.
-  int32_t serializeVariableWidth(vector_size_t index, char* buffer);
+  int32_t serializeVariableWidth(vector_size_t index, char* buffer) const;
 
  private:
   /// Returns serialized size of array row.
-  int32_t arrayRowSize(vector_size_t index);
+  int32_t arrayRowSize(vector_size_t index) const;
 
   /// Serializes array value to buffer. Value must not be null. Returns number
   /// of bytes written to 'buffer'.
-  int32_t serializeArray(vector_size_t index, char* buffer);
+  int32_t serializeArray(vector_size_t index, char* buffer) const;
 
   /// Returns serialized size of map row.
-  int32_t mapRowSize(vector_size_t index);
+  int32_t mapRowSize(vector_size_t index) const;
 
   /// Serializes map value to buffer. Value must not be null. Returns number of
   /// bytes written to 'buffer'.
-  int32_t serializeMap(vector_size_t index, char* buffer);
+  int32_t serializeMap(vector_size_t index, char* buffer) const;
 
   /// Returns serialized size of a range of values.
   int32_t arrayRowSize(
-      UnsafeRowFast& elements,
+      const UnsafeRowFast& elements,
       vector_size_t offset,
       vector_size_t size,
-      bool fixedWidth);
+      bool fixedWidth) const;
 
   /// Serializes a range of values into buffer using UnsafeRow Array
   /// serialization. Returns number of bytes written to 'buffer'.
   int32_t serializeAsArray(
-      UnsafeRowFast& elements,
+      const UnsafeRowFast& elements,
       vector_size_t offset,
       vector_size_t size,
       bool fixedWidth,
-      char* buffer);
+      char* buffer) const;
 
   /// Returns serialized size of struct value.
-  int32_t rowRowSize(vector_size_t index);
+  int32_t rowRowSize(vector_size_t index) const;
 
   /// Serializes struct value to buffer. Value must not be null.
-  int32_t serializeRow(vector_size_t index, char* buffer);
+  int32_t serializeRow(vector_size_t index, char* buffer) const;
 
   const TypeKind typeKind_;
   DecodedVector decoded_;

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -69,6 +69,20 @@ class CompactRowTest : public ::testing::Test, public VectorTestBase {
       }
     }
 
+    std::vector<vector_size_t> rows(numRows);
+    std::iota(rows.begin(), rows.end(), 0);
+    std::vector<vector_size_t> serializedRowSizes(numRows);
+    std::vector<vector_size_t*> serializedRowSizesPtr(numRows);
+    for (auto i = 0; i < numRows; ++i) {
+      serializedRowSizesPtr[i] = &serializedRowSizes[i];
+    }
+    row.serializedRowSizes(
+        folly::Range(rows.data(), numRows), serializedRowSizesPtr.data());
+    for (auto i = 0; i < numRows; ++i) {
+      // The serialized row includes the size of the row.
+      ASSERT_EQ(serializedRowSizes[i], row.rowSize(i) + sizeof(uint32_t));
+    }
+
     BufferPtr buffer = AlignedBuffer::allocate<char>(totalSize, pool(), 0);
     auto* rawBuffer = buffer->asMutable<char>();
     {

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -22,14 +22,12 @@ namespace facebook::velox::serializer {
 
 class CompactRowVectorSerde : public VectorSerde {
  public:
-  CompactRowVectorSerde() = default;
+  CompactRowVectorSerde() : VectorSerde(VectorSerde::Kind::kCompactRow) {}
 
-  // We do not implement this method since it is not used in production code.
   void estimateSerializedSize(
-      const BaseVector* vector,
-      const folly::Range<const IndexRange*>& ranges,
-      vector_size_t** sizes,
-      Scratch& scratch) override;
+      const row::CompactRow* compactRow,
+      const folly::Range<const vector_size_t*>& rows,
+      vector_size_t** sizes) override;
 
   // This method is not used in production code. It is only used to
   // support round-trip tests for deserialization.
@@ -48,6 +46,7 @@ class CompactRowVectorSerde : public VectorSerde {
       const Options* options) override;
 
   static void registerVectorSerde();
+  static void registerNamedVectorSerde();
 };
 
 } // namespace facebook::velox::serializer

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -81,6 +81,8 @@ class PrestoVectorSerde : public VectorSerde {
     bool preserveEncodings{false};
   };
 
+  PrestoVectorSerde() : VectorSerde(Kind::kPresto) {}
+
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
   /// '*sizes[i]'.
   void estimateSerializedSize(
@@ -89,9 +91,11 @@ class PrestoVectorSerde : public VectorSerde {
       vector_size_t** sizes,
       Scratch& scratch) override;
 
+  /// Adds the serialized sizes of the rows of 'vector' in 'rows[i]' to
+  /// '*sizes[i]'.
   void estimateSerializedSize(
       const BaseVector* vector,
-      const folly::Range<const vector_size_t*> rows,
+      const folly::Range<const vector_size_t*>& rows,
       vector_size_t** sizes,
       Scratch& scratch) override;
 
@@ -195,6 +199,7 @@ class PrestoVectorSerde : public VectorSerde {
       const Options* options = nullptr);
 
   static void registerVectorSerde();
+  static void registerNamedVectorSerde();
 };
 
 class PrestoOutputStreamListener : public OutputStreamListener {

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -21,13 +21,12 @@ namespace facebook::velox::serializer::spark {
 
 class UnsafeRowVectorSerde : public VectorSerde {
  public:
-  UnsafeRowVectorSerde() = default;
-  // We do not implement this method since it is not used in production code.
+  UnsafeRowVectorSerde() : VectorSerde(VectorSerde::Kind::kUnsafeRow) {}
+
   void estimateSerializedSize(
-      const BaseVector* vector,
-      const folly::Range<const IndexRange*>& ranges,
-      vector_size_t** sizes,
-      Scratch& scratch) override;
+      const row::UnsafeRowFast* unsafeRow,
+      const folly::Range<const vector_size_t*>& rows,
+      vector_size_t** sizes) override;
 
   // This method is not used in production code. It is only used to
   // support round-trip tests for deserialization.
@@ -46,5 +45,6 @@ class UnsafeRowVectorSerde : public VectorSerde {
       const Options* options) override;
 
   static void registerVectorSerde();
+  static void registerNamedVectorSerde();
 };
 } // namespace facebook::velox::serializer::spark

--- a/velox/serializers/benchmarks/RowSerializerBenchmark.cpp
+++ b/velox/serializers/benchmarks/RowSerializerBenchmark.cpp
@@ -43,7 +43,7 @@ class RowSerializerBenchmark {
     suspender.dismiss();
 
     Scratch scratch;
-    auto group = std::make_unique<VectorStreamGroup>(pool_.get());
+    auto group = std::make_unique<VectorStreamGroup>(pool_.get(), nullptr);
     group->createStreamTree(rowType, data->size());
     group->append(
         data, folly::Range(indexRanges.data(), indexRanges.size()), scratch);

--- a/velox/serializers/tests/SerializerBenchmark.cpp
+++ b/velox/serializers/tests/SerializerBenchmark.cpp
@@ -106,7 +106,7 @@ class SerializerBenchmark : public VectorTestBase {
       auto rowVector = vm.rowVector({vector});
       {
         MicrosecondTimer t(&item.irTime);
-        auto group = std::make_unique<VectorStreamGroup>(pool_.get());
+        auto group = std::make_unique<VectorStreamGroup>(pool_.get(), nullptr);
         group->createStreamTree(rowType, rowSets[selIdx].size() - kPad);
         for (auto repeat = 0; repeat < numRepeat; ++repeat) {
           group->append(
@@ -119,7 +119,7 @@ class SerializerBenchmark : public VectorTestBase {
 
       {
         MicrosecondTimer t(&item.rrTime);
-        auto group = std::make_unique<VectorStreamGroup>(pool_.get());
+        auto group = std::make_unique<VectorStreamGroup>(pool_.get(), nullptr);
         group->createStreamTree(rowType, rowSets[selIdx].size());
 
         for (auto repeat = 0; repeat < numRepeat; ++repeat) {

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -16,13 +16,15 @@
 #include "velox/serializers/UnsafeRowSerializer.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/row/UnsafeRowFast.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
 
 class UnsafeRowSerializerTest : public ::testing::Test,
-                                public test::VectorTestBase {
+                                public test::VectorTestBase,
+                                public testing::WithParamInterface<bool> {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
@@ -30,24 +32,56 @@ class UnsafeRowSerializerTest : public ::testing::Test,
 
   void SetUp() override {
     pool_ = memory::memoryManager()->addLeafPool();
-    serde_ = std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
+    deregisterVectorSerde();
+    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+    ASSERT_EQ(getVectorSerde()->kind(), VectorSerde::Kind::kUnsafeRow);
+    ASSERT_EQ(
+        getNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)->kind(),
+        VectorSerde::Kind::kUnsafeRow);
+  }
+
+  void TearDown() override {
+    deregisterVectorSerde();
+    deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
   }
 
   void serialize(RowVectorPtr rowVector, std::ostream* output) {
-    auto numRows = rowVector->size();
+    const auto numRows = rowVector->size();
 
-    std::vector<IndexRange> rows(numRows);
+    std::vector<IndexRange> ranges(numRows);
     for (int i = 0; i < numRows; i++) {
-      rows[i] = IndexRange{i, 1};
+      ranges[i] = IndexRange{i, 1};
+    }
+
+    std::unique_ptr<row::UnsafeRowFast> unsafeRow;
+    std::vector<vector_size_t> serializedRowSizes(numRows);
+    std::vector<vector_size_t*> serializedRowSizesPtr(numRows);
+    std::vector<vector_size_t> rows(numRows);
+    std::iota(rows.begin(), rows.end(), 0);
+    for (auto i = 0; i < numRows; ++i) {
+      serializedRowSizesPtr[i] = &serializedRowSizes[i];
+    }
+    if (GetParam()) {
+      unsafeRow = std::make_unique<row::UnsafeRowFast>(rowVector);
+      getVectorSerde()->estimateSerializedSize(
+          unsafeRow.get(), rows, serializedRowSizesPtr.data());
     }
 
     auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
-    auto serializer =
-        serde_->createIterativeSerializer(rowType, numRows, arena.get());
+    auto serializer = getVectorSerde()->createIterativeSerializer(
+        rowType, numRows, arena.get());
 
-    Scratch scratch;
-    serializer->append(rowVector, folly::Range(rows.data(), numRows), scratch);
+    if (GetParam()) {
+      serializer->append(*unsafeRow, rows, serializedRowSizes);
+    } else {
+      Scratch scratch;
+      serializer->append(
+          rowVector, folly::Range(ranges.data(), numRows), scratch);
+    }
+
     auto size = serializer->maxSerializedSize();
     OStreamOutputStream out(output);
     serializer->flush(&out);
@@ -74,7 +108,8 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     auto byteStream = toByteStream(input);
 
     RowVectorPtr result;
-    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
+    getVectorSerde()->deserialize(
+        byteStream.get(), pool_.get(), rowType, &result);
     return result;
   }
 
@@ -109,11 +144,10 @@ class UnsafeRowSerializerTest : public ::testing::Test,
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  std::unique_ptr<VectorSerde> serde_;
 };
 
 // These expected binary buffers were samples taken using Spark's java code.
-TEST_F(UnsafeRowSerializerTest, tinyint) {
+TEST_P(UnsafeRowSerializerTest, tinyint) {
   int8_t data[20] = {0, 0, 0,   16, 0, 0, 0, 0, 0, 0,
                      0, 0, 123, 0,  0, 0, 0, 0, 0, 0};
   auto expected = makeRowVector({makeFlatVector(std::vector<int8_t>{123})});
@@ -122,7 +156,7 @@ TEST_F(UnsafeRowSerializerTest, tinyint) {
   testDeserialize(data, 20, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, bigint) {
+TEST_P(UnsafeRowSerializerTest, bigint) {
   int8_t data[20] = {0, 0, 0,  16, 0,   0,   0, 0, 0, 0,
                      0, 0, 62, 28, -36, -33, 2, 0, 0, 0};
   auto expected =
@@ -132,7 +166,7 @@ TEST_F(UnsafeRowSerializerTest, bigint) {
   testDeserialize(data, 20, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, double) {
+TEST_P(UnsafeRowSerializerTest, double) {
   int8_t data[20] = {0, 0, 0,   16, 0,  0,  0,   0,  0,    0,
                      0, 0, 125, 63, 53, 94, -70, 73, -109, 64};
   auto expected =
@@ -142,7 +176,7 @@ TEST_F(UnsafeRowSerializerTest, double) {
   testDeserialize(data, 20, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, boolean) {
+TEST_P(UnsafeRowSerializerTest, boolean) {
   int8_t data[20] = {0, 0, 0, 16, 0, 0, 0, 0, 0, 0,
                      0, 0, 1, 0,  0, 0, 0, 0, 0, 0};
   auto expected = makeRowVector({makeFlatVector(std::vector<bool>{true})});
@@ -151,7 +185,7 @@ TEST_F(UnsafeRowSerializerTest, boolean) {
   testDeserialize(data, 20, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, string) {
+TEST_P(UnsafeRowSerializerTest, string) {
   int8_t data[28] = {0, 0, 0,  24, 0, 0, 0,  0,  0,  0,  0,  0, 5, 0,
                      0, 0, 16, 0,  0, 0, 72, 69, 76, 76, 79, 0, 0, 0};
   auto expected =
@@ -161,7 +195,7 @@ TEST_F(UnsafeRowSerializerTest, string) {
   testDeserialize(data, 28, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, null) {
+TEST_P(UnsafeRowSerializerTest, null) {
   int8_t data[20] = {0, 0, 0, 16, 1, 0, 0, 0, 0, 0,
                      0, 0, 0, 0,  0, 0, 0, 0, 0, 0};
   auto expected = makeRowVector({makeNullableFlatVector(
@@ -182,7 +216,7 @@ TEST_F(UnsafeRowSerializerTest, null) {
 //   unsafeRow.getBaseObject().asInstanceOf[Array[Byte]].foreach(b => print(b +
 //   ", ")) print("\n")
 // }
-TEST_F(UnsafeRowSerializerTest, decimal) {
+TEST_P(UnsafeRowSerializerTest, decimal) {
   // short decimal
   int8_t data[20] = {0, 0, 0,  16, 0,   0,   0, 0, 0, 0,
                      0, 0, 62, 28, -36, -33, 2, 0, 0, 0};
@@ -206,7 +240,7 @@ TEST_F(UnsafeRowSerializerTest, decimal) {
   testDeserialize(longData, 36, longExpected);
 }
 
-TEST_F(UnsafeRowSerializerTest, manyRows) {
+TEST_P(UnsafeRowSerializerTest, manyRows) {
   int8_t data[140] = {0, 0, 0,  24, 0, 0, 0,   0,   0,   0,   0,   0,  4,   0,
                       0, 0, 16, 0,  0, 0, 109, 97,  110, 121, 0,   0,  0,   0,
                       0, 0, 0,  24, 0, 0, 0,   0,   0,   0,   0,   0,  4,   0,
@@ -224,7 +258,7 @@ TEST_F(UnsafeRowSerializerTest, manyRows) {
   testDeserialize(data, 140, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, splitRow) {
+TEST_P(UnsafeRowSerializerTest, splitRow) {
   int8_t data[20] = {0, 0, 0,  16, 0,   0,   0, 0, 0, 0,
                      0, 0, 62, 28, -36, -33, 2, 0, 0, 0};
   auto expected =
@@ -254,7 +288,7 @@ TEST_F(UnsafeRowSerializerTest, splitRow) {
   testDeserialize(buffers, expected);
 }
 
-TEST_F(UnsafeRowSerializerTest, incompleteRow) {
+TEST_P(UnsafeRowSerializerTest, incompleteRow) {
   int8_t data[20] = {0, 0, 0,  16, 0,   0,   0, 0, 0, 0,
                      0, 0, 62, 28, -36, -33, 2, 0, 0, 0};
   auto expected =
@@ -288,7 +322,7 @@ TEST_F(UnsafeRowSerializerTest, incompleteRow) {
       "(1 vs. 1) Reading past end of BufferInputStream");
 }
 
-TEST_F(UnsafeRowSerializerTest, types) {
+TEST_P(UnsafeRowSerializerTest, types) {
   auto rowType = ROW(
       {BOOLEAN(),
        TINYINT(),
@@ -330,7 +364,7 @@ TEST_F(UnsafeRowSerializerTest, types) {
   testRoundTrip(data);
 }
 
-TEST_F(UnsafeRowSerializerTest, date) {
+TEST_P(UnsafeRowSerializerTest, date) {
   auto rowVector = makeRowVector({
       makeFlatVector<int32_t>({0, 1}, DATE()),
   });
@@ -338,7 +372,7 @@ TEST_F(UnsafeRowSerializerTest, date) {
   testRoundTrip(rowVector);
 }
 
-TEST_F(UnsafeRowSerializerTest, unknown) {
+TEST_P(UnsafeRowSerializerTest, unknown) {
   // UNKNOWN type.
   auto rowVector = makeRowVector({
       BaseVector::createNullConstant(UNKNOWN(), 10, pool()),
@@ -374,7 +408,7 @@ TEST_F(UnsafeRowSerializerTest, unknown) {
   });
 }
 
-TEST_F(UnsafeRowSerializerTest, decimalVector) {
+TEST_P(UnsafeRowSerializerTest, decimalVector) {
   auto rowVectorDecimal = makeRowVector({makeFlatVector<int128_t>(
       {
           0,
@@ -397,3 +431,8 @@ TEST_F(UnsafeRowSerializerTest, decimalVector) {
 
   testRoundTrip(rowVectorArray);
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    UnsafeRowSerializerTest,
+    UnsafeRowSerializerTest,
+    testing::Values(false, true));

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -109,7 +109,8 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
     const std::string& queryId,
     const std::string& taskId,
     const std::string& nodeId,
-    const int32_t pipelineId,
+    int32_t pipelineId,
+    VectorSerde::Kind serdeKind,
     const std::string& operatorType,
     const ConsumerCallBack& consumerCb)
     : OperatorReplayerBase(
@@ -125,6 +126,7 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
               [this](const core::PlanNode* node) {
                 return node->id() == nodeId_;
               }))),
+      serdeKind_(serdeKind),
       consumerCb_(consumerCb) {
   VELOX_CHECK_NOT_NULL(originalNode_);
   consumerExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
@@ -165,6 +167,7 @@ core::PlanNodePtr PartitionedOutputReplayer::createPlanNode(
       originalNode->isReplicateNullsAndAny(),
       originalNode->partitionFunctionSpecPtr(),
       originalNode->outputType(),
+      serdeKind_,
       source);
 }
 

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -45,7 +45,8 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       const std::string& queryId,
       const std::string& taskId,
       const std::string& nodeId,
-      const int32_t pipelineId,
+      int32_t pipelineId,
+      VectorSerde::Kind serdeKind,
       const std::string& operatorType,
       const ConsumerCallBack& consumerCb = [](auto partition, auto page) {});
 
@@ -58,6 +59,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       const core::PlanNodePtr& source) const override;
 
   const core::PartitionedOutputNode* const originalNode_;
+  const VectorSerde::Kind serdeKind_;
   const std::shared_ptr<exec::OutputBufferManager> bufferManager_{
       exec::OutputBufferManager::getInstance().lock()};
   const std::unique_ptr<folly::Executor> executor_{

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -30,6 +30,7 @@ DECLARE_int32(pipeline_id);
 DECLARE_string(operator_type);
 DECLARE_string(table_writer_output_dir);
 DECLARE_double(hiveConnectorExecutorHwMultiplier);
+DECLARE_int32(shuffle_serialization_format);
 
 namespace facebook::velox::tool::trace {
 

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -34,6 +34,7 @@ velox_link_libraries(
   velox_vector
   velox_encode
   velox_memory
+  velox_row_fast
   velox_time
   velox_type
   velox_buffer)

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -51,14 +51,14 @@ void DecodedVector::decode(
   reset(end(vector.size(), rows));
   partialRowsDecoded_ = rows != nullptr;
   loadLazy_ = loadLazy;
-  bool isTopLevelLazyAndLoaded =
+  const bool isTopLevelLazyAndLoaded =
       vector.isLazy() && vector.asUnchecked<LazyVector>()->isLoaded();
   if (isTopLevelLazyAndLoaded || (loadLazy_ && isLazyNotLoaded(vector))) {
     decode(*vector.loadedVector(), rows, loadLazy);
     return;
   }
 
-  auto encoding = vector.encoding();
+  const auto encoding = vector.encoding();
   switch (encoding) {
     case VectorEncoding::Simple::FLAT:
     case VectorEncoding::Simple::BIASED:

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "velox/vector/VectorStream.h"
+
 #include <memory>
-#include "velox/common/base/RawVector.h"
 
 namespace facebook::velox {
 namespace {
@@ -66,11 +66,11 @@ std::unique_ptr<VectorSerde>& getVectorSerdeImpl() {
   return serde;
 }
 
-std::unordered_map<std::string, std::unique_ptr<VectorSerde>>&
+std::unordered_map<VectorSerde::Kind, std::unique_ptr<VectorSerde>>&
 getNamedVectorSerdeImpl() {
-  static std::unordered_map<std::string, std::unique_ptr<VectorSerde>>
-      namedSerde;
-  return namedSerde;
+  static std::unordered_map<VectorSerde::Kind, std::unique_ptr<VectorSerde>>
+      namedSerdes;
+  return namedSerdes;
 }
 
 } // namespace
@@ -92,6 +92,35 @@ std::unique_ptr<BatchVectorSerializer> VectorSerde::createBatchSerializer(
     memory::MemoryPool* pool,
     const Options* options) {
   return std::make_unique<DefaultBatchVectorSerializer>(pool, this, options);
+}
+
+std::string VectorSerde::kindName(Kind kind) {
+  switch (kind) {
+    case Kind::kPresto:
+      return "Presto";
+    case Kind::kCompactRow:
+      return "CompactRow";
+    case Kind::kUnsafeRow:
+      return "UnsafeRow";
+  }
+  VELOX_UNREACHABLE(
+      fmt::format("Unknown vector serde kind: {}", static_cast<int32_t>(kind)));
+}
+
+VectorSerde::Kind VectorSerde::kindByName(const std::string& kindName) {
+  static const std::unordered_map<std::string, Kind> kNameToKind = {
+      {"Presto", Kind::kPresto},
+      {"CompactRow", Kind::kCompactRow},
+      {"UnsafeRow", Kind::kUnsafeRow}};
+  const auto it = kNameToKind.find(kindName);
+  VELOX_CHECK(
+      it != kNameToKind.end(), "Unknown vector serde kind: {}", kindName);
+  return it->second;
+}
+
+std::ostream& operator<<(std::ostream& out, VectorSerde::Kind kind) {
+  out << VectorSerde::kindName(kind);
+  return out;
 }
 
 VectorSerde* getVectorSerde() {
@@ -118,33 +147,33 @@ bool isRegisteredVectorSerde() {
 
 /// Named serde helper functions.
 void registerNamedVectorSerde(
-    std::string_view serdeName,
+    VectorSerde::Kind kind,
     std::unique_ptr<VectorSerde> serdeToRegister) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   VELOX_CHECK(
-      namedSerdeMap.find(std::string(serdeName)) == namedSerdeMap.end(),
+      namedSerdeMap.find(kind) == namedSerdeMap.end(),
       "Vector serde '{}' is already registered.",
-      serdeName);
-  namedSerdeMap[std::string(serdeName)] = std::move(serdeToRegister);
+      kind);
+  namedSerdeMap[kind] = std::move(serdeToRegister);
 }
 
-void deregisterNamedVectorSerde(std::string_view serdeName) {
+void deregisterNamedVectorSerde(VectorSerde::Kind kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  namedSerdeMap.erase(std::string(serdeName));
+  namedSerdeMap.erase(kind);
 }
 
-bool isRegisteredNamedVectorSerde(std::string_view serdeName) {
+bool isRegisteredNamedVectorSerde(VectorSerde::Kind kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  return namedSerdeMap.find(std::string(serdeName)) != namedSerdeMap.end();
+  return namedSerdeMap.find(kind) != namedSerdeMap.end();
 }
 
-VectorSerde* getNamedVectorSerde(std::string_view serdeName) {
+VectorSerde* getNamedVectorSerde(VectorSerde::Kind kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  auto it = namedSerdeMap.find(std::string(serdeName));
+  auto it = namedSerdeMap.find(kind);
   VELOX_CHECK(
       it != namedSerdeMap.end(),
       "Named vector serde '{}' is not registered.",
-      serdeName);
+      kind);
   return it->second.get();
 }
 
@@ -173,6 +202,20 @@ void VectorStreamGroup::append(const RowVectorPtr& vector) {
   serializer_->append(vector);
 }
 
+void VectorStreamGroup::append(
+    const row::CompactRow& compactRow,
+    const folly::Range<const vector_size_t*>& rows,
+    const std::vector<vector_size_t>& sizes) {
+  serializer_->append(compactRow, rows, sizes);
+}
+
+void VectorStreamGroup::append(
+    const row::UnsafeRowFast& unsafeRow,
+    const folly::Range<const vector_size_t*>& rows,
+    const std::vector<vector_size_t>& sizes) {
+  serializer_->append(unsafeRow, rows, sizes);
+}
+
 void VectorStreamGroup::flush(OutputStream* out) {
   serializer_->flush(out);
 }
@@ -181,18 +224,54 @@ void VectorStreamGroup::flush(OutputStream* out) {
 void VectorStreamGroup::estimateSerializedSize(
     const BaseVector* vector,
     const folly::Range<const IndexRange*>& ranges,
+    VectorSerde* serde,
     vector_size_t** sizes,
     Scratch& scratch) {
-  getVectorSerde()->estimateSerializedSize(vector, ranges, sizes, scratch);
+  if (serde == nullptr) {
+    getVectorSerde()->estimateSerializedSize(vector, ranges, sizes, scratch);
+  } else {
+    serde->estimateSerializedSize(vector, ranges, sizes, scratch);
+  }
 }
 
 // static
 void VectorStreamGroup::estimateSerializedSize(
     const BaseVector* vector,
-    folly::Range<const vector_size_t*> rows,
+    const folly::Range<const vector_size_t*>& rows,
+    VectorSerde* serde,
     vector_size_t** sizes,
     Scratch& scratch) {
-  getVectorSerde()->estimateSerializedSize(vector, rows, sizes, scratch);
+  if (serde == nullptr) {
+    getVectorSerde()->estimateSerializedSize(vector, rows, sizes, scratch);
+  } else {
+    serde->estimateSerializedSize(vector, rows, sizes, scratch);
+  }
+}
+
+// static
+void VectorStreamGroup::estimateSerializedSize(
+    const row::CompactRow* compactRow,
+    const folly::Range<const vector_size_t*>& rows,
+    VectorSerde* serde,
+    vector_size_t** sizes) {
+  if (serde == nullptr) {
+    getVectorSerde()->estimateSerializedSize(compactRow, rows, sizes);
+  } else {
+    serde->estimateSerializedSize(compactRow, rows, sizes);
+  }
+}
+
+// static
+void VectorStreamGroup::estimateSerializedSize(
+    const row::UnsafeRowFast* unsafeRow,
+    const folly::Range<const vector_size_t*>& rows,
+    VectorSerde* serde,
+    vector_size_t** sizes) {
+  if (serde == nullptr) {
+    getVectorSerde()->estimateSerializedSize(unsafeRow, rows, sizes);
+  } else {
+    serde->estimateSerializedSize(unsafeRow, rows, sizes);
+  }
 }
 
 // static
@@ -200,9 +279,14 @@ void VectorStreamGroup::read(
     ByteInputStream* source,
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
+    VectorSerde* serde,
     RowVectorPtr* result,
     const VectorSerde::Options* options) {
-  getVectorSerde()->deserialize(source, pool, type, result, options);
+  if (serde == nullptr) {
+    getVectorSerde()->deserialize(source, pool, type, result, options);
+  } else {
+    serde->deserialize(source, pool, type, result, options);
+  }
 }
 
 folly::IOBuf rowVectorToIOBuf(

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -818,10 +818,10 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto sourceRow = makeRowVector({"c"}, {source});
     auto sourceRowType = asRowType(sourceRow->type());
 
-    VectorStreamGroup even(pool());
+    VectorStreamGroup even(pool(), nullptr);
     even.createStreamTree(sourceRowType, source->size() / 4);
 
-    VectorStreamGroup odd(pool());
+    VectorStreamGroup odd(pool(), nullptr);
     odd.createStreamTree(sourceRowType, source->size() / 3);
 
     std::vector<IndexRange> evenIndices;
@@ -847,9 +847,9 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     }
 
     VectorStreamGroup::estimateSerializedSize(
-        source.get(), evenIndices, evenSizePointers.data());
+        source.get(), evenIndices, nullptr, evenSizePointers.data());
     VectorStreamGroup::estimateSerializedSize(
-        source.get(), oddIndices, oddSizePointers.data());
+        source.get(), oddIndices, nullptr, oddSizePointers.data());
     even.append(
         sourceRow, folly::Range(evenIndices.data(), evenIndices.size() / 2));
     even.append(
@@ -878,7 +878,8 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto evenInput = prepareInput(evenString);
 
     RowVectorPtr resultRow;
-    VectorStreamGroup::read(evenInput.get(), pool(), sourceRowType, &resultRow);
+    VectorStreamGroup::read(
+        evenInput.get(), pool(), sourceRowType, nullptr, &resultRow);
     VectorPtr result = resultRow->childAt(0);
     switch (source->encoding()) {
       case VectorEncoding::Simple::FLAT:
@@ -907,7 +908,8 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto oddString = oddStream.str();
     auto oddInput = prepareInput(oddString);
 
-    VectorStreamGroup::read(oddInput.get(), pool(), sourceRowType, &resultRow);
+    VectorStreamGroup::read(
+        oddInput.get(), pool(), sourceRowType, nullptr, &resultRow);
     result = resultRow->childAt(0);
     for (int32_t i = 0; i < oddIndices.size(); ++i) {
       EXPECT_TRUE(result->equalValueAt(source.get(), i, oddIndices[i].begin))

--- a/velox/vector/tests/utils/CMakeLists.txt
+++ b/velox/vector/tests/utils/CMakeLists.txt
@@ -14,4 +14,8 @@
 add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
 target_link_libraries(
-  velox_vector_test_lib velox_vector GTest::gtest GTest::gtest_main)
+  velox_vector_test_lib
+  velox_row_fast
+  velox_vector
+  GTest::gtest
+  GTest::gtest_main)


### PR DESCRIPTION
Summary:
Add to support row wise shuffle to optimize both cpu and memory efficiency in workload with very large
number of shuffle columns. This PR includes:
(1) make the vector serde format configurable through plan node: producer side: partition output
consumer side: exchange and merge exchange
(2) all the three shuffle operators support to get the vector serde for serialization/deserialization based
on the one specified in the corresponding query plan node. A separate change from Presto
coordinator will set the format based on the number of column streams in shuffle data type plus
a per-query session property to enable/disable
(3) add two set of APIs in VectorSerde and the corresponding serializer to support estimate and serialize the
vectors in two different row formats: compact row and unsafe row. The construction of the two row formats are
cpu intensive and we shall construct them once per one partition output batch processing. Also the two row formats
serialized size estimations are accurate which is unlike the columnar size estimation which is approximate and the
actual memory allocations happens progressively during the serialization process through a memory arena.
The row wise serialization allocates memory once before the actual serialization. Given that, we optimize that by directly
leveraging the estimated serialized size for
serialization buffer allocation. So we construct row wise vector once, estimate serialized size once.
(4) changes exchange to optimize the row deserializer which don't support append deserialization (as for now) by
merging the iobufs from multiple serialized pages and deserialize all together and we expect row deserializer can consume
all the serialized vectors given its serialization format
(5) Fix the bug in compact row and unsafe row's deserialization code path as the vector extends, the pointers (string view) to the existing
buffers are invalid. The current processing is very inefficient and optimize the process with unique_ptr to the string buffer and
avoid unnecessary data copy.
(6) Add an operator runtime stats to indicate if the serialization format used for shuffle to help performance debugging
(7) Fix a couple of issues in operator trace replay like fix partition output close to call base operator
close to write the summary trace file
( some code, test refactor and cleanup in relevant code path.
With partition output replay with trace collected from production, we have seen the peak memory usage
has been reduced by 10x and replay execution time reduced by half.

A couple of followup optimizations:
(1) support compression for unsafe row and compact row on flush
if needs
(2) support columnar wise row size estimations which might have 2x improvement on estimation time based on
a draft implementation
(3) support row wise deserialize append to avoid potential small vectors at consumer side.

Differential Revision: D65258176
