### PR TITLE
feat: Allow to control level of detail in MultiFragmentPlan::toString

### DIFF
--- a/velox/runner/CMakeLists.txt
+++ b/velox/runner/CMakeLists.txt
@@ -15,7 +15,12 @@ if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
 
-velox_add_library(velox_local_runner LocalRunner.cpp LocalSchema.cpp Runner.cpp)
+velox_add_library(
+  velox_local_runner
+  LocalRunner.cpp
+  LocalSchema.cpp
+  MultiFragmentPlan.cpp
+  Runner.cpp)
 
 velox_link_libraries(
   velox_local_runner

--- a/velox/runner/MultiFragmentPlan.cpp
+++ b/velox/runner/MultiFragmentPlan.cpp
@@ -18,7 +18,7 @@
 
 namespace facebook::velox::runner {
 
-std::string MultiFragmentPlan::toString() const {
+std::string MultiFragmentPlan::toString(bool detailed) const {
   std::stringstream out;
   for (auto i = 0; i < fragments_.size(); ++i) {
     out << fmt::format(
@@ -26,7 +26,8 @@ std::string MultiFragmentPlan::toString() const {
         i,
         fragments_[i].taskPrefix,
         fragments_[i].width);
-    out << fragments_[i].fragment.planNode->toString(true, true) << std::endl;
+    out << fragments_[i].fragment.planNode->toString(detailed, true)
+        << std::endl;
     if (!fragments_[i].inputStages.empty()) {
       out << "Inputs: ";
       for (auto& input : fragments_[i].inputStages) {

--- a/velox/runner/MultiFragmentPlan.cpp
+++ b/velox/runner/MultiFragmentPlan.cpp
@@ -14,25 +14,29 @@
  * limitations under the License.
  */
 
-#include "velox/runner/Runner.h"
+#include "velox/runner/MultiFragmentPlan.h"
 
 namespace facebook::velox::runner {
 
-// static
-std::string Runner::stateString(Runner::State state) {
-  switch (state) {
-    case Runner::State::kInitialized:
-      return "initialized";
-    case Runner::State::kRunning:
-      return "running";
-    case Runner::State::kCancelled:
-      return "cancelled";
-    case Runner::State::kError:
-      return "error";
-    case Runner::State::kFinished:
-      return "finished";
+std::string MultiFragmentPlan::toString() const {
+  std::stringstream out;
+  for (auto i = 0; i < fragments_.size(); ++i) {
+    out << fmt::format(
+        "Fragment {}: {} numWorkers={}:\n",
+        i,
+        fragments_[i].taskPrefix,
+        fragments_[i].width);
+    out << fragments_[i].fragment.planNode->toString(true, true) << std::endl;
+    if (!fragments_[i].inputStages.empty()) {
+      out << "Inputs: ";
+      for (auto& input : fragments_[i].inputStages) {
+        out << fmt::format(
+            " {} <- {} ", input.consumerNodeId, input.producerTaskPrefix);
+      }
+      out << std::endl;
+    }
   }
-  return fmt::format("invalid state {}", static_cast<int32_t>(state));
+  return out.str();
 }
 
 } // namespace facebook::velox::runner

--- a/velox/runner/MultiFragmentPlan.h
+++ b/velox/runner/MultiFragmentPlan.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/exec/Task.h"
+#include "velox/core/PlanFragment.h"
 
 namespace facebook::velox::runner {
 

--- a/velox/runner/MultiFragmentPlan.h
+++ b/velox/runner/MultiFragmentPlan.h
@@ -84,7 +84,9 @@ class MultiFragmentPlan {
     return options_;
   }
 
-  std::string toString() const;
+  /// @param detailed If true, includes details of each plan node. Otherwise,
+  /// only node types are included.
+  std::string toString(bool detailed = true) const;
 
  private:
   const std::vector<ExecutableFragment> fragments_;


### PR DESCRIPTION
Summary: Add 'detailed' argument to MultiFragmentPlan::toString() method to allow controlling whether plan nodes are included with details or not. Useful when printing large plans.

Differential Revision: D66666653


