### PR TITLE
Fix shadowed variable in velox/exec/LocalPlanner.cpp

### DIFF
--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1396,11 +1396,11 @@ struct LevenshteinDistanceFunction {
       distances.push_back(INT32_MAX);
     }
 
-    for (auto i = 0; i < leftCodePointsSize; i++) {
-      auto lower = std::max<int32_t>(0, i - threshold);
+    for (auto i_2 = 0; i_2 < leftCodePointsSize; i_2++) {
+      auto lower = std::max<int32_t>(0, i_2 - threshold);
       int32_t maxValueWithThreshold;
       int32_t upper = rightCodePointsSize;
-      if (!__builtin_add_overflow(i + 1, threshold, &maxValueWithThreshold)) {
+      if (!__builtin_add_overflow(i_2 + 1, threshold, &maxValueWithThreshold)) {
         upper = std::min<int32_t>(rightCodePointsSize, maxValueWithThreshold);
       }
       if (lower > upper) {
@@ -1410,10 +1410,10 @@ struct LevenshteinDistanceFunction {
       int32_t leftUpDistance;
       if (lower == 0) {
         leftUpDistance = distances[lower];
-        if (leftCodePoints[i] == rightCodePoints[0]) {
-          distances[0] = i;
+        if (leftCodePoints[i_2] == rightCodePoints[0]) {
+          distances[0] = i_2;
         } else {
-          distances[0] = std::min(i, distances[0]) + 1;
+          distances[0] = std::min(i_2, distances[0]) + 1;
         }
         lower = 1;
       } else {
@@ -1423,7 +1423,7 @@ struct LevenshteinDistanceFunction {
       }
       for (int j = lower; j < upper; j++) {
         auto leftUpDistanceNext = distances[j];
-        if (leftCodePoints[i] == rightCodePoints[j]) {
+        if (leftCodePoints[i_2] == rightCodePoints[j]) {
           distances[j] = leftUpDistance;
         } else {
           distances[j] =

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -3387,13 +3387,14 @@ void estimateSerializedSizeInt(
       ScratchPtr<uint64_t, 1> nullsHolder(scratch);
       auto* innerRows = rows.data();
       auto* innerSizes = sizes;
-      const auto numRows = rows.size();
-      int32_t numInner = numRows;
+      const auto numRows_2 = rows.size();
+      int32_t numInner = numRows_2;
       if (vector->mayHaveNulls()) {
-        auto nulls = nullsHolder.get(bits::nwords(numRows));
+        auto nulls = nullsHolder.get(bits::nwords(numRows_2));
         simd::gatherBits(vector->rawNulls(), rows, nulls);
-        auto mutableInnerRows = innerRowsHolder.get(numRows);
-        numInner = simd::indicesOfSetBits(nulls, 0, numRows, mutableInnerRows);
+        auto mutableInnerRows = innerRowsHolder.get(numRows_2);
+        numInner =
+            simd::indicesOfSetBits(nulls, 0, numRows_2, mutableInnerRows);
         innerSizes = innerSizesHolder.get(numInner);
         for (auto i = 0; i < numInner; ++i) {
           innerSizes[i] = sizes[mutableInnerRows[i]];


### PR DESCRIPTION
Summary:
Our upcoming compiler upgrade will require us not to have shadowed variables. Such variables have a _high_ bug rate and reduce readability, so we would like to avoid them even if the compiler was not forcing us to do so.

This codemod attempts to fix an instance of a shadowed variable. Please review with care: if it's failed the result will be a silent bug.

**What's a shadowed variable?**

Shadowed variables are variables in an inner scope with the same name as another variable in an outer scope. Having the same name for both variables might be semantically correct, but it can make the code confusing to read! It can also hide subtle bugs.

This diff fixes such an issue by renaming the variable.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65347920


