### PR TITLE
Change IPPREFIX type to row type in typeof

### DIFF
--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -79,8 +79,6 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARBINARY:
       if (isHyperLogLogType(type)) {
         return "HyperLogLog";
-      } else if (isIPPrefixType(type)) {
-        return "ipprefix";
       }
       return "varbinary";
     case TypeKind::TIMESTAMP:
@@ -93,6 +91,9 @@ std::string typeName(const TypePtr& type) {
           typeName(type->childAt(0)),
           typeName(type->childAt(1)));
     case TypeKind::ROW: {
+      if (isIPPrefixType(type)) {
+        return "ipprefix";
+      }
       const auto& rowType = type->asRow();
       std::ostringstream out;
       out << "row(";


### PR DESCRIPTION
When switching from varbinary based to row based ipprefix the typeof was not changed. Changed here to fix the issue. 

Split from:
https://github.com/facebookincubator/velox/pull/11309