### PR TITLE
refactor(fuzzer): add supporting map functions

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -197,6 +197,11 @@ class VectorFuzzer {
   VectorPtr fuzzFlatNotNull(const TypePtr& type);
   VectorPtr fuzzFlatNotNull(const TypePtr& type, vector_size_t size);
 
+  /// Returns a map vector with randomized values and nulls. Returns a vector
+  /// containing `opts_.vectorSize` or `size` elements.
+  VectorPtr
+  fuzzMap(const TypePtr& keyType, const TypePtr& valueType, vector_size_t size);
+
   /// Returns a random constant vector (which could be a null constant). Returns
   /// a vector with size set to `opts_.vectorSize` or 'size'.
   VectorPtr fuzzConstant(const TypePtr& type);
@@ -279,6 +284,13 @@ class VectorFuzzer {
   RowTypePtr randRowType(
       const std::vector<TypePtr>& scalarTypes,
       int maxDepth = 5);
+
+  /// Generates a random map type where keys cannot be nested. maxDepth limits
+  /// the maximum level of nesting for values.
+  TypePtr randMapType(int maxDepth = 5);
+
+  /// Returns a random integer between min and max inclusive
+  size_t randInRange(size_t min, size_t max);
 
   /// Generates short decimal TypePtr with random precision and scale.
   inline TypePtr randShortDecimalType() {
@@ -397,6 +409,13 @@ class VectorFuzzer {
 TypePtr randType(FuzzerGenerator& rng, int maxDepth = 5);
 
 TypePtr randType(
+    FuzzerGenerator& rng,
+    const std::vector<TypePtr>& scalarTypes,
+    int maxDepth = 5);
+
+/// Generates a random map type given a vector of scalarTypes as keys. maxDepth
+/// limits the maximum level of nesting for values.
+TypePtr randMapType(
     FuzzerGenerator& rng,
     const std::vector<TypePtr>& scalarTypes,
     int maxDepth = 5);

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -940,4 +940,12 @@ TEST_F(VectorFuzzerTest, randOrderableType) {
     ASSERT_TRUE(fuzzer.randOrderableType()->isOrderable());
   }
 }
+
+TEST_F(VectorFuzzerTest, randMapType) {
+  VectorFuzzer::Options opts;
+  VectorFuzzer fuzzer(opts, pool());
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_TRUE(fuzzer.randMapType()->isMap());
+  }
+}
 } // namespace


### PR DESCRIPTION
Summary: This diff adds some supporting functions for my diff [D65926722](https://www.internalfb.com/diff/D65926722) for new benchmark tests for metalake's map_concat. In my benchmark tests, I want to be able to control the density of map columns. And generate the number of columns given a range, using the same seed.


Differential Revision: D65755011


