### PR TITLE
feat: Print operator stats in query replayer

### DIFF
--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -50,7 +50,7 @@ class OperatorReplayerBase {
       const core::PlanNodeId& nodeId,
       const core::PlanNodePtr& source) const = 0;
 
-  core::PlanNodePtr createPlan() const;
+  core::PlanNodePtr createPlan();
 
   const std::string queryId_;
   const std::string taskId_;
@@ -68,6 +68,9 @@ class OperatorReplayerBase {
   std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
       connectorConfigs_;
   core::PlanNodePtr planFragment_;
+  core::PlanNodeId replayPlanNodeId_;
+
+  void printStats(const std::shared_ptr<exec::Task>& task) const;
 
  private:
   std::function<core::PlanNodePtr(std::string, core::PlanNodePtr)>

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -135,7 +135,7 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
 }
 
 RowVectorPtr PartitionedOutputReplayer::run() {
-  auto task = Task::create(
+  const auto task = Task::create(
       "local://partitioned-output-replayer",
       core::PlanFragment{createPlan()},
       0,
@@ -150,6 +150,7 @@ RowVectorPtr PartitionedOutputReplayer::run() {
       executor_.get(),
       consumerExecutor_.get(),
       consumerCb_);
+  printStats(task);
   return nullptr;
 }
 

--- a/velox/tool/trace/TableScanReplayer.cpp
+++ b/velox/tool/trace/TableScanReplayer.cpp
@@ -28,13 +28,17 @@ using namespace facebook::velox::exec::test;
 namespace facebook::velox::tool::trace {
 
 RowVectorPtr TableScanReplayer::run() {
+  std::shared_ptr<exec::Task> task;
   const auto plan = createPlan();
-  return exec::test::AssertQueryBuilder(plan)
-      .maxDrivers(driverIds_.size())
-      .configs(queryConfigs_)
-      .connectorSessionProperties(connectorConfigs_)
-      .splits(getSplits())
-      .copyResults(memory::MemoryManager::getInstance()->tracePool());
+  const auto result =
+      exec::test::AssertQueryBuilder(plan)
+          .maxDrivers(driverIds_.size())
+          .configs(queryConfigs_)
+          .connectorSessionProperties(connectorConfigs_)
+          .splits(getSplits())
+          .copyResults(memory::MemoryManager::getInstance()->tracePool(), task);
+  printStats(task);
+  return result;
 }
 
 core::PlanNodePtr TableScanReplayer::createPlanNode(


### PR DESCRIPTION
Print operator stats in query replayer.

Part of #9668 