### PR TITLE
feat: Allow non standard partition functions in ScaleWriterPartitioningLocalPartition

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -76,15 +76,13 @@ std::unique_ptr<Operator> createScaleWriterLocalPartition(
     const std::shared_ptr<const core::LocalPartitionNode>& localPartitionNode,
     int32_t operatorId,
     DriverCtx* ctx) {
-  if (dynamic_cast<const HashPartitionFunctionSpec*>(
+  if (dynamic_cast<const RoundRobinPartitionFunctionSpec*>(
           &localPartitionNode->partitionFunctionSpec())) {
-    return std::make_unique<ScaleWriterPartitioningLocalPartition>(
+    return std::make_unique<ScaleWriterLocalPartition>(
         operatorId, ctx, localPartitionNode);
   }
 
-  VELOX_CHECK_NOT_NULL(dynamic_cast<const RoundRobinPartitionFunctionSpec*>(
-      &localPartitionNode->partitionFunctionSpec()));
-  return std::make_unique<ScaleWriterLocalPartition>(
+  return std::make_unique<ScaleWriterPartitioningLocalPartition>(
       operatorId, ctx, localPartitionNode);
 }
 

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -57,10 +57,6 @@ ScaleWriterPartitioningLocalPartition::ScaleWriterPartitioningLocalPartition(
       : planNode->partitionFunctionSpec().create(
             numTablePartitions_,
             /*localExchange=*/true);
-  if (partitionFunction_ != nullptr) {
-    VELOX_CHECK_NOT_NULL(
-        dynamic_cast<HashPartitionFunction*>(partitionFunction_.get()));
-  }
 }
 
 void ScaleWriterPartitioningLocalPartition::initialize() {

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -43,6 +43,7 @@ class PlanNodeSerdeTest : public testing::Test,
     connector::hive::LocationHandle::registerSerDe();
     connector::hive::HiveColumnHandle::registerSerDe();
     connector::hive::HiveInsertTableHandle::registerSerDe();
+    connector::hive::registerHivePartitionFunctionSerDe();
     core::PlanNode::registerSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();


### PR DESCRIPTION
Summary: For example Hive connector partitioning function

Differential Revision: D66833831


