### PR TITLE
build: Removed GTest::gtest_main from CMakeLists.txt for velox_simple_aggregate_test

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -284,8 +284,9 @@ target_link_libraries(
   velox_simple_aggregate
   velox_exec
   velox_functions_aggregates_test_lib
-  GTest::gtest
-  GTest::gtest_main)
+  GTest::gtest)
+
+add_test(velox_simple_aggregate_test velox_simple_aggregate_test)
 
 add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
                                               SpillerBenchmarkBase.cpp)


### PR DESCRIPTION
Removed GTest::gtest_main from CMakeLists.txt for velox_simple_aggregate_test.

```
add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp
                                           Main.cpp)
```

Since Main.cpp is already included here, GTest::gtest_main is not needed in target_link_libraries.