### PR TITLE
feat: Use Velox fs for ssd cache evictlog file

### DIFF
--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -367,7 +367,13 @@ class SsdFile {
 
   /// Returns the checkpoint file path.
   std::string getCheckpointFilePath() const {
-    return fileName_ + kCheckpointExtension;
+    // Faulty file path needs to be handled manually before we switch checkpoint
+    // file to Velox filesystem.
+    const std::string faultyPrefix = "faulty:";
+    std::string checkpointPath = fileName_ + kCheckpointExtension;
+    return checkpointPath.find(faultyPrefix) == 0
+        ? checkpointPath.substr(faultyPrefix.size())
+        : checkpointPath;
   }
 
   /// Deletes the backing file. Used in testing.
@@ -477,7 +483,7 @@ class SsdFile {
 
   // Synchronously logs that 'regions' are no longer valid in a possibly
   // existing checkpoint.
-  void logEviction(const std::vector<int32_t>& regions);
+  void logEviction(std::vector<int32_t>& regions);
 
   // Computes the checksum of data in cache 'entry'.
   uint32_t checksumEntry(const AsyncDataCacheEntry& entry) const;
@@ -572,6 +578,9 @@ class SsdFile {
   // WriteFile for cache data file.
   std::unique_ptr<WriteFile> writeFile_;
 
+  // WriteFile for evict log file.
+  std::unique_ptr<WriteFile> evictLogWriteFile_;
+
   // Counters.
   SsdCacheStats stats_;
 
@@ -584,9 +593,6 @@ class SsdFile {
 
   // Count of bytes written after last checkpoint.
   std::atomic<uint64_t> bytesAfterCheckpoint_{0};
-
-  // fd for logging evictions.
-  int32_t evictLogFd_{-1};
 
   // True if there was an error with checkpoint and the checkpoint was deleted.
   bool checkpointDeleted_{false};

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   PRIVATE
     velox_caching
     velox_file
+    velox_file_test_utils
     velox_memory
     velox_temp_path
     Folly::folly

--- a/velox/common/file/tests/FaultyFile.cpp
+++ b/velox/common/file/tests/FaultyFile.cpp
@@ -99,7 +99,7 @@ FaultyWriteFile::FaultyWriteFile(
 
 void FaultyWriteFile::append(std::string_view data) {
   if (injectionHook_ != nullptr) {
-    FaultFileWriteOperation op(path_, data);
+    FaultFileAppendOperation op(path_, data);
     injectionHook_(&op);
     if (!op.delegate) {
       return;
@@ -116,6 +116,13 @@ void FaultyWriteFile::write(
     const std::vector<iovec>& iovecs,
     int64_t offset,
     int64_t length) {
+  if (injectionHook_ != nullptr) {
+    FaultFileWriteOperation op(path_, iovecs, offset, length);
+    injectionHook_(&op);
+    if (!op.delegate) {
+      return;
+    }
+  }
   delegatedFile_->write(iovecs, offset, length);
 }
 

--- a/velox/common/file/tests/FaultyFile.h
+++ b/velox/common/file/tests/FaultyFile.h
@@ -26,6 +26,7 @@ struct FaultFileOperation {
     /// Injects faults for file read operations.
     kRead,
     kReadv,
+    kAppend,
     kWrite,
     /// TODO: add to support fault injections for the other file operation
     /// types.
@@ -85,15 +86,32 @@ struct FaultFileReadvOperation : FaultFileOperation {
         buffers(_buffers) {}
 };
 
+/// Fault injection parameters for file append API.
+struct FaultFileAppendOperation : FaultFileOperation {
+  std::string_view* data;
+
+  FaultFileAppendOperation(
+      const std::string& _path,
+      const std::string_view& _data)
+      : FaultFileOperation(FaultFileOperation::Type::kAppend, _path),
+        data(const_cast<std::string_view*>(&_data)) {}
+};
+
 /// Fault injection parameters for file write API.
 struct FaultFileWriteOperation : FaultFileOperation {
-  std::string_view* data;
+  const std::vector<iovec>& iovecs;
+  int64_t offset;
+  int64_t length;
 
   FaultFileWriteOperation(
       const std::string& _path,
-      const std::string_view& _data)
+      const std::vector<iovec>& _iovecs,
+      int64_t _offset,
+      int64_t _length)
       : FaultFileOperation(FaultFileOperation::Type::kWrite, _path),
-        data(const_cast<std::string_view*>(&_data)) {}
+        iovecs(_iovecs),
+        offset(_offset),
+        length(_length) {}
 };
 
 /// The fault injection hook on the file operation path.

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -654,7 +654,7 @@ TEST_F(FaultyFsTest, fileReadFaultHookInjection) {
 
 TEST_F(FaultyFsTest, fileWriteErrorInjection) {
   // Set write error.
-  fs_->setFileInjectionError(fileError_, {FaultFileOperation::Type::kWrite});
+  fs_->setFileInjectionError(fileError_, {FaultFileOperation::Type::kAppend});
   {
     auto writeFile = fs_->openFileForWrite(writeFilePath_, {});
     VELOX_ASSERT_THROW(writeFile->append("hello"), "InjectedFaultFileError");
@@ -672,7 +672,7 @@ TEST_F(FaultyFsTest, fileWriteErrorInjection) {
 TEST_F(FaultyFsTest, fileWriteDelayInjection) {
   // Set 2 seconds delay.
   const uint64_t injectDelay{2'000'000};
-  fs_->setFileInjectionDelay(injectDelay, {FaultFileOperation::Type::kWrite});
+  fs_->setFileInjectionDelay(injectDelay, {FaultFileOperation::Type::kAppend});
   {
     auto writeFile = fs_->openFileForWrite(writeFilePath_, {});
     uint64_t readDurationUs{0};
@@ -691,14 +691,14 @@ TEST_F(FaultyFsTest, fileWriteFaultHookInjection) {
   // Set to write fake data.
   fs_->setFileInjectionHook([&](FaultFileOperation* op) {
     // Only inject for write.
-    if (op->type != FaultFileOperation::Type::kWrite) {
+    if (op->type != FaultFileOperation::Type::kAppend) {
       return;
     }
     // Only inject for path2.
     if (op->path != path2) {
       return;
     }
-    auto* writeOp = static_cast<FaultFileWriteOperation*>(op);
+    auto* writeOp = static_cast<FaultFileAppendOperation*>(op);
     *writeOp->data = "Error data";
   });
   {
@@ -725,14 +725,14 @@ TEST_F(FaultyFsTest, fileWriteFaultHookInjection) {
   // Set to not delegate.
   fs_->setFileInjectionHook([&](FaultFileOperation* op) {
     // Only inject for write.
-    if (op->type != FaultFileOperation::Type::kWrite) {
+    if (op->type != FaultFileOperation::Type::kAppend) {
       return;
     }
     // Only inject for path2.
     if (op->path != path2) {
       return;
     }
-    auto* writeOp = static_cast<FaultFileWriteOperation*>(op);
+    auto* writeOp = static_cast<FaultFileAppendOperation*>(op);
     writeOp->delegate = false;
   });
   {


### PR DESCRIPTION
Summary:
Switch the eviction log file to use Velox filesystem for file r/w operations, so that more advanced testing can be built by leveraging features like fault injections.

This change is a resubmission for D65740612 which was wrongfully reverted in D66119405.

Differential Revision: D66140029


