### PR TITLE
build: Install packages and modules for format

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -42,6 +42,7 @@ USE_CLANG="${USE_CLANG:-false}"
 export INSTALL_PREFIX=${INSTALL_PREFIX:-"/usr/local"}
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
 VERSION=$(cat /etc/os-release | grep VERSION_ID)
+PYTHON_VENV=${PYTHON_VENV:-"${SCRIPTDIR}/../.venv"}
 
 # On Ubuntu 20.04 dependencies need to be built using gcc11.
 # On Ubuntu 22.04 gcc11 is already the system gcc installed.
@@ -93,7 +94,12 @@ function install_build_prerequisites {
     git \
     pkg-config \
     wget
-
+  
+  if [ ! -f ${PYTHON_VENV}/pyvenv.cfg ]; then
+    echo "Creating Python Virtual Environment at ${PYTHON_VENV}"
+    python3 -m venv ${PYTHON_VENV}
+  fi
+  source ${PYTHON_VENV}/bin/activate;   
   # Install to /usr/local to make it available to all users.
   ${SUDO} pip3 install cmake==3.28.3
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -105,6 +105,14 @@ function install_build_prerequisites {
 
 }
 
+# Install packages required to fix format
+function install_format_prerequisites {
+  pip3 install regex
+  ${SUDO} apt install -y \
+    clang-format \
+    cmake-format
+}
+
 # Install packages required for build.
 function install_velox_deps_from_apt {
   ${SUDO} apt update
@@ -286,6 +294,7 @@ function install_velox_deps {
 
 function install_apt_deps {
   install_build_prerequisites
+  install_format_prerequisites
   install_velox_deps_from_apt
 }
 


### PR DESCRIPTION
Install regex, cmake-format and clang-format.

make format-fix on a fresh Ubuntu installation returns
```
scripts/check.py format main --fix
Traceback (most recent call last):
  File "/home/av/src/Velox/scripts/check.py", line 20, in <module>
    import regex
ModuleNotFoundError: No module named 'regex'
make: *** [Makefile:172: format-fix] Error 1
/bin/sh: 1: cmake-format: not found
error: cannot find executable "clang-format"
```