### PR TITLE
refactor: Move some logic from URLFunctions.h to URIParser

### DIFF
--- a/velox/functions/prestosql/URIParser.cpp
+++ b/velox/functions/prestosql/URIParser.cpp
@@ -380,6 +380,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
             hasCompression = true;
             // Consume the hex block and the compression '::'.
             posInAddress = posInHex + 2;
+
+            continue;
           }
         } else {
           if (posInHex == len || !test(kHex, str[posInHex + 1])) {
@@ -390,6 +392,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
           numBytes += 2;
           // Consume the hex block and the ':'.
           posInAddress = posInHex + 1;
+
+          continue;
         }
       } else {
         // We found a 2 byte hex value at the end of the string.
@@ -398,6 +402,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
         break;
       }
     }
+
+    break;
   }
 
   // A valid IPv6 address must have exactly 16 bytes, or a compression.

--- a/velox/functions/prestosql/URIParser.h
+++ b/velox/functions/prestosql/URIParser.h
@@ -15,9 +15,16 @@
  */
 #pragma once
 
+#include <boost/regex.hpp>
 #include "velox/type/StringView.h"
 
 namespace facebook::velox::functions {
+namespace detail {
+FOLLY_ALWAYS_INLINE StringView submatch(const boost::cmatch& match, int idx) {
+  const auto& sub = match[idx];
+  return StringView(sub.first, sub.length());
+}
+} // namespace detail
 /// A struct containing the parts of the URI that were extracted during parsing.
 /// If the field was not found, it is empty.
 ///
@@ -38,4 +45,64 @@ struct URI {
 
 /// Parse a URI string into a URI struct according to RFC 3986.
 bool parseUri(const StringView& uriStr, URI& uri);
+
+/// If the string starting at str is a valid IPv6 address, returns true and pos
+/// is updated to the first character after the IP address. Otherwise returns
+/// false and pos is unchanged.
+bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos);
+
+template <typename T>
+FOLLY_ALWAYS_INLINE bool isMultipleInvalidSequences(
+    const T& inputBuffer,
+    size_t inputIndex) {
+  return
+      // 0xe0 followed by a value less than 0xe0 or 0xf0 followed by a
+      // value less than 0x90 is considered an overlong encoding.
+      (inputBuffer[inputIndex] == '\xe0' &&
+       (inputBuffer[inputIndex + 1] & 0xe0) == 0x80) ||
+      (inputBuffer[inputIndex] == '\xf0' &&
+       (inputBuffer[inputIndex + 1] & 0xf0) == 0x80) ||
+      // 0xf4 followed by a byte >= 0x90 looks valid to
+      // tryGetUtf8CharLength, but is actually outside the range of valid
+      // code points.
+      (inputBuffer[inputIndex] == '\xf4' &&
+       (inputBuffer[inputIndex + 1] & 0xf0) != 0x80) ||
+      // The bytes 0xf5-0xff, 0xc0, and 0xc1 look like the start of
+      // multi-byte code points to tryGetUtf8CharLength, but are not part of
+      // any valid code point.
+      (unsigned char)inputBuffer[inputIndex] > 0xf4 ||
+      inputBuffer[inputIndex] == '\xc0' || inputBuffer[inputIndex] == '\xc1';
+}
+
+/// Find an extract the value for the parameter with key `param` from the query
+/// portion of a URI `query`. `query` should already be decoded if necessary.
+template <typename TString>
+std::optional<StringView> extractParameter(
+    const StringView& query,
+    const TString& param) {
+  if (!query.empty()) {
+    // Parse query string.
+    static const boost::regex kQueryParamRegex(
+        "(^|&)" // start of query or start of parameter "&"
+        "([^=&]*)=?" // parameter name and "=" if value is expected
+        "([^&]*)" // parameter value (allows "=" to appear)
+        "(?=(&|$))" // forward reference, next should be end of query or
+                    // start of next parameter
+    );
+
+    const boost::cregex_iterator begin(
+        query.data(), query.data() + query.size(), kQueryParamRegex);
+    boost::cregex_iterator end;
+
+    for (auto it = begin; it != end; ++it) {
+      if (it->length(2) != 0 && (*it)[2].matched) { // key shouldnt be empty.
+        auto key = detail::submatch((*it), 2);
+        if (param.compare(key) == 0) {
+          return detail::submatch((*it), 3);
+        }
+      }
+    }
+  }
+  return std::nullopt;
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -299,6 +299,8 @@ TEST_F(URLFunctionsTest, extractHostIPv6) {
   // Two compressions.
   EXPECT_EQ(std::nullopt, extractHost("http://[0123::4567::]"));
   EXPECT_EQ(std::nullopt, extractHost("http://[::0123::]"));
+  // IPv6 address doesn't end with ']'.
+  EXPECT_EQ(std::nullopt, extractHost("http://[0123:4567:89ab::cdef:0123"));
 
   // Invalid IPv4 addresses.
   // Too many dec-octets.
@@ -338,6 +340,8 @@ TEST_F(URLFunctionsTest, extractHostIPvFuture) {
   EXPECT_EQ(std::nullopt, extractHost("http://[v0.]"));
   // Invalid character in suffix.
   EXPECT_EQ(std::nullopt, extractHost("http://[v0.a/]"));
+  // IPvFuture address doesn't end with ']'.
+  EXPECT_EQ(std::nullopt, extractHost("http://[v0.a"));
 }
 
 TEST_F(URLFunctionsTest, extractHostRegName) {


### PR DESCRIPTION
Summary:
There's some UDFs outside of prestosql's URL functions where I'd like to reuse some of the logic I
wrote for handling URIs.

Specifically:
* tryConsumeIPV6Address: this is generally useful for parsing IPv6 addresses  
* isMultipleInvalidSequences: this is generally useful for determining how many valid subsequences
  make up an invalid code point from tryGetUtf8CharLength.
* extractParameter: this is generally useful for extracting the parameter from a URI's query string

This change moves those functions into URIParser where they can be reused.

Differential Revision: D66832201


