### PR TITLE
feat: Update throttler to support network signal

### DIFF
--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -357,4 +357,7 @@ constexpr folly::StringPiece kMetricStorageLocalThrottled{
 
 constexpr folly::StringPiece kMetricStorageGlobalThrottled{
     "velox.storage_global_throttled_count"};
+
+constexpr folly::StringPiece kMetricStorageNetworkThrottled{
+    "velox.storage_network_throttled_count"};
 } // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -435,7 +435,9 @@ Storage
    * - storage_global_throttled_count
      - Count
      - The number of times that storage IOs get throttled in a storage cluster.
-
+   * - storage_network_throttled_count
+     - Count
+     - The number of times that storage IOs get throttled in a storage cluster because of network.
 Spilling
 --------
 


### PR DESCRIPTION
Summary: Storage systems may return a network signal telling us that the backbone has transient issues. We should respect this signal and backoff




