### PR TITLE
fix: Array_intersect with a single argument doesn't correctly handle nulls in dictionary encoded inner arrays

### DIFF
--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -80,8 +80,12 @@ class WidthBucketArrayFunction : public exec::VectorFunction {
     auto rawSizes = binsArray->rawSizes();
     auto rawOffsets = binsArray->rawOffsets();
     auto elementsVector = binsArray->elements();
-    auto elementsRows =
-        toElementRows(elementsVector->size(), rows, binsArray, bins->indices());
+    auto elementsRows = toElementRows(
+        elementsVector->size(),
+        rows,
+        binsArray,
+        bins->nulls(&rows),
+        bins->indices());
     exec::LocalDecodedVector elementsHolder(
         context, *elementsVector, elementsRows);
 

--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -245,14 +245,10 @@ void PrestoHasher::hash<TypeKind::ARRAY>(
     BufferPtr& hashes) {
   auto baseArray = vector_->base()->as<ArrayVector>();
   auto indices = vector_->indices();
-
-  auto nonNullRows = SelectivityVector(rows);
-  if (vector_->nulls(&nonNullRows)) {
-    nonNullRows.deselectNulls(vector_->nulls(), 0, nonNullRows.end());
-  }
+  auto decodedNulls = vector_->nulls(&rows);
 
   auto elementRows = functions::toElementRows(
-      baseArray->elements()->size(), nonNullRows, baseArray, indices);
+      baseArray->elements()->size(), rows, baseArray, decodedNulls, indices);
 
   BufferPtr elementHashes =
       AlignedBuffer::allocate<int64_t>(elementRows.end(), baseArray->pool());
@@ -263,7 +259,6 @@ void PrestoHasher::hash<TypeKind::ARRAY>(
   auto rawOffsets = baseArray->rawOffsets();
   auto rawElementHashes = elementHashes->as<int64_t>();
   auto rawHashes = hashes->asMutable<int64_t>();
-  auto decodedNulls = vector_->nulls();
 
   rows.applyToSelected([&](auto row) {
     int64_t hash = 0;
@@ -285,15 +280,11 @@ void PrestoHasher::hash<TypeKind::MAP>(
     BufferPtr& hashes) {
   auto baseMap = vector_->base()->as<MapVector>();
   auto indices = vector_->indices();
+  auto decodedNulls = vector_->nulls(&rows);
   VELOX_CHECK_EQ(children_.size(), 2);
 
-  auto nonNullRows = SelectivityVector(rows);
-  if (vector_->nulls(&nonNullRows)) {
-    nonNullRows.deselectNulls(vector_->nulls(), 0, nonNullRows.end());
-  }
-
   auto elementRows = functions::toElementRows(
-      baseMap->mapKeys()->size(), nonNullRows, baseMap, indices);
+      baseMap->mapKeys()->size(), rows, baseMap, decodedNulls, indices);
   BufferPtr keyHashes =
       AlignedBuffer::allocate<int64_t>(elementRows.end(), baseMap->pool());
 
@@ -309,7 +300,6 @@ void PrestoHasher::hash<TypeKind::MAP>(
 
   auto rawSizes = baseMap->rawSizes();
   auto rawOffsets = baseMap->rawOffsets();
-  auto decodedNulls = vector_->nulls();
 
   rows.applyToSelected([&](auto row) {
     int64_t hash = 0;


### PR DESCRIPTION
Summary:
The single argument flavor of array_intersect computes the intersection of the inner arrays in an array of arrays.
It currently does not correctly handle nulls in the dictionary if the inner arrays are dictionary encoded.

There are 2 bugs:
1) toElementRows requires that nulls be deselected in the SelectivityVector, array_intersect does not do this
when calling it on the inner arrays.  This means it will attempt to use the index from the DecodedVector's
indices() to get the offset and size of the null arrays, which can lead to accessing arbitrary memory as the index
may point off the end of the buffers getting the size and offset, which can further lead to writing to arbitrary 
memory as we can write off the end of the SelectivityVector.
2) When actually doing the intersection we get the innerOffset and innerSize before checking if the inner array
is null. We don't end up using these values if the inner array is null, so this just results in an error when ASAN is
enabled.

To fix 1) I created separate APIs for toElementRows for use with DecodedVectors and otherwise. It forces the
user to pass in the nulls from the DecodedVector in addition to the indices to help avoid mistakes like this.

Note that this worked in PrestoHasher because it was correctly deselecting nulls in the SelectivityVector, and in
WidthBucketArray because it has default null behavior so the nulls would have been automatically deselected
by the expression eval code.

Differential Revision: D66994602


