### PR TITLE
fix: Match Presto's behavior for invalid UTF-8 in url_encode

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -54,6 +54,7 @@ velox_add_library(
   TransformKeys.cpp
   TransformValues.cpp
   TypeOf.cpp
+  URIParser.cpp
   URLFunctions.cpp
   VectorArithmetic.cpp
   WidthBucketArray.cpp

--- a/velox/functions/prestosql/URIParser.cpp
+++ b/velox/functions/prestosql/URIParser.cpp
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/URIParser.h"
+
+namespace facebook::velox::functions {
+
+namespace detail {
+using Mask = std::bitset<128>;
+
+Mask createMask(size_t low, size_t high) {
+  VELOX_DCHECK_LE(low, high);
+  VELOX_DCHECK_LE(high, 128);
+
+  Mask mask = 0;
+
+  for (size_t i = low; i <= high; i++) {
+    mask.set(i);
+  }
+
+  return mask;
+}
+
+Mask createMask(const std::vector<size_t>& values) {
+  Mask mask = 0;
+
+  for (const auto& value : values) {
+    VELOX_DCHECK_LE(value, 128);
+    mask.set(value);
+  }
+
+  return mask;
+}
+// a-z or A-Z.
+const Mask kAlpha = createMask('a', 'z') | createMask('A', 'Z');
+// 0-9.
+const Mask kNum = createMask('0', '9');
+// 0-9, a-f, or A-F.
+const Mask kHex = kNum | createMask('a', 'f') | createMask('A', 'F');
+// sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
+//               / "*" / "+" / "," / ";" / "="
+const Mask kSubDelims =
+    createMask({'!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '='});
+// unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
+const Mask kUnreserved = kAlpha | kNum | createMask({'-', '.', '_', '~'});
+// pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
+const Mask kPChar = kUnreserved | kSubDelims | createMask({':', '@'});
+// query         = *( pchar / "/" / "?" )
+// fragment      = *( pchar / "/" / "?" )
+//
+// DEVIATION FROM RFC 3986!!!
+// We support the characters '[' and ']' appearing in the query and fragment
+// strings.  This was done in RFC 2732, but undone in RFC 3986. We add support
+// for it here so we support a superset of the URLs supported by Presto Java.
+const Mask kQueryOrFragment = kPChar | createMask({'/', '?', '[', ']'});
+// path          = path-abempty    ; begins with "/" or is empty
+//                / path-absolute   ; begins with "/" but not "//"
+//                / path-noscheme   ; begins with a non-colon segment
+//                / path-rootless   ; begins with a segment
+//                / path-empty      ; zero characters
+//
+//  path-abempty  = *( "/" segment )
+//  path-absolute = "/" [ segment-nz *( "/" segment ) ]
+//  path-noscheme = segment-nz-nc *( "/" segment )
+//  path-rootless = segment-nz *( "/" segment )
+//  path-empty    = 0<pchar>
+//
+//  segment       = *pchar
+//  segment-nz    = 1*pchar
+//  segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+//                ; non-zero-length segment without any colon ":"
+const Mask kPath = kPChar | createMask({'/'});
+// segment-nz-nc  = 1*( unreserved / pct-encoded / sub-delims / "@" )
+//                ; non-zero-length segment without any colon ":"
+const Mask kPathNoColonPrefix = kPChar & createMask({':'}).flip();
+// reg-name      = *( unreserved / pct-encoded / sub-delims )
+const Mask kRegName = kUnreserved | kSubDelims;
+// IPvFuture     = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+// userinfo      = *( unreserved / pct-encoded / sub-delims / ":" )
+const Mask kIPVFutureSuffixOrUserInfo =
+    kUnreserved | kSubDelims | createMask({':'});
+// scheme        = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+const Mask kScheme = kAlpha | kNum | createMask({'+', '-', '.'});
+// Not explicitly called out in the spec, but these are the only characters that
+// can legally follow a host name in a URI (as part of a port, query, fragment,
+// or path respectively). Used to differentiate an IPv4 address from a reg-name
+// that has an IPv4 address as its prefix.
+const Mask kFollowingHost = createMask({':', '?', '#', '/'});
+
+// The functions below follow the general conventions:
+//
+// They are named consumeX or tryConsumeX where X is a part of the URI string
+// that generally corresponds to a rule in the ABNF grammar for URIs defined in
+// Appendix A of RFC 3986.
+//
+// Functions will take 3 or 4 arguments, `str` the URI string we are parsing,
+// `len` the length of the URI string we are parsing, and `pos` our current
+// position in the string at the time this function was called. Some functions
+// all take a fourth `uri` argument, the URI struct that is to be populated with
+// extracted sections of the URI string as part of parsing. If a function
+// successfully parses the string, pos is updated to be the first character
+// after the substring that was successfully parsed. In addition, if the
+// function takes `uri` it will be populated with the relevant section of the
+// URI.
+//
+// Functions named consumeX will always succeed because they can accept an empty
+// string.
+//
+// Functions named tryConsumeX may not successfully parse a substring, they will
+// return a bool, with `true` indicating that it was successful and `false`
+// indicating it was not. If it was not successful `pos` and `uri` will not be
+// modified.
+//
+// All rules are greedy and will consume as much of the string as possible
+// starting from `pos`.
+//
+// Naturally these conventions do not apply to helper functions.
+
+// pct-encoded   = "%" HEXDIG HEXDIG
+bool tryConsumePercentEncoded(const char* str, const size_t len, int32_t& pos) {
+  if (len - pos < 3) {
+    return false;
+  }
+
+  if (str[pos] != '%' || !kHex.test(str[pos + 1]) || !kHex.test(str[pos + 2])) {
+    return false;
+  }
+
+  pos += 3;
+
+  return true;
+}
+
+// Helper function that consumes as much of `str` from `pos` as possible where a
+// character passes mask or is part of a percent encoded character.
+//
+// `pos` is updated to the first character in `str` that was not consumed and
+// `hasEncoded` is set to true if any percent encoded characters were
+// encountered.
+void consume(
+    const Mask& mask,
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    bool& hasEncoded) {
+  while (pos < len) {
+    if (mask.test(str[pos])) {
+      pos++;
+      continue;
+    }
+
+    if (tryConsumePercentEncoded(str, len, pos)) {
+      hasEncoded = true;
+      continue;
+    }
+
+    break;
+  }
+}
+
+// path          = path-abempty    ; begins with "/" or is empty
+//                / path-absolute   ; begins with "/" but not "//"
+//                / path-noscheme   ; begins with a non-colon segment
+//                / path-rootless   ; begins with a segment
+//                / path-empty      ; zero characters
+//
+//  path-abempty  = *( "/" segment )
+//  path-absolute = "/" [ segment-nz *( "/" segment ) ]
+//  path-noscheme = segment-nz-nc *( "/" segment )
+//  path-rootless = segment-nz *( "/" segment )
+//  path-empty    = 0<pchar>
+//
+//  segment       = *pchar
+//  segment-nz    = 1*pchar
+//  segment-nz-nc = 1*( unreserved / pct-encoded / sub-delims / "@" )
+//                ; non-zero-length segment without any colon ":"
+//
+// For our purposes this is just a complicated way of saying a possibly empty
+// string of characters that match the kPath Mask or are percent encoded.
+//
+// The only case in Velox for distinguishing the different types of paths is in
+// the relative-part of a relative-ref which only supports path-noscheme, but
+// not path-rootless. Without this, it can be impossible to distinguish the ":"
+// between the scheme and hier-part of a URL and a colon appearining in the
+// relative-part of a relative-ref.
+//
+// To handle this we add the template bool restrictColonInPrefix which when set
+// just means we don't allow any ":" to appear before the first "/".
+//
+// As an example "a:b/c/d" would be allowed when restrictColonInPrefix is false,
+// but not when it's true. While "/a:b/c/d" would be allowed in either case.
+template <bool restrictColonInPrefix>
+void consumePath(const char* str, const size_t len, int32_t& pos, URI& uri) {
+  int32_t posInPath = pos;
+
+  if constexpr (restrictColonInPrefix) {
+    // Consume a prefix without ':' or '/'.
+    consume(kPathNoColonPrefix, str, len, posInPath, uri.pathHasEncoded);
+    // The path continues only if the next character is a '/'.
+    if (posInPath != len && str[posInPath] == '/') {
+      consume(kPath, str, len, posInPath, uri.pathHasEncoded);
+    }
+  } else {
+    consume(kPath, str, len, posInPath, uri.pathHasEncoded);
+  }
+
+  uri.path = StringView(str + pos, posInPath - pos);
+  pos = posInPath;
+}
+
+// Returns whether `probe` is in the range[`low`, `high`].
+FOLLY_ALWAYS_INLINE bool inRange(char probe, char low, char high) {
+  return probe >= low && probe <= high;
+}
+
+// IPv4address   = dec-octet "." dec-octet "." dec-octet "." dec-octet
+// dec-octet     = DIGIT                 ; 0-9
+//               / %x31-39 DIGIT         ; 10-99
+//               / "1" 2DIGIT            ; 100-199
+//               / "2" %x30-34 DIGIT     ; 200-249
+//               / "25" %x30-35          ; 250-255
+bool tryConsumeIPV4Address(const char* str, const size_t len, int32_t& pos) {
+  int32_t posInAddress = pos;
+
+  for (int i = 0; i < 4; i++) {
+    if (posInAddress == len) {
+      return false;
+    }
+
+    if (str[posInAddress] == '2' && posInAddress < len - 2 &&
+        str[posInAddress + 1] == '5' &&
+        inRange(str[posInAddress + 2], '0', '5')) {
+      // 250-255
+      posInAddress += 3;
+    } else if (
+        str[posInAddress] == '2' && posInAddress < len - 2 &&
+        inRange(str[posInAddress + 1], '0', '4') &&
+        inRange(str[posInAddress + 2], '0', '9')) {
+      // 200-249
+      posInAddress += 3;
+    } else if (
+        str[posInAddress] == '1' && posInAddress < len - 2 &&
+        inRange(str[posInAddress + 1], '0', '9') &&
+        inRange(str[posInAddress + 2], '0', '9')) {
+      // 100-199
+      posInAddress += 3;
+    } else if (inRange(str[posInAddress], '0', '9')) {
+      if (posInAddress < len - 1 && inRange(str[posInAddress + 1], '0', '9')) {
+        // 10-99
+        posInAddress += 2;
+      } else {
+        // 0-9
+        posInAddress += 1;
+      }
+    } else {
+      return false;
+    }
+
+    if (i < 3) {
+      // An IPv4 address must have exactly 4 parts.
+      if (posInAddress == len || str[posInAddress] != '.') {
+        return false;
+      }
+
+      // Consume '.'.
+      posInAddress++;
+    }
+  }
+
+  pos = posInAddress;
+  return true;
+}
+
+// Returns true if the substring starting from `pos` is '::'.
+bool isAtCompression(const char* str, const size_t len, const int32_t pos) {
+  return pos < len - 1 && str[pos] == ':' && str[pos + 1] == ':';
+}
+
+// IPv6address   =                            6( h16 ":" ) ls32
+//               /                       "::" 5( h16 ":" ) ls32
+//               / [               h16 ] "::" 4( h16 ":" ) ls32
+//               / [ *1( h16 ":" ) h16 ] "::" 3( h16 ":" ) ls32
+//               / [ *2( h16 ":" ) h16 ] "::" 2( h16 ":" ) ls32
+//               / [ *3( h16 ":" ) h16 ] "::"    h16 ":"   ls32
+//               / [ *4( h16 ":" ) h16 ] "::"              ls32
+//               / [ *5( h16 ":" ) h16 ] "::"              h16
+//               / [ *6( h16 ":" ) h16 ] "::"
+// h16           = 1*4HEXDIG
+// ls32          = ( h16 ":" h16 ) / IPv4address
+bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
+  bool hasCompression = false;
+  uint8_t numBytes = 0;
+  int32_t posInAddress = pos;
+
+  if (isAtCompression(str, len, posInAddress)) {
+    hasCompression = true;
+    // Consume the compression '::'.
+    posInAddress += 2;
+  }
+
+  while (posInAddress < len && numBytes < 16) {
+    int32_t posInHex = posInAddress;
+    for (int i = 0; i < 4; i++) {
+      if (posInHex == len || !kHex.test(str[posInHex])) {
+        break;
+      }
+
+      posInHex++;
+    }
+
+    if (posInHex == posInAddress) {
+      // We need to be able to consume at least one hex digit.
+      break;
+    }
+
+    if (posInHex < len) {
+      if (str[posInHex] == '.') {
+        // We may be in the IPV4 Address.
+        if (tryConsumeIPV4Address(str, len, posInAddress)) {
+          numBytes += 4;
+          break;
+        } else {
+          // A '.' can't appear anywhere except in a valid IPV4 address.
+          return false;
+        }
+      }
+      if (str[posInHex] == ':') {
+        if (isAtCompression(str, len, posInHex)) {
+          if (hasCompression) {
+            // We can't have two compressions.
+            return false;
+          } else {
+            // We found a 2 byte hex value followed by a compression.
+            numBytes += 2;
+            hasCompression = true;
+            // Consume the hex block and the compression '::'.
+            posInAddress = posInHex + 2;
+          }
+        } else {
+          if (posInHex == len || !kHex.test(str[posInHex + 1])) {
+            // Peak ahead, we can't end on a single ':'.
+            return false;
+          }
+          // We found a 2 byte hex value followed by a single ':'.
+          numBytes += 2;
+          // Consume the hex block and the ':'.
+          posInAddress = posInHex + 1;
+        }
+      } else {
+        // We found a 2 byte hex value at the end of the string.
+        numBytes += 2;
+        posInAddress = posInHex;
+        break;
+      }
+    }
+  }
+
+  // A valid IPv6 address must have exactly 16 bytes, or a compression.
+  if ((numBytes == 16 && !hasCompression) ||
+      (hasCompression && numBytes <= 14 && numBytes % 2 == 0)) {
+    pos = posInAddress;
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// IPvFuture     = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+bool tryConsumeIPVFuture(const char* str, const size_t len, int32_t& pos) {
+  int32_t posInAddress = pos;
+
+  if (posInAddress == len || str[posInAddress] != 'v') {
+    return false;
+  }
+
+  // Consume 'v'.
+  posInAddress++;
+
+  // Consume a string of hex digits.
+  int32_t posInHex = posInAddress;
+  while (posInHex < len) {
+    if (kHex.test(str[posInHex])) {
+      posInHex++;
+    } else {
+      break;
+    }
+  }
+
+  // The string of hex digits has to be non-empty.
+  if (posInHex == posInAddress) {
+    return false;
+  }
+
+  posInAddress = posInHex;
+
+  // The string of hex digits must be followed by a '.'.
+  if (posInAddress == len || str[posInAddress] != '.') {
+    return false;
+  }
+
+  // Consume '.'.
+  posInAddress++;
+
+  int32_t posInSuffix = posInAddress;
+  while (posInSuffix < len) {
+    if (kIPVFutureSuffixOrUserInfo.test(str[posInSuffix])) {
+      posInSuffix++;
+    } else {
+      break;
+    }
+  }
+
+  // The suffix must be non-empty.
+  if (posInSuffix == posInAddress) {
+    return false;
+  }
+
+  pos = posInSuffix;
+  return true;
+}
+
+// IP-literal    = "[" ( IPv6address / IPvFuture  ) "]"
+bool tryConsumeIPLiteral(const char* str, const size_t len, int32_t& pos) {
+  int32_t posInAddress = pos;
+
+  // The IP Literal must start with '['.
+  if (posInAddress == len || str[posInAddress] != '[') {
+    return false;
+  }
+
+  // Consume '['.
+  posInAddress++;
+
+  // The contents must be an IPv6 address or an IPvFuture.
+  if (!tryConsumeIPV6Address(str, len, posInAddress) &&
+      !tryConsumeIPVFuture(str, len, posInAddress)) {
+    return false;
+  }
+
+  // The IP literal must end with ']'.
+  if (posInAddress == len || str[posInAddress] != ']') {
+    return false;
+  }
+
+  // Consume ']'.
+  posInAddress++;
+  pos = posInAddress;
+
+  return true;
+}
+
+// port          = *DIGIT
+void consumePort(const char* str, const size_t len, int32_t& pos, URI& uri) {
+  int32_t posInPort = pos;
+
+  while (posInPort < len) {
+    if (kNum.test(str[posInPort])) {
+      posInPort++;
+      continue;
+    }
+
+    break;
+  }
+
+  uri.port = StringView(str + pos, posInPort - pos);
+  pos = posInPort;
+}
+
+// host          = IP-literal / IPv4address / reg-name
+// reg-name      = *( unreserved / pct-encoded / sub-delims )
+void consumeHost(const char* str, const size_t len, int32_t& pos, URI& uri) {
+  int32_t posInHost = pos;
+
+  if (!tryConsumeIPLiteral(str, len, posInHost)) {
+    int32_t posInIPV4Address = posInHost;
+    if (tryConsumeIPV4Address(str, len, posInIPV4Address) &&
+        (posInIPV4Address == len ||
+         kFollowingHost.test(str[posInIPV4Address]))) {
+      // reg-name and IPv4 addresses are hard to distinguish, a reg-name could
+      // have a valid IPv4 address as a prefix, but treating that prefix as an
+      // IPv4 address would make this URI invalid. We make sure that if we
+      // detect an IPv4 address it either goes to the end of the string, or is
+      // followed by one of the characters that can appear after a host name
+      // (and importantly can't appear in a reg-name).
+      posInHost = posInIPV4Address;
+    } else {
+      consume(kRegName, str, len, posInHost, uri.hostHasEncoded);
+    }
+  }
+
+  uri.host = StringView(str + pos, posInHost - pos);
+  pos = posInHost;
+}
+
+// authority     = [ userinfo "@" ] host [ ":" port ]
+void consumeAuthority(
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    URI& uri) {
+  int32_t posInAuthority = pos;
+
+  // Dummy variable to pass in as reference.
+  bool authorityHasEncoded;
+  consume(
+      kIPVFutureSuffixOrUserInfo,
+      str,
+      len,
+      posInAuthority,
+      authorityHasEncoded);
+
+  // The user info must be followed by '@'.
+  if (posInAuthority != len && str[posInAuthority] == '@') {
+    // Consume '@'.
+    posInAuthority++;
+  } else {
+    posInAuthority = pos;
+  }
+
+  consumeHost(str, len, posInAuthority, uri);
+
+  // The port must be preceded by a ':'.
+  if (posInAuthority < len && str[posInAuthority] == ':') {
+    // Consume ':'.
+    posInAuthority++;
+    consumePort(str, len, posInAuthority, uri);
+  }
+
+  pos = posInAuthority;
+}
+
+// scheme        = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+bool tryConsumeScheme(
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    URI& uri) {
+  int32_t posInScheme = pos;
+
+  // The scheme must start with a letter.
+  if (posInScheme == len || !kAlpha.test(str[posInScheme])) {
+    return false;
+  }
+
+  // Consume the first letter.
+  posInScheme++;
+
+  while (posInScheme < len && kScheme.test(str[posInScheme])) {
+    posInScheme++;
+  }
+
+  uri.scheme = StringView(str + pos, posInScheme - pos);
+  pos = posInScheme;
+  return true;
+}
+
+// relative-part = "//" authority path-abempty
+//               / path-absolute
+//               / path-noscheme
+//               / path-empty
+//
+// hier-part     = "//" authority path-abempty
+//               / path-absolute
+//               / path-rootless
+//               / path-empty
+//
+// Since we don't distinguish between path types these are functionally the same
+// thing.
+template <bool isRelativePart>
+void consumeRelativePartOrHierPart(
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    URI& uri) {
+  if (pos < len - 1 && str[pos] == '/' && str[pos + 1] == '/') {
+    // Consume '//'.
+    pos += 2;
+    consumeAuthority(str, len, pos, uri);
+
+    if (pos < len && str[pos] == '/') {
+      consumePath<false>(str, len, pos, uri);
+    }
+
+    return;
+  }
+
+  if constexpr (isRelativePart) {
+    // In the relative part, there's a restriction that there cannot be any ':'
+    // until the first '/'.
+    consumePath<true>(str, len, pos, uri);
+  } else {
+    consumePath<false>(str, len, pos, uri);
+  }
+}
+
+// query         = *( pchar / "/" / "?" )
+// fragment      = *( pchar / "/" / "?" )
+void consumeQueryAndFragment(
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    URI& uri) {
+  if (pos < len && str[pos] == '?') {
+    int32_t posInQuery = pos;
+    // Consume '?'.
+    posInQuery++;
+    // Consume query.
+    consume(kQueryOrFragment, str, len, posInQuery, uri.queryHasEncoded);
+
+    // Don't include the '?'.
+    uri.query = StringView(str + pos + 1, posInQuery - pos - 1);
+    pos = posInQuery;
+  }
+
+  if (pos < len && str[pos] == '#') {
+    int32_t posInFragment = pos;
+    // Consume '#'.
+    posInFragment++;
+    // Consume fragment.
+    consume(kQueryOrFragment, str, len, posInFragment, uri.fragmentHasEncoded);
+
+    // Don't include the '#'.
+    uri.fragment = StringView(str + pos + 1, posInFragment - pos - 1);
+    pos = posInFragment;
+  }
+}
+
+// relative-ref  = relative-part [ "?" query ] [ "#" fragment ]
+void consumeRelativeRef(
+    const char* str,
+    const size_t len,
+    int32_t& pos,
+    URI& uri) {
+  consumeRelativePartOrHierPart<true>(str, len, pos, uri);
+
+  consumeQueryAndFragment(str, len, pos, uri);
+}
+
+// URI           = scheme ":" hier-part [ "?" query ] [ "#" fragment ]
+bool tryConsumeUri(const char* str, const size_t len, int32_t& pos, URI& uri) {
+  URI result;
+  int32_t posInUri = pos;
+
+  if (!tryConsumeScheme(str, len, posInUri, result)) {
+    return false;
+  }
+
+  // Scheme is always followed by ':'.
+  if (posInUri == len || str[posInUri] != ':') {
+    return false;
+  }
+
+  // Consume ':'.
+  posInUri++;
+
+  consumeRelativePartOrHierPart<false>(str, len, posInUri, result);
+  consumeQueryAndFragment(str, len, posInUri, result);
+
+  pos = posInUri;
+  uri = result;
+  return true;
+}
+
+} // namespace detail
+
+// URI-reference = URI / relative-ref
+bool parseUri(const StringView& uriStr, URI& uri) {
+  int32_t pos = 0;
+  if (detail::tryConsumeUri(uriStr.data(), uriStr.size(), pos, uri) &&
+      pos == uriStr.size()) {
+    return true;
+  }
+
+  pos = 0;
+  detail::consumeRelativeRef(uriStr.data(), uriStr.size(), pos, uri);
+
+  return pos == uriStr.size();
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/URIParser.h
+++ b/velox/functions/prestosql/URIParser.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/StringView.h"
+
+namespace facebook::velox::functions {
+/// A struct containing the parts of the URI that were extracted during parsing.
+/// If the field was not found, it is empty.
+///
+/// For fields that can contain percent-encoded characters, the `...HasEncoded`
+/// flag indicates whether the field contains any percent-encoded characters.
+struct URI {
+  StringView scheme;
+  StringView path;
+  bool pathHasEncoded = false;
+  StringView query;
+  bool queryHasEncoded = false;
+  StringView fragment;
+  bool fragmentHasEncoded = false;
+  StringView host;
+  bool hostHasEncoded = false;
+  StringView port;
+};
+
+/// Parse a URI string into a URI struct according to RFC 3986.
+bool parseUri(const StringView& uriStr, URI& uri);
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/URLFunctions.h
+++ b/velox/functions/prestosql/URLFunctions.h
@@ -20,75 +20,14 @@
 #include <optional>
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/string/StringImpl.h"
+#include "velox/functions/prestosql/URIParser.h"
 
 namespace facebook::velox::functions {
 
 namespace detail {
-
-const auto kScheme = 2;
-const auto kAuthority = 3;
-const auto kPath = 5;
-const auto kQuery = 7;
-const auto kFragment = 9;
-const auto kHost = 3; // From the authority and path regex.
-const auto kPort = 4; // From the authority and path regex.
-
 FOLLY_ALWAYS_INLINE StringView submatch(const boost::cmatch& match, int idx) {
   const auto& sub = match[idx];
   return StringView(sub.first, sub.length());
-}
-
-FOLLY_ALWAYS_INLINE bool
-parse(const char* rawUrlData, size_t rawUrlsize, boost::cmatch& match) {
-  /// This regex is taken from RFC - 3986.
-  /// See: https://www.rfc-editor.org/rfc/rfc3986#appendix-B
-  /// The basic groups are:
-  ///      scheme    = $2
-  ///      authority = $4
-  ///      path      = $5
-  ///      query     = $7
-  ///      fragment  = $9
-  /// For example a URI like below :
-  ///  http://www.ics.uci.edu/pub/ietf/uri/#Related
-  ///
-  ///   results in the following subexpression matches:
-  ///
-  ///      $1 = http:
-  ///      $2 = http
-  ///      $3 = //www.ics.uci.edu
-  ///      $4 = www.ics.uci.edu
-  ///      $5 = /pub/ietf/uri/
-  ///      $6 = <undefined>
-  ///      $7 = <undefined>
-  ///      $8 = #Related
-  ///      $9 = Related
-  static const boost::regex kUriRegex(
-      "^(([^:\\/?#]+):)?" // scheme:
-      "(\\/\\/([^\\/?#]*))?([^?#]*)" // authority and path
-      "(\\?([^#]*))?" // ?query
-      "(#(.*))?"); // #fragment
-
-  return boost::regex_match(
-      rawUrlData, rawUrlData + rawUrlsize, match, kUriRegex);
-}
-
-/// Parses the url and returns the matching subgroup if the particular sub group
-/// is matched by the call to parse call above.
-FOLLY_ALWAYS_INLINE std::optional<StringView> parse(
-    StringView rawUrl,
-    int subGroup) {
-  boost::cmatch match;
-  if (!parse(rawUrl.data(), rawUrl.size(), match)) {
-    return std::nullopt;
-  }
-
-  VELOX_CHECK_LT(subGroup, match.size());
-
-  if (match[subGroup].matched) {
-    return submatch(match, subGroup);
-  }
-
-  return std::nullopt;
 }
 
 FOLLY_ALWAYS_INLINE unsigned char toHex(unsigned char c) {
@@ -136,38 +75,7 @@ FOLLY_ALWAYS_INLINE void urlEscape(TOutString& output, const TInString& input) {
   output.resize(outIndex);
 }
 
-/// Performs initial validation of the URI.
-/// Checks if the URI contains ascii whitespaces or
-/// unescaped '%' chars.
-FOLLY_ALWAYS_INLINE bool isValidURI(StringView input) {
-  const char* p = input.data();
-  const char* end = p + input.size();
-  char buf[3];
-  buf[2] = '\0';
-  char* endptr;
-  for (; p < end; ++p) {
-    if (stringImpl::isAsciiWhiteSpace(*p)) {
-      return false;
-    }
-
-    if (*p == '%') {
-      if (p + 2 < end) {
-        buf[0] = p[1];
-        buf[1] = p[2];
-        strtol(buf, &endptr, 16);
-        p += 2;
-        if (endptr != buf + 2) {
-          return false;
-        }
-      } else {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-template <typename TOutString, typename TInString>
+template <typename TOutString, typename TInString, bool unescapePlus = false>
 FOLLY_ALWAYS_INLINE void urlUnescape(
     TOutString& output,
     const TInString& input) {
@@ -181,9 +89,13 @@ FOLLY_ALWAYS_INLINE void urlUnescape(
   buf[2] = '\0';
   char* endptr;
   for (; p < end; ++p) {
-    if (*p == '+') {
-      *outputBuffer++ = ' ';
-    } else if (*p == '%') {
+    if constexpr (unescapePlus) {
+      if (*p == '+') {
+        *outputBuffer++ = ' ';
+        continue;
+      }
+    }
+    if (*p == '%') {
       if (p + 2 < end) {
         buf[0] = p[1];
         buf[1] = p[2];
@@ -204,15 +116,6 @@ FOLLY_ALWAYS_INLINE void urlUnescape(
   }
   output.resize(outputBuffer - output.data());
 }
-
-/// Matches the authority (i.e host[:port], ipaddress), and path from a string
-/// representing the authority and path. Returns true if the regex matches, and
-/// sets the appropriate groups matching authority in authorityMatch.
-std::optional<StringView> matchAuthorityAndPath(
-    StringView authorityAndPath,
-    boost::cmatch& authorityMatch,
-    int subGroup);
-
 } // namespace detail
 
 template <typename T>
@@ -228,15 +131,13 @@ struct UrlExtractProtocolFunction {
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    if (auto protocol = detail::parse(url, detail::kScheme)) {
-      result.setNoCopy(protocol.value());
-    } else {
-      result.setEmpty();
-    }
+    result.setNoCopy(uri.scheme);
+
     return true;
   }
 };
@@ -248,21 +149,22 @@ struct UrlExtractFragmentFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  // ASCII input always produces ASCII result.
-  static constexpr bool is_default_ascii_behavior = true;
+  // Input is always ASCII, but result may or may not be ASCII.
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    if (auto fragment = detail::parse(url, detail::kFragment)) {
-      result.setNoCopy(fragment.value());
+    if (uri.fragmentHasEncoded) {
+      detail::urlUnescape(result, uri.fragment);
     } else {
-      result.setEmpty();
+      result.setNoCopy(uri.fragment);
     }
+
     return true;
   }
 };
@@ -274,29 +176,22 @@ struct UrlExtractHostFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  // ASCII input always produces ASCII result.
-  static constexpr bool is_default_ascii_behavior = true;
+  // Input is always ASCII, but result may or may not be ASCII.
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    auto authAndPath = detail::parse(url, detail::kAuthority);
-    if (!authAndPath) {
-      result.setEmpty();
-      return true;
-    }
-    boost::cmatch authorityMatch;
-
-    if (auto host = detail::matchAuthorityAndPath(
-            authAndPath.value(), authorityMatch, detail::kHost)) {
-      result.setNoCopy(host.value());
+    if (uri.hostHasEncoded) {
+      detail::urlUnescape(result, uri.host);
     } else {
-      result.setEmpty();
+      result.setNoCopy(uri.host);
     }
+
     return true;
   }
 };
@@ -306,26 +201,19 @@ struct UrlExtractPortFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    auto authAndPath = detail::parse(url, detail::kAuthority);
-    if (!authAndPath) {
-      return false;
-    }
-
-    boost::cmatch authorityMatch;
-    if (auto port = detail::matchAuthorityAndPath(
-            authAndPath.value(), authorityMatch, detail::kPort)) {
-      if (!port.value().empty()) {
-        try {
-          result = to<int64_t>(port.value());
-          return true;
-        } catch (folly::ConversionError const&) {
-        }
+    if (!uri.port.empty()) {
+      try {
+        result = to<int64_t>(uri.port);
+        return true;
+      } catch (folly::ConversionError const&) {
       }
     }
+
     return false;
   }
 };
@@ -336,17 +224,22 @@ struct UrlExtractPathFunction {
 
   // Input is always ASCII, but result may or may not be ASCII.
 
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    auto path = detail::parse(url, detail::kPath);
-    VELOX_USER_CHECK(
-        path.has_value(), "Unable to determine path for URL: {}", url);
-    detail::urlUnescape(result, path.value());
+    if (uri.pathHasEncoded) {
+      detail::urlUnescape(result, uri.path);
+    } else {
+      result.setNoCopy(uri.path);
+    }
 
     return true;
   }
@@ -359,20 +252,20 @@ struct UrlExtractQueryFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  // ASCII input always produces ASCII result.
-  static constexpr bool is_default_ascii_behavior = true;
+  // Input is always ASCII, but result may or may not be ASCII.
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    if (auto query = detail::parse(url, detail::kQuery)) {
-      result.setNoCopy(query.value());
+    if (uri.queryHasEncoded) {
+      detail::urlUnescape(result, uri.query);
     } else {
-      result.setEmpty();
+      result.setNoCopy(uri.query);
     }
 
     return true;
@@ -386,23 +279,18 @@ struct UrlExtractParameterFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  // ASCII input always produces ASCII result.
-  static constexpr bool is_default_ascii_behavior = true;
+  // Input is always ASCII, but result may or may not be ASCII.
 
   FOLLY_ALWAYS_INLINE bool call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& url,
       const arg_type<Varchar>& param) {
-    if (!detail::isValidURI(url)) {
+    URI uri;
+    if (!parseUri(url, uri)) {
       return false;
     }
 
-    auto query = detail::parse(url, detail::kQuery);
-    if (!query) {
-      return false;
-    }
-
-    if (!query.value().empty()) {
+    if (!uri.query.empty()) {
       // Parse query string.
       static const boost::regex kQueryParamRegex(
           "(^|&)" // start of query or start of parameter "&"
@@ -413,8 +301,8 @@ struct UrlExtractParameterFunction {
       );
 
       const boost::cregex_iterator begin(
-          query.value().data(),
-          query.value().data() + query.value().size(),
+          uri.query.data(),
+          uri.query.data() + uri.query.size(),
           kQueryParamRegex);
       boost::cregex_iterator end;
 
@@ -452,7 +340,8 @@ struct UrlDecodeFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    detail::urlUnescape(result, input);
+    detail::urlUnescape<out_type<Varchar>, arg_type<Varbinary>, true>(
+        result, input);
   }
 };
 


### PR DESCRIPTION
Summary:
Presto Java converts the URL to a Java String before encoding it in url_encode. Java replaces bytes
in an invalid UTF-8 character with 0xEF 0xBF 0xBD.

Velox encodes invalid UTF-8 characters as is, which leads to differences in results from Java and 
C++.

This diff adds a check when encoding URLs for invalid UTF-8 characters and does the same
replacement as Java.

Differential Revision: D65856104


