### PR TITLE
feat: Add priority based memory reclaim framework

### DIFF
--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -131,7 +131,8 @@ class MockTask : public std::enable_shared_from_this<MockTask> {
 
   class RootMemoryReclaimer : public memory::MemoryReclaimer {
    public:
-    RootMemoryReclaimer(const std::shared_ptr<MockTask>& task) : task_(task) {}
+    RootMemoryReclaimer(const std::shared_ptr<MockTask>& task)
+        : memory::MemoryReclaimer(0), task_(task) {}
 
     static std::unique_ptr<MemoryReclaimer> create(
         const std::shared_ptr<MockTask>& task) {
@@ -179,7 +180,8 @@ class MockTask : public std::enable_shared_from_this<MockTask> {
         bool reclaimable,
         ReclaimInjectionCallback reclaimInjectCb = nullptr,
         ArbitrationInjectionCallback arbitrationInjectCb = nullptr)
-        : task_(task),
+        : memory::MemoryReclaimer(0),
+          task_(task),
           reclaimable_(reclaimable),
           reclaimInjectCb_(std::move(reclaimInjectCb)),
           arbitrationInjectCb_(std::move(arbitrationInjectCb)) {}

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -505,7 +505,8 @@ class MockLeafMemoryReclaimer : public MemoryReclaimer {
       std::atomic<uint64_t>& totalUsedBytes,
       bool reclaimable = true,
       bool* underArbitration = nullptr)
-      : reclaimable_(reclaimable),
+      : MemoryReclaimer(0),
+        reclaimable_(reclaimable),
         underArbitration_(underArbitration),
         totalUsedBytes_(totalUsedBytes) {}
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -3572,7 +3572,8 @@ class MockMemoryReclaimer : public MemoryReclaimer {
   }
 
  private:
-  explicit MockMemoryReclaimer(bool doThrow) : doThrow_(doThrow) {}
+  explicit MockMemoryReclaimer(bool doThrow)
+      : MemoryReclaimer(0), doThrow_(doThrow) {}
 
   const bool doThrow_;
 };

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -92,7 +92,8 @@ class MockTask : public std::enable_shared_from_this<MockTask> {
 
   class MemoryReclaimer : public memory::MemoryReclaimer {
    public:
-    MemoryReclaimer(const std::shared_ptr<MockTask>& task) : task_(task) {}
+    MemoryReclaimer(const std::shared_ptr<MockTask>& task)
+        : memory::MemoryReclaimer(0), task_(task) {}
 
     static std::unique_ptr<MemoryReclaimer> create(
         const std::shared_ptr<MockTask>& task) {
@@ -178,7 +179,8 @@ class MockMemoryOperator {
         bool reclaimable,
         ReclaimInjectionCallback reclaimInjectCb = nullptr,
         ArbitrationInjectionCallback arbitrationInjectCb = nullptr)
-        : op_(op),
+        : memory::MemoryReclaimer(0),
+          op_(op),
           reclaimable_(reclaimable),
           reclaimInjectCb_(std::move(reclaimInjectCb)),
           arbitrationInjectCb_(std::move(arbitrationInjectCb)) {}

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -494,7 +494,7 @@ class HiveDataSink : public DataSink {
         HiveDataSink* dataSink,
         HiveWriterInfo* writerInfo,
         io::IoStatistics* ioStats)
-        : exec::MemoryReclaimer(),
+        : exec::MemoryReclaimer(0),
           dataSink_(dataSink),
           writerInfo_(writerInfo),
           ioStats_(ioStats) {

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -170,8 +170,9 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
    protected:
     MemoryReclaimer(
         const std::shared_ptr<QueryCtx>& queryCtx,
-        memory::MemoryPool* pool)
-        : queryCtx_(queryCtx), pool_(pool) {
+        memory::MemoryPool* pool,
+        int32_t priority = 0)
+        : memory::MemoryReclaimer(priority), queryCtx_(queryCtx), pool_(pool) {
       VELOX_CHECK_NOT_NULL(pool_);
     }
 

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -63,8 +63,8 @@ class SortingWriter : public Writer {
         memory::MemoryReclaimer::Stats& stats) override;
 
    private:
-    explicit MemoryReclaimer(SortingWriter* writer)
-        : exec::MemoryReclaimer(),
+    MemoryReclaimer(SortingWriter* writer)
+        : exec::MemoryReclaimer(0),
           writer_(writer),
           canReclaim_(writer_->sortBuffer_->canSpill()) {}
 

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -163,7 +163,8 @@ class Writer : public dwio::common::Writer {
         memory::MemoryReclaimer::Stats& stats) override;
 
    private:
-    explicit MemoryReclaimer(Writer* writer) : writer_(writer) {
+    MemoryReclaimer(Writer* writer)
+        : exec::MemoryReclaimer(0), writer_(writer) {
       VELOX_CHECK_NOT_NULL(writer_);
     }
 

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -174,9 +174,10 @@ bool isLeftNullAwareJoinWithFilter(
 class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
   static std::unique_ptr<memory::MemoryReclaimer> create(
-      std::shared_ptr<HashJoinBridge> joinBridge) {
+      std::shared_ptr<HashJoinBridge> joinBridge,
+      int32_t priority = 0) {
     return std::unique_ptr<memory::MemoryReclaimer>(
-        new HashJoinMemoryReclaimer(joinBridge));
+        new HashJoinMemoryReclaimer(joinBridge, priority));
   }
 
   uint64_t reclaim(
@@ -186,9 +187,10 @@ class HashJoinMemoryReclaimer final : public MemoryReclaimer {
       memory::MemoryReclaimer::Stats& stats) final;
 
  private:
-  explicit HashJoinMemoryReclaimer(
-      const std::shared_ptr<HashJoinBridge>& joinBridge)
-      : MemoryReclaimer(), joinBridge_(joinBridge) {}
+  HashJoinMemoryReclaimer(
+      const std::shared_ptr<HashJoinBridge>& joinBridge,
+      int32_t priority)
+      : MemoryReclaimer(priority), joinBridge_(joinBridge) {}
   std::weak_ptr<HashJoinBridge> joinBridge_;
 };
 

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -25,7 +25,7 @@ class MemoryReclaimer : public memory::MemoryReclaimer {
  public:
   virtual ~MemoryReclaimer() = default;
 
-  static std::unique_ptr<memory::MemoryReclaimer> create();
+  static std::unique_ptr<memory::MemoryReclaimer> create(int32_t priority = 0);
 
   void enterArbitration() override;
 
@@ -35,7 +35,7 @@ class MemoryReclaimer : public memory::MemoryReclaimer {
       override;
 
  protected:
-  MemoryReclaimer() = default;
+  explicit MemoryReclaimer(int32_t priortity);
 };
 
 /// Provides the parallel memory reclaimer implementation for velox task
@@ -46,7 +46,8 @@ class ParallelMemoryReclaimer : public memory::MemoryReclaimer {
   virtual ~ParallelMemoryReclaimer() = default;
 
   static std::unique_ptr<memory::MemoryReclaimer> create(
-      folly::Executor* executor);
+      folly::Executor* executor,
+      int32_t priority = 0);
 
   uint64_t reclaim(
       memory::MemoryPool* pool,
@@ -55,7 +56,7 @@ class ParallelMemoryReclaimer : public memory::MemoryReclaimer {
       Stats& stats) override;
 
  protected:
-  explicit ParallelMemoryReclaimer(folly::Executor* executor);
+  ParallelMemoryReclaimer(folly::Executor* executor, int32_t priority);
 
   folly::Executor* const executor_{nullptr};
 };

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -708,7 +708,7 @@ class Operator : public BaseRuntimeStatWriter {
 
    protected:
     MemoryReclaimer(const std::shared_ptr<Driver>& driver, Operator* op)
-        : driver_(driver), op_(op) {
+        : memory::MemoryReclaimer(0), driver_(driver), op_(op) {
       VELOX_CHECK_NOT_NULL(op_);
     }
 

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -178,7 +178,8 @@ class TableWriter : public Operator {
         const std::shared_ptr<Driver>& driver,
         Operator* op)
         : ParallelMemoryReclaimer(
-              spillConfig.has_value() ? spillConfig.value().executor : nullptr),
+              spillConfig.has_value() ? spillConfig.value().executor : nullptr,
+              0),
           canReclaim_(spillConfig.has_value()),
           driver_(driver),
           op_(op) {}

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -236,48 +236,6 @@ bool unregisterTaskListener(const std::shared_ptr<TaskListener>& listener) {
   });
 }
 
-// static.
-std::shared_ptr<Task> Task::create(
-    const std::string& taskId,
-    core::PlanFragment planFragment,
-    int destination,
-    std::shared_ptr<core::QueryCtx> queryCtx,
-    ExecutionMode mode,
-    Consumer consumer,
-    std::function<void(std::exception_ptr)> onError) {
-  return Task::create(
-      taskId,
-      std::move(planFragment),
-      destination,
-      std::move(queryCtx),
-      mode,
-      (consumer ? [c = std::move(consumer)]() { return c; }
-                : ConsumerSupplier{}),
-      std::move(onError));
-}
-
-// static
-std::shared_ptr<Task> Task::create(
-    const std::string& taskId,
-    core::PlanFragment planFragment,
-    int destination,
-    std::shared_ptr<core::QueryCtx> queryCtx,
-    ExecutionMode mode,
-    ConsumerSupplier consumerSupplier,
-    std::function<void(std::exception_ptr)> onError) {
-  auto task = std::shared_ptr<Task>(new Task(
-      taskId,
-      std::move(planFragment),
-      destination,
-      std::move(queryCtx),
-      mode,
-      std::move(consumerSupplier),
-      std::move(onError)));
-  task->initTaskPool();
-  task->addToTaskList();
-  return task;
-}
-
 Task::Task(
     const std::string& taskId,
     core::PlanFragment planFragment,
@@ -285,11 +243,13 @@ Task::Task(
     std::shared_ptr<core::QueryCtx> queryCtx,
     ExecutionMode mode,
     ConsumerSupplier consumerSupplier,
+    int32_t memoryArbitrationPriority,
     std::function<void(std::exception_ptr)> onError)
     : uuid_{makeUuid()},
       taskId_(taskId),
       destination_(destination),
       mode_(mode),
+      memoryArbitrationPriority_(memoryArbitrationPriority),
       queryCtx_(std::move(queryCtx)),
       planFragment_(std::move(planFragment)),
       traceConfig_(maybeMakeTraceConfig()),
@@ -514,6 +474,7 @@ memory::MemoryPool* Task::getOrAddJoinNodePool(
   }
   childPools_.push_back(pool_->addAggregateChild(
       fmt::format("node.{}", nodeId), createNodeReclaimer([&]() {
+        // Set join reclaimer lower priority as cost of reclaiming join is high.
         return HashJoinMemoryReclaimer::create(
             getHashJoinBridgeLocked(splitGroupId, planNodeId));
       })));
@@ -548,7 +509,8 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createTaskReclaimer() {
   if (queryCtx_->pool()->reclaimer() == nullptr) {
     return nullptr;
   }
-  return Task::MemoryReclaimer::create(shared_from_this());
+  return Task::MemoryReclaimer::create(
+      shared_from_this(), memoryArbitrationPriority_);
 }
 
 velox::memory::MemoryPool* Task::addOperatorPool(
@@ -3023,9 +2985,10 @@ void Task::testingVisitDrivers(const std::function<void(Driver*)>& callback) {
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::MemoryReclaimer::create(
-    const std::shared_ptr<Task>& task) {
+    const std::shared_ptr<Task>& task,
+    int64_t priority) {
   return std::unique_ptr<memory::MemoryReclaimer>(
-      new Task::MemoryReclaimer(task));
+      new Task::MemoryReclaimer(task, priority));
 }
 
 uint64_t Task::MemoryReclaimer::reclaim(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -51,24 +51,29 @@ class Task : public std::enable_shared_from_this<Task> {
     kParallel,
   };
 
-  /// Creates a task to execute a plan fragment, but doesn't start execution
-  /// until Task::start() method is called.
-  /// @param taskId Unique task identifier.
-  /// @param planFragment Plan fragment.
-  /// @param destination Partition number if task is expected to receive data
-  /// for a particular partition from a set of upstream tasks participating in a
-  /// distributed execution. Used to initialize an ExchangeClient. Ignored if
-  /// plan fragment doesn't have an ExchangeNode.
-  /// @param queryCtx Query context containing MemoryPool and MemoryAllocator
-  /// instances to use for memory allocations during execution, executor to
-  /// schedule operators on, and session properties.
-  /// @param mode Execution mode for this task. The task can be executed in
-  /// Serial and Parallel mode.
-  /// @param consumer Optional factory function to get callbacks to pass the
-  /// results of the execution. In a parallel execution mode, results from each
-  /// thread are passed on to a separate consumer.
-  /// @param onError Optional callback to receive an exception if task
-  /// execution fails.
+/// Creates a task to execute a plan fragment, but doesn't start execution
+/// until Task::start() method is called.
+/// @param taskId Unique task identifier.
+/// @param planFragment Plan fragment.
+/// @param destination Partition number if task is expected to receive data
+/// for a particular partition from a set of upstream tasks participating in a
+/// distributed execution. Used to initialize an ExchangeClient. Ignored if
+/// plan fragment doesn't have an ExchangeNode.
+/// @param queryCtx Query context containing MemoryPool and MemoryAllocator
+/// instances to use for memory allocations during execution, executor to
+/// schedule operators on, and session properties.
+/// @param mode Execution mode for this task. The task can be executed in
+/// Serial and Parallel mode.
+/// @param consumer Optional factory function to get callbacks to pass the
+/// results of the execution. In a parallel execution mode, results from each
+/// thread are passed on to a separate consumer.
+/// @param onError Optional callback to receive an exception if task
+/// execution fails.
+/// @param memoryArbitrationPriority Optional priority on task that, in a
+/// multi task system, is used for memory arbitration to decide the order of
+/// reclaiming.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  // TODO: Remove this overload once call sites are updated.
   static std::shared_ptr<Task> create(
       const std::string& taskId,
       core::PlanFragment planFragment,
@@ -76,7 +81,64 @@ class Task : public std::enable_shared_from_this<Task> {
       std::shared_ptr<core::QueryCtx> queryCtx,
       ExecutionMode mode,
       Consumer consumer = nullptr,
-      std::function<void(std::exception_ptr)> onError = nullptr);
+      std::function<void(std::exception_ptr)> onError = nullptr) {
+    return Task::create(
+        taskId,
+        std::move(planFragment),
+        destination,
+        std::move(queryCtx),
+        mode,
+        (consumer ? [c = std::move(consumer)]() { return c; }
+                  : ConsumerSupplier{}),
+        std::move(onError));
+  }
+
+  // TODO: Remove this overload once call sites are updated.
+  static std::shared_ptr<Task> create(
+      const std::string& taskId,
+      core::PlanFragment planFragment,
+      int destination,
+      std::shared_ptr<core::QueryCtx> queryCtx,
+      ExecutionMode mode,
+      ConsumerSupplier consumerSupplier,
+      std::function<void(std::exception_ptr)> onError = nullptr) {
+    auto task = std::shared_ptr<Task>(new Task(
+        taskId,
+        std::move(planFragment),
+        destination,
+        std::move(queryCtx),
+        mode,
+        std::move(consumerSupplier),
+        0,
+        std::move(onError)));
+    task->initTaskPool();
+    task->addToTaskList();
+    return task;
+  }
+#else
+  // TODO: Move the definition of this function to the cpp file after above is
+  // cleaned up. The temporary move of definition from cpp to header is because
+  // compatibility macro does not work in cpp file.
+  static std::shared_ptr<Task> create(
+      const std::string& taskId,
+      core::PlanFragment planFragment,
+      int destination,
+      std::shared_ptr<core::QueryCtx> queryCtx,
+      ExecutionMode mode,
+      Consumer consumer = nullptr,
+      int32_t memoryArbitrationPriority = 0,
+      std::function<void(std::exception_ptr)> onError = nullptr) {
+    return Task::create(
+        taskId,
+        std::move(planFragment),
+        destination,
+        std::move(queryCtx),
+        mode,
+        (consumer ? [c = std::move(consumer)]() { return c; }
+                  : ConsumerSupplier{}),
+        memoryArbitrationPriority,
+        std::move(onError));
+  }
 
   static std::shared_ptr<Task> create(
       const std::string& taskId,
@@ -85,7 +147,22 @@ class Task : public std::enable_shared_from_this<Task> {
       std::shared_ptr<core::QueryCtx> queryCtx,
       ExecutionMode mode,
       ConsumerSupplier consumerSupplier,
-      std::function<void(std::exception_ptr)> onError = nullptr);
+      int32_t memoryArbitrationPriority = 0,
+      std::function<void(std::exception_ptr)> onError = nullptr) {
+    auto task = std::shared_ptr<Task>(new Task(
+        taskId,
+        std::move(planFragment),
+        destination,
+        std::move(queryCtx),
+        mode,
+        std::move(consumerSupplier),
+        memoryArbitrationPriority,
+        std::move(onError)));
+    task->initTaskPool();
+    task->addToTaskList();
+    return task;
+  }
+#endif
 
   /// Convenience function for shortening a Presto taskId. To be used
   /// in debugging messages and listings.
@@ -718,6 +795,7 @@ class Task : public std::enable_shared_from_this<Task> {
       std::shared_ptr<core::QueryCtx> queryCtx,
       ExecutionMode mode,
       ConsumerSupplier consumerSupplier,
+      int32_t memoryArbitrationPriority = 0,
       std::function<void(std::exception_ptr)> onError = nullptr);
 
   // Invoked to add this to the system-wide running task list on task creation.
@@ -816,7 +894,8 @@ class Task : public std::enable_shared_from_this<Task> {
   class MemoryReclaimer : public exec::MemoryReclaimer {
    public:
     static std::unique_ptr<memory::MemoryReclaimer> create(
-        const std::shared_ptr<Task>& task);
+        const std::shared_ptr<Task>& task,
+        int64_t priority = 0);
 
     uint64_t reclaim(
         memory::MemoryPool* pool,
@@ -828,7 +907,8 @@ class Task : public std::enable_shared_from_this<Task> {
         override;
 
    private:
-    explicit MemoryReclaimer(const std::shared_ptr<Task>& task) : task_(task) {
+    MemoryReclaimer(const std::shared_ptr<Task>& task, int64_t priority)
+        : exec::MemoryReclaimer(priority), task_(task) {
       VELOX_CHECK_NOT_NULL(task);
     }
 
@@ -1016,6 +1096,10 @@ class Task : public std::enable_shared_from_this<Task> {
   // The execution mode of the task. It is enforced that a task can only be
   // executed in a single mode throughout its lifetime
   const ExecutionMode mode_;
+
+  // In a multi-task system, it is used to make cross task decisions by memory
+  // arbitration to determine which task to reclaim first.
+  const int32_t memoryArbitrationPriority_;
 
   std::shared_ptr<core::QueryCtx> queryCtx_;
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -18,7 +18,6 @@
 #include <atomic>
 #include <thread>
 #include "velox/common/base/tests/GTestUtils.h"
-// #include "velox/exec/Exchange.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -36,7 +36,7 @@ constexpr uint64_t kMemoryPoolInitCapacity = 16 * MB;
 
 class FakeMemoryReclaimer : public exec::MemoryReclaimer {
  public:
-  FakeMemoryReclaimer() = default;
+  FakeMemoryReclaimer() : exec::MemoryReclaimer(0) {}
 
   static std::unique_ptr<MemoryReclaimer> create() {
     return std::make_unique<FakeMemoryReclaimer>();

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -243,6 +243,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
           copy->copy(vector.get(), 0, 0, vector->size());
           return queue->enqueue(std::move(copy), future);
         },
+        0,
         [queue](std::exception_ptr) {
           // onError close the queue to unblock producers and consumers.
           // moveNext will handle rethrowing the error once it's

--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -166,6 +166,7 @@ LocalRunner::makeStages() {
           params_.queryCtx,
           exec::Task::ExecutionMode::kParallel,
           consumer,
+          0,
           onError);
       stages_.back().push_back(task);
       if (fragment.numBroadcastDestinations) {


### PR DESCRIPTION
* Adds priority base reclaiming to memory reclaim framework. The priority determines which memory pool to reclaim first on the same level. This would help to make reclaim more application logic aware. 
* Make join node reclaim priority lower than others. This is because cost of reclaiming (spilling) on join node is high compared to other nodes.