### PR TITLE
fix: Fix flaky caleWriterLocalPartitionTest.unpartitionBasic

### DIFF
--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -552,7 +552,7 @@ class ScaleWriterLocalPartitionTest : public HiveConnectorTestBase {
 };
 
 TEST_F(ScaleWriterLocalPartitionTest, unpartitionBasic) {
-  const std::vector<RowVectorPtr> inputVectors = makeVectors(32, 1024);
+  const std::vector<RowVectorPtr> inputVectors = makeVectors(128, 1024);
   const uint64_t queryCapacity = 256 << 20;
   const uint32_t maxDrivers = 32;
   const uint32_t maxExchanegBufferSize = 2 << 20;


### PR DESCRIPTION
Summary: Fix flaky caleWriterLocalPartitionTest.unpartitionBasic witb more input data

Differential Revision: D66918241


