### PR TITLE
fix: Incorrect result when hash probe dynamic filters push down through right join

### DIFF
--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -129,7 +129,7 @@ class HashProbe : public Operator {
   // number mappings or input vectors. In this way input vectors do
   // not have to be copied and will be singly referenced by their
   // producer.
-  void clearIdentityProjectedOutput();
+  void clearProjectedOutput();
 
   // Populate output columns with matching build-side rows
   // for the right semi join and non-matching build-side rows
@@ -422,7 +422,7 @@ class HashProbe : public Operator {
   RowTypePtr filterInputType_;
 
   // The input channels that are projected to the output.
-  std::unordered_set<column_index_t> projectedInputColumns_;
+  folly::F14FastMap<column_index_t, column_index_t> projectedInputColumns_;
 
   // Maps input channels to channels in 'filterInputType_'.
   std::vector<IdentityProjection> filterInputProjections_;


### PR DESCRIPTION
Summary:
Right/full join could introduce extra null values in the output column compared to probe side, so they should not be considered as "identity projection" and not qualified for dynamic filter push through.  When the condition of completely replacement of hash probe is satisfied, we were allowing all these extra null rows to pass through the join and generating incorrect result.  This change fixes this bug.

It's possible to generate a filter using hash join, but not completely replacing the hash probe though, since the extra nulls should be filtered out during the actual probe process.  Having such mechanism requires extra information to be added in addition to "identity projections" though (i.e. whether only new nulls will be introduced for certain column).  We can revisit this if we see there is a use case for such optimization.

Differential Revision: D66833193


