### PR TITLE
feat: Add ipprefix cast operators for ipaddr [2/n]

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -30,7 +30,7 @@ are supported if the conversion of their element types are supported. In additio
 supported conversions to/from JSON are listed in :doc:`json`.
 
 .. list-table::
-   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
    :header-rows: 1
 
    * -
@@ -49,6 +49,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - interval day to second
      - decimal
      - ipaddress
+     - ipprefix
    * - tinyint
      - Y
      - Y
@@ -58,13 +59,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - smallint
      - Y
      - Y
@@ -74,13 +76,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - integer
      - Y
      - Y
@@ -90,13 +93,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - bigint
      - Y
      - Y
@@ -106,13 +110,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - boolean
      - Y
      - Y
@@ -122,13 +127,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - real
      - Y
      - Y
@@ -138,13 +144,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - double
      - Y
      - Y
@@ -154,13 +161,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
-     - 
+     -
+     -
    * - varchar
      - Y
      - Y
@@ -170,29 +178,31 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      - Y
      - Y
      - Y
      -
+     - Y
      - Y
      - Y
    * - varbinary
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
      -
-     - 
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
      - Y
+     -
    * - timestamp
      -
      -
@@ -202,13 +212,14 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      - Y
      - Y
      -
      -
-     - 
+     -
+     -
    * - timestamp with time zone
      -
      -
@@ -218,10 +229,11 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      -
      - Y
+     -
      -
      -
      -
@@ -234,9 +246,10 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
      - Y
      - Y
+     -
      -
      -
      -
@@ -250,7 +263,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     - 
+     -
+     -
      -
      -
      -
@@ -266,30 +280,48 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     - 
+     -
      -
      -
      -
      -
      - Y
+     -
      -
    * - ipaddress
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
-     - 
+     -
+     -
+     -
+     -
+     -
+     -
+     -
      - Y
      - Y
      -
      -
      -
      -
-     - 
-     - 
-
+     -
+     -
+     - Y
+   * - ipprefix
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     - Y
+     -
+     -
+     -
+     -
+     -
+     -
+     - Y
+     - Y
 Cast to Integral Types
 ----------------------
 
@@ -689,6 +721,33 @@ IPV4 mapped IPV6:
 
   SELECT cast(ipaddress '::ffff:ffff:ffff' as varchar); -- '255.255.255.255'
 
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Casting from IPPREFIX to VARCHAR returns a string formatted as *x.x.x.x/<prefix-length>* for IPv4 formatted IPv6 addresses.
+
+For all other IPv6 addresses it will be formatted in compressed alternate form IPv6 defined in `RFC 4291#section-2.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.2>`_
+followed by */<prefix-length>*. [`RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_]
+
+IPv4:
+
+::
+
+  SELECT cast(ipprefix '1.2.0.0/16' as varchar); -- '1.2.0.0/16'
+
+IPv6:
+
+::
+
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/128' as varchar); -- '2001:db8::ff00:42:8329/128'
+  SELECT cast(ipprefix '0:0:0:0:0:0:13.1.68.3/32' as varchar); -- '::/32'
+
+IPv4 mapped IPv6:
+
+::
+
+  SELECT cast(ipaddress '::ffff:ffff:0000/16' as varchar); -- '255.255.0.0/16'
+
 Cast to VARBINARY
 -----------------
 
@@ -1036,6 +1095,8 @@ Invalid example
 Cast to IPADDRESS
 -----------------
 
+.. _ipaddress-from-varchar:
+
 From VARCHAR
 ^^^^^^^^^^^^
 
@@ -1127,6 +1188,66 @@ Invalid examples:
 ::
 
   SELECT cast(from_hex('f000001100') as ipaddress); -- Invalid IP address binary length: 5
+
+From IPPREFIX
+^^^^^^^^^^^^^
+
+Returns the canonical(lowest) IPADDRESS in the subnet range.
+
+Examples:
+
+::
+
+  SELECT cast(ipprefix '1.2.3.4/24' as ipaddress) -- ipaddress '1.2.3.0'
+  SELECT cast(ipprefix '2001:db8::ff00:42:8329/64' as ipaddress) -- ipaddress '2001:db8::'
+
+Cast to IPPREFIX
+----------------
+
+From VARCHAR
+^^^^^^^^^^^^
+
+The IPPREFIX string must be in the form of *<ip_address>/<ip_prefix>* as defined in `RFC 4291#section-2.3 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.3>`_.
+The IPADDRESS portion of the IPPREFIX follows the same rules as casting
+`IPADDRESS from VARCHAR <#ipaddress-from-varchar>`_.
+
+The prefix portion must be <= 32 if the IP is an IPv4 address or <= 128 for an IPv6 address.
+As with IPADDRESS, any IPv6 address in the form of an IPv4 mapped IPv6 address will be
+interpreted as an IPv4 address. Only the canonical(smallest) IP address will be stored
+in the IPPREFIX.
+
+Examples:
+
+Valid examples:
+
+::
+
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/32' as ipprefix); -- ipprefix '2001:0db8::/32'
+  SELECT cast('1.2.3.4/24' as ipprefix); -- ipprefix '1.2.3.0/24'
+  SELECT cast('::ffff:ffff:ffff/16' as ipprefix); -- ipprefix '255.255.0.0/16'
+
+Invalid examples:
+
+::
+
+  SELECT cast('2001:db8::1::1/1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:db8::1::1/1
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/129' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/129
+  SELECT cast('2001:0db8:0000:0000:0000:ff00:0042:8329/-1' as ipprefix); -- Cannot cast value to IPPREFIX: 2001:0db8:0000:0000:0000:ff00:0042:8329/-1
+  SELECT cast('255.2.3.4/33' as ipprefix); -- Cannot cast value to IPPREFIX: 255.2.3.4/33
+  SELECT cast('::ffff:ffff:ffff/33' as ipprefix); -- Cannot cast value to IPPREFIX: ::ffff:ffff:ffff/33
+
+From IPADDRESS
+^^^^^^^^^^^^^^
+
+Returns an IPPREFIX where the prefix length is the length of the entire IP address.
+Prefix length for IPv4 is 32 and for IPv6 it is 128.
+
+Examples:
+
+::
+
+  SELECT cast(ipaddress '1.2.3.4' as ipprefix) -- ipprefix '1.2.3.4/32'
+  SELECT cast(ipaddress '2001:db8::ff00:42:8329' as ipprefix) -- ipprefix '2001:db8::ff00:42:8329/128'
 
 Miscellaneous
 -------------

--- a/velox/functions/prestosql/tests/IPAddressCastTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressCastTest.cpp
@@ -43,6 +43,13 @@ class IPAddressCastTest : public functions::test::FunctionBaseTest {
         input);
     return result;
   }
+
+  auto castToIPPrefixAndBackToIpVarchar(
+      const std::optional<std::string>& input) {
+    return evaluateOnce<std::string>(
+        "cast(cast(cast(cast(cast(cast(c0 as ipaddress) as ipprefix) as varchar) as ipprefix) as ipaddress)  as varchar)",
+        input);
+  }
 };
 
 int128_t stringToInt128(const std::string& value) {
@@ -51,6 +58,24 @@ int128_t stringToInt128(const std::string& value) {
     res = res * 10 + c - '0';
   }
   return res;
+}
+
+TEST_F(IPAddressCastTest, castToIPPrefix) {
+  EXPECT_EQ(castToIPPrefixAndBackToIpVarchar("1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castToIPPrefixAndBackToIpVarchar("::ffff:1.2.3.4"), "1.2.3.4");
+  EXPECT_EQ(castToIPPrefixAndBackToIpVarchar("::ffff:102:304"), "1.2.3.4");
+  EXPECT_EQ(castToIPPrefixAndBackToIpVarchar("192.168.0.0"), "192.168.0.0");
+  EXPECT_EQ(
+      castToIPPrefixAndBackToIpVarchar(
+          "2001:0db8:0000:0000:0000:ff00:0042:8329"),
+      "2001:db8::ff00:42:8329");
+  EXPECT_EQ(
+      castToIPPrefixAndBackToIpVarchar("2001:db8:0:0:1:0:0:1"),
+      "2001:db8::1:0:0:1");
+  EXPECT_EQ(castToIPPrefixAndBackToIpVarchar("::1"), "::1");
+  EXPECT_EQ(
+      castToIPPrefixAndBackToIpVarchar("2001:db8::ff00:42:8329"),
+      "2001:db8::ff00:42:8329");
 }
 
 TEST_F(IPAddressCastTest, castToVarchar) {


### PR DESCRIPTION
Summary:
Support casting ipprefix -> ipaddress, and ipaddress -> ipprefix.

We just need one new helper function, tryIpPrefixLengthFromIPAddressType, which takes in int128_t, gets the ippaddress, and then we check if the ippaddress is ipv4 or ipv6 mapped. We return 32 for ipv4 and 128 for ipv6 mapped.

Differential Revision: D65641994


