### PR TITLE
Make arbitration timed lock TSAN compatible

### DIFF
--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -1876,6 +1876,7 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperationState) {
       "unknown state: 10");
 }
 
+#ifndef TSAN_BUILD
 TEST_F(ArbitrationParticipantTest, arbitrationOperationTimedLock) {
   auto participantPool = manager_->addRootPool("arbitrationOperationTimedLock");
   auto config = ArbitrationParticipant::Config(0, 1024, 0, 0, 0, 0, 128, 512);
@@ -1956,5 +1957,6 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperationTimedLock) {
     }
   }
 }
+#endif
 } // namespace
 } // namespace facebook::velox::memory


### PR DESCRIPTION
Summary: TSAN does not work with timed lock with timeout applied. So we need to make the piece of timed lock code not compiled in TSAN build. This PR makes sure the timed lock does trivial locking without timeout applied whenever it is TSAN build.

Differential Revision: D65849737


