### PR TITLE
docs: Add CONTRIBUTING guidelines for broken CI jobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ The contribution process is outlined below:
 
 3. Start a discussion by creating a Github Issue, or asking on Slack (unless the change is trivial).
    * This step helps you identify possible collaborators and reviewers.
-   * Does the proposed change align with technical vision and project values?
+   * Does the proposed change align with the technical vision and project values?
    * Will the change conflict with another change in progress? If so, work with others to minimize impact.
 
 4. Implement the change.
@@ -85,8 +85,16 @@ The contribution process is outlined below:
      with the title prefixed with [WIP], and share with collaborators to get early feedback.
    * Ensure the PR follows the [title and description
      guidelines](#commit-messages) presented below.
-   * Make sure the PR passes all CI tests.
-   * Create/submit a Github PR and tag the reviewers identified in Step 3.
+   * Make sure the PR passes **all CI tests**.
+     * Do not ignore red CI signals, even if they seem preexisting.
+     * If you believe a red CI signal is unrelated to your change, please search for
+     existing Issues reporting this particular test. They should contain the test name
+     in the Issue title.
+     * If an Issue already exist, add a comment containing the link to your failed CI job.
+     * If an Issue does not exist, please create one with the title "Broken CI \<test\_name\>",
+     tagging the appropriate maintainers for that component.
+   * Once all CI signals are green, create/submit a Github PR and tag the reviewers
+   identified in Step 3.
 
 5. Review is performed by one or more reviewers.
    * This normally happens within a few days, but may take longer if the change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ The contribution process is outlined below:
      with the title prefixed with [WIP], and share with collaborators to get early feedback.
    * Ensure the PR follows the [title and description
      guidelines](#commit-messages) presented below.
-   * Make sure the PR passes **all CI tests**.
+   * Create/submit a Github PR and make sure it passes **all CI tests**.
      * Do not ignore red CI signals, even if they seem preexisting.
      * If you believe a red CI signal is unrelated to your change, please search for
      existing Issues reporting this particular test. They should contain the test name
@@ -93,8 +93,7 @@ The contribution process is outlined below:
      * If an Issue already exist, add a comment containing the link to your failed CI job.
      * If an Issue does not exist, please create one with the title "Broken CI \<test\_name\>",
      tagging the appropriate maintainers for that component.
-   * Once all CI signals are green, create/submit a Github PR and tag the reviewers
-   identified in Step 3.
+   * Once all CI signals are green, tag the reviewers identified in Step 3.
 
 5. Review is performed by one or more reviewers.
    * This normally happens within a few days, but may take longer if the change


### PR DESCRIPTION
Following up on offline discussion, adding instructions to CONTRIBUTING.md file
to instruct contributors not to ignore broken CI jobs, and create github Issues
when appropriate.