### PR TITLE
misc: Update Codeowners for breeze

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,9 @@ CMake/ @assignUser @majetideepak
 scripts/ @assignUser @majetideepak
 .github/ @assignUser @majetideepak
 
+# clear codeownership in these dirs
+velox/experimental/breeze
+
 # Parquet
 velox/dwio/parquet/ @majetideepak
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,8 +29,8 @@ CMake/ @assignUser @majetideepak
 scripts/ @assignUser @majetideepak
 .github/ @assignUser @majetideepak
 
-# clear codeownership in these dirs
-velox/experimental/breeze
+# Breeze 
+velox/experimental/breeze @dreveman
 
 # Parquet
 velox/dwio/parquet/ @majetideepak


### PR DESCRIPTION
Breeze is an entire separate library that is not build in CI. I would like to not get notifications for the dir, the way to do this in CODEOWNERS is to specify the dir and explicitly add a CO (or none to clear).  