### PR TITLE
feat: Allow fixed random seed in approx_percentile for debug purpose

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -423,6 +423,14 @@ class QueryConfig {
   static constexpr const char* kDebugDisableExpressionWithLazyInputs =
       "debug_disable_expression_with_lazy_inputs";
 
+  /// Fix the random seed used to create data structure used in
+  /// approx_percentile.  This makes the query result deterministic on single
+  /// node; multi-node partial aggregation is still subject to non-determinism
+  /// due to non-deterministic merge order.
+  static constexpr const char*
+      kDebugAggregationApproxPercentileFixedRandomSeed =
+          "debug_aggregation_approx_percentile_fixed_random_seed";
+
   /// Temporary flag to control whether selective Nimble reader should be used
   /// in this query or not.  Will be removed after the selective Nimble reader
   /// is fully rolled out.
@@ -447,6 +455,11 @@ class QueryConfig {
 
   bool debugDisableExpressionsWithLazyInputs() const {
     return get<bool>(kDebugDisableExpressionWithLazyInputs, false);
+  }
+
+  std::optional<uint32_t> debugAggregationApproxPercentileFixedRandomSeed()
+      const {
+    return get<uint32_t>(kDebugAggregationApproxPercentileFixedRandomSeed);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/functions/lib/KllSketch.h
+++ b/velox/functions/lib/KllSketch.h
@@ -124,6 +124,10 @@ struct KllSketch {
     return n_;
   }
 
+  uint32_t k() const {
+    return k_;
+  }
+
   /// Calculate the size needed for serialization.
   size_t serializedByteSize() const;
 

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -90,6 +90,9 @@ class ApproxPercentileTest : public AggregationTestBase {
   void SetUp() override {
     AggregationTestBase::SetUp();
     random::setSeed(0);
+    queryConfig_
+        [core::QueryConfig::kDebugAggregationApproxPercentileFixedRandomSeed] =
+            "0";
   }
 
   template <typename T>
@@ -142,12 +145,14 @@ class ApproxPercentileTest : public AggregationTestBase {
         {rows},
         {},
         {functionCall(false, weights.get(), percentile, accuracy, -1)},
-        expected);
+        expected,
+        queryConfig_);
     testAggregations(
         {rows},
         {},
         {functionCall(false, weights.get(), percentile, accuracy, 3)},
-        expectedArray);
+        expectedArray,
+        queryConfig_);
 
     // Companion functions of approx_percentile do not support test streaming
     // because intermediate results are KLL that has non-deterministic shape.
@@ -159,7 +164,8 @@ class ApproxPercentileTest : public AggregationTestBase {
         {functionCall(false, weights.get(), percentile, accuracy, -1)},
         {getArgTypes(values->type(), weights.get(), accuracy, -1)},
         {},
-        expected);
+        expected,
+        queryConfig_);
     testAggregationsWithCompanion(
         {rows},
         [](auto& /*builder*/) {},
@@ -167,7 +173,8 @@ class ApproxPercentileTest : public AggregationTestBase {
         {functionCall(false, weights.get(), percentile, accuracy, 3)},
         {getArgTypes(values->type(), weights.get(), accuracy, 3)},
         {},
-        expectedArray);
+        expectedArray,
+        queryConfig_);
   }
 
   template <typename T>
@@ -208,7 +215,8 @@ class ApproxPercentileTest : public AggregationTestBase {
         {rows},
         {"c0"},
         {functionCall(true, weights.get(), percentile, accuracy, -1)},
-        {expectedResult});
+        {expectedResult},
+        queryConfig_);
 
     // Companion functions of approx_percentile do not support test streaming
     // because intermediate results are KLL that has non-deterministic shape.
@@ -220,7 +228,8 @@ class ApproxPercentileTest : public AggregationTestBase {
         {functionCall(true, weights.get(), percentile, accuracy, -1)},
         {getArgTypes(values->type(), weights.get(), accuracy, -1)},
         {},
-        {expectedResult});
+        {expectedResult},
+        queryConfig_);
 
     {
       SCOPED_TRACE("Percentile array");
@@ -264,7 +273,8 @@ class ApproxPercentileTest : public AggregationTestBase {
           {rows},
           {"c0"},
           {functionCall(true, weights.get(), percentile, accuracy, 3)},
-          {expected});
+          {expected},
+          queryConfig_);
 
       // Companion functions of approx_percentile do not support test streaming
       // because intermediate results are KLL that has non-deterministic shape.
@@ -276,9 +286,13 @@ class ApproxPercentileTest : public AggregationTestBase {
           {functionCall(true, weights.get(), percentile, accuracy, 3)},
           {getArgTypes(values->type(), weights.get(), accuracy, 3)},
           {},
-          {expected});
+          {expected},
+          queryConfig_);
     }
   }
+
+ private:
+  std::unordered_map<std::string, std::string> queryConfig_;
 };
 
 TEST_F(ApproxPercentileTest, globalAgg) {


### PR DESCRIPTION
Summary:
Also reduce the memory usage by removing redundant information from
accumulator.

Differential Revision: D66602894


