### PR TITLE
fix: Remove same page hack for simdStrstr

### DIFF
--- a/velox/common/base/SimdUtil.cpp
+++ b/velox/common/base/SimdUtil.cpp
@@ -62,7 +62,6 @@ const LeadingMask<int64_t, xsimd::default_arch> leadingMask64;
 const FromBitMask<int32_t, xsimd::default_arch> fromBitMask32;
 const FromBitMask<int64_t, xsimd::default_arch> fromBitMask64;
 
-const int kPageSize = sysconf(_SC_PAGESIZE);
 } // namespace detail
 
 namespace {


### PR DESCRIPTION
Summary:
The hack is breaking ASAN check, removing it does not give huge
performance loss though so we remove it.

Benchmark results before vs after change:
https://gist.github.com/Yuhta/b3f66e85d52b62240c09c15d6e7941bb

Differential Revision: D66012678


