### PR TITLE
refactor: Change C-style casts to C++-style (Part 2)

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -606,7 +606,7 @@ bool CacheShard::removeFileEntries(
       }
 
       numAgedOut_++;
-      pagesRemoved += (int64_t)cacheEntry->data().numPages();
+      pagesRemoved += static_cast<int64_t>(cacheEntry->data().numPages());
 
       toFree.push_back(std::move(cacheEntry->data()));
       removeEntryLocked(cacheEntry.get());
@@ -864,7 +864,7 @@ uint64_t AsyncDataCache::shrink(uint64_t targetBytes) {
 }
 
 bool AsyncDataCache::canTryAllocate(
-    int32_t numPages,
+    MachinePageCount numPages,
     const memory::Allocation& acquired) const {
   if (numPages <= acquired.numPages()) {
     return true;
@@ -1059,7 +1059,8 @@ CoalesceIoStats readPins(
       [&](int32_t size, std::vector<folly::Range<char*>>& ranges) {
         // This hack allows us to store the size of the gap in the Range,
         // without actually allocating a buffer for it.
-        ranges.push_back(folly::Range<char*>(nullptr, (char*)(uint64_t)size));
+        ranges.push_back(folly::Range<char*>(
+            nullptr, reinterpret_cast<char*>(static_cast<uint64_t>(size))));
       },
       std::move(readFunc));
 }

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -875,8 +875,9 @@ class AsyncDataCache : public memory::Cache {
 
   // True if 'acquired' has more pages than 'numPages' or allocator has space
   // for numPages - acquired pages of more allocation.
-  bool canTryAllocate(int32_t numPages, const memory::Allocation& acquired)
-      const;
+  bool canTryAllocate(
+      memory::MachinePageCount numPages,
+      const memory::Allocation& acquired) const;
 
   static AsyncDataCache** getInstancePtr();
 

--- a/velox/common/config/Config.cpp
+++ b/velox/common/config/Config.cpp
@@ -35,7 +35,7 @@ double toBytesPerCapacityUnit(CapacityUnit unit) {
     case CapacityUnit::PETABYTE:
       return exp2(50);
     default:
-      VELOX_USER_FAIL("Invalid capacity unit '{}'", (int)unit);
+      VELOX_USER_FAIL("Invalid capacity unit '{}'", static_cast<int>(unit));
   }
 }
 

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -215,9 +215,9 @@ void Base64::encodeImpl(
   // For each group of 3 bytes (24 bits) in the input, split that into
   // 4 groups of 6 bits and encode that using the supplied charset lookup
   for (; inputSize > 2; inputSize -= 3) {
-    uint32_t inputBlock = uint8_t(*inputIterator++) << 16;
-    inputBlock |= uint8_t(*inputIterator++) << 8;
-    inputBlock |= uint8_t(*inputIterator++);
+    uint32_t inputBlock = static_cast<uint8_t>(*inputIterator++) << 16;
+    inputBlock |= static_cast<uint8_t>(*inputIterator++) << 8;
+    inputBlock |= static_cast<uint8_t>(*inputIterator++);
 
     *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
     *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
@@ -229,10 +229,10 @@ void Base64::encodeImpl(
     // We have either 1 or 2 input bytes left.  Encode this similar to the
     // above (assuming 0 for all other bytes).  Optionally append the '='
     // character if it is requested.
-    uint32_t inputBlock = uint8_t(*inputIterator++) << 16;
+    uint32_t inputBlock = static_cast<uint8_t>(*inputIterator++) << 16;
     *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
     if (inputSize > 1) {
-      inputBlock |= uint8_t(*inputIterator) << 8;
+      inputBlock |= static_cast<uint8_t>(*inputIterator) << 8;
       *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
       *outputPointer++ = charset[(inputBlock >> 6) & 0x3f];
       if (includePadding) {
@@ -334,7 +334,7 @@ void Base64::decode(const char* input, size_t size, char* output) {
 uint8_t Base64::base64ReverseLookup(
     char encodedChar,
     const Base64::ReverseIndex& reverseIndex) {
-  auto reverseLookupValue = reverseIndex[(uint8_t)encodedChar];
+  auto reverseLookupValue = reverseIndex[static_cast<uint8_t>(encodedChar)];
   if (reverseLookupValue >= 0x40) {
     VELOX_USER_FAIL("decode() - invalid input string: invalid characters");
   }

--- a/velox/common/hyperloglog/DenseHll.cpp
+++ b/velox/common/hyperloglog/DenseHll.cpp
@@ -155,7 +155,7 @@ void DenseHll::insert(int32_t index, int8_t value) {
   }
 
   if (delta > kMaxDelta) {
-    int8_t overflow = (int8_t)(delta - kMaxDelta);
+    int8_t overflow = static_cast<int8_t>(delta - kMaxDelta);
 
     int overflowEntry = findOverflowEntry(index);
     if (overflowEntry != -1) {
@@ -287,11 +287,11 @@ void DenseHll::setDelta(int32_t index, int8_t value) {
   int slot = index >> 1;
 
   // Clear the old value.
-  int8_t clearMask = (int8_t)(kBucketMask << shiftForBucket(index));
+  int8_t clearMask = static_cast<int8_t>(kBucketMask << shiftForBucket(index));
   deltas_[slot] &= ~clearMask;
 
   // Set the new value.
-  int8_t setMask = (int8_t)(value << shiftForBucket(index));
+  int8_t setMask = static_cast<int8_t>(value << shiftForBucket(index));
   deltas_[slot] |= setMask;
 }
 
@@ -619,7 +619,7 @@ int32_t DenseHll::mergeWithSimd(const HllView& other, int8_t newBaseline) {
   const auto baselineBatch = xsimd::broadcast(baseline_);
   const auto otherBaselineBatch = xsimd::broadcast(other.baseline);
   const auto newBaselineBatch = xsimd::broadcast(newBaseline);
-  const auto zeroBatch = xsimd::broadcast((int8_t)0);
+  const auto zeroBatch = xsimd::broadcast(static_cast<int8_t>(0));
 
   // SIMD doesn't support 4-bit integers. The smallest integer is 8-bit.
   // We are going to use 2 SIMD registers to process a batch of values.

--- a/velox/common/hyperloglog/SparseHll.cpp
+++ b/velox/common/hyperloglog/SparseHll.cpp
@@ -114,7 +114,7 @@ void SparseHll::serialize(int8_t indexBitLength, char* output) const {
   common::OutputByteStream stream(output);
   stream.appendOne(kPrestoSparseV2);
   stream.appendOne(indexBitLength);
-  stream.appendOne((int16_t)entries_.size());
+  stream.appendOne(static_cast<int16_t>(entries_.size()));
   for (auto entry : entries_) {
     stream.appendOne(entry);
   }
@@ -130,7 +130,7 @@ std::string SparseHll::serializeEmpty(int8_t indexBitLength) {
   common::OutputByteStream stream(serialized.data());
   stream.appendOne(kPrestoSparseV2);
   stream.appendOne(indexBitLength);
-  stream.appendOne((int16_t)0);
+  stream.appendOne(static_cast<int16_t>(0));
   return serialized;
 }
 

--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -26,7 +26,7 @@ std::vector<ByteRange> byteRangesFromIOBuf(folly::IOBuf* iobuf) {
   auto* current = iobuf;
   do {
     byteRanges.push_back(
-        {current->writableData(), (int32_t)current->length(), 0});
+        {current->writableData(), static_cast<int32_t>(current->length()), 0});
     current = current->next();
   } while (current != iobuf);
   return byteRanges;
@@ -255,7 +255,7 @@ void ByteOutputStream::appendBits(
 }
 
 void ByteOutputStream::appendStringView(StringView value) {
-  appendStringView((std::string_view)value);
+  appendStringView(static_cast<std::string_view>(value));
 }
 
 void ByteOutputStream::appendStringView(std::string_view value) {

--- a/velox/common/process/StackTrace.cpp
+++ b/velox/common/process/StackTrace.cpp
@@ -178,7 +178,7 @@ std::string StackTrace::translateFrame(void* addressPtr, bool /*lineNumbers*/) {
   return folly::fibers::runInMainContext(
       [addressPtr]() { return translateFrameImpl(addressPtr); });
 #else
-  (void)addressPtr;
+  static_cast<void>(addressPtr);
   return std::string{};
 #endif
 }

--- a/velox/dwio/common/Throttler.cpp
+++ b/velox/dwio/common/Throttler.cpp
@@ -261,7 +261,9 @@ uint64_t Throttler::calculateBackoffDurationAndUpdateThrottleCache(
   return std::min(
       backoffDelayMs +
           boost::random::uniform_int_distribution<uint64_t>(
-              1, std::max<uint64_t>(1, (uint64_t)(backoffDelayMs * 0.1)))(rng_),
+              1,
+              std::max<uint64_t>(
+                  1, static_cast<uint64_t>(backoffDelayMs * 0.1)))(rng_),
       maxThrottleBackoffDurationMs_);
 }
 


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast