### PR TITLE
fix: Remove log in RemoteFunctionService.cpp

### DIFF
--- a/velox/functions/remote/server/RemoteFunctionService.cpp
+++ b/velox/functions/remote/server/RemoteFunctionService.cpp
@@ -112,9 +112,6 @@ void RemoteFunctionServiceHandler::invokeFunction(
   const auto& functionHandle = request->get_remoteFunctionHandle();
   const auto& inputs = request->get_inputs();
 
-  LOG(INFO) << "Got a request for '" << functionHandle.get_name()
-            << "': " << inputs.get_rowCount() << " input rows.";
-
   // Deserialize types and data.
   auto inputType = deserializeArgTypes(functionHandle.get_argumentTypes());
   auto outputType = deserializeType(functionHandle.get_returnType());


### PR DESCRIPTION
Summary:
This can spam the logs and make it hard to debug issues, e.g.

https://fburl.com/logarithm/nte8jcg8

Ideally we'd have a rate limiter like `LOG_EVERY_MS()` but not sure we want to add that as dependency to Velox.

Reviewed By: xiaoxmeng

Differential Revision: D66914913


