### PR TITLE
fix: Delta update reader lifecycle issue

### DIFF
--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -346,7 +346,7 @@ class ScanSpec {
     for (auto& child : children_) {
       // Only top level columns can have delta updates.
       if (child->deltaUpdate_) {
-        setDeltaUpdate(nullptr);
+        child->setDeltaUpdate(nullptr);
       }
     }
   }


### PR DESCRIPTION
Summary:
In ScanSpec we only clear the column updater for root but not the
actual columns, this results in lifecycle issue when a non-Metalake split is
following a Makelake split.

Differential Revision: D66402400


