### PR TITLE
docs: Fix invalid PR title in examples of valid PR titles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,7 @@ where:
 
 Examples of PR titles are:
 
-* feature(type): Add IPPREFIX
+* feat(type): Add IPPREFIX
 * fix: Prevent unnecessary flatmap to map conversion
 * refactor(vector): Use 'if constexpr' for Buffer::is_pod_like_v\<T\>
 


### PR DESCRIPTION
Summary: "feature" is not a valid type keyword, only "feat" is ("feature" won't match the regex)

Differential Revision: D66134945


