### PR TITLE
fix: velox_local_runner_test fails to build due to missing GTest::gtest_main in CMakeLists.txt

### DIFF
--- a/velox/runner/tests/CMakeLists.txt
+++ b/velox/runner/tests/CMakeLists.txt
@@ -24,4 +24,5 @@ target_link_libraries(
   velox_dwio_dwrf_proto
   velox_parse_parser
   velox_parse_expression
-  GTest::gtest)
+  GTest::gtest
+  GTest::gtest_main)


### PR DESCRIPTION
GTest wasn't able to be found when building velox_local_runner_test. CMakeLists.txt was missing GTest::gtest_main to be in the target_link_libraries. This PR adds the missing GTest::gtest_main.

```
20:52:36  #10 2.268 CMake Error at velox/velox/runner/tests/CMakeLists.txt:19 (target_link_libraries):
20:52:36  #10 2.268   Target "velox_local_runner_test" links to:
20:52:36  #10 2.268 
20:52:36  #10 2.268     GTest::gtest
20:52:36  #10 2.268 
20:52:36  #10 2.268   but the target was not found.  Possible reasons include:
20:52:36  #10 2.268 
20:52:36  #10 2.268     * There is a typo in the target name.
20:52:36  #10 2.268     * A find_package call is missing for an IMPORTED target.
20:52:36  #10 2.268     * An ALIAS target is missing.
20:52:36  #10 2.268 
20:52:36  #10 2.268 
20:52:36  #10 2.268 
20:52:36  #10 2.273 CMake Generate step failed.  Build files cannot be regenerated correctly.
20:52:36  #10 2.302 make: *** [Makefile:96: cmake-and-build] Error 1
20:52:36  #10 2.302 make: Leaving directory '/prestissimo'
20:52:36  #10 ERROR: process "/bin/sh -c EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS}     NUM_THREADS=${NUM_THREADS} make --directory=\"/prestissimo/\" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR}" did not complete successfully: exit code: 2
```