### PR TITLE
fix: Unsigned index underflow in trimWhiteSpace

### DIFF
--- a/velox/type/Conversions.cpp
+++ b/velox/type/Conversions.cpp
@@ -67,7 +67,7 @@ std::string_view trimWhiteSpace(const char* data, size_t length) {
   }
 
   // Trim whitespace from right side.
-  for (auto i = length - 1; i >= startIndex; i--) {
+  for (int i = length - 1; i >= startIndex; i--) {
     size = 0;
     auto isWhiteSpaceOrControlChar = false;
 


### PR DESCRIPTION
Summary: We should prefer signed type for numeric values whenever possible.  Unsigned types are only for opaque bits.

Differential Revision: D66587108


