### PR TITLE
build: Make benchmarks respect `VELOX_ENABLE_BENCHMARKS` cmake option

### DIFF
--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -53,15 +53,17 @@ target_link_libraries(
 
 gtest_add_tests(velox_memory_test "" AUTO)
 
-add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
 
-target_link_libraries(
-  velox_fragmentation_benchmark
-  PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
+  target_link_libraries(
+    velox_fragmentation_benchmark
+    PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
 
-add_executable(velox_concurrent_allocation_benchmark
-               ConcurrentAllocationBenchmark.cpp)
+  add_executable(velox_concurrent_allocation_benchmark
+                 ConcurrentAllocationBenchmark.cpp)
 
-target_link_libraries(
-  velox_concurrent_allocation_benchmark
-  PRIVATE velox_memory velox_time)
+  target_link_libraries(
+    velox_concurrent_allocation_benchmark
+    PRIVATE velox_memory velox_time)
+endif()

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -57,13 +57,12 @@ if(VELOX_ENABLE_BENCHMARKS)
   add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
 
   target_link_libraries(
-    velox_fragmentation_benchmark
-    PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
+    velox_fragmentation_benchmark PRIVATE velox_memory Folly::folly
+                                          gflags::gflags glog::glog)
 
   add_executable(velox_concurrent_allocation_benchmark
                  ConcurrentAllocationBenchmark.cpp)
 
-  target_link_libraries(
-    velox_concurrent_allocation_benchmark
-    PRIVATE velox_memory velox_time)
+  target_link_libraries(velox_concurrent_allocation_benchmark
+                        PRIVATE velox_memory velox_time)
 endif()

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -22,18 +22,20 @@ target_link_libraries(
   ${FOLLY_BENCHMARK}
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_iceberg_reader_benchmark
-               IcebergSplitReaderBenchmarkMain.cpp)
-target_link_libraries(
-  velox_dwio_iceberg_reader_benchmark
-  velox_dwio_iceberg_reader_benchmark_lib
-  velox_dwio_dwrf_proto
-  velox_exec_test_lib
-  velox_exec
-  velox_hive_connector
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  ${TEST_LINK_LIBS})
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwio_iceberg_reader_benchmark
+                 IcebergSplitReaderBenchmarkMain.cpp)
+  target_link_libraries(
+    velox_dwio_iceberg_reader_benchmark
+    velox_dwio_iceberg_reader_benchmark_lib
+    velox_dwio_dwrf_proto
+    velox_exec_test_lib
+    velox_exec
+    velox_hive_connector
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    ${TEST_LINK_LIBS})
+endif()
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
 

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -76,7 +76,8 @@ target_link_libraries(
   protobuf::libprotobuf)
 
 if(VELOX_ENABLE_BENCHMARKS)
-  add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
+  add_executable(velox_dwio_common_data_buffer_benchmark
+                 DataBufferBenchmark.cpp)
 
   target_link_libraries(
     velox_dwio_common_data_buffer_benchmark
@@ -86,7 +87,8 @@ if(VELOX_ENABLE_BENCHMARKS)
     Folly::folly
     ${FOLLY_BENCHMARK})
 
-  add_executable(velox_dwio_common_int_decoder_benchmark IntDecoderBenchmark.cpp)
+  add_executable(velox_dwio_common_int_decoder_benchmark
+                 IntDecoderBenchmark.cpp)
   target_link_libraries(
     velox_dwio_common_int_decoder_benchmark
     velox_dwio_common_exception

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -75,39 +75,41 @@ target_link_libraries(
   fmt::fmt
   protobuf::libprotobuf)
 
-add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
-
-target_link_libraries(
-  velox_dwio_common_data_buffer_benchmark
-  velox_dwio_common
-  velox_memory
-  velox_dwio_common_exception
-  Folly::folly
-  ${FOLLY_BENCHMARK})
-
-add_executable(velox_dwio_common_int_decoder_benchmark IntDecoderBenchmark.cpp)
-target_link_libraries(
-  velox_dwio_common_int_decoder_benchmark
-  velox_dwio_common_exception
-  velox_exception
-  velox_dwio_dwrf_common
-  Folly::folly
-  ${FOLLY_BENCHMARK})
-
-if(VELOX_ENABLE_ARROW AND VELOX_ENABLE_BENCHMARKS)
-  add_subdirectory(Lemire/FastPFor)
-  add_executable(velox_dwio_common_bitpack_decoder_benchmark
-                 BitPackDecoderBenchmark.cpp)
-
-  target_compile_options(velox_dwio_common_bitpack_decoder_benchmark
-                         PRIVATE -Wno-deprecated-declarations)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwio_common_data_buffer_benchmark DataBufferBenchmark.cpp)
 
   target_link_libraries(
-    velox_dwio_common_bitpack_decoder_benchmark
+    velox_dwio_common_data_buffer_benchmark
     velox_dwio_common
-    arrow
-    velox_fastpforlib
-    duckdb_static
+    velox_memory
+    velox_dwio_common_exception
     Folly::folly
     ${FOLLY_BENCHMARK})
+
+  add_executable(velox_dwio_common_int_decoder_benchmark IntDecoderBenchmark.cpp)
+  target_link_libraries(
+    velox_dwio_common_int_decoder_benchmark
+    velox_dwio_common_exception
+    velox_exception
+    velox_dwio_dwrf_common
+    Folly::folly
+    ${FOLLY_BENCHMARK})
+
+  if(VELOX_ENABLE_ARROW)
+    add_subdirectory(Lemire/FastPFor)
+    add_executable(velox_dwio_common_bitpack_decoder_benchmark
+                   BitPackDecoderBenchmark.cpp)
+
+    target_compile_options(velox_dwio_common_bitpack_decoder_benchmark
+                           PRIVATE -Wno-deprecated-declarations)
+
+    target_link_libraries(
+      velox_dwio_common_bitpack_decoder_benchmark
+      velox_dwio_common
+      arrow
+      velox_fastpforlib
+      duckdb_static
+      Folly::folly
+      ${FOLLY_BENCHMARK})
+  endif()
 endif()

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -541,25 +541,27 @@ target_link_libraries(
   ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
-target_link_libraries(
-  velox_dwrf_int_encoder_benchmark
-  velox_dwio_dwrf_common
-  velox_memory
-  velox_dwio_common_exception
-  Folly::folly
-  ${FOLLY_BENCHMARK})
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
+  target_link_libraries(
+    velox_dwrf_int_encoder_benchmark
+    velox_dwio_dwrf_common
+    velox_memory
+    velox_dwio_common_exception
+    Folly::folly
+    ${FOLLY_BENCHMARK})
 
-add_executable(velox_dwrf_float_column_writer_benchmark
-               FloatColumnWriterBenchmark.cpp)
-target_link_libraries(
-  velox_dwrf_float_column_writer_benchmark
-  velox_vector
-  velox_dwio_common_exception
-  velox_dwio_dwrf_writer
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  fmt::fmt)
+  add_executable(velox_dwrf_float_column_writer_benchmark
+                 FloatColumnWriterBenchmark.cpp)
+  target_link_libraries(
+    velox_dwrf_float_column_writer_benchmark
+    velox_vector
+    velox_dwio_common_exception
+    velox_dwio_dwrf_writer
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    fmt::fmt)
+endif()
 
 add_executable(velox_dwio_cache_test CacheInputTest.cpp
                                      DirectBufferedInputTest.cpp)

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -49,8 +49,8 @@ target_link_libraries(
 if(VELOX_ENABLE_BENCHMARKS)
   add_executable(velox_dwio_parquet_reader_benchmark
                  ParquetReaderBenchmarkMain.cpp)
-  target_link_libraries(
-    velox_dwio_parquet_reader_benchmark velox_dwio_parquet_reader_benchmark_lib)
+  target_link_libraries(velox_dwio_parquet_reader_benchmark
+                        velox_dwio_parquet_reader_benchmark_lib)
 endif()
 
 add_executable(

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -46,10 +46,12 @@ target_link_libraries(
   ${FOLLY_BENCHMARK}
   Folly::folly)
 
-add_executable(velox_dwio_parquet_reader_benchmark
-               ParquetReaderBenchmarkMain.cpp)
-target_link_libraries(
-  velox_dwio_parquet_reader_benchmark velox_dwio_parquet_reader_benchmark_lib)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwio_parquet_reader_benchmark
+                 ParquetReaderBenchmarkMain.cpp)
+  target_link_libraries(
+    velox_dwio_parquet_reader_benchmark velox_dwio_parquet_reader_benchmark_lib)
+endif()
 
 add_executable(
   velox_dwio_parquet_reader_test
@@ -72,11 +74,13 @@ target_link_libraries(
   velox_dwio_parquet_structure_decoder_test velox_dwio_native_parquet_reader
   velox_link_libs ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_parquet_structure_decoder_benchmark
-               NestedStructureDecoderBenchmark.cpp)
-target_link_libraries(
-  velox_dwio_parquet_structure_decoder_benchmark
-  velox_dwio_native_parquet_reader Folly::folly ${FOLLY_BENCHMARK})
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_dwio_parquet_structure_decoder_benchmark
+                 NestedStructureDecoderBenchmark.cpp)
+  target_link_libraries(
+    velox_dwio_parquet_structure_decoder_benchmark
+    velox_dwio_native_parquet_reader Folly::folly ${FOLLY_BENCHMARK})
+endif()
 
 add_executable(velox_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
 add_test(

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -287,42 +287,44 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main)
 
-add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
-                                              SpillerBenchmarkBase.cpp)
-target_link_libraries(
-  velox_spiller_join_benchmark_base
-  velox_exec
-  velox_exec_test_lib
-  velox_memory
-  velox_vector_fuzzer
-  glog::glog
-  gflags::gflags
-  Folly::folly
-  pthread)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_library(velox_spiller_join_benchmark_base JoinSpillInputBenchmarkBase.cpp
+                                                SpillerBenchmarkBase.cpp)
+  target_link_libraries(
+    velox_spiller_join_benchmark_base
+    velox_exec
+    velox_exec_test_lib
+    velox_memory
+    velox_vector_fuzzer
+    glog::glog
+    gflags::gflags
+    Folly::folly
+    pthread)
 
-add_executable(velox_spiller_join_benchmark SpillerJoinInputBenchmarkTest.cpp)
-target_link_libraries(
-  velox_spiller_join_benchmark velox_exec velox_exec_test_lib
-  velox_spiller_join_benchmark_base)
+  add_executable(velox_spiller_join_benchmark SpillerJoinInputBenchmarkTest.cpp)
+  target_link_libraries(
+    velox_spiller_join_benchmark velox_exec velox_exec_test_lib
+    velox_spiller_join_benchmark_base)
 
-add_library(velox_spiller_aggregate_benchmark_base
-            AggregateSpillBenchmarkBase.cpp SpillerBenchmarkBase.cpp)
-target_link_libraries(
-  velox_spiller_aggregate_benchmark_base
-  velox_exec
-  velox_exec_test_lib
-  velox_memory
-  velox_vector_fuzzer
-  glog::glog
-  gflags::gflags
-  Folly::folly
-  pthread)
+  add_library(velox_spiller_aggregate_benchmark_base
+              AggregateSpillBenchmarkBase.cpp SpillerBenchmarkBase.cpp)
+  target_link_libraries(
+    velox_spiller_aggregate_benchmark_base
+    velox_exec
+    velox_exec_test_lib
+    velox_memory
+    velox_vector_fuzzer
+    glog::glog
+    gflags::gflags
+    Folly::folly
+    pthread)
 
-add_executable(velox_spiller_aggregate_benchmark
-               SpillerAggregateBenchmarkTest.cpp)
-target_link_libraries(
-  velox_spiller_aggregate_benchmark velox_exec velox_exec_test_lib
-  velox_spiller_aggregate_benchmark_base)
+  add_executable(velox_spiller_aggregate_benchmark
+                 SpillerAggregateBenchmarkTest.cpp)
+  target_link_libraries(
+    velox_spiller_aggregate_benchmark velox_exec velox_exec_test_lib
+    velox_spiller_aggregate_benchmark_base)
+endif()
 
 add_executable(cpr_http_client_test CprHttpClientTest.cpp)
 add_test(

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -302,9 +302,8 @@ if(VELOX_ENABLE_BENCHMARKS)
     pthread)
 
   add_executable(velox_spiller_join_benchmark SpillerJoinInputBenchmarkTest.cpp)
-  target_link_libraries(
-    velox_spiller_join_benchmark velox_exec velox_exec_test_lib
-    velox_spiller_join_benchmark_base)
+  target_link_libraries(velox_spiller_join_benchmark velox_exec
+                        velox_exec_test_lib velox_spiller_join_benchmark_base)
 
   add_library(velox_spiller_aggregate_benchmark_base
               AggregateSpillBenchmarkBase.cpp SpillerBenchmarkBase.cpp)

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -29,14 +29,16 @@ target_link_libraries(
   gflags::gflags
   glog::glog)
 
-add_executable(velox_serializer_benchmark SerializerBenchmark.cpp)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_serializer_benchmark SerializerBenchmark.cpp)
 
-target_link_libraries(
-  velox_serializer_benchmark
-  velox_presto_serializer
-  velox_vector_test_lib
-  velox_vector_fuzzer
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_serializer_benchmark
+    velox_presto_serializer
+    velox_vector_test_lib
+    velox_vector_fuzzer
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
+endif()

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -42,83 +42,85 @@ target_link_libraries(
   gflags::gflags
   glog::glog)
 
-add_executable(velox_filter_benchmark FilterBenchmark.cpp)
+if(VELOX_ENABLE_BENCHMARKS)
+  add_executable(velox_filter_benchmark FilterBenchmark.cpp)
 
-target_link_libraries(
-  velox_filter_benchmark
-  velox_type
-  velox_serialization
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_filter_benchmark
+    velox_type
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
 
-add_executable(velox_negated_values_filter_benchmark
-               NegatedValuesFilterBenchmark.cpp)
+  add_executable(velox_negated_values_filter_benchmark
+                 NegatedValuesFilterBenchmark.cpp)
 
-target_link_libraries(
-  velox_negated_values_filter_benchmark
-  velox_type
-  velox_serialization
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_negated_values_filter_benchmark
+    velox_type
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
 
-add_executable(velox_negated_bytes_values_benchmark
-               NegatedBytesValuesBenchmark.cpp)
+  add_executable(velox_negated_bytes_values_benchmark
+                 NegatedBytesValuesBenchmark.cpp)
 
-target_link_libraries(
-  velox_negated_bytes_values_benchmark
-  velox_type
-  velox_serialization
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_negated_bytes_values_benchmark
+    velox_type
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
 
-add_executable(velox_negated_bigint_range_benchmark
-               NegatedBigintRangeBenchmark.cpp)
+  add_executable(velox_negated_bigint_range_benchmark
+                 NegatedBigintRangeBenchmark.cpp)
 
-target_link_libraries(
-  velox_negated_bigint_range_benchmark
-  velox_type
-  velox_serialization
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_negated_bigint_range_benchmark
+    velox_type
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
 
-add_executable(velox_negated_bytes_range_benchmark
-               NegatedBytesRangeBenchmark.cpp)
+  add_executable(velox_negated_bytes_range_benchmark
+                 NegatedBytesRangeBenchmark.cpp)
 
-target_link_libraries(
-  velox_negated_bytes_range_benchmark
-  velox_type
-  velox_serialization
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_negated_bytes_range_benchmark
+    velox_type
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
 
-add_executable(velox_string_view_benchmark StringViewBenchmark.cpp)
+  add_executable(velox_string_view_benchmark StringViewBenchmark.cpp)
 
-target_link_libraries(
-  velox_string_view_benchmark
-  velox_type
-  Folly::folly
-  ${FOLLY_BENCHMARK}
-  GTest::gtest
-  GTest::gtest_main
-  gflags::gflags
-  glog::glog)
+  target_link_libraries(
+    velox_string_view_benchmark
+    velox_type
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    GTest::gtest
+    GTest::gtest_main
+    gflags::gflags
+    glog::glog)
+endif()


### PR DESCRIPTION
There is a number of benchmarks that are getting built even without `VELOX_ENABLE_BENCHMARKS` enabled, namely:

	velox/serializers/tests/velox_serializer_benchmark
	velox/dwio/parquet/tests/reader/velox_dwio_parquet_reader_benchmark
	velox/dwio/parquet/tests/reader/velox_dwio_parquet_structure_decoder_benchmark
	velox/dwio/dwrf/test/velox_dwrf_int_encoder_benchmark
	velox/dwio/dwrf/test/velox_dwrf_float_column_writer_benchmark
	velox/dwio/common/tests/velox_dwio_common_data_buffer_benchmark
	velox/dwio/common/tests/velox_dwio_common_int_decoder_benchmark
	velox/connectors/hive/iceberg/tests/velox_dwio_iceberg_reader_benchmark
	velox/exec/tests/velox_spiller_aggregate_benchmark
	velox/exec/tests/velox_spiller_join_benchmark
	velox/common/memory/tests/velox_fragmentation_benchmark
	velox/common/memory/tests/velox_concurrent_allocation_benchmark
	velox/type/tests/velox_negated_bytes_values_benchmark
	velox/type/tests/velox_filter_benchmark
	velox/type/tests/velox_negated_values_filter_benchmark
	velox/type/tests/velox_string_view_benchmark
	velox/type/tests/velox_negated_bigint_range_benchmark
	velox/type/tests/velox_negated_bytes_range_benchmark

This unnecessarily increases build times for basic builds.