### PR TITLE
fix: Fix Stream not close because it holds in TreeOfLoser

### DIFF
--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -78,6 +78,14 @@ int32_t SpillMergeStream::compare(const MergeStream& other) const {
   return 0;
 }
 
+void SpillMergeStream::close() {
+  rowVector_.reset();
+  decoded_.clear();
+  rows_.resize(0);
+  index_ = 0;
+  size_ = 0;
+}
+
 SpillState::SpillState(
     const common::GetSpillDirectoryPathCB& getSpillDirPathCb,
     const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
@@ -299,9 +307,15 @@ void FileSpillMergeStream::nextBatch() {
   index_ = 0;
   if (!spillFile_->nextBatch(rowVector_)) {
     size_ = 0;
+    close();
     return;
   }
   size_ = rowVector_->size();
+}
+
+void FileSpillMergeStream::close() {
+  SpillMergeStream::close();
+  spillFile_.reset();
 }
 
 SpillPartitionIdSet toSpillPartitionIdSet(

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -38,12 +38,14 @@ const std::vector<CompareFlags> getCompareFlagsOrDefault(
 } // namespace
 
 void SpillMergeStream::pop() {
+  VELOX_CHECK(!closed_);
   if (++index_ >= size_) {
     setNextBatch();
   }
 }
 
 int32_t SpillMergeStream::compare(const MergeStream& other) const {
+  VELOX_CHECK(!closed_);
   auto& otherStream = static_cast<const SpillMergeStream&>(other);
   auto& children = rowVector_->children();
   auto& otherChildren = otherStream.current().children();
@@ -79,6 +81,8 @@ int32_t SpillMergeStream::compare(const MergeStream& other) const {
 }
 
 void SpillMergeStream::close() {
+  VELOX_CHECK(!closed_);
+  closed_ = true;
   rowVector_.reset();
   decoded_.clear();
   rows_.resize(0);
@@ -300,10 +304,12 @@ SpillPartition::createOrderedReader(
 }
 
 uint32_t FileSpillMergeStream::id() const {
+  VELOX_CHECK(!closed_);
   return spillFile_->id();
 }
 
 void FileSpillMergeStream::nextBatch() {
+  VELOX_CHECK(!closed_);
   index_ = 0;
   if (!spillFile_->nextBatch(rowVector_)) {
     size_ = 0;
@@ -314,6 +320,7 @@ void FileSpillMergeStream::nextBatch() {
 }
 
 void FileSpillMergeStream::close() {
+  VELOX_CHECK(!closed_);
   SpillMergeStream::close();
   spillFile_.reset();
 }

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -46,7 +46,6 @@ class SpillMergeStream : public MergeStream {
   }
 
   bool operator<(const MergeStream& other) const final {
-    VELOX_CHECK(!closed_);
     return compare(other) < 0;
   }
 


### PR DESCRIPTION
SpillPartion::createOrderedReader opens all the spill files and holds it in TreeOfLoser, SpillFile -> FileInputStream->buffer_(readBufferSize), so it holds memory readBufferSize * numFiles,  so we need to close the stream as soon as possible after it reaches the end as Spark does. 
After close, the function SpillMergeStream::hasData() returns false, then it won't access the fields of SpillMergeStream. 
https://github.com/apache/spark/blob/master/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java#L134