### PR TITLE
build: Update CI container

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -29,7 +29,7 @@ jobs:
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: 8-core-ubuntu
-    container: ghcr.io/assignuser/velox-dev:adapters
+    container: ghcr.io/facebookincubator/velox-dev:adapters
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
#10732 temporarily changed to a different container. The docker images should be rebuilt with the necessary shared ependencies now so we can witch back.