### PR TITLE
fix: Remove unnecessary method in HdfsReadFile.h

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
-#include <mutex>
 #include "velox/common/config/Config.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h"

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "HdfsReadFile.h"
-#include <folly/synchronization/CallOnce.h>
 #include "velox/external/hdfs/ArrowHdfsInternal.h"
 
 namespace facebook::velox {

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -52,7 +52,6 @@ class HdfsReadFile final : public ReadFile {
   }
 
  private:
-  void preadInternal(uint64_t offset, uint64_t length, char* pos) const;
   void checkFileReadParameters(uint64_t offset, uint64_t length) const;
 
   class Impl;


### PR DESCRIPTION
Remove unnecessary method in HdfsReadFile.h, since this method has been move to other place due to https://github.com/facebookincubator/velox/commit/e27867ca27149ba5047c5020ac1d187c7bc8a4b6