### PR TITLE
fix(json_parse): Tape failure due to out of bounds ':'

### DIFF
--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -280,6 +280,19 @@ TEST_F(JsonFunctionsTest, jsonParse) {
       JSON());
   velox::test::assertEqualVectors(expected, result);
 
+  // ':' are placed below to make parser think its a key and not a value.
+  // when processing the next string.
+  auto svData = {
+      "\"SomeVerylargeStringThatIsUsedAaaBbbService::someSortOfImpressions\""_sv,
+      "\"SomeBusinessClusterImagesSignal::genValue\""_sv,
+      "\"SomeVerylargeStringThatIsUsedAaaBbbCc::Service::someSortOfImpressions\""_sv,
+      "\"SomePreviewUtils::genMediaComponent\""_sv};
+
+  data = makeRowVector({makeFlatVector<StringView>(svData)});
+  expected = makeFlatVector<StringView>(svData, JSON());
+  result = evaluate("json_parse(c0)", data);
+  velox::test::assertEqualVectors(expected, result);
+
   data = makeRowVector({makeConstant(R"("apple")", 2)});
   result = evaluate("json_parse(c0)", data);
   expected = makeFlatVector<StringView>({{R"("apple")", R"("apple")"}}, JSON());


### PR DESCRIPTION
Summary: SIMDJSON fails with a tape failure when if a ':' immediately follows the end of a \" when parsing even though ':' is outside the range of the input. This can happen if the previous string had a ':' at just the right location as we dont clear the buffer when processing strings. Fixes T210222818 .

Differential Revision: D67108827


