### PR TITLE
build(ci): Fix build metrics report

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -117,7 +117,6 @@ jobs:
             "/tmp/metrics"
 
   upload-report:
-    # if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'facebookincubator/velox' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -151,6 +151,12 @@ jobs:
           cd scripts/bm-report
           nix-shell --run "quarto render report.qmd"
 
+      - name: Upload Report Artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: report
+          path: scripts/bm-report/report.html
+
       - name: Push Report
         # The report only uses conbench data from 'main'
         # so any data generated in a PR won't be included

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -117,7 +117,7 @@ jobs:
             "/tmp/metrics"
 
   upload-report:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'facebookincubator/velox' }}
+    # if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'facebookincubator/velox' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -156,6 +156,7 @@ jobs:
         with:
           name: report
           path: scripts/bm-report/report.html
+          retention-days: 5
 
       - name: Push Report
         # The report only uses conbench data from 'main'

--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -47,10 +47,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      VELOX_DEPENDENCY_SOURCE: SYSTEM
-      simdjson_SOURCE: BUNDLED
-      xsimd_SOURCE: BUNDLED
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Changes to finding GTest caused the build metrics job to fail as we don't have GTest in the image yet. See https://github.com/facebookincubator/velox/issues/11837