### PR TITLE
feat: Add 'expression.max_compiled_regexes' Query Config

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -82,6 +82,11 @@ class QueryConfig {
   static constexpr const char* kExprMaxArraySizeInReduce =
       "expression.max_array_size_in_reduce";
 
+  /// Controls maximum number of compiled regular expression patterns per
+  /// function instance per thread of execution.
+  static constexpr const char* kExprMaxCompiledRegexes =
+      "expression.max_compiled_regexes";
+
   /// Used for backpressure to block local exchange producers when the local
   /// exchange buffer reaches or exceeds this size.
   static constexpr const char* kMaxLocalExchangeBufferSize =
@@ -615,6 +620,10 @@ class QueryConfig {
 
   uint64_t exprMaxArraySizeInReduce() const {
     return get<uint64_t>(kExprMaxArraySizeInReduce, 100'000);
+  }
+
+  uint64_t exprMaxCompiledRegexes() const {
+    return get<uint64_t>(kExprMaxCompiledRegexes, 100);
   }
 
   bool adjustTimestampToTimezone() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -183,6 +183,10 @@ Expression Evaluation Configuration
      - integer
      - 100000
      - ``Reduce`` function will throw an error if encountered an array of size greater than this.
+   * - expression.max_compiled_regexes
+     - integer
+     - 100
+     - Controls maximum number of compiled regular expression patterns per batch.
    * - debug_disable_expression_with_peeling
      - bool
      - false

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -26,9 +26,9 @@ See https://github.com/google/re2/wiki/Syntax for more information.
     Note: The wildcard '%' represents 0, 1 or multiple characters and the
     wildcard '_' represents exactly one character.
 
-    Note: Each function instance allow for a maximum of 20 regular expressions to
-    be compiled per thread of execution. Not all patterns require
-    compilation of regular expressions. Patterns 'hello', 'hello%', '_hello__%',
+    Note: Each function instance allow for a maximum of ``expression.max_compiled_regexes``
+    (default 100) regular expressions to be compiled per thread of execution. Not all patterns
+    require compilation of regular expressions. Patterns 'hello', 'hello%', '_hello__%',
     '%hello', '%__hello_', '%hello%', where 'hello', 'velox'
     contains only regular characters and '_' wildcards are evaluated without
     using regular expressions. Only those patterns that require the compilation of

--- a/velox/functions/sparksql/Split.h
+++ b/velox/functions/sparksql/Split.h
@@ -28,10 +28,29 @@ namespace facebook::velox::functions::sparksql {
 /// applied as many times as possible.
 template <typename T>
 struct Split {
+  Split() : cache_(0) {}
+
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* input,
+      const arg_type<Varchar>* delimiter) {
+    initialize(inputTypes, config, input, delimiter, nullptr);
+  }
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* /*input*/,
+      const arg_type<Varchar>* /*delimiter*/,
+      const arg_type<int32_t>* /*limit*/) {
+    cache_.setMaxCompiledRegexes(config.exprMaxCompiledRegexes());
+  }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Array<Varchar>>& result,

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -551,8 +551,9 @@ TEST_F(RegexFunctionsTest, regexpReplaceCacheLimitTest) {
   std::vector<std::string> strings;
   std::vector<std::string> replaces;
   std::vector<std::string> expectedOutputs;
+  const core::QueryConfig config({});
 
-  for (int i = 0; i <= kMaxCompiledRegexes; ++i) {
+  for (int i = 0; i <= config.exprMaxCompiledRegexes(); ++i) {
     patterns.push_back("\\d" + std::to_string(i) + "-\\d" + std::to_string(i));
     strings.push_back("1" + std::to_string(i) + "-2" + std::to_string(i));
     replaces.push_back("X" + std::to_string(i) + "-Y" + std::to_string(i));
@@ -571,8 +572,9 @@ TEST_F(RegexFunctionsTest, regexpReplaceCacheMissLimit) {
   std::vector<std::string> replaces;
   std::vector<std::string> expectedOutputs;
   std::vector<int32_t> positions;
+  const core::QueryConfig config({});
 
-  for (int i = 0; i <= kMaxCompiledRegexes - 1; ++i) {
+  for (int i = 0; i <= config.exprMaxCompiledRegexes() - 1; ++i) {
     patterns.push_back("\\d" + std::to_string(i) + "-\\d" + std::to_string(i));
     strings.push_back("1" + std::to_string(i) + "-2" + std::to_string(i));
     replaces.push_back("X" + std::to_string(i) + "-Y" + std::to_string(i));


### PR DESCRIPTION
Summary:
Adding 'expression.max_compiled_regexes' Query Config property, so it
can be adjusted per query.
Also increasing the dfault value to 100 from 20.

Differential Revision: D67183811


