### PR TITLE
fix: IN does not handle User errors thrown during eval

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -87,7 +87,7 @@ class VectorSetInPredicate : public exec::VectorFunction {
     result->clearNulls(rows);
     auto* boolResult = result->asUnchecked<FlatVector<bool>>();
 
-    rows.applyToSelected([&](vector_size_t row) {
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
       if (arg->isNullAt(row)) {
         boolResult->setNull(row, true);
       } else {
@@ -543,12 +543,15 @@ class InPredicate : public exec::VectorFunction {
       if (simpleArg->isNullAt(rows.begin())) {
         localResult = createBoolConstantNull(rows.end(), context);
       } else {
-        bool pass = testFunction(simpleArg->valueAt(rows.begin()));
-        if (!pass && passOrNull) {
-          localResult = createBoolConstantNull(rows.end(), context);
-        } else {
-          localResult = createBoolConstant(pass, rows.end(), context);
-        }
+        static const SelectivityVector oneRow(1, true);
+        context.applyToSelectedNoThrow(oneRow, [&](vector_size_t row) {
+          bool pass = testFunction(simpleArg->valueAt(rows.begin()));
+          if (!pass && passOrNull) {
+            localResult = createBoolConstantNull(rows.end(), context);
+          } else {
+            localResult = createBoolConstant(pass, rows.end(), context);
+          }
+        });
       }
 
       context.moveOrCopyResult(localResult, rows, result);
@@ -565,7 +568,7 @@ class InPredicate : public exec::VectorFunction {
     auto* rawResults = boolResult->mutableRawValues<uint64_t>();
 
     if (flatArg->mayHaveNulls() || passOrNull) {
-      rows.applyToSelected([&](auto row) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
         if (flatArg->isNullAt(row)) {
           boolResult->setNull(row, true);
         } else {
@@ -578,7 +581,7 @@ class InPredicate : public exec::VectorFunction {
         }
       });
     } else {
-      rows.applyToSelected([&](auto row) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
         bool pass = testFunction(flatArg->valueAtFast(row));
         bits::setBit(rawResults, row, pass);
       });


### PR DESCRIPTION
Summary:
IN does not handle user errors thrown during eval. This means that if the IN is wrapped with a TRY, user errors
will still get thrown rather than producing a null.

The fuzzer tests demonstrated a case of this, Velox allows creating Timestamps that are large enough that they
cannot be represented as milliseconds, there would be an overflow, in this case toMillis throws a user exception.
When evaluating IN, the argument is converted to milliseconds and compared to the set of Timestamps. When
wrapped in a TRY the IN still throws an exception rather than returning NULL.

Differential Revision: D67063377


