### PR TITLE
fix: Let SharedArbitrator check leak only when dbg

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -467,7 +467,7 @@ void SharedArbitrator::addPool(const std::shared_ptr<MemoryPool>& pool) {
 }
 
 void SharedArbitrator::removePool(MemoryPool* pool) {
-  VELOX_CHECK_EQ(pool->reservedBytes(), 0);
+  VELOX_DCHECK_EQ(pool->reservedBytes(), 0);
   const uint64_t freedBytes = shrinkPool(pool, 0);
   VELOX_CHECK_EQ(pool->capacity(), 0);
   freeCapacity(freedBytes);


### PR DESCRIPTION
The current leak check behavior is not consistent between memory pool and shared arbitrator. Memory pool prints error message and logs metrics but not fail. However shared arbitrator throw failures. And when it does there is no wrapping exception handling so it will crash entire server. Change shared arbitrator behavior to be consistent with memory pool by do the deadly check only in debug mode