### PR TITLE
Extracts trace node name automatically in trace replayer

### DIFF
--- a/velox/exec/TraceUtil.h
+++ b/velox/exec/TraceUtil.h
@@ -79,6 +79,13 @@ std::string getOpTraceSplitFilePath(const std::string& opTraceDir);
 /// Returns the file path for a given operator's traced input file.
 std::string getOpTraceSummaryFilePath(const std::string& opTraceDir);
 
+/// Extracts the trace node name from the trace metadata file.
+std::string getNodeName(
+    const std::string& nodeId,
+    const std::string& taskMetaFilePath,
+    const std::shared_ptr<filesystems::FileSystem>& fs,
+    memory::MemoryPool* pool);
+
 /// Extracts the input data type for the trace scan operator. The function first
 /// uses the traced node id to find traced operator's plan node from the traced
 /// plan fragment. Then it uses the specified source node index to find the

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <utility>
+#include "velox/common/file/FileSystems.h"
+#include "velox/tool/trace/OperatorReplayerBase.h"
 
 #include <folly/executors/IOThreadPoolExecutor.h>
 
@@ -27,7 +29,6 @@ DECLARE_string(query_id);
 DECLARE_string(task_id);
 DECLARE_string(node_id);
 DECLARE_int32(driver_id);
-DECLARE_string(operator_type);
 DECLARE_string(table_writer_output_dir);
 DECLARE_double(hiveConnectorExecutorHwMultiplier);
 DECLARE_int32(shuffle_serialization_format);
@@ -49,7 +50,10 @@ class TraceReplayRunner {
   virtual void run();
 
  private:
+  std::unique_ptr<tool::trace::OperatorReplayerBase> createReplayer() const;
+
   const std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  std::shared_ptr<filesystems::FileSystem> fs_;
 };
 
 } // namespace facebook::velox::tool::trace


### PR DESCRIPTION
Extracts trace node name from the task metadata file and create
a trace replayer accordingly, hence users do not need to pass the
'operatorType' parameter when using the replayer.

Part of #9668 

