### PR TITLE
fix(fuzzer): Reduce input size of window fuzzer test to avoid OOM

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1000,6 +1000,7 @@ jobs:
           ./velox_window_fuzzer_test \
                 --seed ${RANDOM} \
                 --duration_sec $DURATION \
+                --batch_size=50 \
                 --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/window_fuzzer_repro/logs \


### PR DESCRIPTION
Summary:
The window fuzzer test occasionally fails in CI due to OOM. This diff change the configuration to run window fuzzer test with less and smaller batches to avoid OOM.

This diff fixes https://github.com/facebookincubator/velox/issues/11567.

Differential Revision: D66667055


