### PR TITLE
fix(hashjoin): Turn off dynamic filter push downs for null aware right semi porject join

### DIFF
--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -354,7 +354,12 @@ std::optional<std::string> DuckQueryRunner::toSql(
     return out.str();
   };
 
-  const auto& equiClausesToSql = [](auto joinNode) {
+  const auto filterToSql = [](core::TypedExprPtr filter) {
+    auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(filter);
+    return toCallSql(call);
+  };
+
+  const auto& joinConditionAsSql = [&](auto joinNode) {
     std::stringstream out;
     for (auto i = 0; i < joinNode->leftKeys().size(); ++i) {
       if (i > 0) {
@@ -362,6 +367,9 @@ std::optional<std::string> DuckQueryRunner::toSql(
       }
       out << joinNode->leftKeys()[i]->name() << " = "
           << joinNode->rightKeys()[i]->name();
+    }
+    if (joinNode->filter()) {
+      out << " AND " << filterToSql(joinNode->filter());
     }
     return out.str();
   };
@@ -378,39 +386,56 @@ std::optional<std::string> DuckQueryRunner::toSql(
 
   switch (joinNode->joinType()) {
     case core::JoinType::kInner:
-      sql << " FROM t INNER JOIN u ON " << equiClausesToSql(joinNode);
+      sql << " FROM t INNER JOIN u ON " << joinConditionAsSql(joinNode);
       break;
     case core::JoinType::kLeft:
-      sql << " FROM t LEFT JOIN u ON " << equiClausesToSql(joinNode);
+      sql << " FROM t LEFT JOIN u ON " << joinConditionAsSql(joinNode);
       break;
     case core::JoinType::kFull:
-      sql << " FROM t FULL OUTER JOIN u ON " << equiClausesToSql(joinNode);
+      sql << " FROM t FULL OUTER JOIN u ON " << joinConditionAsSql(joinNode);
       break;
     case core::JoinType::kLeftSemiFilter:
+      // Multiple columns returned by a scalar subquery is not supported in
+      // DuckDB. A scalar subquery expression is a subquery that returns one
+      // result row from exactly one column for every input row.
       if (joinNode->leftKeys().size() > 1) {
         return std::nullopt;
       }
       sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
           << " IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
-          << " FROM u)";
+          << " FROM u";
+      if (joinNode->filter()) {
+        sql << " WHERE " << filterToSql(joinNode->filter());
+      }
+      sql << ")";
       break;
     case core::JoinType::kLeftSemiProject:
       if (joinNode->isNullAware()) {
         sql << ", " << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
-            << joinKeysToSql(joinNode->rightKeys()) << " FROM u) FROM t";
+            << joinKeysToSql(joinNode->rightKeys()) << " FROM u";
+        if (joinNode->filter()) {
+          sql << " WHERE " << filterToSql(joinNode->filter());
+        }
+        sql << ") FROM t";
       } else {
-        sql << ", EXISTS (SELECT * FROM u WHERE " << equiClausesToSql(joinNode)
-            << ") FROM t";
+        sql << ", EXISTS (SELECT * FROM u WHERE "
+            << joinConditionAsSql(joinNode);
+        sql << ") FROM t";
       }
       break;
     case core::JoinType::kAnti:
       if (joinNode->isNullAware()) {
         sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
             << " NOT IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
-            << " FROM u)";
+            << " FROM u";
+        if (joinNode->filter()) {
+          sql << " WHERE " << filterToSql(joinNode->filter());
+        }
+        sql << ")";
       } else {
         sql << " FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE "
-            << equiClausesToSql(joinNode) << ")";
+            << joinConditionAsSql(joinNode);
+        sql << ")";
       }
       break;
     default:

--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -449,6 +449,7 @@ std::optional<std::string> DuckQueryRunner::toSql(
 std::optional<std::string> DuckQueryRunner::toSql(
     const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
   std::stringstream sql;
+  sql << "SELECT " << folly::join(", ", joinNode->outputType()->names());
 
   // Nested loop join without filter.
   VELOX_CHECK(

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -669,6 +669,7 @@ std::optional<std::string> PrestoQueryRunner::toSql(
 std::optional<std::string> PrestoQueryRunner::toSql(
     const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
   std::stringstream sql;
+  sql << "SELECT " << folly::join(", ", joinNode->outputType()->names());
 
   // Nested loop join without filter.
   VELOX_CHECK(


### PR DESCRIPTION
Summary: Currently, when there are no matches for a null aware right semi project join but the build side has nulls, the dynamic push down filter filters out all the rows from the probe side. This causes the probe side to be considered empty and therefore sets the entire match column to falses, even in rows where the match value should be null.

Differential Revision: D66903863
