### PR TITLE
fix: Build runner test only when VELOX_BUILD_TESTING enabled

### DIFF
--- a/velox/runner/CMakeLists.txt
+++ b/velox/runner/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-add_subdirectory(tests)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()
 
 velox_add_library(velox_local_runner LocalRunner.cpp LocalSchema.cpp Runner.cpp)
 


### PR DESCRIPTION
A minor CMake fix for #11609, to address the linking issue when `VELOX_BUILD_TESTING` is off.

```C++
20:52:36  #10 2.268 CMake Error at velox/velox/runner/tests/CMakeLists.txt:19 (target_link_libraries):
20:52:36  #10 2.268   Target "velox_local_runner_test" links to:
20:52:36  #10 2.268 
20:52:36  #10 2.268     GTest::gtest
20:52:36  #10 2.268 
20:52:36  #10 2.268   but the target was not found.  Possible reasons include:
20:52:36  #10 2.268 
20:52:36  #10 2.268     * There is a typo in the target name.
20:52:36  #10 2.268     * A find_package call is missing for an IMPORTED target.
20:52:36  #10 2.268     * An ALIAS target is missing.
20:52:36  #10 2.268 
20:52:36  #10 2.268 
20:52:36  #10 2.268 
20:52:36  #10 2.273 CMake Generate step failed.  Build files cannot be regenerated correctly.
20:52:36  #10 2.302 make: *** [Makefile:96: cmake-and-build] Error 1
20:52:36  #10 2.302 make: Leaving directory '/prestissimo'
20:52:36  #10 ERROR: process "/bin/sh -c EXTRA_CMAKE_FLAGS=${EXTRA_CMAKE_FLAGS}     NUM_THREADS=${NUM_THREADS} make --directory=\"/prestissimo/\" cmake-and-build BUILD_TYPE=${BUILD_TYPE} BUILD_DIR=${BUILD_DIR} BUILD_BASE_DIR=${BUILD_BASE_DIR}" did not complete successfully: exit code: 2
```