### PR TITLE
feat: Add indexed priority queue for auto writer thread scaling

### DIFF
--- a/velox/common/base/IndexedPriorityQueue.h
+++ b/velox/common/base/IndexedPriorityQueue.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+#include <set>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+/// A priority queue with values of type 'T'. Each value has assigned priority
+/// on insertion which determines the value's position in the quue. It supports
+/// to update the priority of the existing values, which adjusts the value's
+/// position in the queue accordingly. Ties are broken by insertion order. If
+/// 'MaxQueue' is true, it is a max priority queue, otherwise a min priority
+/// queue.
+///
+/// NOTE: this class is not thread-safe.
+template <typename T, bool MaxQueue>
+class IndexedPriorityQueue {
+ public:
+  IndexedPriorityQueue() = default;
+
+  ~IndexedPriorityQueue() {
+    VELOX_CHECK_EQ(queue_.size(), index_.size());
+  }
+
+  size_t size() const {
+    return queue_.size();
+  }
+
+  bool empty() const {
+    return queue_.empty();
+  }
+
+  /// Inserts 'value' into the queue with specified 'priority'. If 'value'
+  /// already exists, then update its priority and the corresponding position in
+  /// the queue.
+  bool addOrUpdate(T value, uint64_t priority) {
+    auto it = index_.find(value);
+    if (it != index_.end()) {
+      if (it->second->priority() == priority) {
+        return false;
+      }
+      queue_.erase(it->second.get());
+
+      it->second->updatePriority(priority);
+      queue_.insert(it->second.get());
+      return false;
+    }
+
+    auto newEntry = std::make_unique<Entry>(value, priority, generation_++);
+    queue_.insert(newEntry.get());
+    index_.emplace(value, std::move(newEntry));
+    return true;
+  }
+
+  std::optional<T> pop() {
+    VELOX_CHECK_EQ(queue_.size(), index_.size());
+    if (queue_.empty()) {
+      return std::nullopt;
+    }
+
+    auto it = queue_.begin();
+    Entry* removedEntry = *it;
+    const auto value = removedEntry->value();
+    queue_.erase(it);
+    VELOX_CHECK(index_.contains(removedEntry->value()));
+    index_.erase(removedEntry->value());
+    return value;
+  }
+
+  /// Describes the state of an inserted 'value' in the queue.
+  class Entry {
+   public:
+    Entry(T value, uint64_t priority, uint64_t generation)
+        : value_(std::move(value)),
+          priority_(priority),
+          generation_(generation) {}
+
+    const T& value() const {
+      return value_;
+    }
+
+    uint64_t priority() const {
+      return priority_;
+    }
+
+    void updatePriority(uint64_t priority) {
+      priority_ = priority;
+    }
+
+    uint64_t generation() const {
+      return generation_;
+    }
+
+   private:
+    const T value_;
+    uint64_t priority_;
+    const uint64_t generation_;
+  };
+
+  /// Used to iterate through the queue in priority order.
+  class Iterator {
+   public:
+    Iterator(
+        typename std::set<Entry*>::const_iterator cur,
+        typename std::set<Entry*>::const_iterator end)
+        : end_{end}, cur_{cur}, val_{0} {
+      if (cur_ != end_) {
+        val_ = (*cur_)->value();
+      }
+    }
+
+    bool operator==(const Iterator& other) const {
+      return std::tie(cur_, end_) == std::tie(other.cur_, other.end_);
+    }
+
+    bool operator!=(const Iterator& other) const {
+      return !operator==(other);
+    }
+
+    Iterator& operator++() {
+      VELOX_DCHECK(cur_ != end_);
+      ++cur_;
+      if (cur_ != end_) {
+        val_ = (*cur_)->value();
+      }
+      return *this;
+    }
+
+    const T& operator*() const {
+      VELOX_DCHECK(cur_ != end_);
+      return val_;
+    }
+
+   private:
+    const typename std::set<Entry*>::const_iterator end_;
+    typename std::set<Entry*>::const_iterator cur_;
+    T val_;
+  };
+
+  Iterator begin() const {
+    return Iterator{queue_.cbegin(), queue_.cend()};
+  }
+
+  Iterator end() const {
+    return Iterator{queue_.cend(), queue_.cend()};
+  }
+
+ private:
+  struct EntrySetComparator {
+    bool operator()(Entry* lhs, Entry* rhs) const {
+      if (MaxQueue) {
+        if (lhs->priority() > rhs->priority()) {
+          return true;
+        }
+        if (lhs->priority() < rhs->priority()) {
+          return false;
+        }
+      } else {
+        if (lhs->priority() > rhs->priority()) {
+          return false;
+        }
+        if (lhs->priority() < rhs->priority()) {
+          return true;
+        }
+      }
+      return lhs->generation() < rhs->generation();
+    }
+  };
+
+  uint64_t generation_{0};
+  folly::F14FastMap<T, std::unique_ptr<Entry>> index_;
+  std::set<Entry*, EntrySetComparator> queue_;
+};
+
+} // namespace facebook::velox

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ConcurrentCounterTest.cpp
   ExceptionTest.cpp
   FsTest.cpp
+  IndexedPriorityQueueTest.cpp
   RangeTest.cpp
   RawVectorTest.cpp
   RuntimeMetricsTest.cpp

--- a/velox/common/base/tests/IndexedPriorityQueueTest.cpp
+++ b/velox/common/base/tests/IndexedPriorityQueueTest.cpp
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/IndexedPriorityQueue.h"
+
+#include <gtest/gtest.h>
+
+#include "folly/Random.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/time/Timer.h"
+
+namespace facebook::velox {
+namespace {
+class IndexedPriorityQueueTest : public testing::Test {
+ protected:
+  template <typename T, bool MaxQueue>
+  void verify(
+      const IndexedPriorityQueue<T, MaxQueue>& queue,
+      const std::vector<T>& expectedValues) {
+    int i{0};
+    for (auto value : queue) {
+      ASSERT_EQ(value, expectedValues[i++]);
+    }
+  }
+
+  template <typename T, bool MaxQueue>
+  void verifyWithIterate(
+      const IndexedPriorityQueue<T, MaxQueue>& queue,
+      const std::vector<T>& expectedValues) {
+    int i{0};
+    auto it = queue.begin();
+    while (it != queue.end()) {
+      ASSERT_EQ(*it, expectedValues[i++]);
+      ++it;
+    }
+  }
+
+  template <typename T, bool MaxQueue>
+  void verifyAndRemove(
+      const std::vector<T>& expectedValues,
+      IndexedPriorityQueue<T, MaxQueue>& queue) {
+    ASSERT_EQ(expectedValues.size(), queue.size());
+    int i{0};
+    while (!queue.empty()) {
+      ASSERT_EQ(queue.pop().value(), expectedValues[i++]);
+    }
+    ASSERT_TRUE(queue.empty());
+  }
+
+  template <typename T, bool MaxQueue>
+  void fuzz(
+      IndexedPriorityQueue<T, MaxQueue>& queue,
+      int numIterations,
+      std::mt19937& rng) {
+    SCOPED_TRACE(fmt::format("MaxQueue: ", MaxQueue));
+    std::unordered_map<uint32_t, uint64_t> valuePriorities;
+    for (auto i = 0; i < numIterations; ++i) {
+      const uint32_t value = folly::Random::rand32(100, rng);
+      const uint64_t priority = folly::Random::rand32(80, rng);
+      valuePriorities[value] = priority;
+      queue.addOrUpdate(value, priority);
+    }
+    ASSERT_EQ(queue.size(), valuePriorities.size());
+    std::unordered_set<uint32_t> queuedValues;
+    uint64_t prev = MaxQueue ? std::numeric_limits<uint64_t>::max() : 0;
+    for (auto value : queue) {
+      queuedValues.insert(value);
+      ASSERT_TRUE(valuePriorities.find(value) != valuePriorities.end());
+      if (MaxQueue) {
+        ASSERT_LE(valuePriorities[value], prev);
+        prev = valuePriorities[value];
+      } else {
+        ASSERT_GE(valuePriorities[value], prev);
+        prev = valuePriorities[value];
+      }
+    }
+    ASSERT_EQ(queuedValues.size(), queue.size());
+    ASSERT_EQ(queue.size(), valuePriorities.size());
+  }
+};
+
+TEST_F(IndexedPriorityQueueTest, insertOnly) {
+  const int numValues{5};
+  const std::vector<uint32_t> priorities = {0, 10, 100, 20, 80};
+  const std::vector<uint32_t> expectedMaxValues = {2, 4, 3, 1, 0};
+  const std::vector<uint32_t> expectedMinValues = {0, 1, 3, 4, 2};
+
+  IndexedPriorityQueue<uint32_t, true> maxQueue;
+  IndexedPriorityQueue<uint32_t, false> minQueue;
+  ASSERT_EQ(maxQueue.size(), 0);
+  ASSERT_EQ(minQueue.size(), 0);
+  ASSERT_TRUE(maxQueue.empty());
+  ASSERT_TRUE(minQueue.empty());
+  ASSERT_FALSE(maxQueue.pop().has_value());
+  ASSERT_FALSE(minQueue.pop().has_value());
+
+  for (int value = 0; value < numValues; ++value) {
+    maxQueue.addOrUpdate(value, priorities[value]);
+    minQueue.addOrUpdate(value, priorities[value]);
+  }
+  ASSERT_EQ(maxQueue.size(), numValues);
+  ASSERT_EQ(minQueue.size(), numValues);
+  verify(maxQueue, expectedMaxValues);
+  verify(minQueue, expectedMinValues);
+
+  ASSERT_EQ(maxQueue.size(), numValues);
+  ASSERT_EQ(minQueue.size(), numValues);
+
+  verifyWithIterate(maxQueue, expectedMaxValues);
+  verifyWithIterate(minQueue, expectedMinValues);
+
+  verifyAndRemove(expectedMaxValues, maxQueue);
+  verifyAndRemove(expectedMinValues, minQueue);
+}
+
+TEST_F(IndexedPriorityQueueTest, priorityTie) {
+  const uint32_t value1{31};
+  const uint32_t value2{32};
+  const uint32_t value3{33};
+  const std::vector<uint32_t> expectedValues{31, 32, 33};
+
+  IndexedPriorityQueue<uint32_t, true> maxQueue;
+  maxQueue.addOrUpdate(value1, /*priority=*/1);
+  maxQueue.addOrUpdate(value2, /*priority=*/1);
+  maxQueue.addOrUpdate(value3, /*priority=*/1);
+  verify(maxQueue, expectedValues);
+  verifyAndRemove(expectedValues, maxQueue);
+
+  IndexedPriorityQueue<uint32_t, false> minQueue;
+  minQueue.addOrUpdate(value1, /*priority=*/1);
+  minQueue.addOrUpdate(value2, /*priority=*/1);
+  minQueue.addOrUpdate(value3, /*priority=*/1);
+  verify(minQueue, expectedValues);
+  verifyAndRemove(expectedValues, minQueue);
+}
+
+TEST_F(IndexedPriorityQueueTest, insertWithUpdate) {
+  const uint32_t value1{31};
+  const uint32_t value2{32};
+  const uint32_t value3{33};
+  IndexedPriorityQueue<uint32_t, true> maxQueue;
+  maxQueue.addOrUpdate(value1, /*priority=*/1);
+  maxQueue.addOrUpdate(value2, /*priority=*/1);
+  maxQueue.addOrUpdate(value3, /*priority=*/1);
+  verify(maxQueue, {31, 32, 33});
+
+  maxQueue.addOrUpdate(value2, 20);
+  verify(maxQueue, {32, 31, 33});
+
+  maxQueue.addOrUpdate(value2, 0);
+  verify(maxQueue, {31, 33, 32});
+
+  maxQueue.addOrUpdate(value2, 10);
+  verify(maxQueue, {32, 31, 33});
+
+  maxQueue.addOrUpdate(value1, 20);
+  verify(maxQueue, {31, 32, 33});
+
+  maxQueue.addOrUpdate(value3, 15);
+  verify(maxQueue, {31, 33, 32});
+
+  maxQueue.addOrUpdate(value2, 40);
+  verify(maxQueue, {32, 31, 33});
+
+  IndexedPriorityQueue<uint32_t, false> minQueue;
+  minQueue.addOrUpdate(value1, /*priority=*/1);
+  minQueue.addOrUpdate(value2, /*priority=*/1);
+  minQueue.addOrUpdate(value3, /*priority=*/1);
+  verify(minQueue, {31, 32, 33});
+
+  minQueue.addOrUpdate(value2, 20);
+  verify(minQueue, {31, 33, 32});
+
+  minQueue.addOrUpdate(value2, 0);
+  verify(minQueue, {32, 31, 33});
+
+  minQueue.addOrUpdate(value2, 10);
+  verify(minQueue, {31, 33, 32});
+
+  minQueue.addOrUpdate(value1, 20);
+  verify(minQueue, {33, 32, 31});
+
+  minQueue.addOrUpdate(value3, 15);
+  verify(minQueue, {32, 33, 31});
+
+  minQueue.addOrUpdate(value2, 40);
+  verify(minQueue, {33, 31, 32});
+}
+
+TEST_F(IndexedPriorityQueueTest, remove) {
+  const uint32_t value1{31};
+  const uint32_t value2{32};
+  const uint32_t value3{33};
+  IndexedPriorityQueue<uint32_t, true> maxQueue;
+  maxQueue.addOrUpdate(value1, /*priority=*/1);
+  maxQueue.addOrUpdate(value2, /*priority=*/2);
+  maxQueue.addOrUpdate(value3, /*priority=*/3);
+  verify(maxQueue, {33, 32, 31});
+  ASSERT_EQ(maxQueue.pop().value(), 33);
+  verify(maxQueue, {32, 31});
+  maxQueue.addOrUpdate(value2, 0);
+  ASSERT_EQ(maxQueue.pop().value(), 31);
+  verify(maxQueue, {32});
+  ASSERT_EQ(maxQueue.pop().value(), 32);
+  ASSERT_TRUE(maxQueue.empty());
+
+  IndexedPriorityQueue<uint32_t, false> minQueue;
+  minQueue.addOrUpdate(value1, /*priority=*/1);
+  minQueue.addOrUpdate(value2, /*priority=*/2);
+  minQueue.addOrUpdate(value3, /*priority=*/3);
+  verify(minQueue, {31, 32, 33});
+  ASSERT_EQ(minQueue.pop().value(), 31);
+  verify(minQueue, {32, 33});
+  minQueue.addOrUpdate(value2, 20);
+  ASSERT_EQ(minQueue.pop().value(), 33);
+  verify(minQueue, {32});
+  ASSERT_EQ(minQueue.pop().value(), 32);
+  ASSERT_TRUE(minQueue.empty());
+}
+
+TEST_F(IndexedPriorityQueueTest, fuzz) {
+  const int numIterations{1000};
+  std::mt19937 rng{100};
+  IndexedPriorityQueue<uint32_t, true> maxQueue;
+  fuzz<uint32_t, true>(maxQueue, 1'000, rng);
+
+  IndexedPriorityQueue<uint32_t, false> minQueue;
+  fuzz<uint32_t, false>(minQueue, 1'000, rng);
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -54,6 +54,7 @@ class SsdRun {
     fileBits_ = other.fileBits_;
     checksum_ = other.checksum_;
   }
+
   void operator=(SsdRun&& other) {
     fileBits_ = other.fileBits_;
     checksum_ = other.checksum_;


### PR DESCRIPTION
Summary:
Add indexed priority queue for table writer thread auto-scaling. The indexed priority queue organize the insert value
by priority. It supports to (1) pop from the top of the queue, (2) update the existing value's priority and correspondingly
adjusts its position in the queue. It support both min and max queue.

Differential Revision: D66117014


