### PR TITLE
feat(prefix sort): Support string type key in prefix sort

### DIFF
--- a/velox/common/base/PrefixSortConfig.h
+++ b/velox/common/base/PrefixSortConfig.h
@@ -42,6 +42,6 @@ struct PrefixSortConfig {
 
   /// Maximum number of bytes to be stored in prefix-sort buffer for a string
   /// column.
-  uint32_t maxStringPrefixLength{12};
+  uint32_t maxStringPrefixLength{16};
 };
 } // namespace facebook::velox::common

--- a/velox/common/base/PrefixSortConfig.h
+++ b/velox/common/base/PrefixSortConfig.h
@@ -40,7 +40,7 @@ struct PrefixSortConfig {
   /// with small datasets.
   uint32_t minNumRows{128};
 
-  /// Max number of bytes to be stored in prefix-sort buffer for a string
+  /// Maximum number of bytes to be stored in prefix-sort buffer for a string
   /// column.
   uint32_t maxStringPrefixLength{12};
 };

--- a/velox/common/base/PrefixSortConfig.h
+++ b/velox/common/base/PrefixSortConfig.h
@@ -24,9 +24,13 @@ namespace facebook::velox::common {
 struct PrefixSortConfig {
   PrefixSortConfig() = default;
 
-  PrefixSortConfig(uint32_t _maxNormalizedKeyBytes, uint32_t _minNumRows)
+  PrefixSortConfig(
+      uint32_t _maxNormalizedKeyBytes,
+      uint32_t _minNumRows,
+      uint32_t _maxStringPrefixLength)
       : maxNormalizedKeyBytes(_maxNormalizedKeyBytes),
-        minNumRows(_minNumRows) {}
+        minNumRows(_minNumRows),
+        maxStringPrefixLength(_maxStringPrefixLength) {}
 
   /// Maximum bytes that can be used to store normalized keys in prefix-sort
   /// buffer per entry. Same with QueryConfig kPrefixSortNormalizedKeyMaxBytes.
@@ -35,5 +39,9 @@ struct PrefixSortConfig {
   /// Minimum number of rows to apply prefix sort. Prefix sort does not perform
   /// with small datasets.
   uint32_t minNumRows{128};
+
+  /// Max number of bytes to be stored in prefix-sort buffer for a string
+  /// column.
+  uint32_t maxStringPrefixLength{12};
 };
 } // namespace facebook::velox::common

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -380,8 +380,8 @@ class QueryConfig {
 
   /// Maximum number of bytes to be stored in prefix-sort buffer for a string
   /// key.
-  static constexpr const char* kPrefixSortMaxStringPrefixLength =
-      "prefixsort_max_string_prefix_length";
+  static constexpr const char* kPrefixSortMaxStringLength =
+      "prefixsort_max_string_length";
 
   /// Enable query tracing flag.
   static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
@@ -849,8 +849,8 @@ class QueryConfig {
     return get<uint32_t>(kPrefixSortMinRows, 128);
   }
 
-  uint32_t prefixSortMaxStringPrefixLength() const {
-    return get<uint32_t>(kPrefixSortMaxStringPrefixLength, 12);
+  uint32_t prefixSortMaxStringLength() const {
+    return get<uint32_t>(kPrefixSortMaxStringLength, 16);
   }
 
   double scaleWriterRebalanceMaxMemoryUsageRatio() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -380,8 +380,8 @@ class QueryConfig {
 
   /// Maximum number of bytes to be stored in prefix-sort buffer for a string
   /// key.
-  static constexpr const char* kPrefixSortMaxStringLength =
-      "prefixsort_max_string_length";
+  static constexpr const char* kPrefixSortMaxStringPrefixLength =
+      "prefixsort_max_string_prefix_length";
 
   /// Enable query tracing flag.
   static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
@@ -849,8 +849,8 @@ class QueryConfig {
     return get<uint32_t>(kPrefixSortMinRows, 128);
   }
 
-  uint32_t prefixSortMaxStringLength() const {
-    return get<uint32_t>(kPrefixSortMaxStringLength, 16);
+  uint32_t prefixSortMaxStringPrefixLength() const {
+    return get<uint32_t>(kPrefixSortMaxStringPrefixLength, 16);
   }
 
   double scaleWriterRebalanceMaxMemoryUsageRatio() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -378,6 +378,11 @@ class QueryConfig {
   /// derived using micro-benchmarking.
   static constexpr const char* kPrefixSortMinRows = "prefixsort_min_rows";
 
+  /// Maximum number of bytes to be stored in prefix-sort buffer for a string
+  /// key.
+  static constexpr const char* kPrefixSortMaxStringPrefixLength =
+      "prefixsort_max_string_prefix_length";
+
   /// Enable query tracing flag.
   static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
 
@@ -842,6 +847,10 @@ class QueryConfig {
 
   uint32_t prefixSortMinRows() const {
     return get<uint32_t>(kPrefixSortMinRows, 128);
+  }
+
+  uint32_t prefixSortMaxStringPrefixLength() const {
+    return get<uint32_t>(kPrefixSortMaxStringPrefixLength, 12);
   }
 
   double scaleWriterRebalanceMaxMemoryUsageRatio() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -144,9 +144,9 @@ Generic Configuration
      - integer
      - 128
      - Minimum number of rows to use prefix-sort. The default value has been derived using micro-benchmarking.
-   * - prefixsort_max_string_prefix_length
+   * - prefixsort_max_string_length
      - integer
-     - 12
+     - 16
      - Byte length of the string prefix stored in the prefix-sort buffer. This doesn't include the null byte.
 
 .. _expression-evaluation-conf:

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -144,6 +144,10 @@ Generic Configuration
      - integer
      - 128
      - Minimum number of rows to use prefix-sort. The default value has been derived using micro-benchmarking.
+   * - prefixsort_max_string_prefix_length
+     - integer
+     - 12
+     - Byte length of the string prefix stored in the prefix-sort buffer. This doesn't include the null byte.
 
 .. _expression-evaluation-conf:
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -144,7 +144,7 @@ Generic Configuration
      - integer
      - 128
      - Minimum number of rows to use prefix-sort. The default value has been derived using micro-benchmarking.
-   * - prefixsort_max_string_length
+   * - prefixsort_max_string_prefix_length
      - integer
      - 16
      - Byte length of the string prefix stored in the prefix-sort buffer. This doesn't include the null byte.

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -300,7 +300,8 @@ struct DriverCtx {
   common::PrefixSortConfig prefixSortConfig() const {
     return common::PrefixSortConfig{
         queryConfig().prefixSortNormalizedKeyMaxBytes(),
-        queryConfig().prefixSortMinRows()};
+        queryConfig().prefixSortMinRows(),
+        queryConfig().prefixSortMaxStringPrefixLength()};
   }
 };
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -301,7 +301,7 @@ struct DriverCtx {
     return common::PrefixSortConfig{
         queryConfig().prefixSortNormalizedKeyMaxBytes(),
         queryConfig().prefixSortMinRows(),
-        queryConfig().prefixSortMaxStringPrefixLength()};
+        queryConfig().prefixSortMaxStringLength()};
   }
 };
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -301,7 +301,7 @@ struct DriverCtx {
     return common::PrefixSortConfig{
         queryConfig().prefixSortNormalizedKeyMaxBytes(),
         queryConfig().prefixSortMinRows(),
-        queryConfig().prefixSortMaxStringLength()};
+        queryConfig().prefixSortMaxStringPrefixLength()};
   }
 };
 

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -208,7 +208,7 @@ void PrefixSortLayout::optimizeSortKeysOrder(
       rowType->size(), std::nullopt);
   for (const auto& projection : keyColumnProjections) {
     // Set stringPrefixLength to UINT_MAX - 1 to ensure VARCHAR columns are
-    // processed after all other types.
+    // processed after all other supported types.
     encodedKeySizes[projection.inputChannel] = PrefixSortEncoder::encodedSize(
         rowType->childAt(projection.inputChannel)->kind(), UINT_MAX - 1);
   }

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -39,8 +39,15 @@ FOLLY_ALWAYS_INLINE void encodeRowColumn(
   } else {
     value = *(reinterpret_cast<T*>(row + rowColumn.offset()));
   }
-  prefixSortLayout.encoders[index].encode(
-      value, prefixBuffer + prefixSortLayout.prefixOffsets[index]);
+  if constexpr (std::is_same_v<T, StringView>) {
+    prefixSortLayout.encoders[index].encode(
+        value,
+        prefixBuffer + prefixSortLayout.prefixOffsets[index],
+        prefixSortLayout.encodeSizes[index]);
+  } else {
+    prefixSortLayout.encoders[index].encode(
+        value, prefixBuffer + prefixSortLayout.prefixOffsets[index]);
+  }
 }
 
 FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
@@ -83,6 +90,13 @@ FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
     }
     case TypeKind::HUGEINT: {
       encodeRowColumn<int128_t>(
+          prefixSortLayout, index, rowColumn, row, prefixBuffer);
+      return;
+    }
+    case TypeKind::VARCHAR:
+      [[fallthrough]];
+    case TypeKind::VARBINARY: {
+      encodeRowColumn<StringView>(
           prefixSortLayout, index, rowColumn, row, prefixBuffer);
       return;
     }
@@ -130,28 +144,42 @@ compareByWord(uint64_t* left, uint64_t* right, int32_t bytes) {
 PrefixSortLayout PrefixSortLayout::makeSortLayout(
     const std::vector<TypePtr>& types,
     const std::vector<CompareFlags>& compareFlags,
-    uint32_t maxNormalizedKeySize) {
+    uint32_t maxNormalizedKeySize,
+    uint32_t maxStringPrefixLength,
+    const std::vector<uint32_t>& maxStringLengths) {
   const uint32_t numKeys = types.size();
   std::vector<uint32_t> prefixOffsets;
   prefixOffsets.reserve(numKeys);
+  std::vector<uint32_t> encodeSizes;
+  encodeSizes.reserve(numKeys);
   std::vector<PrefixSortEncoder> encoders;
   encoders.reserve(numKeys);
 
   // Calculate encoders and prefix-offsets, and stop the loop if a key that
-  // cannot be normalized is encountered.
+  // cannot be normalized is encountered or only partial data of a key is
+  // normalized.
   uint32_t normalizedKeySize{0};
   uint32_t numNormalizedKeys{0};
+
+  bool lastKeyInPrefixIsPartial{false};
   for (auto i = 0; i < numKeys; ++i) {
-    const std::optional<uint32_t> encodedSize =
-        PrefixSortEncoder::encodedSize(types[i]->kind());
+    const std::optional<uint32_t> encodedSize = PrefixSortEncoder::encodedSize(
+        types[i]->kind(), std::min(maxStringLengths[i], maxStringPrefixLength));
     if (!encodedSize.has_value() ||
         normalizedKeySize + encodedSize.value() > maxNormalizedKeySize) {
       break;
     }
     prefixOffsets.push_back(normalizedKeySize);
     encoders.push_back({compareFlags[i].ascending, compareFlags[i].nullsFirst});
+    encodeSizes.push_back(encodedSize.value());
     normalizedKeySize += encodedSize.value();
     ++numNormalizedKeys;
+    if ((types[i]->kind() == TypeKind::VARCHAR ||
+         types[i]->kind() == TypeKind::VARBINARY) &&
+        maxStringPrefixLength < maxStringLengths[i]) {
+      lastKeyInPrefixIsPartial = true;
+      break;
+    }
   }
 
   const auto numPaddingBytes = alignmentPadding(normalizedKeySize, kAlignment);
@@ -165,7 +193,9 @@ PrefixSortLayout PrefixSortLayout::makeSortLayout(
       compareFlags,
       numNormalizedKeys != 0,
       numNormalizedKeys < numKeys,
+      lastKeyInPrefixIsPartial ? numNormalizedKeys - 1 : numNormalizedKeys,
       std::move(prefixOffsets),
+      std::move(encodeSizes),
       std::move(encoders),
       numPaddingBytes};
 }
@@ -177,8 +207,10 @@ void PrefixSortLayout::optimizeSortKeysOrder(
   std::vector<std::optional<uint32_t>> encodedKeySizes(
       rowType->size(), std::nullopt);
   for (const auto& projection : keyColumnProjections) {
+    // Set stringPrefixLength to UINT_MAX - 1 to ensure VARCHAR columns are
+    // processed after all other types.
     encodedKeySizes[projection.inputChannel] = PrefixSortEncoder::encodedSize(
-        rowType->childAt(projection.inputChannel)->kind());
+        rowType->childAt(projection.inputChannel)->kind(), UINT_MAX - 1);
   }
 
   std::sort(
@@ -222,7 +254,8 @@ int PrefixSort::comparePartNormalizedKeys(char* left, char* right) {
   // If prefixes are equal, compare the remaining sort keys with rowContainer.
   char* leftRow = getRowAddrFromPrefixBuffer(left);
   char* rightRow = getRowAddrFromPrefixBuffer(right);
-  for (auto i = sortLayout_.numNormalizedKeys; i < sortLayout_.numKeys; ++i) {
+  for (auto i = sortLayout_.comparisonStartIndex; i < sortLayout_.numKeys;
+       ++i) {
     result = rowContainer_->compare(
         leftRow, rightRow, i, sortLayout_.compareFlags[i]);
     if (result != 0) {
@@ -276,9 +309,8 @@ uint32_t PrefixSort::maxRequiredBytes(
   if (rowContainer->numRows() < config.minNumRows) {
     return 0;
   }
-  VELOX_CHECK_EQ(rowContainer->keyTypes().size(), compareFlags.size());
-  const auto sortLayout = PrefixSortLayout::makeSortLayout(
-      rowContainer->keyTypes(), compareFlags, config.maxNormalizedKeyBytes);
+  const auto sortLayout =
+      generateSortLayout(rowContainer, compareFlags, config);
   if (!sortLayout.hasNormalizedKeys) {
     return 0;
   }
@@ -346,7 +378,8 @@ void PrefixSort::sortInternal(
           RuntimeCounter(
               sortLayout_.numNormalizedKeys, RuntimeCounter::Unit::kNone));
     }
-    if (sortLayout_.hasNonNormalizedKey) {
+    if (sortLayout_.hasNonNormalizedKey ||
+        sortLayout_.comparisonStartIndex < sortLayout_.numNormalizedKeys) {
       sortRunner.quickSort(
           prefixBufferStart, prefixBufferEnd, [&](char* lhs, char* rhs) {
             return comparePartNormalizedKeys(lhs, rhs);

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -207,8 +207,10 @@ void PrefixSortLayout::optimizeSortKeysOrder(
   std::vector<std::optional<uint32_t>> encodedKeySizes(
       rowType->size(), std::nullopt);
   for (const auto& projection : keyColumnProjections) {
+    // Set maxStringPrefixLength to UINT_MAX - 1 to ensure VARCHAR columns are
+    // placed after all other supported types and before un-supported types.
     encodedKeySizes[projection.inputChannel] = PrefixSortEncoder::encodedSize(
-        rowType->childAt(projection.inputChannel)->kind(), std::nullopt);
+        rowType->childAt(projection.inputChannel)->kind(), UINT_MAX - 1);
   }
 
   std::sort(

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -192,7 +192,7 @@ PrefixSortLayout PrefixSortLayout::generate(
       compareFlags,
       numNormalizedKeys != 0,
       numNormalizedKeys < numKeys,
-      /* nonPrefixSortStartIndex */
+      /*nonPrefixSortStartIndex=*/
       lastPrefixKeyPartial ? numNormalizedKeys - 1 : numNormalizedKeys,
       std::move(prefixOffsets),
       std::move(encodeSizes),

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -182,7 +182,6 @@ class PrefixSort {
           keyTypes[i]->kind() == TypeKind::VARCHAR) {
         const auto stats = rowContainer->columnStats(i);
         if (stats.has_value()) {
-          // zhli ? stats.value().maxBytes() > 0
           maxStringLength = stats.value().maxBytes();
         }
       }

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -175,15 +175,15 @@ class PrefixSort {
     std::vector<uint32_t> maxStringLengths;
     maxStringLengths.reserve(keyTypes.size());
     for (int i = 0; i < keyTypes.size(); ++i) {
-      auto maxPrefixLength = config.maxStringPrefixLength;
+      auto maxStringLength = UINT_MAX;
       if (keyTypes[i]->kind() == TypeKind::VARBINARY ||
           keyTypes[i]->kind() == TypeKind::VARCHAR) {
         const auto stats = rowContainer->columnStats(i);
-        maxPrefixLength = stats.has_value() && stats.value().maxBytes() > 0
+        maxStringLength = stats.has_value() && stats.value().maxBytes() > 0
             ? stats.value().maxBytes()
             : UINT_MAX;
       }
-      maxStringLengths.emplace_back(maxPrefixLength);
+      maxStringLengths.emplace_back(maxStringLength);
     }
     return PrefixSortLayout::makeSortLayout(
         keyTypes,

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -53,9 +53,17 @@ struct PrefixSortLayout {
   /// Whether the sort keys contains non-normalized key.
   const bool hasNonNormalizedKey;
 
+  /// Indicates the starting index for key comparison.
+  /// If the last key is only partially encoded in the prefix, start from
+  /// numNormalizedKeys - 1. Otherwise, start from numNormalizedKeys.
+  const uint32_t comparisonStartIndex;
+
   /// Offsets of normalized keys, used to find write locations when
   /// extracting columns
   const std::vector<uint32_t> prefixOffsets;
+
+  /// Sizes of normalized keys.
+  const std::vector<uint32_t> encodeSizes;
 
   /// The encoders for normalized keys.
   const std::vector<prefixsort::PrefixSortEncoder> encoders;
@@ -67,7 +75,9 @@ struct PrefixSortLayout {
   static PrefixSortLayout makeSortLayout(
       const std::vector<TypePtr>& types,
       const std::vector<CompareFlags>& compareFlags,
-      uint32_t maxNormalizedKeySize);
+      uint32_t maxNormalizedKeySize,
+      uint32_t maxStringPrefixLength,
+      const std::vector<uint32_t>& maxStringLengths);
 
   /// Optimizes the order of sort key columns to maximize the number of prefix
   /// sort keys for acceleration. This only applies for use case which doesn't
@@ -121,10 +131,8 @@ class PrefixSort {
       stdSort(rows, rowContainer, compareFlags);
       return;
     }
-
-    VELOX_CHECK_EQ(rowContainer->keyTypes().size(), compareFlags.size());
-    const auto sortLayout = PrefixSortLayout::makeSortLayout(
-        rowContainer->keyTypes(), compareFlags, config.maxNormalizedKeyBytes);
+    const auto sortLayout =
+        generateSortLayout(rowContainer, compareFlags, config);
     // All keys can not normalize, skip the binary string compare opt.
     // Putting this outside sort-internal helps with stdSort.
     if (!sortLayout.hasNormalizedKeys) {
@@ -157,6 +165,33 @@ class PrefixSort {
       std::vector<char*, memory::StlAllocator<char*>>& rows,
       const RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags);
+
+  FOLLY_ALWAYS_INLINE static PrefixSortLayout generateSortLayout(
+      const RowContainer* rowContainer,
+      const std::vector<CompareFlags>& compareFlags,
+      const velox::common::PrefixSortConfig& config) {
+    const auto keyTypes = rowContainer->keyTypes();
+    VELOX_CHECK_EQ(keyTypes.size(), compareFlags.size());
+    std::vector<uint32_t> maxStringLengths;
+    maxStringLengths.reserve(keyTypes.size());
+    for (int i = 0; i < keyTypes.size(); ++i) {
+      auto maxPrefixLength = config.maxStringPrefixLength;
+      if (keyTypes[i]->kind() == TypeKind::VARBINARY ||
+          keyTypes[i]->kind() == TypeKind::VARCHAR) {
+        const auto stats = rowContainer->columnStats(i);
+        maxPrefixLength = stats.has_value() && stats.value().maxBytes() > 0
+            ? stats.value().maxBytes()
+            : UINT_MAX;
+      }
+      maxStringLengths.emplace_back(maxPrefixLength);
+    }
+    return PrefixSortLayout::makeSortLayout(
+        keyTypes,
+        compareFlags,
+        config.maxNormalizedKeyBytes,
+        config.maxStringPrefixLength,
+        maxStringLengths);
+  }
 
   // Estimates the memory required for prefix sort such as prefix buffer and
   // swap buffer.

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -567,7 +567,8 @@ void RowContainer::store(
         decoded,
         rows,
         isKey,
-        offsets_[column]);
+        offsets_[column],
+        column);
   } else {
     const auto rowColumn = rowColumns_[column];
     VELOX_DYNAMIC_TYPE_DISPATCH_ALL(

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1056,6 +1056,7 @@ class RowContainer {
     for (int32_t i = 0; i < rows.size(); ++i) {
       storeWithNulls<Kind>(
           decoded, i, isKey, rows[i], offset, nullByte, nullMask, column);
+      updateColumnStats(decoded, i, rows[i], column);
     }
   }
 
@@ -1064,9 +1065,11 @@ class RowContainer {
       const DecodedVector& decoded,
       folly::Range<char**> rows,
       bool isKey,
-      int32_t offset) {
+      int32_t offset,
+      int32_t column) {
     for (int32_t i = 0; i < rows.size(); ++i) {
       storeNoNulls<Kind>(decoded, i, isKey, rows[i], offset);
+      updateColumnStats(decoded, i, rows[i], column);
     }
   }
 

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -60,7 +60,8 @@ Window::Window(
         pool(),
         common::PrefixSortConfig{
             driverCtx->queryConfig().prefixSortNormalizedKeyMaxBytes(),
-            driverCtx->queryConfig().prefixSortMinRows()},
+            driverCtx->queryConfig().prefixSortMinRows(),
+            driverCtx->queryConfig().prefixSortMaxStringPrefixLength()},
         spillConfig,
         &nonReclaimableSection_,
         &spillStats_);

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -61,7 +61,7 @@ Window::Window(
         common::PrefixSortConfig{
             driverCtx->queryConfig().prefixSortNormalizedKeyMaxBytes(),
             driverCtx->queryConfig().prefixSortMinRows(),
-            driverCtx->queryConfig().prefixSortMaxStringLength()},
+            driverCtx->queryConfig().prefixSortMaxStringPrefixLength()},
         spillConfig,
         &nonReclaimableSection_,
         &spillStats_);

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -61,7 +61,7 @@ Window::Window(
         common::PrefixSortConfig{
             driverCtx->queryConfig().prefixSortNormalizedKeyMaxBytes(),
             driverCtx->queryConfig().prefixSortMinRows(),
-            driverCtx->queryConfig().prefixSortMaxStringPrefixLength()},
+            driverCtx->queryConfig().prefixSortMaxStringLength()},
         spillConfig,
         &nonReclaimableSection_,
         &spillStats_);

--- a/velox/exec/benchmarks/PrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/PrefixSortBenchmark.cpp
@@ -125,15 +125,14 @@ class TestCase {
 
 // You could config threshold, e.i. 0, to test prefix-sort for small
 // dateset.
-static const common::PrefixSortConfig kDefaultSortConfig(1024, 100);
+static const common::PrefixSortConfig kDefaultSortConfig(1024, 100, 50);
 
 // For small dataset, in some test environments, if std-sort is defined in the
 // benchmark file, the test results may be strangely regressed. When the
 // threshold is particularly large, PrefixSort is actually std-sort, hence, we
 // can use this as std-sort benchmark base.
-static const common::PrefixSortConfig kStdSortConfig(
-    1024,
-    std::numeric_limits<int>::max());
+static const common::PrefixSortConfig
+    kStdSortConfig(1024, std::numeric_limits<int>::max(), 50);
 
 class PrefixSortBenchmark {
  public:

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -69,7 +69,7 @@ class PrefixSortEncoder {
   ///         For not supported types, returns 'std::nullopt'.
   FOLLY_ALWAYS_INLINE static std::optional<uint32_t> encodedSize(
       TypeKind typeKind,
-      std::optional<uint32_t> stringPrefixLength) {
+      uint32_t maxStringPrefixLength) {
     // NOTE: one byte is reserved for nullable comparison.
     switch ((typeKind)) {
       case ::facebook::velox::TypeKind::SMALLINT: {
@@ -96,14 +96,7 @@ class PrefixSortEncoder {
       case ::facebook::velox::TypeKind::VARBINARY:
         [[fallthrough]];
       case ::facebook::velox::TypeKind::VARCHAR: {
-        if (stringPrefixLength.has_value()) {
-          return 1 + stringPrefixLength.value();
-        } else {
-          // Return a big value to ensure VARCHAR columns are
-          // processed after all other supported types and before unsupported
-          // types.
-          return 256;
-        }
+        return 1 + maxStringPrefixLength;
       }
       default:
         return std::nullopt;

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -55,7 +55,7 @@ class PrefixSortEncoder {
   /// zeros'. If `!ascending_`, the bits for both the content and padding zeros
   /// need to be inverted.
   FOLLY_ALWAYS_INLINE void encode(
-      std::optional<StringView> value,
+      const std::optional<StringView>& value,
       char* dest,
       uint32_t encodeSize) const {
     auto* destDataPtr = dest + 1;

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -225,7 +225,9 @@ class PrefixEncoderTest : public testing::Test,
 
     auto test = [&](const PrefixSortEncoder& encoder) {
       TypePtr type = TypeTraits<Kind>::ImplType::create();
-      VectorFuzzer fuzzer({.vectorSize = vectorSize, .nullRatio = 0.1}, pool());
+      VectorFuzzer fuzzer(
+          {.vectorSize = vectorSize, .nullRatio = 0.1, .stringLength = 16},
+          pool());
 
       CompareFlags compareFlag = {
           encoder.isNullsFirst(),
@@ -250,8 +252,14 @@ class PrefixEncoderTest : public testing::Test,
         const auto rightValue = rightVector->isNullAt(i)
             ? std::nullopt
             : std::optional<ValueDataType>(rightVector->valueAt(i));
-        encoder.encode(leftValue, leftEncoded);
-        encoder.encode(rightValue, rightEncoded);
+        if constexpr (
+            Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+          encoder.encode(leftValue, leftEncoded, 17);
+          encoder.encode(rightValue, rightEncoded, 17);
+        } else {
+          encoder.encode(leftValue, leftEncoded);
+          encoder.encode(rightValue, rightEncoded);
+        }
 
         const auto result = compare(leftEncoded, rightEncoded);
         const auto expected =
@@ -264,7 +272,23 @@ class PrefixEncoderTest : public testing::Test,
     test(ascNullsLastEncoder_);
     test(descNullsFirstEncoder_);
     test(descNullsLastEncoder_);
-  };
+  }
+
+  const PrefixSortEncoder& ascNullsFirstEncoder() const {
+    return ascNullsFirstEncoder_;
+  }
+
+  const PrefixSortEncoder ascNullsLastEncoder() const {
+    return ascNullsLastEncoder_;
+  }
+
+  const PrefixSortEncoder descNullsFirstEncoder() const {
+    return descNullsFirstEncoder_;
+  }
+
+  const PrefixSortEncoder descNullsLastEncoder() const {
+    return descNullsLastEncoder_;
+  }
 
  protected:
   static void SetUpTestCase() {
@@ -347,6 +371,46 @@ TEST_F(PrefixEncoderTest, encode) {
   }
 }
 
+TEST_F(PrefixEncoderTest, encodeString) {
+  constexpr int32_t encodeSize = 13;
+  StringView testValue = StringView("aaaaaabbbbbb");
+  char expectedAsc[encodeSize] = "aaaaaabbbbbb";
+  char expectedDesc[encodeSize];
+  for (int i = 0; i < encodeSize - 1; ++i) {
+    expectedDesc[i] = ~expectedAsc[i];
+  }
+  std::optional<StringView> nullValue = std::nullopt;
+  std::optional<StringView> value = testValue;
+  char encoded[encodeSize + 1];
+  char nullFirst[encodeSize + 1];
+  char nullLast[encodeSize + 1];
+  memset(nullFirst, 0, encodeSize);
+  memset(nullLast, 1, 1);
+  memset(nullLast + 1, 0, encodeSize - 1);
+
+  auto compare = [&](char* left, char* right) {
+    return std::memcmp(left, right, encodeSize);
+  };
+
+  ascNullsFirstEncoder().encode(nullValue, encoded, encodeSize);
+  ASSERT_EQ(compare(nullFirst, encoded), 0);
+  ascNullsLastEncoder().encode(nullValue, encoded, encodeSize);
+  ASSERT_EQ(compare(nullLast, encoded), 0);
+
+  ascNullsFirstEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(encoded[0], 1);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
+  ascNullsLastEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(encoded[0], 0);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
+  descNullsFirstEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(encoded[0], 1);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
+  descNullsLastEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(encoded[0], 0);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
+}
+
 TEST_F(PrefixEncoderTest, compare) {
   testCompare<uint64_t>();
   testCompare<uint32_t>();
@@ -386,6 +450,14 @@ TEST_F(PrefixEncoderTest, fuzzyDouble) {
 
 TEST_F(PrefixEncoderTest, fuzzyTimestamp) {
   testFuzz<TypeKind::TIMESTAMP>();
+}
+
+TEST_F(PrefixEncoderTest, fuzzyStringView) {
+  testFuzz<TypeKind::VARCHAR>();
+}
+
+TEST_F(PrefixEncoderTest, fuzzyBinary) {
+  testFuzz<TypeKind::VARBINARY>();
 }
 
 } // namespace facebook::velox::exec::prefixsort::test

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -74,9 +74,9 @@ class PrefixEncoderTest : public testing::Test,
   template <typename T>
   void testEncodeNoNull(T value, char* expectedAsc, char* expectedDesc) {
     char encoded[sizeof(T)];
-    ascNullsFirstEncoder_.encodeNoNulls(value, (char*)encoded);
+    ascNullsFirstEncoder_.encodeNoNulls(value, (char*)encoded, sizeof(T) + 1);
     ASSERT_EQ(std::memcmp(encoded, expectedAsc, sizeof(T)), 0);
-    descNullsFirstEncoder_.encodeNoNulls(value, (char*)encoded);
+    descNullsFirstEncoder_.encodeNoNulls(value, (char*)encoded, sizeof(T) + 1);
     ASSERT_EQ(std::memcmp(encoded, expectedDesc, sizeof(T)), 0);
   }
 
@@ -95,21 +95,21 @@ class PrefixEncoderTest : public testing::Test,
       return std::memcmp(left, right, sizeof(T) + 1);
     };
 
-    ascNullsFirstEncoder_.encode(nullValue, encoded);
+    ascNullsFirstEncoder_.encode(nullValue, encoded, sizeof(T) + 1);
     ASSERT_EQ(compare(nullFirst, encoded), 0);
-    ascNullsLastEncoder_.encode(nullValue, encoded);
+    ascNullsLastEncoder_.encode(nullValue, encoded, sizeof(T) + 1);
     ASSERT_EQ(compare(nullLast, encoded), 0);
 
-    ascNullsFirstEncoder_.encode(value, encoded);
+    ascNullsFirstEncoder_.encode(value, encoded, sizeof(T) + 1);
     ASSERT_EQ(encoded[0], 1);
     ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, sizeof(T)), 0);
-    ascNullsLastEncoder_.encode(value, encoded);
+    ascNullsLastEncoder_.encode(value, encoded, sizeof(T) + 1);
     ASSERT_EQ(encoded[0], 0);
     ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, sizeof(T)), 0);
-    descNullsFirstEncoder_.encode(value, encoded);
+    descNullsFirstEncoder_.encode(value, encoded, sizeof(T) + 1);
     ASSERT_EQ(encoded[0], 1);
     ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, sizeof(T)), 0);
-    descNullsLastEncoder_.encode(value, encoded);
+    descNullsLastEncoder_.encode(value, encoded, sizeof(T) + 1);
     ASSERT_EQ(encoded[0], 0);
     ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, sizeof(T)), 0);
   }
@@ -122,21 +122,22 @@ class PrefixEncoderTest : public testing::Test,
 
   template <typename T>
   void testNullCompare() {
+    constexpr uint32_t kEncodeSize = sizeof(T) + 1;
     std::optional<T> nullValue = std::nullopt;
     std::optional<T> max = std::numeric_limits<T>::max();
     std::optional<T> min = std::numeric_limits<T>::min();
-    char encodedNull[sizeof(T) + 1];
-    char encodedMax[sizeof(T) + 1];
-    char encodedMin[sizeof(T) + 1];
+    char encodedNull[kEncodeSize];
+    char encodedMax[kEncodeSize];
+    char encodedMin[kEncodeSize];
 
     auto encode = [&](auto& encoder) {
-      encoder.encode(nullValue, encodedNull);
-      encoder.encode(min, encodedMin);
-      encoder.encode(max, encodedMax);
+      encoder.encode(nullValue, encodedNull, kEncodeSize);
+      encoder.encode(min, encodedMin, kEncodeSize);
+      encoder.encode(max, encodedMax, kEncodeSize);
     };
 
     auto compare = [](char* left, char* right) {
-      return std::memcmp(left, right, sizeof(T) + 1);
+      return std::memcmp(left, right, kEncodeSize);
     };
 
     // Nulls first: NULL < non-NULL.
@@ -154,34 +155,35 @@ class PrefixEncoderTest : public testing::Test,
     // For float / double`s NaN.
     if (TypeLimits<T>::isFloat) {
       std::optional<T> nan = TypeLimits<T>::nan();
-      char encodedNaN[sizeof(T) + 1];
+      char encodedNaN[kEncodeSize];
 
-      ascNullsFirstEncoder_.encode(nan, encodedNaN);
-      ascNullsFirstEncoder_.encode(max, encodedMax);
+      ascNullsFirstEncoder_.encode(nan, encodedNaN, kEncodeSize);
+      ascNullsFirstEncoder_.encode(max, encodedMax, kEncodeSize);
       ASSERT_GT(compare(encodedNaN, encodedMax), 0);
 
-      ascNullsFirstEncoder_.encode(nan, encodedNaN);
-      ascNullsFirstEncoder_.encode(nullValue, encodedNull);
+      ascNullsFirstEncoder_.encode(nan, encodedNaN, kEncodeSize);
+      ascNullsFirstEncoder_.encode(nullValue, encodedNull, kEncodeSize);
       ASSERT_LT(compare(encodedNull, encodedNaN), 0);
     }
   }
 
   template <typename T>
   void testValidValueCompare() {
+    constexpr uint32_t kEncodeSize = sizeof(T) + 1;
     std::optional<T> max = std::numeric_limits<T>::max();
     std::optional<T> min = TypeLimits<T>::min();
     std::optional<T> mid = TypeLimits<T>::mid();
-    char encodedMax[sizeof(T) + 1];
-    char encodedMin[sizeof(T) + 1];
-    char encodedMid[sizeof(T) + 1];
+    char encodedMax[kEncodeSize];
+    char encodedMin[kEncodeSize];
+    char encodedMid[kEncodeSize];
     auto encode = [&](auto& encoder) {
-      encoder.encode(mid, encodedMid);
-      encoder.encode(min, encodedMin);
-      encoder.encode(max, encodedMax);
+      encoder.encode(mid, encodedMid, kEncodeSize);
+      encoder.encode(min, encodedMin, kEncodeSize);
+      encoder.encode(max, encodedMax, kEncodeSize);
     };
 
     auto compare = [](char* left, char* right) {
-      return std::memcmp(left, right, sizeof(T) + 1);
+      return std::memcmp(left, right, kEncodeSize);
     };
 
     encode(ascNullsFirstEncoder_);
@@ -257,8 +259,8 @@ class PrefixEncoderTest : public testing::Test,
           encoder.encode(leftValue, leftEncoded, 17);
           encoder.encode(rightValue, rightEncoded, 17);
         } else {
-          encoder.encode(leftValue, leftEncoded);
-          encoder.encode(rightValue, rightEncoded);
+          encoder.encode(leftValue, leftEncoded, sizeof(ValueDataType) + 1);
+          encoder.encode(rightValue, rightEncoded, sizeof(ValueDataType) + 1);
         }
 
         const auto result = compare(leftEncoded, rightEncoded);
@@ -372,43 +374,43 @@ TEST_F(PrefixEncoderTest, encode) {
 }
 
 TEST_F(PrefixEncoderTest, encodeString) {
-  constexpr int32_t encodeSize = 13;
+  constexpr uint32_t kEncodeSize = 13;
   StringView testValue = StringView("aaaaaabbbbbb");
-  char expectedAsc[encodeSize] = "aaaaaabbbbbb";
-  char expectedDesc[encodeSize];
-  for (int i = 0; i < encodeSize - 1; ++i) {
+  char expectedAsc[kEncodeSize] = "aaaaaabbbbbb";
+  char expectedDesc[kEncodeSize];
+  for (int i = 0; i < kEncodeSize - 1; ++i) {
     expectedDesc[i] = ~expectedAsc[i];
   }
   std::optional<StringView> nullValue = std::nullopt;
   std::optional<StringView> value = testValue;
-  char encoded[encodeSize + 1];
-  char nullFirst[encodeSize + 1];
-  char nullLast[encodeSize + 1];
-  memset(nullFirst, 0, encodeSize);
+  char encoded[kEncodeSize + 1];
+  char nullFirst[kEncodeSize + 1];
+  char nullLast[kEncodeSize + 1];
+  memset(nullFirst, 0, kEncodeSize);
   memset(nullLast, 1, 1);
-  memset(nullLast + 1, 0, encodeSize - 1);
+  memset(nullLast + 1, 0, kEncodeSize - 1);
 
   auto compare = [&](char* left, char* right) {
-    return std::memcmp(left, right, encodeSize);
+    return std::memcmp(left, right, kEncodeSize);
   };
 
-  ascNullsFirstEncoder().encode(nullValue, encoded, encodeSize);
+  ascNullsFirstEncoder().encode(nullValue, encoded, kEncodeSize);
   ASSERT_EQ(compare(nullFirst, encoded), 0);
-  ascNullsLastEncoder().encode(nullValue, encoded, encodeSize);
+  ascNullsLastEncoder().encode(nullValue, encoded, kEncodeSize);
   ASSERT_EQ(compare(nullLast, encoded), 0);
 
-  ascNullsFirstEncoder().encode(value, encoded, encodeSize);
+  ascNullsFirstEncoder().encode(value, encoded, kEncodeSize);
   ASSERT_EQ(encoded[0], 1);
-  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
-  ascNullsLastEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, kEncodeSize - 1), 0);
+  ascNullsLastEncoder().encode(value, encoded, kEncodeSize);
   ASSERT_EQ(encoded[0], 0);
-  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, encodeSize - 1), 0);
-  descNullsFirstEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedAsc, kEncodeSize - 1), 0);
+  descNullsFirstEncoder().encode(value, encoded, kEncodeSize);
   ASSERT_EQ(encoded[0], 1);
-  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
-  descNullsLastEncoder().encode(value, encoded, encodeSize);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, kEncodeSize - 1), 0);
+  descNullsLastEncoder().encode(value, encoded, kEncodeSize);
   ASSERT_EQ(encoded[0], 0);
-  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, encodeSize - 1), 0);
+  ASSERT_EQ(std::memcmp(encoded + 1, expectedDesc, kEncodeSize - 1), 0);
 }
 
 TEST_F(PrefixEncoderTest, compare) {

--- a/velox/exec/prefixsort/tests/utils/EncoderTestUtils.cpp
+++ b/velox/exec/prefixsort/tests/utils/EncoderTestUtils.cpp
@@ -32,7 +32,8 @@ void decodeNoNulls(char* encoded, int64_t& value) {
 void encodeInPlace(std::vector<int64_t>& data) {
   const static auto encoder = PrefixSortEncoder(true, true);
   for (auto i = 0; i < data.size(); i++) {
-    encoder.encodeNoNulls(data[i], (char*)data.data() + i * sizeof(int64_t));
+    encoder.encodeNoNulls(
+        data[i], (char*)data.data() + i * sizeof(int64_t), sizeof(int64_t) + 1);
   }
 }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2036,92 +2036,108 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       {true, 0, 0, 0},
       {false, 0, 0, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() -
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() -
            1,
        0,
        0},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() -
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value(),
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+           .value(),
        0,
        1},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value(),
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+           .value(),
        0,
        0},
-      {true, 1'000'000, 0, 3},
+      {true, 1'000'000, 0, 4},
       {false, 1'000'000, 0, 0},
       {true, 1'000'000, 1'000'000, 0},
       {false, 1'000'000, 1'000'000, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
-               .value(),
-       0,
-       2},
-      {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
-               .value(),
-       0,
-       0},
-      {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
-               .value(),
-       1'000'000,
-       0},
-      {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
-               .value(),
-       1'000'000,
-       0},
-      {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT).value(),
-       0,
-       2},
-      {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT).value(),
-       0,
-       0},
-      {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+               .value(),
+       0,
+       2},
+      {false,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+               .value(),
+       0,
+       0},
+      {true,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+               .value(),
+       1'000'000,
+       0},
+      {false,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+               .value(),
+       1'000'000,
+       0},
+      {true,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value(),
+       0,
+       2},
+      {false,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value(),
+       0,
+       0},
+      {true,
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
                .value() -
            1,
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
                .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
                .value(),
        0,
        3},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT).value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER)
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+               .value() +
+           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
                .value(),
        0,
        0}};

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -66,7 +66,8 @@ class PrefixSortTest : public exec::test::OperatorTestBase {
         common::PrefixSortConfig{
             1024,
             // Set threshold to 0 to enable prefix-sort in small dataset.
-            0},
+            0,
+            12},
         sortPool.get());
     const auto beforeBytes = sortPool->peakBytes();
     ASSERT_EQ(sortPool->peakBytes(), 0);
@@ -77,7 +78,8 @@ class PrefixSortTest : public exec::test::OperatorTestBase {
         common::PrefixSortConfig{
             1024,
             // Set threshold to 0 to enable prefix-sort in small dataset.
-            0},
+            0,
+            12},
         sortPool.get(),
         rows);
     ASSERT_GE(maxBytes, sortPool->peakBytes() - beforeBytes);
@@ -151,8 +153,6 @@ const RowVectorPtr PrefixSortTest::generateExpectedResult(
 }
 
 TEST_F(PrefixSortTest, singleKey) {
-  const int columnsSize = 7;
-
   // Vectors without nulls.
   const std::vector<VectorPtr> testData = {
       makeFlatVector<int64_t>({5, 4, 3, 2, 1}),
@@ -172,8 +172,22 @@ TEST_F(PrefixSortTest, singleKey) {
            Timestamp(3, 3),
            Timestamp(2, 2),
            Timestamp(1, 1)}),
-      makeFlatVector<std::string_view>({"eee", "ddd", "ccc", "bbb", "aaa"})};
-  for (int i = 5; i < columnsSize; ++i) {
+      makeFlatVector<std::string_view>({"eee", "ddd", "ccc", "bbb", "aaa"}),
+      makeFlatVector<std::string_view>({"e", "dddddd", "bbb", "ddd", "aaa"}),
+      makeFlatVector<std::string_view>(
+          {"ddd_not_inline",
+           "aaa_is_not_inline",
+           "aaa_is_not_inline_a",
+           "ddd_is_not_inline",
+           "aaa_is_not_inline_b"}),
+      makeNullableFlatVector<std::string_view>(
+          {"\u7231",
+           "\u671B\u5E0C\u2014\u5FF5\u4FE1",
+           "\u671B\u5E0C",
+           "\u7231\u2014",
+           "\u4FE1 \u7231"},
+          VARBINARY())};
+  for (int i = 0; i < testData.size(); ++i) {
     const auto data = makeRowVector({testData[i]});
 
     testPrefixSort({kAsc}, data);
@@ -182,9 +196,6 @@ TEST_F(PrefixSortTest, singleKey) {
 }
 
 TEST_F(PrefixSortTest, singleKeyWithNulls) {
-  const int columnsSize = 7;
-
-  Timestamp ts = {5, 5};
   // Vectors with nulls.
   const std::vector<VectorPtr> testData = {
       makeNullableFlatVector<int64_t>({5, 4, std::nullopt, 2, 1}),
@@ -205,9 +216,24 @@ TEST_F(PrefixSortTest, singleKeyWithNulls) {
            Timestamp(2, 2),
            Timestamp(1, 1)}),
       makeNullableFlatVector<std::string_view>(
-          {"eee", "ddd", std::nullopt, "bbb", "aaa"})};
+          {"eee", "ddd", std::nullopt, "bbb", "aaa"}),
+      makeNullableFlatVector<std::string_view>(
+          {"ee", "aaa", std::nullopt, "d", "aaaaaaaaaaaaaa"}),
+      makeNullableFlatVector<std::string_view>(
+          {"aaa_is_not_inline",
+           "aaa_is_not_inline_2",
+           std::nullopt,
+           "aaa_is_not_inline_1",
+           "aaaaaaaaaaaaaa"}),
+      makeNullableFlatVector<std::string_view>(
+          {"\u7231",
+           "\u671B\u5E0C\u2014\u5FF5\u4FE1",
+           std::nullopt,
+           "\u7231\u2014",
+           "\u4FE1 \u7231"},
+          VARBINARY())};
 
-  for (int i = 5; i < columnsSize; ++i) {
+  for (int i = 0; i < testData.size(); ++i) {
     const auto data = makeRowVector({testData[i]});
 
     testPrefixSort({kAsc}, data);
@@ -232,7 +258,7 @@ TEST_F(PrefixSortTest, multipleKeys) {
     const auto data = makeRowVector({
         makeNullableFlatVector<int64_t>({5, 2, std::nullopt, 2, 1}),
         makeNullableFlatVector<std::string_view>(
-            {"eee", "ddd", std::nullopt, "bbb", "aaa"}),
+            {"eee", "aaa", std::nullopt, "bbb", "aaaa"}),
     });
 
     testPrefixSort({kAsc, kAsc}, data);
@@ -298,27 +324,32 @@ TEST_F(PrefixSortTest, checkMaxNormalizedKeySizeForMultipleKeys) {
   // The normalizedKeySize for BIGINT should be 8 + 1.
   std::vector<TypePtr> keyTypes = {BIGINT(), BIGINT()};
   std::vector<CompareFlags> compareFlags = {kAsc, kDesc};
-  auto sortLayout = PrefixSortLayout::makeSortLayout(keyTypes, compareFlags, 8);
+  std::vector<uint32_t> maxStringLengths = {9, 9};
+  auto sortLayout = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 8, 9, maxStringLengths);
   ASSERT_FALSE(sortLayout.hasNormalizedKeys);
 
-  auto sortLayoutOneKey =
-      PrefixSortLayout::makeSortLayout(keyTypes, compareFlags, 9);
+  auto sortLayoutOneKey = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 9, 9, maxStringLengths);
   ASSERT_TRUE(sortLayoutOneKey.hasNormalizedKeys);
   ASSERT_TRUE(sortLayoutOneKey.hasNonNormalizedKey);
   ASSERT_EQ(sortLayoutOneKey.prefixOffsets.size(), 1);
   ASSERT_EQ(sortLayoutOneKey.prefixOffsets[0], 0);
 
-  auto sortLayoutOneKey1 =
-      PrefixSortLayout::makeSortLayout(keyTypes, compareFlags, 17);
+  auto sortLayoutOneKey1 = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 17, 12, maxStringLengths);
   ASSERT_TRUE(sortLayoutOneKey1.hasNormalizedKeys);
   ASSERT_TRUE(sortLayoutOneKey1.hasNonNormalizedKey);
   ASSERT_EQ(sortLayoutOneKey1.prefixOffsets.size(), 1);
   ASSERT_EQ(sortLayoutOneKey1.prefixOffsets[0], 0);
 
-  auto sortLayoutTwoKeys =
-      PrefixSortLayout::makeSortLayout(keyTypes, compareFlags, 18);
+  auto sortLayoutTwoKeys = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 18, 12, maxStringLengths);
   ASSERT_TRUE(sortLayoutTwoKeys.hasNormalizedKeys);
   ASSERT_FALSE(sortLayoutTwoKeys.hasNonNormalizedKey);
+  ASSERT_FALSE(
+      sortLayoutTwoKeys.comparisonStartIndex <
+      sortLayoutTwoKeys.numNormalizedKeys);
   ASSERT_EQ(sortLayoutTwoKeys.prefixOffsets.size(), 2);
   ASSERT_EQ(sortLayoutTwoKeys.prefixOffsets[0], 0);
   ASSERT_EQ(sortLayoutTwoKeys.prefixOffsets[1], 9);
@@ -346,10 +377,10 @@ TEST_F(PrefixSortTest, optimizeSortKeysOrder) {
       {ROW({BIGINT(), SMALLINT(), VARCHAR()}), {0, 1, 2}, {1, 0, 2}},
       {ROW({TINYINT(), BIGINT(), VARCHAR(), TINYINT(), INTEGER(), VARCHAR()}),
        {2, 1, 0, 4, 5, 3},
-       {4, 1, 2, 0, 5, 3}},
+       {4, 1, 2, 5, 0, 3}},
       {ROW({INTEGER(), BIGINT(), VARCHAR(), TINYINT(), INTEGER(), VARCHAR()}),
        {5, 4, 3, 2, 1, 0},
-       {4, 0, 1, 5, 3, 2}}};
+       {4, 0, 1, 5, 2, 3}}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -369,5 +400,47 @@ TEST_F(PrefixSortTest, optimizeSortKeysOrder) {
     }
   }
 }
+
+TEST_F(PrefixSortTest, makeSortLayoutForString) {
+  std::vector<TypePtr> keyTypes = {VARCHAR(), BIGINT()};
+  std::vector<CompareFlags> compareFlags = {kAsc, kDesc};
+  std::vector<uint32_t> maxStringLengths = {9, 9};
+
+  auto sortLayoutOneKey = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 24, 8, maxStringLengths);
+  ASSERT_TRUE(sortLayoutOneKey.hasNormalizedKeys);
+  ASSERT_TRUE(sortLayoutOneKey.hasNonNormalizedKey);
+  ASSERT_TRUE(
+      sortLayoutOneKey.comparisonStartIndex <
+      sortLayoutOneKey.numNormalizedKeys);
+  ASSERT_EQ(sortLayoutOneKey.encodeSizes.size(), 1);
+  ASSERT_EQ(sortLayoutOneKey.encodeSizes[0], 9);
+
+  auto sortLayoutTwoCompleteKeys = PrefixSortLayout::makeSortLayout(
+      keyTypes, compareFlags, 26, 9, maxStringLengths);
+  ASSERT_TRUE(sortLayoutTwoCompleteKeys.hasNormalizedKeys);
+  ASSERT_FALSE(sortLayoutTwoCompleteKeys.hasNonNormalizedKey);
+  ASSERT_TRUE(
+      sortLayoutTwoCompleteKeys.comparisonStartIndex ==
+      sortLayoutTwoCompleteKeys.numNormalizedKeys);
+  ASSERT_EQ(sortLayoutTwoCompleteKeys.encodeSizes.size(), 2);
+  ASSERT_EQ(sortLayoutTwoCompleteKeys.encodeSizes[0], 10);
+  ASSERT_EQ(sortLayoutTwoCompleteKeys.encodeSizes[1], 9);
+
+  // The last key type is VARBINARY, indicating that only partial data is
+  // encoded in the prefix.
+  std::vector<TypePtr> keyTypes1 = {BIGINT(), VARBINARY()};
+  auto sortLayoutTwoKeys = PrefixSortLayout::makeSortLayout(
+      keyTypes1, compareFlags, 26, 8, maxStringLengths);
+  ASSERT_TRUE(sortLayoutTwoKeys.hasNormalizedKeys);
+  ASSERT_FALSE(sortLayoutTwoKeys.hasNonNormalizedKey);
+  ASSERT_TRUE(
+      sortLayoutTwoKeys.comparisonStartIndex <
+      sortLayoutTwoKeys.numNormalizedKeys);
+  ASSERT_EQ(sortLayoutTwoKeys.encodeSizes.size(), 2);
+  ASSERT_EQ(sortLayoutTwoKeys.encodeSizes[0], 9);
+  ASSERT_EQ(sortLayoutTwoKeys.encodeSizes[1], 9);
+}
+
 } // namespace
 } // namespace facebook::velox::exec::prefixsort::test

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -659,7 +659,7 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
     const auto plan = usePrefixSort ? prefixSortPlan : nonPrefixSortPlan;
     velox::common::PrefixSortConfig prefixSortConfig =
         velox::common::PrefixSortConfig{
-            std::numeric_limits<int32_t>::max(), 130};
+            std::numeric_limits<int32_t>::max(), 130, 12};
     auto sortWindowBuild = std::make_unique<SortWindowBuild>(
         plan,
         pool_.get(),

--- a/velox/exec/tests/utils/LocalRunnerTestBase.cpp
+++ b/velox/exec/tests/utils/LocalRunnerTestBase.cpp
@@ -59,7 +59,7 @@ void LocalRunnerTestBase::ensureTestData() {
 void LocalRunnerTestBase::makeSchema() {
   auto schemaQueryCtx = makeQueryCtx("schema", rootPool_.get());
   common::SpillConfig spillConfig;
-  common::PrefixSortConfig prefixSortConfig(100, 130);
+  common::PrefixSortConfig prefixSortConfig(100, 130, 12);
   auto leafPool = schemaQueryCtx->pool()->addLeafChild("schemaReader");
   auto connectorQueryCtx = std::make_shared<connector::ConnectorQueryCtx>(
       leafPool.get(),


### PR DESCRIPTION
Support string type key in PrefixSort.
We introduce the configuration parameter `prefixsort_max_string_length`, 
which sets the maximum prefix length for strings. The implementation dynamically 
determines the prefix length by comparing the configured maximum with the 
actual maximum column length from RowContainer, using the smaller of the two. 
This ensures efficient and flexible prefix sorting for variable-length string types.

Default value of `prefixsort_max_string_length` is 16.

Perf result:
```
StdSort_no-payloads_1_varchar_1k                          158.23ns     6.32M
PrefixSort                                      415.89%    38.05ns    26.28M
StdSort_no-payloads_2_varchar_1k                          186.19ns     5.37M
PrefixSort                                      197.21%    94.41ns    10.59M
StdSort_no-payloads_3_varchar_1k                          197.90ns     5.05M
PrefixSort                                      148.93%   132.89ns     7.53M
StdSort_no-payloads_4_varchar_1k                          211.35ns     4.73M
PrefixSort                                      126.75%   166.75ns     6.00M
StdSort_no-payloads_1_varchar_10k                         257.23ns     3.89M
PrefixSort                                      358.08%    71.84ns    13.92M
StdSort_no-payloads_2_varchar_10k                         272.61ns     3.67M
PrefixSort                                      227.46%   119.85ns     8.34M
StdSort_no-payloads_3_varchar_10k                         295.37ns     3.39M
PrefixSort                                      170.20%   173.55ns     5.76M
StdSort_no-payloads_4_varchar_10k                         319.42ns     3.13M
PrefixSort                                      152.60%   209.31ns     4.78M
StdSort_no-payloads_1_varchar_100k                        348.19ns     2.87M
PrefixSort                                      403.18%    86.36ns    11.58M
StdSort_no-payloads_2_varchar_100k                        409.94ns     2.44M
PrefixSort                                      261.56%   156.73ns     6.38M
StdSort_no-payloads_3_varchar_100k                        469.93ns     2.13M
PrefixSort                                      206.32%   227.76ns     4.39M
StdSort_no-payloads_4_varchar_100k                        526.94ns     1.90M
PrefixSort                                      186.66%   282.29ns     3.54M
StdSort_no-payloads_1_varchar_1000k                       780.28ns     1.28M
PrefixSort                                      627.88%   124.27ns     8.05M
StdSort_no-payloads_2_varchar_1000k                       976.32ns     1.02M
PrefixSort                                      491.56%   198.62ns     5.03M
StdSort_no-payloads_3_varchar_1000k                         1.08us   928.51K
PrefixSort                                      376.44%   286.10ns     3.50M
StdSort_no-payloads_4_varchar_1000k                         1.12us   889.85K
PrefixSort                                      321.50%   349.54ns     2.86M
```