### PR TITLE
fix: Add include cstdint explicitly

### DIFF
--- a/velox/exec/Trace.h
+++ b/velox/exec/Trace.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace facebook::velox::exec::trace {
 /// Defines the shared constants used by query trace implementation.

--- a/velox/exec/Trace.h
+++ b/velox/exec/Trace.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
-#include <string>
 #include <cstdint>
+#include <string>
 
 namespace facebook::velox::exec::trace {
 /// Defines the shared constants used by query trace implementation.

--- a/velox/exec/TraceConfig.h
+++ b/velox/exec/TraceConfig.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include <string>
 #include <unordered_set>
+#include <cstdint>
 
 namespace facebook::velox::exec::trace {
 

--- a/velox/exec/TraceConfig.h
+++ b/velox/exec/TraceConfig.h
@@ -16,10 +16,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <unordered_set>
-#include <cstdint>
 
 namespace facebook::velox::exec::trace {
 


### PR DESCRIPTION
Description:
Without the explicit include, it throws error with gcc 13.2 on Ubuntu 24.04.
The fix is to specify it explicitly.