### PR TITLE
feat: Make PartitionedOutput reclaimable

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -106,7 +106,7 @@ struct SpillConfig {
   uint64_t readBufferSize;
 
   /// Executor for spilling. If nullptr spilling writes on the Driver's thread.
-  folly::Executor* executor; // Not owned.
+  folly::Executor* executor{nullptr}; // Not owned.
 
   /// The minimal spillable memory reservation in percentage of the current
   /// memory usage.

--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -359,6 +359,9 @@ void ByteOutputStream::extend(int32_t bytes) {
       ranges_.size() == 1 ? nullptr : &ranges_[ranges_.size() - 2],
       current_);
   allocatedBytes_ += current_->size;
+  if (allocatedBytes_ <= 0) {
+    VELOX_CHECK_GT(allocatedBytes_, 0);
+  }
   VELOX_CHECK_GT(allocatedBytes_, 0);
   if (isBits_) {
     // size and position are in units of bits for a bits stream.

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -76,6 +76,7 @@ void StreamArena::newTinyRange(
   range->buffer = reinterpret_cast<uint8_t*>(tinyRanges_.back().data());
   range->size = bytes;
 }
+
 void StreamArena::clear() {
   allocations_.clear();
   pool_->freeNonContiguous(allocation_);

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1371,6 +1371,10 @@ class PartitionedOutputNode : public PlanNode {
     return sources_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return isPartitioned() && queryConfig.partitionedOutputSpillEnabled();
+  }
+
   const RowTypePtr& inputType() const {
     return sources_[0]->outputType();
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -211,6 +211,11 @@ class QueryConfig {
   static constexpr const char* kTopNRowNumberSpillEnabled =
       "topn_row_number_spill_enabled";
 
+  /// PartitionedOutput spilling flag, only applies if "spill_enabled" flag is
+  /// set.
+  static constexpr const char* kPartitionedOutputSpillEnabled =
+      "partitioned_output_spill_enabled";
+
   /// The max row numbers to fill and spill for each spill run. This is used to
   /// cap the memory used for spilling. If it is zero, then there is no limit
   /// and spilling might run out of memory.
@@ -692,6 +697,10 @@ class QueryConfig {
 
   bool topNRowNumberSpillEnabled() const {
     return get<bool>(kTopNRowNumberSpillEnabled, true);
+  }
+
+  bool partitionedOutputSpillEnabled() const {
+    return get<bool>(kPartitionedOutputSpillEnabled, true);
   }
 
   int32_t maxSpillLevel() const {

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -96,8 +96,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     this->queryConfig_.testingOverrideConfigUnsafe(std::move(values));
   }
 
-  // Overrides the previous connector-specific configuration. Note that this
-  // function is NOT thread-safe and should probably only be used in tests.
+  /// Overrides the previous connector-specific configuration. Note that this
+  /// function is NOT thread-safe and should probably only be used in tests.
   void setConnectorSessionOverridesUnsafe(
       const std::string& connectorId,
       std::unordered_map<std::string, std::string>&& configOverrides) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -185,6 +185,7 @@ struct ThreadState {
 enum class BlockingReason {
   kNotBlocked,
   kWaitForConsumer,
+  kWaitForSpill,
   kWaitForSplit,
   /// Some operators can get blocked due to the producer(s) (they are
   /// currently waiting data from) not having anything produced. Used by

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -60,7 +60,7 @@ class SerializedPage {
   // Buffers containing the serialized data. The memory is owned by 'iobuf_'.
   std::vector<ByteRange> ranges_;
 
-  // IOBuf holding the data in 'ranges_.
+  // IOBuf holding the data in 'ranges_'.
   std::unique_ptr<folly::IOBuf> iobuf_;
 
   // Number of payload bytes in 'iobuf_'.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -754,7 +754,7 @@ uint64_t Operator::MemoryReclaimer::reclaim(
             reclaimedBytes,
             0,
             "Unexpected memory growth after reclaim from operator memory pool {}",
-            pool->name());
+            op_->pool()->name());
         return reclaimedBytes;
       },
       stats);

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -29,11 +29,12 @@ class OutputBufferManager {
 
   explicit OutputBufferManager(Options /*unused*/) {}
 
-  void initializeTask(
+  std::shared_ptr<OutputBuffer> initializeTask(
       std::shared_ptr<Task> task,
       core::PartitionedOutputNode::Kind kind,
       int numDestinations,
-      int numDrivers);
+      int numDrivers,
+      memory::MemoryPool* pool = nullptr);
 
   /// Updates the number of buffers. Returns true if the buffer exists for a
   /// given taskId, else returns false.
@@ -122,7 +123,7 @@ class OutputBufferManager {
 
   // If the output buffer from a task of taskId is over-utilized and blocks its
   // producers. When the task of this taskId is not found, return false.
-  bool isOverutilized(const std::string& taskId);
+  bool isOverUtilized(const std::string& taskId);
 
   // Returns nullopt when the specified output buffer doesn't exist.
   std::optional<OutputBuffer::Stats> stats(const std::string& taskId);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -796,6 +796,11 @@ class Task : public std::enable_shared_from_this<Task> {
   // to ensure lifetime and returns a raw pointer.
   memory::MemoryPool* getOrAddNodePool(const core::PlanNodeId& planNodeId);
 
+  // Smilar to getOrAddNodePool but creates the memory pool instance for a
+  // partitioned output plan node.
+  memory::MemoryPool* getOrAddPartitionedOutputNodePool(
+      const core::PlanNodeId& planNodeId);
+
   // Similar to getOrAddNodePool but creates the memory pool instance for a hash
   // join plan node. If 'splitGroupId' is not kUngroupedGroupId, it specifies
   // the split group id under the grouped execution mode.
@@ -817,6 +822,10 @@ class Task : public std::enable_shared_from_this<Task> {
   // memory arbitration request initiated under the driver execution context.
   std::unique_ptr<memory::MemoryReclaimer> createExchangeClientReclaimer()
       const;
+
+  // Creates a memory reclaimer instance for the output buffer of the task, if
+  // the task memory pool has set memory reclaimer.
+  std::unique_ptr<memory::MemoryReclaimer> createOutputBufferReclaimer() const;
 
   // Creates a memory reclaimer instance for this task. If the query memory
   // pool doesn't set memory reclaimer, then the function simply returns null.

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -812,10 +812,12 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          std::thread::hardware_concurrency(),
+          std::make_shared<folly::NamedThreadFactory>("Driver"))};
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          std::thread::hardware_concurrency(),
+          std::make_shared<folly::NamedThreadFactory>("Spiller"))};
 };
 
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {


### PR DESCRIPTION
Partitioned output spill work as following:
As soon as partitioned output is triggered to reclaim from itself, this task's output buffer switches to spill mode, meaning:
* Any time the output buffer reaches its max in memory buffer bytes, it spills the data to disk, instead of waiting for consumers to retrieve. 
* Any consumer retrieving will not receive any data, until all current task's results have been produced and spilled.
* When all current task's results have been produced and spilled, consumer will retrieve the unspilled data directly from disk. 

Partitioned output spill currently only works for PARTITION mode. This PR has limitations of not efficiently save memory by spilling, due to unspilling using a considerably large amount of memory. But it lays a foundation for persistent shuffle. Future changes are coming, to make this spill more coordinated with other plan nodes' spill so that node memory usage is more efficient.