### PR TITLE
Remove unused-variable in velox/experimental/wave/exec/Wave.cpp

### DIFF
--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -748,7 +748,6 @@ LaunchControl* WaveStream::prepareProgramLaunch(
   int32_t numBlocks = std::max<int32_t>(1, exes.size()) * blocksPerExe;
   int32_t size = 2 * numBlocks * sizeof(int32_t);
   std::vector<ExeLaunchInfo> info(exes.size());
-  auto exeOffset = size;
   // 2 pointers per exe: TB program and start of its param array and 1 int for
   // start PC. Round to 3 for alignment.
   size += exes.size() * sizeof(void*) * 3;
@@ -1370,7 +1369,6 @@ int32_t Program::addLiteralTyped(AbstractOperand* op) {
   }
   T value = op->constant->as<SimpleVector<T>>()->valueAt(0);
   if constexpr (std::is_same_v<T, StringView>) {
-    int64_t inlined = 0;
     StringView* stringView = reinterpret_cast<StringView*>(&value);
     if (stringView->size() <= 6) {
       int64_t inlined = static_cast<int64_t>(stringView->size()) << 48;


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65584300


