### PR TITLE
refactor: Change C style casts to C++ style (Part 8)

### DIFF
--- a/velox/external/md5/md5.cpp
+++ b/velox/external/md5/md5.cpp
@@ -36,8 +36,8 @@ namespace facebook::velox::crypto {
     static void ByteReverse(unsigned char *buf, unsigned longs) {
         unsigned int t;
         do {
-            t = (unsigned int)((unsigned)buf[3] << 8 | buf[2]) << 16 | ((unsigned)buf[1] << 8 | buf[0]);
-            *(unsigned int *)buf = t;
+            t = static_cast<unsigned int>(static_cast<unsigned>(buf[3]) << 8 | buf[2]) << 16 | (static_cast<unsigned>(buf[1]) << 8 | buf[0]);
+            *reinterpret_cast<unsigned int *>(buf) = t;
             buf += 4;
         } while (--longs);
     }
@@ -65,73 +65,73 @@ namespace facebook::velox::crypto {
         c = buf[2];
         d = buf[3];
 
-        MD5STEP(F1, a, b, c, d, in[0] + 0xd76aa478, 7);
-        MD5STEP(F1, d, a, b, c, in[1] + 0xe8c7b756, 12);
-        MD5STEP(F1, c, d, a, b, in[2] + 0x242070db, 17);
-        MD5STEP(F1, b, c, d, a, in[3] + 0xc1bdceee, 22);
-        MD5STEP(F1, a, b, c, d, in[4] + 0xf57c0faf, 7);
-        MD5STEP(F1, d, a, b, c, in[5] + 0x4787c62a, 12);
-        MD5STEP(F1, c, d, a, b, in[6] + 0xa8304613, 17);
-        MD5STEP(F1, b, c, d, a, in[7] + 0xfd469501, 22);
-        MD5STEP(F1, a, b, c, d, in[8] + 0x698098d8, 7);
-        MD5STEP(F1, d, a, b, c, in[9] + 0x8b44f7af, 12);
-        MD5STEP(F1, c, d, a, b, in[10] + 0xffff5bb1, 17);
-        MD5STEP(F1, b, c, d, a, in[11] + 0x895cd7be, 22);
-        MD5STEP(F1, a, b, c, d, in[12] + 0x6b901122, 7);
-        MD5STEP(F1, d, a, b, c, in[13] + 0xfd987193, 12);
-        MD5STEP(F1, c, d, a, b, in[14] + 0xa679438e, 17);
-        MD5STEP(F1, b, c, d, a, in[15] + 0x49b40821, 22);
+        MD5STEP(F1, a, b, c, d, in[0] + static_cast<unsigned int>(0xd76aa478), 7);
+        MD5STEP(F1, d, a, b, c, in[1] + static_cast<unsigned int>(0xe8c7b756), 12);
+        MD5STEP(F1, c, d, a, b, in[2] + static_cast<unsigned int>(0x242070db), 17);
+        MD5STEP(F1, b, c, d, a, in[3] + static_cast<unsigned int>(0xc1bdceee), 22);
+        MD5STEP(F1, a, b, c, d, in[4] + static_cast<unsigned int>(0xf57c0faf), 7);
+        MD5STEP(F1, d, a, b, c, in[5] + static_cast<unsigned int>(0x4787c62a), 12);
+        MD5STEP(F1, c, d, a, b, in[6] + static_cast<unsigned int>(0xa8304613), 17);
+        MD5STEP(F1, b, c, d, a, in[7] + static_cast<unsigned int>(0xfd469501), 22);
+        MD5STEP(F1, a, b, c, d, in[8] + static_cast<unsigned int>(0x698098d8), 7);
+        MD5STEP(F1, d, a, b, c, in[9] + static_cast<unsigned int>(0x8b44f7af), 12);
+        MD5STEP(F1, c, d, a, b, in[10] + static_cast<unsigned int>(0xffff5bb1), 17);
+        MD5STEP(F1, b, c, d, a, in[11] + static_cast<unsigned int>(0x895cd7be), 22);
+        MD5STEP(F1, a, b, c, d, in[12] + static_cast<unsigned int>(0x6b901122), 7);
+        MD5STEP(F1, d, a, b, c, in[13] + static_cast<unsigned int>(0xfd987193), 12);
+        MD5STEP(F1, c, d, a, b, in[14] + static_cast<unsigned int>(0xa679438e), 17);
+        MD5STEP(F1, b, c, d, a, in[15] + static_cast<unsigned int>(0x49b40821), 22);
 
-        MD5STEP(F2, a, b, c, d, in[1] + 0xf61e2562, 5);
-        MD5STEP(F2, d, a, b, c, in[6] + 0xc040b340, 9);
-        MD5STEP(F2, c, d, a, b, in[11] + 0x265e5a51, 14);
-        MD5STEP(F2, b, c, d, a, in[0] + 0xe9b6c7aa, 20);
-        MD5STEP(F2, a, b, c, d, in[5] + 0xd62f105d, 5);
-        MD5STEP(F2, d, a, b, c, in[10] + 0x02441453, 9);
-        MD5STEP(F2, c, d, a, b, in[15] + 0xd8a1e681, 14);
-        MD5STEP(F2, b, c, d, a, in[4] + 0xe7d3fbc8, 20);
-        MD5STEP(F2, a, b, c, d, in[9] + 0x21e1cde6, 5);
-        MD5STEP(F2, d, a, b, c, in[14] + 0xc33707d6, 9);
-        MD5STEP(F2, c, d, a, b, in[3] + 0xf4d50d87, 14);
-        MD5STEP(F2, b, c, d, a, in[8] + 0x455a14ed, 20);
-        MD5STEP(F2, a, b, c, d, in[13] + 0xa9e3e905, 5);
-        MD5STEP(F2, d, a, b, c, in[2] + 0xfcefa3f8, 9);
-        MD5STEP(F2, c, d, a, b, in[7] + 0x676f02d9, 14);
-        MD5STEP(F2, b, c, d, a, in[12] + 0x8d2a4c8a, 20);
+        MD5STEP(F2, a, b, c, d, in[1] + static_cast<unsigned int>(0xf61e2562), 5);
+        MD5STEP(F2, d, a, b, c, in[6] + static_cast<unsigned int>(0xc040b340), 9);
+        MD5STEP(F2, c, d, a, b, in[11] + static_cast<unsigned int>(0x265e5a51), 14);
+        MD5STEP(F2, b, c, d, a, in[0] + static_cast<unsigned int>(0xe9b6c7aa), 20);
+        MD5STEP(F2, a, b, c, d, in[5] + static_cast<unsigned int>(0xd62f105d), 5);
+        MD5STEP(F2, d, a, b, c, in[10] + static_cast<unsigned int>(0x02441453), 9);
+        MD5STEP(F2, c, d, a, b, in[15] + static_cast<unsigned int>(0xd8a1e681), 14);
+        MD5STEP(F2, b, c, d, a, in[4] + static_cast<unsigned int>(0xe7d3fbc8), 20);
+        MD5STEP(F2, a, b, c, d, in[9] + static_cast<unsigned int>(0x21e1cde6), 5);
+        MD5STEP(F2, d, a, b, c, in[14] + static_cast<unsigned int>(0xc33707d6), 9);
+        MD5STEP(F2, c, d, a, b, in[3] + static_cast<unsigned int>(0xf4d50d87), 14);
+        MD5STEP(F2, b, c, d, a, in[8] + static_cast<unsigned int>(0x455a14ed), 20);
+        MD5STEP(F2, a, b, c, d, in[13] + static_cast<unsigned int>(0xa9e3e905), 5);
+        MD5STEP(F2, d, a, b, c, in[2] + static_cast<unsigned int>(0xfcefa3f8), 9);
+        MD5STEP(F2, c, d, a, b, in[7] + static_cast<unsigned int>(0x676f02d9), 14);
+        MD5STEP(F2, b, c, d, a, in[12] + static_cast<unsigned int>(0x8d2a4c8a), 20);
 
-        MD5STEP(F3, a, b, c, d, in[5] + 0xfffa3942, 4);
-        MD5STEP(F3, d, a, b, c, in[8] + 0x8771f681, 11);
-        MD5STEP(F3, c, d, a, b, in[11] + 0x6d9d6122, 16);
-        MD5STEP(F3, b, c, d, a, in[14] + 0xfde5380c, 23);
-        MD5STEP(F3, a, b, c, d, in[1] + 0xa4beea44, 4);
-        MD5STEP(F3, d, a, b, c, in[4] + 0x4bdecfa9, 11);
-        MD5STEP(F3, c, d, a, b, in[7] + 0xf6bb4b60, 16);
-        MD5STEP(F3, b, c, d, a, in[10] + 0xbebfbc70, 23);
-        MD5STEP(F3, a, b, c, d, in[13] + 0x289b7ec6, 4);
-        MD5STEP(F3, d, a, b, c, in[0] + 0xeaa127fa, 11);
-        MD5STEP(F3, c, d, a, b, in[3] + 0xd4ef3085, 16);
-        MD5STEP(F3, b, c, d, a, in[6] + 0x04881d05, 23);
-        MD5STEP(F3, a, b, c, d, in[9] + 0xd9d4d039, 4);
-        MD5STEP(F3, d, a, b, c, in[12] + 0xe6db99e5, 11);
-        MD5STEP(F3, c, d, a, b, in[15] + 0x1fa27cf8, 16);
-        MD5STEP(F3, b, c, d, a, in[2] + 0xc4ac5665, 23);
+        MD5STEP(F3, a, b, c, d, in[5] + static_cast<unsigned int>(0xfffa3942), 4);
+        MD5STEP(F3, d, a, b, c, in[8] + static_cast<unsigned int>(0x8771f681), 11);
+        MD5STEP(F3, c, d, a, b, in[11] + static_cast<unsigned int>(0x6d9d6122), 16);
+        MD5STEP(F3, b, c, d, a, in[14] + static_cast<unsigned int>(0xfde5380c), 23);
+        MD5STEP(F3, a, b, c, d, in[1] + static_cast<unsigned int>(0xa4beea44), 4);
+        MD5STEP(F3, d, a, b, c, in[4] + static_cast<unsigned int>(0x4bdecfa9), 11);
+        MD5STEP(F3, c, d, a, b, in[7] + static_cast<unsigned int>(0xf6bb4b60), 16);
+        MD5STEP(F3, b, c, d, a, in[10] + static_cast<unsigned int>(0xbebfbc70), 23);
+        MD5STEP(F3, a, b, c, d, in[13] + static_cast<unsigned int>(0x289b7ec6), 4);
+        MD5STEP(F3, d, a, b, c, in[0] + static_cast<unsigned int>(0xeaa127fa), 11);
+        MD5STEP(F3, c, d, a, b, in[3] + static_cast<unsigned int>(0xd4ef3085), 16);
+        MD5STEP(F3, b, c, d, a, in[6] + static_cast<unsigned int>(0x04881d05), 23);
+        MD5STEP(F3, a, b, c, d, in[9] + static_cast<unsigned int>(0xd9d4d039), 4);
+        MD5STEP(F3, d, a, b, c, in[12] + static_cast<unsigned int>(0xe6db99e5), 11);
+        MD5STEP(F3, c, d, a, b, in[15] + static_cast<unsigned int>(0x1fa27cf8), 16);
+        MD5STEP(F3, b, c, d, a, in[2] + static_cast<unsigned int>(0xc4ac5665), 23);
 
-        MD5STEP(F4, a, b, c, d, in[0] + 0xf4292244, 6);
-        MD5STEP(F4, d, a, b, c, in[7] + 0x432aff97, 10);
-        MD5STEP(F4, c, d, a, b, in[14] + 0xab9423a7, 15);
-        MD5STEP(F4, b, c, d, a, in[5] + 0xfc93a039, 21);
-        MD5STEP(F4, a, b, c, d, in[12] + 0x655b59c3, 6);
-        MD5STEP(F4, d, a, b, c, in[3] + 0x8f0ccc92, 10);
-        MD5STEP(F4, c, d, a, b, in[10] + 0xffeff47d, 15);
-        MD5STEP(F4, b, c, d, a, in[1] + 0x85845dd1, 21);
-        MD5STEP(F4, a, b, c, d, in[8] + 0x6fa87e4f, 6);
-        MD5STEP(F4, d, a, b, c, in[15] + 0xfe2ce6e0, 10);
-        MD5STEP(F4, c, d, a, b, in[6] + 0xa3014314, 15);
-        MD5STEP(F4, b, c, d, a, in[13] + 0x4e0811a1, 21);
-        MD5STEP(F4, a, b, c, d, in[4] + 0xf7537e82, 6);
-        MD5STEP(F4, d, a, b, c, in[11] + 0xbd3af235, 10);
-        MD5STEP(F4, c, d, a, b, in[2] + 0x2ad7d2bb, 15);
-        MD5STEP(F4, b, c, d, a, in[9] + 0xeb86d391, 21);
+        MD5STEP(F4, a, b, c, d, in[0] + static_cast<unsigned int>(0xf4292244), 6);
+        MD5STEP(F4, d, a, b, c, in[7] + static_cast<unsigned int>(0x432aff97), 10);
+        MD5STEP(F4, c, d, a, b, in[14] + static_cast<unsigned int>(0xab9423a7), 15);
+        MD5STEP(F4, b, c, d, a, in[5] + static_cast<unsigned int>(0xfc93a039), 21);
+        MD5STEP(F4, a, b, c, d, in[12] + static_cast<unsigned int>(0x655b59c3), 6);
+        MD5STEP(F4, d, a, b, c, in[3] + static_cast<unsigned int>(0x8f0ccc92), 10);
+        MD5STEP(F4, c, d, a, b, in[10] + static_cast<unsigned int>(0xffeff47d), 15);
+        MD5STEP(F4, b, c, d, a, in[1] + static_cast<unsigned int>(0x85845dd1), 21);
+        MD5STEP(F4, a, b, c, d, in[8] + static_cast<unsigned int>(0x6fa87e4f), 6);
+        MD5STEP(F4, d, a, b, c, in[15] + static_cast<unsigned int>(0xfe2ce6e0), 10);
+        MD5STEP(F4, c, d, a, b, in[6] + static_cast<unsigned int>(0xa3014314), 15);
+        MD5STEP(F4, b, c, d, a, in[13] + static_cast<unsigned int>(0x4e0811a1), 21);
+        MD5STEP(F4, a, b, c, d, in[4] + static_cast<unsigned int>(0xf7537e82), 6);
+        MD5STEP(F4, d, a, b, c, in[11] + static_cast<unsigned int>(0xbd3af235), 10);
+        MD5STEP(F4, c, d, a, b, in[2] + static_cast<unsigned int>(0x2ad7d2bb), 15);
+        MD5STEP(F4, b, c, d, a, in[9] + static_cast<unsigned int>(0xeb86d391), 21);
 
         buf[0] += a;
         buf[1] += b;
@@ -162,7 +162,7 @@ namespace facebook::velox::crypto {
         /* Update bitcount */
 
         t = bits[0];
-        if ((bits[0] = t + ((unsigned int)len << 3)) < t) {
+        if ((bits[0] = t + (static_cast<unsigned int>(len) << 3)) < t) {
             bits[1]++; /* Carry from low to high */
         }
         bits[1] += len >> 29;
@@ -172,7 +172,7 @@ namespace facebook::velox::crypto {
         /* Handle any leading odd-sized chunks */
 
         if (t) {
-            unsigned char *p = (unsigned char *)in + t;
+            unsigned char *p = static_cast<unsigned char *>(in) + t;
 
             t = 64 - t;
             if (len < t) {
@@ -181,7 +181,7 @@ namespace facebook::velox::crypto {
             }
             std::memcpy(p, input, t);
             ByteReverse(in, 16);
-            MD5Transform(buf, (unsigned int *)in);
+            MD5Transform(buf, reinterpret_cast<unsigned int *>(in));
             input += t;
             len -= t;
         }
@@ -191,7 +191,7 @@ namespace facebook::velox::crypto {
         while (len >= 64) {
             std::memcpy(in, input, 64);
             ByteReverse(in, 16);
-            MD5Transform(buf, (unsigned int *)in);
+            MD5Transform(buf, reinterpret_cast<unsigned int *>(in));
             input += 64;
             len -= 64;
         }
@@ -235,11 +235,11 @@ namespace facebook::velox::crypto {
         ByteReverse(in, 14);
 
         /* Append length in bits and transform */
-        ((unsigned int *)in)[14] = bits[0];
-        ((unsigned int *)in)[15] = bits[1];
+        (reinterpret_cast<unsigned int *>(in))[14] = bits[0];
+        (reinterpret_cast<unsigned int *>(in))[15] = bits[1];
 
-        MD5Transform(buf, (unsigned int *)in);
-        ByteReverse((unsigned char *)buf, 4);
+        MD5Transform(buf, reinterpret_cast<unsigned int *>(in));
+        ByteReverse(reinterpret_cast<unsigned char *>(buf), 4);
         std::memcpy(out_digest, buf, 16);
     }
 


### PR DESCRIPTION
As per the security guideline in
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast

Covers the findings in velox/external/md5/md5.cpp

This is the last PR of this series :)