### PR TITLE
- NOT FOR COMMIT - Re-allocate vectors against impulse pool to avoid memory leak detection

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1269,8 +1269,8 @@ void MemoryPoolImpl::leakCheckDbg() {
   }
   std::stringbuf buf;
   std::ostream oss(&buf);
-  oss << "Detected total of " << debugAllocRecords_.size()
-      << " leaked allocations:\n";
+  oss << "[MemoryPool] : " << name_ << " - Detected total of "
+      << debugAllocRecords_.size() << " leaked allocations:\n";
   struct AllocationStats {
     uint64_t size{0};
     uint64_t numAllocations{0};

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -335,6 +335,80 @@ void FlatVector<StringView>::copy(
   }
 }
 
+// For strings if backing memory pool is not the same as the vector pool, we
+// need to perform a deep copy and reconstruct the string views against the
+// updated stringBuffers.
+template <>
+VectorPtr FlatVector<StringView>::copyPreserveEncodings(
+    velox::memory::MemoryPool* pool) const {
+  auto allocPool = pool ? pool : BaseVector::pool_;
+  // If the backing memory pool is the same as the vector pool
+  // we can do a shallow copy as string buffers can be shared.
+  if (pool == BaseVector::pool_) {
+    return std::make_shared<FlatVector<StringView>>(
+        allocPool,
+        BaseVector::type_,
+        AlignedBuffer::copy(allocPool, BaseVector::nulls_),
+        BaseVector::length_,
+        AlignedBuffer::copy(allocPool, values_),
+        std::vector<BufferPtr>(stringBuffers_),
+        SimpleVector<StringView>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<StringView>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  } else {
+    size_t totalBytes = 0;
+    auto newValuesBuffer =
+        AlignedBuffer::allocate<StringView>(BaseVector::size(), allocPool);
+    auto rawCopyValues = newValuesBuffer->asMutable<StringView>();
+    // Copy non Null StringViews to value buffer
+    for (vector_size_t i = 0; i < BaseVector::size(); i++) {
+      if (!BaseVector::isNullAt(i)) {
+        auto v = valueAt(i);
+        if (v.isInline()) {
+          rawCopyValues[i] = v;
+        } else {
+          totalBytes += v.size();
+        }
+      }
+    }
+
+    BufferPtr newStringBuffer = nullptr;
+    if (totalBytes > 0) {
+      newStringBuffer = AlignedBuffer::allocate<char>(totalBytes, allocPool);
+      char* rawBuffer = newStringBuffer->asMutable<char>();
+
+      for (vector_size_t i = 0; i < BaseVector::size(); i++) {
+        if (!BaseVector::isNullAt(i)) {
+          auto v = valueAt(i);
+          if (!v.isInline()) {
+            memcpy(rawBuffer, v.data(), v.size());
+            rawCopyValues[i] = StringView(rawBuffer, v.size());
+            rawBuffer += v.size();
+          }
+        }
+      }
+    }
+
+    return std::make_shared<FlatVector<StringView>>(
+        allocPool,
+        BaseVector::type_,
+        AlignedBuffer::copy(allocPool, BaseVector::nulls_),
+        BaseVector::length_,
+        newValuesBuffer,
+        newStringBuffer ? std::vector<BufferPtr>({newStringBuffer})
+                        : std::vector<BufferPtr>(),
+        SimpleVector<StringView>::stats_,
+        BaseVector::distinctValueCount_,
+        BaseVector::nullCount_,
+        SimpleVector<StringView>::isSorted_,
+        BaseVector::representedByteCount_,
+        BaseVector::storageByteCount_);
+  }
+}
+
 // For strings, we also verify if they point to valid memory locations inside
 // the string buffers.
 template <>

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -274,12 +274,13 @@ class FlatVector final : public SimpleVector<T> {
 
   VectorPtr copyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
+    auto allocPool = pool ? pool : BaseVector::pool_;
     return std::make_shared<FlatVector<T>>(
-        pool ? pool : BaseVector::pool_,
+        allocPool,
         BaseVector::type_,
-        AlignedBuffer::copy(BaseVector::pool_, BaseVector::nulls_),
+        AlignedBuffer::copy(allocPool, BaseVector::nulls_),
         BaseVector::length_,
-        AlignedBuffer::copy(BaseVector::pool_, values_),
+        AlignedBuffer::copy(allocPool, values_),
         std::vector<BufferPtr>(stringBuffers_),
         SimpleVector<T>::stats_,
         BaseVector::distinctValueCount_,
@@ -637,6 +638,10 @@ char* FlatVector<StringView>::getRawStringBufferWithSpace(
 
 template <>
 void FlatVector<StringView>::prepareForReuse();
+
+template <>
+VectorPtr FlatVector<StringView>::copyPreserveEncodings(
+    velox::memory::MemoryPool* pool) const;
 
 template <typename T>
 using FlatVectorPtr = std::shared_ptr<FlatVector<T>>;


### PR DESCRIPTION
Summary:
This is not for commit until we add additional testing. 

The main idea here is that the underlying data that is produced in the table scan needs to be re-allocated against the impulse memory pool vs the operator pool that created it (exchange). This ensures that when the scan/ insert tasks are completed -> subsequently deleted that the operator memory pool will not trigger leak detection. 


We need a longer term fix here, exchange should not be part of the local plan, etc, but this should unblock testing.

Differential Revision: D65306907


