### PR TITLE
feat(hashjoin): Add fast row size estimation for hash probe

### DIFF
--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -28,7 +28,7 @@
 
 namespace facebook::velox::test {
 
-class InsertTest : public test::VectorTestBase {
+class InsertTest : public velox::test::VectorTestBase {
  public:
   void runInsertTest(
       std::string_view outputDirectory,

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -21,10 +21,11 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 
 class HivePartitionFunctionTest : public ::testing::Test,
-                                  public test::VectorTestBase {
+                                  public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -21,12 +21,13 @@
 
 #include "gtest/gtest.h"
 
-using namespace facebook::velox::connector::hive;
+using namespace facebook;
 using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
 using namespace facebook::velox::dwio::catalog::fbhive;
 
 class HivePartitionUtilTest : public ::testing::Test,
-                              public test::VectorTestBase {
+                              public velox::test::VectorTestBase {
  protected:
   template <typename T>
   VectorPtr makeDictionary(const std::vector<T>& data) {

--- a/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
@@ -23,7 +23,7 @@
 namespace facebook::velox::connector::hive {
 
 class PartitionIdGeneratorTest : public ::testing::Test,
-                                 public test::VectorTestBase {
+                                 public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -25,7 +25,7 @@ namespace {
 
 using namespace facebook::velox::common;
 
-class ReaderTest : public testing::Test, public test::VectorTestBase {
+class ReaderTest : public testing::Test, public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -31,7 +31,8 @@
 
 namespace facebook::velox::parquet {
 
-class ParquetTestBase : public testing::Test, public test::VectorTestBase {
+class ParquetTestBase : public testing::Test,
+                        public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -22,6 +22,7 @@
 
 #include <folly/init/Init.h>
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::common;
 using namespace facebook::velox::dwio::common;
@@ -29,7 +30,8 @@ using namespace facebook::velox::parquet;
 
 using dwio::common::MemorySink;
 
-class E2EFilterTest : public E2EFilterTestBase, public test::VectorTestBase {
+class E2EFilterTest : public E2EFilterTestBase,
+                      public velox::test::VectorTestBase {
  protected:
   void SetUp() override {
     E2EFilterTestBase::SetUp();

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1064,6 +1064,7 @@ bool GroupingSet::getOutputWithSpill(
           false,
           false,
           false,
+          false,
           &pool_);
 
       initializeAggregates(aggregates_, *mergeRows_, false);
@@ -1278,6 +1279,7 @@ void GroupingSet::abandonPartialAggregation() {
       !ignoreNullKeys_,
       accumulators(true),
       std::vector<TypePtr>(),
+      false,
       false,
       false,
       false,

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -312,6 +312,23 @@ class HashProbe : public Operator {
   // memory reclamation or operator close.
   void clearBuffers();
 
+  // Returns the estimated row size of the projected output columns. nullopt
+  // will be returned if insufficient column stats is presented in 'table_', or
+  // the row size variation is too large. The row size is too large if ratio of
+  // max row size and avg row size is larger than 'kToleranceRatio' which is set
+  // to 10.
+  std::optional<uint64_t> estimatedRowSize(
+      const std::vector<vector_size_t>& varColumnsStats,
+      uint64_t totalFixedColumnsBytes);
+
+  // Returns the aggregated column stats at 'columnIndex' of 'table_'. Returns
+  // nullopt if the column stats is not available.
+  //
+  // NOTE: The column stats is collected by default for hash join table but it
+  // could be invalidated in case of spilling. But we should never expect usage
+  // of an invalidated table as we always spill the entire table.
+  std::optional<RowColumn::Stats> columnStats(int32_t columnIndex) const;
+
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const vector_size_t outputBatchSize_;
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -343,6 +343,7 @@ std::unique_ptr<RowContainer> StreamingAggregation::makeRowContainer(
       false,
       false,
       false,
+      false,
       pool());
 }
 

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -435,7 +435,9 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
       }
     }
     return BaseHashTable::JoinResultIterator(
-        std::move(varSizeListColumns), fixedSizeListColumnsSizeSum);
+        std::move(varSizeListColumns),
+        fixedSizeListColumnsSizeSum,
+        std::nullopt);
   }
 
   // Hash probe and list join result.

--- a/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
+++ b/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
@@ -21,6 +21,7 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
@@ -28,7 +29,7 @@ namespace {
 
 // Adds 10M mostly unique values to a single SetAccumulator, then extracts
 // unique values from it.
-class SetAccumulatorBenchmark : public facebook::velox::test::VectorTestBase {
+class SetAccumulatorBenchmark : public velox::test::VectorTestBase {
  public:
   void setup() {
     VectorFuzzer::Options opts;

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -19,6 +19,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
@@ -71,7 +72,7 @@ void benchmarkComputeValueIds(bool withNulls) {
   auto values = base.vectorMaker().flatVector<T>(
       size,
       [](vector_size_t row) { return row % 17; },
-      withNulls ? test::VectorMaker::nullEvery(7) : nullptr);
+      withNulls ? velox::test::VectorMaker::nullEvery(7) : nullptr);
 
   raw_vector<uint64_t> hashes(size);
   SelectivityVector rows(size);

--- a/velox/exec/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/exec/tests/AddressableNonNullValueListTest.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::aggregate::prestosql {
 namespace {
 
 class AddressableNonNullValueListTest : public testing::Test,
-                                        public test::VectorTestBase {
+                                        public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -40,6 +40,7 @@ std::unique_ptr<RowContainer> makeRowContainer(
       false, // isJoinBuild
       false, // hasProbedFlag
       false, // hasNormalizedKey
+      false, // collectColumnStats
       pool.get());
 }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -377,6 +377,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         true,
         true,
+        false,
         pool_.get());
   }
 
@@ -3635,6 +3636,7 @@ TEST_F(AggregationTest, destroyAfterPartialInitialization) {
       false, // isJoinBuild
       false, // hasProbedFlag
       false, // hasNormalizedKeys
+      false, // collectColumnStats
       pool());
   const auto rowColumn = rows.columnAt(0);
   agg.setOffsets(

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -17,10 +17,12 @@
 #include "velox/exec/HashBitRange.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class HashRangeBitTest : public test::VectorTestBase, public testing::Test {
+class HashRangeBitTest : public velox::test::VectorTestBase,
+                         public testing::Test {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/exec/tests/HashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/HashPartitionFunctionTest.cpp
@@ -18,10 +18,11 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class HashPartitionFunctionTest : public test::VectorTestBase,
+class HashPartitionFunctionTest : public velox::test::VectorTestBase,
                                   public testing::Test {
  protected:
   static void SetUpTestCase() {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -23,12 +23,14 @@
 
 #include <gtest/gtest.h>
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::common::test;
 
 using facebook::velox::exec::test::PlanBuilder;
 
-class PlanNodeToStringTest : public testing::Test, public test::VectorTestBase {
+class PlanNodeToStringTest : public testing::Test,
+                             public velox::test::VectorTestBase {
  public:
   PlanNodeToStringTest() {
     functions::prestosql::registerAllScalarFunctions();

--- a/velox/exec/tests/PrestoQueryRunnerTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -18,10 +18,11 @@
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class RoundRobinPartitionFunctionTest : public test::VectorTestBase,
+class RoundRobinPartitionFunctionTest : public velox::test::VectorTestBase,
                                         public testing::Test {
  protected:
   static void SetUpTestCase() {
@@ -33,7 +34,7 @@ TEST_F(RoundRobinPartitionFunctionTest, basic) {
   exec::RoundRobinPartitionFunction partitionFunction(10);
 
   auto pool = memory::memoryManager()->addLeafPool();
-  test::VectorMaker vm(pool.get());
+  velox::test::VectorMaker vm(pool.get());
 
   auto data = vm.rowVector(ROW({}, {}), 1024);
   std::vector<uint32_t> partitions;

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/type/Timestamp.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::filesystems;

--- a/velox/exec/tests/UnorderedStreamReaderTest.cpp
+++ b/velox/exec/tests/UnorderedStreamReaderTest.cpp
@@ -18,10 +18,11 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 
 class UnorderedStreamReaderTest : public testing::Test,
-                                  public test::VectorTestBase {
+                                  public velox::test::VectorTestBase {
  protected:
   void SetUp() override {
     rowType_ = ROW(

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
@@ -48,7 +49,8 @@ class VectorHasherTest : public testing::Test, public VectorTestBase {
   template <typename T>
   void testComputeValueIds(bool withNulls) {
     vector_size_t size = 1'111;
-    auto isNullAt = withNulls ? test::VectorMaker::nullEvery(5) : nullptr;
+    auto isNullAt =
+        withNulls ? velox::test::VectorMaker::nullEvery(5) : nullptr;
 
     // values in the middle of the range
     auto vector = makeFlatVector<T>(
@@ -1123,7 +1125,7 @@ TEST_F(VectorHasherTest, customComparisonArray) {
            {259, 260, 261},
            {515, 516, 517},
            {std::nullopt}},
-          ARRAY(test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())),
+          ARRAY(velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())),
       // Different values that are equal mod 256 should hash to the same value.
       makeNullableArrayVector<int64_t>(
           {{0, 1, 2},
@@ -1133,7 +1135,7 @@ TEST_F(VectorHasherTest, customComparisonArray) {
            {3, 4, 5},
            {3, 4, 5},
            {std::nullopt}},
-          ARRAY(test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())));
+          ARRAY(velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())));
 }
 
 TEST_F(VectorHasherTest, customComparisonMap) {
@@ -1156,8 +1158,8 @@ TEST_F(VectorHasherTest, customComparisonMap) {
                {515, 615}, {516, 616}, {517, 617}},
            std::vector<std::pair<int64_t, std::optional<int64_t>>>{
                {0, std::nullopt}}},
-          MAP(test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(),
-              test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())),
+          MAP(velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(),
+              velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())),
       // Different values that are equal mod 256 should hash to the same value.
       makeNullableMapVector<int64_t, int64_t>(
           {std::vector<std::pair<int64_t, std::optional<int64_t>>>{
@@ -1174,8 +1176,8 @@ TEST_F(VectorHasherTest, customComparisonMap) {
                {3, 103}, {4, 104}, {5, 105}},
            std::vector<std::pair<int64_t, std::optional<int64_t>>>{
                {0, std::nullopt}}},
-          MAP(test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(),
-              test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())));
+          MAP(velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(),
+              velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())));
 }
 
 TEST_F(VectorHasherTest, customComparisonRow) {
@@ -1187,11 +1189,11 @@ TEST_F(VectorHasherTest, customComparisonRow) {
           {"a"},
           {makeNullableFlatVector<int64_t>(
               {std::nullopt, 0, 1, 256, 257, 512, 513},
-              test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())}),
+              velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())}),
       // Different values that are equal mod 256 should hash to the same value.
       makeRowVector(
           {"a"},
           {makeNullableFlatVector<int64_t>(
               {std::nullopt, 0, 1, 0, 1, 0, 1},
-              test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())}));
+              velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())}));
 }

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -86,6 +86,7 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         true,
         true,
+        true,
         pool_.get());
     VELOX_CHECK(container->testingMutable());
     return container;

--- a/velox/expression/tests/EvalErrorsTest.cpp
+++ b/velox/expression/tests/EvalErrorsTest.cpp
@@ -24,7 +24,8 @@
 namespace facebook::velox::exec {
 namespace {
 
-class EvalErrorsTest : public testing::Test, public test::VectorTestBase {
+class EvalErrorsTest : public testing::Test,
+                       public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/functions/lib/tests/LambdaFunctionUtilTest.cpp
+++ b/velox/functions/lib/tests/LambdaFunctionUtilTest.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::functions {
 namespace {
 
 class LambdaFunctionUtilTest : public testing::Test,
-                               public test::VectorTestBase {
+                               public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/functions/prestosql/aggregates/tests/MapAccumulatorTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAccumulatorTest.cpp
@@ -21,7 +21,8 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-class MapAccumulatorTest : public testing::Test, public test::VectorTestBase {
+class MapAccumulatorTest : public testing::Test,
+                           public velox::test::VectorTestBase {
  protected:
  protected:
   static void SetUpTestCase() {

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -27,7 +27,7 @@ namespace facebook::velox::functions::prestosql {
 namespace {
 
 class SimpleComparisonMatcherTest : public testing::Test,
-                                    public test::VectorTestBase {
+                                    public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/functions/sparksql/fuzzer/tests/SparkQueryRunnerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/tests/SparkQueryRunnerTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -24,7 +24,7 @@ namespace facebook::velox::serializer {
 namespace {
 
 class CompactRowSerializerTest : public ::testing::Test,
-                                 public test::VectorTestBase,
+                                 public velox::test::VectorTestBase,
                                  public testing::WithParamInterface<bool> {
  protected:
   static void SetUpTestCase() {

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -20,10 +20,11 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 
 class UnsafeRowSerializerTest : public ::testing::Test,
-                                public test::VectorTestBase,
+                                public velox::test::VectorTestBase,
                                 public testing::WithParamInterface<bool> {
  protected:
   static void SetUpTestCase() {

--- a/velox/vector/tests/EncodingTest.cpp
+++ b/velox/vector/tests/EncodingTest.cpp
@@ -19,10 +19,11 @@
 #include "velox/vector/tests/VectorTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class EncodingTest : public testing::Test, public test::VectorTestBase {
+class EncodingTest : public testing::Test, public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
+++ b/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
@@ -16,12 +16,13 @@
 #include <gtest/gtest.h>
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 
 class VectorEstimateFlatSizeTest : public testing::Test,
-                                   public test::VectorTestBase {
+                                   public velox::test::VectorTestBase {
  protected:
-  using test::VectorTestBase::makeArrayVector;
+  using velox::test::VectorTestBase::makeArrayVector;
 
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -20,7 +20,8 @@
 
 namespace facebook::velox::test {
 
-class VectorPoolTest : public testing::Test, public test::VectorTestBase {
+class VectorPoolTest : public testing::Test,
+                       public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/vector/tests/VectorPrepareForReuseTest.cpp
+++ b/velox/vector/tests/VectorPrepareForReuseTest.cpp
@@ -17,10 +17,11 @@
 #include "velox/vector/tests/VectorTestUtils.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook;
 using namespace facebook::velox;
 
 class VectorPrepareForReuseTest : public testing::Test,
-                                  public test::VectorTestBase {
+                                  public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -107,7 +107,7 @@ struct NonPOD {
 
 int NonPOD::alive = 0;
 
-class VectorTest : public testing::Test, public test::VectorTestBase {
+class VectorTest : public testing::Test, public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});


### PR DESCRIPTION
* Add column stats for row container to collect aggregated column stats. The aggregated column stats will be used in hash probe to decide if row size estimation is applicable. If it is applicable, column stats will be used to compose a fast row size estimation to avoid memory exploding when probing and listing results. This added feature makes hash join more performant, and in some extreme skew cases that we've seen in Meta internal queries, it helped to decrease the query latency by >20x. 
* The work of this feature also helped to discovered a bug in HashTable when using simd for fast path result listing -> when max number of rows is smaller than kWidth, the unsigned integer overflow bug will make the max number of rows be ignored. Fixed the bug and the new test covers that case.