### PR TITLE
build: Remove unnecessary -j option in makefile debug command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build:					#: Build the software based in BUILD_DIR and BUILD_TYPE variables
 
 debug:					#: Build with debugging symbols
 	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=Debug
-	$(MAKE) build BUILD_DIR=debug -j ${NUM_THREADS}
+	$(MAKE) build BUILD_DIR=debug
 
 release:				#: Build the release version
 	$(MAKE) cmake BUILD_DIR=release BUILD_TYPE=Release && \


### PR DESCRIPTION
The `build` target will use `-j` option, so we do not need it in the `debug` target.