### PR TITLE
fix(parquet): Schema Evolution

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -561,14 +561,25 @@ void configureReaderOptions(
   readerOptions.setMaxCoalesceDistance(hiveConfig->maxCoalescedDistanceBytes());
   readerOptions.setFileColumnNamesReadAsLowerCase(
       hiveConfig->isFileColumnNamesReadAsLowerCase(sessionProperties));
+  bool useColumnNamesForColumnMapping = false;
+  switch (hiveSplit->fileFormat) {
+    case dwio::common::FileFormat::DWRF:
+    case dwio::common::FileFormat::ORC: {
+      useColumnNamesForColumnMapping =
+          hiveConfig->isOrcUseColumnNames(sessionProperties);
+      break;
+    }
+    case dwio::common::FileFormat::PARQUET: {
+      useColumnNamesForColumnMapping =
+          hiveConfig->isParquetUseColumnNames(sessionProperties);
+      break;
+    }
+    default:
+      useColumnNamesForColumnMapping = false;
+  }
+
   readerOptions.setUseColumnNamesForColumnMapping(
-      (hiveSplit->fileFormat == dwio::common::FileFormat::DWRF ||
-       hiveSplit->fileFormat == dwio::common::FileFormat::ORC)
-          ? hiveConfig->isOrcUseColumnNames(sessionProperties)
-          : (hiveSplit->fileFormat == dwio::common::FileFormat::PARQUET)
-          ? hiveConfig->isParquetUseColumnNames(sessionProperties)
-          : false // or some default value if none of the conditions are met
-  );
+      useColumnNamesForColumnMapping);
   readerOptions.setFileSchema(fileSchema);
   readerOptions.setFooterEstimatedSize(hiveConfig->footerEstimatedSize());
   readerOptions.setFilePreloadThreshold(hiveConfig->filePreloadThreshold());

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -333,18 +333,18 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       TypePtr childRequestedType = nullptr;
       bool followChild = true;
       if (requestedType && requestedType->isRow()) {
-        auto rowType =
+        auto requestedRowType =
             std::dynamic_pointer_cast<const velox::RowType>(requestedType);
         if (options_.useColumnNamesForColumnMapping()) {
-          auto fileTypeIdx = rowType->getChildIdxIfExists(childName);
+          auto fileTypeIdx = requestedRowType->getChildIdxIfExists(childName);
           if (fileTypeIdx.has_value()) {
-            childRequestedType = rowType->childAt(*fileTypeIdx);
+            childRequestedType = requestedRowType->childAt(*fileTypeIdx);
           }
         } else {
-          // Schema Evolution check
-          if (i < rowType->size()) {
-            columnNames.push_back(rowType->nameOf(i));
-            childRequestedType = requestedType->asRow().childAt(i);
+          // Handle schema evolution.
+          if (i < requestedRowType->size()) {
+            columnNames.push_back(requestedRowType->nameOf(i));
+            childRequestedType = requestedRowType->childAt(i);
           } else {
             followChild = false;
           }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -36,17 +36,6 @@ bool isParquetReservedKeyword(
       ? true
       : false;
 }
-
-TypePtr getUpdatedTableSchema(
-    const TypePtr& tableSchema,
-    uint32_t i,
-    uint32_t parentSchemaIdx,
-    uint32_t curSchemaIdx,
-    std::string name) {
-  return (tableSchema == nullptr || (parentSchemaIdx == 0 && curSchemaIdx != 0))
-      ? tableSchema
-      : tableSchema->childAt(i);
-}
 } // namespace
 
 /// Metadata and options for reading Parquet.
@@ -132,7 +121,6 @@ class ReaderBase {
       uint32_t& columnIdx,
       const TypePtr& requestedType,
       const TypePtr& parentRequestedType,
-      const TypePtr& tableSchema,
       std::vector<std::string>& columnNames) const;
 
   TypePtr convertType(
@@ -266,7 +254,6 @@ void ReaderBase::initializeSchema() {
       columnIdx,
       options_.fileSchema(),
       nullptr,
-      options_.fileSchema(),
       columnNames);
   schema_ = createRowType(
       schemaWithId_->getChildren(), isFileColumnNamesReadAsLowerCase());
@@ -285,7 +272,6 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     uint32_t& columnIdx,
     const TypePtr& requestedType,
     const TypePtr& parentRequestedType,
-    const TypePtr& tableSchema,
     std::vector<std::string>& columnNames) const {
   VELOX_CHECK(fileMetaData_ != nullptr);
   VELOX_CHECK_LT(schemaIdx, fileMetaData_->schema.size());
@@ -345,11 +331,23 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
       }
 
       TypePtr childRequestedType = nullptr;
+      bool followChild = true;
       if (requestedType && requestedType->isRow()) {
-        auto fileTypeIdx =
-            requestedType->asRow().getChildIdxIfExists(childName);
-        if (fileTypeIdx.has_value()) {
-          childRequestedType = requestedType->asRow().childAt(*fileTypeIdx);
+        auto rowType =
+            std::dynamic_pointer_cast<const velox::RowType>(requestedType);
+        if (options_.useColumnNamesForColumnMapping()) {
+          auto fileTypeIdx = rowType->getChildIdxIfExists(childName);
+          if (fileTypeIdx.has_value()) {
+            childRequestedType = rowType->childAt(*fileTypeIdx);
+          }
+        } else {
+          // Schema Evolution check
+          if (i < rowType->size()) {
+            columnNames.push_back(rowType->nameOf(i));
+            childRequestedType = requestedType->asRow().childAt(i);
+          } else {
+            followChild = false;
+          }
         }
       }
 
@@ -368,27 +366,19 @@ std::unique_ptr<ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
         }
       }
 
-      if ((!options_.useColumnNamesForColumnMapping()) &&
-          (options_.fileSchema() != nullptr) &&
-          (tableSchema->kind() == TypeKind::ROW)) {
-        columnNames.push_back(
-            std::dynamic_pointer_cast<const velox::RowType>(tableSchema)
-                ->nameOf(i));
+      if (followChild) {
+        auto child = getParquetColumnInfo(
+            maxSchemaElementIdx,
+            maxRepeat,
+            maxDefine,
+            curSchemaIdx,
+            schemaIdx,
+            columnIdx,
+            childRequestedType,
+            requestedType,
+            columnNames);
+        children.push_back(std::move(child));
       }
-
-      auto child = getParquetColumnInfo(
-          maxSchemaElementIdx,
-          maxRepeat,
-          maxDefine,
-          curSchemaIdx,
-          schemaIdx,
-          columnIdx,
-          childRequestedType,
-          requestedType,
-          getUpdatedTableSchema(
-              tableSchema, i, parentSchemaIdx, curSchemaIdx, name),
-          columnNames);
-      children.push_back(std::move(child));
     }
     VELOX_CHECK(!children.empty());
     name = columnNames.at(curSchemaIdx);

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -963,8 +963,7 @@ TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
   ASSERT_TRUE(rows);
   ASSERT_EQ(rows->childrenSize(), 5);
 
-  auto column = rows->childAt(0);
-  assertEqualVectors(column, primitiveVector);
+  assertEqualVectors(rows->childAt(0), primitiveVector);
 
   auto expected1 =
       makeFlatVector<int64_t>(kSize, [](auto row) { return row * 4; });

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -927,9 +927,6 @@ TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
   auto arrayVector = makeArrayVector(offsets, valuesVector);
   auto primitiveVector = makeFlatVector(offsets);
 
-  std::shared_ptr<memory::MemoryPool> leafPool =
-      rootPool_->addLeafChild("ParquetTableScanTest");
-  VectorMaker vectorMaker{leafPool.get()};
   RowVectorPtr dataFileVectors = makeRowVector(
       {"p", "m", "a"},
       {primitiveVector, mapVector, arrayVector}); // columns in data file

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -37,6 +37,7 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::connector::hive;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::parquet;
+using namespace facebook::velox::test;
 
 class ParquetTableScanTest : public HiveConnectorTestBase {
  protected:
@@ -177,7 +178,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   }
 
   std::string getExampleFilePath(const std::string& fileName) {
-    return facebook::velox::test::getDataFilePath(
+    return getDataFilePath(
         "velox/dwio/parquet/tests/reader", "../examples/" + fileName);
   }
 
@@ -910,16 +911,16 @@ TEST_F(ParquetTableScanTest, testColumnNotExists) {
       "SELECT a, b, NULL, NULL, NULL FROM tmp");
 }
 
-TEST_F(ParquetTableScanTest, readParquetColumnsByIndexMixedType) {
-  vector_size_t size = 100;
+TEST_F(ParquetTableScanTest, schemaMatchWithComplexTypes) {
+  vector_size_t kSize = 100;
   auto valuesVector = makeRowVector(
       {"aa", "bb"},
-      {makeFlatVector<int64_t>(size * 4, [](auto row) { return row; }),
-       makeFlatVector<int32_t>(size * 4, [](auto row) { return row; })});
+      {makeFlatVector<int64_t>(kSize * 4, [](auto row) { return row; }),
+       makeFlatVector<int32_t>(kSize * 4, [](auto row) { return row; })});
   auto keysVector =
-      makeFlatVector<int64_t>(size * 4, [](auto row) { return row % 4; });
+      makeFlatVector<int64_t>(kSize * 4, [](auto row) { return row % 4; });
   std::vector<vector_size_t> offsets;
-  for (auto i = 0; i < size; i++) {
+  for (auto i = 0; i < kSize; i++) {
     offsets.push_back(i * 4);
   }
   auto mapVector = makeMapVector(offsets, keysVector, valuesVector);
@@ -928,7 +929,7 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndexMixedType) {
 
   std::shared_ptr<memory::MemoryPool> leafPool =
       rootPool_->addLeafChild("ParquetTableScanTest");
-  facebook::velox::test::VectorMaker vectorMaker{leafPool.get()};
+  VectorMaker vectorMaker{leafPool.get()};
   RowVectorPtr dataFileVectors = makeRowVector(
       {"p", "m", "a"},
       {primitiveVector, mapVector, arrayVector}); // columns in data file
@@ -941,10 +942,10 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndexMixedType) {
   writeToParquetFile(filePath, {dataFileVectors}, options);
 
   // Create a row type with columns having different names than in the file.
-  auto structType = ROW({"aa1", "bb1"}, {BIGINT(), BIGINT()});
+  auto structType = ROW({"aa1", "bb1"}, {BIGINT(), INTEGER()});
   auto rowType =
       ROW({"p1", "m1", "a1"},
-          {{BIGINT(),
+          {{INTEGER(),
             MAP(BIGINT(), structType),
             ARRAY(structType)}}); // column names in table metadata
 
@@ -960,40 +961,23 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndexMixedType) {
   auto split = makeSplit(filePath);
   auto result = AssertQueryBuilder(op).split(split).copyResults(pool());
 
-  ASSERT_EQ(result->size(), size);
+  ASSERT_EQ(result->size(), kSize);
   auto rows = result->as<RowVector>();
   ASSERT_TRUE(rows);
   ASSERT_EQ(rows->childrenSize(), 5);
 
-  // The fields that exist in the data should be present and correct.
-  // check for column p1
-  auto val = rows->childAt(0)->as<SimpleVector<int64_t>>();
-  ASSERT_TRUE(val);
-  ASSERT_EQ(val->size(), size);
-  for (auto j = 0; j < size; j++) {
-    ASSERT_FALSE(val->isNullAt(j));
-    ASSERT_EQ(val->valueAt(j), j * 4);
-  }
+  auto column = rows->childAt(0);
+  assertEqualVectors(column, primitiveVector);
 
-  // check for rest of the selected columns
-  for (int i = 1; i < 5; i += 2) {
-    val = rows->childAt(i)->as<SimpleVector<int64_t>>();
-    ASSERT_TRUE(val);
-    ASSERT_EQ(val->size(), size);
-    for (auto j = 0; j < size; j++) {
-      ASSERT_FALSE(val->isNullAt(j));
-      ASSERT_EQ(val->valueAt(j), j * 4);
-    }
-  }
-  for (int i = 2; i < 5; i += 2) {
-    val = rows->childAt(i)->as<SimpleVector<int64_t>>();
-    ASSERT_TRUE(val);
-    ASSERT_EQ(val->size(), size);
-    for (auto j = 0; j < size; j++) {
-      ASSERT_FALSE(val->isNullAt(j));
-      ASSERT_EQ(val->valueAt(j), j * 4 + 1);
-    }
-  }
+  auto expected1 =
+      makeFlatVector<int64_t>(kSize, [](auto row) { return row * 4; });
+  assertEqualVectors(rows->childAt(1), expected1);
+  assertEqualVectors(rows->childAt(3), expected1);
+
+  auto expected2 =
+      makeFlatVector<int>(kSize, [](auto row) { return row * 4 + 1; });
+  assertEqualVectors(rows->childAt(2), expected2);
+  assertEqualVectors(rows->childAt(4), expected2);
 
   // Now run query with column mapping using names - we should not be able to
   // find any names.
@@ -1004,48 +988,28 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndexMixedType) {
                    "true")
                .split(split)
                .copyResults(pool());
-
-  ASSERT_EQ(result->size(), size);
   rows = result->as<RowVector>();
-  ASSERT_TRUE(rows);
-  ASSERT_EQ(rows->childrenSize(), 5);
-
-  // check for column p1
-  val = rows->childAt(0)->as<SimpleVector<int64_t>>();
-  ASSERT_TRUE(val);
-  ASSERT_EQ(val->size(), size);
-  for (auto j = 0; j < size; j++) {
-    ASSERT_TRUE(val->isNullAt(j));
-  }
-
   // check for rest of the selected columns
-  for (int i = 1; i < 5; i++) {
-    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
-    ASSERT_TRUE(val != nullptr);
-    ASSERT_EQ(val->size(), size);
-    for (auto j = 0; j < size; j++) {
-      ASSERT_TRUE(val->isNullAt(j));
-    }
+  auto nullBigIntVector = makeFlatVector<int64_t>(
+      kSize, [](auto row) { return row; }, [](auto row) { return true; });
+  auto nullIntVector = makeFlatVector<int>(
+      kSize, [](auto row) { return row; }, [](auto row) { return true; });
+  for (const auto index : std::vector<int>({0, 2, 4})) {
+    assertEqualVectors(rows->childAt(index), nullIntVector);
+  }
+  for (const auto index : std::vector<int>({1, 3})) {
+    assertEqualVectors(rows->childAt(index), nullBigIntVector);
   }
 }
 
-TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
-  vector_size_t size = 100;
-
-  std::vector<int64_t> c1Vector;
-  std::vector<int64_t> c2Vector;
-  for (auto i = 0; i < size; i++) {
-    c1Vector.push_back(i);
-    c2Vector.push_back(i * 4);
-  }
-
+TEST_F(ParquetTableScanTest, schemaMatch) {
+  vector_size_t kSize = 100;
   std::shared_ptr<memory::MemoryPool> leafPool =
       rootPool_->addLeafChild("ParquetTableScanTest");
-  facebook::velox::test::VectorMaker vectorMaker{leafPool.get()};
-  RowVectorPtr dataFileVectors = vectorMaker.rowVector(
+  RowVectorPtr dataFileVectors = makeRowVector(
       {"c1", "c2"},
-      {vectorMaker.flatVector<int64_t>(c1Vector),
-       vectorMaker.flatVector<int64_t>(c2Vector)});
+      {makeFlatVector<int64_t>(kSize, [](auto row) { return row; }),
+       makeFlatVector<int64_t>(kSize, [](auto row) { return row * 4; })});
 
   const std::shared_ptr<exec::test::TempDirectoryPath> dataFileFolder =
       exec::test::TempDirectoryPath::create();
@@ -1055,7 +1019,6 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
   writeToParquetFile(filePath, {dataFileVectors}, options);
 
   auto rowType = ROW({"c2", "c3"}, {BIGINT(), BIGINT()});
-
   auto op = PlanBuilder()
                 .startTableScan()
                 .outputType(rowType)
@@ -1065,25 +1028,10 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
 
   auto split = makeSplit(filePath);
   auto result = AssertQueryBuilder(op).split(split).copyResults(pool());
-
-  ASSERT_EQ(result->size(), size);
   auto rows = result->as<RowVector>();
-  ASSERT_TRUE(rows);
-  ASSERT_EQ(rows->childrenSize(), 2);
 
-  for (int i = 0; i < 2; i++) {
-    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
-    ASSERT_TRUE(val);
-    ASSERT_EQ(val->size(), size);
-    for (auto j = 0; j < size; j++) {
-      ASSERT_FALSE(val->isNullAt(j));
-      if (i == 0) {
-        ASSERT_EQ(val->valueAt(j), j);
-      } else {
-        ASSERT_EQ(val->valueAt(j), j * 4);
-      }
-    }
-  }
+  assertEqualVectors(rows->childAt(0), dataFileVectors->childAt(0));
+  assertEqualVectors(rows->childAt(1), dataFileVectors->childAt(1));
 
   // test when schema has same column name as file schema but different data
   // type for column c3 as varchar
@@ -1102,8 +1050,8 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
   // fileschema & tableschema
   op = PlanBuilder()
            .startTableScan()
-           .outputType(rowType)
-           .dataColumns(rowType)
+           .outputType(rowType1)
+           .dataColumns(rowType1)
            .endTableScan()
            .planNode();
 
@@ -1115,28 +1063,14 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
                .split(split)
                .copyResults(pool());
 
-  ASSERT_EQ(result->size(), size);
   rows = result->as<RowVector>();
-  ASSERT_TRUE(rows);
-  ASSERT_EQ(rows->childrenSize(), 2);
-
-  for (int i = 0; i < 2; i++) {
-    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
-    ASSERT_TRUE(val);
-    ASSERT_EQ(val->size(), size);
-    for (auto j = 0; j < size; j++) {
-      if (i == 0) {
-        ASSERT_FALSE(val->isNullAt(j));
-        ASSERT_EQ(val->valueAt(j), j * 4);
-      } else {
-        ASSERT_TRUE(val->isNullAt(j));
-      }
-    }
-  }
+  auto nullVector = makeFlatVector<std::string>(
+      kSize, [](auto row) { return "row"; }, [](auto row) { return true; });
+  assertEqualVectors(rows->childAt(0), dataFileVectors->childAt(1));
+  assertEqualVectors(rows->childAt(1), nullVector);
 
   // Scan with type mismatch in the 1st item (BIGINT vs REAL)
   rowType = ROW({"c1", "c2"}, {{REAL(), BIGINT()}});
-
   op = PlanBuilder()
            .startTableScan()
            .outputType(rowType)
@@ -1148,6 +1082,36 @@ TEST_F(ParquetTableScanTest, readParquetColumnsByIndex) {
   EXPECT_THROW(
       AssertQueryBuilder(op).split(split).copyResults(pool()),
       VeloxRuntimeError);
+
+  // Schema evolution remove column.
+  rowType = ROW({"c1"}, {{BIGINT()}});
+  op = PlanBuilder()
+           .startTableScan()
+           .outputType(rowType)
+           .dataColumns(rowType)
+           .endTableScan()
+           .project({"c1"})
+           .planNode();
+
+  result = AssertQueryBuilder(op).split(split).copyResults(pool());
+  rows = result->as<RowVector>();
+  assertEqualVectors(rows->childAt(0), dataFileVectors->childAt(0));
+
+  // Schema evolution add column.
+  rowType = ROW({"c1", "c2", "c3"}, {{BIGINT(), BIGINT(), VARCHAR()}});
+  op = PlanBuilder()
+           .startTableScan()
+           .outputType(rowType)
+           .dataColumns(rowType)
+           .endTableScan()
+           .project({"c1", "c2", "c3"})
+           .planNode();
+
+  result = AssertQueryBuilder(op).split(split).copyResults(pool());
+  rows = result->as<RowVector>();
+  assertEqualVectors(rows->childAt(0), dataFileVectors->childAt(0));
+  assertEqualVectors(rows->childAt(1), dataFileVectors->childAt(1));
+  assertEqualVectors(rows->childAt(2), nullVector);
 }
 
 TEST_F(ParquetTableScanTest, deltaByteArray) {

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -286,7 +286,7 @@ velox::variant readSingleValue(
 /// floating-point column in each set. Verifying arbitrary result sets with
 /// epsilon comparison would require more advanced algorithms such as maximum
 /// bipartite matching. Hence we leave them as future work. Check out
-/// https://github.com/facebookincubator/velox/issues/3493 for more dicsussion.
+/// https://github.com/facebookincubator/velox/issues/3493 for more discussion.
 bool assertEqualResults(
     const std::vector<RowVectorPtr>& expected,
     const std::vector<RowVectorPtr>& actual);


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/10517 broke schema evolution. 
Velox crashes with an out of range vector access when the table schema has 
fewer columns compared to the Parquet file schema.
This PR fixes this.

Fixes: https://github.com/facebookincubator/velox/pull/11589