### PR TITLE
feat(planbuilder): Enable passing compressionKind via tableWrite

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -442,7 +442,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::string_view& connectorId,
     const std::unordered_map<std::string, std::string>& serdeParameters,
     const std::shared_ptr<dwio::common::WriterOptions>& options,
-    const std::string& outputFileName) {
+    const std::string& outputFileName,
+    const common::CompressionKind compressionKind) {
   VELOX_CHECK_NOT_NULL(planNode_, "TableWrite cannot be the source node");
   auto rowType = planNode_->outputType();
 
@@ -477,7 +478,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       locationHandle,
       fileFormat,
       bucketProperty,
-      common::CompressionKind_NONE,
+      compressionKind,
       serdeParameters,
       options);
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -483,6 +483,8 @@ class PlanBuilder {
   /// @param outputFileName Optional file name of the output. If specified
   /// (non-empty), use it instead of generating the file name in Velox. Should
   /// only be specified in non-bucketing write.
+  /// @param compressionKind Compression scheme to use for writing the
+  /// output data files.
   PlanBuilder& tableWrite(
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionBy,
@@ -496,7 +498,8 @@ class PlanBuilder {
       const std::string_view& connectorId = kHiveDefaultConnectorId,
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr,
-      const std::string& outputFileName = "");
+      const std::string& outputFileName = "",
+      const common::CompressionKind = common::CompressionKind_NONE);
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(


### PR DESCRIPTION
Summary:
Currently there is no way for users to specify `compressionKind` in the velox plan builder in order for the output to be compressed using one of the supported schemes defined by the `CompressionKind` enum. Instead, we always use the hard-coded `CompressionKind_NONE` value.

This diff fixes this by exposing a new `compressionKind` option in one of the overloaded `tableWrite()` methods, allowing users to specify the compression scheme they want to use when writing the table's output files

Reviewed By: kkaranasos

Differential Revision: D66517547


