### PR TITLE
Support decimal type for Spark unaryminus function

### DIFF
--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -115,17 +115,17 @@ Returns NULL when the actual result cannot be represented with the calculated de
 Decimal Functions
 -----------------
 
-.. spark:function:: unscaled_value(x) -> bigint
-
-    Return the unscaled bigint value of a short decimal ``x``.
-    Supported type is: SHORT_DECIMAL.
-
 .. spark:function:: unaryminus(x: decimal(p, s)) -> r: decimal(p, s)
 
     Returns negated value of x (r = -x). Corresponds to Spark's operator ``-``.
 
     ::
         SELECT unaryminus(cast(-9999999999999999999.9999999999999999999 as DECIMAL(38, 19))); -- 9999999999999999999.9999999999999999999
+
+.. spark:function:: unscaled_value(x) -> bigint
+
+    Return the unscaled bigint value of a short decimal ``x``.
+    Supported type is: SHORT_DECIMAL.
 
 Decimal Special Forms
 ---------------------

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -124,6 +124,9 @@ Decimal Functions
 
     Returns negated value of x (r = -x). Corresponds to Spark's operator ``-``.
 
+    ::
+        SELECT unaryminus(cast(-9999999999999999999.9999999999999999999 as DECIMAL(38, 19))); -- 9999999999999999999.9999999999999999999
+
 Decimal Special Forms
 ---------------------
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -120,6 +120,10 @@ Decimal Functions
     Return the unscaled bigint value of a short decimal ``x``.
     Supported type is: SHORT_DECIMAL.
 
+.. spark:function:: unaryminus(x: decimal(p, s)) -> r: decimal(p, s)
+
+    Returns negated value of x (r = -x). Corresponds to Spark's operator ``-``.
+
 Decimal Special Forms
 ---------------------
 

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -38,6 +38,14 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<DivideFunction, double, double, double>({prefix + "divide"});
   registerBinaryNumeric<RemainderFunction>({prefix + "remainder"});
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});
+  registerFunction<
+      UnaryMinusFunction,
+      LongDecimal<P1, S1>,
+      LongDecimal<P1, S1>>({prefix + "unaryminus"});
+  registerFunction<
+      UnaryMinusFunction,
+      ShortDecimal<P1, S1>,
+      ShortDecimal<P1, S1>>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});
   registerFunction<

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -51,16 +51,6 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
     assertEqualVectors(expected, evaluate(expr, makeRowVector(inputs)));
   }
 
-  template <TypeKind KIND>
-  void testDecimalUnaryminusFunction(
-      const VectorPtr& expected,
-      const std::vector<VectorPtr>& input) {
-    using EvalType = typename velox::TypeTraits<KIND>::NativeType;
-    auto result = evaluate<SimpleVector<EvalType>>(
-        "unaryminus(c0)", makeRowVector(input));
-    assertEqualVectors(expected, result);
-  }
-
   VectorPtr makeNullableLongDecimalVector(
       const std::vector<std::string>& values,
       const TypePtr& type) {


### PR DESCRIPTION
Add support for decimal type to Spark unaryminus function.