### PR TITLE
refactor(nimble selective reader): Extract common deduplicated reader helper class

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -18,6 +18,10 @@
 
 #include "velox/dwio/common/SelectiveColumnReader.h"
 
+namespace facebook::nimble {
+class DeduplicatedReadHelper;
+}
+
 namespace facebook::velox::dwio::common {
 
 // Abstract superclass for list and map readers. Encapsulates common
@@ -80,6 +84,8 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   // corresponding to the last non-null parent.
   int64_t childTargetReadOffset_ = 0;
   std::vector<SelectiveColumnReader*> children_;
+
+  friend class facebook::nimble::DeduplicatedReadHelper;
 };
 
 class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {


### PR DESCRIPTION
Summary:
Extract deduplicated reader helper class to share common logic between DeduplicatedArrayColumnReader and DeduplicatedMapColumnReader.

This class essentially wants to be a DeduplicatedColumnReaderBase, that inherits velox::common::SelectiveRepeatedColumnReader. This pattern is adopted because we can't both inherit from DeduplicatedColumnReaderBase and the specific column readers, without forcing virtual inheritance, or duplicating all other methods from the specific parent classes.

Differential Revision: D66812388


