### PR TITLE
build(fuzzer): Enable biased expression fuzzer with PQR for single functions at PR time

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -769,6 +769,94 @@ jobs:
             /tmp/server.log
 
 
+    presto-java-only-bias-function-expression-fuzzer-run:
+    name: Biased Expression Fuzzer with Only Added/Updated Functions and Presto as source of truth
+    needs: compile
+    runs-on: ubuntu-latest
+    container: ghcr.io/facebookincubator/velox-dev:presto-java
+    timeout-minutes: 120
+    if: ${{ needs.compile.outputs.presto_bias  == 'true' }}
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      LINUX_DISTRO: "centos"
+    steps:
+
+      - name: Download presto expression fuzzer
+        uses: actions/download-artifact@v4
+        with:
+          name: presto
+
+      - name: "Checkout Repo"
+        uses: actions/checkout@v4
+        with:
+          path: velox
+          submodules: 'recursive'
+          ref: "${{ inputs.ref }}"
+
+      - name: Fix git permissions
+        # Usually actions/checkout does this but as we run in a container
+        # it doesn't work
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}/velox
+
+      - name: Download Signatures
+        uses: actions/download-artifact@v4
+        with:
+          name: signatures
+          path: /tmp/signatures
+
+      - name: Run Bias Expression Fuzzer
+        run: |
+          cd  velox
+          cp ./scripts/presto/etc/hive.properties $PRESTO_HOME/etc/catalog
+          ls -lR $PRESTO_HOME/etc
+          $PRESTO_HOME/bin/launcher run -v > /tmp/server.log 2>&1 &
+          # Sleep for 60 seconds to allow Presto server to start.
+          sleep 60
+          /opt/presto-cli --server 127.0.0.1:8080 --execute 'CREATE SCHEMA hive.tpch;'
+          cd -
+          mkdir -p /tmp/presto_only_bias_function_fuzzer_repro/logs/
+          chmod -R 777 /tmp/presto_only_bias_function_fuzzer_repro
+          chmod +x velox_expression_fuzzer_test
+          echo "Biased functions:"
+          cat /tmp/signatures/presto_bias_functions
+          # Convert the list of function names with tickets into a list of function names only.
+          function_names=""
+          IFS=',' read -r -a array <<< $(cat /tmp/signatures/presto_bias_functions)
+          for x in ${array[@]}; do
+            if [ -n "$function_names" ]; then
+              function_names+=","
+            fi
+            function_names+=$(echo $x | cut -d '=' -f 1)
+          done
+          echo "Biased function names: $function_names"
+          echo "Running Fuzzer for $DURATION"
+          ./velox_expression_fuzzer_test \
+                --seed ${RANDOM} \
+                --lazy_vector_generation_ratio 0.2 \
+                --common_dictionary_wraps_generation_ratio=0.3 \
+                --only=$function_names \
+                --duration_sec $DURATION \
+                --enable_variadic_signatures \
+                --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_column_reuse \
+                --velox_fuzzer_enable_expression_reuse \
+                --max_expression_trees_per_step 2 \
+                --retry_with_try \
+                --batch_size=6 \
+                --presto_url=http://127.0.0.1:8080 \
+                --minloglevel=0 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/presto_only_bias_function_fuzzer_repro/logs \
+                --repro_persist_path=/tmp/presto_only_bias_function_fuzzer_repro \
+          && echo -e "\n\nPresto Fuzzer run finished successfully."
+      - name: Archive Presto only-bias-function expression fuzzer production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: presto-only-bias-function-fuzzer-failure-artifacts
+          path: |
+            /tmp/presto_only_bias_function_fuzzer_repro
+
   presto-bias-java-aggregation-fuzzer-run:
     name: Biased Aggregation Fuzzer with Presto as source of truth
     needs: compile


### PR DESCRIPTION
When a PR adds or modifies a Presto function, make the expression fuzzer run with only this function and verify the result against Presto.

Differential Revision: D66141945


