### PR TITLE
Rename tableStorageFormat in HiveInsertTableHandle

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -201,8 +201,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
   HiveInsertTableHandle(
       std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
       std::shared_ptr<const LocationHandle> locationHandle,
-      dwio::common::FileFormat tableStorageFormat =
-          dwio::common::FileFormat::DWRF,
+      dwio::common::FileFormat storageFormat = dwio::common::FileFormat::DWRF,
       std::shared_ptr<const HiveBucketProperty> bucketProperty = nullptr,
       std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
@@ -210,7 +209,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
           nullptr)
       : inputColumns_(std::move(inputColumns)),
         locationHandle_(std::move(locationHandle)),
-        tableStorageFormat_(tableStorageFormat),
+        storageFormat_(storageFormat),
         bucketProperty_(std::move(bucketProperty)),
         compressionKind_(compressionKind),
         serdeParameters_(serdeParameters),
@@ -237,8 +236,8 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
     return compressionKind_;
   }
 
-  dwio::common::FileFormat tableStorageFormat() const {
-    return tableStorageFormat_;
+  dwio::common::FileFormat storageFormat() const {
+    return storageFormat_;
   }
 
   const std::unordered_map<std::string, std::string>& serdeParameters() const {
@@ -272,7 +271,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
  private:
   const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
   const std::shared_ptr<const LocationHandle> locationHandle_;
-  const dwio::common::FileFormat tableStorageFormat_;
+  const dwio::common::FileFormat storageFormat_;
   const std::shared_ptr<const HiveBucketProperty> bucketProperty_;
   const std::optional<common::CompressionKind> compressionKind_;
   const std::unordered_map<std::string, std::string> serdeParameters_;

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -38,7 +38,7 @@ makeHiveInsertTableHandle(
   const auto inputColumns = tracedHandle->inputColumns();
   const auto compressionKind =
       tracedHandle->compressionKind().value_or(common::CompressionKind_NONE);
-  const auto storageFormat = tracedHandle->tableStorageFormat();
+  const auto storageFormat = tracedHandle->storageFormat();
   const auto serdeParameters = tracedHandle->serdeParameters();
   const auto writerOptions = tracedHandle->writerOptions();
   return std::make_shared<connector::hive::HiveInsertTableHandle>(


### PR DESCRIPTION
Each partition can have its own storage format, the format info in 
HiveInsertTableHandle is not necessarily table format