### PR TITLE
fix: Throw on negative numbers in url_decode

### DIFF
--- a/velox/functions/prestosql/URLFunctions.h
+++ b/velox/functions/prestosql/URLFunctions.h
@@ -161,10 +161,15 @@ FOLLY_ALWAYS_INLINE char decodeByte(const char* p, const char* end) {
     p += 2;
 
     char* endptr;
-    char val = strtol(buf, &endptr, 16);
+    auto val = strtol(buf, &endptr, 16);
 
     if (endptr != buf + 2) {
       VELOX_USER_FAIL("Illegal hex characters in escape (%) pattern: {}", buf);
+    }
+
+    if (val < 0) {
+      VELOX_USER_FAIL(
+          "Illegal hex characters in escape (%) pattern - negative value");
     }
 
     return val;

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -648,6 +648,7 @@ TEST_F(URLFunctionsTest, urlDecode) {
   EXPECT_THROW(urlDecode("http%3A%2F%2"), VeloxUserError);
   EXPECT_THROW(urlDecode("http%3A%2F%"), VeloxUserError);
   EXPECT_THROW(urlDecode("http%3A%2F%2H"), VeloxUserError);
+  EXPECT_THROW(urlDecode("%-1"), VeloxUserError);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
url_decode currently accepts negative code points, e.g. url_decode('%-1') will return the same 
results as url_decode('%FF')

Presto Java throws an exception in this case.  This change ensures that Velox does the same.

Note that according to the standard the two characters following the percent should be hex digits, so
this is consistent.  Though Java (and Presto Java through it's dependency) allows plus to appear as 
the first character, e.g. url_decode('%+1') returns the same as url_decode('%01').  I haven't fixed 
that here for consistency though it violates the standard.

Differential Revision: D66728360


