### PR TITLE
fix: Timestamp toMicros should work for all timestamps fitting in bigint

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -163,8 +163,7 @@ struct Timestamp {
     // If the final result does not fit in int64_t we throw.
     __int128_t result =
         (__int128_t)seconds_ * 1'000 + (int64_t)(nanos_ / 1'000'000);
-    if (result < std::numeric_limits<int64_t>::min() ||
-        result > std::numeric_limits<int64_t>::max()) {
+    if (result < INT64_MIN || result > INT64_MAX) {
       VELOX_USER_FAIL(
           "Could not convert Timestamp({}, {}) to milliseconds",
           seconds_,
@@ -183,19 +182,20 @@ struct Timestamp {
 
   // Keep it in header for getting inlined.
   int64_t toMicros() const {
-    // When an integer overflow occurs in the calculation,
-    // an exception will be thrown.
-    try {
-      return checkedPlus(
-          checkedMultiply(seconds_, (int64_t)1'000'000),
-          (int64_t)(nanos_ / 1'000));
-    } catch (const std::exception& e) {
+    // We use int128_t to make sure the computation does not overflows since
+    // there are cases such that seconds*1000000 does not fit in int64_t,
+    // but seconds*1000000 + nanos does, an example is TimeStamp::minMillis().
+
+    // If the final result does not fit in int64_t we throw.
+    __int128_t result =
+        (__int128_t)seconds_ * 1'000'000 + (int64_t)(nanos_ / 1'000);
+    if (result < INT64_MIN || result > INT64_MAX) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, {}",
+          "Could not convert Timestamp({}, {}) to microseconds",
           seconds_,
-          nanos_,
-          e.what());
+          nanos_);
     }
+    return result;
   }
 
   Timestamp toPrecision(const TimestampPrecision& precision) const {

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -188,8 +188,8 @@ struct Timestamp {
     // Timestamp(-9223372036855, 224'192'000).
 
     // If the final result does not fit in int64_t we throw.
-    __int128_t result =
-        (__int128_t)seconds_ * 1'000'000 + (int64_t)(nanos_ / 1'000);
+    __int128_t result = static_cast<__int128_t>(seconds_) * 1'000'000 +
+        static_cast<int64_t>(nanos_ / 1'000);
     if (result < INT64_MIN || result > INT64_MAX) {
       VELOX_USER_FAIL(
           "Could not convert Timestamp({}, {}) to microseconds",

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -158,7 +158,7 @@ struct Timestamp {
   int64_t toMillis() const {
     // We use int128_t to make sure the computation does not overflow since
     // there are cases such that seconds*1000 does not fit in int64_t,
-    // but seconds*1000 + nanos does, an example is TimeStamp::minMillis().
+    // but seconds*1000 + nanos does, an example is Timestamp::minMillis().
 
     // If the final result does not fit in int64_t we throw.
     __int128_t result =
@@ -183,8 +183,9 @@ struct Timestamp {
   // Keep it in header for getting inlined.
   int64_t toMicros() const {
     // We use int128_t to make sure the computation does not overflows since
-    // there are cases such that seconds*1000000 does not fit in int64_t,
-    // but seconds*1000000 + nanos does, an example is TimeStamp::minMillis().
+    // there are cases such that a negative seconds*1000000 does not fit in
+    // int64_t, but seconds*1000000 + nanos does. An example is
+    // Timestamp(-9223372036855, 224'192'000).
 
     // If the final result does not fit in int64_t we throw.
     __int128_t result =

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -155,8 +155,8 @@ TEST(TimestampTest, arithmeticOverflow) {
           0));
   ASSERT_NO_THROW(Timestamp::minMillis().toMillis());
   ASSERT_NO_THROW(Timestamp::maxMillis().toMillis());
-  ASSERT_NO_THROW(Timestamp::minMillis().toMicros());
-  ASSERT_NO_THROW(Timestamp::maxMillis().toMicros());
+  ASSERT_NO_THROW(Timestamp(-9223372036855, 224'192'000).toMicros());
+  ASSERT_NO_THROW(Timestamp(9223372036854, 775'807'000).toMicros());
 }
 
 TEST(TimestampTest, toAppend) {

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -155,6 +155,8 @@ TEST(TimestampTest, arithmeticOverflow) {
           0));
   ASSERT_NO_THROW(Timestamp::minMillis().toMillis());
   ASSERT_NO_THROW(Timestamp::maxMillis().toMillis());
+  ASSERT_NO_THROW(Timestamp::minMillis().toMicros());
+  ASSERT_NO_THROW(Timestamp::maxMillis().toMicros());
 }
 
 TEST(TimestampTest, toAppend) {


### PR DESCRIPTION
As #7506, toMicros() throws because the computation overflows when multiplying 
negative number then add positive number. In this case the final result still 
fits in int64_t. This PR fixes this issue by using int128_t to make sure the 
computation does not overflow.