### PR TITLE
fix(replace_first): Fix up registration of replace_first

### DIFF
--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -153,7 +153,7 @@ void registerStringFunctions(const std::string& prefix) {
   registerSplitToMap(prefix);
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_replaceFirst, prefix + "replaceFirst");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_replaceFirst, prefix + "replace_first");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reverse, prefix + "reverse");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, prefix + "to_utf8");

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1399,7 +1399,7 @@ void StringFunctionsTest::testReplaceInPlace(
   auto result = evaluate<FlatVector<StringView>>(
       fmt::format(
           "{}(c0, '{}', '{}')",
-          replaceFirst ? "replaceFirst" : "replace",
+          replaceFirst ? "replace_first" : "replace",
           search,
           replace),
       makeRowVector({makeInput()}));
@@ -1412,7 +1412,7 @@ void StringFunctionsTest::testReplaceInPlace(
     core::QueryConfig config({});
     auto replaceFunction = replaceFirst
         ? exec::getVectorFunction(
-              "replaceFirst", {VARCHAR(), VARCHAR(), VARCHAR()}, {}, config)
+              "replace_first", {VARCHAR(), VARCHAR(), VARCHAR()}, {}, config)
         : exec::getVectorFunction(
               "replace", {VARCHAR(), VARCHAR()}, {}, config);
     SelectivityVector rows(tests.size());
@@ -1459,7 +1459,7 @@ void StringFunctionsTest::testReplaceFlatVector(
   FlatVectorPtr<StringView> result;
   if (replaceFirst) {
     result = evaluate<FlatVector<StringView>>(
-        "replaceFirst(c0, c1, c2)",
+        "replace_first(c0, c1, c2)",
         makeRowVector({stringVector, searchVector, replaceVector}));
   } else if (withReplaceArgument) {
     result = evaluate<FlatVector<StringView>>(


### PR DESCRIPTION
The function should be replace_first not replaceFirst. This was incorrectly registered so users were not picking it up. Registering it to the correct name now.




