### PR TITLE
feat(column selector): allow row type

### DIFF
--- a/velox/dwio/common/ColumnSelector.cpp
+++ b/velox/dwio/common/ColumnSelector.cpp
@@ -295,10 +295,9 @@ const FilterTypePtr& ColumnSelector::process(const std::string& column, bool) {
     // when seeing this type of column, we require it has to exist
     const auto& node = findNode(pair.first);
     if (node->valid()) {
-      DWIO_ENSURE_EQ(
-          node->getKind(),
-          TypeKind::MAP,
-          "only support expression for map type currently: ",
+      DWIO_ENSURE(
+          node->getKind() == TypeKind::MAP || node->getKind() == TypeKind::ROW,
+          "only support expression for map or row type currently: ",
           column);
 
       // set expression for this node

--- a/velox/dwio/common/tests/ColumnSelectorTests.cpp
+++ b/velox/dwio/common/tests/ColumnSelectorTests.cpp
@@ -367,6 +367,32 @@ TEST(ColumnSelectorTests, testMapKeyFilterSyntax) {
   EXPECT_TRUE(tags2->valid());
 }
 
+TEST(ColumnSelectorTests, testFlatMapKeyFilterAllowed) {
+  const auto schema =
+      "struct<"
+      "id:bigint"
+      "values:array<float>"
+      "tags:struct<1:string, 2:string, 3:string>"
+      "notes:struct<f1:int, f2:double, f3:string>"
+      "memo:string>";
+
+  auto type =
+      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse(schema));
+
+  // check a specialized filter is supported
+  // real data reading support test please refer flat map column reader testing
+
+  ColumnSelector specialSelector(
+      type, std::vector<std::string>{"tags#[1,2,3]"});
+
+  auto filter = specialSelector.getProjection();
+  EXPECT_EQ(filter.size(), 1);
+
+  EXPECT_EQ(filter[0].name, "tags");
+  EXPECT_EQ(filter[0].column, 2);
+  EXPECT_EQ(filter[0].node, 4);
+}
+
 TEST(ColumnSelectorTests, testPartitionKeysMark) {
   const auto schema = std::dynamic_pointer_cast<const RowType>(
       HiveTypeParser().parse("struct<"


### PR DESCRIPTION
Summary: We need to this change to support reading flatmap columns as Row type instead of map type.

Differential Revision:
D66532239

Privacy Context Container: L1309469


