### PR TITLE
Fix IPADDRESS error message

### DIFF
--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -57,7 +57,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       castFromVarbinary(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
-          "Cast from {} to IPAddress not supported", resultType->toString());
+          "Cast from {} to IPAddress not supported", input.type()->toString());
     }
   }
 


### PR DESCRIPTION
We should be returning the input type not the result type, which is IPADDRESS

Split from:
https://github.com/facebookincubator/velox/pull/11309