### PR TITLE
feat: Add auto scale writer support

### DIFF
--- a/velox/common/base/SkewedPartitionBalancer.h
+++ b/velox/common/base/SkewedPartitionBalancer.h
@@ -60,7 +60,6 @@ class SkewedPartitionRebalancer {
   /// processed bytes of a partition.
   void addPartitionRowCount(uint32_t partition, uint32_t numRows) {
     VELOX_CHECK_LT(partition, partitionCount_);
-    VELOX_CHECK_GT(numRows, 0);
     partitionRowCount_[partition] += numRows;
   }
 

--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -320,7 +320,7 @@ TEST_F(SkewedPartitionRebalancerTest, error) {
   auto balancer = createBalancer(32, 4, 128, 256);
   VELOX_ASSERT_THROW(balancer->addProcessedBytes(0), "");
   VELOX_ASSERT_THROW(balancer->addPartitionRowCount(32, 4), "");
-  VELOX_ASSERT_THROW(balancer->addPartitionRowCount(0, 0), "");
+  balancer->addPartitionRowCount(0, 0);
   VELOX_ASSERT_THROW(createBalancer(0, 4, 128, 256), "");
   VELOX_ASSERT_THROW(createBalancer(0, 4, 0, 0), "");
 }

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -64,7 +64,7 @@ uint32_t HiveConfig::maxPartitionsPerWriters(
     const config::ConfigBase* session) const {
   return session->get<uint32_t>(
       kMaxPartitionsPerWritersSession,
-      config_->get<uint32_t>(kMaxPartitionsPerWriters, 100));
+      config_->get<uint32_t>(kMaxPartitionsPerWriters, 128));
 }
 
 bool HiveConfig::immutablePartitions() const {

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -31,7 +31,7 @@ TEST(HiveConfigTest, defaultConfig) {
       hiveConfig.insertExistingPartitionsBehavior(emptySession.get()),
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kError);
-  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 100);
+  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 128);
   ASSERT_EQ(hiveConfig.immutablePartitions(), false);
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
@@ -172,7 +172,7 @@ TEST(HiveConfigTest, overrideSession) {
       hiveConfig.insertExistingPartitionsBehavior(session.get()),
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
-  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(session.get()), 100);
+  ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(session.get()), 128);
   ASSERT_EQ(hiveConfig.immutablePartitions(), false);
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1998,11 +1998,15 @@ void LocalPartitionNode::addDetails(std::stringstream& stream) const {
   if (type_ != Type::kGather) {
     stream << " " << partitionFunctionSpec_->toString();
   }
+  if (scaleWriter_) {
+    stream << " scaleWriter";
+  }
 }
 
 folly::dynamic LocalPartitionNode::serialize() const {
   auto obj = PlanNode::serialize();
   obj["type"] = typeName(type_);
+  obj["scaleWriter"] = scaleWriter_;
   obj["partitionFunctionSpec"] = partitionFunctionSpec_->serialize();
   return obj;
 }
@@ -2014,6 +2018,7 @@ PlanNodePtr LocalPartitionNode::create(
   return std::make_shared<LocalPartitionNode>(
       deserializePlanNodeId(obj),
       typeFromName(obj["type"].asString()),
+      obj["scaleWriter"].asBool(),
       ISerializable::deserialize<PartitionFunctionSpec>(
           obj["partitionFunctionSpec"]),
       deserializeSources(obj, context));

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -437,6 +437,31 @@ class QueryConfig {
   static constexpr const char* kSelectiveNimbleReaderEnabled =
       "selective_nimble_reader_enabled";
 
+  /// The max ratio of a query used memory to its max capacity, and the scale
+  /// writer exchange stops scaling writer processing if the query's current
+  /// memory usage exceeds this ratio. The value is in the range of (0, 1].
+  static constexpr const char* kScaleWriterRebalanceMaxMemoryUsageRatio =
+      "scaled_writer_rebalance_max_memory_usage_ratio";
+
+  /// The max number of logical table partitions that can be assigned to a
+  /// single table writer thread. The logical table partition is used by local
+  /// exchange writer for writer scaling, and multiple physical table
+  /// partitions can be mapped to the same logical table partition based on the
+  /// hash value of calculated partitioned ids.
+  static constexpr const char* kScaleWriterMaxPartitionsPerWriter =
+      "scaled_writer_max_partitions_per_writer";
+
+  /// Minimum amount of data processed by a logical table partition to trigger
+  /// writer scaling if it is detected as overloaded by scale wrirer exchange.
+  static constexpr const char*
+      kScaleWriterMinPartitionProcessedBytesRebalanceThreshold =
+          "scaled_writer_min_partition_processed_bytes_rebalance_threshold";
+
+  /// Minimum amount of data processed by all the logical table partitions to
+  /// trigger skewed partition rebalancing by scale writer exchange.
+  static constexpr const char* kScaleWriterMinProcessedBytesRebalanceThreshold =
+      "scaled_writer_min_processed_bytes_rebalance_threshold";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -817,6 +842,24 @@ class QueryConfig {
 
   int32_t prefixSortMinRows() const {
     return get<int32_t>(kPrefixSortMinRows, 130);
+  }
+
+  double scaleWriterRebalanceMaxMemoryUsageRatio() const {
+    return get<double>(kScaleWriterRebalanceMaxMemoryUsageRatio, 0.7);
+  }
+
+  uint32_t scaleWriterMaxPartitionsPerWriter() const {
+    return get<uint32_t>(kScaleWriterMaxPartitionsPerWriter, 128);
+  }
+
+  uint64_t scaleWriterMinPartitionProcessedBytesRebalanceThreshold() const {
+    return get<uint64_t>(
+        kScaleWriterMinPartitionProcessedBytesRebalanceThreshold, 128 << 20);
+  }
+
+  uint64_t scaleWriterMinProcessedBytesRebalanceThreshold() const {
+    return get<uint64_t>(
+        kScaleWriterMinProcessedBytesRebalanceThreshold, 256 << 20);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -400,7 +400,32 @@ Table Writer
    * - task_partitioned_writer_count
      - integer
      - task_writer_count
-     - The number of parallel table writer threads per task for partitioned table writes. If not set, use 'task_writer_count' as default.
+     - The number of parallel table writer threads per task for partitioned
+       table writes. If not set, use 'task_writer_count' as default.
+   * - scaled_writer_rebalance_max_memory_usage_ratio
+     - double
+     - 0.7
+     - The max ratio of a query used memory to its max capacity, and the scale
+     - writer exchange stops scaling writer processing if the query's current
+     - memory usage exceeds this ratio. The value is in the range of (0, 1].
+   * - scaled_writer_max_partitions_per_writer
+     - integer
+     - 128
+     - The max number of logical table partitions that can be assigned to a
+     - single table writer thread. The logical table partition is used by local
+     - exchange writer for writer scaling, and multiple physical table
+     - partitions can be mapped to the same logical table partition based on the
+     - hash value of calculated partitioned ids.
+     - integer
+     - 128MB
+   * - scaled_writer_min_partition_processed_bytes_rebalance_threshold
+     - Minimum amount of data processed by a logical table partition to trigger
+     - writer scaling if it is detected as overloaded by scale wrirer exchange.
+   * - scaled_writer_min_processed_bytes_rebalance_threshold
+     - Minimum amount of data processed by all the logical table partitions to
+     - trigger skewed partition rebalancing by scale writer exchange.
+     - integer
+     - 256MB
 
 Hive Connector
 --------------

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -438,6 +438,7 @@ Storage
    * - storage_network_throttled_count
      - Count
      - The number of times that storage IOs get throttled in a storage cluster because of network.
+
 Spilling
 --------
 

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -104,6 +104,17 @@ These stats are reported only by TableWriter operator
    * - earlyFlushedRawBytes
      - bytes
      - Number of bytes pre-maturely flushed from file writers because of memory reclaiming.
+   * - rebalanceTriggers
+     -
+     - The number of times that we triggers the rebalance of table partitions
+       for a non-bucketed partition table.
+   * - scaledPartitions
+     -
+     - The number of times that we scale a partition processing for a
+       non-bucketed partition table.
+   * - scaledWriters
+     -
+     - The number of times that we scale writers for a non-partitioned table.
 
 Spilling
 --------

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -74,6 +74,7 @@ velox_add_library(
   RowsStreamingWindowBuild.cpp
   RowContainer.cpp
   RowNumber.cpp
+  ScaleWriterLocalPartition.cpp
   SortBuffer.cpp
   SortedAggregations.cpp
   SortWindowBuild.cpp

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/ScaleWriterLocalPartition.h"
+
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/RoundRobinPartitionFunction.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+ScaleWriterPartitioningLocalPartition::ScaleWriterPartitioningLocalPartition(
+    int32_t operatorId,
+    DriverCtx* ctx,
+    const std::shared_ptr<const core::LocalPartitionNode>& planNode)
+    : LocalPartition(operatorId, ctx, planNode),
+      maxQueryMemoryUsageRatio_(
+          ctx->queryConfig().scaleWriterRebalanceMaxMemoryUsageRatio()),
+      maxTablePartitionsPerWriter_(
+          ctx->queryConfig().scaleWriterMaxPartitionsPerWriter()),
+      numTablePartitions_(maxTablePartitionsPerWriter_ * numPartitions_),
+      queryPool_(pool()->root()),
+      tablePartitionRebalancer_(std::make_unique<SkewedPartitionRebalancer>(
+          numTablePartitions_,
+          numPartitions_,
+          ctx->queryConfig()
+              .scaleWriterMinPartitionProcessedBytesRebalanceThreshold(),
+          ctx->queryConfig()
+              .scaleWriterMinProcessedBytesRebalanceThreshold())) {
+  VELOX_CHECK_GT(maxTablePartitionsPerWriter_, 0);
+
+  writerAssignmentCounts_.resize(numPartitions_, 0);
+  tablePartitionRowCounts_.resize(numTablePartitions_, 0);
+  tablePartitionWriterIds_.resize(numTablePartitions_, -1);
+  tablePartitionWriterIndexes_.resize(numTablePartitions_, 0);
+  writerAssignmmentIndicesBuffers_.resize(numPartitions_);
+  rawWriterAssignmmentIndicesBuffers_.resize(numPartitions_);
+
+  // Reset the hash partition function with the number of logical table
+  // partitions instead of the number of table writers.
+  // 'tablePartitionRebalancer_' is responsible for maintaining the mapping
+  // from logical table partition id to the assigned table writer ids.
+  partitionFunction_ = numPartitions_ == 1
+      ? nullptr
+      : planNode->partitionFunctionSpec().create(
+            numTablePartitions_,
+            /*localExchange=*/true);
+  if (partitionFunction_ != nullptr) {
+    VELOX_CHECK_NOT_NULL(
+        dynamic_cast<HashPartitionFunction*>(partitionFunction_.get()));
+  }
+}
+
+void ScaleWriterPartitioningLocalPartition::initialize() {
+  LocalPartition::initialize();
+  VELOX_CHECK_NULL(memoryManager_);
+  memoryManager_ =
+      operatorCtx_->driver()->task()->getLocalExchangeMemoryManager(
+          operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+}
+
+void ScaleWriterPartitioningLocalPartition::prepareForWriterAssignments(
+    vector_size_t numInput) {
+  const auto maxIndicesBufferBytes = numInput * sizeof(vector_size_t);
+  for (auto writerId = 0; writerId < numPartitions_; ++writerId) {
+    if (writerAssignmmentIndicesBuffers_[writerId] == nullptr ||
+        !writerAssignmmentIndicesBuffers_[writerId]->unique() ||
+        writerAssignmmentIndicesBuffers_[writerId]->size() <
+            maxIndicesBufferBytes) {
+      writerAssignmmentIndicesBuffers_[writerId] =
+          allocateIndices(numInput, pool());
+      rawWriterAssignmmentIndicesBuffers_[writerId] =
+          writerAssignmmentIndicesBuffers_[writerId]
+              ->asMutable<vector_size_t>();
+    }
+  }
+  std::fill(writerAssignmentCounts_.begin(), writerAssignmentCounts_.end(), 0);
+  // Reset the value of partition writer id assignments for the new input.
+  std::fill(
+      tablePartitionWriterIds_.begin(), tablePartitionWriterIds_.end(), -1);
+}
+
+void ScaleWriterPartitioningLocalPartition::addInput(RowVectorPtr input) {
+  prepareForInput(input);
+
+  if (numPartitions_ == 1) {
+    ContinueFuture future;
+    auto blockingReason =
+        queues_[0]->enqueue(input, input->retainedSize(), &future);
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      blockingReasons_.push_back(blockingReason);
+      futures_.push_back(std::move(future));
+    }
+    return;
+  }
+
+  // Scale up writers when current buffer memory utilization is more than 50%
+  // of the maximum. This also mean that we won't scale local  writers if the
+  // writing speed can keep up with incoming data. In another word, buffer
+  // utilization is below 50%.
+  //
+  // TODO: investigate using the consumer/producer queue time ratio as
+  // additional signal to trigger rebalance to avoid unnecessary rebalancing
+  // when the worker is overloaded which might cause a lot of queuing on both
+  // producer and consumer sides. The buffered memory ratio is not a reliable
+  // signal in that case.
+  if ((memoryManager_->bufferedBytes() >
+       memoryManager_->maxBufferBytes() * 0.5) &&
+      // Do not scale up if total memory used is greater than
+      // 'maxQueryMemoryUsageRatio_' of max query memory capacity. We have to be
+      // conservative here otherwise scaling of writers will happen first
+      // before we hit the query memory capacity limit, and then we won't be
+      // able to do anything to prevent query OOM.
+      queryPool_->reservedBytes() <
+          queryPool_->maxCapacity() * maxQueryMemoryUsageRatio_) {
+    tablePartitionRebalancer_->rebalance();
+  }
+
+  const auto singlePartition =
+      partitionFunction_->partition(*input, partitions_);
+
+  const auto numInput = input->size();
+  const int64_t totalInputBytes = input->retainedSize();
+  // Reset the value of partition row count for the new input.
+  std::fill(
+      tablePartitionRowCounts_.begin(), tablePartitionRowCounts_.end(), 0);
+
+  // Assign each row to a writer by looking at logical table partition
+  // assignments maintained by 'tablePartitionRebalancer_'.
+  //
+  // Get partition id which limits to 'tablePartitionCount_'. If there are
+  // more physical table partitions than the logical 'tablePartitionCount_',
+  // then it is possible that multiple physical table partitions will get
+  // assigned the same logical partition id. Thus, multiple table partitions
+  // will be scaled together since we track the written bytes of a logical table
+  // partition.
+  if (singlePartition.has_value()) {
+    const auto partitionId = singlePartition.value();
+    tablePartitionRowCounts_[partitionId] = numInput;
+
+    VELOX_CHECK_EQ(tablePartitionWriterIds_[partitionId], -1);
+    const auto writerId = getNextWriterId(partitionId);
+    ContinueFuture future;
+    auto blockingReason =
+        queues_[writerId]->enqueue(input, totalInputBytes, &future);
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      blockingReasons_.push_back(blockingReason);
+      futures_.push_back(std::move(future));
+    }
+  } else {
+    prepareForWriterAssignments(numInput);
+
+    for (auto row = 0; row < numInput; ++row) {
+      const auto partitionId = partitions_[row];
+      ++tablePartitionRowCounts_[partitionId];
+
+      // Get writer id for this partition by looking at the scaling state.
+      auto writerId = tablePartitionWriterIds_[partitionId];
+      if (writerId == -1) {
+        writerId = getNextWriterId(partitionId);
+        tablePartitionWriterIds_[partitionId] = writerId;
+      }
+      rawWriterAssignmmentIndicesBuffers_[writerId]
+                                         [writerAssignmentCounts_[writerId]++] =
+                                             row;
+    }
+
+    for (auto i = 0; i < numPartitions_; ++i) {
+      const auto writerRowCount = writerAssignmentCounts_[i];
+      if (writerRowCount == 0) {
+        continue;
+      }
+
+      auto writerInput = wrapChildren(
+          input,
+          writerRowCount,
+          std::move(writerAssignmmentIndicesBuffers_[i]));
+      ContinueFuture future;
+      auto reason = queues_[i]->enqueue(
+          writerInput, totalInputBytes * writerRowCount / numInput, &future);
+      if (reason != BlockingReason::kNotBlocked) {
+        blockingReasons_.push_back(reason);
+        futures_.push_back(std::move(future));
+      }
+    }
+  }
+
+  // Only update the scaling state if the memory used is below the
+  // 'maxQueryMemoryUsageRatio_' limit. Otherwise, if we keep updating the
+  // scaling state and the memory used is fluctuating around the limit, then we
+  // could do massive scaling in a single rebalancing cycle which could cause
+  // query OOM.
+  if (queryPool_->reservedBytes() <
+      queryPool_->maxCapacity() * maxQueryMemoryUsageRatio_) {
+    for (auto tablePartition = 0; tablePartition < numTablePartitions_;
+         ++tablePartition) {
+      tablePartitionRebalancer_->addPartitionRowCount(
+          tablePartition, tablePartitionRowCounts_[tablePartition]);
+    }
+    tablePartitionRebalancer_->addProcessedBytes(totalInputBytes);
+  }
+}
+
+uint32_t ScaleWriterPartitioningLocalPartition::getNextWriterId(
+    uint32_t partitionId) {
+  return tablePartitionRebalancer_->getTaskId(
+      partitionId, tablePartitionWriterIndexes_[partitionId]++);
+}
+
+void ScaleWriterPartitioningLocalPartition::close() {
+  LocalPartition::close();
+
+  const auto scaleStats = tablePartitionRebalancer_->stats();
+  auto lockedStats = stats_.wlock();
+  if (scaleStats.numScaledPartitions != 0) {
+    lockedStats->addRuntimeStat(
+        kScaledPartitions, RuntimeCounter(scaleStats.numScaledPartitions));
+  }
+  if (scaleStats.numBalanceTriggers != 0) {
+    lockedStats->addRuntimeStat(
+        kRebalanceTriggers, RuntimeCounter(scaleStats.numBalanceTriggers));
+  }
+}
+
+ScaleWriterLocalPartition::ScaleWriterLocalPartition(
+    int32_t operatorId,
+    DriverCtx* ctx,
+    const std::shared_ptr<const core::LocalPartitionNode>& planNode)
+    : LocalPartition(operatorId, ctx, planNode),
+      maxQueryMemoryUsageRatio_(
+          ctx->queryConfig().scaleWriterRebalanceMaxMemoryUsageRatio()),
+      queryPool_(pool()->root()),
+      minDataProcessedBytes_(
+          ctx->queryConfig()
+              .scaleWriterMinPartitionProcessedBytesRebalanceThreshold()) {
+  if (partitionFunction_ != nullptr) {
+    VELOX_CHECK_NOT_NULL(
+        dynamic_cast<RoundRobinPartitionFunction*>(partitionFunction_.get()));
+  }
+}
+
+void ScaleWriterLocalPartition::initialize() {
+  LocalPartition::initialize();
+  VELOX_CHECK_NULL(memoryManager_);
+  memoryManager_ =
+      operatorCtx_->driver()->task()->getLocalExchangeMemoryManager(
+          operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+}
+
+void ScaleWriterLocalPartition::addInput(RowVectorPtr input) {
+  prepareForInput(input);
+
+  const int64_t totalInputBytes = input->retainedSize();
+  processedDataBytes_ += totalInputBytes;
+
+  uint32_t writerId = 0;
+  if (numPartitions_ > 1) {
+    writerId = getNextWriterId();
+  }
+  VELOX_CHECK_LT(writerId, numPartitions_);
+
+  ContinueFuture future;
+  auto blockingReason =
+      queues_[writerId]->enqueue(input, input->retainedSize(), &future);
+  if (blockingReason != BlockingReason::kNotBlocked) {
+    blockingReasons_.push_back(blockingReason);
+    futures_.push_back(std::move(future));
+  }
+}
+
+uint32_t ScaleWriterLocalPartition::getNextWriterId() {
+  VELOX_CHECK_LE(numWriters_, numPartitions_);
+  VELOX_CHECK_GE(processedDataBytes_, processedBytesAtLastScale_);
+
+  // Scale up writers when current buffer memory utilization is more than 50%
+  // of the maximum. This also mean that we won't scale local  writers if the
+  // writing speed can keep up with incoming data. In another word, buffer
+  // utilization is below 50%.
+  //
+  // TODO: investigate using the consumer/producer queue time ratio as
+  // additional signal to trigger rebalance to avoid unnecessary rebalancing
+  // when the worker is overloaded which might cause a lot of queuing on both
+  // producer and consumer sides. The buffered memory ratio is not a reliable
+  // signal in that case.
+  if ((numWriters_ < numPartitions_) &&
+      (memoryManager_->bufferedBytes() >=
+       memoryManager_->maxBufferBytes() / 2) &&
+      // Do not scale up if total memory used is greater than
+      // 'maxQueryMemoryUsageRatio_' of max query memory capacity. We have to be
+      // conservative here otherwise scaling of writers will happen first
+      // before we hit the query memory capacity limit, and then we won't be
+      // able to do anything to prevent query OOM.
+      (processedDataBytes_ - processedBytesAtLastScale_ >=
+       numWriters_ * minDataProcessedBytes_) &&
+      (queryPool_->reservedBytes() <
+       queryPool_->maxCapacity() * maxQueryMemoryUsageRatio_)) {
+    ++numWriters_;
+    processedBytesAtLastScale_ = processedDataBytes_;
+    LOG(INFO) << "Scaled task writer count to: " << numWriters_
+              << " with max of " << numPartitions_;
+  }
+  return (nextWriterIndex_++) % numWriters_;
+}
+
+void ScaleWriterLocalPartition::close() {
+  LocalPartition::close();
+
+  if (numWriters_ == 1) {
+    return;
+  }
+  stats_.wlock()->addRuntimeStat(
+      kScaledWriters, RuntimeCounter(numWriters_ - 1));
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/ScaleWriterLocalPartition.h
+++ b/velox/exec/ScaleWriterLocalPartition.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/base/SkewedPartitionBalancer.h"
+#include "velox/exec/LocalPartition.h"
+
+namespace facebook::velox::exec {
+
+using namespace facebook::velox::common;
+
+/// Customized local partition for writer scaling for (non-bucketed) partitioned
+/// table write.
+class ScaleWriterPartitioningLocalPartition : public LocalPartition {
+ public:
+  ScaleWriterPartitioningLocalPartition(
+      int32_t operatorId,
+      DriverCtx* ctx,
+      const std::shared_ptr<const core::LocalPartitionNode>& planNode);
+
+  std::string toString() const override {
+    return fmt::format(
+        "ScaleWriterPartitioningLocalPartition({})", numPartitions_);
+  }
+
+  void initialize() override;
+
+  void addInput(RowVectorPtr input) override;
+
+  void close() override;
+
+  /// The name of the runtime stats of writer scaling.
+  /// The number of times that we triggers the rebalance of table partitions.
+  static inline const std::string kRebalanceTriggers{"rebalanceTriggers"};
+  /// The number of times that we scale a partition processing.
+  static inline const std::string kScaledPartitions{"scaledPartitions"};
+
+ private:
+  void prepareForWriterAssignments(vector_size_t numInput);
+
+  uint32_t getNextWriterId(uint32_t partitionId);
+
+  // The max query memory usage ratio before we stop writer scaling.
+  const double maxQueryMemoryUsageRatio_;
+  // The max number of logical table partitions that can be assigned to a single
+  // table writer thread. Multiple physical table partitions can be mapped to
+  // one logical table partition.
+  const uint32_t maxTablePartitionsPerWriter_;
+  // The total number of logical table partitions that can be served by all the
+  // table writer threads.
+  const uint32_t numTablePartitions_;
+
+  memory::MemoryPool* const queryPool_;
+
+  // The skewed partition balancer for writer scaling.
+  const std::unique_ptr<SkewedPartitionRebalancer> tablePartitionRebalancer_;
+
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
+
+  // Reusable memory for writer assignment processing.
+  std::vector<uint32_t> tablePartitionRowCounts_;
+  std::vector<int32_t> tablePartitionWriterIds_;
+  std::vector<uint32_t> tablePartitionWriterIndexes_;
+
+  // Reusable memory for writer assignment processing.
+  std::vector<vector_size_t> writerAssignmentCounts_;
+  std::vector<BufferPtr> writerAssignmmentIndicesBuffers_;
+  std::vector<vector_size_t*> rawWriterAssignmmentIndicesBuffers_;
+};
+
+/// Customized local partition for writer scaling for un-partitioned table
+/// write.
+class ScaleWriterLocalPartition : public LocalPartition {
+ public:
+  ScaleWriterLocalPartition(
+      int32_t operatorId,
+      DriverCtx* ctx,
+      const std::shared_ptr<const core::LocalPartitionNode>& planNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  void initialize() override;
+
+  void close() override;
+
+  /// The name of the runtime stats of writer scaling.
+  /// The number of scaled writers.
+  static inline const std::string kScaledWriters{"scaledWriters"};
+
+ private:
+  // Gets the writer id to process the next input in a round-robin manner.
+  uint32_t getNextWriterId();
+
+  // The max query memory usage ratio before we stop writer scaling.
+  const double maxQueryMemoryUsageRatio_;
+  memory::MemoryPool* const queryPool_;
+  // The minimal amount of processed data bytes before we trigger next writer
+  // scaling.
+  const uint64_t minDataProcessedBytes_;
+
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
+
+  // The number of assigned writers.
+  uint32_t numWriters_{1};
+  // The monotonically increasing writer index to find the next writer id in a
+  // round-robin manner.
+  uint32_t nextWriterIndex_{0};
+  // The total processed data bytes from all writers.
+  uint64_t processedDataBytes_{0};
+  // The total processed data bytes at the last writer scaling.
+  uint64_t processedBytesAtLastScale_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -272,8 +272,10 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
       VELOX_CHECK(stats.spillStats.empty());
       return;
     }
-    lockedStats->addRuntimeStat(
-        "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
+    if (stats.numWrittenFiles != 0) {
+      lockedStats->addRuntimeStat(
+          "numWrittenFiles", RuntimeCounter(stats.numWrittenFiles));
+    }
     lockedStats->addRuntimeStat(
         "writeIOTime",
         RuntimeCounter(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2587,6 +2587,22 @@ Task::getLocalExchangeQueues(
   return it->second.queues;
 }
 
+const std::shared_ptr<LocalExchangeMemoryManager>&
+Task::getLocalExchangeMemoryManager(
+    uint32_t splitGroupId,
+    const core::PlanNodeId& planNodeId) {
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
+
+  auto it = splitGroupState.localExchanges.find(planNodeId);
+  VELOX_CHECK(
+      it != splitGroupState.localExchanges.end(),
+      "Incorrect local exchange ID {} for group {}, task {}",
+      planNodeId,
+      splitGroupId,
+      taskId());
+  return it->second.memoryManager;
+}
+
 void Task::setError(const std::exception_ptr& exception) {
   TestValue::adjust("facebook::velox::exec::Task::setError", this);
   {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -467,6 +467,11 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
+  const std::shared_ptr<LocalExchangeMemoryManager>&
+  getLocalExchangeMemoryManager(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
   void setError(const std::exception_ptr& exception);
 
   void setError(const std::string& message);

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_executable(
   RoundRobinPartitionFunctionTest.cpp
   RowContainerTest.cpp
   RowNumberTest.cpp
+  ScaleWriterLocalPartitionTest.cpp
   SortBufferTest.cpp
   SpillerTest.cpp
   SpillTest.cpp

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -228,6 +228,20 @@ TEST_F(PlanNodeSerdeTest, localPartition) {
   testSerde(plan);
 }
 
+TEST_F(PlanNodeSerdeTest, scaleWriterlocalPartition) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .scaleWriterlocalPartition(std::vector<std::string>{"c0"})
+                  .planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .scaleWriterlocalPartitionRoundRobin()
+             .planNode();
+  testSerde(plan);
+}
+
 TEST_F(PlanNodeSerdeTest, limit) {
   auto plan = PlanBuilder().values({data_}).limit(0, 10, true).planNode();
   testSerde(plan);

--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -1,0 +1,972 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/ScaleWriterLocalPartition.h"
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+using BlockingCallback = std::function<BlockingReason(ContinueFuture*)>;
+using FinishCallback = std::function<void(bool)>;
+
+// The object used to coordinate the behavior of the consumer and producer of
+// the scale writer exchange for test purpose.
+class TestExchangeController {
+ public:
+  TestExchangeController(
+      uint32_t numProducers,
+      uint32_t numConsumers,
+      uint64_t holdBufferBytes,
+      std::optional<double> producerTargetBufferMemoryRatio,
+      std::optional<double> consumerTargetBufferMemoryRatio,
+      std::optional<int32_t> producerMaxDelayUs,
+      std::optional<int32_t> consumerMaxDelayUs,
+      const std::vector<RowVectorPtr>& inputVectors,
+      bool keepConsumerInput = true)
+      : numProducers_(numProducers),
+        numConsumers_(numConsumers),
+        holdBufferBytes_(holdBufferBytes),
+        producerTargetBufferMemoryRatio_(producerTargetBufferMemoryRatio),
+        consumerTargetBufferMemoryRatio_(consumerTargetBufferMemoryRatio),
+        producerMaxDelayUs_(producerMaxDelayUs),
+        consumerMaxDelayUs_(consumerMaxDelayUs),
+        keepConsumerInput_(keepConsumerInput),
+        producerInputVectors_(inputVectors),
+        consumerInputs_(numConsumers_) {}
+
+  ~TestExchangeController() {
+    clear();
+  }
+
+  // The number of drivers of the producer pipeline.
+  uint32_t numProducers() const {
+    return numProducers_;
+  }
+
+  // The number of drivers of the consumer pipeline.
+  uint32_t numConsumers() const {
+    return numConsumers_;
+  }
+
+  // Specifies the buffer to hold to test the effect of query memory usage
+  // ratio for writer scaling control.
+  uint64_t holdBufferBytes() const {
+    return holdBufferBytes_;
+  }
+
+  void maybeHoldBuffer(memory::MemoryPool* pool) {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (holdBufferBytes_ == 0) {
+      return;
+    }
+    holdPool_ = pool;
+    holdBuffer_ = holdPool_->allocate(holdBufferBytes_);
+  }
+
+  std::optional<double> producerTargetBufferMemoryRatio() const {
+    return producerTargetBufferMemoryRatio_;
+  }
+
+  std::optional<double> consumerTargetBufferMemoryRatio() const {
+    return consumerTargetBufferMemoryRatio_;
+  }
+
+  std::optional<int32_t> producerMaxDelayUs() const {
+    return producerMaxDelayUs_;
+  }
+
+  std::optional<int32_t> consumerMaxDelayUs() const {
+    return consumerMaxDelayUs_;
+  }
+
+  RowVectorPtr getInput() {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (nextInput_ >= producerInputVectors_.size()) {
+      return nullptr;
+    }
+    return producerInputVectors_[nextInput_++];
+  }
+
+  core::PlanNodeId exchangeNodeId() const {
+    std::lock_guard<std::mutex> l(mutex_);
+    return exchnangeNodeId_;
+  }
+
+  void setExchangeNodeId(const core::PlanNodeId& nodeId) {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(exchnangeNodeId_.empty());
+    exchnangeNodeId_ = nodeId;
+  }
+
+  void addConsumerInput(uint32_t consumerId, const RowVectorPtr& input) {
+    if (!keepConsumerInput_) {
+      return;
+    }
+    consumerInputs_[consumerId].push_back(input);
+  }
+
+  const std::vector<std::vector<RowVectorPtr>> consumerInputs() const {
+    std::lock_guard<std::mutex> l(mutex_);
+    return consumerInputs_;
+  }
+
+  void clear() {
+    std::lock_guard<std::mutex> l(mutex_);
+    if (holdBuffer_ != nullptr) {
+      holdPool_->free(holdBuffer_, holdBufferBytes_);
+      holdBuffer_ = nullptr;
+    }
+    for (auto& input : consumerInputs_) {
+      input.clear();
+    }
+    consumerInputs_.clear();
+  }
+
+ private:
+  const uint32_t numProducers_;
+  const uint32_t numConsumers_;
+  const uint64_t holdBufferBytes_;
+  const std::optional<double> producerTargetBufferMemoryRatio_;
+  const std::optional<double> consumerTargetBufferMemoryRatio_;
+  const std::optional<int32_t> producerMaxDelayUs_;
+  const std::optional<int32_t> consumerMaxDelayUs_;
+  const bool keepConsumerInput_;
+
+  mutable std::mutex mutex_;
+  memory::MemoryPool* holdPool_{nullptr};
+  void* holdBuffer_{nullptr};
+  core::PlanNodeId exchnangeNodeId_;
+  uint32_t nextInput_{0};
+  std::vector<RowVectorPtr> producerInputVectors_;
+  std::vector<std::vector<RowVectorPtr>> consumerInputs_;
+};
+
+class FakeSourceNode : public core::PlanNode {
+ public:
+  FakeSourceNode(const core::PlanNodeId& id, const RowTypePtr& ouputType)
+      : PlanNode(id), ouputType_{ouputType} {}
+
+  const RowTypePtr& outputType() const override {
+    return ouputType_;
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    static const std::vector<core::PlanNodePtr> kEmptySources;
+    return kEmptySources;
+  }
+
+  std::string_view name() const override {
+    return "FakeSourceNode";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  const RowTypePtr ouputType_;
+};
+
+class FakeSourceOperator : public SourceOperator {
+ public:
+  FakeSourceOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const std::shared_ptr<const FakeSourceNode>& node,
+      const std::shared_ptr<TestExchangeController>& testController)
+      : SourceOperator(
+            ctx,
+            node->outputType(),
+            id,
+            node->id(),
+            "FakeSourceOperator"),
+        testController_(testController) {
+    VELOX_CHECK_NOT_NULL(testController_);
+    rng_.seed(id);
+  }
+
+  RowVectorPtr getOutput() override {
+    VELOX_CHECK(!finished_);
+    auto output = testController_->getInput();
+    if (output == nullptr) {
+      finished_ = true;
+      return nullptr;
+    }
+    waitForOutput();
+    return output;
+  }
+
+  bool isFinished() override {
+    return finished_;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*unused*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+ private:
+  void initialize() override {
+    Operator::initialize();
+
+    if (operatorCtx_->driverCtx()->driverId != 0) {
+      return;
+    }
+
+    testController_->maybeHoldBuffer(pool());
+  }
+
+  void waitForOutput() {
+    if (FOLLY_UNLIKELY(memoryManager_ == nullptr)) {
+      memoryManager_ =
+          operatorCtx_->driver()->task()->getLocalExchangeMemoryManager(
+              operatorCtx_->driverCtx()->splitGroupId,
+              testController_->exchangeNodeId());
+    }
+
+    if (testController_->producerTargetBufferMemoryRatio().has_value()) {
+      while (memoryManager_->bufferedBytes() >
+             (memoryManager_->maxBufferBytes() *
+              testController_->producerTargetBufferMemoryRatio().value())) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100)); // NOLINT
+      }
+    }
+    if (testController_->producerMaxDelayUs().has_value()) {
+      const auto delayUs = folly::Random::rand32(rng_) %
+          testController_->producerMaxDelayUs().value();
+      std::this_thread::sleep_for(std::chrono::microseconds(delayUs)); // NOLINT
+    }
+  }
+
+  const std::shared_ptr<TestExchangeController> testController_;
+  folly::Random::DefaultGenerator rng_;
+
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
+  bool finished_{false};
+};
+
+class FakeSourceNodeFactory : public Operator::PlanNodeTranslator {
+ public:
+  explicit FakeSourceNodeFactory(
+      const std::shared_ptr<TestExchangeController>& testController)
+      : testController_(testController) {}
+
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    auto fakeSourceNode = std::dynamic_pointer_cast<const FakeSourceNode>(node);
+    if (fakeSourceNode == nullptr) {
+      return nullptr;
+    }
+    return std::make_unique<FakeSourceOperator>(
+        ctx,
+        id,
+        std::dynamic_pointer_cast<const FakeSourceNode>(node),
+        testController_);
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    auto fakeSourceNode = std::dynamic_pointer_cast<const FakeSourceNode>(node);
+    if (fakeSourceNode == nullptr) {
+      return std::nullopt;
+    }
+    return testController_->numProducers();
+  }
+
+ private:
+  const std::shared_ptr<TestExchangeController> testController_;
+};
+
+class FakeWriteNode : public core::PlanNode {
+ public:
+  FakeWriteNode(const core::PlanNodeId& id, const core::PlanNodePtr& input)
+      : PlanNode(id), sources_{input} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "FakeWriteNode";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+class FakeWriteOperator : public Operator {
+ public:
+  FakeWriteOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const std::shared_ptr<const FakeWriteNode>& node,
+      const std::shared_ptr<TestExchangeController>& testController)
+      : Operator(ctx, node->outputType(), id, node->id(), "FakeWriteOperator"),
+        testController_(testController) {
+    VELOX_CHECK_NOT_NULL(testController_);
+    rng_.seed(id);
+  }
+
+  void initialize() override {
+    Operator::initialize();
+    VELOX_CHECK(exchangeQueues_.empty());
+    exchangeQueues_ = operatorCtx_->driver()->task()->getLocalExchangeQueues(
+        operatorCtx_->driverCtx()->splitGroupId,
+        testController_->exchangeNodeId());
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    waitForConsume();
+    testController_->addConsumerInput(
+        operatorCtx_->driverCtx()->driverId, input);
+    input_ = std::move(input);
+  }
+
+  RowVectorPtr getOutput() override {
+    return std::move(input_);
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*unused*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+ private:
+  // Returns true if the producers of all the exchange queues are done.
+  bool exchangeQueueClosed() const {
+    for (const auto& queue : exchangeQueues_) {
+      if (!queue->testingProducersDone()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  void waitForConsume() {
+    if (FOLLY_UNLIKELY(memoryManager_ == nullptr)) {
+      memoryManager_ =
+          operatorCtx_->driver()->task()->getLocalExchangeMemoryManager(
+              operatorCtx_->driverCtx()->splitGroupId,
+              testController_->exchangeNodeId());
+    }
+    if (testController_->consumerTargetBufferMemoryRatio().has_value()) {
+      while (!exchangeQueueClosed() &&
+             memoryManager_->bufferedBytes() <
+                 (memoryManager_->maxBufferBytes() *
+                  testController_->consumerTargetBufferMemoryRatio().value())) {
+        std::this_thread::sleep_for(std::chrono::microseconds(100)); // NOLINT
+      }
+    }
+    if (testController_->consumerMaxDelayUs().has_value()) {
+      const auto delayUs = folly::Random::rand32(rng_) %
+          testController_->consumerMaxDelayUs().value();
+      std::this_thread::sleep_for(std::chrono::microseconds(delayUs)); // NOLINT
+    }
+  }
+
+  const std::shared_ptr<TestExchangeController> testController_;
+  folly::Random::DefaultGenerator rng_;
+
+  std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
+  std::vector<std::shared_ptr<LocalExchangeQueue>> exchangeQueues_;
+};
+
+class FakeWriteNodeFactory : public Operator::PlanNodeTranslator {
+ public:
+  explicit FakeWriteNodeFactory(
+      const std::shared_ptr<TestExchangeController>& testController)
+      : testController_(testController) {}
+
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    auto fakeWriteNode = std::dynamic_pointer_cast<const FakeWriteNode>(node);
+    if (fakeWriteNode == nullptr) {
+      return nullptr;
+    }
+    return std::make_unique<FakeWriteOperator>(
+        ctx,
+        id,
+        std::dynamic_pointer_cast<const FakeWriteNode>(node),
+        testController_);
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    auto fakeWriteNode = std::dynamic_pointer_cast<const FakeWriteNode>(node);
+    if (fakeWriteNode == nullptr) {
+      return std::nullopt;
+    }
+    return testController_->numConsumers();
+  }
+
+ private:
+  const std::shared_ptr<TestExchangeController> testController_;
+};
+} // namespace
+
+class ScaleWriterLocalPartitionTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+
+    rng_.seed(123);
+    rowType_ = ROW({"c0", "c1", "c3"}, {BIGINT(), INTEGER(), BIGINT()});
+  }
+
+  void TearDown() override {
+    Operator::unregisterAllOperators();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  std::vector<RowVectorPtr> makeVectors(
+      uint32_t numVectors,
+      uint32_t vectorSize,
+      const std::vector<int32_t>& partitionKeyValues = {}) {
+    VectorFuzzer::Options options;
+    options.vectorSize = vectorSize;
+    options.allowLazyVector = false;
+    // NOTE: order by used to sort data doesn't handle null rows.
+    options.nullRatio = 0.0;
+    VectorFuzzer fuzzer(options, pool_.get());
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < numVectors; ++i) {
+      vectors.push_back(fuzzer.fuzzRow(rowType_));
+    }
+    if (partitionKeyValues.empty()) {
+      return vectors;
+    }
+    for (auto i = 0; i < numVectors; ++i) {
+      auto partitionVector = BaseVector::create(
+          vectors[i]->childAt(partitionChannel_)->type(),
+          vectors[i]->childAt(partitionChannel_)->size(),
+          pool_.get());
+      auto* partitionVectorFlat = partitionVector->asFlatVector<int32_t>();
+      for (auto j = 0; j < partitionVector->size(); ++j) {
+        partitionVectorFlat->set(
+            j,
+            partitionKeyValues
+                [folly::Random::rand32(rng_) % partitionKeyValues.size()]);
+      }
+      vectors[i]->childAt(partitionChannel_) = partitionVector;
+    }
+    return vectors;
+  }
+
+  std::string partitionColumnName() const {
+    return rowType_->nameOf(partitionChannel_);
+  }
+
+  RowVectorPtr sortData(const std::vector<RowVectorPtr>& inputVectors) {
+    std::vector<std::string> orderByKeys;
+    orderByKeys.reserve(rowType_->size());
+    for (const auto& name : rowType_->names()) {
+      orderByKeys.push_back(fmt::format("{} ASC NULLS FIRST", name));
+    }
+    AssertQueryBuilder queryBuilder(PlanBuilder()
+                                        .values(inputVectors)
+                                        .orderBy(orderByKeys, false)
+                                        .planNode());
+    return queryBuilder.copyResults(pool_.get());
+  }
+
+  void verifyResults(
+      const std::vector<RowVectorPtr>& actual,
+      const std::vector<RowVectorPtr>& expected) {
+    const auto actualSorted = sortData(actual);
+    const auto expectedSorted = sortData(expected);
+    exec::test::assertEqualResults({actualSorted}, {expectedSorted});
+  }
+
+  // Returns the partition keys set of the input 'vectors'.
+  std::set<int32_t> partitionKeys(const std::vector<RowVectorPtr>& vectors) {
+    DecodedVector partitionColumnDecoder;
+    std::set<int32_t> keys;
+    for (const auto& vector : vectors) {
+      partitionColumnDecoder.decode(*vector->childAt(partitionChannel_));
+      for (auto i = 0; i < partitionColumnDecoder.size(); ++i) {
+        keys.insert(partitionColumnDecoder.valueAt<int32_t>(i));
+      }
+    }
+    return keys;
+  }
+
+  // Verifies the partition keys of the consumer inputs from 'controller' are
+  // disjoint.
+  void verifyDisjointPartitionKeys(TestExchangeController* controller) {
+    std::set<int32_t> allPartitionKeys;
+    for (const auto& consumerInput : controller->consumerInputs()) {
+      std::set<int32_t> consumerPartitionKeys = partitionKeys(consumerInput);
+      std::set<int32_t> diffPartitionKeys;
+      std::set_difference(
+          consumerPartitionKeys.begin(),
+          consumerPartitionKeys.end(),
+          allPartitionKeys.begin(),
+          allPartitionKeys.end(),
+          std::inserter(diffPartitionKeys, diffPartitionKeys.end()));
+      ASSERT_EQ(diffPartitionKeys.size(), consumerPartitionKeys.size())
+          << "diffPartitionKeys: " << folly::join(",", diffPartitionKeys)
+          << " consumerPartitionKeys: "
+          << folly::join(",", consumerPartitionKeys)
+          << ", allPartitionKeys: " << folly::join(",", allPartitionKeys);
+      allPartitionKeys = diffPartitionKeys;
+    }
+  }
+
+  const column_index_t partitionChannel_{1};
+  folly::Random::DefaultGenerator rng_;
+  RowTypePtr rowType_;
+};
+
+TEST_F(ScaleWriterLocalPartitionTest, unpartitionBasic) {
+  const std::vector<RowVectorPtr> inputVectors = makeVectors(32, 1024);
+  const uint64_t queryCapacity = 256 << 20;
+  const uint32_t maxDrivers = 32;
+  const uint32_t maxExchanegBufferSize = 2 << 20;
+
+  struct {
+    uint32_t numProducers;
+    uint32_t numConsumers;
+    uint64_t rebalanceProcessBytesThreshold;
+    double scaleWriterRebalanceMaxMemoryUsageRatio;
+    uint64_t holdBufferBytes;
+    double producerBufferedMemoryRatio;
+    double consumerBufferedMemoryRatio;
+    bool expectedRebalance;
+
+    std::string debugString() const {
+      return fmt::format(
+          "numProducers {}, numConsumers {}, rebalanceProcessBytesThreshold {}, scaleWriterRebalanceMaxMemoryUsageRatio {}, holdBufferBytes {}, producerBufferedMemoryRatio {}, consumerBufferedMemoryRatio {}, expectedRebalance {}",
+          numProducers,
+          numConsumers,
+          succinctBytes(rebalanceProcessBytesThreshold),
+          scaleWriterRebalanceMaxMemoryUsageRatio,
+          succinctBytes(holdBufferBytes),
+          producerBufferedMemoryRatio,
+          consumerBufferedMemoryRatio,
+          expectedRebalance);
+    }
+  } testSettings[] = {
+      {1, 1, 0, 1.0, 0, 0.8, 0.6, false},
+      {4, 1, 0, 1.0, 0, 0.8, 0.6, false},
+      {1, 4, 1ULL << 30, 1.0, 0, 0.8, 0.6, false},
+      {4, 4, 1ULL << 30, 1.0, 0, 0.8, 0.6, false},
+      {1, 4, 0, 1.0, 0, 0.3, 0.2, false},
+      {4, 4, 0, 1.0, 0, 0.3, 0.2, false},
+      {1, 4, 0, 0.1, queryCapacity / 2, 0.8, 0.6, false},
+      {4, 4, 0, 0.1, queryCapacity / 2, 0.8, 0.6, false},
+      {1, 4, 0, 1.0, 0, 0.8, 0.6, true},
+      {4, 4, 0, 1.0, 0, 0.8, 0.6, true}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    ASSERT_LE(testData.numProducers, maxDrivers);
+    ASSERT_LE(testData.numConsumers, maxDrivers);
+
+    Operator::unregisterAllOperators();
+
+    auto testController = std::make_shared<TestExchangeController>(
+        testData.numProducers,
+        testData.numConsumers,
+        testData.holdBufferBytes,
+        testData.producerBufferedMemoryRatio,
+        testData.consumerBufferedMemoryRatio,
+        std::nullopt,
+        std::nullopt,
+        inputVectors);
+    Operator::registerOperator(
+        std::make_unique<FakeWriteNodeFactory>(testController));
+    Operator::registerOperator(
+        std::make_unique<FakeSourceNodeFactory>(testController));
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId exchnangeNodeId;
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .addNode([&](const core::PlanNodeId& id,
+                                 const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeSourceNode>(id, rowType_);
+                    })
+                    .scaleWriterlocalPartitionRoundRobin()
+                    .capturePlanNodeId(exchnangeNodeId)
+                    .addNode([](const core::PlanNodeId& id,
+                                const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeWriteNode>(id, input);
+                    })
+                    .planNode();
+    testController->setExchangeNodeId(exchnangeNodeId);
+
+    AssertQueryBuilder queryBuilder(plan);
+    std::shared_ptr<Task> task;
+    const auto result =
+        // Consumer and producer have overload the max drivers of their
+        // associated pipelines. We set max driver for the query to make sure it
+        // is larger than the customiized driver count for consumer and
+        // producer.
+        queryBuilder.maxDrivers(maxDrivers)
+            .maxQueryCapacity(queryCapacity)
+            .config(
+                core::QueryConfig::kMaxLocalExchangeBufferSize,
+                std::to_string(maxExchanegBufferSize))
+            .config(
+                core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio,
+                std::to_string(
+                    testData.scaleWriterRebalanceMaxMemoryUsageRatio))
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
+                std::to_string(testData.rebalanceProcessBytesThreshold))
+            .copyResults(pool_.get(), task);
+    uint32_t nonEmptyConsumers{0};
+    for (const auto& consumerInput : testController->consumerInputs()) {
+      if (!consumerInput.empty()) {
+        ++nonEmptyConsumers;
+      }
+    }
+    auto planStats = toPlanStats(task->taskStats());
+    if (testData.expectedRebalance) {
+      ASSERT_GT(
+          planStats.at(exchnangeNodeId)
+              .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+              .sum,
+          0);
+      ASSERT_LE(
+          planStats.at(exchnangeNodeId)
+              .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+              .sum,
+          planStats.at(exchnangeNodeId)
+                  .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+                  .count *
+              (testData.numConsumers - 1));
+      ASSERT_GT(nonEmptyConsumers, 1);
+    } else {
+      ASSERT_EQ(
+          planStats.at(exchnangeNodeId)
+              .customStats.count(ScaleWriterLocalPartition::kScaledWriters),
+          0);
+      ASSERT_EQ(nonEmptyConsumers, 1);
+    }
+
+    testController->clear();
+    task.reset();
+
+    verifyResults(inputVectors, {result});
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+TEST_F(ScaleWriterLocalPartitionTest, unpartitionFuzzer) {
+  const std::vector<RowVectorPtr> inputVectors = makeVectors(256, 512);
+  const uint64_t queryCapacity = 256 << 20;
+  const uint32_t maxDrivers = 32;
+  const uint32_t maxExchanegBufferSize = 2 << 20;
+
+  for (bool fastConsumer : {false, true}) {
+    SCOPED_TRACE(fmt::format("fastConsumer: {}", fastConsumer));
+    Operator::unregisterAllOperators();
+
+    auto testController = std::make_shared<TestExchangeController>(
+        fastConsumer ? 1 : 4,
+        4,
+        0,
+        std::nullopt,
+        std::nullopt,
+        fastConsumer ? 4 : 64,
+        fastConsumer ? 64 : 4,
+        inputVectors,
+        /*keepConsumerInput=*/false);
+    Operator::registerOperator(
+        std::make_unique<FakeWriteNodeFactory>(testController));
+    Operator::registerOperator(
+        std::make_unique<FakeSourceNodeFactory>(testController));
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId exchnangeNodeId;
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .addNode([&](const core::PlanNodeId& id,
+                                 const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeSourceNode>(id, rowType_);
+                    })
+                    .scaleWriterlocalPartitionRoundRobin()
+                    .capturePlanNodeId(exchnangeNodeId)
+                    .addNode([](const core::PlanNodeId& id,
+                                const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeWriteNode>(id, input);
+                    })
+                    .planNode();
+    testController->setExchangeNodeId(exchnangeNodeId);
+
+    AssertQueryBuilder queryBuilder(plan);
+    std::shared_ptr<Task> task;
+    const auto result =
+        // Consumer and producer have overload the max drivers of their
+        // associated pipelines. We set max driver for the query to make sure it
+        // is larger than the customiized driver count for consumer and
+        // producer.
+        queryBuilder.maxDrivers(32)
+            .maxQueryCapacity(queryCapacity)
+            .config(
+                core::QueryConfig::kMaxLocalExchangeBufferSize,
+                std::to_string(maxExchanegBufferSize))
+            .config(
+                core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio,
+                "1.0")
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
+                "256")
+            .copyResults(pool_.get());
+    verifyResults(inputVectors, {result});
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+TEST_F(ScaleWriterLocalPartitionTest, partitionBasic) {
+  const uint64_t queryCapacity = 256 << 20;
+  const uint32_t maxDrivers = 32;
+  const uint32_t maxExchanegBufferSize = 2 << 20;
+
+  struct {
+    uint32_t numProducers;
+    uint32_t numConsumers;
+    uint32_t numPartitionsPerWriter;
+    uint64_t rebalanceProcessBytesThreshold;
+    double scaleWriterRebalanceMaxMemoryUsageRatio;
+    uint64_t holdBufferBytes;
+    std::vector<int32_t> partitionKeys;
+    double producerBufferedMemoryRatio;
+    double consumerBufferedMemoryRatio;
+    bool expectedRebalance;
+
+    std::string debugString() const {
+      return fmt::format(
+          "numProducers {}, numConsumers {}, numPartitionsPerWriter {}, rebalanceProcessBytesThreshold {}, scaleWriterRebalanceMaxMemoryUsageRatio {}, holdBufferBytes {}, partitionKeys {}, producerBufferedMemoryRatio {}, consumerBufferedMemoryRatio {}, expectedRebalance {}",
+          numProducers,
+          numConsumers,
+          numPartitionsPerWriter,
+          succinctBytes(rebalanceProcessBytesThreshold),
+          scaleWriterRebalanceMaxMemoryUsageRatio,
+          succinctBytes(holdBufferBytes),
+          folly::join(":", partitionKeys),
+          producerBufferedMemoryRatio,
+          consumerBufferedMemoryRatio,
+          expectedRebalance);
+    }
+  } testSettings[] = {
+      {1, 1, 4, 0, 1.0, 0, {1, 2}, 0.8, 0.6, false},
+      {4, 1, 4, 0, 1.0, 0, {1, 2}, 0.8, 0.6, false},
+      {1, 4, 4, 1ULL << 30, 1.0, 0, {1, 2}, 0.8, 0.6, false},
+      {4, 4, 4, 1ULL << 30, 1.0, 0, {1, 2}, 0.8, 0.6, false},
+      {1, 4, 4, 0, 1.0, 0, {1, 2}, 0.3, 0.2, false},
+      {4, 4, 4, 0, 1.0, 0, {1, 2}, 0.3, 0.2, false},
+      {1, 4, 4, 0, 0.1, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
+      {4, 4, 4, 0, 0.1, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
+      {1, 32, 128, 0, 1.0, 0, {1, 2, 3, 4, 5, 6, 7, 8}, 0.8, 0.6, true},
+      {4, 32, 128, 0, 1.0, 0, {1, 2, 3, 4, 5, 6, 7, 8}, 0.8, 0.6, true},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    ASSERT_LE(testData.numProducers, maxDrivers);
+    ASSERT_LE(testData.numConsumers, maxDrivers);
+
+    Operator::unregisterAllOperators();
+
+    const std::vector<RowVectorPtr> inputVectors =
+        makeVectors(32, 2048, testData.partitionKeys);
+
+    auto testController = std::make_shared<TestExchangeController>(
+        testData.numProducers,
+        testData.numConsumers,
+        testData.holdBufferBytes,
+        testData.producerBufferedMemoryRatio,
+        testData.consumerBufferedMemoryRatio,
+        std::nullopt,
+        std::nullopt,
+        inputVectors);
+    Operator::registerOperator(
+        std::make_unique<FakeWriteNodeFactory>(testController));
+    Operator::registerOperator(
+        std::make_unique<FakeSourceNodeFactory>(testController));
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId exchnangeNodeId;
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .addNode([&](const core::PlanNodeId& id,
+                                 const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeSourceNode>(id, rowType_);
+                    })
+                    .scaleWriterlocalPartition({partitionColumnName()})
+                    .capturePlanNodeId(exchnangeNodeId)
+                    .addNode([](const core::PlanNodeId& id,
+                                const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeWriteNode>(id, input);
+                    })
+                    .planNode();
+    testController->setExchangeNodeId(exchnangeNodeId);
+
+    AssertQueryBuilder queryBuilder(plan);
+    std::shared_ptr<Task> task;
+    const auto result =
+        // Consumer and producer have overload the max drivers of their
+        // associated pipelines. We set max driver for the query to make sure it
+        // is larger than the customiized driver count for consumer and
+        // producer.
+        queryBuilder.maxDrivers(maxDrivers)
+            .maxQueryCapacity(queryCapacity)
+            .config(
+                core::QueryConfig::kMaxLocalExchangeBufferSize,
+                std::to_string(maxExchanegBufferSize))
+            .config(
+                core::QueryConfig::kScaleWriterMaxPartitionsPerWriter,
+                std::to_string(testData.numPartitionsPerWriter))
+            .config(
+                core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio,
+                std::to_string(
+                    testData.scaleWriterRebalanceMaxMemoryUsageRatio))
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinProcessedBytesRebalanceThreshold,
+                std::to_string(testData.rebalanceProcessBytesThreshold))
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
+                "0")
+            .copyResults(pool_.get(), task);
+    auto planStats = toPlanStats(task->taskStats());
+    if (testData.expectedRebalance) {
+      ASSERT_GT(
+          planStats.at(exchnangeNodeId)
+              .customStats
+              .at(ScaleWriterPartitioningLocalPartition::kScaledPartitions)
+              .sum,
+          0);
+      ASSERT_GT(
+          planStats.at(exchnangeNodeId)
+              .customStats
+              .at(ScaleWriterPartitioningLocalPartition::kRebalanceTriggers)
+              .sum,
+          0);
+    } else {
+      ASSERT_EQ(
+          planStats.at(exchnangeNodeId)
+              .customStats.count(
+                  ScaleWriterPartitioningLocalPartition::kScaledPartitions),
+          0);
+      ASSERT_EQ(
+          planStats.at(exchnangeNodeId)
+              .customStats.count(
+                  ScaleWriterPartitioningLocalPartition::kRebalanceTriggers),
+          0);
+      verifyDisjointPartitionKeys(testController.get());
+    }
+    testController->clear();
+    task.reset();
+
+    verifyResults(inputVectors, {result});
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+TEST_F(ScaleWriterLocalPartitionTest, partitionFuzzer) {
+  const std::vector<RowVectorPtr> inputVectors =
+      makeVectors(1024, 256, {1, 2, 3, 4, 5, 6, 7, 8});
+  const uint64_t queryCapacity = 256 << 20;
+  const uint32_t maxDrivers = 32;
+  const uint32_t maxExchanegBufferSize = 2 << 20;
+
+  for (bool fastConsumer : {false, true}) {
+    SCOPED_TRACE(fmt::format("fastConsumer: {}", fastConsumer));
+    Operator::unregisterAllOperators();
+
+    auto testController = std::make_shared<TestExchangeController>(
+        fastConsumer ? 1 : 4,
+        4,
+        0,
+        std::nullopt,
+        std::nullopt,
+        fastConsumer ? 4 : 64,
+        fastConsumer ? 64 : 4,
+        inputVectors,
+        /*keepConsumerInput=*/false);
+    Operator::registerOperator(
+        std::make_unique<FakeWriteNodeFactory>(testController));
+    Operator::registerOperator(
+        std::make_unique<FakeSourceNodeFactory>(testController));
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId exchnangeNodeId;
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .addNode([&](const core::PlanNodeId& id,
+                                 const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeSourceNode>(id, rowType_);
+                    })
+                    .scaleWriterlocalPartition({partitionColumnName()})
+                    .capturePlanNodeId(exchnangeNodeId)
+                    .addNode([](const core::PlanNodeId& id,
+                                const core::PlanNodePtr& input) {
+                      return std::make_shared<FakeWriteNode>(id, input);
+                    })
+                    .planNode();
+    testController->setExchangeNodeId(exchnangeNodeId);
+
+    AssertQueryBuilder queryBuilder(plan);
+    std::shared_ptr<Task> task;
+    const auto result =
+        // Consumer and producer have overload the max drivers of their
+        // associated pipelines. We set max driver for the query to make sure it
+        // is larger than the customiized driver count for consumer and
+        // producer.
+        queryBuilder.maxDrivers(32)
+            .maxQueryCapacity(queryCapacity)
+            .config(
+                core::QueryConfig::kMaxLocalExchangeBufferSize,
+                std::to_string(maxExchanegBufferSize))
+            .config(
+                core::QueryConfig::kScaleWriterRebalanceMaxMemoryUsageRatio,
+                "1.0")
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinProcessedBytesRebalanceThreshold,
+                "256")
+            .config(
+                core::QueryConfig::
+                    kScaleWriterMinPartitionProcessedBytesRebalanceThreshold,
+                "32")
+            .copyResults(pool_.get());
+    verifyResults(inputVectors, {result});
+    waitForAllTasksToBeDeleted();
+  }
+}

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -35,6 +35,9 @@ class AssertQueryBuilder {
   /// Change requested number of drivers. Default is 1.
   AssertQueryBuilder& maxDrivers(int32_t maxDrivers);
 
+  /// Change the query memory pool capacity. Default has no limit
+  AssertQueryBuilder& maxQueryCapacity(int64_t maxCapacity);
+
   /// Change task's 'destination', the partition number assigned to the task.
   /// Default is 0.
   AssertQueryBuilder& destination(int32_t destination);

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -28,23 +28,26 @@ bool waitForTaskDriversToFinish(
     exec::Task* task,
     uint64_t maxWaitMicros = 1'000'000);
 
-// Parameters for initializing a TaskCursor or RowCursor.
+/// Parameters for initializing a TaskCursor or RowCursor.
 struct CursorParameters {
-  // Root node of the plan tree
+  /// Root node of the plan tree
   std::shared_ptr<const core::PlanNode> planNode;
 
-  int32_t destination = 0;
+  int32_t destination{0};
 
-  // Maximum number of drivers per pipeline.
-  int32_t maxDrivers = 1;
+  /// Maximum number of drivers per pipeline.
+  int32_t maxDrivers{1};
 
-  // Maximum number of split groups processed concurrently.
-  int32_t numConcurrentSplitGroups = 1;
+  /// The max capacity of the query memory pool.
+  int64_t maxQueryCapacity{memory::kMaxMemory};
 
-  // Optional, created if not present.
+  /// Maximum number of split groups processed concurrently.
+  int32_t numConcurrentSplitGroups{1};
+
+  /// Optional, created if not present.
   std::shared_ptr<core::QueryCtx> queryCtx;
 
-  uint64_t bufferedBytes = 512 * 1024;
+  uint64_t bufferedBytes{512 * 1024};
 
   /// Ungrouped (by default) or grouped (bucketed) execution.
   core::ExecutionStrategy executionStrategy{
@@ -57,17 +60,18 @@ struct CursorParameters {
   /// ungrouped execution.
   int numSplitGroups{1};
 
-  /// Spilling directory, if not empty, then the task's spilling directory would
-  /// be built from it.
+  /// Spilling directory, if not empty, then the task's spilling directory
+  /// would be built from it.
   std::string spillDirectory;
 
   bool copyResult = true;
 
-  /// If true, use serial execution mode. Use parallel execution mode otherwise.
+  /// If true, use serial execution mode. Use parallel execution mode
+  /// otherwise.
   bool serialExecution = false;
 
-  /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations in
-  /// 'queryCtx' will be overridden by 'queryConfig'.
+  /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations
+  /// in 'queryCtx' will be overridden by 'queryConfig'.
   std::unordered_map<std::string, std::string> queryConfigs;
 };
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -872,6 +872,14 @@ class PlanBuilder {
   /// current plan node).
   PlanBuilder& localPartitionRoundRobin();
 
+  /// A convenience method to add a LocalPartitionNode for scale writer with
+  /// hash partitioning.
+  PlanBuilder& scaleWriterlocalPartition(const std::vector<std::string>& keys);
+
+  /// A convenience method to add a LocalPartitionNode for scale writer with
+  /// round-robin partitioning.
+  PlanBuilder& scaleWriterlocalPartitionRoundRobin();
+
   /// Add a LocalPartitionNode to partition the input using row-wise
   /// round-robin. Number of partitions is determined at runtime based on
   /// parallelism of the downstream pipeline.


### PR DESCRIPTION
Summary:
This change adds local scale writer partition support to improve memory efficiency in case of a large number of partitions.
We add two customized local partition operators:
ScaleWriterLocalPartition for non-partitioned table write. It starts with single table writer thread and scale the writer processing
if the exchange queue has >50% memory buffering until scale to all the table writer threads;
ScaleWriterPartitioningLocalPartition for partitioned table writer. It starts with assigning a single table writer thread to each logical
table partition. Multiple physical table partitions could be mapped to a single logical partition based on the partition keys of the
written table. Similar, if the exchange queue has > 50% memory buffering, we leverage the skewed partition balancer by scaling
the busy logical table partition by assigning more table writer threads.

Meta internal shadow results show this could prevent query write OOM pattern, reduce the peak memory usage which benefits the
resource usage accounting which takes into account of accumulated memory usage,  it also reduces >2x of written files

The followup is to investigate the more reliable rebalance signal such as consumer/producer queuing delay in the exchange
queue. To complete this feature, we need a Prestissimo change to setup scale writer local partition based on arbitrary partitioning
scheme, and the coordinator needs to configure the query plan accordingly.

Differential Revision: D66380785


