### PR TITLE
refactor: Use KeepAlive instead of Executor*

### DIFF
--- a/velox/dwio/common/ExecutorBarrier.cpp
+++ b/velox/dwio/common/ExecutorBarrier.cpp
@@ -17,7 +17,6 @@
 #include "velox/dwio/common/ExecutorBarrier.h"
 
 namespace facebook::velox::dwio::common {
-
 namespace {
 
 class BarrierElement {
@@ -72,11 +71,11 @@ auto ExecutorBarrier::wrapMethod(folly::Func f) {
 }
 
 void ExecutorBarrier::add(folly::Func f) {
-  executor_.add(wrapMethod(std::move(f)));
+  executor_->add(wrapMethod(std::move(f)));
 }
 
 void ExecutorBarrier::addWithPriority(folly::Func f, int8_t priority) {
-  executor_.addWithPriority(wrapMethod(std::move(f)), priority);
+  executor_->addWithPriority(wrapMethod(std::move(f)), priority);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ParallelFor.cpp
+++ b/velox/dwio/common/ParallelFor.cpp
@@ -19,7 +19,6 @@
 #include "velox/dwio/common/ExecutorBarrier.h"
 
 namespace facebook::velox::dwio::common {
-
 namespace {
 
 std::vector<std::pair<size_t, size_t>>
@@ -60,7 +59,7 @@ splitRange(size_t from, size_t to, size_t factor) {
 } // namespace
 
 ParallelFor::ParallelFor(
-    folly::Executor* executor,
+    folly::Executor::KeepAlive<> executor,
     size_t from,
     size_t to,
     size_t parallelismFactor)
@@ -89,7 +88,7 @@ void ParallelFor::execute(std::function<void(size_t)> func) {
     VELOX_CHECK(
         executor_,
         "Executor wasn't provided so we shouldn't have more than 1 range");
-    ExecutorBarrier barrier(*executor_);
+    ExecutorBarrier barrier(executor_);
     const size_t last = ranges_.size() - 1;
     // First N-1 ranges in executor threads
     for (size_t r = 0; r < last; ++r) {

--- a/velox/dwio/common/ParallelFor.h
+++ b/velox/dwio/common/ParallelFor.h
@@ -36,7 +36,7 @@ namespace facebook::velox::dwio::common {
 class ParallelFor {
  public:
   ParallelFor(
-      folly::Executor* executor,
+      folly::Executor::KeepAlive<> executor,
       size_t from, // start index
       size_t to, // past end index
       // number of threads.
@@ -53,7 +53,7 @@ class ParallelFor {
 
  private:
   std::shared_ptr<folly::Executor> owned_;
-  folly::Executor* executor_;
+  folly::Executor::KeepAlive<> executor_;
   std::vector<std::pair<size_t, size_t>> ranges_;
 };
 

--- a/velox/dwio/common/tests/ExecutorBarrierTest.cpp
+++ b/velox/dwio/common/tests/ExecutorBarrierTest.cpp
@@ -26,7 +26,7 @@ TEST(ExecutorBarrierTest, GetNumPriorities) {
   const uint8_t kNumPriorities = 5;
   auto executor =
       std::make_shared<folly::CPUThreadPoolExecutor>(10, kNumPriorities);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
   EXPECT_EQ(barrier->getNumPriorities(), kNumPriorities);
 }
 
@@ -41,7 +41,7 @@ TEST(ExecutorBarrierTest, CanOwn) {
 
 TEST(ExecutorBarrierTest, CanAwaitMultipleTimes) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
   for (int time = 0, multipleTimes = 10; time < multipleTimes; ++time) {
     barrier->waitAll();
   }
@@ -49,7 +49,7 @@ TEST(ExecutorBarrierTest, CanAwaitMultipleTimes) {
 
 TEST(ExecutorBarrierTest, AddCanBeReused) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -68,7 +68,7 @@ TEST(ExecutorBarrierTest, AddCanBeReused) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityCanBeReused) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;
@@ -88,7 +88,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityCanBeReused) {
 
 TEST(ExecutorBarrierTest, AddCanBeReusedAfterException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -110,7 +110,7 @@ TEST(ExecutorBarrierTest, AddCanBeReusedAfterException) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityCanBeReusedAfterException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;
@@ -135,7 +135,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityCanBeReusedAfterException) {
 
 TEST(ExecutorBarrierTest, Add) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -148,7 +148,7 @@ TEST(ExecutorBarrierTest, Add) {
 
 TEST(ExecutorBarrierTest, AddWithPriority) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;
@@ -162,7 +162,7 @@ TEST(ExecutorBarrierTest, AddWithPriority) {
 
 TEST(ExecutorBarrierTest, AddCanIgnore) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   for (int i = 0; i < kCalls; ++i) {
@@ -173,7 +173,7 @@ TEST(ExecutorBarrierTest, AddCanIgnore) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityCanIgnore) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   for (int i = 0; i < kCalls; ++i) {
@@ -187,7 +187,7 @@ TEST(ExecutorBarrierTest, DestructorDoesntThrow) {
   std::atomic<int> count{0};
   {
     auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-    auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+    auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
     for (int i = 0; i < kCalls; ++i) {
       barrier->add([shouldThrow = (i == 0), &count]() {
@@ -203,7 +203,7 @@ TEST(ExecutorBarrierTest, DestructorDoesntThrow) {
 
 TEST(ExecutorBarrierTest, AddException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -221,7 +221,7 @@ TEST(ExecutorBarrierTest, AddException) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;
@@ -242,7 +242,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityException) {
 
 TEST(ExecutorBarrierTest, AddNonStdException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -261,7 +261,7 @@ TEST(ExecutorBarrierTest, AddNonStdException) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityNonStdException) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;
@@ -283,7 +283,7 @@ TEST(ExecutorBarrierTest, AddWithPriorityNonStdException) {
 
 TEST(ExecutorBarrierTest, AddExceptions) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   std::atomic<int> count{0};
@@ -299,7 +299,7 @@ TEST(ExecutorBarrierTest, AddExceptions) {
 
 TEST(ExecutorBarrierTest, AddWithPriorityExceptions) {
   auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
-  auto barrier = std::make_shared<ExecutorBarrier>(*executor);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor);
 
   const int kCalls = 30;
   const int8_t kPriority = 4;


### PR DESCRIPTION
Summary:
folly::Executor::KeepAlive is the recommended way of holding
references to executors as they ensure they are actually kept alive (block the
executor destructor). A shared_ptr or a naked pointer won't ensure the executor
is still available. Other functions from folly (like global pools) only provide
KeepAlive APIs.

Differential Revision: D66724539


