### PR TITLE
fix: Move the thread local parameter from method to member parameter in HdfsReadFile

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -45,9 +45,7 @@ class HdfsReadFile final : public ReadFile {
 
   bool shouldCoalesce() const final;
 
-  std::string getName() const final {
-    return filePath_;
-  }
+  std::string getName() const final;
 
   uint64_t getNaturalReadSize() const final {
     return 72 << 20;
@@ -57,10 +55,8 @@ class HdfsReadFile final : public ReadFile {
   void preadInternal(uint64_t offset, uint64_t length, char* pos) const;
   void checkFileReadParameters(uint64_t offset, uint64_t length) const;
 
-  filesystems::arrow::io::internal::LibHdfsShim* driver_;
-  hdfsFS hdfsClient_;
-  hdfsFileInfo* fileInfo_;
-  std::string filePath_;
+  class Impl;
+  std::unique_ptr<Impl> pImpl;
 };
 
 } // namespace facebook::velox


### PR DESCRIPTION
To address this [comment](https://github.com/facebookincubator/velox/pull/9835#discussion_r1775374914), we moved the thread local parameter `folly::ThreadLocal<HdfsFile> file_` from a member parameter to a template parameter in the `HdfsReadFile::preadInternal` method. The frequent initialization of the thread local parameter in the method caused about a 5% performance degradation. We reverted the thread local parameter to a member parameter in this PR.