### PR TITLE
feat: Optimize serializer decompress buffer for BufferInputStream

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -253,6 +253,8 @@ class BufferInputStream : public ByteInputStream {
 
   void readBytes(uint8_t* bytes, int32_t size) override;
 
+  std::unique_ptr<folly::IOBuf> readBytes(int32_t size);
+
   std::string_view nextView(int32_t size) override;
 
   void skip(int32_t size) override;


### PR DESCRIPTION
Read the BufferInputStream by new added function readBytes to avoid copying from the buffer cache. Extract the uncompress process to a new function can help release the compressed buffer in time.

FileInputStream reuse the read buffer, so we can get the IOBuf without copy only if the required bytes is in one buffer, which is not the common case, so I don't do the optimization for it.