### PR TITLE
fix: Support hashing ipaddress

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -430,4 +431,22 @@ TEST_F(PrestoHasherTest, timestampWithTimezone) {
       {-3461822077982309083, -3461822077982309083, -8497890125589769483, 0});
 }
 
+TEST_F(PrestoHasherTest, ipAddress) {
+  auto makeIpAdressFromString = [](const std::string& ipAddr) -> int128_t {
+    auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
+    return ret.value();
+  };
+
+  auto ipAddresses = makeNullableFlatVector(
+      std::vector<std::optional<int128_t>>{
+          makeIpAdressFromString("2001:db8::ff00:42:8329"),
+          makeIpAdressFromString("192.168.1.1"),
+          makeIpAdressFromString("::ffff:1.2.3.4"),
+          std::nullopt},
+      IPADDRESS());
+
+  assertHash(
+      ipAddresses,
+      {-4694347089639306204, 2704428192845283049, -1632332718929005309, 0});
+}
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -28,6 +28,15 @@ constexpr int kIPV4ToV6FFIndex = 10;
 constexpr int kIPV4ToV6Index = 12;
 constexpr int kIPAddressBytes = 16;
 
+inline folly::ByteArray16 toIPv6ByteArray(const int128_t& ipAddr) {
+  folly::ByteArray16 bytes{{0}};
+  memcpy(bytes.data(), &ipAddr, sizeof(ipAddr));
+  // Reverse because the velox is always on little endian system
+  // and the byte array needs to be big endian (network byte order)
+  std::reverse(bytes.begin(), bytes.end());
+  return bytes;
+}
+
 inline folly::Expected<int128_t, folly::IPAddressFormatError>
 tryGetIPv6asInt128FromString(const std::string& ipAddressStr) {
   auto maybeIp = folly::IPAddress::tryFromString(ipAddressStr);
@@ -56,8 +65,8 @@ class IPAddressType : public HugeintType {
   }
 
   int32_t compare(const int128_t& left, const int128_t& right) const override {
-    const auto leftAddrBytes = toIPv6ByteArray(left);
-    const auto rightAddrBytes = toIPv6ByteArray(right);
+    const auto leftAddrBytes = ipaddress::toIPv6ByteArray(left);
+    const auto rightAddrBytes = ipaddress::toIPv6ByteArray(right);
     return memcmp(
         leftAddrBytes.begin(),
         rightAddrBytes.begin(),
@@ -86,16 +95,6 @@ class IPAddressType : public HugeintType {
     obj["name"] = "Type";
     obj["type"] = name();
     return obj;
-  }
-
- private:
-  static folly::ByteArray16 toIPv6ByteArray(const int128_t& ipAddr) {
-    folly::ByteArray16 bytes{{0}};
-    memcpy(bytes.data(), &ipAddr, sizeof(ipAddr));
-    // Reverse because the velox is always on little endian system
-    // and the byte array needs to be big endian (network byte order)
-    std::reverse(bytes.begin(), bytes.end());
-    return bytes;
   }
 };
 


### PR DESCRIPTION
Summary:
Checksuming on ipaddress fails because the prestoHasher treats ipaddress as a HUGEINT, which it is; however, the hashing for HUGEINT is different than the hashing for binaries. 

In Velox, we represent IPAddress as a HUGEINT (16 bytes) instead of varbinary. So we need to compute the checksum on the varbinary representation of the int128_t.




