### PR TITLE
fix: Refactor package namespace in HdfsFileSystem

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -15,11 +15,11 @@
  */
 #include "velox/common/file/FileSystems.h"
 
-namespace velox::filesystems::arrow::io::internal {
+namespace facebook::velox::filesystems {
+
+namespace arrow::io::internal {
 class LibHdfsShim;
 }
-
-namespace facebook::velox::filesystems {
 
 struct HdfsServiceEndpoint {
   HdfsServiceEndpoint(const std::string& hdfsHost, const std::string& hdfsPort)


### PR DESCRIPTION
After merging PR #9835, Gluten encountered the following compilation error. This PR refactors the package namespace to resolve the ambiguity issue.

```
/mnt/DP_disk3/jk/projects/gluten/cpp/velox/memory/VeloxColumnarBatch.cc:33:5: error: reference to ‘velox’ is ambiguous
   33 |     velox::memory::MemoryPool* pool,
      |     ^~~~~
In file included from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/operators/writer/VeloxParquetDataSource.h:43,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/compute/VeloxRuntime.h:25,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/memory/VeloxColumnarBatch.cc:18:
/mnt/DP_disk3/jk/projects/gluten/dev/../ep/build-velox/build/velox_ep/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h:18:11: note: candidates are: ‘namespace velox { }’
   18 | namespace velox::filesystems::arrow::io::internal {
      |           ^~~~~
In file included from /mnt/DP_disk3/jk/projects/gluten/dev/../ep/build-velox/build/velox_ep/velox/common/base/VeloxException.h:29,
                 from /mnt/DP_disk3/jk/projects/gluten/dev/../ep/build-velox/build/velox_ep/velox/common/base/Exceptions.h:27,
                 from /mnt/DP_disk3/jk/projects/gluten/dev/../ep/build-velox/build/velox_ep/velox/common/base/BitUtil.h:19,
                 from /mnt/DP_disk3/jk/projects/gluten/dev/../ep/build-velox/build/velox_ep/velox/common/caching/AsyncDataCache.h:27,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/compute/VeloxBackend.h:27,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/memory/VeloxMemoryManager.h:20,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/memory/VeloxColumnarBatch.h:21,
                 from /mnt/DP_disk3/jk/projects/gluten/cpp/velox/memory/VeloxColumnarBatch.cc:17:
```