### PR TITLE
fix: MergeExchange hangs at shutdown after abort/cancel

### DIFF
--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -366,6 +366,9 @@ BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
 }
 
 void MergeExchange::close() {
+  for (auto& source : sources_) {
+    source->close();
+  }
   Operator::close();
   stats_.wlock()->addRuntimeStat(
       Operator::kShuffleSerdeKind,

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -134,6 +134,10 @@ class MergeExchangeSource : public MergeSource {
     client_->noMoreRemoteTasks();
   }
 
+  ~MergeExchangeSource() override {
+    close();
+  }
+
   BlockingReason next(RowVectorPtr& data, ContinueFuture* future) override {
     data.reset();
 


### PR DESCRIPTION
Summary:
When tasks have an MergeExchange operator and the tasks gets canceled or aborted, the task becomes a zombie and the process also hangs at shutdown time.

Inside a driver thread,  `in MergeExchange::addMergeSources`, `MergeExchange` creates ExchangeClients that are to be used during `Merge::isBlocked`.   `Task` is aborted/canceled, and Drivers are supposed to be canceled, operators closed, and unnecessary references to the tasks are released. However, for MergeExchange, we do not close the sources (ExchangeClients) at shutdown. As a result, the driver thread is calling ExchangeClient::request, which will then go to the application's ExchangeSource. This is then stuck in a loop since the exchange client is not closed.

Reviewed By: xiaoxmeng

Differential Revision: D66666334


