### PR TITLE
fix: Complex vector memory tracking

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -74,6 +74,7 @@ class RowVector : public BaseVector {
             rowType->nameOf(i),
             i,
             type->childAt(i)->toString());
+        BaseVector::inMemoryBytes_ += child->inMemoryBytes();
       }
     }
     updateContainsLazyNotLoaded();


### PR DESCRIPTION
Summary: Simple fix, complex vector did not forward memory bytes from child vectors.

Differential Revision: D66374354


