### PR TITLE
Fix data race in ExprToSubfieldFilterParser::getInstance

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -112,28 +112,13 @@ toInt64List(const VectorPtr& vector, vector_size_t start, vector_size_t size) {
   return values;
 }
 
+static std::shared_ptr<ExprToSubfieldFilterParser> defaultParser =
+    std::make_shared<PrestoExprToSubfieldFilterParser>();
+
 } // namespace
 
-std::function<std::unique_ptr<ExprToSubfieldFilterParser>()>
-    ExprToSubfieldFilterParser::parserFactory_ = nullptr;
-
-// static
-std::unique_ptr<ExprToSubfieldFilterParser>
-ExprToSubfieldFilterParser::getInstance() {
-  if (!parserFactory_) {
-    parserFactory_ = []() {
-      return std::make_unique<PrestoExprToSubfieldFilterParser>();
-    };
-  }
-  return parserFactory_();
-}
-
-// static
-void ExprToSubfieldFilterParser::registerParserFactory(
-    std::function<std::unique_ptr<ExprToSubfieldFilterParser>()>
-        parserFactory) {
-  parserFactory_ = parserFactory;
-}
+std::function<std::shared_ptr<ExprToSubfieldFilterParser>()>
+    ExprToSubfieldFilterParser::parserFactory_ = [] { return defaultParser; };
 
 bool ExprToSubfieldFilterParser::toSubfield(
     const core::ITypedExpr* field,

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -418,13 +418,17 @@ class ExprToSubfieldFilterParser {
  public:
   virtual ~ExprToSubfieldFilterParser() = default;
 
-  static std::unique_ptr<ExprToSubfieldFilterParser> getInstance();
+  static std::shared_ptr<ExprToSubfieldFilterParser> getInstance() {
+    return parserFactory_();
+  }
 
   /// Registers a custom parser factory. The factory is called to create a
   /// parser instance.
   static void registerParserFactory(
-      std::function<std::unique_ptr<ExprToSubfieldFilterParser>()>
-          parserFactory);
+      std::function<std::shared_ptr<ExprToSubfieldFilterParser>()>
+          parserFactory) {
+    parserFactory_ = std::move(parserFactory);
+  }
 
   /// Converts a leaf call expression (no conjunction like AND/OR) to subfield
   /// and filter. Return nullptr if not supported for pushdown. This is needed
@@ -488,7 +492,7 @@ class ExprToSubfieldFilterParser {
 
  private:
   // Factory method to create a parser instance.
-  static std::function<std::unique_ptr<ExprToSubfieldFilterParser>()>
+  static std::function<std::shared_ptr<ExprToSubfieldFilterParser>()>
       parserFactory_;
 };
 


### PR DESCRIPTION
Differential Revision: D65824456

Racing condition found with TSAN when accessing the singleton parser factory.


