### PR TITLE
fix: Enable Parquet E2E filter tests on decimal type

### DIFF
--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -315,9 +315,6 @@ bool testFilter(
   if (mayHaveNull && filter->testNull()) {
     return true;
   }
-  if (type->isDecimal()) {
-    return true;
-  }
   switch (type->kind()) {
     case TypeKind::BIGINT:
     case TypeKind::INTEGER:

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -315,6 +315,12 @@ bool testFilter(
   if (mayHaveNull && filter->testNull()) {
     return true;
   }
+  if (type->isDecimal()) {
+    // The min and max value in the metadata for decimal type in Parquet can be
+    // stored in different physical types, including int32, int64 and
+    // fixed_len_byte_array. The loading of them is not supported in Metadata.
+    return true;
+  }
   switch (type->kind()) {
     case TypeKind::BIGINT:
     case TypeKind::INTEGER:

--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -136,13 +136,18 @@ VectorPtr BatchMaker::createVector<TypeKind::INTEGER>(
 
 template <>
 VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
-    const TypePtr& /*type*/,
+    const TypePtr& type,
     size_t size,
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
   return createScalar<int64_t>(
-      size, gen, [&gen]() { return Random::rand64(gen); }, pool, isNullAt);
+      size,
+      gen,
+      [&gen]() { return Random::rand64(gen); },
+      pool,
+      isNullAt,
+      type);
 }
 
 template <>

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -343,6 +343,7 @@ void E2EFilterTestBase::testRowGroupSkip(
   for (auto& field : filterable) {
     VectorPtr child = getChildBySubfield(batches[0].get(), Subfield(field));
     if (child->typeKind() == TypeKind::BIGINT ||
+        child->typeKind() == TypeKind::HUGEINT ||
         child->typeKind() == TypeKind::VARCHAR) {
       specs.emplace_back();
       specs.back().field = field;

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -342,9 +342,7 @@ void E2EFilterTestBase::testRowGroupSkip(
   // Makes a row group skipping filter for the first bigint column.
   for (auto& field : filterable) {
     VectorPtr child = getChildBySubfield(batches[0].get(), Subfield(field));
-    if (child->typeKind() == TypeKind::BIGINT ||
-        child->typeKind() == TypeKind::HUGEINT ||
-        child->typeKind() == TypeKind::VARCHAR) {
+    if (child->type() == BIGINT() || child->typeKind() == TypeKind::VARCHAR) {
       specs.emplace_back();
       specs.back().field = field;
       specs.back().isForRowGroupSkip = true;

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -337,6 +337,10 @@ class ColumnStats : public AbstractColumnStats {
         }
       }
     }
+    if constexpr (std::is_same_v<T, int128_t>) {
+      return std::make_unique<velox::common::HugeintRange>(
+          max, max, false);
+    }
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(max), getIntegerValue(max), false);
   }

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -337,10 +337,6 @@ class ColumnStats : public AbstractColumnStats {
         }
       }
     }
-    if constexpr (std::is_same_v<T, int128_t>) {
-      return std::make_unique<velox::common::HugeintRange>(
-          max, max, false);
-    }
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(max), getIntegerValue(max), false);
   }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -443,7 +443,7 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
               true);
         },
         true,
-        {},
+        {"longdecimal_val"},
         20);
   }
 
@@ -456,7 +456,7 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
             {-479, HugeInt::build(1546093991, 4054979645)});
       },
       false,
-      {},
+      {"longdecimal_val"},
       20);
 }
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -414,7 +414,7 @@ TEST_F(E2EFilterTest, longDecimalDictionary) {
               true);
         },
         true,
-        {},
+        {"longdecimal_val"},
         20);
   }
 }

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -482,6 +482,10 @@ class IsNull final : public Filter {
     return false;
   }
 
+  bool testInt128(int128_t /* unused */) const final {
+    return false;
+  }
+
   bool testInt64Range(int64_t /*min*/, int64_t /*max*/, bool hasNull)
       const final {
     return hasNull;

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -76,6 +76,7 @@ TEST(FilterTest, isNull) {
 
   EXPECT_FALSE(isNull.testNonNull());
   EXPECT_FALSE(isNull.testInt64(10));
+  EXPECT_FALSE(isNull.testInt128(10));
 
   EXPECT_EQ("Filter(IsNull, deterministic, null allowed)", isNull.toString());
 }


### PR DESCRIPTION
1. Fixes 'BatchMaker::createVector<TypeKind::BIGINT>' to ensure decimal vector 
can be generated.
2. Fixes 'testRowGroupSkip' for short decimal. Clarifies that row group skip based 
on column statistics for decimal type is not currently supported.
3. Supports 'testInt128' in IsNull filter.