### PR TITLE
feat(fuzzer): Support multiple joins in the join node "toSql" methods for reference query runners

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -324,6 +324,8 @@ class ValuesNode : public PlanNode {
   const size_t repeatTimes_;
 };
 
+using ValuesNodePtr = std::shared_ptr<const ValuesNode>;
+
 class ArrowStreamNode : public PlanNode {
  public:
   ArrowStreamNode(

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_fuzzer_util DuckQueryRunner.cpp PrestoQueryRunner.cpp
-                              FuzzerUtil.cpp ToSQLUtil.cpp)
+add_library(
+  velox_fuzzer_util
+  ReferenceQueryRunner.cpp
+  DuckQueryRunner.cpp
+  PrestoQueryRunner.cpp
+  FuzzerUtil.cpp
+  ToSQLUtil.cpp)
 
 target_link_libraries(
   velox_fuzzer_util

--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <optional>
+#include <set>
+#include <unordered_map>
+
 #include "velox/exec/fuzzer/DuckQueryRunner.h"
 #include "velox/exec/fuzzer/ToSQLUtil.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
@@ -102,23 +107,39 @@ DuckQueryRunner::aggregationFunctionDataSpecs() const {
   return kAggregationFunctionDataSpecs;
 }
 
+std::pair<
+    std::optional<std::multiset<std::vector<velox::variant>>>,
+    ReferenceQueryErrorCode>
+DuckQueryRunner::execute(const core::PlanNodePtr& plan) {
+  if (std::optional<std::string> sql = toSql(plan)) {
+    try {
+      DuckDbQueryRunner queryRunner;
+      std::unordered_map<std::string, std::vector<RowVectorPtr>> inputMap =
+          getAllTables(plan);
+      for (const auto& [tableName, input] : inputMap) {
+        queryRunner.createTable(tableName, input);
+      }
+      return std::make_pair(
+          queryRunner.execute(*sql, plan->outputType()),
+          ReferenceQueryErrorCode::kSuccess);
+    } catch (...) {
+      LOG(WARNING) << "Query failed in DuckDB";
+      return std::make_pair(
+          std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
+    }
+  }
+
+  LOG(INFO) << "Query not supported in DuckDB";
+  return std::make_pair(
+      std::nullopt, ReferenceQueryErrorCode::kReferenceQueryUnsupported);
+}
+
 std::multiset<std::vector<velox::variant>> DuckQueryRunner::execute(
     const std::string& sql,
     const std::vector<RowVectorPtr>& input,
     const RowTypePtr& resultType) {
   DuckDbQueryRunner queryRunner;
   queryRunner.createTable("tmp", input);
-  return queryRunner.execute(sql, resultType);
-}
-
-std::multiset<std::vector<velox::variant>> DuckQueryRunner::execute(
-    const std::string& sql,
-    const std::vector<RowVectorPtr>& probeInput,
-    const std::vector<RowVectorPtr>& buildInput,
-    const RowTypePtr& resultType) {
-  DuckDbQueryRunner queryRunner;
-  queryRunner.createTable("t", probeInput);
-  queryRunner.createTable("u", buildInput);
   return queryRunner.execute(sql, resultType);
 }
 
@@ -162,6 +183,11 @@ std::optional<std::string> DuckQueryRunner::toSql(
   if (const auto joinNode =
           std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(plan)) {
     return toSql(joinNode);
+  }
+
+  if (const auto valuesNode =
+          std::dynamic_pointer_cast<const core::ValuesNode>(plan)) {
+    return toSql(valuesNode);
   }
 
   VELOX_NYI();
@@ -337,139 +363,6 @@ std::optional<std::string> DuckQueryRunner::toSql(
   }
 
   sql << ") as row_number FROM tmp";
-
-  return sql.str();
-}
-
-std::optional<std::string> DuckQueryRunner::toSql(
-    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
-  const auto& joinKeysToSql = [](auto keys) {
-    std::stringstream out;
-    for (auto i = 0; i < keys.size(); ++i) {
-      if (i > 0) {
-        out << ", ";
-      }
-      out << keys[i]->name();
-    }
-    return out.str();
-  };
-
-  const auto filterToSql = [](core::TypedExprPtr filter) {
-    auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(filter);
-    return toCallSql(call);
-  };
-
-  const auto& joinConditionAsSql = [&](auto joinNode) {
-    std::stringstream out;
-    for (auto i = 0; i < joinNode->leftKeys().size(); ++i) {
-      if (i > 0) {
-        out << " AND ";
-      }
-      out << joinNode->leftKeys()[i]->name() << " = "
-          << joinNode->rightKeys()[i]->name();
-    }
-    if (joinNode->filter()) {
-      out << " AND " << filterToSql(joinNode->filter());
-    }
-    return out.str();
-  };
-
-  const auto& outputNames = joinNode->outputType()->names();
-
-  std::stringstream sql;
-  if (joinNode->isLeftSemiProjectJoin()) {
-    sql << "SELECT "
-        << folly::join(", ", outputNames.begin(), --outputNames.end());
-  } else {
-    sql << "SELECT " << folly::join(", ", outputNames);
-  }
-
-  switch (joinNode->joinType()) {
-    case core::JoinType::kInner:
-      sql << " FROM t INNER JOIN u ON " << joinConditionAsSql(joinNode);
-      break;
-    case core::JoinType::kLeft:
-      sql << " FROM t LEFT JOIN u ON " << joinConditionAsSql(joinNode);
-      break;
-    case core::JoinType::kFull:
-      sql << " FROM t FULL OUTER JOIN u ON " << joinConditionAsSql(joinNode);
-      break;
-    case core::JoinType::kLeftSemiFilter:
-      // Multiple columns returned by a scalar subquery is not supported in
-      // DuckDB. A scalar subquery expression is a subquery that returns one
-      // result row from exactly one column for every input row.
-      if (joinNode->leftKeys().size() > 1) {
-        return std::nullopt;
-      }
-      sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
-          << " IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
-          << " FROM u";
-      if (joinNode->filter()) {
-        sql << " WHERE " << filterToSql(joinNode->filter());
-      }
-      sql << ")";
-      break;
-    case core::JoinType::kLeftSemiProject:
-      if (joinNode->isNullAware()) {
-        sql << ", " << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
-            << joinKeysToSql(joinNode->rightKeys()) << " FROM u";
-        if (joinNode->filter()) {
-          sql << " WHERE " << filterToSql(joinNode->filter());
-        }
-        sql << ") FROM t";
-      } else {
-        sql << ", EXISTS (SELECT * FROM u WHERE "
-            << joinConditionAsSql(joinNode);
-        sql << ") FROM t";
-      }
-      break;
-    case core::JoinType::kAnti:
-      if (joinNode->isNullAware()) {
-        sql << " FROM t WHERE " << joinKeysToSql(joinNode->leftKeys())
-            << " NOT IN (SELECT " << joinKeysToSql(joinNode->rightKeys())
-            << " FROM u";
-        if (joinNode->filter()) {
-          sql << " WHERE " << filterToSql(joinNode->filter());
-        }
-        sql << ")";
-      } else {
-        sql << " FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE "
-            << joinConditionAsSql(joinNode);
-        sql << ")";
-      }
-      break;
-    default:
-      VELOX_UNREACHABLE(
-          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
-  }
-
-  return sql.str();
-}
-
-std::optional<std::string> DuckQueryRunner::toSql(
-    const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
-  std::stringstream sql;
-  sql << "SELECT " << folly::join(", ", joinNode->outputType()->names());
-
-  // Nested loop join without filter.
-  VELOX_CHECK(
-      joinNode->joinCondition() == nullptr,
-      "This code path should be called only for nested loop join without filter");
-  const std::string joinCondition{"(1 = 1)"};
-  switch (joinNode->joinType()) {
-    case core::JoinType::kInner:
-      sql << " FROM t INNER JOIN u ON " << joinCondition;
-      break;
-    case core::JoinType::kLeft:
-      sql << " FROM t LEFT JOIN u ON " << joinCondition;
-      break;
-    case core::JoinType::kFull:
-      sql << " FROM t FULL OUTER JOIN u ON " << joinCondition;
-      break;
-    default:
-      VELOX_UNREACHABLE(
-          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
-  }
 
   return sql.str();
 }

--- a/velox/exec/fuzzer/DuckQueryRunner.h
+++ b/velox/exec/fuzzer/DuckQueryRunner.h
@@ -15,6 +15,10 @@
  */
 #pragma once
 
+#include <optional>
+#include <set>
+#include <unordered_map>
+
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 
 namespace facebook::velox::exec::test {
@@ -46,6 +50,13 @@ class DuckQueryRunner : public ReferenceQueryRunner {
   /// Assumes that source of AggregationNode or Window Node is 'tmp' table.
   std::optional<std::string> toSql(const core::PlanNodePtr& plan) override;
 
+  /// Executes the plan and returns the result along with success or fail error
+  /// code.
+  std::pair<
+      std::optional<std::multiset<std::vector<velox::variant>>>,
+      ReferenceQueryErrorCode>
+  execute(const core::PlanNodePtr& plan) override;
+
   /// Creates 'tmp' table with 'input' data and runs 'sql' query. Returns
   /// results according to 'resultType' schema.
   std::multiset<std::vector<velox::variant>> execute(
@@ -53,13 +64,9 @@ class DuckQueryRunner : public ReferenceQueryRunner {
       const std::vector<RowVectorPtr>& input,
       const RowTypePtr& resultType) override;
 
-  std::multiset<std::vector<velox::variant>> execute(
-      const std::string& sql,
-      const std::vector<RowVectorPtr>& probeInput,
-      const std::vector<RowVectorPtr>& buildInput,
-      const RowTypePtr& resultType) override;
-
  private:
+  using ReferenceQueryRunner::toSql;
+
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::AggregationNode>& aggregationNode);
 
@@ -71,12 +78,6 @@ class DuckQueryRunner : public ReferenceQueryRunner {
 
   std::optional<std::string> toSql(
       const std::shared_ptr<const core::RowNumberNode>& rowNumberNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::HashJoinNode>& joinNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
 
   std::unordered_set<std::string> aggregateFunctionNames_;
 };

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -131,12 +131,6 @@ void setupMemory(
 void registerHiveConnector(
     const std::unordered_map<std::string, std::string>& hiveConfigs);
 
-enum ReferenceQueryErrorCode {
-  kSuccess,
-  kReferenceQueryFail,
-  kReferenceQueryUnsupported
-};
-
 // Converts 'plan' into an SQL query and runs it on 'input' in the reference DB.
 // Result is returned as a MaterializedRowMultiset with the
 // ReferenceQueryErrorCode::kSuccess if successful, or an std::nullopt with a

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -679,12 +679,12 @@ std::optional<MaterializedRowMultiset> JoinFuzzer::computeReferenceResults(
     VELOX_CHECK(!containsUnsupportedTypes(buildInput[0]->type()));
   }
 
-  if (auto sql = referenceQueryRunner_->toSql(plan)) {
-    return referenceQueryRunner_->execute(
-        sql.value(), probeInput, buildInput, plan->outputType());
+  auto result = referenceQueryRunner_->execute(plan);
+  if (result.first) {
+    return result.first;
   }
 
-  LOG(INFO) << "Query not supported by the reference DB";
+  LOG(INFO) << "Query not supported by or failed in the reference DB";
   return std::nullopt;
 }
 

--- a/velox/exec/fuzzer/ReferenceQueryRunner.cpp
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+#include "velox/exec/fuzzer/ToSQLUtil.h"
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+std::string joinKeysToSql(
+    const std::vector<core::FieldAccessTypedExprPtr>& keys) {
+  std::vector<std::string> keyNames;
+  keyNames.reserve(keys.size());
+  for (const core::FieldAccessTypedExprPtr& key : keys) {
+    keyNames.push_back(key->name());
+  }
+  return folly::join(", ", keyNames);
+}
+
+std::string filterToSql(const core::TypedExprPtr& filter) {
+  auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(filter);
+  return toCallSql(call);
+}
+
+std::string joinConditionAsSql(const core::AbstractJoinNode& joinNode) {
+  std::stringstream out;
+  for (auto i = 0; i < joinNode.leftKeys().size(); ++i) {
+    if (i > 0) {
+      out << " AND ";
+    }
+    out << joinNode.leftKeys()[i]->name() << " = "
+        << joinNode.rightKeys()[i]->name();
+  }
+  if (joinNode.filter()) {
+    if (!joinNode.leftKeys().empty()) {
+      out << " AND ";
+    }
+    out << filterToSql(joinNode.filter());
+  }
+  return out.str();
+}
+
+} // namespace
+
+bool ReferenceQueryRunner::isSupportedDwrfType(const TypePtr& type) {
+  if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
+    return false;
+  }
+
+  for (auto i = 0; i < type->size(); ++i) {
+    if (!isSupportedDwrfType(type->childAt(i))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::unordered_map<std::string, std::vector<velox::RowVectorPtr>>
+ReferenceQueryRunner::getAllTables(const core::PlanNodePtr& plan) {
+  std::unordered_map<std::string, std::vector<velox::RowVectorPtr>> result;
+  if (const auto valuesNode =
+          std::dynamic_pointer_cast<const core::ValuesNode>(plan)) {
+    result.insert({getTableName(valuesNode), valuesNode->values()});
+  } else {
+    for (const auto& source : plan->sources()) {
+      auto tablesAndNames = getAllTables(source);
+      result.insert(tablesAndNames.begin(), tablesAndNames.end());
+    }
+  }
+  return result;
+}
+
+std::optional<std::string> ReferenceQueryRunner::joinSourceToSql(
+    const core::PlanNodePtr& planNode) {
+  const std::optional<std::string> subQuery = toSql(planNode);
+  if (subQuery) {
+    return subQuery->find(" ") != std::string::npos
+        ? fmt::format("({})", *subQuery)
+        : *subQuery;
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> ReferenceQueryRunner::toSql(
+    const core::ValuesNodePtr& valuesNode) {
+  if (!isSupportedDwrfType(valuesNode->outputType())) {
+    return std::nullopt;
+  }
+  return getTableName(valuesNode);
+}
+
+std::optional<std::string> ReferenceQueryRunner::toSql(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
+  if (!isSupportedDwrfType(joinNode->sources()[0]->outputType()) ||
+      !isSupportedDwrfType(joinNode->sources()[1]->outputType())) {
+    return std::nullopt;
+  }
+
+  std::optional<std::string> probeTableName =
+      joinSourceToSql(joinNode->sources()[0]);
+  std::optional<std::string> buildTableName =
+      joinSourceToSql(joinNode->sources()[1]);
+  if (!probeTableName || !buildTableName) {
+    return std::nullopt;
+  }
+
+  const auto& outputNames = joinNode->outputType()->names();
+
+  std::stringstream sql;
+  if (joinNode->isLeftSemiProjectJoin()) {
+    sql << "SELECT "
+        << folly::join(", ", outputNames.begin(), --outputNames.end());
+  } else {
+    sql << "SELECT " << folly::join(", ", outputNames);
+  }
+
+  switch (joinNode->joinType()) {
+    case core::JoinType::kInner:
+      sql << " FROM " << *probeTableName << " INNER JOIN " << *buildTableName
+          << " ON " << joinConditionAsSql(*joinNode);
+      break;
+    case core::JoinType::kLeft:
+      sql << " FROM " << *probeTableName << " LEFT JOIN " << *buildTableName
+          << " ON " << joinConditionAsSql(*joinNode);
+      break;
+    case core::JoinType::kFull:
+      sql << " FROM " << *probeTableName << " FULL OUTER JOIN "
+          << *buildTableName << " ON " << joinConditionAsSql(*joinNode);
+      break;
+    case core::JoinType::kLeftSemiFilter:
+      // Multiple columns returned by a scalar subquery is not supported. A
+      // scalar subquery expression is a subquery that returns one result row
+      // from exactly one column for every input row.
+      if (joinNode->leftKeys().size() > 1) {
+        return std::nullopt;
+      }
+      sql << " FROM " << *probeTableName << " WHERE "
+          << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
+          << joinKeysToSql(joinNode->rightKeys()) << " FROM "
+          << *buildTableName;
+      if (joinNode->filter()) {
+        sql << " WHERE " << filterToSql(joinNode->filter());
+      }
+      sql << ")";
+      break;
+    case core::JoinType::kLeftSemiProject:
+      if (joinNode->isNullAware()) {
+        sql << ", " << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
+            << joinKeysToSql(joinNode->rightKeys()) << " FROM "
+            << *buildTableName;
+        if (joinNode->filter()) {
+          sql << " WHERE " << filterToSql(joinNode->filter());
+        }
+        sql << ") FROM " << *probeTableName;
+      } else {
+        sql << ", EXISTS (SELECT * FROM " << *buildTableName << " WHERE "
+            << joinConditionAsSql(*joinNode);
+        sql << ") FROM " << *probeTableName;
+      }
+      break;
+    case core::JoinType::kAnti:
+      if (joinNode->isNullAware()) {
+        sql << " FROM " << *probeTableName << " WHERE "
+            << joinKeysToSql(joinNode->leftKeys()) << " NOT IN (SELECT "
+            << joinKeysToSql(joinNode->rightKeys()) << " FROM "
+            << *buildTableName;
+        if (joinNode->filter()) {
+          sql << " WHERE " << filterToSql(joinNode->filter());
+        }
+        sql << ")";
+      } else {
+        sql << " FROM " << *probeTableName
+            << " WHERE NOT EXISTS (SELECT * FROM " << *buildTableName
+            << " WHERE " << joinConditionAsSql(*joinNode);
+        sql << ")";
+      }
+      break;
+    default:
+      VELOX_UNREACHABLE(
+          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
+  }
+  return sql.str();
+}
+
+std::optional<std::string> ReferenceQueryRunner::toSql(
+    const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
+  std::optional<std::string> probeTableName =
+      joinSourceToSql(joinNode->sources()[0]);
+  std::optional<std::string> buildTableName =
+      joinSourceToSql(joinNode->sources()[1]);
+  if (!probeTableName || !buildTableName) {
+    return std::nullopt;
+  }
+
+  std::stringstream sql;
+  sql << "SELECT " << folly::join(", ", joinNode->outputType()->names());
+
+  // Nested loop join without filter.
+  VELOX_CHECK_NULL(
+      joinNode->joinCondition(),
+      "This code path should be called only for nested loop join without filter");
+  const std::string joinCondition{"(1 = 1)"};
+  switch (joinNode->joinType()) {
+    case core::JoinType::kInner:
+      sql << " FROM " << *probeTableName << " INNER JOIN " << *buildTableName
+          << " ON " << joinCondition;
+      break;
+    case core::JoinType::kLeft:
+      sql << " FROM " << *probeTableName << " LEFT JOIN " << *buildTableName
+          << " ON " << joinCondition;
+      break;
+    case core::JoinType::kFull:
+      sql << " FROM " << *probeTableName << " FULL OUTER JOIN "
+          << *buildTableName << " ON " << joinCondition;
+      break;
+    default:
+      VELOX_UNREACHABLE(
+          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
+  }
+  return sql.str();
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -15,12 +15,21 @@
  */
 #pragma once
 
+#include <optional>
 #include <set>
+#include <unordered_map>
+
 #include "velox/core/PlanNode.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::exec::test {
+
+enum ReferenceQueryErrorCode {
+  kSuccess,
+  kReferenceQueryFail,
+  kReferenceQueryUnsupported
+};
 
 /// Query runner that uses reference database, i.e. DuckDB, Presto, Spark.
 class ReferenceQueryRunner {
@@ -54,6 +63,18 @@ class ReferenceQueryRunner {
   /// reference database.
   virtual std::optional<std::string> toSql(const core::PlanNodePtr& plan) = 0;
 
+  /// Same as the above toSql but for values nodes.
+  virtual std::optional<std::string> toSql(
+      const core::ValuesNodePtr& valuesNode);
+
+  /// Same as the above toSql but for hash join nodes.
+  virtual std::optional<std::string> toSql(
+      const std::shared_ptr<const core::HashJoinNode>& joinNode);
+
+  /// Same as the above toSql but for nested loop join nodes.
+  virtual std::optional<std::string> toSql(
+      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
+
   /// Returns whether a constant expression is supported by the reference
   /// database.
   virtual bool isConstantExprSupported(const core::TypedExprPtr& /*expr*/) {
@@ -64,6 +85,15 @@ class ReferenceQueryRunner {
   /// by the reference database.
   virtual bool isSupported(const exec::FunctionSignature& /*signature*/) {
     return true;
+  }
+
+  /// Executes the plan and returns the result along with success or fail error
+  /// code.
+  virtual std::pair<
+      std::optional<std::multiset<std::vector<velox::variant>>>,
+      ReferenceQueryErrorCode>
+  execute(const core::PlanNodePtr& /*plan*/) {
+    VELOX_UNSUPPORTED();
   }
 
   /// Executes SQL query returned by the 'toSql' method using 'input' data.
@@ -77,10 +107,12 @@ class ReferenceQueryRunner {
   /// 'buildInput' data for join node.
   /// Converts results using 'resultType' schema.
   virtual std::multiset<std::vector<velox::variant>> execute(
-      const std::string& sql,
-      const std::vector<RowVectorPtr>& probeInput,
-      const std::vector<RowVectorPtr>& buildInput,
-      const RowTypePtr& resultType) = 0;
+      const std::string& /*sql*/,
+      const std::vector<RowVectorPtr>& /*probeInput*/,
+      const std::vector<RowVectorPtr>& /*buildInput*/,
+      const RowTypePtr& /*resultType*/) {
+    VELOX_UNSUPPORTED();
+  }
 
   /// Returns true if 'executeVector' can be called to get results as Velox
   /// Vector.
@@ -91,28 +123,19 @@ class ReferenceQueryRunner {
   /// Similar to 'execute' but returns results in RowVector format.
   /// Caller should ensure 'supportsVeloxVectorResults' returns true.
   virtual std::vector<RowVectorPtr> executeVector(
-      const std::string& sql,
-      const std::vector<RowVectorPtr>& input,
-      const RowTypePtr& resultType) {
+      const std::string& /*sql*/,
+      const std::vector<RowVectorPtr>& /*input*/,
+      const RowTypePtr& /*resultType*/) {
     VELOX_UNSUPPORTED();
   }
 
-  /// Similar to above but for join node with 'probeInput' and 'buildInput'.
-  virtual std::vector<RowVectorPtr> executeVector(
-      const std::string& sql,
-      const std::vector<RowVectorPtr>& probeInput,
-      const std::vector<RowVectorPtr>& buildInput,
-      const RowTypePtr& resultType) {
-    VELOX_UNSUPPORTED();
-  }
-
-  virtual std::vector<velox::RowVectorPtr> execute(const std::string& sql) {
+  virtual std::vector<velox::RowVectorPtr> execute(const std::string& /*sql*/) {
     VELOX_UNSUPPORTED();
   }
 
   virtual std::vector<velox::RowVectorPtr> execute(
-      const std::string& sql,
-      const std::string& sessionProperty) {
+      const std::string& /*sql*/,
+      const std::string& /*sessionProperty*/) {
     VELOX_UNSUPPORTED();
   }
 
@@ -121,8 +144,20 @@ class ReferenceQueryRunner {
     return aggregatePool_;
   }
 
+  bool isSupportedDwrfType(const TypePtr& type);
+
+  /// Returns the name of the values node table in the form t_<id>.
+  std::string getTableName(const core::ValuesNodePtr& valuesNode) {
+    return fmt::format("t_{}", valuesNode->id());
+  }
+
+  // Traverses all nodes in the plan and returns all tables and their names.
+  std::unordered_map<std::string, std::vector<velox::RowVectorPtr>>
+  getAllTables(const core::PlanNodePtr& plan);
+
  private:
   memory::MemoryPool* aggregatePool_;
-};
 
+  std::optional<std::string> joinSourceToSql(const core::PlanNodePtr& planNode);
+};
 } // namespace facebook::velox::exec::test

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunner.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunner.h
@@ -88,6 +88,8 @@ class SparkQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   std::vector<velox::RowVectorPtr> execute(const std::string& sql) override;
 
  private:
+  using ReferenceQueryRunner::toSql;
+
   // Generates a random UUID string for Spark. It must be of the format
   // '00112233-4455-6677-8899-aabbccddeeff'.
   std::string generateUUID();


### PR DESCRIPTION
Summary: Currently, the hash join and nested loop join "toSql" methods for all reference query runners only support a single join. This change extends it to support multiple joins, only needing the join node of the last join in the tree. It traverses up the tree and recursively builds the sql query.

Differential Revision: D66977480


