### PR TITLE
fix: Tighten checks for "bins" elements in width_bucket(x, bins)

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -192,11 +192,15 @@ Mathematical Functions
    :noindex:
 
     Returns the zero-based bin number of ``x`` according to the bins specified
-    by the array ``bins``. The ``bins`` parameter must be an array of doubles and
-    is assumed to be in sorted ascending order.
+    by the array ``bins``. The ``bins`` parameter must be an array of doubles, should not
+    contain ``null`` or non-finite elements, and is assumed to be in sorted ascending order.
 
     For example, if ``bins`` is ``ARRAY[0, 2, 4]``, then we have four bins:
     ``(-infinity(), 0)``, ``[0, 2)``, ``[2, 4)`` and ``[4, infinity())``.
+
+    Note: The function returns an error if it encounters a ``null`` or non-finite
+    element in ``bins``, but due to the binary search algorithm some such elements
+    might go unnoticed and the function will return a result.
 
 
 ====================================


### PR DESCRIPTION
Summary:
Make width_bucket(x, bins) throw error if it finds a null or
non-finite element in bins.
As per new Presto Java behavior: https://github.com/prestodb/presto/pull/24103

Differential Revision: D66382264


