### PR TITLE
feat: Add Spark CAST(timestamp as integral)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -99,6 +99,23 @@ Valid examples
   SELECT cast(cast(2147483648.90 as DECIMAL(12, 2)) as integer); -- -2147483648
   SELECT cast(cast(2147483648.90 as DECIMAL(12, 2)) as bigint); -- 2147483648
 
+From timestamp
+^^^^^^^^^^^^^
+
+Casting a timestamp to an integer returns the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+
+Valid examples
+
+::
+
+  SELECT cast(cast('1970-01-01 00:00:00' as timestamp) as bigint); -- 0
+  SELECT cast(cast('2000-01-01 12:21:56' as timestamp) as bigint); -- 946684916
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as bigint); -- 1740470426
+  SELECT cast(cast('2025-02-25 08:00:27.88' as timestamp) as bigint); -- 1740470427
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as int); -- 1740470426
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as short); -- 30874
+  SELECT cast(cast(NULL as timestamp) as bigint); -- NULL
+
 Cast to Boolean
 ---------------
 

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -109,11 +109,13 @@ Valid examples
 ::
 
   SELECT cast(cast('1970-01-01 00:00:00' as timestamp) as bigint); -- 0
+  SELECT cast(cast('1970-01-01 00:00:00' as timestamp) as smallint); -- 0
+  SELECT cast(cast('1970-01-01 00:00:00' as timestamp) as tinyint); -- 0
   SELECT cast(cast('2000-01-01 12:21:56' as timestamp) as bigint); -- 946684916
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as bigint); -- 1740470426
-  SELECT cast(cast('2025-02-25 08:00:27.88' as timestamp) as bigint); -- 1740470427
-  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as int); -- 1740470426
-  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as short); -- 30874
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as integer); -- 1740470426
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as smallint); -- 30874
+  SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as tinyint); -- -102
   SELECT cast(cast(NULL as timestamp) as bigint); -- NULL
 
 Cast to Boolean

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -102,7 +102,7 @@ Valid examples
 From timestamp
 ^^^^^^^^^^^^^
 
-Casting a timestamp from microseconds to seconds by dividing by the number of microseconds in a second and rounding down to the nearest second since the epoch (1970-01-01 00:00:00 UTC).
+Casting timestamp as integral types returns the number of seconds by converting timestamp as microseconds, dividing by the number of microseconds in a second, and then rounding down to the nearest second since the epoch (1970-01-01 00:00:00 UTC).
 
 Valid examples
 
@@ -116,7 +116,6 @@ Valid examples
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as integer); -- 1740470426
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as smallint); -- 30874
   SELECT cast(cast('2025-02-25 08:00:26.88' as timestamp) as tinyint); -- -102
-  SELECT cast(cast(NULL as timestamp) as bigint); -- NULL
 
 Cast to Boolean
 ---------------

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -102,7 +102,7 @@ Valid examples
 From timestamp
 ^^^^^^^^^^^^^
 
-Casting a timestamp to an integer returns the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+Casting a timestamp from microseconds to seconds by dividing by the number of microseconds in a second and rounding down to the nearest second since the epoch (1970-01-01 00:00:00 UTC).
 
 Valid examples
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -289,7 +289,6 @@ void CastExpr::applyCastKernel(
         (ToKind == TypeKind::TINYINT || ToKind == TypeKind::SMALLINT ||
          ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
         FromKind == TypeKind::TIMESTAMP) {
-      using To = typename TypeTraits<ToKind>::NativeType;
       const auto castResult = hooks_->castTimestampToInt(inputRowValue);
       setResultOrError(castResult, row);
       return;

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -291,11 +291,7 @@ void CastExpr::applyCastKernel(
         FromKind == TypeKind::TIMESTAMP) {
       using To = typename TypeTraits<ToKind>::NativeType;
       const auto castResult = hooks_->castTimestampToInt(inputRowValue);
-      if (castResult.hasError()) {
-        setError(castResult.error().message());
-      } else {
-        result->set(row, static_cast<To>(castResult.value()));
-      }
+      setResultOrError(castResult, row);
       return;
     }
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -286,6 +286,20 @@ void CastExpr::applyCastKernel(
     }
 
     if constexpr (
+        (ToKind == TypeKind::TINYINT || ToKind == TypeKind::SMALLINT ||
+         ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT) &&
+        FromKind == TypeKind::TIMESTAMP) {
+      using To = typename TypeTraits<ToKind>::NativeType;
+      const auto castResult = hooks_->castTimestampToInt(inputRowValue);
+      if (castResult.hasError()) {
+        setError(castResult.error().message());
+      } else {
+        result->set(row, static_cast<To>(castResult.value()));
+      }
+      return;
+    }
+
+    if constexpr (
         (FromKind == TypeKind::DOUBLE || FromKind == TypeKind::REAL) &&
         ToKind == TypeKind::TIMESTAMP) {
       const auto castResult =

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -37,6 +37,8 @@ class CastHooks {
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
+  virtual Expected<int64_t> castTimestampToInt(Timestamp timestamp) const = 0;
+
   virtual Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const = 0;
 

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -56,19 +56,19 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
 Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(
     int64_t /*seconds*/) const {
   return folly::makeUnexpected(
-      Status::UserError("Conversion to Timestamp is not supported"));
+      Status::UserError("Conversion from Int to Timestamp is not supported"));
 }
 
 Expected<int64_t> PrestoCastHooks::castTimestampToInt(
     Timestamp /*timestamp*/) const {
   return folly::makeUnexpected(
-      Status::UserError("Conversion from Timestamp is not supported"));
+      Status::UserError("Conversion from Timestamp to Int is not supported"));
 }
 
 Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(
     double seconds) const {
-  return folly::makeUnexpected(
-      Status::UserError("Conversion to Timestamp is not supported"));
+  return folly::makeUnexpected(Status::UserError(
+      "Conversion from Double to Timestamp is not supported"));
 }
 
 Expected<int32_t> PrestoCastHooks::castStringToDate(

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -53,9 +53,16 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
       conversionResult.value(), options_.timeZone);
 }
 
-Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t seconds) const {
+Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(
+    int64_t /*seconds*/) const {
   return folly::makeUnexpected(
       Status::UserError("Conversion to Timestamp is not supported"));
+}
+
+Expected<int64_t> PrestoCastHooks::castTimestampToInt(
+    Timestamp /*timestamp*/) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion from Timestamp is not supported"));
 }
 
 Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -56,7 +56,7 @@ Expected<Timestamp> PrestoCastHooks::castStringToTimestamp(
 Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(
     int64_t /*seconds*/) const {
   return folly::makeUnexpected(
-      Status::UserError("Conversion from Int to Timestamp is not supported"));
+      Status::UserError("Conversion to Timestamp is not supported"));
 }
 
 Expected<int64_t> PrestoCastHooks::castTimestampToInt(
@@ -67,8 +67,8 @@ Expected<int64_t> PrestoCastHooks::castTimestampToInt(
 
 Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(
     double /*seconds*/) const {
-  return folly::makeUnexpected(Status::UserError(
-      "Conversion from Double to Timestamp is not supported"));
+  return folly::makeUnexpected(
+      Status::UserError("Conversion to Timestamp is not supported"));
 }
 
 Expected<int32_t> PrestoCastHooks::castStringToDate(

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -66,7 +66,7 @@ Expected<int64_t> PrestoCastHooks::castTimestampToInt(
 }
 
 Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(
-    double seconds) const {
+    double /*seconds*/) const {
   return folly::makeUnexpected(Status::UserError(
       "Conversion from Double to Timestamp is not supported"));
 }

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -32,6 +32,8 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
+  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const override;
 

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -71,7 +71,7 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
 
 Expected<int64_t> SparkCastHooks::castTimestampToInt(
     Timestamp timestamp) const {
-  int64_t micros = timestamp.toMicros();
+  auto micros = timestamp.toMicros();
   if (micros < 0) {
     return std::floor(
         static_cast<double>(micros) / Timestamp::kMicrosecondsInSecond);

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -69,6 +69,12 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   return castNumberToTimestamp(seconds);
 }
 
+Expected<int64_t> SparkCastHooks::castTimestampToInt(
+    Timestamp timestamp) const {
+  return std::floor(
+      timestamp.toMicros() / (Timestamp::kMicrosecondsInSecond * 1.0));
+}
+
 Expected<std::optional<Timestamp>> SparkCastHooks::castDoubleToTimestamp(
     double value) const {
   if (FOLLY_UNLIKELY(std::isnan(value) || std::isinf(value))) {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -72,7 +72,8 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
 Expected<int64_t> SparkCastHooks::castTimestampToInt(
     Timestamp timestamp) const {
   return std::floor(
-      timestamp.toMicros() / (Timestamp::kMicrosecondsInSecond * 1.0));
+      static_cast<double>(timestamp.toMicros()) /
+      Timestamp::kMicrosecondsInSecond);
 }
 
 Expected<std::optional<Timestamp>> SparkCastHooks::castDoubleToTimestamp(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -71,9 +71,12 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
 
 Expected<int64_t> SparkCastHooks::castTimestampToInt(
     Timestamp timestamp) const {
-  return std::floor(
-      static_cast<double>(timestamp.toMicros()) /
-      Timestamp::kMicrosecondsInSecond);
+  int64_t micros = timestamp.toMicros();
+  if (micros < 0) {
+    return std::floor(
+        static_cast<double>(micros) / Timestamp::kMicrosecondsInSecond);
+  }
+  return micros / Timestamp::kMicrosecondsInSecond;
 }
 
 Expected<std::optional<Timestamp>> SparkCastHooks::castDoubleToTimestamp(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -34,6 +34,8 @@ class SparkCastHooks : public exec::CastHooks {
   /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
+  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+
   /// When casting double as timestamp, the input is treated as
   /// the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -131,6 +131,7 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
   void testTimestampToIntegralCastOverflow(std::vector<T> expected) {
     testCast(
         makeFlatVector<Timestamp>({
+            Timestamp(1740470426, 0),
             Timestamp(2147483647, 0),
             Timestamp(9223372036854, 775'807'000),
             Timestamp(-9223372036855, 224'192'000),
@@ -388,16 +389,19 @@ TEST_F(SparkCastExprTest, timestampToInt) {
 
   // Cast overflowed timestamp as tinyint/smallint/integer.
   testTimestampToIntegralCastOverflow<int8_t>({
+      -102,
       -1,
       -10,
       9,
   });
   testTimestampToIntegralCastOverflow<int16_t>({
+      30874,
       -1,
       23286,
       -23287,
   });
   testTimestampToIntegralCastOverflow<int32_t>({
+      1740470426,
       2147483647,
       2077252342,
       -2077252343,

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -117,14 +117,12 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             {Timestamp(0, 0),
              Timestamp(1, 0),
              Timestamp(std::numeric_limits<T>::max(), 0),
-             Timestamp(std::numeric_limits<T>::min(), 0),
-             std::nullopt}),
+             Timestamp(std::numeric_limits<T>::min(), 0)}),
         makeNullableFlatVector<T>({
             0,
             1,
             std::numeric_limits<T>::max(),
             std::numeric_limits<T>::min(),
-            std::nullopt,
         }));
   }
 
@@ -342,6 +340,17 @@ TEST_F(SparkCastExprTest, timestampToInt) {
   testCast(
       makeNullableFlatVector<Timestamp>({
           Timestamp(0, 0),
+          Timestamp(1, 0),
+          Timestamp(10, 0),
+          Timestamp(-1, 0),
+          Timestamp(-10, 0),
+          Timestamp(-1, 500000),
+          Timestamp(-2, 999999),
+          Timestamp(-10, 999999),
+          Timestamp(1, 999999),
+          Timestamp(-1, 1),
+          Timestamp(1234567, 500000),
+          Timestamp(-9876543, 1234),
           Timestamp(1727181032, 0),
           Timestamp(-1727181032, 0),
           Timestamp(9223372036854, 775'807'000),
@@ -349,6 +358,17 @@ TEST_F(SparkCastExprTest, timestampToInt) {
       }),
       makeNullableFlatVector<int64_t>({
           0,
+          1,
+          10,
+          -1,
+          -10,
+          -1,
+          -2,
+          -10,
+          1,
+          -1,
+          1234567,
+          -9876543,
           1727181032,
           -1727181032,
           9223372036854,

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -127,6 +127,16 @@ class SparkCastExprTest : public functions::test::CastBaseTest {
             std::nullopt,
         }));
   }
+
+  template <typename T>
+  void testTimestampToIntegralCastOverflow(
+      std::vector<std::optional<T>> expected) {
+    testCast(
+        makeNullableFlatVector<Timestamp>(
+            {Timestamp(9223372036854, 775'807'000),
+             Timestamp(-9223372036855, 224'192'000)}),
+        makeNullableFlatVector<T>(expected));
+  }
 };
 
 TEST_F(SparkCastExprTest, date) {
@@ -353,6 +363,11 @@ TEST_F(SparkCastExprTest, timestampToInt) {
   testTimestampToIntegralCast<int8_t>();
   testTimestampToIntegralCast<int16_t>();
   testTimestampToIntegralCast<int32_t>();
+
+  // Cast overflowed timestamp as tinyint/smallint/integer.
+  testTimestampToIntegralCastOverflow<int8_t>({-10, 9});
+  testTimestampToIntegralCastOverflow<int16_t>({23286, -23287});
+  testTimestampToIntegralCastOverflow<int32_t>({2077252342, -2077252343});
 }
 
 TEST_F(SparkCastExprTest, doubleToTimestamp) {


### PR DESCRIPTION
Add Spark CAST (timestamp as integral). Supported types are tinyint, smallint, integer and bigint.

Spark's implementation: https://github.com/apache/spark/blob/fd86f85e181fc2dc0f50a096855acf83a6cc5d9c/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L682