### PR TITLE
fix: Make TopNRowNumber reclaimable when loading lazy

### DIFF
--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -488,7 +488,7 @@ class Operator : public BaseRuntimeStatWriter {
   /// should be called after this.
   virtual void close();
 
-  // Returns true if 'this' never has more output rows than input rows.
+  /// Returns true if 'this' never has more output rows than input rows.
   virtual bool isFilter() const {
     return false;
   }
@@ -832,7 +832,7 @@ std::vector<column_index_t> calculateOutputChannels(
     const RowTypePtr& targetInputType,
     const RowTypePtr& targetOutputType);
 
-// A first operator in a Driver, e.g. table scan or exchange client.
+/// A first operator in a Driver, e.g. table scan or exchange client.
 class SourceOperator : public Operator {
  public:
   SourceOperator(

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -92,6 +92,9 @@ class TopNRowNumber : public Operator {
     return *reinterpret_cast<TopRows*>(group + partitionOffset_);
   }
 
+  // Decodes and potentially loads input if lazy vector.
+  void prepareInput(RowVectorPtr& input);
+
   // Adds input row to a partition or discards the row.
   void processInputRow(vector_size_t index, TopRows& partition);
 


### PR DESCRIPTION
TopNRowNumber stuck in non-reclaimable state when materializing lazy vector in addInput() using TableScan's memory pool, causing query to OOM. Yet at this point the operator is actually reclaimable. And we should not let it fail the query. 