### PR TITLE
Allow single thread execution mode for local partition to support spark union for gluten

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -656,8 +656,7 @@ struct DriverFactory {
   static void registerAdapter(DriverAdapter adapter);
 
   bool supportsSerialExecution() const {
-    return !needsPartitionedOutput() && !needsExchangeClient() &&
-        !needsLocalExchange();
+    return !needsPartitionedOutput() && !needsExchangeClient();
   }
 
   const core::PlanNodeId& leafNodeId() const {


### PR DESCRIPTION
Summary:
Local partition could be used to support spark union for gluten. For union, it will be translated to local partition
with a followup distinct aggregation. Gluten is single thread execution mode using API like task::next to pull data.
Currently, Velox only allow single thread execution mode if the front of a pipeline is not local exchange which is not necessary.
Task::next actually pull results from all the pipelines so it should be good. This PR removes that check and verified with the
unit test.

Differential Revision: D65917749


