### PR TITLE
feat: Add Type::toSummaryString API

### DIFF
--- a/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
@@ -127,7 +127,7 @@ TEST_F(PlanNodeToSummaryStringTest, expressions) {
       "      constants: BIGINT: 2, DOUBLE: 1, VARCHAR: 1\n"
       "      projections: 4 out of 7\n"
       "      dereferences: 1 out of 7\n"
-      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW\n"
+      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW(3)\n"
       "        table: hive_table\n",
       plan->toSummaryString());
 
@@ -143,7 +143,7 @@ TEST_F(PlanNodeToSummaryStringTest, expressions) {
       "         ... 1 more\n"
       "      dereferences: 1 out of 7\n"
       "         y: ROW[\"d\"][y]\n"
-      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW\n"
+      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW(3)\n"
       "        table: hive_table\n",
       plan->toSummaryString(
           {.project = {.maxProjections = 3, .maxDereferences = 2}}));

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -871,6 +871,33 @@ bool Type::containsUnknown() const {
   return false;
 }
 
+std::string Type::toSummaryString(TypeSummaryOptions options) const {
+  std::ostringstream out;
+  out << kindName();
+
+  const auto cnt = std::min(options.maxChildren, size());
+  if (cnt > 0) {
+    out << "(";
+    for (auto i = 0; i < cnt; ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      out << childAt(i)->kindName();
+    }
+
+    if (cnt < size()) {
+      out << ", ..." << (size() - cnt) << " more";
+    }
+    out << ")";
+  } else {
+    if (kind_ == TypeKind::ROW) {
+      out << "(" << size() << ")";
+    }
+  }
+
+  return out.str();
+}
+
 namespace {
 
 std::unordered_map<std::string, std::unique_ptr<const CustomTypeFactories>>&

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -487,6 +487,17 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   virtual std::string toString() const = 0;
 
+  /// Options to control the output of toSummaryString().
+  struct TypeSummaryOptions {
+    /// Maximum number of child types to include in the summary.
+    size_type maxChildren{0};
+  };
+
+  /// Returns human-readable summary of the type. Useful when full output of
+  /// toString() is too large.
+  std::string toSummaryString(
+      TypeSummaryOptions options = {.maxChildren = 0}) const;
+
   /// Types are weakly matched.
   /// Examples: Two RowTypes are equivalent if the children types are
   /// equivalent, but the children names could be different. Two OpaqueTypes are


### PR DESCRIPTION
Summary:
Move summarizeOneType logic from PlanNode::toPlanSummary to Type::toSummaryString to allow for reuse and better unit testing.

Enhance the logic to print the number of child types if not all children are included in the summary.

```
ROW(6)
ROW(BOOLEAN, INTEGER, ...4 more)
```

Differential Revision: D66883089


