### PR TITLE
feat(prefix sort): Eliminate null byte from prefix encoder when single sort key

### DIFF
--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -213,7 +213,11 @@ class PrefixSort {
 
   int comparePartNormalizedKeys(char* left, char* right);
 
-  void extractRowAndEncodePrefixKeys(char* row, char* prefixBuffer);
+  template <bool isSingleSortKey>
+  void extractRowAndEncodePrefixKeys(
+      char* row,
+      char* prefixBuffer,
+      std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   // Return the row address refenence in the prefix encoded buffer.
   FOLLY_ALWAYS_INLINE char*& getRowAddrFromPrefixBuffer(
@@ -223,7 +227,24 @@ class PrefixSort {
   }
 
   const RowContainer* const rowContainer_;
+  const bool isSingleSortKey_;
   const PrefixSortLayout sortLayout_;
+
+  /// Null record is placed before nullBoundary_ in std::vector sortedRows.
+  size_t nullBoundary_{0};
+
   memory::MemoryPool* const pool_;
 };
+
+template <>
+void PrefixSort::extractRowAndEncodePrefixKeys<false>(
+    char* row,
+    char* prefixBuffer,
+    std::vector<char*, memory::StlAllocator<char*>>& rows);
+
+template <>
+void PrefixSort::extractRowAndEncodePrefixKeys<true>(
+    char* row,
+    char* prefixBuffer,
+    std::vector<char*, memory::StlAllocator<char*>>& rows);
 } // namespace facebook::velox::exec

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -76,10 +76,11 @@ class PrefixSortEncoder {
   FOLLY_ALWAYS_INLINE static std::optional<uint32_t> encodedSize(
       TypeKind typeKind,
       uint32_t maxStringPrefixLength,
-      bool columnHasNulls) {
+      bool columnHasNulls,
+      bool isSingleSortKey) {
     // NOTE: if columnHasNulls is true, one byte is reserved for nullable
     // comparison.
-    const uint32_t nullByteSize = columnHasNulls ? 1 : 0;
+    const uint32_t nullByteSize = columnHasNulls && !isSingleSortKey ? 1 : 0;
     switch ((typeKind)) {
 #define SCALAR_CASE(kind) \
   case TypeKind::kind:    \

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2036,24 +2036,28 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       {true, 0, 0, 0},
       {false, 0, 0, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() -
            1,
        0,
        0},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
            .value(),
        0,
        1},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
            .value(),
        0,
        0},
@@ -2062,96 +2066,106 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       {true, 1'000'000, 1'000'000, 0},
       {false, 1'000'000, 1'000'000, 0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        1'000'000,
        0},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        1'000'000,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value(),
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value(),
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value() -
            1,
        0,
        2},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value() -
            1,
        0,
        0},
       {true,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        0,
        3},
       {false,
-       prefixsort::PrefixSortEncoder::encodedSize(TypeKind::SMALLINT, 12, false)
+       prefixsort::PrefixSortEncoder::encodedSize(
+           TypeKind::SMALLINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::BIGINT, 12, false)
+               TypeKind::BIGINT, 12, false, false)
                .value() +
            prefixsort::PrefixSortEncoder::encodedSize(
-               TypeKind::INTEGER, 12, false)
+               TypeKind::INTEGER, 12, false, false)
                .value(),
        0,
        0}};

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -208,7 +208,9 @@ TEST_F(PrefixSortTest, singleKeyWithNulls) {
            HugeInt::parse("12345679"),
            HugeInt::parse("-12345678901234567890")}),
       makeNullableFlatVector<float>({5.5, 4.4, std::nullopt, 2.2, 1.1}),
-      makeNullableFlatVector<double>({5.5, 4.4, std::nullopt, 2.2, 1.1}),
+      // Test number of nulls is more than valid values.
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, std::nullopt, 2.2, 1.1}),
       makeNullableFlatVector<Timestamp>(
           {Timestamp(5, 5),
            Timestamp(4, 4),


### PR DESCRIPTION
There is 1 byte for null byte of each row, it may acquire extra 7 bytes because the alignment 8 bytes, this PR can eliminate null byte when there is only one sort key, set the null address to the beginning of the output sortedRows when encoding, only encode the valid row to prefix buffer. Move the null rows address from beginning to the end when nullsLast.