### PR TITLE
refactor: Change C style casts to C++ style (Part 3)

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -36,7 +36,7 @@ enum class Encoding : int8_t {
 
 template <typename T>
 void write(const T& value, std::ostream& out) {
-  out.write((char*)&value, sizeof(T));
+  out.write(reinterpret_cast<const char*>(&value), sizeof(T));
 }
 
 template <>
@@ -53,7 +53,7 @@ void write<std::string>(const std::string& value, std::ostream& out) {
 template <typename T>
 T read(std::istream& in) {
   T value;
-  in.read((char*)&value, sizeof(T));
+  in.read(reinterpret_cast<char*>(&value), sizeof(T));
   return value;
 }
 
@@ -78,16 +78,16 @@ void writeEncoding(VectorEncoding::Simple encoding, std::ostream& out) {
     case VectorEncoding::Simple::ROW:
     case VectorEncoding::Simple::ARRAY:
     case VectorEncoding::Simple::MAP:
-      write<int32_t>((int8_t)Encoding::kFlat, out);
+      write<int32_t>(static_cast<int8_t>(Encoding::kFlat), out);
       return;
     case VectorEncoding::Simple::CONSTANT:
-      write<int32_t>((int8_t)Encoding::kConstant, out);
+      write<int32_t>(static_cast<int8_t>(Encoding::kConstant), out);
       return;
     case VectorEncoding::Simple::DICTIONARY:
-      write<int32_t>((int8_t)Encoding::kDictionary, out);
+      write<int32_t>(static_cast<int8_t>(Encoding::kDictionary), out);
       return;
     case VectorEncoding::Simple::LAZY:
-      write<int32_t>((int8_t)Encoding::kLazy, out);
+      write<int32_t>(static_cast<int8_t>(Encoding::kLazy), out);
       return;
     default:
       VELOX_UNSUPPORTED("Unsupported encoding: {}", mapSimpleToName(encoding));
@@ -275,7 +275,7 @@ void writeScalarConstant(const BaseVector& vector, std::ostream& out) {
   using T = typename TypeTraits<kind>::NativeType;
 
   auto value = vector.as<ConstantVector<T>>()->valueAt(0);
-  out.write((const char*)&value, sizeof(T));
+  out.write(reinterpret_cast<const char*>(&value), sizeof(T));
 
   if constexpr (std::is_same_v<T, StringView>) {
     if (!value.isInline()) {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -323,7 +323,9 @@ RowVectorPtr IOBufToRowVector(
 
   for (const auto& range : ioBuf) {
     ranges.emplace_back(ByteRange{
-        const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
+        const_cast<uint8_t*>(range.data()),
+        static_cast<int32_t>(range.size()),
+        0});
   }
 
   auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));

--- a/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
@@ -67,7 +67,9 @@ int main() {
   }
 
   std::cout << "Probability of constant encoding = "
-            << (double)numConst / ((double)numConst + (double)numDict) << "\n";
+            << static_cast<double>(numConst) /
+          (static_cast<double>(numConst) + static_cast<double>(numDict))
+            << "\n";
 
   return 0;
 }


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Covers the findings in velox/vector