### PR TITLE
[Velox] [Fix] Throw if Aggregation Filter clause has non boolean expression

### DIFF
--- a/velox/exec/AggregationMasks.cpp
+++ b/velox/exec/AggregationMasks.cpp
@@ -37,6 +37,10 @@ void AggregationMasks::addInput(
 
     // Get the projection column vector that would be our mask.
     const auto& maskVector = input->childAt(entry.first);
+    VELOX_CHECK_EQ(
+        maskVector->type(),
+        BOOLEAN(),
+        "FILTER(WHERE..) clause must use masks that are BOOLEAN");
 
     // Get decoded vector and update the masked selectivity vector.
     decodedMask_.decode(*maskVector, rows);


### PR DESCRIPTION
Summary:
There is difference in behavior in how non boolean aggregation masks behave in Velox and Presto. 
This change causes velox to throw when we encounter non boolean mask.
This is a stop gap for issue #11523.

Differential Revision: D65858866


