### PR TITLE
fix(merge-join): Produce output before advancing key comparison

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -782,7 +782,7 @@ RowVectorPtr MergeJoin::getOutput() {
               }
             }
             rightIndex_ = firstNonNullIndex;
-            if (rightIndex_ == rightInput_->size()) {
+            if (finishedRightBatch()) {
               // Ran out of rows on the right side.
               rightInput_ = nullptr;
             }
@@ -884,12 +884,11 @@ RowVectorPtr MergeJoin::doGetOutput() {
             return std::move(output_);
           }
           addOutputRowForLeftJoin(input_, index_);
-
           ++index_;
-          if (index_ == input_->size()) {
-            // Ran out of rows on the left side.
+
+          if (finishedLeftBatch()) {
             input_ = nullptr;
-            return nullptr;
+            return produceOutput();
           }
         }
       }
@@ -911,11 +910,10 @@ RowVectorPtr MergeJoin::doGetOutput() {
           if (outputSize_ == outputBatchSize_) {
             return std::move(output_);
           }
-
           addOutputRowForRightJoin(rightInput_, rightIndex_);
 
           ++rightIndex_;
-          if (rightIndex_ == rightInput_->size()) {
+          if (finishedRightBatch()) {
             // Ran out of rows on the right side.
             rightInput_ = nullptr;
             return nullptr;
@@ -940,12 +938,11 @@ RowVectorPtr MergeJoin::doGetOutput() {
             return std::move(output_);
           }
           addOutputRowForLeftJoin(input_, index_);
-
           ++index_;
-          if (index_ == input_->size()) {
-            // Ran out of rows on the left side.
+
+          if (finishedLeftBatch()) {
             input_ = nullptr;
-            return nullptr;
+            return produceOutput();
           }
         }
       }
@@ -1021,10 +1018,9 @@ RowVectorPtr MergeJoin::doGetOutput() {
         index_ = firstNonNull(input_, leftKeys_, index_ + 1);
       }
 
-      if (index_ == input_->size()) {
-        // Ran out of rows on the left side.
+      if (finishedLeftBatch()) {
         input_ = nullptr;
-        return nullptr;
+        return produceOutput();
       }
       compareResult = compare();
     }
@@ -1042,17 +1038,15 @@ RowVectorPtr MergeJoin::doGetOutput() {
         if (outputSize_ == outputBatchSize_) {
           return std::move(output_);
         }
-
         addOutputRowForRightJoin(rightInput_, rightIndex_);
         ++rightIndex_;
       } else {
         rightIndex_ = firstNonNull(rightInput_, rightKeys_, rightIndex_ + 1);
       }
 
-      if (rightIndex_ == rightInput_->size()) {
-        // Ran out of rows on the right side.
+      if (finishedRightBatch()) {
         rightInput_ = nullptr;
-        return nullptr;
+        return produceOutput();
       }
       compareResult = compare();
     }
@@ -1105,7 +1099,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
         rightIndex_ = firstNonNull(rightInput_, rightKeys_, endRightIndex);
       }
 
-      if (rightIndex_ == rightInput_->size()) {
+      if (finishedRightBatch()) {
         // Ran out of rows on the right side.
         rightInput_ = nullptr;
       }

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -231,6 +231,26 @@ class MergeJoin : public Operator {
       const RowVectorPtr& right,
       vector_size_t rightIndex);
 
+  /// If all rows from the current left batch have been processed.
+  bool finishedLeftBatch() const {
+    return index_ == input_->size();
+  }
+
+  /// If all rows from the current right batch have been processed.
+  bool finishedRightBatch() const {
+    return rightIndex_ == rightInput_->size();
+  }
+
+  /// Properly resizes and produces the current output vector if one is
+  /// available.
+  RowVectorPtr produceOutput() {
+    if (output_) {
+      output_->resize(outputSize_);
+      return std::move(output_);
+    }
+    return nullptr;
+  }
+
   /// Evaluates join filter on 'filterInput_' and returns 'output' that contains
   /// a subset of rows on which the filter passed. Returns nullptr if no rows
   /// passed the filter.


### PR DESCRIPTION
Summary:
Before we start reading keys from the next batch of input, we need to
make sure we are not holding output_ wrapped around lazy vector from the last
batch, since lazy vectors need to be materialized in order.

Differential Revision: D66169184


