### PR TITLE
fix: Add testInt128Range for filters

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -323,6 +323,11 @@ class AlwaysFalse final : public Filter {
     return false;
   }
 
+  bool testInt128Range(int128_t /*min*/, int128_t /*max*/, bool /*hasNull*/)
+      const final {
+    return false;
+  }
+
   bool testInt128(int128_t /* unused */) const final {
     return false;
   }
@@ -411,6 +416,11 @@ class AlwaysTrue final : public Filter {
     return true;
   }
 
+  bool testInt128Range(int128_t /*min*/, int128_t /*max*/, bool /*hasNull*/)
+      const final {
+    return true;
+  }
+
   bool testDoubleRange(double /*min*/, double /*max*/, bool /*hasNull*/)
       const final {
     return true;
@@ -491,6 +501,11 @@ class IsNull final : public Filter {
     return hasNull;
   }
 
+  bool testInt128Range(int128_t /*min*/, int128_t /*max*/, bool hasNull)
+      const final {
+    return hasNull;
+  }
+
   bool testDoubleRange(double /*min*/, double /*max*/, bool hasNull)
       const final {
     return hasNull;
@@ -566,6 +581,11 @@ class IsNotNull final : public Filter {
   }
 
   bool testInt64Range(int64_t /*min*/, int64_t /*max*/, bool /*hasNull*/)
+      const final {
+    return true;
+  }
+
+  bool testInt128Range(int128_t /*min*/, int128_t /*max*/, bool /*hasNull*/)
       const final {
     return true;
   }

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -33,6 +33,8 @@ using namespace facebook::velox::exec;
 TEST(FilterTest, alwaysFalse) {
   AlwaysFalse alwaysFalse;
   EXPECT_FALSE(alwaysFalse.testInt64(1));
+  EXPECT_FALSE(alwaysFalse.testInt128Range(0, 0, false));
+  EXPECT_FALSE(alwaysFalse.testInt128Range(0, 0, true));
   EXPECT_FALSE(alwaysFalse.testNonNull());
   EXPECT_FALSE(alwaysFalse.testNull());
 
@@ -44,6 +46,8 @@ TEST(FilterTest, alwaysFalse) {
 TEST(FilterTest, alwaysTrue) {
   AlwaysTrue alwaysTrue;
   EXPECT_TRUE(alwaysTrue.testInt64(1));
+  EXPECT_TRUE(alwaysTrue.testInt128Range(0, 0, false));
+  EXPECT_TRUE(alwaysTrue.testInt128Range(0, 0, true));
   EXPECT_TRUE(alwaysTrue.testNonNull());
   EXPECT_TRUE(alwaysTrue.testNull());
   xsimd::batch<int64_t> int64s(1);
@@ -66,6 +70,8 @@ TEST(FilterTest, isNotNull) {
   IsNotNull notNull;
   EXPECT_TRUE(notNull.testNonNull());
   EXPECT_TRUE(notNull.testInt64(10));
+  EXPECT_TRUE(notNull.testInt128Range(0, 0, false));
+  EXPECT_TRUE(notNull.testInt128Range(0, 0, true));
 
   EXPECT_FALSE(notNull.testNull());
 }
@@ -77,6 +83,8 @@ TEST(FilterTest, isNull) {
   EXPECT_FALSE(isNull.testNonNull());
   EXPECT_FALSE(isNull.testInt64(10));
   EXPECT_FALSE(isNull.testInt128(10));
+  EXPECT_FALSE(isNull.testInt128Range(0, 0, false));
+  EXPECT_TRUE(isNull.testInt128Range(0, 0, true));
 
   EXPECT_EQ("Filter(IsNull, deterministic, null allowed)", isNull.toString());
 }


### PR DESCRIPTION
Adds testInt128Range for AlwaysFalse, AlwaysTrue, IsNull, IsNotNull filters.