### PR TITLE
Remove unused-variable in velox/dwio/parquet/reader/DeltaByteArrayDecoder.h

### DIFF
--- a/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
@@ -32,7 +32,6 @@ class DeltaLengthByteArrayDecoder {
   }
 
   std::string_view readString() {
-    int32_t dataSize = 0;
     const int64_t length = bufferedLength_[lengthIdx_++];
     VELOX_CHECK_GE(length, 0, "negative string delta length");
     bufferStart_ += length;

--- a/velox/experimental/wave/exec/Instruction.h
+++ b/velox/experimental/wave/exec/Instruction.h
@@ -229,7 +229,6 @@ struct AbstractWrap : public AbstractInstruction {
   int32_t literalOffset{-1};
 
   void addWrap(AbstractOperand* sourceOp, AbstractOperand* targetOp = nullptr) {
-    int newWrap = AbstractOperand::kNoWrap;
     if (targetOp) {
       targetOp->wrappedAt = id;
     } else if (sourceOp->wrappedAt == AbstractOperand::kNoWrap) {


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

#buildsonlynotests - Builds are sufficient

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D65859977


