### PR TITLE
misc(parquet): IWYU and fix linking errors

### DIFF
--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_dwio_native_parquet_reader
+  velox_dwio_arrow_parquet_writer_lib
   velox_dwio_parquet_thrift
   velox_type
   velox_dwio_common

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
+#include "velox/dwio/parquet/writer/arrow/LevelConversion.h"
 #include "velox/vector/FlatVector.h"
 
 #include <thrift/protocol/TCompactProtocol.h> // @manual


### PR DESCRIPTION
Fix the linking errors for `PageReader.cpp.o` in CI: https://github.com/facebookincubator/velox/actions/runs/11977566772/job/33395741582

- IWYU: add the header `velox/dwio/parquet/writer/arrow/LevelConversion.h` for `DefLevelsToBitmap`, `DefRepLevelsToList`, and `DefRepLevelsToBitmap` https://github.com/facebookincubator/velox/blob/e27867ca27149ba5047c5020ac1d187c7bc8a4b6/velox/dwio/parquet/reader/PageReader.cpp#L610-L637 https://github.com/facebookincubator/velox/blob/f33b40da09441d542f32ee9ed9fb2e340d3c2a75/velox/dwio/parquet/writer/arrow/LevelConversion.h#L171-L212

- Link the library `velox_dwio_arrow_parquet_writer_lib`, which contains `LevelConversion.cpp`
https://github.com/facebookincubator/velox/blob/e27867ca27149ba5047c5020ac1d187c7bc8a4b6/velox/dwio/parquet/writer/arrow/CMakeLists.txt#L21-L35