### PR TITLE
fix: Unaligned memory access in ByteStream and PrestoSerializer

### DIFF
--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -357,6 +357,18 @@ TEST_F(ByteStreamTest, reuse) {
   }
 }
 
+TEST_F(ByteStreamTest, unalignedWrite) {
+  constexpr int kSize = 1 + sizeof(int128_t);
+  auto arena = newArena();
+  ByteOutputStream stream(arena.get());
+  stream.startWrite(kSize);
+  stream.appendStringView(std::string_view("x"));
+  int128_t data{};
+  // This only crashes in opt mode.
+  stream.append<int128_t>(folly::Range(&data, 1));
+  ASSERT_EQ(stream.size(), kSize);
+}
+
 class InputByteStreamTest : public ByteStreamTest,
                             public testing::WithParamInterface<bool> {
  protected:


### PR DESCRIPTION
Summary:
We have a few places in the serialization code that do unaligned memory
access.  This is causing crashes in `ByteOutputStream::append<int128>` and we
clean them up in this change.

Differential Revision: D66125705


