### PR TITLE
misc: Enable Parquet Writer in Bucketed mode in TableWriterTest

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -1538,8 +1538,10 @@ class BucketSortOnlyTableWriterTest
   static std::vector<uint64_t> getTestParams() {
     std::vector<uint64_t> testParams;
     const std::vector<bool> multiDriverOptions = {false, true};
-    // Add Parquet with https://github.com/facebookincubator/velox/issues/5560
     std::vector<FileFormat> fileFormats = {FileFormat::DWRF};
+    if (hasWriterFactory(FileFormat::PARQUET)) {
+      fileFormats.push_back(FileFormat::PARQUET);
+    }
     const std::vector<TestMode> bucketModes = {
         TestMode::kBucketed, TestMode::kOnlyBucketed};
     for (bool multiDrivers : multiDriverOptions) {


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/5560 has been resolved in PR https://github.com/facebookincubator/velox/pull/7025, so we can enable Parquet Writer in Bucketed mode in TableWriterTest.

CC: @majetideepak 