### PR TITLE
build: Remove test component of lib icu

### DIFF
--- a/CMake/resolve_dependency_modules/icu.cmake
+++ b/CMake/resolve_dependency_modules/icu.cmake
@@ -70,8 +70,7 @@ set(icu_components
     i18n
     io
     uc
-    tu
-    test)
+    tu)
 
 foreach(component ${icu_components})
   add_library(ICU::${component} SHARED IMPORTED)

--- a/CMake/resolve_dependency_modules/icu/FindICU.cmake
+++ b/CMake/resolve_dependency_modules/icu/FindICU.cmake
@@ -13,7 +13,12 @@
 # limitations under the License.
 message("Using ICU - Bundled")
 set(ICU_FOUND TRUE)
-set(icu_components data i18n io uc tu test)
+set(icu_components
+    data
+    i18n
+    io
+    uc
+    tu)
 foreach(component icu_components)
   set(ICU_${component}_FOUND TRUE)
 endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -427,8 +427,7 @@ velox_resolve_dependency(
   i18n
   io
   uc
-  tu
-  test)
+  tu)
 
 set(BOOST_INCLUDE_LIBRARIES
     atomic


### PR DESCRIPTION
The test component of lib icu is not used in Velox. This pr simply removes it,
assuming there is no reason for keeping it.