### PR TITLE
refactor: Refactor spiller to have better abstraction

### DIFF
--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -21,6 +21,7 @@
 #include "velox/exec/Spill.h"
 
 namespace facebook::velox::exec {
+class HashBuildSpiller;
 
 namespace test {
 class HashJoinBridgeTestHelper;
@@ -209,19 +210,20 @@ RowTypePtr hashJoinTableType(
     const std::shared_ptr<const core::HashJoinNode>& joinNode);
 
 struct HashJoinTableSpillResult {
-  Spiller* spiller{nullptr};
+  HashBuildSpiller* spiller{nullptr};
   const std::exception_ptr error{nullptr};
 
   explicit HashJoinTableSpillResult(std::exception_ptr _error)
       : error(_error) {}
-  explicit HashJoinTableSpillResult(Spiller* _spiller) : spiller(_spiller) {}
+  explicit HashJoinTableSpillResult(HashBuildSpiller* _spiller)
+      : spiller(_spiller) {}
 };
 
 /// Invoked to spill the hash table from a set of spillers. If 'spillExecutor'
 /// is provided, then we do parallel spill. This is used by hash build to spill
 /// a partially built hash join table.
 std::vector<std::unique_ptr<HashJoinTableSpillResult>> spillHashJoinTable(
-    const std::vector<Spiller*>& spillers,
+    const std::vector<HashBuildSpiller*>& spillers,
     const common::SpillConfig* spillConfig);
 
 /// Invoked to spill 'table' and returns spilled partitions. This is used by

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -649,7 +649,7 @@ class HashProbe : public Operator {
   // 'inputSpiller_' is created if some part of build-side rows have been
   // spilled. It is used to spill probe-side rows if the corresponding
   // build-side rows have been spilled.
-  std::unique_ptr<Spiller> inputSpiller_;
+  std::unique_ptr<NoRowContainerSpiller> inputSpiller_;
 
   // If not empty, the probe inputs with partition id set in
   // 'spillInputPartitionIds_' needs to spill. It is set along with 'spiller_'

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -22,7 +22,6 @@
 #include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
-
 /// OrderBy operator implementation: OrderBy stores all its inputs in a
 /// RowContainer as the inputs are added. Until all inputs are available,
 /// it blocks the pipeline. Once all inputs are available, it sorts pointers

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -21,10 +21,11 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/PrefixSort.h"
 #include "velox/exec/RowContainer.h"
-#include "velox/exec/Spill.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
+class SortInputSpiller;
+class SortOutputSpiller;
 
 /// A utility class to accumulate data inside and output the sorted result.
 /// Spilling would be triggered if spilling is enabled and memory usage exceeds
@@ -71,38 +72,59 @@ class SortBuffer {
  private:
   // Ensures there is sufficient memory reserved to process 'input'.
   void ensureInputFits(const VectorPtr& input);
+
   // Reserves memory for output processing. If reservation cannot be increased,
   // spills enough to make output fit.
   void ensureOutputFits(vector_size_t outputBatchSize);
-  // Reserves memory for sort. If reservation cannot be increased,
-  // spills enough to make output fit.
+
+  // Reserves memory for sort. If reservation cannot be increased, spills enough
+  // to make output fit.
   void ensureSortFits();
+
   void updateEstimatedOutputRowSize();
+
   // Invoked to initialize or reset the reusable output buffer to get output.
   void prepareOutput(vector_size_t outputBatchSize);
+
   // Invoked to initialize reader to read the spilled data from storage for
   // output processing.
   void prepareOutputWithSpill();
+
   void getOutputWithoutSpill();
+
   void getOutputWithSpill();
+
   // Spill during input stage.
   void spillInput();
+
   // Spill during output stage.
   void spillOutput();
+
   // Finish spill, and we shouldn't get any rows from non-spilled partition as
   // there is only one hash partition for SortBuffer.
   void finishSpill();
 
+  // Returns true if the sort buffer has spilled, regardless of during input or
+  // output processing. If spilled() is true, it means the sort buffer is in
+  // minimal memory mode and could not be spilled further.
+  bool hasSpilled() const;
+
   const RowTypePtr input_;
+
   const std::vector<CompareFlags> sortCompareFlags_;
+
   velox::memory::MemoryPool* const pool_;
+
   // The flag is passed from the associated operator such as OrderBy or
   // TableWriter to indicate if this sort buffer object is under non-reclaimable
   // execution section or not.
   tsan_atomic<bool>* const nonReclaimableSection_;
+
   // Configuration settings for prefix-sort.
   const common::PrefixSortConfig prefixSortConfig_;
+
   const common::SpillConfig* const spillConfig_;
+
   folly::Synchronized<common::SpillStats>* const spillStats_;
 
   // The column projection map between 'input_' and 'spillerStoreType_' as sort
@@ -112,30 +134,41 @@ class SortBuffer {
   // Indicates no more input. Once it is set, addInput() can't be called on this
   // sort buffer object.
   bool noMoreInput_ = false;
+
   // The number of received input rows.
   uint64_t numInputRows_ = 0;
+
   // Used to store the input data in row format.
   std::unique_ptr<RowContainer> data_;
+
   std::vector<char*, memory::StlAllocator<char*>> sortedRows_;
 
   // The data type of the rows stored in 'data_' and spilled on disk. The
   // sort key columns are stored first then the non-sorted data columns.
   RowTypePtr spillerStoreType_;
-  std::unique_ptr<Spiller> spiller_;
+
+  std::unique_ptr<SortInputSpiller> inputSpiller_;
+
+  std::unique_ptr<SortOutputSpiller> outputSpiller_;
+
   SpillPartitionSet spillPartitionSet_;
+
   // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
+
   // Records the source rows to copy to 'output_' in order.
   std::vector<const RowVector*> spillSources_;
+
   std::vector<vector_size_t> spillSourceRows_;
 
   // Reusable output vector.
   RowVectorPtr output_;
+
   // Estimated size of a single output row by using the max
   // 'data_->estimateRowSize()' across all accumulated data set.
   std::optional<uint64_t> estimatedOutputRowSize_{};
+
   // The number of rows that has been returned.
   uint64_t numOutputRows_{0};
 };
-
 } // namespace facebook::velox::exec

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -21,7 +21,6 @@
 #include "velox/exec/WindowBuild.h"
 
 namespace facebook::velox::exec {
-
 // Sorts input data of the Window by {partition keys, sort keys}
 // to identify window partitions. This sort fully orders
 // rows as needed for window function computation.
@@ -48,12 +47,7 @@ class SortWindowBuild : public WindowBuild {
 
   void spill() override;
 
-  std::optional<common::SpillStats> spilledStats() const override {
-    if (spiller_ == nullptr) {
-      return std::nullopt;
-    }
-    return spiller_->stats();
-  }
+  std::optional<common::SpillStats> spilledStats() const override;
 
   void noMoreInput() override;
 
@@ -123,10 +117,9 @@ class SortWindowBuild : public WindowBuild {
   vector_size_t currentPartition_ = -1;
 
   // Spiller for contents of the 'data_'.
-  std::unique_ptr<Spiller> spiller_;
+  std::unique_ptr<SortInputSpiller> spiller_;
 
   // Used to sort-merge spilled data.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> merge_;
 };
-
 } // namespace facebook::velox::exec

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -32,7 +32,7 @@
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
-// A source of sorted spilled RowVectors coming either from a file or memory.
+/// A source of sorted spilled RowVectors coming either from a file or memory.
 class SpillMergeStream : public MergeStream {
  public:
   SpillMergeStream() = default;
@@ -135,7 +135,7 @@ class SpillMergeStream : public MergeStream {
   SelectivityVector rows_;
 };
 
-// A source of spilled RowVectors coming from a file.
+/// A source of spilled RowVectors coming from a file.
 class FileSpillMergeStream : public SpillMergeStream {
  public:
   static std::unique_ptr<SpillMergeStream> create(
@@ -448,7 +448,7 @@ class SpillState {
   // the max spill bytes limit.
   common::UpdateAndCheckSpillLimitCB updateAndCheckSpillLimitCb_;
 
-  /// Prefix for spill files.
+  // Prefix for spill files.
   const std::string fileNamePrefix_;
   const int32_t maxPartitions_;
   const int32_t numSortKeys_;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -27,563 +27,63 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
-namespace {
-#define CHECK_NOT_FINALIZED() \
-  VELOX_CHECK(!finalized_, "Spiller has been finalized")
 
-#define CHECK_FINALIZED() \
-  VELOX_CHECK(finalized_, "Spiller hasn't been finalized yet");
-} // namespace
-
-Spiller::Spiller(
-    Type type,
-    RowContainer* container,
-    RowTypePtr rowType,
-    int32_t numSortingKeys,
-    const std::vector<CompareFlags>& sortCompareFlags,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          container,
-          std::move(rowType),
-          HashBitRange{},
-          numSortingKeys,
-          sortCompareFlags,
-          false,
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          std::numeric_limits<uint64_t>::max(),
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          spillConfig->maxSpillRunRows,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK_EQ(
-      type_,
-      Type::kOrderByInput,
-      "Unexpected spiller type: {}",
-      typeName(type_));
-  VELOX_CHECK_EQ(state_.maxPartitions(), 1);
-}
-
-Spiller::Spiller(
-    Type type,
-    RowContainer* container,
-    RowTypePtr rowType,
-    const HashBitRange& hashBitRange,
-    int32_t numSortingKeys,
-    const std::vector<CompareFlags>& sortCompareFlags,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          container,
-          std::move(rowType),
-          hashBitRange,
-          numSortingKeys,
-          sortCompareFlags,
-          false,
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          std::numeric_limits<uint64_t>::max(),
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          spillConfig->maxSpillRunRows,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK(
-      type_ == Type::kOrderByInput || type_ == Type::kAggregateInput,
-      "Unexpected spiller type: {}",
-      typeName(type_));
-  VELOX_CHECK_EQ(state_.targetFileSize(), std::numeric_limits<uint64_t>::max());
-}
-
-Spiller::Spiller(
-    Type type,
-    RowContainer* container,
-    RowTypePtr rowType,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          container,
-          std::move(rowType),
-          HashBitRange{},
-          0,
-          {},
-          false,
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          std::numeric_limits<uint64_t>::max(),
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          spillConfig->maxSpillRunRows,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK(
-      type_ == Type::kAggregateOutput || type_ == Type::kOrderByOutput,
-      "Unexpected spiller type: {}",
-      typeName(type_));
-  VELOX_CHECK_EQ(state_.maxPartitions(), 1);
-  VELOX_CHECK_EQ(state_.targetFileSize(), std::numeric_limits<uint64_t>::max());
-}
-
-Spiller::Spiller(
-    Type type,
-    RowTypePtr rowType,
-    HashBitRange bits,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          nullptr,
-          std::move(rowType),
-          bits,
-          0,
-          {},
-          false,
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          spillConfig->maxFileSize,
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          0,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK_EQ(
-      type_,
-      Type::kHashJoinProbe,
-      "Unexpected spiller type: {}",
-      typeName(type_));
-}
-
-Spiller::Spiller(
-    Type type,
-    core::JoinType joinType,
-    RowContainer* container,
-    RowTypePtr rowType,
-    HashBitRange bits,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          container,
-          std::move(rowType),
-          bits,
-          0,
-          {},
-          needRightSideJoin(joinType),
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          spillConfig->maxFileSize,
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          spillConfig->maxSpillRunRows,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK_EQ(type_, Type::kHashJoinBuild);
-  VELOX_CHECK(isHashJoinTableSpillType(rowType_, joinType));
-}
-
-Spiller::Spiller(
-    Type type,
-    RowContainer* container,
-    RowTypePtr rowType,
-    HashBitRange bits,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : Spiller(
-          type,
-          container,
-          std::move(rowType),
-          bits,
-          0,
-          {},
-          false,
-          spillConfig->getSpillDirPathCb,
-          spillConfig->updateAndCheckSpillLimitCb,
-          spillConfig->fileNamePrefix,
-          spillConfig->maxFileSize,
-          spillConfig->writeBufferSize,
-          spillConfig->compressionKind,
-          spillConfig->prefixSortConfig,
-          spillConfig->executor,
-          spillConfig->maxSpillRunRows,
-          spillConfig->fileCreateConfig,
-          spillStats) {
-  VELOX_CHECK_EQ(type_, Type::kRowNumber);
-}
-
-Spiller::Spiller(
-    Type type,
+SpillerBase::SpillerBase(
     RowContainer* container,
     RowTypePtr rowType,
     HashBitRange bits,
     int32_t numSortingKeys,
     const std::vector<CompareFlags>& sortCompareFlags,
-    bool recordProbedFlag,
-    const common::GetSpillDirectoryPathCB& getSpillDirPathCb,
-    const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
-    const std::string& fileNamePrefix,
     uint64_t targetFileSize,
-    uint64_t writeBufferSize,
-    common::CompressionKind compressionKind,
-    const std::optional<common::PrefixSortConfig>& prefixSortConfig,
-    folly::Executor* executor,
     uint64_t maxSpillRunRows,
-    const std::string& fileCreateConfig,
+    const common::SpillConfig* spillConfig,
     folly::Synchronized<common::SpillStats>* spillStats)
-    : type_(type),
-      container_(container),
-      executor_(executor),
+    : container_(container),
+      executor_(spillConfig->executor),
       bits_(bits),
-      rowType_(std::move(rowType)),
-      spillProbedFlag_(recordProbedFlag),
+      rowType_(rowType),
       maxSpillRunRows_(maxSpillRunRows),
       spillStats_(spillStats),
       state_(
-          getSpillDirPathCb,
-          updateAndCheckSpillLimitCb,
-          fileNamePrefix,
+          spillConfig->getSpillDirPathCb,
+          spillConfig->updateAndCheckSpillLimitCb,
+          spillConfig->fileNamePrefix,
           bits.numPartitions(),
           numSortingKeys,
           sortCompareFlags,
           targetFileSize,
-          writeBufferSize,
-          compressionKind,
-          prefixSortConfig,
+          spillConfig->writeBufferSize,
+          spillConfig->compressionKind,
+          spillConfig->prefixSortConfig,
           memory::spillMemoryPool(),
           spillStats,
-          fileCreateConfig) {
-  TestValue::adjust("facebook::velox::exec::Spiller", this);
+          spillConfig->fileCreateConfig) {
+  TestValue::adjust("facebook::velox::exec::SpillerBase", this);
 
-  VELOX_CHECK(!spillProbedFlag_ || type_ == Type::kHashJoinBuild);
-  VELOX_CHECK_EQ(container_ == nullptr, type_ == Type::kHashJoinProbe);
   spillRuns_.reserve(state_.maxPartitions());
   for (int i = 0; i < state_.maxPartitions(); ++i) {
     spillRuns_.emplace_back(*memory::spillMemoryPool());
   }
 }
 
-void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
-  if (resultPtr == nullptr) {
-    resultPtr = BaseVector::create<RowVector>(
-        rowType_, rows.size(), memory::spillMemoryPool());
-  } else {
-    resultPtr->prepareForReuse();
-    resultPtr->resize(rows.size());
-  }
+NoRowContainerSpiller::NoRowContainerSpiller(
+    RowTypePtr rowType,
+    HashBitRange bits,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<common::SpillStats>* spillStats)
+    : SpillerBase(
+          nullptr,
+          std::move(rowType),
+          bits,
+          0,
+          {},
+          spillConfig->maxFileSize,
+          0,
+          spillConfig,
+          spillStats) {}
 
-  auto* result = resultPtr.get();
-  const auto& types = container_->columnTypes();
-  for (auto i = 0; i < types.size(); ++i) {
-    container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
-  }
-  const auto& accumulators = container_->accumulators();
-  column_index_t accumulatorColumnOffset = types.size();
-  if (spillProbedFlag_) {
-    container_->extractProbedFlags(
-        rows.data(), rows.size(), false, false, result->childAt(types.size()));
-    ++accumulatorColumnOffset;
-  }
-  for (auto i = 0; i < accumulators.size(); ++i) {
-    accumulators[i].extractForSpill(
-        rows, result->childAt(i + accumulatorColumnOffset));
-  }
-}
-
-int64_t Spiller::extractSpillVector(
-    SpillRows& rows,
-    int32_t maxRows,
-    int64_t maxBytes,
-    RowVectorPtr& spillVector,
-    size_t& nextBatchIndex) {
-  VELOX_CHECK_NE(type_, Type::kHashJoinProbe);
-  uint64_t extractNs{0};
-  auto limit = std::min<size_t>(rows.size() - nextBatchIndex, maxRows);
-  VELOX_CHECK(!rows.empty());
-  int32_t numRows = 0;
-  int64_t bytes = 0;
-  {
-    NanosecondTimer timer(&extractNs);
-    for (; numRows < limit; ++numRows) {
-      bytes += container_->rowSize(rows[nextBatchIndex + numRows]);
-      if (bytes > maxBytes) {
-        // Increment because the row that went over the limit is part
-        // of the result. We must spill at least one row.
-        ++numRows;
-        break;
-      }
-    }
-    extractSpill(folly::Range(&rows[nextBatchIndex], numRows), spillVector);
-    nextBatchIndex += numRows;
-  }
-  updateSpillExtractVectorTime(extractNs);
-  return bytes;
-}
-
-namespace {
-// A stream of ordered rows being read from the in memory
-// container. This is the part of a spillable range that is not yet
-// spilled when starting to produce output. This is only used for
-// sorted spills since for hash join spilling we just use the data in
-// the RowContainer as is.
-class RowContainerSpillMergeStream : public SpillMergeStream {
- public:
-  RowContainerSpillMergeStream(
-      int32_t numSortKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
-      Spiller::SpillRows&& rows,
-      Spiller& spiller)
-      : numSortKeys_(numSortKeys),
-        sortCompareFlags_(sortCompareFlags),
-        rows_(std::move(rows)),
-        spiller_(spiller) {
-    if (!rows_.empty()) {
-      RowContainerSpillMergeStream::nextBatch();
-    }
-  }
-
-  uint32_t id() const override {
-    // Returns the max uint32_t as the special id for in-memory spill merge
-    // stream.
-    return std::numeric_limits<uint32_t>::max();
-  }
-
- private:
-  int32_t numSortKeys() const override {
-    return numSortKeys_;
-  }
-
-  const std::vector<CompareFlags>& sortCompareFlags() const override {
-    return sortCompareFlags_;
-  }
-
-  void nextBatch() override {
-    // Extracts up to 64 rows at a time. Small batch size because may
-    // have wide data and no advantage in large size for narrow data
-    // since this is all processed row by row.
-    static constexpr vector_size_t kMaxRows = 64;
-    constexpr uint64_t kMaxBytes = 1 << 18;
-    if (nextBatchIndex_ >= rows_.size()) {
-      index_ = 0;
-      size_ = 0;
-      return;
-    }
-    spiller_.extractSpillVector(
-        rows_, kMaxRows, kMaxBytes, rowVector_, nextBatchIndex_);
-    size_ = rowVector_->size();
-    index_ = 0;
-  }
-
-  const int32_t numSortKeys_;
-  const std::vector<CompareFlags> sortCompareFlags_;
-
-  Spiller::SpillRows rows_;
-  Spiller& spiller_;
-  size_t nextBatchIndex_ = 0;
-};
-} // namespace
-
-std::unique_ptr<SpillMergeStream> Spiller::spillMergeStreamOverRows(
-    int32_t partition) {
-  CHECK_FINALIZED();
-  VELOX_CHECK_LT(partition, state_.maxPartitions());
-
-  if (!state_.isPartitionSpilled(partition)) {
-    return nullptr;
-  }
-  // Skip the merge stream from row container if it is empty.
-  if (spillRuns_[partition].rows.empty()) {
-    return nullptr;
-  }
-  ensureSorted(spillRuns_[partition]);
-  return std::make_unique<RowContainerSpillMergeStream>(
-      container_->keyTypes().size(),
-      state_.sortCompareFlags(),
-      std::move(spillRuns_[partition].rows),
-      *this);
-}
-
-void Spiller::ensureSorted(SpillRun& run) {
-  // The spill data of a hash join doesn't need to be sorted.
-  if (run.sorted || !needSort()) {
-    return;
-  }
-
-  uint64_t sortTimeNs{0};
-  {
-    NanosecondTimer timer(&sortTimeNs);
-
-    if (!state_.prefixSortConfig().has_value()) {
-      gfx::timsort(
-          run.rows.begin(),
-          run.rows.end(),
-          [&](const char* left, const char* right) {
-            return container_->compareRows(
-                       left, right, state_.sortCompareFlags()) < 0;
-          });
-    } else {
-      PrefixSort::sort(
-          container_,
-          state_.sortCompareFlags(),
-          state_.prefixSortConfig().value(),
-          memory::spillMemoryPool(),
-          run.rows);
-    }
-
-    run.sorted = true;
-  }
-
-  // NOTE: Always set a non-zero sort time to avoid flakiness in tests which
-  // check sort time.
-  updateSpillSortTime(std::max<uint64_t>(1, sortTimeNs));
-}
-
-std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(int32_t partition) {
-  VELOX_CHECK_NE(type_, Type::kHashJoinProbe);
-  // Target size of a single vector of spilled content. One of
-  // these will be materialized at a time for each stream of the
-  // merge.
-  constexpr int32_t kTargetBatchBytes = 1 << 18; // 256K
-  constexpr int32_t kTargetBatchRows = 64;
-
-  RowVectorPtr spillVector;
-  auto& run = spillRuns_[partition];
-  try {
-    ensureSorted(run);
-    int64_t totalBytes = 0;
-    size_t written = 0;
-    while (written < run.rows.size()) {
-      extractSpillVector(
-          run.rows, kTargetBatchRows, kTargetBatchBytes, spillVector, written);
-      totalBytes += state_.appendToPartition(partition, spillVector);
-      if (totalBytes > state_.targetFileSize()) {
-        VELOX_CHECK(!needSort());
-        state_.finishFile(partition);
-      }
-    }
-    return std::make_unique<SpillStatus>(partition, written, nullptr);
-  } catch (const std::exception&) {
-    // The exception is passed to the caller thread which checks this in
-    // advanceSpill().
-    return std::make_unique<SpillStatus>(
-        partition, 0, std::current_exception());
-  }
-}
-
-void Spiller::runSpill(bool lastRun) {
-  ++spillStats_->wlock()->spillRuns;
-  VELOX_CHECK(type_ != Spiller::Type::kOrderByOutput || lastRun);
-
-  std::vector<std::shared_ptr<AsyncSource<SpillStatus>>> writes;
-  for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
-    VELOX_CHECK(
-        state_.isPartitionSpilled(partition),
-        "Partition {} is not marked as spilled",
-        partition);
-    if (spillRuns_[partition].rows.empty()) {
-      continue;
-    }
-    writes.push_back(memory::createAsyncMemoryReclaimTask<SpillStatus>(
-        [partition, this]() { return writeSpill(partition); }));
-    if ((writes.size() > 1) && executor_ != nullptr) {
-      executor_->add([source = writes.back()]() { source->prepare(); });
-    }
-  }
-  auto sync = folly::makeGuard([&]() {
-    for (auto& write : writes) {
-      // We consume the result for the pending writes. This is a
-      // cleanup in the guard and must not throw. The first error is
-      // already captured before this runs.
-      try {
-        write->move();
-      } catch (const std::exception&) {
-      }
-    }
-  });
-
-  std::vector<std::unique_ptr<SpillStatus>> results;
-  results.reserve(writes.size());
-  for (auto& write : writes) {
-    results.push_back(write->move());
-  }
-  for (auto& result : results) {
-    if (result->error != nullptr) {
-      std::rethrow_exception(result->error);
-    }
-    const auto numWritten = result->rowsWritten;
-    auto partition = result->partition;
-    auto& run = spillRuns_[partition];
-    VELOX_CHECK_EQ(numWritten, run.rows.size());
-    run.clear();
-    // When a sorted run ends, we start with a new file next time.
-    if (needSort()) {
-      state_.finishFile(partition);
-    }
-  }
-
-  // For aggregation output / orderby output spiller, we expect only one spill
-  // call to spill all the rows starting from the specified row offset.
-  if (lastRun &&
-      (type_ == Spiller::Type::kAggregateOutput ||
-       type_ == Spiller::Type::kOrderByOutput)) {
-    for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
-      state_.finishFile(partition);
-    }
-  }
-}
-
-void Spiller::updateSpillFillTime(uint64_t timeNs) {
-  spillStats_->wlock()->spillFillTimeNanos += timeNs;
-  common::updateGlobalSpillFillTime(timeNs);
-}
-
-void Spiller::updateSpillSortTime(uint64_t timeNs) {
-  spillStats_->wlock()->spillSortTimeNanos += timeNs;
-  common::updateGlobalSpillSortTime(timeNs);
-}
-
-void Spiller::updateSpillExtractVectorTime(uint64_t timeNs) {
-  spillStats_->wlock()->spillExtractVectorTimeNanos += timeNs;
-  common::updateGlobalSpillExtractVectorTime(timeNs);
-}
-
-bool Spiller::needSort() const {
-  return type_ != Type::kHashJoinProbe && type_ != Type::kHashJoinBuild &&
-      type_ != Type::kRowNumber && type_ != Type::kAggregateOutput &&
-      type_ != Type::kOrderByOutput;
-}
-
-void Spiller::spill() {
-  return spill(nullptr);
-}
-
-void Spiller::spill(const RowContainerIterator& startRowIter) {
-  VELOX_CHECK_EQ(type_, Type::kAggregateOutput);
-  return spill(&startRowIter);
-}
-
-void Spiller::spill(const RowContainerIterator* startRowIter) {
-  CHECK_NOT_FINALIZED();
-  VELOX_CHECK_NE(type_, Type::kHashJoinProbe);
-  VELOX_CHECK_NE(type_, Type::kOrderByOutput);
+void SpillerBase::spill(const RowContainerIterator* startRowIter) {
+  VELOX_CHECK(!finalized_);
 
   markAllPartitionsSpilled();
 
@@ -601,76 +101,7 @@ void Spiller::spill(const RowContainerIterator* startRowIter) {
   checkEmptySpillRuns();
 }
 
-void Spiller::spill(SpillRows& rows) {
-  CHECK_NOT_FINALIZED();
-  VELOX_CHECK_EQ(type_, Type::kOrderByOutput);
-  VELOX_CHECK(!rows.empty());
-
-  markAllPartitionsSpilled();
-
-  fillSpillRun(rows);
-  runSpill(true);
-  checkEmptySpillRuns();
-}
-
-void Spiller::checkEmptySpillRuns() const {
-  for (const auto& spillRun : spillRuns_) {
-    VELOX_CHECK(spillRun.rows.empty());
-  }
-}
-
-void Spiller::markAllPartitionsSpilled() {
-  for (auto partition = 0; partition < state_.maxPartitions(); ++partition) {
-    if (!state_.isPartitionSpilled(partition)) {
-      state_.setPartitionSpilled(partition);
-    }
-  }
-}
-
-void Spiller::spill(uint32_t partition, const RowVectorPtr& spillVector) {
-  CHECK_NOT_FINALIZED();
-  VELOX_CHECK(
-      type_ == Type::kHashJoinProbe || type_ == Type::kHashJoinBuild ||
-          type_ == Type::kRowNumber,
-      "Unexpected spiller type: {}",
-      typeName(type_));
-  if (FOLLY_UNLIKELY(!state_.isPartitionSpilled(partition))) {
-    VELOX_FAIL(
-        "Can't spill vector to a non-spilling partition: {}, {}",
-        partition,
-        toString());
-  }
-  VELOX_DCHECK(spillRuns_[partition].rows.empty());
-
-  if (FOLLY_UNLIKELY(spillVector == nullptr)) {
-    return;
-  }
-
-  state_.appendToPartition(partition, spillVector);
-}
-
-void Spiller::finishSpill(SpillPartitionSet& partitionSet) {
-  finalizeSpill();
-
-  for (auto& partition : state_.spilledPartitionSet()) {
-    const SpillPartitionId partitionId(bits_.begin(), partition);
-    if (partitionSet.count(partitionId) == 0) {
-      partitionSet.emplace(
-          partitionId,
-          std::make_unique<SpillPartition>(
-              partitionId, state_.finish(partition)));
-    } else {
-      partitionSet[partitionId]->addFiles(state_.finish(partition));
-    }
-  }
-}
-
-void Spiller::finalizeSpill() {
-  CHECK_NOT_FINALIZED();
-  finalized_ = true;
-}
-
-bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
+bool SpillerBase::fillSpillRuns(RowContainerIterator* iterator) {
   checkEmptySpillRuns();
 
   bool lastRun{false};
@@ -725,7 +156,285 @@ bool Spiller::fillSpillRuns(RowContainerIterator* iterator) {
   return lastRun;
 }
 
-void Spiller::fillSpillRun(SpillRows& rows) {
+void SpillerBase::runSpill(bool lastRun) {
+  ++spillStats_->wlock()->spillRuns;
+
+  std::vector<std::shared_ptr<AsyncSource<SpillStatus>>> writes;
+  for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
+    VELOX_CHECK(
+        state_.isPartitionSpilled(partition),
+        "Partition {} is not marked as spilled",
+        partition);
+    if (spillRuns_[partition].rows.empty()) {
+      continue;
+    }
+    writes.push_back(memory::createAsyncMemoryReclaimTask<SpillStatus>(
+        [partition, this]() { return writeSpill(partition); }));
+    if ((writes.size() > 1) && executor_ != nullptr) {
+      executor_->add([source = writes.back()]() { source->prepare(); });
+    }
+  }
+  auto sync = folly::makeGuard([&]() {
+    for (auto& write : writes) {
+      // We consume the result for the pending writes. This is a
+      // cleanup in the guard and must not throw. The first error is
+      // already captured before this runs.
+      try {
+        write->move();
+      } catch (const std::exception&) {
+      }
+    }
+  });
+
+  std::vector<std::unique_ptr<SpillStatus>> results;
+  results.reserve(writes.size());
+  for (auto& write : writes) {
+    results.push_back(write->move());
+  }
+  for (auto& result : results) {
+    if (result->error != nullptr) {
+      std::rethrow_exception(result->error);
+    }
+    const auto numWritten = result->rowsWritten;
+    auto partition = result->partition;
+    auto& run = spillRuns_[partition];
+    VELOX_CHECK_EQ(numWritten, run.rows.size());
+    run.clear();
+    // When a sorted run ends, we start with a new file next time.
+    if (needSort()) {
+      state_.finishFile(partition);
+    }
+  }
+}
+
+std::unique_ptr<SpillerBase::SpillStatus> SpillerBase::writeSpill(
+    int32_t partition) {
+  // Target size of a single vector of spilled content. One of
+  // these will be materialized at a time for each stream of the
+  // merge.
+  constexpr int32_t kTargetBatchBytes = 1 << 18; // 256K
+  constexpr int32_t kTargetBatchRows = 64;
+
+  RowVectorPtr spillVector;
+  auto& run = spillRuns_[partition];
+  try {
+    ensureSorted(run);
+    int64_t totalBytes = 0;
+    size_t written = 0;
+    while (written < run.rows.size()) {
+      extractSpillVector(
+          run.rows, kTargetBatchRows, kTargetBatchBytes, spillVector, written);
+      totalBytes += state_.appendToPartition(partition, spillVector);
+      if (totalBytes > state_.targetFileSize()) {
+        VELOX_CHECK(!needSort());
+        state_.finishFile(partition);
+      }
+    }
+    return std::make_unique<SpillStatus>(partition, written, nullptr);
+  } catch (const std::exception&) {
+    // The exception is passed to the caller thread which checks this in
+    // advanceSpill().
+    return std::make_unique<SpillStatus>(
+        partition, 0, std::current_exception());
+  }
+}
+
+void SpillerBase::ensureSorted(SpillRun& run) {
+  // The spill data of a hash join doesn't need to be sorted.
+  if (run.sorted || !needSort()) {
+    return;
+  }
+
+  uint64_t sortTimeNs{0};
+  {
+    NanosecondTimer timer(&sortTimeNs);
+
+    if (!state_.prefixSortConfig().has_value()) {
+      gfx::timsort(
+          run.rows.begin(),
+          run.rows.end(),
+          [&](const char* left, const char* right) {
+            return container_->compareRows(
+                       left, right, state_.sortCompareFlags()) < 0;
+          });
+    } else {
+      PrefixSort::sort(
+          container_,
+          state_.sortCompareFlags(),
+          state_.prefixSortConfig().value(),
+          memory::spillMemoryPool(),
+          run.rows);
+    }
+
+    run.sorted = true;
+  }
+
+  // NOTE: Always set a non-zero sort time to avoid flakiness in tests which
+  // check sort time.
+  updateSpillSortTime(std::max<uint64_t>(1, sortTimeNs));
+}
+
+int64_t SpillerBase::extractSpillVector(
+    SpillRows& rows,
+    int32_t maxRows,
+    int64_t maxBytes,
+    RowVectorPtr& spillVector,
+    size_t& nextBatchIndex) {
+  uint64_t extractNs{0};
+  auto limit = std::min<size_t>(rows.size() - nextBatchIndex, maxRows);
+  VELOX_CHECK(!rows.empty());
+  int32_t numRows = 0;
+  int64_t bytes = 0;
+  {
+    NanosecondTimer timer(&extractNs);
+    for (; numRows < limit; ++numRows) {
+      bytes += container_->rowSize(rows[nextBatchIndex + numRows]);
+      if (bytes > maxBytes) {
+        // Increment because the row that went over the limit is part
+        // of the result. We must spill at least one row.
+        ++numRows;
+        break;
+      }
+    }
+    extractSpill(folly::Range(&rows[nextBatchIndex], numRows), spillVector);
+    nextBatchIndex += numRows;
+  }
+  updateSpillExtractVectorTime(extractNs);
+  return bytes;
+}
+
+void SpillerBase::extractSpill(
+    folly::Range<char**> rows,
+    RowVectorPtr& resultPtr) {
+  if (resultPtr == nullptr) {
+    resultPtr = BaseVector::create<RowVector>(
+        rowType_, rows.size(), memory::spillMemoryPool());
+  } else {
+    resultPtr->prepareForReuse();
+    resultPtr->resize(rows.size());
+  }
+
+  auto* result = resultPtr.get();
+  const auto& types = container_->columnTypes();
+  for (auto i = 0; i < types.size(); ++i) {
+    container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
+  }
+  const auto& accumulators = container_->accumulators();
+  column_index_t accumulatorColumnOffset = types.size();
+  for (auto i = 0; i < accumulators.size(); ++i) {
+    accumulators[i].extractForSpill(
+        rows, result->childAt(i + accumulatorColumnOffset));
+  }
+}
+
+void SpillerBase::updateSpillExtractVectorTime(uint64_t timeNs) {
+  spillStats_->wlock()->spillExtractVectorTimeNanos += timeNs;
+  common::updateGlobalSpillExtractVectorTime(timeNs);
+}
+
+void SpillerBase::updateSpillSortTime(uint64_t timeNs) {
+  spillStats_->wlock()->spillSortTimeNanos += timeNs;
+  common::updateGlobalSpillSortTime(timeNs);
+}
+
+void SpillerBase::checkEmptySpillRuns() const {
+  for (const auto& spillRun : spillRuns_) {
+    VELOX_CHECK(spillRun.rows.empty());
+  }
+}
+
+void SpillerBase::updateSpillFillTime(uint64_t timeNs) {
+  spillStats_->wlock()->spillFillTimeNanos += timeNs;
+  common::updateGlobalSpillFillTime(timeNs);
+}
+
+void SpillerBase::finishSpill(SpillPartitionSet& partitionSet) {
+  finalizeSpill();
+
+  for (auto& partition : state_.spilledPartitionSet()) {
+    const SpillPartitionId partitionId(bits_.begin(), partition);
+    if (partitionSet.count(partitionId) == 0) {
+      partitionSet.emplace(
+          partitionId,
+          std::make_unique<SpillPartition>(
+              partitionId, state_.finish(partition)));
+    } else {
+      partitionSet[partitionId]->addFiles(state_.finish(partition));
+    }
+  }
+}
+
+common::SpillStats SpillerBase::stats() const {
+  return spillStats_->copy();
+}
+
+std::string SpillerBase::toString() const {
+  return fmt::format(
+      "{}\t{}\tMAX_PARTITIONS:{}\tFINALIZED:{}",
+      type(),
+      rowType_->toString(),
+      state_.maxPartitions(),
+      finalized_);
+}
+
+void SpillerBase::finalizeSpill() {
+  VELOX_CHECK(!finalized_);
+  finalized_ = true;
+}
+
+void SpillerBase::markAllPartitionsSpilled() {
+  for (auto partition = 0; partition < state_.maxPartitions(); ++partition) {
+    if (!state_.isPartitionSpilled(partition)) {
+      state_.setPartitionSpilled(partition);
+    }
+  }
+}
+
+void NoRowContainerSpiller::spill(
+    uint32_t partition,
+    const RowVectorPtr& spillVector) {
+  VELOX_CHECK(!finalized_);
+  if (FOLLY_UNLIKELY(!state_.isPartitionSpilled(partition))) {
+    VELOX_FAIL(
+        "Can't spill vector to a non-spilling partition: {}, {}",
+        partition,
+        toString());
+  }
+  VELOX_DCHECK(spillRuns_[partition].rows.empty());
+
+  if (FOLLY_UNLIKELY(spillVector == nullptr)) {
+    return;
+  }
+
+  state_.appendToPartition(partition, spillVector);
+}
+
+void SortInputSpiller::spill() {
+  SpillerBase::spill(nullptr);
+}
+
+SortOutputSpiller::SortOutputSpiller(
+    RowContainer* container,
+    RowTypePtr rowType,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<common::SpillStats>* spillStats)
+    : SpillerBase(
+          container,
+          std::move(rowType),
+          HashBitRange{},
+          0,
+          {},
+          std::numeric_limits<uint64_t>::max(),
+          spillConfig->maxSpillRunRows,
+          spillConfig,
+          spillStats) {}
+
+void SortOutputSpiller::spill(SpillRows& rows) {
+  VELOX_CHECK(!finalized_);
+  VELOX_CHECK(!rows.empty());
+
+  markAllPartitionsSpilled();
+
   VELOX_CHECK_EQ(bits_.numPartitions(), 1);
   checkEmptySpillRuns();
   uint64_t execTimeNs{0};
@@ -738,40 +447,16 @@ void Spiller::fillSpillRun(SpillRows& rows) {
     }
   }
   updateSpillFillTime(execTimeNs);
+  runSpill(true);
+  checkEmptySpillRuns();
 }
 
-std::string Spiller::toString() const {
-  return fmt::format(
-      "{}\t{}\tMAX_PARTITIONS:{}\tFINALIZED:{}",
-      typeName(type_),
-      rowType_->toString(),
-      state_.maxPartitions(),
-      finalized_);
-}
-
-// static
-std::string Spiller::typeName(Type type) {
-  switch (type) {
-    case Type::kOrderByInput:
-      return "ORDER_BY_INPUT";
-    case Type::kOrderByOutput:
-      return "ORDER_BY_OUTPUT";
-    case Type::kHashJoinBuild:
-      return "HASH_JOIN_BUILD";
-    case Type::kHashJoinProbe:
-      return "HASH_JOIN_PROBE";
-    case Type::kAggregateInput:
-      return "AGGREGATE_INPUT";
-    case Type::kAggregateOutput:
-      return "AGGREGATE_OUTPUT";
-    case Type::kRowNumber:
-      return "ROW_NUMBER";
-    default:
-      VELOX_UNREACHABLE("Unknown type: {}", static_cast<int>(type));
+void SortOutputSpiller::runSpill(bool lastRun) {
+  SpillerBase::runSpill(lastRun);
+  if (lastRun) {
+    for (auto partition = 0; partition < spillRuns_.size(); ++partition) {
+      state_.finishFile(partition);
+    }
   }
-}
-
-common::SpillStats Spiller::stats() const {
-  return spillStats_->copy();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -758,9 +758,7 @@ void TopNRowNumber::setupSpiller() {
   VELOX_CHECK_NULL(spiller_);
   VELOX_CHECK(spillConfig_.has_value());
 
-  spiller_ = std::make_unique<Spiller>(
-      // TODO Replace Spiller::Type::kOrderBy.
-      Spiller::Type::kOrderByInput,
+  spiller_ = std::make_unique<SortInputSpiller>(
       data_.get(),
       inputType_,
       spillCompareFlags_.size(),

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -19,7 +19,7 @@
 namespace facebook::velox::exec::test {
 class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
  public:
-  explicit AggregateSpillBenchmarkBase(Spiller::Type spillerType)
+  explicit AggregateSpillBenchmarkBase(std::string spillerType)
       : spillerType_(spillerType){};
 
   /// Sets up the test.
@@ -32,9 +32,9 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
 
  private:
   void writeSpillData();
-  std::unique_ptr<Spiller> makeSpiller();
+  std::unique_ptr<SpillerBase> makeSpiller();
 
-  const Spiller::Type spillerType_;
+  const std::string spillerType_;
   std::unique_ptr<RowContainer> rowContainer_;
   std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
 };

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -45,19 +45,19 @@ void JoinSpillInputBenchmarkBase::setUp() {
   spillConfig.maxSpillRunRows = 0;
   spillConfig.fileCreateConfig = {};
 
-  spiller_ = std::make_unique<Spiller>(
-      exec::Spiller::Type::kHashJoinProbe,
-      rowType_,
-      HashBitRange{29, 29},
-      &spillConfig,
-      &spillStats_);
-  spiller_->setPartitionsSpilled({0});
+  spiller_ = std::make_unique<NoRowContainerSpiller>(
+      rowType_, HashBitRange{29, 29}, &spillConfig, &spillStats_);
+  dynamic_cast<NoRowContainerSpiller*>(spiller_.get())
+      ->setPartitionsSpilled({0});
 }
 
 void JoinSpillInputBenchmarkBase::run() {
   MicrosecondTimer timer(&executionTimeUs_);
+  auto noRowContainerSpiller =
+      dynamic_cast<NoRowContainerSpiller*>(spiller_.get());
+  VELOX_CHECK_NOT_NULL(noRowContainerSpiller);
   for (auto i = 0; i < numInputVectors_; ++i) {
-    spiller_->spill(0, rowVectors_[i % numSampleVectors]);
+    noRowContainerSpiller->spill(0, rowVectors_[i % numSampleVectors]);
   }
 }
 

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.h
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.h
@@ -17,7 +17,7 @@
 #include "velox/exec/tests/SpillerBenchmarkBase.h"
 
 namespace facebook::velox::exec::test {
-// This test measures the spill input overhead in spill join & probe.
+/// This test measures the spill input overhead in spill join & probe.
 class JoinSpillInputBenchmarkBase : public SpillerBenchmarkBase {
  public:
   JoinSpillInputBenchmarkBase() = default;

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/exec/GroupingSet.h"
 #include "velox/exec/tests/AggregateSpillBenchmarkBase.h"
 #include "velox/serializers/PrestoSerializer.h"
 
@@ -28,22 +29,13 @@ int main(int argc, char* argv[]) {
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   filesystems::registerLocalFileSystem();
 
-  auto spillerTypeName = FLAGS_spiller_benchmark_spiller_type;
-  std::transform(
-      spillerTypeName.begin(),
-      spillerTypeName.end(),
-      spillerTypeName.begin(),
-      [](unsigned char c) { return std::toupper(c); });
-  Spiller::Type spillerType;
-  if (spillerTypeName == Spiller::typeName(Spiller::Type::kAggregateInput)) {
-    spillerType = Spiller::Type::kAggregateInput;
-  } else if (
-      spillerTypeName == Spiller::typeName(Spiller::Type::kAggregateOutput)) {
-    spillerType = Spiller::Type::kAggregateOutput;
-  } else {
+  auto spillerType = FLAGS_spiller_benchmark_spiller_type;
+  if (spillerType != AggregationInputSpiller::kType &&
+      spillerType != AggregationOutputSpiller::kType) {
     VELOX_UNSUPPORTED(
-        "The spiller type {} is not one of [AGGREGATE_INPUT, AGGREGATE_OUTPUT], the aggregate spiller dose not support it.",
-        spillerTypeName);
+        "The spiller type {} is not one of [AggregationInputSpiller, "
+        "AggregationOutputSpiller], the aggregate spiller dose not support it.",
+        spillerType);
   }
   auto test = std::make_unique<test::AggregateSpillBenchmarkBase>(spillerType);
   test->setUp();

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -44,7 +44,7 @@ DEFINE_string(
     "The compression kind to compress spill rows before write to disk");
 DEFINE_string(
     spiller_benchmark_spiller_type,
-    "AGGREGATE_INPUT",
+    "AggregationInputSpiller",
     "The spiller type name.");
 DEFINE_uint32(
     spiller_benchmark_num_spill_vectors,

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -37,7 +37,7 @@ DECLARE_uint64(spiller_benchmark_min_spill_run_size);
 DECLARE_uint64(spiller_benchmark_write_buffer_size);
 
 namespace facebook::velox::exec::test {
-// This test measures the spill input overhead in spill join & probe.
+/// This test measures the spill input overhead in spill join & probe.
 class SpillerBenchmarkBase {
  public:
   SpillerBenchmarkBase() = default;
@@ -68,7 +68,7 @@ class SpillerBenchmarkBase {
   std::shared_ptr<exec::test::TempDirectoryPath> tempDir_;
   std::string spillDir_;
   std::shared_ptr<filesystems::FileSystem> fs_;
-  std::unique_ptr<Spiller> spiller_;
+  std::unique_ptr<SpillerBase> spiller_;
   // Stats.
   uint64_t executionTimeUs_{0};
   folly::Synchronized<common::SpillStats> spillStats_;

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2299,9 +2299,9 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimFailure) {
 
   const std::string spillTableError{"spillTableError"};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Spiller",
-      std::function<void(Spiller*)>(
-          [&](Spiller* /*unused*/) { VELOX_FAIL(spillTableError); }));
+      "facebook::velox::exec::SpillerBase",
+      std::function<void(SpillerBase*)>(
+          [&](SpillerBase* /*unused*/) { VELOX_FAIL(spillTableError); }));
 
   TestScopedSpillInjection injection(100);
   const auto spillDirectory = exec::test::TempDirectoryPath::create();

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -33,7 +33,6 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/SignatureBinder.h"
 
-using facebook::velox::exec::Spiller;
 using facebook::velox::exec::test::AssertQueryBuilder;
 using facebook::velox::exec::test::CursorParameters;
 using facebook::velox::exec::test::PlanBuilder;


### PR DESCRIPTION
Spiller is a single class dealing with multiple different spilling scenarios. We want to abstract out Spiller and make its implementations closer to its use sites and expose different use case APIs. 