### PR TITLE
fix: Fix the MergeSource data lost issue

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -266,8 +266,9 @@ BlockingReason MergeJoinSource::next(
       "facebook::velox::exec::MergeSource::next", this);
   PromiseNotifier notifier(1);
   return state_.withWLock([&](auto& state) {
-    if (state.data != nullptr) {
-      *data = std::move(state.data);
+    if (!state.dataQueue.empty()) {
+      *data = std::move(state.dataQueue.front());
+      state.dataQueue.pop();
 
       deferNotify(producerPromise_, notifier);
       return BlockingReason::kNotBlocked;
@@ -309,9 +310,9 @@ BlockingReason MergeJoinSource::enqueue(
       return BlockingReason::kNotBlocked;
     }
 
-    VELOX_CHECK_NULL(state.data);
-    state.data = std::move(data);
+    state.dataQueue.push(std::move(data));
     deferNotify(consumerPromise_, notifier);
+
     return waitForConsumer(future);
   });
 }

--- a/velox/exec/MergeSource.h
+++ b/velox/exec/MergeSource.h
@@ -74,6 +74,7 @@ class MergeJoinSource {
   struct State {
     bool atEnd = false;
     RowVectorPtr data;
+    std::queue<RowVectorPtr> dataQueue;
   };
 
   folly::Synchronized<State> state_;


### PR DESCRIPTION
When running the TPCH Q21 query, we found that performing a left semi join followed by a left anti join in the same stage resulted in incorrect results. Upon investigation, we discovered that MergeSource was losing data in such complex join scenarios. This PR addresses the issue by placing the data from MergeSource into a queue, ensuring that the next method call only ends when the queue is empty.