### PR TITLE
fix(function): Fix the timestamp precision of Spark 'in' function

### DIFF
--- a/velox/functions/sparksql/In.cpp
+++ b/velox/functions/sparksql/In.cpp
@@ -74,6 +74,39 @@ class Set<StringView> {
   folly::F14FastSet<std::string_view> set_;
 };
 
+// Specialization for Timestamp to store micros.
+template <>
+class Set<Timestamp> {
+ public:
+  using value_type = int64_t;
+
+  void emplace(const Timestamp& ts) {
+    const value_type micros = ts.toMicros();
+    if (!set_.contains(micros)) {
+      set_.emplace(micros);
+    }
+  }
+
+  bool contains(const Timestamp& ts) const {
+    return set_.contains(ts.toMicros());
+  }
+
+  void reserve(size_t size) {
+    set_.reserve(size);
+  }
+
+  size_t size() const {
+    return set_.size();
+  }
+
+  auto begin() const {
+    return set_.begin();
+  }
+
+ private:
+  folly::F14FastSet<value_type> set_;
+};
+
 template <typename TInput>
 struct InFunctionOuter {
   template <typename TExecCtx>

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -178,6 +178,18 @@ TEST_F(InTest, Timestamp) {
       std::nullopt);
   EXPECT_EQ(
       in<Timestamp>(Timestamp(0, 0), {Timestamp(0, 0), Timestamp()}), true);
+
+  // The precision of Spark 'in' is microseconds.
+  EXPECT_EQ(
+      in<Timestamp>(
+          Timestamp(0, 123'456'000),
+          {Timestamp(0, 123'000'000), Timestamp(0, 123'123'000)}),
+      false);
+  EXPECT_EQ(
+      in<Timestamp>(
+          Timestamp(0, 123'456'789),
+          {Timestamp(0, 123'456'000), Timestamp(0, 123'456'123)}),
+      true);
 }
 
 TEST_F(InTest, Date) {


### PR DESCRIPTION
Changes the timestamp precision of Spark 'in' function to microseconds.
Fixes: https://github.com/facebookincubator/velox/issues/11755.