### PR TITLE
fix(fuzzer): Ensure common dictionary generation skips row_number column

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
@@ -201,10 +201,10 @@ class ExpressionFuzzerVerifier {
       const RowVectorPtr& rowVector,
       VectorFuzzer& vectorFuzzer);
 
-  // Fuzzes the input vector of type with an additional row number column.
-  RowVectorPtr fuzzInputWithRowNumber(
-      VectorFuzzer& fuzzer,
-      const RowTypePtr& type);
+  // Appends an additional row number column called 'row_number' at the end of
+  // the 'inputRow'. This column is then used to line up rows when comparing
+  // results against a reference database.
+  RowVectorPtr appendRowNumberColumn(RowVectorPtr& inputRow);
 
   const Options options_;
 


### PR DESCRIPTION
Ensure that the row_number column, used for lining up results with the
reference database, is not treated as a candidate for wrapping by the
fuzzer's feature that probabilistically adds a common dictionary layer.
This prevents verification mismatches caused by the column being
wrapped and losing its intended purpose.