### PR TITLE
refactor: Change C style casts to C++ style (Part 5)

### DIFF
--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -129,8 +129,9 @@ void TpchDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   currentSplit_ = std::dynamic_pointer_cast<TpchConnectorSplit>(split);
   VELOX_CHECK(currentSplit_, "Wrong type of split for TpchDataSource.");
 
-  size_t partSize =
-      std::ceil((double)tpchTableRowCount_ / (double)currentSplit_->totalParts);
+  size_t partSize = std::ceil(
+      static_cast<double>(tpchTableRowCount_) /
+      static_cast<double>(currentSplit_->totalParts));
 
   splitOffset_ = partSize * currentSplit_->partNumber;
   splitEnd_ = splitOffset_ + partSize;

--- a/velox/tpch/gen/TpchGen.cpp
+++ b/velox/tpch/gen/TpchGen.cpp
@@ -78,7 +78,7 @@ std::vector<VectorPtr> allocateVectors(
 }
 
 double decimalToDouble(int64_t value) {
-  return (double)value * 0.01;
+  return static_cast<double>(value) * 0.01;
 }
 
 int32_t toDate(std::string_view stringDate) {

--- a/velox/tpch/gen/dbgen/bm_utils.cpp
+++ b/velox/tpch/gen/dbgen/bm_utils.cpp
@@ -153,8 +153,8 @@ void e_str(distribution* d, int min, int max, seed_t* seed, char* dest) {
 
   tpch_a_rnd(min, max, seed, dest);
   pick_str(d, seed, strtmp);
-  len = (int)strlen(strtmp);
-  RANDOM(loc, 0, ((int)strlen(dest) - 1 - len), seed);
+  len = static_cast<int>(strlen(strtmp));
+  RANDOM(loc, 0, (static_cast<int>(strlen(dest)) - 1 - len), seed);
   memcpy(dest + loc, strtmp, sizeof(char) * len);
 
   return;
@@ -277,12 +277,14 @@ void read_dist(const char* path, const char* name, distribution* target) {
 
     if (!dsscasecmp(token, "count")) {
       target->count = weight;
-      target->list = (set_member*)malloc((size_t)(weight * sizeof(set_member)));
+      target->list = reinterpret_cast<set_member*>(
+          malloc(static_cast<size_t>(weight * sizeof(set_member))));
       MALLOC_CHECK(target->list);
       target->max = 0;
       continue;
     }
-    target->list[count].text = (char*)malloc((size_t)((int)strlen(token) + 1));
+    target->list[count].text = reinterpret_cast<char*>(
+        malloc(static_cast<size_t>((static_cast<int>(strlen(token)) + 1))));
     MALLOC_CHECK(target->list[count].text);
     strcpy(target->list[count].text, token);
     target->max += weight;
@@ -295,7 +297,7 @@ void read_dist(const char* path, const char* name, distribution* target) {
     fprintf(stderr, "Read error on dist '%s'\n", name);
     exit(1);
   }
-  target->permute = (long*)NULL;
+  target->permute = reinterpret_cast<long*>(NULL);
   return;
 }
 
@@ -315,7 +317,7 @@ void agg_str(distribution* set, long count, seed_t* seed, char* dest) {
     strcat(dest, DIST_MEMBER(set, DIST_PERMUTE(d, i)));
     strcat(dest, " ");
   }
-  *(dest + (int)strlen(dest) - 1) = '\0';
+  *(dest + static_cast<int>(strlen(dest)) - 1) = '\0';
 
   return;
 }
@@ -398,7 +400,8 @@ char** mk_ascdate(void) {
   dss_time_t t;
   DSS_HUGE i;
 
-  m = (char**)malloc((size_t)(TOTDATE * sizeof(char*)));
+  m = reinterpret_cast<char**>(
+      malloc(static_cast<size_t>(TOTDATE * sizeof(char*))));
   MALLOC_CHECK(m);
   for (i = 0; i < TOTDATE; i++) {
     mk_time(i + 1, &t);

--- a/velox/tpch/gen/dbgen/include/dbgen/dss.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dss.h
@@ -135,7 +135,7 @@ typedef struct {
  * some handy access functions
  */
 #define DIST_SIZE(d) d->count
-#define DIST_MEMBER(d, i) ((set_member*)((d)->list + i))->text
+#define DIST_MEMBER(d, i) (reinterpret_cast<set_member*>((d)->list + i))->text
 #define DIST_PERMUTE(d, i) (d->permute[i])
 
 typedef struct {

--- a/velox/tpch/gen/dbgen/permute.cpp
+++ b/velox/tpch/gen/dbgen/permute.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright owned by the Transaction Processing Performance Council.
  *
  * A copy of the license is included under extension/tpch/dbgen/LICENSE
@@ -32,9 +47,9 @@ void permute(long* a, int c, seed_t* seed) {
   static DSS_HUGE source;
   static long temp;
 
-  if (a != (long*)NULL) {
+  if (a != reinterpret_cast<long*>(NULL)) {
     for (i = 0; i < c; i++) {
-      RANDOM(source, (long)i, (long)(c - 1), seed);
+      RANDOM(source, static_cast<long>(i), static_cast<long>(c - 1), seed);
       temp = *(a + source);
       *(a + source) = *(a + i);
       *(a + i) = temp;
@@ -48,8 +63,8 @@ void permute_dist(distribution* d, seed_t* seed) {
   int i;
 
   if (d != NULL) {
-    if (d->permute == (long*)NULL) {
-      d->permute = (long*)malloc(sizeof(long) * DIST_SIZE(d));
+    if (d->permute == reinterpret_cast<long*>(NULL)) {
+      d->permute = reinterpret_cast<long*>(malloc(sizeof(long) * DIST_SIZE(d)));
       MALLOC_CHECK(d->permute);
     }
     for (i = 0; i < DIST_SIZE(d); i++)

--- a/velox/tpch/gen/dbgen/rnd.cpp
+++ b/velox/tpch/gen/dbgen/rnd.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright owned by the Transaction Processing Performance Council.
  *
  * A copy of the license is included under extension/tpch/dbgen/LICENSE
@@ -40,7 +55,6 @@ void dss_random(DSS_HUGE* tgt, DSS_HUGE lower, DSS_HUGE upper, seed_t* seed) {
 }
 
 void row_start(int t, DBGenContext* ctx) {
-  (void)t;
   int i;
   for (i = 0; i <= MAX_STREAM; i++)
     ctx->Seed[i].usage = 0;
@@ -138,19 +152,21 @@ UnifInt(DSS_HUGE nLow, DSS_HUGE nHigh, seed_t* seed)
 {
   double dRange;
   DSS_HUGE nTemp;
-  int32_t nLow32 = (int32_t)nLow, nHigh32 = (int32_t)nHigh;
+  int32_t nLow32 = static_cast<int32_t>(nLow),
+          nHigh32 = static_cast<int32_t>(nHigh);
 
   if ((nHigh == MAX_LONG) && (nLow == 0)) {
-    dRange = (double)((DSS_HUGE)(nHigh32 - nLow32) + 1);
+    dRange = static_cast<double>(static_cast<DSS_HUGE>(nHigh32 - nLow32) + 1);
   } else {
-    dRange = (double)(nHigh - nLow + 1);
+    dRange = static_cast<double>(nHigh - nLow + 1);
   }
 
   seed->value = NextRand(seed->value);
 #ifdef RNG_TEST
   seed->nCalls += 1;
 #endif
-  nTemp = (DSS_HUGE)(((double)seed->value / DBGenContext::dM) * (dRange));
+  nTemp = static_cast<DSS_HUGE>(
+      (static_cast<double>(seed->value) / DBGenContext::dM) * (dRange));
   return (nLow + nTemp);
 }
 

--- a/velox/tpch/gen/dbgen/rng64.cpp
+++ b/velox/tpch/gen/dbgen/rng64.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright owned by the Transaction Processing Performance Council.
  *
  * A copy of the license is included under extension/tpch/dbgen/LICENSE
@@ -94,8 +109,8 @@ void dss_random64(DSS_HUGE* tgt, DSS_HUGE nLow, DSS_HUGE nHigh, seed_t* seed) {
 
 DSS_HUGE
 NextRand64(DSS_HUGE nSeed) {
-  DSS_HUGE a = (unsigned DSS_HUGE)RNG_A;
-  DSS_HUGE c = (unsigned DSS_HUGE)RNG_C;
+  DSS_HUGE a = static_cast<unsigned DSS_HUGE>(RNG_A);
+  DSS_HUGE c = static_cast<unsigned DSS_HUGE>(RNG_C);
   nSeed = (nSeed * a + c); /* implicitely truncated to 64bits */
 
   return (nSeed);

--- a/velox/tpch/gen/dbgen/speed_seed.cpp
+++ b/velox/tpch/gen/dbgen/speed_seed.cpp
@@ -1,4 +1,19 @@
 /*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * Copyright owned by the Transaction Processing Performance Council.
  *
  * A copy of the license is included under extension/tpch/dbgen/LICENSE
@@ -75,7 +90,7 @@ void NthElement(DSS_HUGE N, DSS_HUGE* StartSeed) {
     fprintf(stderr, "%c\b", lnoise[i]);
   }
   Mult = Multiplier;
-  Z = (DSS_HUGE)*StartSeed;
+  Z = static_cast<DSS_HUGE>(*StartSeed);
   while (N > 0) {
     if (N % 2 != 0) /* testing for oddness, this seems portable */
       Z = (Mult * Z) % Modulus;
@@ -104,8 +119,7 @@ void fake_tpch_a_rnd(int min, int max, seed_t* seed) {
   return;
 }
 
-long sd_part(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
+long sd_part(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   int i;
 
   for (i = P_MFG_SD; i <= P_CNTR_SD; i++)
@@ -140,8 +154,7 @@ long sd_line(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
   return (0L);
 }
 
-long sd_order(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
+long sd_order(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   ADVANCE_STREAM(&ctx->Seed[O_LCNT_SD], skip_count);
   /*
       if (ctx->scale_factor >= 30000)
@@ -158,9 +171,7 @@ long sd_order(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
   return (0L);
 }
 
-long sd_psupp(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
-
+long sd_psupp(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   int j;
 
   for (j = 0; j < SUPP_PER_PART; j++) {
@@ -172,9 +183,7 @@ long sd_psupp(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
   return (0L);
 }
 
-long sd_cust(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
-
+long sd_cust(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   ADVANCE_STREAM(&ctx->Seed[C_ADDR_SD], skip_count * 9);
   ADVANCE_STREAM(&ctx->Seed[C_CMNT_SD], skip_count * 2);
   ADVANCE_STREAM(&ctx->Seed[C_NTRG_SD], skip_count);
@@ -184,9 +193,7 @@ long sd_cust(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
   return (0L);
 }
 
-long sd_supp(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
-
+long sd_supp(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   ADVANCE_STREAM(&ctx->Seed[S_NTRG_SD], skip_count);
   ADVANCE_STREAM(&ctx->Seed[S_PHNE_SD], 3L * skip_count);
   ADVANCE_STREAM(&ctx->Seed[S_ABAL_SD], skip_count);
@@ -200,17 +207,13 @@ long sd_supp(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
   return (0L);
 }
 
-long sd_nation(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
-
+long sd_nation(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   ADVANCE_STREAM(&ctx->Seed[N_CMNT_SD], skip_count * 2);
 
   return (0L);
 }
 
-long sd_region(int child, DSS_HUGE skip_count, DBGenContext* ctx) {
-  (void)child;
-
+long sd_region(int /*child*/, DSS_HUGE skip_count, DBGenContext* ctx) {
   ADVANCE_STREAM(&ctx->Seed[R_CMNT_SD], skip_count * 2);
 
   return (0L);

--- a/velox/tpch/gen/dbgen/text.cpp
+++ b/velox/tpch/gen/dbgen/text.cpp
@@ -259,7 +259,7 @@ void init_text_pool(long bSize, DBGenContext* ctx) {
   gen_index(prepositions_index, &prepositions);
 
   txtBufferSize = bSize;
-  szTextPool = (char*)malloc(bSize + 1 + 100);
+  szTextPool = reinterpret_cast<char*>(malloc(bSize + 1 + 100));
   MALLOC_CHECK(szTextPool);
   memset(szTextPool, 0, bSize + 1 + 100);
 
@@ -285,7 +285,7 @@ void dbg_text(char* tgt, int min, int max, seed_t* seed) {
 
   RANDOM(hgOffset, 0, txtBufferSize - max, seed);
   RANDOM(hgLength, min, max, seed);
-  strncpy(&tgt[0], &szTextPool[hgOffset], (int)hgLength);
+  strncpy(&tgt[0], &szTextPool[hgOffset], static_cast<int>(hgLength));
   tgt[hgLength] = '\0';
 
   return;


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Covers the findings in velox/tpch