### PR TITLE
Spill prefix sort related code cleanup plus test improvement

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -234,10 +234,10 @@ class QueryConfig {
       "spill_compression_codec";
 
   /// Enable the prefix sort or fallback to timsort in spill. The prefix sort is
-  /// faster than timsort but requires the memory to build prefix data, which
-  /// may cause out of memory.
-  static constexpr const char* kSpillEnablePrefixSort =
-      "spill_enable_prefix_sort";
+  /// faster than std::sort but requires the memory to build normalized prefix
+  /// keys, which might have potential risk of running out of server memory.
+  static constexpr const char* kSpillPrefixSortEnabled =
+      "spill_prefixsort_enabled";
 
   /// Specifies spill write buffer size in bytes. The spiller tries to buffer
   /// serialized spill data up to the specified size before write to storage
@@ -641,8 +641,8 @@ class QueryConfig {
     return get<std::string>(kSpillCompressionKind, "none");
   }
 
-  bool spillEnablePrefixSort() const {
-    return get<bool>(kSpillEnablePrefixSort, false);
+  bool spillPrefixSortEnabled() const {
+    return get<bool>(kSpillPrefixSortEnabled, false);
   }
 
   uint64_t spillWriteBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -349,11 +349,11 @@ Spilling
      - Specifies the compression algorithm type to compress the spilled data before write to disk to trade CPU for IO
        efficiency. The supported compression codecs are: ZLIB, SNAPPY, LZO, ZSTD, LZ4 and GZIP.
        NONE means no compression.
-   * - spill_enable_prefix_sort
+   * - spill_prefixsort_enabled
      - bool
      - false
-     - Enable the prefix sort or fallback to timsort in spill. The prefix sort is faster than timsort but requires the
-       memory to build prefix data, which might have potential risk of running out of server memory.
+     - Enable the prefix sort or fallback to timsort in spill. The prefix sort is faster than std::sort but requires the
+       memory to build normalized prefix keys, which might have potential risk of running out of server memory.
    * - spiller_start_partition_bit
      - integer
      - 29

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -141,7 +141,7 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       queryConfig.maxSpillRunRows(),
       queryConfig.writerFlushThresholdBytes(),
       queryConfig.spillCompressionKind(),
-      queryConfig.spillEnablePrefixSort()
+      queryConfig.spillPrefixSortEnabled()
           ? std::optional<common::PrefixSortConfig>(prefixSortConfig())
           : std::nullopt,
       queryConfig.spillFileCreateConfig());


### PR DESCRIPTION
Summary:
The followup is to add session property at Prestissimo to allow configure
in Presto

Differential Revision: D65791663


