### PR TITLE
fix: Indices in elements null checks for width_bucket() function

### DIFF
--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -36,8 +36,9 @@ int64_t widthBucket(
   while (lower < upper) {
     const int index = (lower + upper) / 2;
     VELOX_USER_CHECK(
-        !elementsHolder.isNullAt(lower) && !elementsHolder.isNullAt(index) &&
-            !elementsHolder.isNullAt(upper - 1),
+        !elementsHolder.isNullAt(offset + lower) &&
+            !elementsHolder.isNullAt(offset + index) &&
+            !elementsHolder.isNullAt(offset + upper - 1),
         "Bin values cannot be NULL");
 
     const auto bin = elementsHolder.valueAt<T>(offset + index);

--- a/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
+++ b/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
@@ -106,6 +106,9 @@ TEST_F(WidthBucketArrayTest, failure) {
   testFailure(3.14, {{0.0, std::nullopt, 4.0}}, "Bin values cannot be NULL");
   testFailure(
       3.14, {{0.0, 2.0, 4.0, std::nullopt}}, "Bin values cannot be NULL");
+
+  testFailure(1, {{std::nullopt}, {1.0, 2.0}}, "Bin values cannot be NULL");
+  testFailure(1, {{1.0, 2.0}, {std::nullopt}}, "Bin values cannot be NULL");
 }
 
 TEST_F(WidthBucketArrayTest, successForConstantArray) {


### PR DESCRIPTION
Summary:
The previous fix introduced the wrong null checks.
This change is fixing it.

Differential Revision: D67007276


