### PR TITLE
Fix MockSharedArbitrationTest.ensureMemoryPoolMaxCapacity

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -1384,7 +1384,6 @@ SharedArbitrator::GlobalArbitrationSection::GlobalArbitrationSection(
 SharedArbitrator::GlobalArbitrationSection::~GlobalArbitrationSection() {
   VELOX_CHECK(arbitrator_->globalArbitrationRunning_);
   arbitrator_->globalArbitrationRunning_ = false;
-  ;
 }
 
 std::string SharedArbitrator::kind() const {

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -2287,6 +2287,7 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
        memCapacity - memCapacity / 2,
        false,
        false}};
+
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     setupMemory(
@@ -2322,6 +2323,8 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     } else if (testData.hasOtherTask) {
       ASSERT_EQ(otherOp->reclaimer()->stats().numReclaims, 0);
     }
+    test::SharedArbitratorTestHelper arbitratorHelper(arbitrator_);
+    arbitratorHelper.waitForGlobalArbitrationToFinish();
     if (testData.expectedSuccess &&
         (((testData.allocatedBytes + testData.requestBytes) >
           testData.poolMaxCapacity) ||


### PR DESCRIPTION
global arbitration now runs in a separate thread. The stats updating is async to the main testing thread. So the check might be flaky in this test. Making sure global arbitration finishes before checking stats eliminates the flakiness.