### PR TITLE
build(ci): Enforce `build(ci)` prefix on dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
+    commit-message:
+      prefix: "build(ci): "


### PR DESCRIPTION
Dependabot does automatically adapt to conventions but we should just enforce it via the config.