### PR TITLE
feat: Make skewed partition balancer thread-safe and share among scale writer partitioners

### DIFF
--- a/velox/common/base/SkewedPartitionBalancer.cpp
+++ b/velox/common/base/SkewedPartitionBalancer.cpp
@@ -16,58 +16,96 @@
 
 #include "velox/common/base/SkewedPartitionBalancer.h"
 
+#include "velox/common/testutil/TestValue.h"
+
+using facebook::velox::common::testutil::TestValue;
+
 namespace facebook::velox::common {
 SkewedPartitionRebalancer::SkewedPartitionRebalancer(
-    uint32_t partitionCount,
-    uint32_t taskCount,
+    uint32_t numPartitions,
+    uint32_t numTasks,
     uint64_t minProcessedBytesRebalanceThresholdPerPartition,
     uint64_t minProcessedBytesRebalanceThreshold)
-    : partitionCount_(partitionCount),
-      taskCount_(taskCount),
+    : numPartitions_(numPartitions),
+      numTasks_(numTasks),
       minProcessedBytesRebalanceThresholdPerPartition_(
           minProcessedBytesRebalanceThresholdPerPartition),
       minProcessedBytesRebalanceThreshold_(std::max(
           minProcessedBytesRebalanceThreshold,
-          minProcessedBytesRebalanceThresholdPerPartition_)) {
-  VELOX_CHECK_GT(partitionCount_, 0);
-  VELOX_CHECK_GT(taskCount_, 0);
+          minProcessedBytesRebalanceThresholdPerPartition_)),
+      partitionRowCount_(numPartitions_),
+      partitionAssignments_(numPartitions_) {
+  VELOX_CHECK_GT(numPartitions_, 0);
+  VELOX_CHECK_GT(numTasks_, 0);
 
-  partitionRowCount_.resize(partitionCount_, 0);
-  partitionBytes_.resize(partitionCount_, 0);
-  partitionBytesAtLastRebalance_.resize(partitionCount_, 0);
-  partitionBytesSinceLastRebalancePerTask_.resize(partitionCount_, 0);
-  estimatedTaskBytesSinceLastRebalance_.resize(taskCount_, 0);
-
-  partitionAssignments_.resize(partitionCount_);
+  partitionBytes_.resize(numPartitions_, 0);
+  partitionBytesAtLastRebalance_.resize(numPartitions_, 0);
+  partitionBytesSinceLastRebalancePerTask_.resize(numPartitions_, 0);
+  estimatedTaskBytesSinceLastRebalance_.resize(numTasks_, 0);
 
   // Assigns one task for each partition intitially.
-  for (auto partition = 0; partition < partitionCount_; ++partition) {
-    const uint32_t taskId = partition % taskCount;
-    partitionAssignments_[partition].emplace_back(taskId);
+  for (auto partition = 0; partition < numPartitions_; ++partition) {
+    const uint32_t taskId = partition % numTasks_;
+    partitionAssignments_[partition].addTaskId(taskId);
   }
+}
+
+void SkewedPartitionRebalancer::PartitionAssignment::addTaskId(
+    uint32_t taskId) {
+  std::unique_lock guard{lock_};
+  taskIds_.push_back(taskId);
+}
+
+uint32_t SkewedPartitionRebalancer::PartitionAssignment::nextTaskId(
+    uint64_t index) const {
+  std::shared_lock guard{lock_};
+  const auto taskIndex = index % taskIds_.size();
+  return taskIds_[taskIndex];
+}
+
+uint32_t SkewedPartitionRebalancer::PartitionAssignment::size() const {
+  std::shared_lock guard{lock_};
+  return taskIds_.size();
+}
+
+const std::vector<uint32_t>&
+SkewedPartitionRebalancer::PartitionAssignment::taskIds() const {
+  std::shared_lock guard{lock_};
+  return taskIds_;
 }
 
 void SkewedPartitionRebalancer::rebalance() {
-  if (shouldRebalance()) {
-    rebalancePartitions();
+  const int64_t processedBytes = processedBytes_.load();
+  if (shouldRebalance(processedBytes)) {
+    rebalancePartitions(processedBytes);
   }
 }
 
-bool SkewedPartitionRebalancer::shouldRebalance() const {
-  VELOX_CHECK_GE(processedBytes_, processedBytesAtLastRebalance_);
-  return (processedBytes_ - processedBytesAtLastRebalance_) >=
+bool SkewedPartitionRebalancer::shouldRebalance(int64_t processedBytes) const {
+  return (processedBytes - processedBytesAtLastRebalance_) >=
       minProcessedBytesRebalanceThreshold_;
 }
 
-void SkewedPartitionRebalancer::rebalancePartitions() {
-  VELOX_DCHECK(shouldRebalance());
-  ++stats_.numBalanceTriggers;
+void SkewedPartitionRebalancer::rebalancePartitions(int64_t processedBytes) {
+  if (rebalancing_.exchange(true)) {
+    return;
+  }
+
+  SCOPE_EXIT {
+    VELOX_CHECK(rebalancing_);
+    rebalancing_ = false;
+  };
+  ++numBalanceTriggers_;
+
+  TestValue::adjust(
+      "facebook::velox::common::SkewedPartitionRebalancer::rebalancePartitions",
+      this);
 
   // Updates the processed bytes for each partition.
   calculatePartitionProcessedBytes();
 
   // Updates 'partitionBytesSinceLastRebalancePerTask_'.
-  for (auto partition = 0; partition < partitionCount_; ++partition) {
+  for (auto partition = 0; partition < numPartitions_; ++partition) {
     const auto totalAssignedTasks = partitionAssignments_[partition].size();
     const auto partitionBytes = partitionBytes_[partition];
     partitionBytesSinceLastRebalancePerTask_[partition] =
@@ -80,10 +118,10 @@ void SkewedPartitionRebalancer::rebalancePartitions() {
   // max processed bytes since last rebalance at the top of the queue for
   // rebalance later.
   std::vector<IndexedPriorityQueue<uint32_t, /*MaxQueue=*/true>>
-      taskMaxPartitions{taskCount_};
-  for (auto partition = 0; partition < partitionCount_; ++partition) {
+      taskMaxPartitions{numTasks_};
+  for (auto partition = 0; partition < numPartitions_; ++partition) {
     auto& taskAssignments = partitionAssignments_[partition];
-    for (uint32_t taskId : taskAssignments) {
+    for (uint32_t taskId : taskAssignments.taskIds()) {
       auto& taskQueue = taskMaxPartitions[taskId];
       taskQueue.addOrUpdate(
           partition, partitionBytesSinceLastRebalancePerTask_[partition]);
@@ -94,7 +132,7 @@ void SkewedPartitionRebalancer::rebalancePartitions() {
   // last rebalance.
   IndexedPriorityQueue<uint32_t, /*MaxQueue=*/true> maxTasks;
   IndexedPriorityQueue<uint32_t, /*MaxQueue=*/false> minTasks;
-  for (auto taskId = 0; taskId < taskCount_; ++taskId) {
+  for (auto taskId = 0; taskId < numTasks_; ++taskId) {
     estimatedTaskBytesSinceLastRebalance_[taskId] =
         calculateTaskDataSizeSinceLastRebalance(taskMaxPartitions[taskId]);
     maxTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
@@ -102,7 +140,7 @@ void SkewedPartitionRebalancer::rebalancePartitions() {
   }
 
   rebalanceBasedOnTaskSkewness(maxTasks, minTasks, taskMaxPartitions);
-  processedBytesAtLastRebalance_ = processedBytes_;
+  processedBytesAtLastRebalance_.store(processedBytes);
 }
 
 void SkewedPartitionRebalancer::rebalanceBasedOnTaskSkewness(
@@ -159,7 +197,7 @@ void SkewedPartitionRebalancer::rebalanceBasedOnTaskSkewness(
     }
   }
 
-  stats_.numScaledPartitions += scaledPartitions.size();
+  numScaledPartitions_ += scaledPartitions.size();
 }
 
 bool SkewedPartitionRebalancer::rebalancePartition(
@@ -168,49 +206,49 @@ bool SkewedPartitionRebalancer::rebalancePartition(
     IndexedPriorityQueue<uint32_t, true>& maxTasks,
     IndexedPriorityQueue<uint32_t, false>& minTasks) {
   auto& taskAssignments = partitionAssignments_[rebalancePartition];
-  for (auto taskId : taskAssignments) {
+  for (auto taskId : taskAssignments.taskIds()) {
     if (taskId == targetTaskId) {
       return false;
     }
   }
 
-  taskAssignments.push_back(targetTaskId);
+  taskAssignments.addTaskId(targetTaskId);
   VELOX_CHECK_GT(partitionAssignments_[rebalancePartition].size(), 1);
 
-  const auto newTaskCount = taskAssignments.size();
-  const auto oldTaskCount = newTaskCount - 1;
+  const auto newNumTasks = taskAssignments.size();
+  const auto oldNumTasks = newNumTasks - 1;
   // Since a partition is rebalanced from max to min skewed tasks,
   // decrease the priority of max taskBucket as well as increase the priority
   // of min taskBucket.
-  for (uint32_t taskId : taskAssignments) {
+  for (uint32_t taskId : taskAssignments.taskIds()) {
     if (taskId == targetTaskId) {
       estimatedTaskBytesSinceLastRebalance_[taskId] +=
           (partitionBytesSinceLastRebalancePerTask_[rebalancePartition] *
-           oldTaskCount) /
-          newTaskCount;
+           oldNumTasks) /
+          newNumTasks;
     } else {
       estimatedTaskBytesSinceLastRebalance_[taskId] -=
           partitionBytesSinceLastRebalancePerTask_[rebalancePartition] /
-          newTaskCount;
+          newNumTasks;
     }
 
     maxTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
     minTasks.addOrUpdate(taskId, estimatedTaskBytesSinceLastRebalance_[taskId]);
   }
 
-  LOG(INFO) << "Rebalanced partition " << rebalancePartition << " to task "
-            << targetTaskId << " with taskCount " << newTaskCount;
+  VLOG(3) << "Rebalanced partition " << rebalancePartition << " to task "
+          << targetTaskId << " with num of assigned tasks " << newNumTasks;
   return true;
 }
 
 void SkewedPartitionRebalancer::calculatePartitionProcessedBytes() {
   uint64_t totalPartitionRowCount{0};
-  for (auto partition = 0; partition < partitionCount_; ++partition) {
+  for (auto partition = 0; partition < numPartitions_; ++partition) {
     totalPartitionRowCount += partitionRowCount_[partition];
   }
   VELOX_CHECK_GT(totalPartitionRowCount, 0);
 
-  for (auto partition = 0; partition < partitionCount_; ++partition) {
+  for (auto partition = 0; partition < numPartitions_; ++partition) {
     // Since we estimate 'partitionBytes_' based on 'partitionRowCount_' and
     // total 'processedBytes_'. It is possible that the estimated
     // 'partitionBytes_' is slightly less than it was estimated at the last

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -688,16 +688,17 @@ struct DriverFactory {
     return std::nullopt;
   }
 
-  /// Returns LocalPartition plan node ID if the pipeline gets data from a
-  /// local exchange.
-  std::optional<core::PlanNodeId> needsLocalExchange() const {
+  /// Returns true if the pipeline gets data from a local exchange. The function
+  /// sets plan node in 'planNode'.
+  bool needsLocalExchange(core::PlanNodePtr& planNode) const {
     VELOX_CHECK(!planNodes.empty());
     if (auto exchangeNode =
             std::dynamic_pointer_cast<const core::LocalPartitionNode>(
                 planNodes.front())) {
-      return exchangeNode->id();
+      planNode = exchangeNode;
+      return true;
     }
-    return std::nullopt;
+    return false;
   }
 
   /// Returns plan node IDs for which Hash Join Bridges must be created based

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -32,14 +32,15 @@ ScaleWriterPartitioningLocalPartition::ScaleWriterPartitioningLocalPartition(
           ctx->queryConfig().scaleWriterMaxPartitionsPerWriter()),
       numTablePartitions_(maxTablePartitionsPerWriter_ * numPartitions_),
       queryPool_(pool()->root()),
-      tablePartitionRebalancer_(std::make_unique<SkewedPartitionRebalancer>(
-          numTablePartitions_,
-          numPartitions_,
-          ctx->queryConfig()
-              .scaleWriterMinPartitionProcessedBytesRebalanceThreshold(),
-          ctx->queryConfig()
-              .scaleWriterMinProcessedBytesRebalanceThreshold())) {
+      tablePartitionRebalancer_(ctx->task->getScaleWriterPartitionBalancer(
+          ctx->splitGroupId,
+          planNodeId())) {
   VELOX_CHECK_GT(maxTablePartitionsPerWriter_, 0);
+  VELOX_CHECK_NOT_NULL(tablePartitionRebalancer_);
+
+  VELOX_CHECK_EQ(
+      numTablePartitions_, tablePartitionRebalancer_->numPartitions());
+  VELOX_CHECK_EQ(numPartitions_, tablePartitionRebalancer_->numTasks());
 
   writerAssignmentCounts_.resize(numPartitions_, 0);
   tablePartitionRowCounts_.resize(numTablePartitions_, 0);
@@ -221,6 +222,13 @@ uint32_t ScaleWriterPartitioningLocalPartition::getNextWriterId(
 
 void ScaleWriterPartitioningLocalPartition::close() {
   LocalPartition::close();
+
+  // The last driver operator reports the shared table partition rebalancer
+  // stats. We expect one reference hold by this operator and one referenced by
+  // the task.
+  if (tablePartitionRebalancer_.use_count() != 2) {
+    return;
+  }
 
   const auto scaleStats = tablePartitionRebalancer_->stats();
   auto lockedStats = stats_.wlock();

--- a/velox/exec/ScaleWriterLocalPartition.h
+++ b/velox/exec/ScaleWriterLocalPartition.h
@@ -66,7 +66,7 @@ class ScaleWriterPartitioningLocalPartition : public LocalPartition {
   memory::MemoryPool* const queryPool_;
 
   // The skewed partition balancer for writer scaling.
-  const std::unique_ptr<SkewedPartitionRebalancer> tablePartitionRebalancer_;
+  const std::shared_ptr<SkewedPartitionRebalancer> tablePartitionRebalancer_;
 
   std::shared_ptr<LocalExchangeMemoryManager> memoryManager_;
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/base/SkewedPartitionBalancer.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"
@@ -529,7 +530,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   void createLocalExchangeQueuesLocked(
       uint32_t splitGroupId,
-      const core::PlanNodeId& planNodeId,
+      const core::PlanNodePtr& planNode,
       int numPartitions);
 
   void noMoreLocalExchangeProducers(uint32_t splitGroupId);
@@ -546,6 +547,13 @@ class Task : public std::enable_shared_from_this<Task> {
 
   const std::shared_ptr<LocalExchangeMemoryManager>&
   getLocalExchangeMemoryManager(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
+  /// Returns the shared skewed partition balancer for scale writer local
+  /// partitioning with the given split group id and plan node id.
+  const std::shared_ptr<common::SkewedPartitionRebalancer>&
+  getScaleWriterPartitionBalancer(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -89,6 +89,8 @@ struct SplitsState {
 struct LocalExchangeState {
   std::shared_ptr<LocalExchangeMemoryManager> memoryManager;
   std::vector<std::shared_ptr<LocalExchangeQueue>> queues;
+  std::shared_ptr<common::SkewedPartitionRebalancer>
+      scaleWriterPartitionBalancer;
 };
 
 /// Stores inter-operator state (exchange, bridges) for split groups.
@@ -98,8 +100,7 @@ struct SplitGroupState {
   std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>> bridges;
   /// This map will contain all other custom bridges.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>>
-      custom_bridges;
-
+      customBridges;
   /// Holds states for Task::allPeersFinished.
   std::unordered_map<core::PlanNodeId, BarrierState> barriers;
 
@@ -135,7 +136,7 @@ struct SplitGroupState {
   void clear() {
     if (!mixedExecutionMode) {
       bridges.clear();
-      custom_bridges.clear();
+      customBridges.clear();
       barriers.clear();
     }
     localMergeSources.clear();

--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -867,12 +867,22 @@ TEST_F(ScaleWriterLocalPartitionTest, partitionBasic) {
             .copyResults(pool_.get(), task);
     auto planStats = toPlanStats(task->taskStats());
     if (testData.expectedRebalance) {
+      ASSERT_EQ(
+          planStats.at(exchnangeNodeId)
+              .customStats.count(
+                  ScaleWriterPartitioningLocalPartition::kScaledPartitions),
+          1);
       ASSERT_GT(
           planStats.at(exchnangeNodeId)
               .customStats
               .at(ScaleWriterPartitioningLocalPartition::kScaledPartitions)
               .sum,
           0);
+      ASSERT_EQ(
+          planStats.at(exchnangeNodeId)
+              .customStats.count(
+                  ScaleWriterPartitioningLocalPartition::kRebalanceTriggers),
+          1);
       ASSERT_GT(
           planStats.at(exchnangeNodeId)
               .customStats


### PR DESCRIPTION
Summary:
Make skewed partition balancer thread-safe and share it with all the scale writer local partitioners.
Skewed partition balance is created by the first scale writer local partitioner on constructor.
This will help further reduces the unnecessary written files and make memory usage more efficient as
all the local scale writer partitioners have the consistent partition assignment views

Differential Revision: D66628614


