### PR TITLE
fix(fuzzer): Fix sanitize(type) in FuzzerUtil for IPPREFIX type

### DIFF
--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -22,6 +22,7 @@
 #include "velox/dwio/catalog/fbhive/FileUtils.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/expression/SignatureBinder.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
 
 using namespace facebook::velox::dwio::catalog::fbhive;
 
@@ -283,7 +284,7 @@ bool usesTypeName(
 // If 'type' is a RowType or contains RowTypes with empty field names, adds
 // default names to these fields in the RowTypes.
 TypePtr sanitize(const TypePtr& type) {
-  if (!type) {
+  if (!type || isIPPrefixType(type)) {
     return type;
   }
 

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -560,14 +560,17 @@ void WindowFuzzer::go() {
   }
 
   stats_.print(iteration);
-  // Check that at least half of the iterations were verified, either against
-  // the reference DB or through custom result verifiers.
-  // stats_.numVerificationSkipped tracks the number of iterations verified
-  // through custom result verifiers.
-  VELOX_CHECK_GE(
-      (stats_.numVerified + stats_.numVerificationSkipped) / (double)iteration,
-      0.5);
   printSignatureStats();
+  if (FLAGS_enable_window_reference_verification) {
+    // Check that at least half of the iterations were verified, either against
+    // the reference DB or through custom result verifiers.
+    // stats_.numVerificationSkipped tracks the number of iterations verified
+    // through custom result verifiers.
+    VELOX_CHECK_GE(
+        (stats_.numVerified + stats_.numVerificationSkipped) /
+            (double)iteration,
+        0.5);
+  }
 }
 
 void WindowFuzzer::go(const std::string& /*planPath*/) {

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
@@ -21,7 +21,9 @@
 
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/expression/ReverseSignatureBinder.h"
-#include "velox/expression/SignatureBinder.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/type/Type.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -32,6 +34,12 @@ using exec::test::sanitizeTryResolveType;
 std::string typeToBaseName(const TypePtr& type) {
   if (type->isDecimal()) {
     return "decimal";
+  } else if (isIPPrefixType(type)) {
+    return "ipprefix";
+  } else if (isIPAddressType(type)) {
+    return "ipaddress";
+  } else if (isJsonType(type)) {
+    return "json";
   }
   return boost::algorithm::to_lower_copy(std::string{type->kindName()});
 }

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   velox_type
   velox_expression_functions
   velox_fuzzer_util
+  velox_presto_types
   GTest::gtest)
 
 add_library(

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -676,7 +676,6 @@ bool ExpressionFuzzer::isSupportedSignature(
   if (usesTypeName(signature, "opaque") ||
       usesTypeName(signature, "timestamp with time zone") ||
       usesTypeName(signature, "interval day to second") ||
-      usesTypeName(signature, "ipprefix") ||
       (!options_.enableDecimalType && usesTypeName(signature, "decimal")) ||
       (!options_.enableComplexTypes && useComplexType) ||
       (options_.enableComplexTypes && usesTypeName(signature, "unknown"))) {

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -22,6 +22,7 @@
 #include <locale>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/type/Timestamp.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/FlatVector.h"
@@ -605,8 +606,14 @@ VectorPtr VectorFuzzer::fuzzComplex(const TypePtr& type, vector_size_t size) {
   opts_.allowLazyVector = false;
 
   switch (type->kind()) {
-    case TypeKind::ROW:
+    case TypeKind::ROW: {
+      if (isIPPrefixType(type)) {
+        ScopedOptions restorer(this);
+        opts_.containerHasNulls = false;
+        return fuzzRow(std::dynamic_pointer_cast<const RowType>(type), size);
+      }
       return fuzzRow(std::dynamic_pointer_cast<const RowType>(type), size);
+    }
 
     case TypeKind::ARRAY: {
       const auto& elementType = type->asArray().elementType();


### PR DESCRIPTION
The sanitize(type) method incorrectly converts the IPPrefixType into a RowType, which cause error during expression compilation of a fuzzer run. Since IPPrefixType already has field names, there is no need to sanitize it. This diff makes sanitize(type) skip sanitizing IPPrefixType.