### PR TITLE
Remove unused-variable in velox/common/memory/tests/MockSharedArbitratorTest.cpp

### DIFF
--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -204,7 +204,6 @@ class MockMemoryOperator {
         return 0;
       }
       if (reclaimInjectCb_ != nullptr) {
-        uint64_t injectedReclaimedBytes{0};
         if (!reclaimInjectCb_(pool, targetBytes)) {
           return 0;
         }
@@ -788,7 +787,6 @@ TEST_F(MockSharedArbitrationTest, constructor) {
 
 TEST_F(MockSharedArbitrationTest, arbitrationStateCheck) {
   const int memCapacity = 256 * MB;
-  const int minPoolCapacity = 32 * MB;
   std::atomic<int> checkCount{0};
   MemoryArbitrationStateCheckCB checkCountCb = [&](MemoryPool& pool) {
     const std::string re("RootPool.*");
@@ -2139,7 +2137,6 @@ TEST_F(MockSharedArbitrationTest, singlePoolGrowWithoutArbitration) {
 }
 
 TEST_F(MockSharedArbitrationTest, maxCapacityReserve) {
-  const int memCapacity = 256 * MB;
   struct {
     uint64_t memCapacity;
     uint64_t reservedCapacity;
@@ -2437,7 +2434,6 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, arbitrationAbort) {
   ASSERT_EQ(task3->capacity(), memoryCapacity / 4);
 
   folly::EventCount globalArbitrationWait;
-  std::atomic_bool globalArbitrationWaitFlag{true};
   SCOPED_TESTVALUE_SET(
       "facebook::velox::memory::SharedArbitrator::runGlobalArbitration",
       std::function<void(const SharedArbitrator*)>(
@@ -3112,7 +3108,6 @@ TEST_F(MockSharedArbitrationTest, minReclaimBytes) {
 
 TEST_F(MockSharedArbitrationTest, globalArbitrationReclaimPct) {
   const int64_t memoryCapacity = 256 << 20;
-  const int64_t memoryPoolCapacity = 64 << 20;
 
   struct TestTask {
     uint64_t capacity{0};

--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -233,11 +233,9 @@ std::vector<int32_t> oddRowNumbers;
 RowSet allRows;
 RowSet oddRows;
 
-static size_t len_u32 = 0;
 std::vector<uint32_t> randomInts_u32;
 std::vector<uint64_t> randomInts_u32_result;
 
-static size_t len_u64 = 0;
 std::vector<uint64_t> randomInts_u64;
 std::vector<uint64_t> randomInts_u64_result;
 std::vector<char> buffer_u64;

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -33,7 +33,6 @@ class ReaderTest : public testing::Test, public test::VectorTestBase {
 };
 
 TEST_F(ReaderTest, getOrCreateChild) {
-  constexpr int kSize = 5;
   auto input = makeRowVector(
       {"c.0", "c.1"},
       {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65584421


