### PR TITLE
fix: Fix flaky TaskPauseTest.resumeFuture test

### DIFF
--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1543,7 +1543,9 @@ DEBUG_ONLY_TEST_F(TaskPauseTest, resumeFuture) {
   observeThread.join();
 
   ASSERT_EQ(task_->numTotalDrivers(), 1);
-  ASSERT_EQ(task_->numFinishedDrivers(), 1);
+  while (task_->numFinishedDrivers() != 1) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100)); // NOLINT
+  }
   ASSERT_EQ(task_->numRunningDrivers(), 0);
 }
 


### PR DESCRIPTION
Summary: There is race condition that task driver finish asynchronously

Differential Revision: D66862540


