### PR TITLE
ci: Fix scheduled.yml syntax

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -769,7 +769,7 @@ jobs:
             /tmp/server.log
 
 
-    presto-java-only-bias-function-expression-fuzzer-run:
+  presto-java-only-bias-function-expression-fuzzer-run:
     name: Biased Expression Fuzzer with Only Added/Updated Functions and Presto as source of truth
     needs: compile
     runs-on: ubuntu-latest


### PR DESCRIPTION
#11581 caused an indentation issue breaking the entire workflow. For some inexplicable reason Github does not display invalid workflows so this was easy to miss.  