### PR TITLE
refactor: Change C style casts to C++ style (Part 1)

### DIFF
--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -183,8 +183,8 @@ char** AggregateCompanionAdapter::ExtractFunction::allocateGroups(
     memory::AllocationPool& allocationPool,
     const SelectivityVector& rows,
     uint64_t offsetInGroup) const {
-  auto* groups =
-      (char**)allocationPool.allocateFixed(sizeof(char*) * rows.end());
+  auto* groups = reinterpret_cast<char**>(
+      allocationPool.allocateFixed(sizeof(char*) * rows.end()));
 
   auto size = fn_->accumulatorFixedWidthSize();
   auto alignment = fn_->accumulatorAlignmentSize();

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -37,7 +37,7 @@ AssignUniqueId::AssignUniqueId(
       uniqueTaskId,
       kTaskUniqueIdLimit,
       "Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
-  uniqueValueMask_ = ((int64_t)uniqueTaskId) << 40;
+  uniqueValueMask_ = static_cast<int64_t>(uniqueTaskId) << 40;
 
   const auto numColumns = planNode->outputType()->size();
   identityProjections_.reserve(numColumns - 1);
@@ -93,7 +93,8 @@ void AssignUniqueId::generateIdColumn(vector_size_t size) {
 
     const auto numAvailableIds =
         std::min(maxRowIdCounterValue_ - rowIdCounter_, kRowIdsPerRequest);
-    const auto end = (int32_t)std::min((int64_t)size, start + numAvailableIds);
+    const vector_size_t end =
+        std::min(static_cast<int64_t>(size), start + numAvailableIds);
     VELOX_CHECK_EQ(
         (rowIdCounter_ + (end - start)) & uniqueValueMask_,
         0,

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -476,9 +476,8 @@ RowVectorPtr NestedLoopJoinProbe::genCrossProductSingleBuildVector(
   if (buildRowCount > outputBatchSize_) {
     probeRowCount_ = 1;
   } else {
-    probeRowCount_ = std::min(
-        (vector_size_t)outputBatchSize_ / buildRowCount,
-        input_->size() - probeRow_);
+    probeRowCount_ =
+        std::min(outputBatchSize_ / buildRowCount, input_->size() - probeRow_);
   }
   size_t numOutputRows = probeRowCount_ * buildRowCount;
 

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -777,7 +777,7 @@ std::string OutputBuffer::toStringLocked() const {
 }
 
 double OutputBuffer::getUtilization() const {
-  return bufferedBytes_ / (double)maxSize_;
+  return bufferedBytes_ / static_cast<double>(maxSize_);
 }
 
 bool OutputBuffer::isOverutilized() const {

--- a/velox/exec/PartitionStreamingWindowBuild.cpp
+++ b/velox/exec/PartitionStreamingWindowBuild.cpp
@@ -98,7 +98,8 @@ PartitionStreamingWindowBuild::nextPartition() {
 
 bool PartitionStreamingWindowBuild::hasNextPartition() {
   return partitionStartRows_.size() > 0 &&
-      currentPartition_ < int(partitionStartRows_.size() - 2);
+      currentPartition_ <
+      static_cast<vector_size_t>(partitionStartRows_.size() - 2);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -369,7 +369,7 @@ bool SortWindowBuild::hasNextPartition() {
   }
 
   return partitionStartRows_.size() > 0 &&
-      currentPartition_ < int(partitionStartRows_.size() - 2);
+      currentPartition_ < static_cast<int>(partitionStartRows_.size() - 2);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -212,7 +212,7 @@ RowVectorPtr TableWriter::getOutput() {
   // 1. Set rows column.
   FlatVectorPtr<int64_t> writtenRowsVector =
       BaseVector::create<FlatVector<int64_t>>(BIGINT(), numOutputRows, pool());
-  writtenRowsVector->set(0, (int64_t)numWrittenRows_);
+  writtenRowsVector->set(0, static_cast<int64_t>(numWrittenRows_));
   for (int idx = 1; idx < numOutputRows; ++idx) {
     writtenRowsVector->setNull(idx, true);
   }

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -327,7 +327,7 @@ void updateKRowsOffsetsColumn(
   const int precedingFactor = isKPreceding ? -1 : 1;
   for (auto i = 0; i < numRows; ++i) {
     const auto startValue =
-        (int64_t)(startRow + i) + precedingFactor * offsets[i];
+        static_cast<int64_t>(startRow + i) + precedingFactor * offsets[i];
     if (startValue < INT32_MIN) {
       // Same as the handling of startValue < INT32_MIN in
       // updateKRowsFrameBounds.
@@ -352,8 +352,8 @@ void Window::updateKRowsFrameBounds(
     vector_size_t* rawFrameBounds) {
   if (frameArg.index == kConstantChannel) {
     const auto constantOffset = frameArg.constant.value();
-    const auto startValue =
-        (int64_t)startRow + (isKPreceding ? -constantOffset : constantOffset);
+    const auto startValue = static_cast<int64_t>(startRow) +
+        (isKPreceding ? -constantOffset : constantOffset);
 
     if (isKPreceding) {
       if (startValue < INT32_MIN) {
@@ -375,7 +375,7 @@ void Window::updateKRowsFrameBounds(
     // KFollowing.
     // The start index that overflow happens.
     int32_t overflowStart;
-    if (startValue > (int64_t)INT32_MAX) {
+    if (startValue > static_cast<int64_t>(INT32_MAX)) {
       overflowStart = 0;
     } else {
       overflowStart = INT32_MAX - startValue + 1;

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<ByteInputStream> toByteStream(const std::string& input) {
   std::vector<ByteRange> ranges;
   ranges.push_back(
       {reinterpret_cast<uint8_t*>(const_cast<char*>(input.data())),
-       (int32_t)input.length(),
+       static_cast<int32_t>(input.length()),
        0});
   return std::make_unique<BufferInputStream>(std::move(ranges));
 }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -95,7 +95,7 @@ Status detail::parseDecimalComponents(
     }
     // Make sure all chars after sign are digits, as as folly::tryTo allows
     // leading and trailing whitespaces.
-    for (auto i = (size_t)withSign; i < size - pos; ++i) {
+    for (auto i = static_cast<size_t>(withSign); i < size - pos; ++i) {
       if (!std::isdigit(s[pos + i])) {
         return Status::UserError(
             "Non-digit character '{}' is not allowed in the exponent part.",

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -583,19 +583,21 @@ ExpressionFuzzer::ExpressionFuzzer(
   LOG(INFO) << fmt::format(
       "Functions with at least one supported signature: {} ({:.2f}%)",
       supportedFunctions_.size(),
-      (double)supportedFunctions_.size() / totalFunctions * 100);
+      static_cast<double>(supportedFunctions_.size()) / totalFunctions * 100);
   LOG(INFO) << fmt::format(
       "Functions with no supported signature: {} ({:.2f}%)",
       unsupportedFunctions,
-      (double)unsupportedFunctions / totalFunctions * 100);
+      static_cast<double>(unsupportedFunctions) / totalFunctions * 100);
   LOG(INFO) << fmt::format(
       "Supported function signatures: {} ({:.2f}%)",
       supportedFunctionSignatures,
-      (double)supportedFunctionSignatures / totalFunctionSignatures * 100);
+      static_cast<double>(supportedFunctionSignatures) /
+          totalFunctionSignatures * 100);
   LOG(INFO) << fmt::format(
       "Unsupported function signatures: {} ({:.2f}%)",
       unsupportedFunctionSignatures,
-      (double)unsupportedFunctionSignatures / totalFunctionSignatures * 100);
+      static_cast<double>(unsupportedFunctionSignatures) /
+          totalFunctionSignatures * 100);
 
   getTicketsForFunctions();
 

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -110,7 +110,7 @@ void setLiteralValue(
     }
   } else if (vector->type()->isDate()) {
     auto dateVector = vector->template asFlatVector<int32_t>();
-    dateVector->set(index, int(literal.date()));
+    dateVector->set(index, static_cast<int32_t>(literal.date()));
   } else {
     vector->set(index, getLiteralValue<T>(literal));
   }
@@ -247,7 +247,7 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
       return std::make_shared<core::ConstantTypedExpr>(
-          DATE(), variant(int(substraitLit.date())));
+          DATE(), variant(static_cast<int32_t>(substraitLit.date())));
     default:
       VELOX_NYI(
           "Substrait conversion not supported for type case '{}'", typeCase);

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -345,8 +345,8 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
   } else {
     return std::make_shared<core::LimitNode>(
         nextPlanNodeId(),
-        (int32_t)fetchRel.offset(),
-        (int32_t)fetchRel.count(),
+        static_cast<int32_t>(fetchRel.offset()),
+        static_cast<int32_t>(fetchRel.count()),
         false /*isPartial*/,
         childNode);
   }

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -820,7 +820,7 @@ BigintValuesUsingHashTable::BigintValuesUsingHashTable(
   // Size the hash table to be 2+x the entry count, e.g. 10 entries
   // gets 1 << log2 of 50 == 32. The filter is expected to fail often so we
   // wish to increase the chance of hitting empty on first probe.
-  auto size = 1u << (uint32_t)std::log2(values.size() * 5);
+  auto size = 1u << static_cast<uint32_t>(std::log2(values.size() * 5));
   hashTable_.resize(size + kPaddingElements);
   sizeMask_ = size - 1;
   std::fill(hashTable_.begin(), hashTable_.end(), kEmptyMarker);
@@ -1152,7 +1152,7 @@ std::unique_ptr<Filter> createBigintValuesFilter(
   bool overflow = __builtin_sub_overflow(max, min, &range);
   if (LIKELY(!overflow)) {
     // all accepted/rejected values form one contiguous block
-    if ((uint64_t)range + 1 == values.size()) {
+    if (static_cast<uint64_t>(range) + 1 == values.size()) {
       if (negated) {
         return std::make_unique<NegatedBigintRange>(min, max, nullAllowed);
       }

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -250,9 +250,9 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
     // VeloxRuntimeError to avoid it being suppressed by TRY().
     VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
         "Timepoint is outside of supported year range: [{}, {}], got {}",
-        (int)kMinYear,
-        (int)kMaxYear,
-        (int)year);
+        static_cast<int>(kMinYear),
+        static_cast<int>(kMaxYear),
+        static_cast<int>(year));
   }
 }
 


### PR DESCRIPTION
As per security guideline :
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

This is the first of several changes for this cleanup.

