### PR TITLE
fix: Fix HashJoinTest.buildReclaimedMemoryReport

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -30,7 +30,6 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/core/PlanNode.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -469,7 +468,7 @@ DEBUG_ONLY_TEST_P(
           }
         }
         auto* driver = op->testingOperatorCtx()->driver();
-        SuspendedSection suspendedSection(driver);
+        TestSuspendedSection suspendedSection(driver);
         arbitrationWait.await([&]() { return !arbitrationWaitFlag.load(); });
       })));
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -1101,21 +1101,6 @@ StopReason Driver::blockDriver(
   return StopReason::kBlock;
 }
 
-SuspendedSection::SuspendedSection(Driver* driver) : driver_(driver) {
-  if (driver->task()->enterSuspended(driver->state()) != StopReason::kNone) {
-    VELOX_FAIL("Terminate detected when entering suspended section");
-  }
-}
-
-SuspendedSection::~SuspendedSection() {
-  if (driver_->task()->leaveSuspended(driver_->state()) != StopReason::kNone) {
-    LOG(WARNING)
-        << "Terminate detected when leaving suspended section for driver "
-        << driver_->driverCtx()->driverId << " from task "
-        << driver_->task()->taskId();
-  }
-}
-
 std::string Driver::label() const {
   return fmt::format("<Driver {}:{}>", task()->taskId(), ctx_->driverId);
 }

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -711,24 +711,6 @@ struct DriverFactory {
   static std::vector<DriverAdapter> adapters;
 };
 
-/// Begins and ends a section where a thread is running but not counted in its
-/// Task. Using this, a Driver thread can for example stop its own Task. For
-/// arbitrating memory overbooking, the contending threads go suspended and each
-/// in turn enters a global critical section. When running the arbitration
-/// strategy, a thread can stop and restart Tasks, including its own. When a
-/// Task is stopped, its drivers are blocked or suspended and the strategy
-/// thread can alter the Task's memory including spilling or killing the whole
-/// Task. Other threads waiting to run the arbitration, are in a suspended state
-/// which also means that they are instantaneously killable or spillable.
-class SuspendedSection {
- public:
-  explicit SuspendedSection(Driver* driver);
-  ~SuspendedSection();
-
- private:
-  Driver* driver_;
-};
-
 /// Provides the execution context of a driver thread. This is set to a
 /// per-thread local variable if the running thread is a driver thread.
 class DriverThreadContext {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -29,6 +29,7 @@
 #include "velox/exec/GroupingSet.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/Values.h"
+#include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -2266,7 +2267,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
             ASSERT_TRUE(reclaimable);
             ASSERT_GT(reclaimableBytes, 0);
             auto* driver = op->testingOperatorCtx()->driver();
-            SuspendedSection suspendedSection(driver);
+            TestSuspendedSection suspendedSection(driver);
             testWait.notify();
             driverWait.wait(driverWaitKey);
           })));
@@ -2383,7 +2384,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
                 ASSERT_EQ(reclaimableBytes, 0);
               }
               auto* driver = op->testingOperatorCtx()->driver();
-              SuspendedSection suspendedSection(driver);
+              TestSuspendedSection suspendedSection(driver);
               testWait.notify();
               driverWait.wait(driverWaitKey);
             })));
@@ -3107,7 +3108,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
             task->pool()->root(), 0);
         {
           MemoryReclaimer::Stats stats;
-          SuspendedSection suspendedSection(driver);
+          TestSuspendedSection suspendedSection(driver);
           task->pool()->reclaim(kMaxBytes, 0, stats);
           ASSERT_EQ(stats.numNonReclaimableAttempts, 0);
           ASSERT_GE(stats.reclaimExecTimeUs, 0);
@@ -3177,7 +3178,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
             task->pool()->root(), 0);
         {
           MemoryReclaimer::Stats stats;
-          SuspendedSection suspendedSection(driver);
+          TestSuspendedSection suspendedSection(driver);
           memory::ScopedMemoryArbitrationContext ctx(op->pool());
           task->pool()->reclaim(kMaxBytes, 0, stats);
           ASSERT_EQ(stats.numNonReclaimableAttempts, 0);

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -746,7 +746,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
             ASSERT_TRUE(reclaimable);
             ASSERT_GT(reclaimableBytes, 0);
             auto* driver = op->testingOperatorCtx()->driver();
-            SuspendedSection suspendedSection(driver);
+            TestSuspendedSection suspendedSection(driver);
             testWait.notify();
             driverWait.wait(driverWaitKey);
           })));
@@ -866,7 +866,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
                 ASSERT_EQ(reclaimableBytes, 0);
               }
               auto* driver = op->testingOperatorCtx()->driver();
-              SuspendedSection suspendedSection(driver);
+              TestSuspendedSection suspendedSection(driver);
               testWait.notify();
               driverWait.wait(driverWaitKey);
             })));
@@ -1308,7 +1308,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimFromOrderBy) {
           return;
         }
         auto* driver = op->testingOperatorCtx()->driver();
-        SuspendedSection suspendedSection(driver);
+        TestSuspendedSection suspendedSection(driver);
         memory::testingRunArbitration();
       })));
 

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -374,4 +374,19 @@ QueryTestResult runWriteTask(
   }
   return result;
 }
+
+TestSuspendedSection::TestSuspendedSection(Driver* driver) : driver_(driver) {
+  if (driver->task()->enterSuspended(driver->state()) != StopReason::kNone) {
+    VELOX_FAIL("Terminate detected when entering suspended section");
+  }
+}
+
+TestSuspendedSection::~TestSuspendedSection() {
+  if (driver_->task()->leaveSuspended(driver_->state()) != StopReason::kNone) {
+    LOG(WARNING)
+        << "Terminate detected when leaving suspended section for driver "
+        << driver_->driverCtx()->driverId << " from task "
+        << driver_->task()->taskId();
+  }
+}
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -85,6 +85,24 @@ struct TestAllocation {
   }
 };
 
+/// Begins and ends a section where a thread is running but not counted in its
+/// Task. Using this, a Driver thread can for example stop its own Task. For
+/// arbitrating memory overbooking, the contending threads go suspended and each
+/// in turn enters a global critical section. When running the arbitration
+/// strategy, a thread can stop and restart Tasks, including its own. When a
+/// Task is stopped, its drivers are blocked or suspended and the strategy
+/// thread can alter the Task's memory including spilling or killing the whole
+/// Task. Other threads waiting to run the arbitration, are in a suspended state
+/// which also means that they are instantaneously killable or spillable.
+class TestSuspendedSection {
+ public:
+  explicit TestSuspendedSection(Driver* driver);
+  ~TestSuspendedSection();
+
+ private:
+  Driver* driver_;
+};
+
 std::shared_ptr<core::QueryCtx> newQueryCtx(
     facebook::velox::memory::MemoryManager* memoryManager,
     folly::Executor* executor,


### PR DESCRIPTION
This test tried to suspend another driver thread from the current one, creating check failures because the other driver could potentially be in blocked state (wait for build etc.). Made correction to the test plus moved the old SuspendedSection out from production code as no prod code reference is currently using it anymore after arbitrator refac.