### PR TITLE
fix: copyPreserveEncodings for LazyVector

### DIFF
--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -364,8 +364,9 @@ class LazyVector : public BaseVector {
   void validate(const VectorValidateOptions& options) const override;
 
   VectorPtr copyPreserveEncodings(
-      velox::memory::MemoryPool* /* pool */ = nullptr) const override {
-    VELOX_UNSUPPORTED("copyPreserveEncodings not defined for LazyVector");
+      velox::memory::MemoryPool* pool = nullptr) const override {
+    VELOX_CHECK(isLoaded());
+    return loadedVector()->copyPreserveEncodings(pool);
   }
 
  private:


### PR DESCRIPTION
Summary:
When loading data without a predicate we can the hive connector can return some LazyVectors. Currently the data sink attempts a call to copyPreserveEncodings (which is unsupported by LazyVector) to get a long lived owned copy of the data against its own memory pool. Putting this aside, we actually want to see impulse preload this data ahead of time for reliable query perf. 

This diff patches LazyVector::copyPreserveEncodings and ensures Impulse preloads data prior to obtaining a copy.

Reviewed By: Yuhta

Differential Revision: D67204919


