### PR TITLE
feat(prefix sort): Exclude null byte from sort prefix if column has no nulls

### DIFF
--- a/velox/exec/benchmarks/PrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/PrefixSortBenchmark.cpp
@@ -20,6 +20,8 @@
 #include "velox/exec/PrefixSort.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
+DEFINE_double(data_null_ratio, 0.7, "Data null ratio");
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
@@ -92,7 +94,7 @@ class TestCase {
   RowVectorPtr fuzzRows(size_t numRows, int numKeys) {
     VectorFuzzer fuzzer({.vectorSize = numRows}, pool_);
     VectorFuzzer fuzzerWithNulls(
-        {.vectorSize = numRows, .nullRatio = 0.7}, pool_);
+        {.vectorSize = numRows, .nullRatio = FLAGS_data_null_ratio}, pool_);
     std::vector<VectorPtr> children;
 
     // Fuzz keys: for front keys (column 0 to numKeys -2) use high

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -34,15 +34,21 @@ class PrefixSortEncoder {
   /// int32_t, uint16_t, int16_t, float, double, Timestamp).
   /// 1. The first byte of the encoded result is null byte. The value is 0 if
   ///    (nulls first and value is null) or (nulls last and value is not null).
-  ///    Otherwise, the value is 1.
+  ///    Otherwise, the value is 1. If this column has no null values, we can
+  ///    skip the null byte.
   /// 2. The remaining bytes are the encoding result of value:
   ///    -If value is null, we set the remaining sizeof(T) bytes to '0', they
   ///     do not affect the comparison results at all.
   ///    -If value is not null, the result is set by calling encodeNoNulls.
   template <typename T>
-  FOLLY_ALWAYS_INLINE void
-  encode(const std::optional<T>& value, char* dest, uint32_t encodeSize) const {
-    if (value.has_value()) {
+  FOLLY_ALWAYS_INLINE void encode(
+      std::optional<T> value,
+      char* dest,
+      uint32_t encodeSize,
+      bool includeNullByte) const {
+    if (!includeNullByte) {
+      encodeNoNulls(value.value(), dest, encodeSize);
+    } else if (value.has_value()) {
       dest[0] = nullsFirst_ ? 1 : 0;
       encodeNoNulls(value.value(), dest + 1, encodeSize - 1);
     } else {
@@ -69,34 +75,27 @@ class PrefixSortEncoder {
   ///         For not supported types, returns 'std::nullopt'.
   FOLLY_ALWAYS_INLINE static std::optional<uint32_t> encodedSize(
       TypeKind typeKind,
-      uint32_t maxStringPrefixLength) {
-    // NOTE: one byte is reserved for nullable comparison.
+      uint32_t maxStringPrefixLength,
+      bool columnHasNulls) {
+    // NOTE: if columnHasNulls is true, one byte is reserved for nullable
+    // comparison.
+    const uint32_t nullByteSize = columnHasNulls ? 1 : 0;
     switch ((typeKind)) {
-      case ::facebook::velox::TypeKind::SMALLINT: {
-        return 3;
-      }
-      case ::facebook::velox::TypeKind::INTEGER: {
-        return 5;
-      }
-      case ::facebook::velox::TypeKind::BIGINT: {
-        return 9;
-      }
-      case ::facebook::velox::TypeKind::REAL: {
-        return 5;
-      }
-      case ::facebook::velox::TypeKind::DOUBLE: {
-        return 9;
-      }
-      case ::facebook::velox::TypeKind::TIMESTAMP: {
-        return 17;
-      }
-      case ::facebook::velox::TypeKind::HUGEINT: {
-        return 17;
-      }
-      case ::facebook::velox::TypeKind::VARBINARY:
+#define SCALAR_CASE(kind) \
+  case TypeKind::kind:    \
+    return nullByteSize + sizeof(TypeTraits<TypeKind::kind>::NativeType);
+    SCALAR_CASE(SMALLINT)
+    SCALAR_CASE(INTEGER)
+    SCALAR_CASE(BIGINT)
+    SCALAR_CASE(HUGEINT)
+    SCALAR_CASE(REAL)
+    SCALAR_CASE(DOUBLE)
+    SCALAR_CASE(TIMESTAMP)
+#undef SCALAR_CASE
+      case TypeKind::VARBINARY:
         [[fallthrough]];
-      case ::facebook::velox::TypeKind::VARCHAR: {
-        return 1 + maxStringPrefixLength;
+      case TypeKind::VARCHAR: {
+        return nullByteSize + maxStringPrefixLength;
       }
       default:
         return std::nullopt;

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -84,13 +84,13 @@ class PrefixSortEncoder {
 #define SCALAR_CASE(kind) \
   case TypeKind::kind:    \
     return nullByteSize + sizeof(TypeTraits<TypeKind::kind>::NativeType);
-    SCALAR_CASE(SMALLINT)
-    SCALAR_CASE(INTEGER)
-    SCALAR_CASE(BIGINT)
-    SCALAR_CASE(HUGEINT)
-    SCALAR_CASE(REAL)
-    SCALAR_CASE(DOUBLE)
-    SCALAR_CASE(TIMESTAMP)
+      SCALAR_CASE(SMALLINT)
+      SCALAR_CASE(INTEGER)
+      SCALAR_CASE(BIGINT)
+      SCALAR_CASE(HUGEINT)
+      SCALAR_CASE(REAL)
+      SCALAR_CASE(DOUBLE)
+      SCALAR_CASE(TIMESTAMP)
 #undef SCALAR_CASE
       case TypeKind::VARBINARY:
         [[fallthrough]];

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2036,24 +2036,24 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       {true, 0, 0, 0},
       {false, 0, 0, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() -
            1,
        0,
        0},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
            .value(),
        0,
        1},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
            .value(),
        0,
        0},
@@ -2062,82 +2062,96 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       {true, 1'000'000, 1'000'000, 0},
       {false, 1'000'000, 1'000'000, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        1'000'000,
        0},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        1'000'000,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value(),
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value(),
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value() -
            1,
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        0,
        3},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12)
+       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::BIGINT, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::BIGINT, 12, false)
                .value() +
-           prefixsort::PrefixSortEncoder::encodedSize(TypeKind::INTEGER, 12)
+           prefixsort::PrefixSortEncoder::encodedSize(
+               TypeKind::INTEGER, 12, false)
                .value(),
        0,
        0}};


### PR DESCRIPTION
When inserting data into a RowContainer, we collect information about whether 
columns contain null values. If a column does not contain nulls, we can omit 
the null byte in the normalized key. This reduces memory usage and decreases 
word-by-word comparisons.

For example, with a single sort key of type bigint, without this feature, the 
normalized key size is 16 bytes (8 + 1 + alignment padding). With this feature, 
the normalized key size is reduced to 8 bytes. However, this improvement only 
makes a difference if alignment padding does not negate the optimization. For 
instance, with a single sort key of type int, the normalized key size remains 8 
bytes regardless of whether this feature is enabled.