### PR TITLE
refactor: Change C style casts to C++ style (Part 7)

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -42,7 +42,7 @@ VectorPtr newConstantFromString(
   }
 
   if (type->isDate()) {
-    auto days = DATE()->toDays((folly::StringPiece)value.value());
+    auto days = DATE()->toDays(static_cast<folly::StringPiece>(value.value()));
     return std::make_shared<ConstantVector<int32_t>>(
         pool, size, false, type, std::move(days));
   }

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -233,7 +233,7 @@ void PositionalDeleteFileReader::updateDeleteBitmap(
   // There might be multiple delete files for a single base file. The size of
   // the deleteBitmapBuffer should be the largest position among all delte files
   deleteBitmapBuffer->setSize(std::max(
-      (uint64_t)deleteBitmapBuffer->size(),
+      static_cast<uint64_t>(deleteBitmapBuffer->size()),
       deletePositionsOffset_ == 0 ||
               (deletePositionsOffset_ < deletePositionsVector->size() &&
                deletePositions[deletePositionsOffset_] > rowNumberUpperBound)

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -973,7 +973,7 @@ uint64_t DwrfReader::getMemoryUse(
   uint64_t memoryBytes = hasStringColumn
       ? 2 * maxDataLength
       : std::min(
-            uint64_t(maxDataLength),
+            static_cast<uint64_t>(maxDataLength),
             numSelectedStreams *
                 readerBase.bufferedInput().getReadFile()->getNaturalReadSize());
 

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -30,7 +30,7 @@ constexpr vector_size_t kVectorSize = 10000;
 vector_size_t kNumIterations = 1000;
 
 float genData(float pos) {
-  return float(pos * (float)3.14);
+  return float(pos * static_cast<float>(3.14));
 }
 
 bool isNotNull(int32_t pos, int32_t nullEvery) {

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -347,7 +347,8 @@ TEST_F(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
     intDictEncoder.addKey(key);
   }
 
-  int32_t dictSize = (int32_t)2 + std::numeric_limits<int16_t>::max();
+  int32_t dictSize =
+      static_cast<int32_t>(2) + std::numeric_limits<int16_t>::max();
   std::vector<int16_t> dictValues;
 
   auto actualSize =

--- a/velox/dwio/dwrf/test/TestOrcColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestOrcColumnStatistics.cpp
@@ -88,7 +88,7 @@ TEST_F(ColumnStatisticsTest, stringEmptyStats) {
   proto.set_numberofvalues(0);
   auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
   testStringEmptyStats(
-      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+      columnStatisticsWrapper, static_cast<void*>(&proto), DwrfFormat::kOrc);
 }
 
 TEST_F(ColumnStatisticsTest, stringLengthThreshold) {

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -239,7 +239,7 @@ void Writer::ensureWriteFits(size_t appendBytes, size_t appendRows) {
   const size_t estimatedAppendMemoryBytes =
       std::max(appendBytes, context.estimateNextWriteSize(appendRows));
   const double estimatedMemoryGrowthRatio =
-      (double)estimatedAppendMemoryBytes / totalMemoryUsage;
+      static_cast<double>(estimatedAppendMemoryBytes) / totalMemoryUsage;
   if (!maybeReserveMemory(
           MemoryUsageCategory::GENERAL, estimatedMemoryGrowthRatio)) {
     return;
@@ -281,7 +281,7 @@ void Writer::ensureStripeFlushFits() {
         .maybeReserve(outputMemoryToReserve);
   } else {
     const double estimatedMemoryGrowthRatio =
-        (double)estimateFlushMemoryBytes / outputMemoryUsage;
+        static_cast<double>(estimateFlushMemoryBytes) / outputMemoryUsage;
     maybeReserveMemory(
         MemoryUsageCategory::OUTPUT_STREAM, estimatedMemoryGrowthRatio);
   }

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.cpp
@@ -34,14 +34,14 @@ bool containsList(const ParquetTypeWithId& type) {
 } // namespace
 
 std::vector<std::unique_ptr<ParquetTypeWithId::TypeWithId>>
-ParquetTypeWithId::moveChildren() && {
+ParquetTypeWithId::moveChildren() const&& {
   std::vector<std::unique_ptr<TypeWithId>> children;
   for (auto& child : getChildren()) {
     auto type = child->type();
     auto id = child->id();
     auto maxId = child->maxId();
     auto column = child->column();
-    auto* parquetChild = (ParquetTypeWithId*)child.get();
+    auto* parquetChild = dynamic_cast<const ParquetTypeWithId*>(child.get());
     auto name = parquetChild->name_;
     auto parquetType = parquetChild->parquetType_;
     auto logicalType = parquetChild->logicalType_;

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -78,7 +78,8 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
   /// Fills 'info' and returns the mode for interpreting levels.
   LevelMode makeLevelInfo(LevelInfo& info) const;
 
-  std::vector<std::unique_ptr<ParquetTypeWithId::TypeWithId>> moveChildren() &&;
+  std::vector<std::unique_ptr<ParquetTypeWithId::TypeWithId>> moveChildren()
+      const&&;
 
   const std::string name_;
   const std::optional<thrift::Type::type> parquetType_;

--- a/velox/dwio/parquet/reader/RleBpDecoder.cpp
+++ b/velox/dwio/parquet/reader/RleBpDecoder.cpp
@@ -85,7 +85,8 @@ void RleBpDecoder::readBits(
 void RleBpDecoder::readHeader() {
   bitOffset_ = 0;
   auto maxVarIntLen = std::min<uint64_t>(
-      (uint64_t)folly::kMaxVarintLength64, bufferEnd_ - bufferStart_);
+      static_cast<uint64_t>(folly::kMaxVarintLength64),
+      bufferEnd_ - bufferStart_);
   folly::ByteRange headerRange(
       reinterpret_cast<const unsigned char*>(bufferStart_),
       reinterpret_cast<const unsigned char*>(bufferStart_ + maxVarIntLen));

--- a/velox/dwio/parquet/writer/arrow/util/CompressionZlib.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionZlib.cpp
@@ -368,7 +368,7 @@ class GZipCodec : public Codec {
 
   void EndCompressor() {
     if (compressor_initialized_) {
-      (void)deflateEnd(&stream_);
+      static_cast<void>(deflateEnd(&stream_));
     }
     compressor_initialized_ = false;
   }
@@ -389,7 +389,7 @@ class GZipCodec : public Codec {
 
   void EndDecompressor() {
     if (decompressor_initialized_) {
-      (void)inflateEnd(&stream_);
+      static_cast<void>(inflateEnd(&stream_));
     }
     decompressor_initialized_ = false;
   }

--- a/velox/dwio/parquet/writer/arrow/util/Crc32.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/Crc32.cpp
@@ -864,16 +864,17 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
   const uint8_t* current_char;
   const uint32_t* current;
 
-  unaligned = ALIGNOF_UINT32_T - ((uintptr_t)data % ALIGNOF_UINT32_T);
+  unaligned =
+      ALIGNOF_UINT32_T - (reinterpret_cast<uintptr_t>(data) % ALIGNOF_UINT32_T);
   if (unaligned == ALIGNOF_UINT32_T)
     unaligned = 0;
 
   /* process a byte at a time until we hit an alignment boundary (max 3) */
-  current_char = (const uint8_t*)data;
+  current_char = reinterpret_cast<const uint8_t*>(data);
   for (; unaligned && length; unaligned--, length--)
     crc = (crc >> 8) ^ crc32_lookup[0][(crc & 0xFF) ^ *current_char++];
 
-  current = (const uint32_t*)current_char;
+  current = reinterpret_cast<const uint32_t*>(current_char);
 
   /* process 64 bytes at once (Slicing-by-16) */
 
@@ -969,7 +970,7 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
 
   /* Finish with any remaining bytes one by one */
 
-  current_char = (const uint8_t*)current;
+  current_char = reinterpret_cast<const uint8_t*>(current);
   /* remaining 1 to 3 bytes (standard algorithm) */
   while (length-- != 0)
     crc = (crc >> 8) ^ crc32_lookup[0][(crc & 0xFF) ^ *current_char++];

--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -2833,8 +2833,8 @@ static
 std::unique_ptr<CURL, curl_deleter>
 curl_init()
 {
-    static const auto curl_is_now_initiailized = curl_global();
-    (void)curl_is_now_initiailized;
+    static const auto curl_is_now_initialized = curl_global();
+    static_cast<void>(curl_is_now_initialized);
     return std::unique_ptr<CURL, curl_deleter>{::curl_easy_init()};
 }
 

--- a/velox/external/timsort/TimSort.hpp
+++ b/velox/external/timsort/TimSort.hpp
@@ -53,13 +53,13 @@
 #ifdef GFX_TIMSORT_ENABLE_ASSERT
 #define GFX_TIMSORT_ASSERT(expr) assert(expr)
 #else
-#define GFX_TIMSORT_ASSERT(expr) ((void)0)
+#define GFX_TIMSORT_ASSERT(expr) (static_cast<void>(0))
 #endif
 
 #ifdef GFX_TIMSORT_ENABLE_AUDIT
 #define GFX_TIMSORT_AUDIT(expr) assert(expr)
 #else
-#define GFX_TIMSORT_AUDIT(expr) ((void)0)
+#define GFX_TIMSORT_AUDIT(expr) (static_cast<void>(0))
 #endif
 
 #ifdef GFX_TIMSORT_ENABLE_LOG
@@ -67,7 +67,7 @@
 #define GFX_TIMSORT_LOG(expr) \
   (std::clog << "# " << __func__ << ": " << expr << std::endl)
 #else
-#define GFX_TIMSORT_LOG(expr) ((void)0)
+#define GFX_TIMSORT_LOG(expr) (static_cast<void>(0))
 #endif
 
 namespace gfx {

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -78,7 +78,7 @@ std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
       break;
     }
     default: // make compilers happy
-      (void)0; // Statement to avoid empty semicolon warning
+      break;
   }
   return targetTypes;
 }

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -42,7 +42,8 @@ class CompactRowVectorSerializer : public RowSerializer<row::CompactRow> {
     for (const auto& range : ranges) {
       if (range.size == 1) {
         // Fast path for single-row serialization.
-        *(TRowSize*)(rawBuffer + offset) = folly::Endian::big(rowSize[index]);
+        *reinterpret_cast<TRowSize*>(rawBuffer + offset) =
+            folly::Endian::big(rowSize[index]);
         auto size =
             row.serialize(range.begin, rawBuffer + offset + sizeof(TRowSize));
         offset += size + sizeof(TRowSize);


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Findings in many miscellaneous files.