### PR TITLE
fix: Fix hash join reclaim bytes accounting

### DIFF
--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -394,7 +394,7 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
       if (!hasReclaimedFromBuild) {
         // We just need to reclaim from any one of the hash build operator.
         hasReclaimedFromBuild = true;
-        reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
+        reclaimedBytes += child->reclaim(targetBytes, maxWaitMs, stats);
       }
       return !hasReclaimedFromProbe;
     }
@@ -403,7 +403,7 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
       // The same as build operator, we only need to reclaim from any one of the
       // hash probe operator.
       hasReclaimedFromProbe = true;
-      reclaimedBytes = child->reclaim(targetBytes, maxWaitMs, stats);
+      reclaimedBytes += child->reclaim(targetBytes, maxWaitMs, stats);
     }
     return !hasReclaimedFromBuild;
   });

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5925,10 +5925,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
 
   {
     memory::ScopedMemoryArbitrationContext ctx(op->pool());
-    op->pool()->reclaim(
+    uint64_t reclaimedBytes = task->pool()->reclaim(
         folly::Random::oneIn(2) ? 0 : folly::Random::rand32(),
         0,
         reclaimerStats_);
+    ASSERT_GT(reclaimedBytes, 0);
   }
   ASSERT_GT(reclaimerStats_.reclaimedBytes, 0);
   ASSERT_GT(reclaimerStats_.reclaimExecTimeUs, 0);


### PR DESCRIPTION
Current hash join reclaim bytes accounting has a bug. It let the later reclaimed op type override the previous one, which we should be adding. This made some reclaimed bytes from hash join to be 0 because when it firstly reclaims from build it might reclaimed some bytes but later when it tries to reclaim from probe, it reclaimed 0 because probe has not started yet. Then the reclaimed result is 0 which is wrong. This wrong reclaimed bytes can make the reclaiming framework to reclaim from additional nodes which could at most of the times be avoided. For some hand picked spilling queries, fixing this can bring up to 50% of latency gain.