### PR TITLE
Ensure prefix length does not exceed configured maximum

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -136,12 +136,10 @@ PrefixSortLayout PrefixSortLayout::makeSortLayout(
   uint32_t normalizedKeySize{0};
   uint32_t numNormalizedKeys{0};
   for (auto i = 0; i < numKeys; ++i) {
-    if (normalizedKeySize > maxNormalizedKeySize) {
-      break;
-    }
     const std::optional<uint32_t> encodedSize =
         PrefixSortEncoder::encodedSize(types[i]->kind());
-    if (!encodedSize.has_value()) {
+    if (!encodedSize.has_value() ||
+        normalizedKeySize + encodedSize.value() > maxNormalizedKeySize) {
       break;
     }
     prefixOffsets.push_back(normalizedKeySize);


### PR DESCRIPTION
The check can't make sure the normalizedKeySize is less than or equal to 
maxNormalizedKeySize. That is possible 
`normalizedKeySize + encodedSize.value() > maxNormalizedKeySize` but related 
column is included in the prefix.
Move the check to fix this.
This is found when doing the PR: https://github.com/facebookincubator/velox/pull/11272