### PR TITLE
fix: Possible infinite loop in URIParser's tryConsumeIPV6Address

### DIFF
--- a/velox/functions/prestosql/URIParser.cpp
+++ b/velox/functions/prestosql/URIParser.cpp
@@ -380,6 +380,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
             hasCompression = true;
             // Consume the hex block and the compression '::'.
             posInAddress = posInHex + 2;
+
+            continue;
           }
         } else {
           if (posInHex == len || !test(kHex, str[posInHex + 1])) {
@@ -390,6 +392,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
           numBytes += 2;
           // Consume the hex block and the ':'.
           posInAddress = posInHex + 1;
+
+          continue;
         }
       } else {
         // We found a 2 byte hex value at the end of the string.
@@ -398,6 +402,8 @@ bool tryConsumeIPV6Address(const char* str, const size_t len, int32_t& pos) {
         break;
       }
     }
+
+    break;
   }
 
   // A valid IPv6 address must have exactly 16 bytes, or a compression.

--- a/velox/functions/prestosql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/URLFunctionsTest.cpp
@@ -299,6 +299,8 @@ TEST_F(URLFunctionsTest, extractHostIPv6) {
   // Two compressions.
   EXPECT_EQ(std::nullopt, extractHost("http://[0123::4567::]"));
   EXPECT_EQ(std::nullopt, extractHost("http://[::0123::]"));
+  // IPv6 address doesn't end with ']'.
+  EXPECT_EQ(std::nullopt, extractHost("http://[0123:4567:89ab::cdef:0123"));
 
   // Invalid IPv4 addresses.
   // Too many dec-octets.
@@ -338,6 +340,8 @@ TEST_F(URLFunctionsTest, extractHostIPvFuture) {
   EXPECT_EQ(std::nullopt, extractHost("http://[v0.]"));
   // Invalid character in suffix.
   EXPECT_EQ(std::nullopt, extractHost("http://[v0.a/]"));
+  // IPvFuture address doesn't end with ']'.
+  EXPECT_EQ(std::nullopt, extractHost("http://[v0.a"));
 }
 
 TEST_F(URLFunctionsTest, extractHostRegName) {


### PR DESCRIPTION
Summary:
When an IPv6 address in a URI does not end with a closing ']' and this happens at the end of the
string, the parser will enter an infinite loop.

The fix is to break out of the loop when we realize we're at the end of the string. 
tryConsumeIPV6Address is not responsible for consume the closing ']' so the caller will realize the 
issue when it attempts to consume it (this is already handled properly there).

Differential Revision: D66904149


