### PR TITLE
fix: Support timestamp type partition filter

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -665,6 +665,13 @@ bool applyPartitionFilter(
     case TypeKind::BOOLEAN: {
       return applyFilter(*filter, folly::to<bool>(partitionValue));
     }
+    case TypeKind::TIMESTAMP: {
+      auto result = util::fromTimestampString(
+          StringView(partitionValue), util::TimestampParseMode::kPrestoCast);
+      VELOX_CHECK(!result.hasError());
+      result.value().toGMT(Timestamp::defaultTimezone());
+      return applyFilter(*filter, result.value());
+    }
     case TypeKind::VARCHAR: {
       return applyFilter(*filter, partitionValue);
     }


### PR DESCRIPTION
This PR fixes timestamp type partition filter by utilizing `fromTimestampString` with standard cast behavior. Fixes https://github.com/facebookincubator/velox/issues/11791

