### PR TITLE
fix: Remove unused-variable in velox/

### DIFF
--- a/velox/common/base/tests/IndexedPriorityQueueTest.cpp
+++ b/velox/common/base/tests/IndexedPriorityQueueTest.cpp
@@ -232,7 +232,6 @@ TEST_F(IndexedPriorityQueueTest, remove) {
 }
 
 TEST_F(IndexedPriorityQueueTest, fuzz) {
-  const int numIterations{1000};
   std::mt19937 rng{100};
   IndexedPriorityQueue<uint32_t, true> maxQueue;
   fuzz<uint32_t, true>(maxQueue, 1'000, rng);

--- a/velox/common/base/tests/ScratchTest.cpp
+++ b/velox/common/base/tests/ScratchTest.cpp
@@ -35,7 +35,7 @@ TEST(ScratchTest, basic) {
   {
     ScratchPtr<int32_t> ints(scratch);
     ScratchPtr<int64_t> longs(scratch);
-    auto tempLongs = longs.get(2000);
+    longs.get(2000);
     auto tempInts = ints.get(1000);
     std::fill(tempInts, tempInts + 1000, -1);
     std::fill(tempInts, tempInts + 2000, -1);

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -171,7 +171,6 @@ TEST_F(SimdUtilTest, gather32) {
 
 TEST_F(SimdUtilTest, gather64) {
   int32_t indices4[4] = {3, 2, 1, 0};
-  int32_t indices3[4] = {3, 2, 1, 1 << 31};
   int64_t data[4] = {44, 55, 66, 77};
   constexpr int kBatchSize = xsimd::batch<int64_t>::size;
   const int32_t* indices = indices4 + (4 - kBatchSize);

--- a/velox/common/memory/tests/AllocationPoolTest.cpp
+++ b/velox/common/memory/tests/AllocationPoolTest.cpp
@@ -53,7 +53,6 @@ TEST_F(AllocationPoolTest, hugePages) {
   allocationPool->setHugePageThreshold(128 << 10);
   int32_t counter = 0;
   for (;;) {
-    int32_t usedKB = 0;
     allocationPool->newRun(32 << 10);
     // Initial allocations round up to 64K
     EXPECT_EQ(1, allocationPool->numRanges());

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -637,7 +637,6 @@ TEST_P(MemoryAllocatorTest, allocationClass2) {
 
 TEST_P(MemoryAllocatorTest, stats) {
   const std::vector<MachinePageCount>& sizes = instance_->sizeClasses();
-  MachinePageCount capacity = kCapacityPages;
   for (auto i = 0; i < sizes.size(); ++i) {
     std::unique_ptr<Allocation> allocation = std::make_unique<Allocation>();
     auto size = sizes[i];
@@ -963,7 +962,6 @@ TEST_P(MemoryAllocatorTest, allocContiguous) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(fmt::format("{} useMmap{}", testData.debugString(), useMmap_));
     setupAllocator();
-    const MachinePageCount nonContiguousPages = 100;
     Allocation allocation;
     if (testData.nonContiguousPages != 0) {
       instance_->allocateNonContiguous(testData.nonContiguousPages, allocation);
@@ -1065,7 +1063,6 @@ TEST_P(MemoryAllocatorTest, allocContiguousFail) {
     SCOPED_TRACE(
         fmt::format("{} useMmap {}", testData.debugString(), useMmap_));
     setupAllocator();
-    const MachinePageCount nonContiguousPages = 100;
     Allocation allocation;
     if (testData.nonContiguousPages != 0) {
       instance_->allocateNonContiguous(testData.nonContiguousPages, allocation);
@@ -1376,7 +1373,6 @@ TEST_P(MemoryAllocatorTest, StlMemoryAllocator) {
     // Allocation from classes and ContiguousAllocation outside size
     // classes.
     constexpr int32_t kNumDoubles = 256 * 1024;
-    size_t capacity = 0;
     for (auto i = 0; i < kNumDoubles; i++) {
       data.push_back(i);
     }

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -554,7 +554,7 @@ TEST_F(MemoryManagerTest, concurrentPoolAccess) {
   std::atomic<bool> stopCheck{false};
   std::thread checkThread([&]() {
     while (!stopCheck) {
-      const int numPools = manager.numPools();
+      [[maybe_unused]] const int numPools = manager.numPools();
       std::this_thread::sleep_for(std::chrono::microseconds(1));
     }
   });

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -144,7 +144,6 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
 };
 
 TEST_P(MemoryPoolTest, ctor) {
-  constexpr uint16_t kAlignment = 64;
   setupMemory({.alignment = 64, .allocatorCapacity = kDefaultCapacity});
   MemoryManager& manager = *getMemoryManager();
   const int64_t capacity = 4 * GB;
@@ -690,7 +689,6 @@ TEST_P(MemoryPoolTest, alignmentCheck) {
     ASSERT_EQ(
         pool->alignment(),
         alignment == 0 ? MemoryAllocator::kMinAlignment : alignment);
-    const int32_t kTestIterations = 10;
     for (int32_t i = 0; i < 10; ++i) {
       const int64_t bytesToAlloc = 1 + folly::Random::rand32() % (1 * MB);
       void* ptr = pool->allocate(bytesToAlloc);
@@ -1028,11 +1026,6 @@ TEST_P(MemoryPoolTest, contiguousAllocate) {
       ASSERT_GE(numAllocatedPages, 0);
       allocations.erase(allocations.begin() + freeAllocationIdx);
     }
-    const MachinePageCount minSizeClass = folly::Random().oneIn(4)
-        ? 0
-        : std::min(
-              manager->allocator()->largestSizeClass(),
-              folly::Random().rand32() % kMaxAllocationPages);
     pool->allocateContiguous(pagesToAllocate, allocation);
     numAllocatedPages += allocation.numPages();
     for (int32_t j = 0; j < allocation.size(); ++j) {
@@ -1082,7 +1075,6 @@ TEST_P(MemoryPoolTest, contiguousAllocateExceedLimit) {
 TEST_P(MemoryPoolTest, badContiguousAllocation) {
   auto manager = getMemoryManager();
   auto pool = manager->addLeafPool("badContiguousAllocation");
-  constexpr MachinePageCount kAllocSize = 8;
   ContiguousAllocation allocation;
   ASSERT_THROW(pool->allocateContiguous(0, allocation), VeloxRuntimeError);
 }
@@ -2500,7 +2492,6 @@ TEST_P(MemoryPoolTest, concurrentUpdateToSharedPools) {
 TEST_P(MemoryPoolTest, concurrentPoolStructureAccess) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1234);
-  constexpr int64_t kMaxMemory = 8 * GB;
   MemoryManager& manager = *getMemoryManager();
   auto root = manager.addRootPool();
   std::atomic<int64_t> poolId{0};
@@ -2665,7 +2656,6 @@ TEST(MemoryPoolTest, debugMode) {
 
 TEST(MemoryPoolTest, debugModeWithFilter) {
   constexpr int64_t kMaxMemory = 10 * GB;
-  constexpr int64_t kNumIterations = 100;
   const std::vector<int64_t> kAllocSizes = {128, 8 * KB, 2 * MB};
   const std::vector<bool> debugEnabledSet{true, false};
   for (const auto& debugEnabled : debugEnabledSet) {

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -976,7 +976,6 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, sortWriterAbortDuringFinish) {
     dataSink->appendData(vector);
   }
 
-  std::atomic_int injectCount{0};
   SCOPED_TESTVALUE_SET(
       "facebook::velox::dwrf::Writer::write",
       std::function<void(dwrf::Writer*)>([&](dwrf::Writer* /*unused*/) {

--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -542,7 +542,6 @@ void naiveDecodeBitsLE(
     }
     return;
   }
-  auto lastSafe = bufferEnd - sizeof(uint64_t);
   int32_t numSafeRows = numRows;
   bool anyUnsafe = false;
   if (bufferEnd) {

--- a/velox/dwio/common/tests/IntDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/IntDecoderBenchmark.cpp
@@ -910,7 +910,6 @@ BENCHMARK_RELATIVE(decodeNew_16) {
 BENCHMARK(decodeOld_32) {
   size_t currentLen = len_u32;
   const size_t startingLen = len_u32;
-  int32_t i = 0;
   while (currentLen != 0) {
     auto result =
         readVuLong(buffer_u32.data() + (startingLen - currentLen), currentLen);

--- a/velox/dwio/common/tests/utils/DataSetBuilder.cpp
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.cpp
@@ -254,7 +254,6 @@ DataSetBuilder& DataSetBuilder::makeMapStringValues(
     auto keyKind = map->type()->childAt(0)->kind();
     auto valueKind = map->type()->childAt(1)->kind();
     auto offsets = map->rawOffsets();
-    auto sizes = map->rawSizes();
     int32_t offsetIndex = 0;
     auto mapSize = map->size();
     auto getNextOffset = [&]() {

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -476,8 +476,6 @@ TEST_F(CacheTest, window) {
   auto cacheInput = dynamic_cast<CacheInputStream*>(stream.get());
   EXPECT_TRUE(cacheInput != nullptr);
   ASSERT_EQ(cacheInput->getName(), "CacheInputStream 0 of 13631488");
-  auto maxSize =
-      allocator_->sizeClasses().back() * memory::AllocationTraits::kPageSize;
   const void* buffer;
   int32_t size;
   int32_t numRead = 0;

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1873,7 +1873,6 @@ int64_t generateRangeWithCustomLimits(
   // Generate the range such that we have similar amounts of values generated
   // for each exponent.
   double center = size % 2 ? -0.5 : interval / 2 - 0.5;
-  double value = center + (i - size / 2) * interval;
   // Return a guard-railed value with the numeric limits.
   // NOTE: There can be a more compact way to write this if we cast i and size
   // to signed types, but it's not worth the effort enforcing the assumptions.

--- a/velox/dwio/dwrf/test/DecryptionTests.cpp
+++ b/velox/dwio/dwrf/test/DecryptionTests.cpp
@@ -43,7 +43,7 @@ TEST(Decryption, NoKeyProvider) {
   auto type = parser.parse("struct<a:int>");
   proto::Footer footer;
   ProtoUtils::writeType(*type, footer);
-  auto enc = footer.mutable_encryption();
+  footer.mutable_encryption();
   TestDecrypterFactory factory;
   ASSERT_THROW(
       DecryptionHandler::create(footer, &factory), exception::LoggedException);

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -231,7 +231,6 @@ TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
         ASSERT_TRUE(resultTypeRow.childAt(col)->isMap());
         ASSERT_EQ(batchRow->childAt(col)->typeKind(), TypeKind::MAP);
         auto& resultTypeChild = resultTypeRow.childAt(col)->as<TypeKind::MAP>();
-        auto* batchRowChild = batchRow->childAt(col)->as<MapVector>();
         ASSERT_EQ(
             resultTypeChild.keyType()->kind(), schemaChild.keyType()->kind());
         ASSERT_EQ(

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -1960,7 +1960,6 @@ TEST_F(E2EWriterTest, memoryReclaimAfterClose) {
     VELOX_ASSERT_THROW(writer->flush(), "Writer is not running");
 
     memory::MemoryReclaimer::Stats stats;
-    const auto oldCapacity = writerPool->capacity();
     writerPool->reclaim(1L << 30, 0, stats);
     if (testData.abort || !testData.canReclaim) {
       ASSERT_EQ(stats.numNonReclaimableAttempts, 0);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1365,7 +1365,6 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyArrayValue) {
   facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
-  auto numRows = reader->numberOfRows();
   auto type = reader->typeWithId();
   RowReaderOptions rowReaderOpts;
   auto rowType = ROW({"test"}, {ARRAY(MAP(VARCHAR(), ARRAY(INTEGER())))});
@@ -1399,7 +1398,6 @@ TEST_F(ParquetReaderTest, arrayOfMapOfIntKeyStructValue) {
   facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
-  auto numRows = reader->numberOfRows();
   auto type = reader->typeWithId();
   RowReaderOptions rowReaderOpts;
   auto rowType = reader->rowType();
@@ -1433,7 +1431,6 @@ TEST_F(ParquetReaderTest, struct_of_array_of_array) {
       getExampleFilePath("struct_of_array_of_array.parquet"));
   facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
-  auto numRows = reader->numberOfRows();
   auto type = reader->typeWithId();
   EXPECT_EQ(type->size(), 1ULL);
   EXPECT_EQ(reader->rowType()->toString(), expectedVeloxType);
@@ -1507,7 +1504,6 @@ TEST_F(ParquetReaderTest, testLzoDataPage) {
   rowReaderOpts.setScanSpec(makeScanSpec(outputRowType));
   auto rowReader = reader->createRowReader(rowReaderOpts);
 
-  uint64_t total = 0;
   VectorPtr result = BaseVector::create(outputRowType, 0, &*leafPool_);
   rowReader->next(23'547ULL, result);
   EXPECT_EQ(23'547ULL, result->size());

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -256,7 +256,7 @@ void HashJoinBridge::appendSpilledHashTablePartitionsLocked(
   }
   auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
   if (restoringSpillPartitionId_.has_value()) {
-    for (const auto& id : spillPartitionIdSet) {
+    for ([[maybe_unused]] const auto& id : spillPartitionIdSet) {
       VELOX_DCHECK_LT(
           restoringSpillPartitionId_->partitionBitOffset(),
           id.partitionBitOffset());

--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -423,18 +423,6 @@ std::optional<std::string> DuckQueryRunner::toSql(
 
 std::optional<std::string> DuckQueryRunner::toSql(
     const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
-  const auto& joinKeysToSql = [](auto keys) {
-    std::stringstream out;
-    for (auto i = 0; i < keys.size(); ++i) {
-      if (i > 0) {
-        out << ", ";
-      }
-      out << keys[i]->name();
-    }
-    return out.str();
-  };
-
-  const auto& outputNames = joinNode->outputType()->names();
   std::stringstream sql;
 
   // Nested loop join without filter.

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -638,18 +638,6 @@ std::optional<std::string> PrestoQueryRunner::toSql(
 
 std::optional<std::string> PrestoQueryRunner::toSql(
     const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
-  const auto& joinKeysToSql = [](auto keys) {
-    std::stringstream out;
-    for (auto i = 0; i < keys.size(); ++i) {
-      if (i > 0) {
-        out << ", ";
-      }
-      out << keys[i]->name();
-    }
-    return out.str();
-  };
-
-  const auto& outputNames = joinNode->outputType()->names();
   std::stringstream sql;
 
   // Nested loop join without filter.

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -329,7 +329,6 @@ class OutputBufferManagerTest : public testing::Test {
         return;
       }
       const int64_t maxBytes = folly::Random().oneIn(4, rng) ? 32'000'000 : 1;
-      int64_t receivedSequence;
       bool atEnd{false};
       folly::EventCount dataWait;
       auto dataWaitKey = dataWait.prepareWait();

--- a/velox/exec/tests/PrefixSortTest.cpp
+++ b/velox/exec/tests/PrefixSortTest.cpp
@@ -151,7 +151,6 @@ const RowVectorPtr PrefixSortTest::generateExpectedResult(
 }
 
 TEST_F(PrefixSortTest, singleKey) {
-  const int numRows = 5;
   const int columnsSize = 7;
 
   // Vectors without nulls.
@@ -183,7 +182,6 @@ TEST_F(PrefixSortTest, singleKey) {
 }
 
 TEST_F(PrefixSortTest, singleKeyWithNulls) {
-  const int numRows = 5;
   const int columnsSize = 7;
 
   Timestamp ts = {5, 5};

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -2476,7 +2476,7 @@ TEST_F(RowContainerTest, invalidatedColumnStats) {
     EXPECT_EQ(data->columnStats(4)->numCells(), 0);
 
     for (int i = 0; i < kNumRows; ++i) {
-      auto row = data->newRow();
+      data->newRow();
     }
     EXPECT_EQ(kNumRows, data->numRows());
     RowContainerIterator iter;

--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -690,7 +690,6 @@ TEST_F(ScaleWriterLocalPartitionTest, unpartitionBasic) {
 TEST_F(ScaleWriterLocalPartitionTest, unpartitionFuzzer) {
   const std::vector<RowVectorPtr> inputVectors = makeVectors(256, 512);
   const uint64_t queryCapacity = 256 << 20;
-  const uint32_t maxDrivers = 32;
   const uint32_t maxExchanegBufferSize = 2 << 20;
 
   for (bool fastConsumer : {false, true}) {
@@ -914,7 +913,6 @@ TEST_F(ScaleWriterLocalPartitionTest, partitionFuzzer) {
   const std::vector<RowVectorPtr> inputVectors =
       makeVectors(1024, 256, {1, 2, 3, 4, 5, 6, 7, 8});
   const uint64_t queryCapacity = 256 << 20;
-  const uint32_t maxDrivers = 32;
   const uint32_t maxExchanegBufferSize = 2 << 20;
 
   for (bool fastConsumer : {false, true}) {

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2330,7 +2330,6 @@ TEST_P(PartitionedTableWriterTest, singlePartition) {
 }
 
 TEST_P(PartitionedWithoutBucketTableWriterTest, fromSinglePartitionToMultiple) {
-  const int32_t numBatches = 1;
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
   setDataTypes(rowType);
   std::vector<std::string> partitionKeys = {"c0"};
@@ -3077,8 +3076,7 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
   const auto countStatsVector =
       result->childAt(nextColumnStatsIndex++)->asFlatVector<int64_t>();
   ASSERT_EQ(countStatsVector->valueAt(0), 1000);
-  const auto countIfStatsVector =
-      result->childAt(nextColumnStatsIndex++)->asFlatVector<int64_t>();
+  nextColumnStatsIndex++;
   ASSERT_EQ(countStatsVector->valueAt(0), 1000);
   const auto countMapStatsVector =
       result->childAt(nextColumnStatsIndex++)->asFlatVector<int64_t>();
@@ -3145,13 +3143,10 @@ TEST_P(AllTableWriterTest, columnStats) {
   auto result = AssertQueryBuilder(plan).copyResults(pool());
   auto rowVector = result->childAt(0)->asFlatVector<int64_t>();
   auto fragmentVector = result->childAt(1)->asFlatVector<StringView>();
-  auto commitContextVector = result->childAt(2)->asFlatVector<StringView>();
   auto columnStatsVector =
       result->childAt(3 + partitionedBy_.size())->asFlatVector<int64_t>();
 
-  const int64_t expectedRows = 10 * 100;
   std::vector<std::string> writeFiles;
-  int64_t numRows{0};
 
   // For partitioned, expected result is as follows:
   // Row     Fragment           Context       partition           c1_min_value
@@ -3255,13 +3250,10 @@ TEST_P(AllTableWriterTest, columnStatsWithTableWriteMerge) {
   auto result = AssertQueryBuilder(finalPlan).copyResults(pool());
   auto rowVector = result->childAt(0)->asFlatVector<int64_t>();
   auto fragmentVector = result->childAt(1)->asFlatVector<StringView>();
-  auto commitContextVector = result->childAt(2)->asFlatVector<StringView>();
   auto columnStatsVector =
       result->childAt(3 + partitionedBy_.size())->asFlatVector<int64_t>();
 
-  const int64_t expectedRows = 10 * 100;
   std::vector<std::string> writeFiles;
-  int64_t numRows{0};
 
   // For partitioned, expected result is as follows:
   // Row     Fragment           Context       partition           c1_min_value
@@ -4387,7 +4379,6 @@ DEBUG_ONLY_TEST_F(
 }
 
 DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
-  const uint64_t memoryCapacity = 32 * MB;
   VectorFuzzer::Options options;
   const int batchSize = 1'000;
   options.vectorSize = batchSize;
@@ -4404,7 +4395,6 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableFileWriteError", kQueryMemoryCapacity);
-  auto* arbitrator = memory::memoryManager()->arbitrator();
   auto queryCtx = core::QueryCtx::create(
       executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
@@ -4460,7 +4450,6 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
 }
 
 DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteSpillUseMoreMemory) {
-  const uint64_t memoryCapacity = 256 * MB;
   // Create a large number of vectors to trigger writer spill.
   fuzzerOpts_.vectorSize = 1000;
   fuzzerOpts_.stringLength = 2048;
@@ -4486,7 +4475,6 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteSpillUseMoreMemory) {
       fakeLeafPool->allocate(fakeAllocationSize),
       fakeAllocationSize};
 
-  void* allocatedBuffer;
   TestAllocation injectedWriterAllocation;
   SCOPED_TESTVALUE_SET(
       "facebook::velox::dwrf::Writer::flushInternal",
@@ -4560,7 +4548,6 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteReclaimOnClose) {
     numRows += vectors.back()->size();
   }
 
-  auto* arbitrator = memory::memoryManager()->arbitrator();
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableWriteSpillUseMoreMemory", kQueryMemoryCapacity);
   auto queryCtx = core::QueryCtx::create(

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -504,7 +504,6 @@ TEST_F(WindowTest, nagativeFrameArg) {
 
   auto sizeAt = [](vector_size_t row) { return row % 5; };
   auto keyAt = [](vector_size_t row) { return row % 11; };
-  auto valueAt = [](vector_size_t row) { return row % 13; };
   auto keys = makeArrayVector<float>(size, sizeAt, keyAt);
   auto data = makeRowVector(
       {"c0", "c1", "p0", "p1", "k0", "row_number"},

--- a/velox/experimental/wave/dwio/FormatData.cpp
+++ b/velox/experimental/wave/dwio/FormatData.cpp
@@ -96,7 +96,6 @@ void SplitStaging::transfer(
   hostBuffer_ = getTransferArena().allocate<char>(fill_);
   auto transferBuffer = hostBuffer_->as<char>();
   int firstToCopy = 0;
-  int32_t numCopies = staging_.size();
   int64_t copySize = 0;
   auto targetCopySize = FLAGS_staging_bytes_per_thread;
   int32_t numThreads = 0;

--- a/velox/experimental/wave/dwio/ReadStream.cpp
+++ b/velox/experimental/wave/dwio/ReadStream.cpp
@@ -352,7 +352,6 @@ void ReadStream::launch(
   // kBlockSize top level rows of output and to have Operand structs for the
   // produced column.
   readStream->makeControl();
-  auto numRows = readStream->rows_.size();
   auto waveStream = readStream->waveStream;
   WaveStats& stats = waveStream->stats();
   bool firstLaunch = true;

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -382,7 +382,6 @@ void CompileState::addFilterProject(
   auto filterProject = reinterpret_cast<exec::FilterProject*>(op);
   outputType = driverFactory_.planNodes[nodeIndex]->outputType();
   auto data = filterProject->exprsAndProjection();
-  auto& identityProjections = filterProject->identityProjections();
   int32_t firstProjection = 0;
   if (data.hasFilter) {
     addFilter(*data.exprs->exprs()[0], outputType);
@@ -538,7 +537,6 @@ void CompileState::makeAggregateAccumulate(const core::AggregationNode* node) {
       nthContinuable_++, aggInstruction));
 
   makeProject(numPrograms, node->outputType());
-  auto project = reinterpret_cast<Project*>(operators_.back().get());
   for (auto i = 0; i < node->groupingKeys().size(); ++i) {
     std::string name = aggInstruction->keys[i]->label;
     operators_.back()->defined(

--- a/velox/experimental/wave/exec/WaveDriver.cpp
+++ b/velox/experimental/wave/exec/WaveDriver.cpp
@@ -189,7 +189,6 @@ WaveDriver::WaveDriver(
       states_(std::move(states)),
       instructionStatus_(instructionStatus) {
   VELOX_CHECK(!waveOperators.empty());
-  auto returnBatchSize = 10000 * outputType_->size() * 10;
   deviceArena_ = std::make_unique<GpuArena>(
       100000000, getDeviceAllocator(getDevice()), 400000000);
   pipelines_.emplace_back();
@@ -222,7 +221,6 @@ RowVectorPtr WaveDriver::getOutput() {
     return nullptr;
   }
   barrier_->enter();
-  auto guard = [&]() { barrier_->leave(); };
   startTimeMs_ = getCurrentTimeMs();
   int32_t last = pipelines_.size() - 1;
   try {

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -993,7 +993,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
   // its a shared subexpression.
   const auto& rowsToPeel =
       context.isFinalSelection() ? rows : *context.finalSelection();
-  auto numFields = context.row()->childrenSize();
+  [[maybe_unused]] const auto numFields = context.row()->childrenSize();
   std::vector<VectorPtr> vectorsToPeel;
   vectorsToPeel.reserve(distinctFields_.size());
   for (auto* field : distinctFields_) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -4902,7 +4902,6 @@ TEST_F(ExprTest, disableMemoization) {
       makeIndices(2 * flatSize, [&](auto row) { return row % flatSize; }),
       2 * flatSize,
       flatInput);
-  auto dictSize = dictInput->size();
   auto inputRow = makeRowVector({dictInput});
 
   auto exprSet = compileExpression("c0 + 1", asRowType(inputRow->type()));

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -212,11 +212,11 @@ TEST_F(GenericWriterTest, castToDifferentTypesNotSupported) {
   writer.init(*result);
 
   writer.setOffset(0);
-  auto& current1 = writer.current().castTo<Array<Any>>();
+  writer.current().castTo<Array<Any>>();
   writer.commit(false);
 
   writer.setOffset(1);
-  auto& current2 = writer.current().castTo<Array<Any>>();
+  writer.current().castTo<Array<Any>>();
   writer.commit(false);
 
   writer.setOffset(2);

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -199,7 +199,7 @@ TEST_F(MapWriterTest, writeThenCommitNullNestedInRow) {
 
   {
     vectorWriter.setOffset(1);
-    auto& mapWriter = vectorWriter.current().get_writer_at<0>();
+    vectorWriter.current().get_writer_at<0>();
     vectorWriter.commit();
   }
   vectorWriter.finish();

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -249,7 +249,6 @@ TEST_F(KllSketchTest, serialize) {
 }
 
 TEST_F(KllSketchTest, deserialize) {
-  constexpr int N = 1e5;
   constexpr int M = 1001;
   auto readFile = [](const std::string& path) {
     std::ifstream input(path);

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -33,8 +33,6 @@ class MapAggTest : public AggregationTestBase {
 };
 
 TEST_F(MapAggTest, groupBy) {
-  vector_size_t num = 10;
-
   auto data = makeRowVector({
       makeFlatVector<int32_t>({0, 0, 0, 1, 1, 1, 2, 2, 2, 3}),
       makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
@@ -74,8 +72,6 @@ TEST_F(MapAggTest, groupBy) {
 
 // Verify that null keys are skipped.
 TEST_F(MapAggTest, groupByNullKeys) {
-  vector_size_t num = 10;
-
   auto data = makeRowVector({
       makeFlatVector<int32_t>({0, 0, 0, 1, 1, 1, 2, 2, 2, 3}),
       makeNullableFlatVector<int32_t>(

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -98,7 +98,6 @@ class DateTimeBenchmark : public functions::test::FunctionBenchmarkBase {
 
   void run(const std::string& functionName) {
     folly::BenchmarkSuspender suspender;
-    constexpr vector_size_t size = 10'000;
 
     VectorFuzzer::Options opts;
     opts.vectorSize = 10'000;

--- a/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/GenericBenchmark.cpp
@@ -120,9 +120,6 @@ int main(int argc, char** argv) {
   facebook::velox::registerFunction<TypedArraySum, int64_t, Array<int64_t>>(
       {"typed_sum"});
 
-  auto* pool = benchmarkBuilder.pool();
-  auto& vm = benchmarkBuilder.vectorMaker();
-
   benchmarkBuilder
       .addBenchmarkSet(
           fmt::format("array_sum"),

--- a/velox/functions/prestosql/benchmarks/RegexpReplaceBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RegexpReplaceBenchmark.cpp
@@ -38,9 +38,6 @@ int main(int argc, char** argv) {
   options.vectorSize = 1'000;
   options.nullRatio = 0.01;
 
-  auto* pool = benchmarkBuilder.pool();
-  auto& vm = benchmarkBuilder.vectorMaker();
-
   // Compare regexp_replace with fixed and lambda replacement.
   benchmarkBuilder.addBenchmarkSet("lambda_one_group", ROW({"c0"}, {VARCHAR()}))
       .withFuzzerOptions(options)

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -300,13 +300,6 @@ TEST_F(BinaryFunctionsTest, xxhash64) {
     return evaluateOnce<std::string>("xxhash64(c0)", VARBINARY(), value);
   };
 
-  const auto toVarbinary = [](const int64_t input) {
-    std::string out;
-    out.resize(sizeof(input));
-    std::memcpy(out.data(), &input, sizeof(input));
-    return out;
-  };
-
   EXPECT_EQ(hexToDec("EF46DB3751D8E999"), xxhash64(""));
   EXPECT_EQ(std::nullopt, xxhash64(std::nullopt));
 

--- a/velox/runner/tests/LocalRunnerTest.cpp
+++ b/velox/runner/tests/LocalRunnerTest.cpp
@@ -83,7 +83,6 @@ class LocalRunnerTest : public LocalRunnerTestBase {
   MultiFragmentPlanPtr makeScanPlan(const std::string& id, int32_t numWorkers) {
     MultiFragmentPlan::Options options = {
         .queryId = id, .numWorkers = numWorkers, .numDrivers = 2};
-    const int32_t width = 3;
 
     DistributedPlanBuilder rootBuilder(options, idGenerator_, pool_.get());
     rootBuilder.tableScan("T", rowType_);

--- a/velox/serializers/tests/SerializerBenchmark.cpp
+++ b/velox/serializers/tests/SerializerBenchmark.cpp
@@ -136,7 +136,6 @@ class SerializerBenchmark : public VectorTestBase {
     for (auto bits : bitsValues) {
       for (auto nullIdx = 0; nullIdx < nullPctValues.size(); ++nullIdx) {
         for (auto selIdx = 0; selIdx < numSelectedValues.size(); ++selIdx) {
-          int32_t numRepeat = 10 / numSelectedValues[selIdx];
           cases.push_back(runCase(nullIdx, selIdx, bits));
         }
       }

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -545,7 +545,6 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
 core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     const ::substrait::RelRoot& root) {
   // TODO: Use the names as the output names for the whole computing.
-  const auto& names = root.names();
   if (root.has_input()) {
     const auto& rel = root.input();
     return toVeloxPlan(rel);

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -1748,7 +1748,9 @@ TEST(FilterTest, mergeWithBytesMultiRange) {
 
 TEST(FilterTest, hugeIntRange) {
   auto filter = equalHugeint(HugeInt::build(1, 1), false);
-  auto testInt128 = [&](int128_t x) { return filter->testInt128(x); };
+  [[maybe_unused]] auto testInt128 = [&](int128_t x) {
+    return filter->testInt128(x);
+  };
   auto max = DecimalUtil::kLongDecimalMax;
   auto min = DecimalUtil::kLongDecimalMin;
 

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -442,7 +442,7 @@ const uint64_t* DecodedVector::nulls(const SelectivityVector* rows) {
         // end but not greater.
         VELOX_CHECK_LE(rows->end(), size_);
       }
-      auto baseSize = baseVector_->size();
+      [[maybe_unused]] auto baseSize = baseVector_->size();
       applyToRows(rows, [&](auto i) {
         VELOX_DCHECK_LT(indices_[i], baseSize);
         bits::setNull(rawCopiedNulls, i, bits::isBitNull(nulls_, indices_[i]));

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -309,9 +309,6 @@ TEST_F(VectorCompareTest, compareNullAsIndeterminateSimpleOfComplex) {
 
   // Test equality with nulls.
   {
-    CompareFlags equalityFlags = CompareFlags::equality(
-        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
-
     // Constat vector.
     testCompare(
         constantVectorNull, 0, constantVectorOne, 1, kEquality, kIndeterminate);

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -164,7 +164,6 @@ class VectorTest : public testing::Test, public velox::test::VectorTestBase {
     BufferPtr nulls;
     if (withNulls) {
       nulls = allocateNulls(numRows, pool());
-      int32_t childCounter = 0;
       auto rawNulls = nulls->asMutable<uint64_t>();
       for (int32_t i = 0; i < numRows; ++i) {
         bits::setNull(rawNulls, i, i % 8 == 0);


### PR DESCRIPTION
Summary:
LLVM-15 has a warning `-Wunused-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused variables can compromise readability or, worse, performance.

This diff either (a) removes an unused variable and, possibly, it's associated code or (b) qualifies the variable with `[[maybe_unused]]`.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: palmje

Differential Revision: D66978870
