### PR TITLE
fix: Array_distinct under allocates Buffer for result elements with overlapping input arrays

### DIFF
--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -137,7 +137,9 @@ class ArrayDistinctFunction : public exec::VectorFunction {
         toElementRows(elementsVector->size(), rows, arrayVector);
     exec::LocalDecodedVector elements(context, *elementsVector, elementsRows);
 
-    vector_size_t elementsCount = elementsRows.end();
+    vector_size_t elementsCount = 0;
+    rows.applyToSelected(
+        [&](vector_size_t row) { elementsCount += arrayVector->sizeAt(row); });
     vector_size_t rowCount = rows.end();
 
     // Allocate new vectors for indices, length and offsets.


### PR DESCRIPTION
Summary:
When the input arrays to array_distinct have overlapping ranges of elements, it under counts the upper bound
of the cumulative size of the result arrays. Currently it uses the index of the last referred to element in the
elements Vector, which ignores duplicates in the case of overlapping ranges.

This change makes it so it sums the sizes of the input arrays instead. This should also prevent overallocating in
the case where a significant subset of the elements Vector is unused.

On a side note, there is a plan to ensure arrays do not overlap 
https://github.com/facebookincubator/velox/issues/10876 but until that is implemented and enforced, this fixes
a potential issue, and as mentioned, has the potential to save some memory at a small CPU cost in the case of
non-overlapping arrays.

Differential Revision: D67049306


