### PR TITLE
build(ci): Add conventional commit title check

### DIFF
--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -30,7 +30,6 @@ concurrency:
 
 jobs:
   check-matrix:
-    if: ${{ github.event.action != 'edited' }}
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/facebookincubator/velox-dev:check
@@ -78,10 +77,8 @@ jobs:
           fi
 
   title-check:
-    name: CC Titel
+    name: CC PR Titel
     runs-on: ubuntu-latest
-    # Run this on every commit for now to notify existing PRs after they rebase
-    # if: ${{ github.event.action == 'opened' || github.event.action == 'edited' }}
     steps:
       - shell: python
         env:

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
   title-check:
-    name: CC PR Titel
+    name: CC PR Title
     runs-on: ubuntu-latest
     steps:
       - shell: python

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -15,6 +15,11 @@ name: Run Checks
 
 on:
   pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
 
 permissions:
   contents: read
@@ -25,6 +30,7 @@ concurrency:
 
 jobs:
   check-matrix:
+    if: ${{ github.event.action != 'edited' }}
     name: ${{ matrix.config.name }}
     runs-on: ubuntu-latest
     container: ghcr.io/facebookincubator/velox-dev:check

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -70,3 +70,25 @@ jobs:
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+
+  title-check:
+    name: CC Titel
+    runs-on: ubuntu-latest
+    # Run this on every commit for now to notify existing PRs after they rebase
+    # if: ${{ github.event.action == 'opened' || github.event.action == 'edited' }}
+    steps:
+      - shell: python
+        env:
+          title: "${{ github.event.pull_request.title }}"
+        run: |
+          import re 
+          import os
+          title = os.environ["title"]
+          title_re = r"^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?: (.+)"
+          match = re.search(title_re, title)
+
+          if match is None:
+            print("::error::Please follow conventional commit guidelines in CONTRIBUTING.md: https://github.com/facebookincubator/velox/blob/main/CONTRIBUTING.md#commit-messages")
+            exit(1)
+          else:
+            exit(0)

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -77,7 +77,7 @@ jobs:
           fi
 
   title-check:
-    name: CC PR Title
+    name: PR Title Format
     runs-on: ubuntu-latest
     steps:
       - shell: python
@@ -91,7 +91,7 @@ jobs:
           match = re.search(title_re, title)
 
           if match is None:
-            print("::error::Please follow conventional commit guidelines in CONTRIBUTING.md: https://github.com/facebookincubator/velox/blob/main/CONTRIBUTING.md#commit-messages")
+            print("::error::Please follow conventional commit guidelines in commit titles as described in CONTRIBUTING.md: https://github.com/facebookincubator/velox/blob/main/CONTRIBUTING.md#commit-messages")
             exit(1)
           else:
             exit(0)

--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -87,7 +87,7 @@ jobs:
           import re 
           import os
           title = os.environ["title"]
-          title_re = r"^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?: (.+)"
+          title_re = r"^(feat|fix|build|test|docs|refactor|misc)(\(.+\))?!?: ([A-Z].+)[^.]$"
           match = re.search(title_re, title)
 
           if match is None:


### PR DESCRIPTION
Check the PR title against cc pattern added  in #11356. Fails with a pointer to  CONTRIBUTING.md. 
We are running the title change on every commit as it takes under 5 seconds to run and this way we avoid weird states with skipped checks overriding failed results when the title was triggered outside of a commit.

We could add a comment to the PR but that would require a workflow with elevated permissions using `pull_request_target` which should be avoided if possible. So I think the marginally lower ux is justified, we still get a marker/reminder for reviewers through this job.