### PR TITLE
refactor: Change C style casts to C++ style (Part 6)

### DIFF
--- a/velox/dwio/parquet/thrift/ParquetThriftTypes.cpp
+++ b/velox/dwio/parquet/thrift/ParquetThriftTypes.cpp
@@ -910,19 +910,14 @@ uint32_t StringType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(StringType& a, StringType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(StringType& /*a*/, StringType& /*b*/) {}
 
-StringType::StringType(const StringType& other2) {
-  (void)other2;
-}
-StringType& StringType::operator=(const StringType& other3) {
-  (void)other3;
+StringType::StringType(const StringType& /*other2*/) {}
+
+StringType& StringType::operator=(const StringType& /*other3*/) {
   return *this;
 }
+
 void StringType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "StringType(";
@@ -971,19 +966,14 @@ uint32_t UUIDType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(UUIDType& a, UUIDType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(UUIDType& /*a*/, UUIDType& /*b*/) {}
 
-UUIDType::UUIDType(const UUIDType& other4) {
-  (void)other4;
-}
-UUIDType& UUIDType::operator=(const UUIDType& other5) {
-  (void)other5;
+UUIDType::UUIDType(const UUIDType& /*other4*/) {}
+
+UUIDType& UUIDType::operator=(const UUIDType& /*other5*/) {
   return *this;
 }
+
 void UUIDType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "UUIDType(";
@@ -1032,19 +1022,14 @@ uint32_t MapType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(MapType& a, MapType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(MapType& /*a*/, MapType& /*b*/) {}
 
-MapType::MapType(const MapType& other6) {
-  (void)other6;
-}
-MapType& MapType::operator=(const MapType& other7) {
-  (void)other7;
+MapType::MapType(const MapType& /*other6*/) {}
+
+MapType& MapType::operator=(const MapType& /*other7*/) {
   return *this;
 }
+
 void MapType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "MapType(";
@@ -1093,19 +1078,14 @@ uint32_t ListType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(ListType& a, ListType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(ListType& /*a*/, ListType& /*b*/) {}
 
-ListType::ListType(const ListType& other8) {
-  (void)other8;
-}
-ListType& ListType::operator=(const ListType& other9) {
-  (void)other9;
+ListType::ListType(const ListType& /*other8*/) {}
+
+ListType& ListType::operator=(const ListType& /*other9*/) {
   return *this;
 }
+
 void ListType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "ListType(";
@@ -1154,19 +1134,14 @@ uint32_t EnumType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(EnumType& a, EnumType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(EnumType& /*a*/, EnumType& /*b*/) {}
 
-EnumType::EnumType(const EnumType& other10) {
-  (void)other10;
-}
-EnumType& EnumType::operator=(const EnumType& other11) {
-  (void)other11;
+EnumType::EnumType(const EnumType& /*other10*/) {}
+
+EnumType& EnumType::operator=(const EnumType& /*other11*/) {
   return *this;
 }
+
 void EnumType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "EnumType(";
@@ -1215,19 +1190,14 @@ uint32_t DateType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(DateType& a, DateType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(DateType& /*a*/, DateType& /*b*/) {}
 
-DateType::DateType(const DateType& other12) {
-  (void)other12;
-}
-DateType& DateType::operator=(const DateType& other13) {
-  (void)other13;
+DateType::DateType(const DateType& /*other12*/) {}
+
+DateType& DateType::operator=(const DateType& /*other13*/) {
   return *this;
 }
+
 void DateType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "DateType(";
@@ -1276,19 +1246,14 @@ uint32_t NullType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(NullType& a, NullType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(NullType& /*a*/, NullType& /*b*/) {}
 
-NullType::NullType(const NullType& other14) {
-  (void)other14;
-}
-NullType& NullType::operator=(const NullType& other15) {
-  (void)other15;
+NullType::NullType(const NullType& /*other14*/) {}
+
+NullType& NullType::operator=(const NullType& /*other15*/) {
   return *this;
 }
+
 void NullType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "NullType(";
@@ -1448,19 +1413,14 @@ uint32_t MilliSeconds::write(
   return xfer;
 }
 
-void swap(MilliSeconds& a, MilliSeconds& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(MilliSeconds& /*a*/, MilliSeconds& /*b*/) {}
 
-MilliSeconds::MilliSeconds(const MilliSeconds& other18) {
-  (void)other18;
-}
-MilliSeconds& MilliSeconds::operator=(const MilliSeconds& other19) {
-  (void)other19;
+MilliSeconds::MilliSeconds(const MilliSeconds& /*other18*/) {}
+
+MilliSeconds& MilliSeconds::operator=(const MilliSeconds& /*other19*/) {
   return *this;
 }
+
 void MilliSeconds::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "MilliSeconds(";
@@ -1510,19 +1470,14 @@ uint32_t MicroSeconds::write(
   return xfer;
 }
 
-void swap(MicroSeconds& a, MicroSeconds& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(MicroSeconds& /*a*/, MicroSeconds& /*b*/) {}
 
-MicroSeconds::MicroSeconds(const MicroSeconds& other20) {
-  (void)other20;
-}
-MicroSeconds& MicroSeconds::operator=(const MicroSeconds& other21) {
-  (void)other21;
+MicroSeconds::MicroSeconds(const MicroSeconds& /*other20*/) {}
+
+MicroSeconds& MicroSeconds::operator=(const MicroSeconds& /*other21*/) {
   return *this;
 }
+
 void MicroSeconds::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "MicroSeconds(";
@@ -1572,19 +1527,14 @@ uint32_t NanoSeconds::write(
   return xfer;
 }
 
-void swap(NanoSeconds& a, NanoSeconds& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(NanoSeconds& /*a*/, NanoSeconds& /*b*/) {}
 
-NanoSeconds::NanoSeconds(const NanoSeconds& other22) {
-  (void)other22;
-}
-NanoSeconds& NanoSeconds::operator=(const NanoSeconds& other23) {
-  (void)other23;
+NanoSeconds::NanoSeconds(const NanoSeconds& /*other22*/) {}
+
+NanoSeconds& NanoSeconds::operator=(const NanoSeconds& /*other23*/) {
   return *this;
 }
+
 void NanoSeconds::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "NanoSeconds(";
@@ -2101,19 +2051,14 @@ uint32_t JsonType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(JsonType& a, JsonType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(JsonType& /*a*/, JsonType& /*b*/) {}
 
-JsonType::JsonType(const JsonType& other32) {
-  (void)other32;
-}
-JsonType& JsonType::operator=(const JsonType& other33) {
-  (void)other33;
+JsonType::JsonType(const JsonType& /*other32*/) {}
+
+JsonType& JsonType::operator=(const JsonType& /*other33*/) {
   return *this;
 }
+
 void JsonType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "JsonType(";
@@ -2162,19 +2107,14 @@ uint32_t BsonType::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(BsonType& a, BsonType& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(BsonType& /*a*/, BsonType& /*b*/) {}
 
-BsonType::BsonType(const BsonType& other34) {
-  (void)other34;
-}
-BsonType& BsonType::operator=(const BsonType& other35) {
-  (void)other35;
+BsonType::BsonType(const BsonType& /*other34*/) {}
+
+BsonType& BsonType::operator=(const BsonType& /*other35*/) {
   return *this;
 }
+
 void BsonType::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "BsonType(";
@@ -2647,7 +2587,7 @@ uint32_t SchemaElement::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast38;
           xfer += iprot->readI32(ecast38);
-          this->type = (Type::type)ecast38;
+          this->type = static_cast<Type::type>(ecast38);
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2665,7 +2605,8 @@ uint32_t SchemaElement::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast39;
           xfer += iprot->readI32(ecast39);
-          this->repetition_type = (FieldRepetitionType::type)ecast39;
+          this->repetition_type =
+              static_cast<FieldRepetitionType::type>(ecast39);
           this->__isset.repetition_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2691,7 +2632,7 @@ uint32_t SchemaElement::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast40;
           xfer += iprot->readI32(ecast40);
-          this->converted_type = (ConvertedType::type)ecast40;
+          this->converted_type = static_cast<ConvertedType::type>(ecast40);
           this->__isset.converted_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2752,7 +2693,7 @@ uint32_t SchemaElement::write(
   if (this->__isset.type) {
     xfer +=
         oprot->writeFieldBegin("type", ::apache::thrift::protocol::T_I32, 1);
-    xfer += oprot->writeI32((int32_t)this->type);
+    xfer += oprot->writeI32(static_cast<int32_t>(this->type));
     xfer += oprot->writeFieldEnd();
   }
   if (this->__isset.type_length) {
@@ -2764,7 +2705,7 @@ uint32_t SchemaElement::write(
   if (this->__isset.repetition_type) {
     xfer += oprot->writeFieldBegin(
         "repetition_type", ::apache::thrift::protocol::T_I32, 3);
-    xfer += oprot->writeI32((int32_t)this->repetition_type);
+    xfer += oprot->writeI32(static_cast<int32_t>(this->repetition_type));
     xfer += oprot->writeFieldEnd();
   }
   xfer +=
@@ -2781,7 +2722,7 @@ uint32_t SchemaElement::write(
   if (this->__isset.converted_type) {
     xfer += oprot->writeFieldBegin(
         "converted_type", ::apache::thrift::protocol::T_I32, 6);
-    xfer += oprot->writeI32((int32_t)this->converted_type);
+    xfer += oprot->writeI32(static_cast<int32_t>(this->converted_type));
     xfer += oprot->writeFieldEnd();
   }
   if (this->__isset.scale) {
@@ -2952,7 +2893,7 @@ uint32_t DataPageHeader::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast43;
           xfer += iprot->readI32(ecast43);
-          this->encoding = (Encoding::type)ecast43;
+          this->encoding = static_cast<Encoding::type>(ecast43);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2962,7 +2903,8 @@ uint32_t DataPageHeader::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast44;
           xfer += iprot->readI32(ecast44);
-          this->definition_level_encoding = (Encoding::type)ecast44;
+          this->definition_level_encoding =
+              static_cast<Encoding::type>(ecast44);
           isset_definition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -2972,7 +2914,8 @@ uint32_t DataPageHeader::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast45;
           xfer += iprot->readI32(ecast45);
-          this->repetition_level_encoding = (Encoding::type)ecast45;
+          this->repetition_level_encoding =
+              static_cast<Encoding::type>(ecast45);
           isset_repetition_level_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3019,17 +2962,19 @@ uint32_t DataPageHeader::write(
 
   xfer +=
       oprot->writeFieldBegin("encoding", ::apache::thrift::protocol::T_I32, 2);
-  xfer += oprot->writeI32((int32_t)this->encoding);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->encoding));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
       "definition_level_encoding", ::apache::thrift::protocol::T_I32, 3);
-  xfer += oprot->writeI32((int32_t)this->definition_level_encoding);
+  xfer +=
+      oprot->writeI32(static_cast<int32_t>(this->definition_level_encoding));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
       "repetition_level_encoding", ::apache::thrift::protocol::T_I32, 4);
-  xfer += oprot->writeI32((int32_t)this->repetition_level_encoding);
+  xfer +=
+      oprot->writeI32(static_cast<int32_t>(this->repetition_level_encoding));
   xfer += oprot->writeFieldEnd();
 
   if (this->__isset.statistics) {
@@ -3129,19 +3074,15 @@ uint32_t IndexPageHeader::write(
   return xfer;
 }
 
-void swap(IndexPageHeader& a, IndexPageHeader& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(IndexPageHeader& /*a*/, IndexPageHeader& /*b*/) {}
 
-IndexPageHeader::IndexPageHeader(const IndexPageHeader& other48) {
-  (void)other48;
-}
-IndexPageHeader& IndexPageHeader::operator=(const IndexPageHeader& other49) {
-  (void)other49;
+IndexPageHeader::IndexPageHeader(const IndexPageHeader& /*other48*/) {}
+
+IndexPageHeader& IndexPageHeader::operator=(
+    const IndexPageHeader& /*other49*/) {
   return *this;
 }
+
 void IndexPageHeader::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "IndexPageHeader(";
@@ -3200,7 +3141,7 @@ uint32_t DictionaryPageHeader::read(
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast50;
           xfer += iprot->readI32(ecast50);
-          this->encoding = (Encoding::type)ecast50;
+          this->encoding = static_cast<Encoding::type>(ecast50);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3243,7 +3184,7 @@ uint32_t DictionaryPageHeader::write(
 
   xfer +=
       oprot->writeFieldBegin("encoding", ::apache::thrift::protocol::T_I32, 2);
-  xfer += oprot->writeI32((int32_t)this->encoding);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->encoding));
   xfer += oprot->writeFieldEnd();
 
   if (this->__isset.is_sorted) {
@@ -3384,7 +3325,7 @@ uint32_t DataPageHeaderV2::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast53;
           xfer += iprot->readI32(ecast53);
-          this->encoding = (Encoding::type)ecast53;
+          this->encoding = static_cast<Encoding::type>(ecast53);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -3469,7 +3410,7 @@ uint32_t DataPageHeaderV2::write(
 
   xfer +=
       oprot->writeFieldBegin("encoding", ::apache::thrift::protocol::T_I32, 4);
-  xfer += oprot->writeI32((int32_t)this->encoding);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->encoding));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
@@ -3605,20 +3546,16 @@ uint32_t SplitBlockAlgorithm::write(
   return xfer;
 }
 
-void swap(SplitBlockAlgorithm& a, SplitBlockAlgorithm& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(SplitBlockAlgorithm& /*a*/, SplitBlockAlgorithm& /*b*/) {}
 
-SplitBlockAlgorithm::SplitBlockAlgorithm(const SplitBlockAlgorithm& other56) {
-  (void)other56;
-}
+SplitBlockAlgorithm::SplitBlockAlgorithm(
+    const SplitBlockAlgorithm& /*other56*/) {}
+
 SplitBlockAlgorithm& SplitBlockAlgorithm::operator=(
-    const SplitBlockAlgorithm& other57) {
-  (void)other57;
+    const SplitBlockAlgorithm& /*other57*/) {
   return *this;
 }
+
 void SplitBlockAlgorithm::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "SplitBlockAlgorithm(";
@@ -3758,19 +3695,14 @@ uint32_t XxHash::write(::apache::thrift::protocol::TProtocol* oprot) const {
   return xfer;
 }
 
-void swap(XxHash& a, XxHash& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(XxHash& /*a*/, XxHash& /*b*/) {}
 
-XxHash::XxHash(const XxHash& other60) {
-  (void)other60;
-}
-XxHash& XxHash::operator=(const XxHash& other61) {
-  (void)other61;
+XxHash::XxHash(const XxHash& /*other60*/) {}
+
+XxHash& XxHash::operator=(const XxHash& /*other61*/) {
   return *this;
 }
+
 void XxHash::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "XxHash(";
@@ -3908,19 +3840,14 @@ uint32_t Uncompressed::write(
   return xfer;
 }
 
-void swap(Uncompressed& a, Uncompressed& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(Uncompressed& /*a*/, Uncompressed& /*b*/) {}
 
-Uncompressed::Uncompressed(const Uncompressed& other64) {
-  (void)other64;
-}
-Uncompressed& Uncompressed::operator=(const Uncompressed& other65) {
-  (void)other65;
+Uncompressed::Uncompressed(const Uncompressed& /*other64*/) {}
+
+Uncompressed& Uncompressed::operator=(const Uncompressed& /*other65*/) {
   return *this;
 }
+
 void Uncompressed::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "Uncompressed(";
@@ -4248,7 +4175,7 @@ uint32_t PageHeader::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast70;
           xfer += iprot->readI32(ecast70);
-          this->type = (PageType::type)ecast70;
+          this->type = static_cast<PageType::type>(ecast70);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4334,7 +4261,7 @@ uint32_t PageHeader::write(::apache::thrift::protocol::TProtocol* oprot) const {
   xfer += oprot->writeStructBegin("PageHeader");
 
   xfer += oprot->writeFieldBegin("type", ::apache::thrift::protocol::T_I32, 1);
-  xfer += oprot->writeI32((int32_t)this->type);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->type));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
@@ -4739,7 +4666,7 @@ uint32_t PageEncodingStats::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast77;
           xfer += iprot->readI32(ecast77);
-          this->page_type = (PageType::type)ecast77;
+          this->page_type = static_cast<PageType::type>(ecast77);
           isset_page_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4749,7 +4676,7 @@ uint32_t PageEncodingStats::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast78;
           xfer += iprot->readI32(ecast78);
-          this->encoding = (Encoding::type)ecast78;
+          this->encoding = static_cast<Encoding::type>(ecast78);
           isset_encoding = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4789,12 +4716,12 @@ uint32_t PageEncodingStats::write(
 
   xfer +=
       oprot->writeFieldBegin("page_type", ::apache::thrift::protocol::T_I32, 1);
-  xfer += oprot->writeI32((int32_t)this->page_type);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->page_type));
   xfer += oprot->writeFieldEnd();
 
   xfer +=
       oprot->writeFieldBegin("encoding", ::apache::thrift::protocol::T_I32, 2);
-  xfer += oprot->writeI32((int32_t)this->encoding);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->encoding));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin("count", ::apache::thrift::protocol::T_I32, 3);
@@ -4936,7 +4863,7 @@ uint32_t ColumnMetaData::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast81;
           xfer += iprot->readI32(ecast81);
-          this->type = (Type::type)ecast81;
+          this->type = static_cast<Type::type>(ecast81);
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -4954,7 +4881,7 @@ uint32_t ColumnMetaData::read(::apache::thrift::protocol::TProtocol* iprot) {
             for (_i86 = 0; _i86 < _size82; ++_i86) {
               int32_t ecast87;
               xfer += iprot->readI32(ecast87);
-              this->encodings[_i86] = (Encoding::type)ecast87;
+              this->encodings[_i86] = static_cast<Encoding::type>(ecast87);
             }
             xfer += iprot->readListEnd();
           }
@@ -4986,7 +4913,7 @@ uint32_t ColumnMetaData::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast93;
           xfer += iprot->readI32(ecast93);
-          this->codec = (CompressionCodec::type)ecast93;
+          this->codec = static_cast<CompressionCodec::type>(ecast93);
           isset_codec = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -5129,7 +5056,7 @@ uint32_t ColumnMetaData::write(
   xfer += oprot->writeStructBegin("ColumnMetaData");
 
   xfer += oprot->writeFieldBegin("type", ::apache::thrift::protocol::T_I32, 1);
-  xfer += oprot->writeI32((int32_t)this->type);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->type));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
@@ -5141,7 +5068,7 @@ uint32_t ColumnMetaData::write(
     std::vector<Encoding::type>::const_iterator _iter104;
     for (_iter104 = this->encodings.begin(); _iter104 != this->encodings.end();
          ++_iter104) {
-      xfer += oprot->writeI32((int32_t)(*_iter104));
+      xfer += oprot->writeI32(static_cast<int32_t>(*_iter104));
     }
     xfer += oprot->writeListEnd();
   }
@@ -5164,7 +5091,7 @@ uint32_t ColumnMetaData::write(
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin("codec", ::apache::thrift::protocol::T_I32, 4);
-  xfer += oprot->writeI32((int32_t)this->codec);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->codec));
   xfer += oprot->writeFieldEnd();
 
   xfer += oprot->writeFieldBegin(
@@ -5394,21 +5321,16 @@ uint32_t EncryptionWithFooterKey::write(
   return xfer;
 }
 
-void swap(EncryptionWithFooterKey& a, EncryptionWithFooterKey& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(EncryptionWithFooterKey& /*a*/, EncryptionWithFooterKey& /*b*/) {}
 
 EncryptionWithFooterKey::EncryptionWithFooterKey(
-    const EncryptionWithFooterKey& other110) {
-  (void)other110;
-}
+    const EncryptionWithFooterKey& /*other110*/) {}
+
 EncryptionWithFooterKey& EncryptionWithFooterKey::operator=(
-    const EncryptionWithFooterKey& other111) {
-  (void)other111;
+    const EncryptionWithFooterKey& /*other111*/) {
   return *this;
 }
+
 void EncryptionWithFooterKey::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "EncryptionWithFooterKey(";
@@ -6301,20 +6223,15 @@ uint32_t TypeDefinedOrder::write(
   return xfer;
 }
 
-void swap(TypeDefinedOrder& a, TypeDefinedOrder& b) {
-  using ::std::swap;
-  (void)a;
-  (void)b;
-}
+void swap(TypeDefinedOrder& /*a*/, TypeDefinedOrder& /*b*/) {}
 
-TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& other138) {
-  (void)other138;
-}
+TypeDefinedOrder::TypeDefinedOrder(const TypeDefinedOrder& /*other138*/) {}
+
 TypeDefinedOrder& TypeDefinedOrder::operator=(
-    const TypeDefinedOrder& other139) {
-  (void)other139;
+    const TypeDefinedOrder& /*other139*/) {
   return *this;
 }
+
 void TypeDefinedOrder::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "TypeDefinedOrder(";
@@ -6763,7 +6680,7 @@ uint32_t ColumnIndex::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_I32) {
           int32_t ecast167;
           xfer += iprot->readI32(ecast167);
-          this->boundary_order = (BoundaryOrder::type)ecast167;
+          this->boundary_order = static_cast<BoundaryOrder::type>(ecast167);
           isset_boundary_order = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -6864,7 +6781,7 @@ uint32_t ColumnIndex::write(
 
   xfer += oprot->writeFieldBegin(
       "boundary_order", ::apache::thrift::protocol::T_I32, 4);
-  xfer += oprot->writeI32((int32_t)this->boundary_order);
+  xfer += oprot->writeI32(static_cast<int32_t>(this->boundary_order));
   xfer += oprot->writeFieldEnd();
 
   if (this->__isset.null_counts) {


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Covers the findings velox/dwio/parquet/thrift/ParquetThriftTypes.cpp