### PR TITLE
feat: Add skewed partition balancer

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -34,6 +34,7 @@ velox_add_library(
   RawVector.cpp
   RuntimeMetrics.cpp
   SimdUtil.cpp
+  SkewedPartitionBalancer.cpp
   SpillConfig.cpp
   SpillStats.cpp
   StatsReporter.cpp

--- a/velox/common/base/SkewedPartitionBalancer.cpp
+++ b/velox/common/base/SkewedPartitionBalancer.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/SkewedPartitionBalancer.h"
+
+namespace facebook::velox::common {
+SkewedPartitionRebalancer::SkewedPartitionRebalancer(
+    uint32_t partitionCount,
+    uint32_t taskCount,
+    uint64_t minProcessedBytesRebalanceThresholdPerPartition,
+    uint64_t minProcessedBytesRebalanceThreshold)
+    : partitionCount_(partitionCount),
+      taskCount_(taskCount),
+      minProcessedBytesRebalanceThresholdPerPartition_(
+          minProcessedBytesRebalanceThresholdPerPartition),
+      minProcessedBytesRebalanceThreshold_(std::max(
+          minProcessedBytesRebalanceThreshold,
+          minProcessedBytesRebalanceThresholdPerPartition_)) {
+  VELOX_CHECK_GT(partitionCount_, 0);
+  VELOX_CHECK_GT(taskCount_, 0);
+
+  partitionRowCount_.resize(partitionCount_, 0);
+  partitionBytes_.resize(partitionCount_, 0);
+  partitionBytesAtLastRebalance_.resize(partitionCount_, 0);
+  partitionBytesSinceLastRebalancePerTask_.resize(partitionCount_, 0);
+  estimatedTaskBytesSinceLastRebalance_.resize(taskCount_, 0);
+
+  partitionAssignments_.resize(partitionCount_);
+
+  // Assigns one task for each partition intitially.
+  for (auto partition = 0; partition < partitionCount_; ++partition) {
+    const uint32_t taskId = partition % taskCount;
+    partitionAssignments_[partition].emplace_back(taskId);
+  }
+}
+
+void SkewedPartitionRebalancer::rebalance() {
+  if (shouldRebalance()) {
+    rebalancePartitions();
+  }
+}
+
+bool SkewedPartitionRebalancer::shouldRebalance() const {
+  VELOX_CHECK_GE(processedBytes_, processedBytesAtLastRebalance_);
+  return (processedBytes_ - processedBytesAtLastRebalance_) >=
+      minProcessedBytesRebalanceThreshold_;
+}
+
+void SkewedPartitionRebalancer::rebalancePartitions() {
+  VELOX_DCHECK(shouldRebalance());
+  ++stats_.numBalanceTriggers;
+
+  // Updates the processed bytes for each partition.
+  calculatePartitionProcessedBytes();
+
+  // Updates 'partitionBytesSinceLastRebalancePerTask_'.
+  for (auto partition = 0; partition < partitionCount_; ++partition) {
+    const auto totalAssignedTasks = partitionAssignments_[partition].size();
+    const auto partitionBytes = partitionBytes_[partition];
+    partitionBytesSinceLastRebalancePerTask_[partition] =
+        (partitionBytes - partitionBytesAtLastRebalance_[partition]) /
+        totalAssignedTasks;
+    partitionBytesAtLastRebalance_[partition] = partitionBytes;
+  }
+
+  // Builds the max partition queue for each partition with the partition having
+  // max processed bytes since last rebalance at the top of the queue for
+  // rebalance later.
+  std::vector<IndexedPriorityQueue<uint32_t, /*MaxQueue=*/true>>
+      taskMaxPartitions{taskCount_};
+  for (auto partition = 0; partition < partitionCount_; ++partition) {
+    auto& taskAssignments = partitionAssignments_[partition];
+    for (uint32_t taskId : taskAssignments) {
+      auto& taskQueue = taskMaxPartitions[taskId];
+      taskQueue.addOrUpdate(
+          partition, partitionBytesSinceLastRebalancePerTask_[partition]);
+    }
+  }
+
+  // Builds max and min task queue based on the estimated processed bytes since
+  // last rebalance.
+  IndexedPriorityQueue<uint32_t, /*MaxQueue=*/true> maxTasks;
+  IndexedPriorityQueue<uint32_t, /*MaxQueue=*/false> minTasks;
+  for (auto taskId = 0; taskId < taskCount_; ++taskId) {
+    estimatedTaskBytesSinceLastRebalance_[taskId] =
+        calculateTaskDataSizeSinceLastRebalance(taskMaxPartitions[taskId]);
+    maxTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
+    minTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
+  }
+
+  rebalanceBasedOnTaskSkewness(maxTasks, minTasks, taskMaxPartitions);
+  processedBytesAtLastRebalance_ = processedBytes_;
+}
+
+void SkewedPartitionRebalancer::rebalanceBasedOnTaskSkewness(
+    IndexedPriorityQueue<uint32_t, true>& maxTasks,
+    IndexedPriorityQueue<uint32_t, false>& minTasks,
+    std::vector<IndexedPriorityQueue<uint32_t, true>>& taskMaxPartitions) {
+  std::unordered_set<uint32_t> scaledPartitions;
+
+  while (true) {
+    const auto maxTaskIdOpt = maxTasks.pop();
+    if (!maxTaskIdOpt.has_value()) {
+      break;
+    }
+    const uint32_t maxTaskId = maxTaskIdOpt.value();
+
+    auto& maxPartitions = taskMaxPartitions[maxTaskId];
+    if (maxPartitions.empty()) {
+      continue;
+    }
+
+    std::vector<uint32_t> minSkewedTasks =
+        findSkewedMinTasks(maxTaskId, minTasks);
+    if (minSkewedTasks.empty()) {
+      break;
+    }
+
+    while (true) {
+      const auto maxPartitionOpt = maxPartitions.pop();
+      if (!maxPartitionOpt.has_value()) {
+        break;
+      }
+      const uint32_t maxPartition = maxPartitionOpt.value();
+
+      // Rebalance partition only once in a single cycle to avoid aggressive
+      // rebalancing.
+      if (scaledPartitions.count(maxPartition) != 0) {
+        continue;
+      }
+
+      const uint32_t totalAssignedTasks =
+          partitionAssignments_[maxPartition].size();
+      if (partitionBytes_[maxPartition] <
+          (minProcessedBytesRebalanceThresholdPerPartition_ *
+           totalAssignedTasks)) {
+        break;
+      }
+
+      for (uint32_t minTaskId : minSkewedTasks) {
+        if (rebalancePartition(maxPartition, minTaskId, maxTasks, minTasks)) {
+          scaledPartitions.insert(maxPartition);
+          break;
+        }
+      }
+    }
+  }
+
+  stats_.numScaledPartitions += scaledPartitions.size();
+}
+
+bool SkewedPartitionRebalancer::rebalancePartition(
+    uint32_t rebalancePartition,
+    uint32_t targetTaskId,
+    IndexedPriorityQueue<uint32_t, true>& maxTasks,
+    IndexedPriorityQueue<uint32_t, false>& minTasks) {
+  auto& taskAssignments = partitionAssignments_[rebalancePartition];
+  for (auto taskId : taskAssignments) {
+    if (taskId == targetTaskId) {
+      return false;
+    }
+  }
+
+  taskAssignments.push_back(targetTaskId);
+  VELOX_CHECK_GT(partitionAssignments_[rebalancePartition].size(), 1);
+
+  const auto newTaskCount = taskAssignments.size();
+  const auto oldTaskCount = newTaskCount - 1;
+  // Since a partition is rebalanced from max to min skewed tasks,
+  // decrease the priority of max taskBucket as well as increase the priority
+  // of min taskBucket.
+  for (uint32_t taskId : taskAssignments) {
+    if (taskId == targetTaskId) {
+      estimatedTaskBytesSinceLastRebalance_[taskId] +=
+          (partitionBytesSinceLastRebalancePerTask_[rebalancePartition] *
+           oldTaskCount) /
+          newTaskCount;
+    } else {
+      estimatedTaskBytesSinceLastRebalance_[taskId] -=
+          partitionBytesSinceLastRebalancePerTask_[rebalancePartition] /
+          newTaskCount;
+    }
+
+    maxTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
+    minTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
+  }
+
+  LOG(INFO) << "Rebalanced partition " << rebalancePartition << " to task "
+            << targetTaskId << " with taskCount " << newTaskCount;
+  return true;
+}
+
+void SkewedPartitionRebalancer::calculatePartitionProcessedBytes() {
+  uint64_t totalPartitionRowCount{0};
+  for (auto partition = 0; partition < partitionCount_; ++partition) {
+    totalPartitionRowCount += partitionRowCount_[partition];
+  }
+  VELOX_CHECK_GT(totalPartitionRowCount, 0);
+
+  for (auto partition = 0; partition < partitionCount_; ++partition) {
+    // Since we estimate 'partitionBytes_' based on 'partitionRowCount_' and
+    // total 'processedBytes_'. It is possible that the estimated
+    // 'partitionBytes_' is slightly less than it was estimated at the last
+    // rebalance cycle 'partitionBytesAtLastRebalance_'. That's because for
+    // a given partition, 'partitionRowCount_' has increased, however overall
+    // 'processedBytes_' hasn't increased that much. Therefore, we need to make
+    // sure that the estimated 'partitionBytes_' should be at least
+    // 'partitionBytesAtLastRebalance_'. Otherwise, it will affect the ordering
+    // of 'minTasks' priority queue.
+    partitionBytes_[partition] = std::max(
+        (partitionRowCount_[partition] * processedBytes_) /
+            totalPartitionRowCount,
+        partitionBytes_[partition]);
+  }
+}
+
+std::vector<uint32_t> SkewedPartitionRebalancer::findSkewedMinTasks(
+    uint32_t maxTaskId,
+    const IndexedPriorityQueue<uint32_t, false>& minTasks) const {
+  std::vector<uint32_t> minSkewdTaskIds;
+  for (uint32_t minTaskId : minTasks) {
+    if (minTaskId == maxTaskId) {
+      break;
+    }
+    const double skewness =
+        ((double)(estimatedTaskBytesSinceLastRebalance_[maxTaskId] -
+                  estimatedTaskBytesSinceLastRebalance_[minTaskId])) /
+        estimatedTaskBytesSinceLastRebalance_[maxTaskId];
+    if (skewness <= kTaskSkewnessThreshod_ || std::isnan(skewness)) {
+      break;
+    }
+    minSkewdTaskIds.push_back(minTaskId);
+  }
+  return minSkewdTaskIds;
+}
+
+std::string SkewedPartitionRebalancer::Stats::toString() const {
+  return fmt::format(
+      "numBalanceTriggers {}, numScaledPartitions {}",
+      numBalanceTriggers,
+      numScaledPartitions);
+}
+} // namespace facebook::velox::common

--- a/velox/common/base/SkewedPartitionBalancer.h
+++ b/velox/common/base/SkewedPartitionBalancer.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/base/IndexedPriorityQueue.h"
+
+namespace facebook::velox::common {
+
+namespace test {
+class SkewedPartitionRebalancerTestHelper;
+}
+
+/// This class is used to auto-scale partition processing by assigning more
+/// tasks to busy partition measured by processed data size. This is used by
+/// local partition to scale table writers for now.
+///
+/// NOTE: this object is not thread-safe.
+class SkewedPartitionRebalancer {
+ public:
+  /// 'partitionCount' is the number of partitions to process. 'taskCount' is
+  /// number of tasks for execution.
+  /// 'minProcessedBytesRebalanceThresholdPerPartition' is the processed bytes
+  /// threshold to trigger task scaling for a single partition.
+  /// 'minProcessedBytesRebalanceThreshold' is the threshold to trigger
+  /// partition assignment rebalancing across tasks, which assigns under-loaded
+  /// tasks to busy partitions from the busy tasks. A partition load is measured
+  /// as the number of processed data size in bytes. Similarly, a task load is
+  /// measured in the total number of processed data size from all its serving
+  /// partitions.
+  SkewedPartitionRebalancer(
+      uint32_t partitionCount,
+      uint32_t taskCount,
+      uint64_t minProcessedBytesRebalanceThresholdPerPartition,
+      uint64_t minProcessedBytesRebalanceThreshold);
+
+  /// Invoked to rebalance the partition assignments if applicable.
+  void rebalance();
+
+  /// Gets the assigned task id for a given 'partition'. 'index' is used to
+  /// choose one of multiple assigned tasks in a round-robin order.
+  uint32_t getTaskId(uint32_t partition, uint64_t index) const {
+    const auto& taskList = partitionAssignments_[partition];
+    return taskList[index % taskList.size()];
+  }
+
+  /// Adds the processed partition row count. This is used to estimate the
+  /// processed bytes of a partition.
+  void addPartitionRowCount(uint32_t partition, uint32_t numRows) {
+    VELOX_CHECK_LT(partition, partitionCount_);
+    VELOX_CHECK_GT(numRows, 0);
+    partitionRowCount_[partition] += numRows;
+  }
+
+  /// Adds the total processed bytes from all the partitions.
+  void addProcessedBytes(long bytes) {
+    VELOX_CHECK_GT(bytes, 0);
+    processedBytes_ += bytes;
+  }
+
+  /// The rebalancer internal stats.
+  struct Stats {
+    /// The number of times that triggers rebalance.
+    size_t numBalanceTriggers{0};
+    /// The number of times that we scale a partition processing.
+    size_t numScaledPartitions{0};
+
+    std::string toString() const;
+
+    inline bool operator==(const Stats& other) const {
+      return std::tie(numBalanceTriggers, numScaledPartitions) ==
+          std::tie(other.numBalanceTriggers, other.numScaledPartitions);
+    }
+  };
+
+  Stats stats() const {
+    return stats_;
+  }
+
+ private:
+  bool shouldRebalance() const;
+
+  void rebalancePartitions();
+
+  // Calculates the partition processed data size based on the number of
+  // processed rows and the averaged row size.
+  void calculatePartitionProcessedBytes();
+
+  template <bool MaxQueue>
+  uint64_t calculateTaskDataSizeSinceLastRebalance(
+      const IndexedPriorityQueue<uint32_t, MaxQueue>& maxPartitions) {
+    uint64_t estimatedDataBytesSinceLastRebalance{0};
+    for (uint32_t partition : maxPartitions) {
+      estimatedDataBytesSinceLastRebalance +=
+          partitionBytesSinceLastRebalancePerTask_[partition];
+    }
+    return estimatedDataBytesSinceLastRebalance;
+  }
+
+  // Tries to rebalance by assigning 'minTasks' to busy partitions in
+  // 'maxTasks'. 'taskMaxPartitions' tracks the partitions served by eack task
+  // in a max priority queue.
+  void rebalanceBasedOnTaskSkewness(
+      IndexedPriorityQueue<uint32_t, true>& maxTasks,
+      IndexedPriorityQueue<uint32_t, false>& minTasks,
+      std::vector<IndexedPriorityQueue<uint32_t, true>>& taskMaxPartitions);
+
+  // Finds the skew min tasks compared with the max task as specified by
+  // 'maxTaskId'.
+  std::vector<uint32_t> findSkewedMinTasks(
+      uint32_t maxTaskId,
+      const IndexedPriorityQueue<uint32_t, false>& minTasks) const;
+
+  // Tries to assign 'targetTaskId' to 'rebalancePartition' for rebalancing.
+  // Returns true if rebalanced, otherwise false.
+  bool rebalancePartition(
+      uint32_t rebalancePartition,
+      uint32_t targetTaskId,
+      IndexedPriorityQueue<uint32_t, true>& maxTasks,
+      IndexedPriorityQueue<uint32_t, false>& minTasks);
+
+  static constexpr double kTaskSkewnessThreshod_{0.7};
+
+  const uint32_t partitionCount_;
+  const uint32_t taskCount_;
+  const uint64_t minProcessedBytesRebalanceThresholdPerPartition_;
+  const uint64_t minProcessedBytesRebalanceThreshold_;
+
+  // The accumulated number of rows processed by each partition.
+  std::vector<uint64_t> partitionRowCount_;
+
+  // The accumulated number of bytes processed by all the partitions.
+  uint64_t processedBytes_{0};
+  // 'processedBytes_' at the last rebalance. It is used to calculate the
+  // processed bytes changes since the last rebalance.
+  uint64_t processedBytesAtLastRebalance_{0};
+  // The accumulated number of bytes processed by each partition.
+  std::vector<uint64_t> partitionBytes_;
+  // 'partitionBytes_' at the last rebalance. It is used to calculate the
+  // processed bytes changes for each partition since the last rebalance.
+  std::vector<uint64_t> partitionBytesAtLastRebalance_;
+  // The average processed bytes for each partition on its assigned tasks since
+  // the last rebalance. It is used to calculate the processed byte changes for
+  // each task since the last rebalance.
+  std::vector<uint64_t> partitionBytesSinceLastRebalancePerTask_;
+  // The estimated task processed bytes since the last rebalance.
+  std::vector<uint64_t> estimatedTaskBytesSinceLastRebalance_;
+
+  // The assigned task id list for each partition.
+  std::vector<std::vector<uint32_t>> partitionAssignments_;
+
+  Stats stats_;
+
+  friend class test::SkewedPartitionRebalancerTestHelper;
+};
+} // namespace facebook::velox::common

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ScratchTest.cpp
   SemaphoreTest.cpp
   SimdUtilTest.cpp
+  SkewedPartitionBalancerTest.cpp
   SpillConfigTest.cpp
   SpillStatsTest.cpp
   StatsReporterTest.cpp

--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/SkewedPartitionBalancer.h"
+
+#include <gtest/gtest.h>
+
+#include "folly/Random.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::common::test {
+class SkewedPartitionRebalancerTestHelper {
+ public:
+  explicit SkewedPartitionRebalancerTestHelper(
+      SkewedPartitionRebalancer* balancer)
+      : balancer_(balancer) {
+    VELOX_CHECK_NOT_NULL(balancer_);
+  }
+
+  void verifyPartitionAssignment(
+      uint32_t partition,
+      const std::set<uint32_t>& expectedAssignedTasks) const {
+    const std::set<uint32_t> assignedTasks(
+        balancer_->partitionAssignments_[partition].begin(),
+        balancer_->partitionAssignments_[partition].end());
+    ASSERT_EQ(assignedTasks, expectedAssignedTasks)
+        << "\nExpected: " << folly::join(",", expectedAssignedTasks)
+        << "\nActual: " << folly::join(",", assignedTasks);
+  }
+
+  void verifyPartitionRowCount(uint32_t partition, uint32_t expectedRowCount)
+      const {
+    ASSERT_EQ(balancer_->partitionRowCount_[partition], expectedRowCount);
+  }
+
+  uint32_t taskCount() const {
+    return balancer_->taskCount_;
+  }
+
+  uint32_t partitionCount() const {
+    return balancer_->partitionCount_;
+  }
+
+  uint64_t processedBytes() const {
+    return balancer_->processedBytes_;
+  }
+
+  bool shouldRebalance() const {
+    return balancer_->shouldRebalance();
+  }
+
+ private:
+  SkewedPartitionRebalancer* const balancer_;
+};
+
+class SkewedPartitionRebalancerTest : public testing::Test {
+ protected:
+  std::unique_ptr<SkewedPartitionRebalancer> createBalancer(
+      uint32_t partitionCount = 128,
+      uint32_t taskCount = 8,
+      uint64_t minPartitionDataProcessedBytesRebalanceThreshold = 128,
+      uint64_t minProcessedBytesRebalanceThreshold = 256) {
+    return std::make_unique<SkewedPartitionRebalancer>(
+        partitionCount,
+        taskCount,
+        minPartitionDataProcessedBytesRebalanceThreshold,
+        minProcessedBytesRebalanceThreshold);
+  }
+};
+
+TEST_F(SkewedPartitionRebalancerTest, basic) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  SkewedPartitionRebalancerTestHelper helper(balancer.get());
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+  }
+  ASSERT_EQ(balancer->stats(), SkewedPartitionRebalancer::Stats{});
+  ASSERT_EQ(
+      balancer->stats().toString(),
+      "numBalanceTriggers 0, numScaledPartitions 0");
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats(), SkewedPartitionRebalancer::Stats{});
+
+  balancer->addProcessedBytes(128);
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats(), SkewedPartitionRebalancer::Stats{});
+
+  balancer->addProcessedBytes(128);
+  VELOX_ASSERT_THROW(balancer->rebalance(), "");
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 1);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 0);
+
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+  }
+
+  ASSERT_EQ(helper.processedBytes(), 256);
+  ASSERT_TRUE(helper.shouldRebalance());
+  balancer->addPartitionRowCount(0, 100);
+  ASSERT_TRUE(helper.shouldRebalance());
+
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 2);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 1);
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    if (i == 0) {
+      helper.verifyPartitionAssignment(0, {0, 1});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+
+  ASSERT_FALSE(helper.shouldRebalance());
+  ASSERT_EQ(helper.processedBytes(), 256);
+  balancer->addProcessedBytes(128);
+  ASSERT_FALSE(helper.shouldRebalance());
+  ASSERT_EQ(helper.processedBytes(), 256 + 128);
+  balancer->addProcessedBytes(128);
+  ASSERT_TRUE(helper.shouldRebalance());
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 3);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 2);
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    if (i == 0) {
+      helper.verifyPartitionAssignment(0, {0, 1, 2});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+
+  balancer->addProcessedBytes(512);
+  balancer->addPartitionRowCount(1, 100);
+  ASSERT_TRUE(helper.shouldRebalance());
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 4);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 4);
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    SCOPED_TRACE(fmt::format("partition {}", i));
+    if (i == 0) {
+      helper.verifyPartitionAssignment(0, {0, 1, 2, 3});
+    } else if (i == 1) {
+      helper.verifyPartitionAssignment(1, {0, 1});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+  ASSERT_EQ(
+      balancer->stats().toString(),
+      "numBalanceTriggers 4, numScaledPartitions 4");
+}
+
+TEST_F(SkewedPartitionRebalancerTest, rebalanceCondition) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  SkewedPartitionRebalancerTestHelper helper(balancer.get());
+  ASSERT_FALSE(helper.shouldRebalance());
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 0);
+  balancer->addProcessedBytes(128);
+  ASSERT_FALSE(helper.shouldRebalance());
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 0);
+  balancer->addProcessedBytes(128);
+  ASSERT_TRUE(helper.shouldRebalance());
+  VELOX_ASSERT_THROW(balancer->rebalance(), "");
+  balancer->addPartitionRowCount(0, 1);
+  balancer->addPartitionRowCount(31, 1);
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    if (i == 0 || i == 31) {
+      helper.verifyPartitionRowCount(i, 1);
+    } else {
+      helper.verifyPartitionRowCount(i, 0);
+    }
+  }
+  ASSERT_TRUE(helper.shouldRebalance());
+  balancer->rebalance();
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    SCOPED_TRACE(fmt::format("partition {}", i));
+    if (i == 0) {
+      helper.verifyPartitionAssignment(0, {0, 1});
+    } else if (i == 31) {
+      helper.verifyPartitionAssignment(31, {2, 3});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 2);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 2);
+
+  ASSERT_FALSE(helper.shouldRebalance());
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 2);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 2);
+}
+
+// Verify the round-robin selection of assigned tasks.
+TEST_F(SkewedPartitionRebalancerTest, assignedTaskSelection) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  SkewedPartitionRebalancerTestHelper helper(balancer.get());
+  for (int round = 0; round < 10; ++round) {
+    for (int partition = 0; partition < helper.partitionCount(); ++partition) {
+      ASSERT_EQ(
+          balancer->getTaskId(partition, round),
+          partition % helper.taskCount());
+    }
+  }
+  balancer->addProcessedBytes(512);
+  balancer->addPartitionRowCount(0, 1);
+  balancer->addPartitionRowCount(15, 1);
+  balancer->addPartitionRowCount(31, 1);
+
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 1);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 3);
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    SCOPED_TRACE(fmt::format("partition {}", i));
+    if (i == 0) {
+      helper.verifyPartitionAssignment(i, {0, 2});
+    } else if (i == 15) {
+      helper.verifyPartitionAssignment(i, {1, 3});
+    } else if (i == 31) {
+      helper.verifyPartitionAssignment(i, {1, 3});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+  for (int round = 0; round < 10; ++round) {
+    for (int partition = 0; partition < helper.partitionCount(); ++partition) {
+      SCOPED_TRACE(fmt::format("partition {}, round {}", partition, round));
+      if (partition == 0) {
+        ASSERT_EQ(balancer->getTaskId(partition, round), round % 2 ? 2 : 0);
+      } else if (partition == 15 || partition == 31) {
+        ASSERT_EQ(balancer->getTaskId(partition, round), round % 2 ? 1 : 3);
+      } else {
+        ASSERT_EQ(
+            balancer->getTaskId(partition, round),
+            partition % helper.taskCount());
+      }
+    }
+  }
+}
+
+TEST_F(SkewedPartitionRebalancerTest, partitionScaleProcessBytesThreshold) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  SkewedPartitionRebalancerTestHelper helper(balancer.get());
+  balancer->addProcessedBytes(256);
+  balancer->addPartitionRowCount(0, 64);
+  for (int partition = 1; partition < helper.partitionCount(); ++partition) {
+    balancer->addPartitionRowCount(partition, 3);
+  }
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 1);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 0);
+
+  balancer->addProcessedBytes(256);
+  balancer->addPartitionRowCount(0, 128);
+
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 2);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 1);
+
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    SCOPED_TRACE(fmt::format("partition {}", i));
+    if (i == 0) {
+      helper.verifyPartitionAssignment(i, {0, 1});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+}
+
+TEST_F(SkewedPartitionRebalancerTest, skewTasksCondition) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  SkewedPartitionRebalancerTestHelper helper(balancer.get());
+  for (int partition = 0; partition < helper.taskCount(); ++partition) {
+    balancer->addProcessedBytes(400);
+    balancer->addPartitionRowCount(partition, 4);
+  }
+  balancer->addProcessedBytes(600);
+  balancer->addPartitionRowCount(0, 6);
+
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 1);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 0);
+
+  for (int partition = 0; partition < helper.taskCount(); ++partition) {
+    balancer->addProcessedBytes(3000);
+    balancer->addPartitionRowCount(partition, 3);
+  }
+  balancer->addProcessedBytes(7000);
+  balancer->addPartitionRowCount(0, 10);
+
+  balancer->rebalance();
+  ASSERT_EQ(balancer->stats().numBalanceTriggers, 2);
+  ASSERT_EQ(balancer->stats().numScaledPartitions, 1);
+
+  for (int i = 0; i < helper.partitionCount(); ++i) {
+    SCOPED_TRACE(fmt::format("partition {}", i));
+    if (i == 0) {
+      helper.verifyPartitionAssignment(i, {0, 1});
+    } else {
+      helper.verifyPartitionAssignment(i, {i % helper.taskCount()});
+    }
+  }
+}
+
+TEST_F(SkewedPartitionRebalancerTest, error) {
+  auto balancer = createBalancer(32, 4, 128, 256);
+  VELOX_ASSERT_THROW(balancer->addProcessedBytes(0), "");
+  VELOX_ASSERT_THROW(balancer->addPartitionRowCount(32, 4), "");
+  VELOX_ASSERT_THROW(balancer->addPartitionRowCount(0, 0), "");
+  VELOX_ASSERT_THROW(createBalancer(0, 4, 128, 256), "");
+  VELOX_ASSERT_THROW(createBalancer(0, 4, 0, 0), "");
+}
+
+TEST_F(SkewedPartitionRebalancerTest, fuzz) {
+  std::mt19937 rng{100};
+  for (int taskCount = 1; taskCount <= 10; ++taskCount) {
+    const uint64_t rebalanceThreshold = folly::Random::rand32(128, rng);
+    const uint64_t perPartitionRebalanceThreshold =
+        folly::Random::rand32(rebalanceThreshold / 2, rng);
+    auto balancer = createBalancer(
+        32, taskCount, perPartitionRebalanceThreshold, rebalanceThreshold);
+    SkewedPartitionRebalancerTestHelper helper(balancer.get());
+    for (int iteration = 0; iteration < 1'000; ++iteration) {
+      SCOPED_TRACE(
+          fmt::format("taskCount {}, iteration {}", taskCount, iteration));
+      const uint64_t processedBytes = 1 + folly::Random::rand32(512, rng);
+      balancer->addProcessedBytes(processedBytes);
+      const auto numPartitons = folly::Random::rand32(32, rng);
+      for (auto i = 0; i < numPartitons; ++i) {
+        const auto partition = folly::Random::rand32(32, rng);
+        const auto numRows = 1 + folly::Random::rand32(32, rng);
+        balancer->addPartitionRowCount(partition, numRows);
+      }
+      balancer->rebalance();
+      for (int round = 0; round < 10; ++round) {
+        for (int partition = 0; partition < helper.partitionCount();
+             ++partition) {
+          ASSERT_LT(balancer->getTaskId(partition, round), taskCount);
+        }
+      }
+    }
+  }
+}
+} // namespace facebook::velox::common::test


### PR DESCRIPTION
Summary:
Add skewed partition balancer which implements the following functions:
(1) the task assignments for a number of partitions;
(2) tracks the processed bytes/rows for each partition and the corresponding estimates of task and partition workloads in terms
of the processed bytes;
(3) rebalance (or scaling busy partition processing) by assigning under-loaded tasks to hot partition from a over-loaded tasks.
(4) get the next serving task for a given partition in round-robin manner if there is multiple assigned tasks.

The followup is to leverage this to auto-scale writer processing for hot table partition through a customized local partition for
table writer

Differential Revision: D66380972


