### PR TITLE
legacy code cleanup

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -738,30 +738,6 @@ class TableWriteNode : public PlanNode {
     }
   }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  TableWriteNode(
-      const PlanNodeId& id,
-      const RowTypePtr& columns,
-      const std::vector<std::string>& columnNames,
-      std::shared_ptr<AggregationNode> aggregationNode,
-      std::shared_ptr<InsertTableHandle> insertTableHandle,
-      bool hasPartitioningScheme,
-      bool /*unused*/,
-      RowTypePtr outputType,
-      connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source)
-      : TableWriteNode(
-            id,
-            columns,
-            columnNames,
-            std::move(aggregationNode),
-            std::move(insertTableHandle),
-            hasPartitioningScheme,
-            std::move(outputType),
-            commitStrategy,
-            source) {}
-#endif
-
   const std::vector<PlanNodePtr>& sources() const override {
     return sources_;
   }
@@ -1013,11 +989,6 @@ class GroupIdNode : public PlanNode {
 
 class ExchangeNode : public PlanNode {
  public:
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  ExchangeNode(const PlanNodeId& id, RowTypePtr type)
-      : ExchangeNode(id, std::move(type), VectorSerde::Kind::kPresto) {}
-#endif
-
   ExchangeNode(
       const PlanNodeId& id,
       RowTypePtr type,
@@ -1059,20 +1030,6 @@ class ExchangeNode : public PlanNode {
 
 class MergeExchangeNode : public ExchangeNode {
  public:
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  MergeExchangeNode(
-      const PlanNodeId& id,
-      const RowTypePtr& type,
-      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
-      const std::vector<SortOrder>& sortingOrders)
-      : MergeExchangeNode(
-            id,
-            type,
-            sortingKeys,
-            sortingOrders,
-            VectorSerde::Kind::kPresto) {}
-#endif
-
   MergeExchangeNode(
       const PlanNodeId& id,
       const RowTypePtr& type,
@@ -1297,28 +1254,6 @@ class PartitionedOutputNode : public PlanNode {
   static std::string kindString(Kind kind);
   static Kind stringToKind(const std::string& str);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PartitionedOutputNode(
-      const PlanNodeId& id,
-      Kind kind,
-      const std::vector<TypedExprPtr>& keys,
-      int numPartitions,
-      bool replicateNullsAndAny,
-      PartitionFunctionSpecPtr partitionFunctionSpec,
-      RowTypePtr outputType,
-      PlanNodePtr source)
-      : PartitionedOutputNode(
-            id,
-            kind,
-            keys,
-            numPartitions,
-            replicateNullsAndAny,
-            std::move(partitionFunctionSpec),
-            std::move(outputType),
-            VectorSerde::Kind::kPresto,
-            std::move(source)) {}
-#endif
-
   PartitionedOutputNode(
       const PlanNodeId& id,
       Kind kind,
@@ -1330,55 +1265,18 @@ class PartitionedOutputNode : public PlanNode {
       VectorSerde::Kind serdeKind,
       PlanNodePtr source);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode> broadcast(
-      const PlanNodeId& id,
-      int numPartitions,
-      RowTypePtr outputType,
-      PlanNodePtr source) {
-    return broadcast(
-        id,
-        numPartitions,
-        std::move(outputType),
-        VectorSerde::Kind::kPresto,
-        std::move(source));
-  }
-#endif
-
   static std::shared_ptr<PartitionedOutputNode> broadcast(
       const PlanNodeId& id,
       int numPartitions,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
       PlanNodePtr source);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode>
-  arbitrary(const PlanNodeId& id, RowTypePtr outputType, PlanNodePtr source) {
-    return arbitrary(
-        id,
-        std::move(outputType),
-        VectorSerde::Kind::kPresto,
-        std::move(source));
-  }
-#endif
 
   static std::shared_ptr<PartitionedOutputNode> arbitrary(
       const PlanNodeId& id,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
       PlanNodePtr source);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode>
-  single(const PlanNodeId& id, RowTypePtr outputType, PlanNodePtr source) {
-    return single(
-        id,
-        std::move(outputType),
-        VectorSerde::Kind::kPresto,
-        std::move(source));
-  }
-#endif
 
   static std::shared_ptr<PartitionedOutputNode> single(
       const PlanNodeId& id,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -31,27 +31,6 @@ class QueryConfig {
 
   explicit QueryConfig(std::unordered_map<std::string, std::string>&& values);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static constexpr const char* kCodegenEnabled = "codegen.enabled";
-
-  static constexpr const char* kCodegenConfigurationFilePath =
-      "codegen.configuration_file_path";
-
-  static constexpr const char* kCodegenLazyLoading = "codegen.lazy_loading";
-
-  bool codegenEnabled() const {
-    return get<bool>(kCodegenEnabled, false);
-  }
-
-  std::string codegenConfigurationFilePath() const {
-    return get<std::string>(kCodegenConfigurationFilePath, "");
-  }
-
-  bool codegenLazyLoading() const {
-    return get<bool>(kCodegenLazyLoading, true);
-  }
-#endif
-
   /// Maximum memory that a query can use on a single host.
   static constexpr const char* kQueryMaxMemoryPerNode =
       "query_max_memory_per_node";

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -252,10 +252,8 @@ class SpillReadFile {
       memory::MemoryPool* pool,
       folly::Synchronized<common::SpillStats>* stats);
 
-#ifndef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   // Invoked to record spill read stats at the end of read input.
   void recordSpillStats();
-#endif
 
   // The spill file id which is monotonically increasing and unique for each
   // associated spill partition.

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -334,11 +334,6 @@ class PlanBuilder {
   ///
   /// @param outputType The type of the data coming in and out of the exchange.
   /// @param serdekind The kind of seralized data format.
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& exchange(const RowTypePtr& outputType) {
-    return exchange(outputType, VectorSerde::Kind::kPresto);
-  }
-#endif
   PlanBuilder& exchange(
       const RowTypePtr& outputType,
       VectorSerde::Kind serdekind);
@@ -351,13 +346,6 @@ class PlanBuilder {
   ///
   /// By default, uses ASC NULLS LAST sort order, e.g. column "a" above will use
   /// ASC NULLS LAST and column "b" will use DESC NULLS LAST.
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& mergeExchange(
-      const RowTypePtr& outputType,
-      const std::vector<std::string>& keys) {
-    return mergeExchange(outputType, keys, VectorSerde::Kind::kPresto);
-  }
-#endif
   PlanBuilder& mergeExchange(
       const RowTypePtr& outputType,
       const std::vector<std::string>& keys,

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -391,16 +391,6 @@ class VectorStreamGroup : public StreamArena {
   void flush(OutputStream* stream);
 
   // Reads data in wire format. Returns the RowVector in 'result'.
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static void read(
-      ByteInputStream* source,
-      velox::memory::MemoryPool* pool,
-      RowTypePtr type,
-      RowVectorPtr* result,
-      const VectorSerde::Options* options = nullptr) {
-    read(source, pool, type, nullptr, result, options);
-  }
-#endif
   static void read(
       ByteInputStream* source,
       velox::memory::MemoryPool* pool,


### PR DESCRIPTION
Summary: Remove the backward compatibility code from row-wise shuffle support

Differential Revision: D65720389


