### PR TITLE
Add option to disable flatenning optimization in PrestoSerializer

### DIFF
--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -50,10 +50,12 @@ class PrestoVectorSerde : public VectorSerde {
     PrestoOptions(
         bool _useLosslessTimestamp,
         common::CompressionKind _compressionKind,
-        bool _nullsFirst = false)
+        bool _nullsFirst = false,
+        bool _preserveEncodings = false)
         : VectorSerde::Options(_compressionKind),
           useLosslessTimestamp(_useLosslessTimestamp),
-          nullsFirst(_nullsFirst) {}
+          nullsFirst(_nullsFirst),
+          preserveEncodings(_preserveEncodings) {}
 
     /// Currently presto only supports millisecond precision and the serializer
     /// converts velox native timestamp to that resulting in loss of precision.
@@ -72,6 +74,11 @@ class PrestoVectorSerde : public VectorSerde {
     /// than this causes subsequent compression attempts to be skipped. The more
     /// times compression misses the target the less frequently it is tried.
     float minCompressionRatio{0.8};
+
+    /// If true, the serializer will not employ any optimizations that can
+    /// affect the encoding of the input vectors. This is only relevant when
+    /// using BatchVectorSerializer.
+    bool preserveEncodings{false};
   };
 
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to


### PR DESCRIPTION
Summary:
This change introduces an option, "preserveEncoding" to the SerDe
Options, to disable the flattening optimization in the
PrestoBatchVectorSerializer, enabling support for use-cases
where encodings need to be preserved between the serialization
and deserialization steps.

Note:
There are still 2 cases where encodings can be lost:
1. Nulls in dictionary layer: Presto page format does not support having
nulls so this gets flattened
2. If there are multiple levels of dictionary or a constant underneath:
Currently, the presto serializer only preserves the top most layer and
flattens everything underneath it.

Differential Revision: D65569946


