### PR TITLE
Fix PlanNodeStats overflow

### DIFF
--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -46,7 +46,7 @@ struct PlanNodeStats {
 
   /// Sum of input rows for all corresponding operators. Useful primarily for
   /// leaf plan nodes or plan nodes that correspond to a single operator type.
-  vector_size_t inputRows{0};
+  uint64_t inputRows{0};
 
   /// Sum of input batches for all corresponding operators.
   vector_size_t inputVectors{0};
@@ -57,7 +57,7 @@ struct PlanNodeStats {
   /// Sum of raw input rows for all corresponding operators. Applies primarily
   /// to TableScan operator which reports rows before pushed down filter as raw
   /// input.
-  vector_size_t rawInputRows{0};
+  uint64_t rawInputRows{0};
 
   /// Sum of raw input bytes for all corresponding operators.
   uint64_t rawInputBytes{0};
@@ -68,7 +68,7 @@ struct PlanNodeStats {
   /// Sum of output rows for all corresponding operators. When
   /// plan node corresponds to multiple operator types, operators of only one of
   /// these types report non-zero output rows.
-  vector_size_t outputRows{0};
+  uint64_t outputRows{0};
 
   /// Sum of output batches for all corresponding operators.
   vector_size_t outputVectors{0};


### PR DESCRIPTION
PlanNodeStats uses vector_size_t for the number of rows counters, but
it's actually int32_t. This caused overflow for some cases, e.g.
"Exchange: Output: -1734967296 rows (37.14GB, 3171 batches)". This
commit fixes it by changing vector_size_t to uint64_t, which is already
used for the number of bytes counters.