### PR TITLE
Remove unused-variable in velox/experimental/wave/exec/ToWave.cpp +3

### DIFF
--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -625,7 +625,6 @@ bool isProjectedThrough(
 
 bool CompileState::compile() {
   auto operators = driver_.operators();
-  auto& nodes = driverFactory_.planNodes;
 
   int32_t first = 0;
   int32_t operatorIndex = 0;


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D65755246


