### PR TITLE
fix: ExchangeBenchmark "Named vector serde 'Presto' is not registered"

### DIFF
--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -466,7 +466,9 @@ int main(int argc, char** argv) {
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();
-  serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
   exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);
 
   bm = std::make_unique<ExchangeBenchmark>();


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/11445 introduced named vector SerDe registration. ExchangeBenchmark broke after that because it didn't register the kPresto Serde. This commit fixes it by registering it in the main() function.

Error code before:
```
E20241114 20:40:54.505862 3012487 Exceptions.h:66] Line: /Users/yingsu/repo/velox5/velox/velox/vector/VectorStream.cpp:176, Function:getNamedVectorSerde, Expression: it != namedSerdeMap.end() Named vector serde 'Presto' is not registered., Source: RUNTIME, ErrorCode: INVALID_STATE
libc++abi: terminating due to uncaught exception of type facebook::velox::VeloxRuntimeError: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Named vector serde 'Presto' is not registered.
Retriable: False
Expression: it != namedSerdeMap.end()
Function: getNamedVectorSerde
File: /Users/yingsu/repo/velox5/velox/velox/vector/VectorStream.cpp
Line: 176
```
