### PR TITLE
refactor: Add new callback to log plan fragment from TaskListener

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2309,7 +2309,8 @@ void Task::onTaskCompletion() {
     }
 
     for (auto& listener : listeners) {
-      listener->onTaskCompletion(uuid_, taskId_, state, exception, stats);
+      listener->onTaskCompletion(
+          uuid_, taskId_, state, exception, stats, planFragment_);
     }
   });
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1196,6 +1196,17 @@ class TaskListener {
       TaskState state,
       std::exception_ptr error,
       TaskStats stats) = 0;
+
+  // onTaskCompletion() overload for the case when we pass PlanFragment
+  virtual void onTaskCompletion(
+      const std::string& taskUuid,
+      const std::string& taskId,
+      TaskState state,
+      std::exception_ptr error,
+      const TaskStats& stats,
+      const core::PlanFragment& /*fragment*/) {
+    onTaskCompletion(taskUuid, taskId, state, error, stats);
+  }
 };
 
 /// Register a listener to be invoked on task completion. Returns true if


### PR DESCRIPTION
Summary: We would like to use TaskListener framework to log the planfragmant along with task stats and other details. To accomplish that, we need an override of TaskListner::onTaskCompletion() which takes planFragment.

Differential Revision: D65468501


