### PR TITLE
feat: Add method to print plan summary

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -67,6 +67,12 @@ void ITypedExpr::registerSerDe() {
   registry.Register("LambdaTypedExpr", core::LambdaTypedExpr::create);
 }
 
+void InputTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
 folly::dynamic InputTypedExpr::serialize() const {
   return ITypedExpr::serializeBase("InputTypedExpr");
 }
@@ -76,6 +82,12 @@ TypedExprPtr InputTypedExpr::create(const folly::dynamic& obj, void* context) {
   auto type = core::deserializeType(obj, context);
 
   return std::make_shared<InputTypedExpr>(std::move(type));
+}
+
+void ConstantTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
 }
 
 folly::dynamic ConstantTypedExpr::serialize() const {
@@ -113,6 +125,12 @@ TypedExprPtr ConstantTypedExpr::create(
   return std::make_shared<ConstantTypedExpr>(restoreVector(dataStream, pool));
 }
 
+void CallTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
 folly::dynamic CallTypedExpr::serialize() const {
   auto obj = ITypedExpr::serializeBase("CallTypedExpr");
   obj["functionName"] = name_;
@@ -126,6 +144,12 @@ TypedExprPtr CallTypedExpr::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<CallTypedExpr>(
       std::move(type), std::move(inputs), obj["functionName"].asString());
+}
+
+void FieldAccessTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
 }
 
 folly::dynamic FieldAccessTypedExpr::serialize() const {
@@ -152,6 +176,12 @@ TypedExprPtr FieldAccessTypedExpr::create(
   }
 }
 
+void DereferenceTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
 folly::dynamic DereferenceTypedExpr::serialize() const {
   auto obj = ITypedExpr::serializeBase("DereferenceTypedExpr");
   obj["fieldIndex"] = index_;
@@ -172,6 +202,12 @@ TypedExprPtr DereferenceTypedExpr::create(
       std::move(type), std::move(inputs[0]), index);
 }
 
+void ConcatTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
 folly::dynamic ConcatTypedExpr::serialize() const {
   return ITypedExpr::serializeBase("ConcatTypedExpr");
 }
@@ -183,6 +219,12 @@ TypedExprPtr ConcatTypedExpr::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<ConcatTypedExpr>(
       type->asRow().names(), std::move(inputs));
+}
+
+void LambdaTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
 }
 
 folly::dynamic LambdaTypedExpr::serialize() const {
@@ -199,6 +241,12 @@ TypedExprPtr LambdaTypedExpr::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<LambdaTypedExpr>(
       asRowType(signature), std::move(body));
+}
+
+void CastTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
 }
 
 folly::dynamic CastTypedExpr::serialize() const {

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -16,11 +16,12 @@
 #pragma once
 
 #include "velox/type/Type.h"
-#include "velox/type/Variant.h"
 
 namespace facebook::velox::core {
 
 class ITypedExpr;
+class ITypedExprVisitor;
+class ITypedExprVisitorContext;
 
 using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
 
@@ -50,6 +51,12 @@ class ITypedExpr : public ISerializable {
   /// Used to bind inputs to lambda functions.
   virtual TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, TypedExprPtr>& mapping) const = 0;
+
+  /// Part of the visitor pattern. Calls visitor.vist(*this, context) with the
+  /// "right" type of the first argument.
+  virtual void accept(
+      const ITypedExprVisitor& visitor,
+      ITypedExprVisitorContext& context) const = 0;
 
   virtual std::string toString() const = 0;
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -108,6 +108,36 @@ extern const SortOrder kAscNullsLast;
 extern const SortOrder kDescNullsFirst;
 extern const SortOrder kDescNullsLast;
 
+struct PlanSummaryOptions {
+  /// Options that apply specifically to PROJECT nodes.
+  struct ProjectOptions {
+    /// For a given PROJECT node, maximum number of non-identity projection
+    /// expressions to include in the summary. By default, no expression is
+    /// included.
+    size_t maxProjections = 0;
+
+    /// For a given PROJECT node, maximum number of dereference (access of a
+    /// struct field) expressions to include in the summary. By default, no
+    /// expression is included.
+    size_t maxDereferences = 0;
+  };
+
+  ProjectOptions project = {};
+
+  /// For a given node, maximum number of output fields to include in the
+  /// summary. Each field has a name and a type. The amount of type information
+  /// is controlled by 'maxChildTypes' option. Use 0 to include only the number
+  /// of output fields.
+  size_t maxOutputFileds = 5;
+
+  /// For a given output type, maximum number of child types to include in the
+  /// summary. By default, only top-level type is included: BIGINT, ARRAY, MAP,
+  /// ROW. Set to 2 to include types of array elements, map keys and values as
+  /// well as up to 2 fields of a struct: ARRAY(REAL), MAP(INTEGER, ARRAY),
+  /// ROW(VARCHAR, ARRAY,...).
+  size_t maxChildTypes = 0;
+};
+
 class PlanNode : public ISerializable {
  public:
   explicit PlanNode(const PlanNodeId& id) : id_{id} {}
@@ -175,6 +205,12 @@ class PlanNode : public ISerializable {
     return stream.str();
   }
 
+  std::string toSummaryString(PlanSummaryOptions options = {}) const {
+    std::stringstream stream;
+    toSummaryString(options, stream, 0);
+    return stream.str();
+  }
+
   /// The name of the plan node, used in toString.
   virtual std::string_view name() const = 0;
 
@@ -216,6 +252,16 @@ class PlanNode : public ISerializable {
           const PlanNodeId& planNodeId,
           const std::string& indentation,
           std::stringstream& stream)>& addContext) const;
+
+  virtual void addSummaryDetails(
+      const std::string& indentation,
+      const PlanSummaryOptions& options,
+      std::stringstream& stream) const;
+
+  void toSummaryString(
+      const PlanSummaryOptions& options,
+      std::stringstream& stream,
+      size_t indentationSize) const;
 
   const std::string id_;
 };
@@ -399,6 +445,11 @@ class FilterNode : public PlanNode {
     stream << "expression: " << filter_->toString();
   }
 
+  void addSummaryDetails(
+      const std::string& indentation,
+      const PlanSummaryOptions& options,
+      std::stringstream& stream) const override;
+
   const std::vector<PlanNodePtr> sources_;
   const TypedExprPtr filter_;
 };
@@ -455,6 +506,16 @@ class ProjectNode : public PlanNode {
 
  private:
   void addDetails(std::stringstream& stream) const override;
+
+  /// Append a summary of the plan node to 'stream'. Make sure to append full
+  /// lines that start with 'identation' and end with std::endl. It is append
+  /// one or multiple lines or not append anything. Make sure to truncate any
+  /// output that can be arbitrary long. The default implementation appends
+  /// truncated output of 'addDetails'.
+  void addSummaryDetails(
+      const std::string& indentation,
+      const PlanSummaryOptions& options,
+      std::stringstream& stream) const override;
 
   static RowTypePtr makeOutputType(
       const std::vector<std::string>& names,

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(
   PartitionedOutputTest.cpp
   PlanNodeSerdeTest.cpp
   PlanNodeToStringTest.cpp
+  PlanNodeToSummaryStringTest.cpp
   PrefixSortTest.cpp
   PrintPlanWithStatsTest.cpp
   ProbeOperatorStateTest.cpp

--- a/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+using facebook::velox::exec::test::PlanBuilder;
+
+namespace facebook::velox::core {
+namespace {
+
+class PlanNodeToSummaryStringTest : public testing::Test,
+                                    public velox::test::VectorTestBase {
+ public:
+  PlanNodeToSummaryStringTest() {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(PlanNodeToSummaryStringTest, basic) {
+  auto rowType = ROW(
+      {"a", "b", "c"}, {INTEGER(), ARRAY(BIGINT()), MAP(TINYINT(), BIGINT())});
+  auto plan =
+      PlanBuilder()
+          .tableScan(rowType)
+          .filter("a > 10 AND cardinality(b) > 20 AND c[1::tinyint] + 11 > 30")
+          .project({
+              "a + 1",
+              "b[1::integer]",
+              "b[2::integer]",
+              "b[3::integer]",
+              "b[4::integer]",
+              "c[1::tinyint] + 11",
+              "c[2::tinyint] + 12",
+          })
+          .planNode();
+  ASSERT_EQ(
+      "-- Project[2]: 7 fields: p0 BIGINT, p1 BIGINT, p2 BIGINT, p3 BIGINT, p4 BIGINT, ...\n"
+      "      expressions: call: 9, cast: 7, constant: 9, field: 7\n"
+      "      functions: plus: 3, subscript: 6\n"
+      "      constants: BIGINT: 9\n"
+      "      projections: 7 out of 7\n"
+      "      dereferences: 0 out of 7\n"
+      "  -- Filter[1]: 3 fields: a INTEGER, b ARRAY, c MAP\n"
+      "        expressions: call: 8, cast: 2, constant: 5, field: 3\n"
+      "        functions: and: 2, cardinality: 1, gt: 3, plus: 1, subscript: 1\n"
+      "        constants: BIGINT: 5\n"
+      "        filter: and(and(gt(cast ROW[\"a\"] as BIGINT,10),gt(cardinal...\n"
+      "    -- TableScan[0]: 3 fields: a INTEGER, b ARRAY, c MAP\n"
+      "          table: hive_table\n",
+      plan->toSummaryString());
+
+  ASSERT_EQ(
+      "-- Project[2]: 7 fields: p0 BIGINT, p1 BIGINT, p2 BIGINT, ...\n"
+      "      expressions: call: 9, cast: 7, constant: 9, field: 7\n"
+      "      functions: plus: 3, subscript: 6\n"
+      "      constants: BIGINT: 9\n"
+      "      projections: 7 out of 7\n"
+      "         p0: plus(cast ROW[\"a\"] as BIGINT,1)\n"
+      "         p1: subscript(ROW[\"b\"],cast 1 as INTEGER)\n"
+      "         ... 5 more\n"
+      "      dereferences: 0 out of 7\n"
+      "  -- Filter[1]: 3 fields: a INTEGER, b ARRAY(BIGINT), c MAP(TINYINT, BIGINT)\n"
+      "        expressions: call: 8, cast: 2, constant: 5, field: 3\n"
+      "        functions: and: 2, cardinality: 1, gt: 3, plus: 1, subscript: 1\n"
+      "        constants: BIGINT: 5\n"
+      "        filter: and(and(gt(cast ROW[\"a\"] as BIGINT,10),gt(cardinal...\n"
+      "    -- TableScan[0]: 3 fields: a INTEGER, b ARRAY(BIGINT), c MAP(TINYINT, BIGINT)\n"
+      "          table: hive_table\n",
+      plan->toSummaryString({
+          .project = {.maxProjections = 2},
+          .maxOutputFileds = 3,
+          .maxChildTypes = 2,
+      }));
+}
+
+TEST_F(PlanNodeToSummaryStringTest, expressions) {
+  auto rowType =
+      ROW({"a", "b", "c", "d"},
+          {
+              INTEGER(),
+              ARRAY(BIGINT()),
+              MAP(TINYINT(), BIGINT()),
+              ROW({"x", "y", "z"}, {BIGINT(), BIGINT(), VARCHAR()}),
+          });
+
+  auto plan = PlanBuilder()
+                  .tableScan(rowType)
+                  .project({
+                      "a",
+                      "transform(b, x -> x + 1)",
+                      "c",
+                      "d.x * 10",
+                      "d.y",
+                      "length(d.z) * strpos(d.z, 'foo')",
+                      "12.345",
+                  })
+                  .planNode();
+
+  ASSERT_EQ(
+      "-- Project[1]: 7 fields: a INTEGER, p1 ARRAY, c MAP, p3 BIGINT, y BIGINT, ...\n"
+      "      expressions: call: 6, constant: 4, dereference: 4, field: 8, lambda: 1\n"
+      "      functions: length: 1, multiply: 2, plus: 1, strpos: 1, transform: 1\n"
+      "      constants: BIGINT: 2, DOUBLE: 1, VARCHAR: 1\n"
+      "      projections: 4 out of 7\n"
+      "      dereferences: 1 out of 7\n"
+      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW\n"
+      "        table: hive_table\n",
+      plan->toSummaryString());
+
+  ASSERT_EQ(
+      "-- Project[1]: 7 fields: a INTEGER, p1 ARRAY, c MAP, p3 BIGINT, y BIGINT, ...\n"
+      "      expressions: call: 6, constant: 4, dereference: 4, field: 8, lambda: 1\n"
+      "      functions: length: 1, multiply: 2, plus: 1, strpos: 1, transform: 1\n"
+      "      constants: BIGINT: 2, DOUBLE: 1, VARCHAR: 1\n"
+      "      projections: 4 out of 7\n"
+      "         p1: transform(ROW[\"b\"],lambda ROW<x:BIGINT> -> plus(RO...\n"
+      "         p3: multiply(ROW[\"d\"][x],10)\n"
+      "         p5: multiply(length(ROW[\"d\"][z]),strpos(ROW[\"d\"][z],\"f...\n"
+      "         ... 1 more\n"
+      "      dereferences: 1 out of 7\n"
+      "         y: ROW[\"d\"][y]\n"
+      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW\n"
+      "        table: hive_table\n",
+      plan->toSummaryString(
+          {.project = {.maxProjections = 3, .maxDereferences = 2}}));
+}
+
+} // namespace
+} // namespace facebook::velox::core


### PR DESCRIPTION
Summary:
Introduce PlanNode::toSummaryString(options) method to summarize large plans for debugging.

The existing PlanNode::toString() output applied to plans used in AI training is often so large that it is hard to see even overall shape of the plan (the tree of plan nodes). This is usually due to very large expressions with 100s of nodes, large complex type constants (arrays and maps), huge output types.

PlanNode::toSummaryString is designed to be readable and provide some basic information about the plan. It shows a tree of nodes, where each node has a 'header' line and a few detail lines. A header includes node type - TableScan, Filter, Project - and a summary of the output type - # of output fields along with details of the first few fields.

```
 -- TableScan[ts-7]: 6 fields: label DOUBLE, prod_prediction DOUBLE, weight DOUBLE, float_features ROW, id_list_features ROW, ...
```

The header includes limited information about the types of the output fields. By default, it shows top-level type: BIGINT, ARRAY, MAP, ROW. 'maxChildTypes = 2' option allows to include more details: types of array elements, map keys and values and up to 2 fields of a struct: ARRAY(REAL), MAP(BIGINT, ARRAY), ROW(VARCHAR, MAP,...).

```
-- Project[proj-7]: 45 fields: float_list_enrichment MAP(INTEGER, ARRAY), ds VARCHAR, augmentations MAP(INTEGER, REAL), event_based_features MAP(INTEGER, ARRAY), lcc_sampling_bucket VARCHAR, ...
```

The details lines are specific to node type. For FILTER and PROJECT, details include counts of expression types, counts of function names, counts of constant types. PROJECT node also shows number of non-identity projections and optionally includes a few of these projections.

```
-- Project[proj-4]: 9 fields: timestamp BIGINT, label DOUBLE, prod_prediction DOUBLE, weight DOUBLE, float_features MAP(INTEGER, REAL), ...
      expressions: field: 18
      projections: 0 out of 9
      dereferences: 9 out of 9
         timestamp: ROW["udf"]["timestamp"]
         label: ROW["udf"]["label"]
         prod_prediction: ROW["udf"]["prod_prediction"]
         weight: ROW["udf"]["weight"]
         float_features: ROW["udf"]["float_features"]
         ... 4 more
  -- Filter[filter-5]: 1 fields: udf ROW(BOOLEAN, BIGINT, ...)
        expressions: call: 1, constant: 1, field: 2
        functions: eq: 1
        constants: BOOLEAN: 1
        filter: eq(ROW["udf"]["dropped"],false)
```

Differential Revision: D66793705


