### PR TITLE
feat: Support compress UnsafeRow and CompactRow

### DIFF
--- a/velox/exec/OperatorTraceReader.h
+++ b/velox/exec/OperatorTraceReader.h
@@ -43,6 +43,7 @@ class OperatorTraceInputReader {
   const serializer::presto::PrestoVectorSerde::PrestoOptions readOptions_{
       true,
       common::CompressionKind_ZSTD, // TODO: Use trace config.
+      0.8,
       /*_nullsFirst=*/true};
   const std::shared_ptr<filesystems::FileSystem> fs_;
   const RowTypePtr dataType_;

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -58,6 +58,7 @@ class OperatorTraceInputWriter {
   const serializer::presto::PrestoVectorSerde::PrestoOptions options_ = {
       true,
       common::CompressionKind::CompressionKind_ZSTD,
+      0.8,
       /*nullsFirst=*/true};
   const std::shared_ptr<filesystems::FileSystem> fs_;
   memory::MemoryPool* const pool_;

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -33,17 +33,10 @@ class Destination {
       const std::string& taskId,
       int destination,
       VectorSerde* serde,
+      VectorSerde::Options* options,
       memory::MemoryPool* pool,
       bool eagerFlush,
-      std::function<void(uint64_t bytes, uint64_t rows)> recordEnqueued)
-      : taskId_(taskId),
-        destination_(destination),
-        serde_(serde),
-        pool_(pool),
-        eagerFlush_(eagerFlush),
-        recordEnqueued_(std::move(recordEnqueued)) {
-    setTargetSizePct();
-  }
+      std::function<void(uint64_t bytes, uint64_t rows)> recordEnqueued);
 
   /// Resets the destination before starting a new batch.
   void beginBatch() {
@@ -112,6 +105,7 @@ class Destination {
   const std::string taskId_;
   const int destination_;
   VectorSerde* const serde_;
+  VectorSerde::Options* const options_;
   memory::MemoryPool* const pool_;
   const bool eagerFlush_;
   const std::function<void(uint64_t bytes, uint64_t rows)> recordEnqueued_;
@@ -226,6 +220,7 @@ class PartitionedOutput : public Operator {
   const int64_t maxBufferedBytes_;
   const bool eagerFlush_;
   VectorSerde* const serde_;
+  const std::unique_ptr<VectorSerde::Options> options_;
 
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
   ContinueFuture future_;

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -175,7 +175,10 @@ uint64_t SpillWriter::write(
     NanosecondTimer timer(&timeNs);
     if (batch_ == nullptr) {
       serializer::presto::PrestoVectorSerde::PrestoOptions options = {
-          kDefaultUseLosslessTimestamp, compressionKind_, true /*nullsFirst*/};
+          kDefaultUseLosslessTimestamp,
+          compressionKind_,
+          0.8,
+          /*nullsFirst=*/true};
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(
           std::static_pointer_cast<const RowType>(rows->type()),
@@ -300,6 +303,7 @@ SpillReadFile::SpillReadFile(
       readOptions_{
           kDefaultUseLosslessTimestamp,
           compressionKind_,
+          0.8,
           /*nullsFirst=*/true},
       pool_(pool),
       serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -2408,22 +2408,18 @@ TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
     test(100'000, 1);
   } else if (GetParam() == VectorSerde::Kind::kCompactRow) {
     test(1, 1'000);
-    test(1'000, 28);
-    test(10'000, 3);
+    test(1'000, 38);
+    test(10'000, 4);
     test(100'000, 1);
   } else {
     test(1, 1'000);
-    test(1'000, 63);
+    test(1'000, 72);
     test(10'000, 7);
     test(100'000, 1);
   }
 }
 
 TEST_P(MultiFragmentTest, compression) {
-  // NOTE: only presto format supports compression for now
-  if (GetParam() != VectorSerde::Kind::kPresto) {
-    return;
-  }
   bufferManager_->testingSetCompression(
       common::CompressionKind::CompressionKind_LZ4);
   auto guard = folly::makeGuard([&]() {

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -4230,21 +4230,6 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
   }
 
  private:
-  struct CompressionStats {
-    // Number of times compression was not attempted.
-    int32_t numCompressionSkipped{0};
-
-    // uncompressed size for which compression was attempted.
-    int64_t compressionInputBytes{0};
-
-    // Compressed bytes.
-    int64_t compressedBytes{0};
-
-    // Bytes for which compression was not attempted because of past
-    // non-performance.
-    int64_t compressionSkippedBytes{0};
-  };
-
   const SerdeOpts opts_;
   StreamArena* const streamArena_;
   const std::unique_ptr<folly::io::Codec> codec_;

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -54,9 +54,10 @@ class PrestoVectorSerde : public VectorSerde {
     PrestoOptions(
         bool _useLosslessTimestamp,
         common::CompressionKind _compressionKind,
+        float _minCompressionRatio = 0.8,
         bool _nullsFirst = false,
         bool _preserveEncodings = false)
-        : VectorSerde::Options(_compressionKind),
+        : VectorSerde::Options(_compressionKind, _minCompressionRatio),
           useLosslessTimestamp(_useLosslessTimestamp),
           nullsFirst(_nullsFirst),
           preserveEncodings(_preserveEncodings) {}
@@ -73,11 +74,6 @@ class PrestoVectorSerde : public VectorSerde {
     /// TODO: Make Presto also serialize nulls before columns of
     /// structs.
     bool nullsFirst{false};
-
-    /// Minimum achieved compression if compression is enabled. Compressing less
-    /// than this causes subsequent compression attempts to be skipped. The more
-    /// times compression misses the target the less frequently it is tried.
-    float minCompressionRatio{0.8};
 
     /// If true, the serializer will not employ any optimizations that can
     /// affect the encoding of the input vectors. This is only relevant when

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -65,9 +65,7 @@ struct RowHeader {
 template <class Serializer>
 class RowSerializer : public IterativeVectorSerializer {
  public:
-  explicit RowSerializer(
-      memory::MemoryPool* pool,
-      const VectorSerde::Options* options)
+  RowSerializer(memory::MemoryPool* pool, const VectorSerde::Options* options)
       : pool_(pool),
         options_(options == nullptr ? VectorSerde::Options() : *options),
         codec_(common::compressionKindToCodec(options_.compressionKind)) {}
@@ -155,7 +153,7 @@ class RowSerializer : public IterativeVectorSerializer {
   }
 
   // The serialization format is | uncompressedSize | compressedSize |
-  // compressed | data |.
+  // compressed | data.
   void flush(OutputStream* stream) override {
     constexpr int32_t kMaxCompressionAttemptsToSkip = 30;
     const auto size = uncompressedSize();

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -52,7 +52,7 @@ struct RowHeader {
     return sizeof(int32_t) * 2 + sizeof(char);
   }
 
-  std::string debugString() const {
+  std::string toString() const {
     return fmt::format(
         "uncompressedSize: {}, compressedSize: {}, compressed: {}",
         succinctBytes(uncompressedSize),

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -23,10 +23,54 @@ namespace facebook::velox::serializer {
 
 using TRowSize = uint32_t;
 
+namespace detail {
+struct RowHeader {
+  int32_t uncompressedSize;
+  int32_t compressedSize;
+  bool compressed;
+
+  static RowHeader read(ByteInputStream* source) {
+    RowHeader header;
+    header.uncompressedSize = source->read<int32_t>();
+    header.compressedSize = source->read<int32_t>();
+    header.compressed = source->read<char>();
+
+    VELOX_CHECK_GE(header.uncompressedSize, 0);
+    VELOX_CHECK_GE(header.compressedSize, 0);
+
+    return header;
+  }
+
+  void write(OutputStream* out) {
+    out->write(reinterpret_cast<char*>(&uncompressedSize), sizeof(int32_t));
+    out->write(reinterpret_cast<char*>(&compressedSize), sizeof(int32_t));
+    char writeValue = compressed ? 1 : 0;
+    out->write(reinterpret_cast<char*>(&writeValue), sizeof(char));
+  }
+
+  static size_t size() {
+    return sizeof(int32_t) * 2 + sizeof(char);
+  }
+
+  std::string debugString() const {
+    return fmt::format(
+        "uncompressedSize: {}, compressedSize: {}, compressed: {}",
+        uncompressedSize,
+        compressedSize,
+        compressed);
+  }
+};
+} // namespace detail
+
 template <class Serializer>
 class RowSerializer : public IterativeVectorSerializer {
  public:
-  explicit RowSerializer(memory::MemoryPool* pool) : pool_(pool) {}
+  explicit RowSerializer(
+      memory::MemoryPool* pool,
+      const VectorSerde::Options* options)
+      : pool_(pool),
+        options_(options == nullptr ? VectorSerde::Options() : *options),
+        codec_(common::compressionKindToCodec(options_.compressionKind)) {}
 
   void append(
       const RowVectorPtr& vector,
@@ -99,18 +143,67 @@ class RowSerializer : public IterativeVectorSerializer {
   }
 
   size_t maxSerializedSize() const override {
-    size_t totalSize = 0;
-    for (const auto& buffer : buffers_) {
-      totalSize += buffer->size();
+    const auto size = uncompressedSize();
+    if (!needCompression()) {
+      return detail::RowHeader::size() + size;
     }
-    return totalSize;
+    VELOX_CHECK_LE(
+        size,
+        codec_->maxUncompressedLength(),
+        "UncompressedSize exceeds limit");
+    return detail::RowHeader::size() + codec_->maxCompressedLength(size);
   }
 
+  // The serialization format is | uncompressedSize | compressedSize |
+  // compressed | data |.
   void flush(OutputStream* stream) override {
-    for (const auto& buffer : buffers_) {
-      stream->write(buffer->template asMutable<char>(), buffer->size());
+    constexpr int32_t kMaxCompressionAttemptsToSkip = 30;
+    const auto size = uncompressedSize();
+    if (!needCompression()) {
+      flushUncompressed(size, stream);
+    } else if (numCompressionToSkip_ > 0) {
+      flushUncompressed(size, stream);
+      stats_.compressionSkippedBytes += size;
+      --numCompressionToSkip_;
+      ++stats_.numCompressionSkipped;
+    } else {
+      // Compress the buffer if satisfied condition.
+      const auto toCompress = toIOBuf(buffers_);
+      const auto compressedBuffer = codec_->compress(toCompress.get());
+      const int32_t compressedSize = compressedBuffer->length();
+      stats_.compressionInputBytes += size;
+      stats_.compressedBytes += compressedSize;
+      if (compressedSize > options_.minCompressionRatio * size) {
+        // Skip this compression.
+        numCompressionToSkip_ = std::min<int64_t>(
+            kMaxCompressionAttemptsToSkip, 1 + stats_.numCompressionSkipped);
+        flushUncompressed(size, stream);
+      } else {
+        // Do the compression.
+        detail::RowHeader header = {size, compressedSize, true};
+        header.write(stream);
+        for (auto range : *compressedBuffer) {
+          stream->write(
+              reinterpret_cast<const char*>(range.data()), range.size());
+        }
+      }
     }
+
     buffers_.clear();
+  }
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+    std::unordered_map<std::string, RuntimeCounter> map;
+    map.insert(
+        {{"compressedBytes",
+          RuntimeCounter(stats_.compressedBytes, RuntimeCounter::Unit::kBytes)},
+         {"compressionInputBytes",
+          RuntimeCounter(
+              stats_.compressionInputBytes, RuntimeCounter::Unit::kBytes)},
+         {"compressionSkippedBytes",
+          RuntimeCounter(
+              stats_.compressionSkippedBytes, RuntimeCounter::Unit::kBytes)}});
+    return map;
   }
 
   void clear() override {}
@@ -137,6 +230,47 @@ class RowSerializer : public IterativeVectorSerializer {
 
   memory::MemoryPool* const pool_;
   std::vector<BufferPtr> buffers_;
+
+ private:
+  std::unique_ptr<folly::IOBuf> toIOBuf(const std::vector<BufferPtr>& buffers) {
+    std::unique_ptr<folly::IOBuf> iobuf;
+    for (const auto& buffer : buffers) {
+      auto newBuf =
+          folly::IOBuf::wrapBuffer(buffer->asMutable<char>(), buffer->size());
+      if (iobuf) {
+        iobuf->prev()->appendChain(std::move(newBuf));
+      } else {
+        iobuf = std::move(newBuf);
+      }
+    }
+    return iobuf;
+  }
+
+  int32_t uncompressedSize() const {
+    int32_t totalSize = 0;
+    for (const auto& buffer : buffers_) {
+      totalSize += buffer->size();
+    }
+    return totalSize;
+  }
+
+  bool needCompression() const {
+    return codec_->type() != folly::io::CodecType::NO_COMPRESSION;
+  }
+
+  void flushUncompressed(int32_t size, OutputStream* stream) {
+    detail::RowHeader header = {size, size, false};
+    header.write(stream);
+    for (const auto& buffer : buffers_) {
+      stream->write(buffer->template asMutable<char>(), buffer->size());
+    }
+  }
+
+  const VectorSerde::Options options_;
+  const std::unique_ptr<folly::io::Codec> codec_;
+  // Count of forthcoming compressions to skip.
+  int32_t numCompressionToSkip_{0};
+  CompressionStats stats_;
 };
 
 template <typename SerializeView>
@@ -145,25 +279,59 @@ class RowDeserializer {
   static void deserialize(
       ByteInputStream* source,
       std::vector<SerializeView>& serializedRows,
-      std::vector<std::unique_ptr<std::string>>& serializedBuffers) {
+      std::vector<std::unique_ptr<std::string>>& serializedBuffers,
+      const VectorSerde::Options* options) {
+    const auto compressionKind = options == nullptr
+        ? VectorSerde::Options().compressionKind
+        : options->compressionKind;
     while (!source->atEnd()) {
-      // First read row size in big endian order.
-      const auto rowSize = folly::Endian::big(source->read<TRowSize>());
-      auto serializedBuffer = std::make_unique<std::string>();
-      serializedBuffer->reserve(rowSize);
+      std::unique_ptr<folly::IOBuf> uncompressedBuf = nullptr;
+      const auto header = detail::RowHeader::read(source);
+      if (header.compressed) {
+        VELOX_DCHECK(
+            compressionKind != common::CompressionKind::CompressionKind_NONE);
+        auto compressBuf = folly::IOBuf::create(header.compressedSize);
+        source->readBytes(compressBuf->writableData(), header.compressedSize);
+        compressBuf->append(header.compressedSize);
 
-      const auto row = source->nextView(rowSize);
-      serializedBuffer->append(row.data(), row.size());
-      // If we couldn't read the entire row at once, we need to concatenate it
-      // in a different buffer.
-      if (serializedBuffer->size() < rowSize) {
-        concatenatePartialRow(source, rowSize, *serializedBuffer);
+        // Process chained uncompressed results IOBufs.
+        const auto codec = common::compressionKindToCodec(compressionKind);
+        uncompressedBuf =
+            codec->uncompress(compressBuf.get(), header.uncompressedSize);
       }
+      std::unique_ptr<ByteInputStream> uncompressedStream;
+      ByteInputStream* uncompressedSource;
+      if (uncompressedBuf == nullptr) {
+        uncompressedSource = source;
+      } else {
+        uncompressedStream = std::make_unique<BufferInputStream>(
+            byteRangesFromIOBuf(uncompressedBuf.get()));
+        uncompressedSource = uncompressedStream.get();
+      }
+      const std::streampos initialSize = uncompressedSource->tellp();
+      while (uncompressedSource->tellp() - initialSize <
+             header.uncompressedSize) {
+        // First read row size in big endian order.
+        const auto rowSize =
+            folly::Endian::big(uncompressedSource->read<TRowSize>());
 
-      VELOX_CHECK_EQ(serializedBuffer->size(), rowSize);
-      serializedBuffers.emplace_back(std::move(serializedBuffer));
-      serializedRows.push_back(std::string_view(
-          serializedBuffers.back()->data(), serializedBuffers.back()->size()));
+        auto serializedBuffer = std::make_unique<std::string>();
+        serializedBuffer->reserve(rowSize);
+
+        const auto row = uncompressedSource->nextView(rowSize);
+        serializedBuffer->append(row.data(), row.size());
+        // If we couldn't read the entire row at once, we need to concatenate it
+        // in a different buffer.
+        if (serializedBuffer->size() < rowSize) {
+          concatenatePartialRow(uncompressedSource, rowSize, *serializedBuffer);
+        }
+
+        VELOX_CHECK_EQ(serializedBuffer->size(), rowSize);
+        serializedBuffers.emplace_back(std::move(serializedBuffer));
+        serializedRows.push_back(std::string_view(
+            serializedBuffers.back()->data(),
+            serializedBuffers.back()->size()));
+      }
     }
   }
 

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -33,9 +33,9 @@ UnsafeRowVectorSerde::createIterativeSerializer(
     RowTypePtr /* type */,
     int32_t /* numRows */,
     StreamArena* streamArena,
-    const Options* /* options */) {
+    const Options* options) {
   return std::make_unique<RowSerializer<row::UnsafeRowFast>>(
-      streamArena->pool());
+      streamArena->pool(), options);
 }
 
 void UnsafeRowVectorSerde::deserialize(
@@ -43,11 +43,11 @@ void UnsafeRowVectorSerde::deserialize(
     velox::memory::MemoryPool* pool,
     RowTypePtr type,
     RowVectorPtr* result,
-    const Options* /* options */) {
+    const Options* options) {
   std::vector<std::optional<std::string_view>> serializedRows;
   std::vector<std::unique_ptr<std::string>> serializedBuffers;
   RowDeserializer<std::optional<std::string_view>>::deserialize(
-      source, serializedRows, serializedBuffers);
+      source, serializedRows, serializedBuffers, options);
 
   if (serializedRows.empty()) {
     *result = BaseVector::create<RowVector>(type, 0, pool);

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -23,9 +23,29 @@
 namespace facebook::velox::serializer {
 namespace {
 
+struct TestParam {
+  common::CompressionKind compressionKind;
+  bool appendRow;
+
+  TestParam(common::CompressionKind _compressionKind, bool _appendRow)
+      : compressionKind(_compressionKind), appendRow(_appendRow) {}
+};
+
 class CompactRowSerializerTest : public ::testing::Test,
                                  public velox::test::VectorTestBase,
-                                 public testing::WithParamInterface<bool> {
+                                 public testing::WithParamInterface<TestParam> {
+ public:
+  static std::vector<TestParam> getTestParams() {
+    static std::vector<TestParam> testParams = {
+        {common::CompressionKind::CompressionKind_NONE, false},
+        {common::CompressionKind::CompressionKind_ZLIB, true},
+        {common::CompressionKind::CompressionKind_SNAPPY, false},
+        {common::CompressionKind::CompressionKind_ZSTD, true},
+        {common::CompressionKind::CompressionKind_LZ4, false},
+        {common::CompressionKind::CompressionKind_GZIP, true}};
+    return testParams;
+  }
+
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
@@ -41,6 +61,9 @@ class CompactRowSerializerTest : public ::testing::Test,
     ASSERT_EQ(
         getNamedVectorSerde(VectorSerde::Kind::kCompactRow)->kind(),
         VectorSerde::Kind::kCompactRow);
+    appendRow_ = GetParam().appendRow;
+    compressionKind_ = GetParam().compressionKind;
+    options_ = std::make_unique<VectorSerde::Options>(compressionKind_, 0.8);
   }
 
   void TearDown() override {
@@ -56,7 +79,7 @@ class CompactRowSerializerTest : public ::testing::Test,
     vector_size_t offset = 0;
     vector_size_t rangeSize = 1;
     std::unique_ptr<row::CompactRow> compactRow;
-    if (GetParam()) {
+    if (appendRow_) {
       compactRow = std::make_unique<row::CompactRow>(rowVector);
     }
     while (offset < numRows) {
@@ -69,10 +92,10 @@ class CompactRowSerializerTest : public ::testing::Test,
     auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = asRowType(rowVector->type());
     auto serializer = getVectorSerde()->createIterativeSerializer(
-        rowType, numRows, arena.get());
+        rowType, numRows, arena.get(), options_.get());
 
     Scratch scratch;
-    if (GetParam()) {
+    if (appendRow_) {
       std::vector<vector_size_t> serializedRowSizes(numRows);
       std::vector<vector_size_t*> serializedRowSizesPtr(numRows);
       for (auto i = 0; i < numRows; ++i) {
@@ -97,7 +120,11 @@ class CompactRowSerializerTest : public ::testing::Test,
     auto size = serializer->maxSerializedSize();
     OStreamOutputStream out(output);
     serializer->flush(&out);
-    ASSERT_EQ(size, output->tellp());
+    if (!needCompression()) {
+      ASSERT_EQ(size, output->tellp());
+    } else {
+      ASSERT_GT(size, output->tellp());
+    }
   }
 
   std::unique_ptr<ByteInputStream> toByteStream(
@@ -127,7 +154,7 @@ class CompactRowSerializerTest : public ::testing::Test,
 
     RowVectorPtr result;
     getVectorSerde()->deserialize(
-        byteStream.get(), pool_.get(), rowType, &result);
+        byteStream.get(), pool_.get(), rowType, &result, options_.get());
     return result;
   }
 
@@ -141,6 +168,16 @@ class CompactRowSerializerTest : public ::testing::Test,
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
+
+ private:
+  bool needCompression() {
+    return compressionKind_ != common::CompressionKind::CompressionKind_NONE;
+  }
+
+  static constexpr int32_t kHeaderSize = sizeof(int32_t) * 2 + sizeof(char);
+  common::CompressionKind compressionKind_;
+  std::unique_ptr<VectorSerde::Options> options_;
+  bool appendRow_;
 };
 
 TEST_P(CompactRowSerializerTest, fuzz) {
@@ -187,6 +224,6 @@ TEST_P(CompactRowSerializerTest, fuzz) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     CompactRowSerializerTest,
     CompactRowSerializerTest,
-    testing::Values(false, true));
+    testing::ValuesIn(CompactRowSerializerTest::getTestParams()));
 } // namespace
 } // namespace facebook::velox::serializer

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -120,7 +120,7 @@ class PrestoSerializerTest
     const bool preserveEncodings =
         serdeOptions == nullptr ? false : serdeOptions->preserveEncodings;
     serializer::presto::PrestoVectorSerde::PrestoOptions paramOptions{
-        useLosslessTimestamp, kind, nullsFirst, preserveEncodings};
+        useLosslessTimestamp, kind, 0.8, nullsFirst, preserveEncodings};
 
     return paramOptions;
   }


### PR DESCRIPTION
Convert the buffers to `folly::IOBuf`, then compress it, and record some stats, skip compression when compressedSize/uncompressedSize exceeds minCompressionRatio with default value 0.8.
Serialization format is:
 | uncompressedSize | compressedSize | compressed | serializedData for Iterator[Row] |
Test the RowVector with all types and size is 500, the test output is as following:

row kind | compression kind | uncompressedSize | compressedSize | compression ratio
-- | -- | -- | -- | --
UnsafeRow    | zlib | 519344 | 227749 | 44%
UnsafeRow    | snappy | 307936 | 115012 | 37%
UnsafeRow    | zstd | 689544 | 273433 | 40%
UnsafeRow    | lz4 | 622688 | 205956 | 33%
UnsafeRow    | gzip | 759608 | 213922 | 28%
CompactRow | zlib | 263474 | 129241 | 49%
CompactRow | snappy | 388313 | 78297 | 20%
CompactRow | zstd | 224144 | 92744 | 41%
CompactRow | lz4 | 110043 | 61615 | 56%
CompactRow | gzip | 224631 | 93989 | 42%
