### PR TITLE
fix(build): Remove unused variable from the function decodeArrayElements

### DIFF
--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -140,7 +140,6 @@ DecodedVector* decodeArrayElements(
     exec::LocalDecodedVector& elementsDecoder,
     const SelectivityVector& rows,
     SelectivityVector* elementRows) {
-  auto decodedVector = arrayDecoder.get();
   auto baseArrayVector = arrayDecoder->base()->as<ArrayVector>();
 
   // Decode and acquire array elements vector.


### PR DESCRIPTION
Summary:
Seeing the following error during build diff due to unused variable

```
Stdout: <empty>
Stderr:
fbcode/velox/functions/prestosql/ArrayIntersectExcept.cpp:143:8: error: unused variable 'decodedVector' [-Werror,-Wunused-variable]
  143 |   auto decodedVector = arrayDecoder.get();
      |        ^~~~~~~~~~~~~
1 error generated.
```

Differential Revision: D67071311


