### PR TITLE
feat: Add utility to print summary of a vector

### DIFF
--- a/velox/vector/VectorPrinter.h
+++ b/velox/vector/VectorPrinter.h
@@ -40,4 +40,73 @@ std::string printVector(
     const BaseVector& vector,
     const SelectivityVector& rows);
 
+class VectorPrinter {
+ public:
+  struct Options {
+    // Options that control summarization of types.
+    velox::Type::TypeSummaryOptions types;
+
+    // Maximum number of child vectors to include in the summary.
+    size_t maxChildren{5};
+
+    // Whether to include the names of the RowVector child vectors.
+    bool includeChildNames{false};
+
+    // Whether to include unique IDs for each node in the vector hierarchy.
+    bool includeNodeIds{false};
+
+    // Optional indent to add to all lines. Useful when embedding the output of
+    // the printer into some other text. Each indentation is 3 spaces. 0 means
+    // no indentation. 1 - 3 spaces. 2 - 6 spaces.
+    int32_t indent{0};
+
+    // Whether to skip printing the summary of the top level vector. Similar to
+    // 'indent', useful when embedding the output of the printer into some other
+    // text.
+    bool skipTopSummary{false};
+
+    // Workaround for compiler error: default member initializer for
+    // 'maxChildren' needed within definition of enclosing class 'VectorPrinter'
+    // outside of member functions
+    //
+    // static std::string summarizeToText(
+    //    const BaseVector& vector,
+    //    Options options = {});
+    static Options defaultOptions() {
+      return {};
+    }
+  };
+
+  // Returns a summary of the vector in human-readable text format.
+  //
+  // Prints a hierarchy of vectors with up to options.maxChildren children at
+  // each level. For each vector, prints a header that includes the data type,
+  // number of rows, encoding.
+  //
+  // For example,
+  //
+  // A flat vector of integers:
+  //
+  //  INTEGER 8 rows FLAT 32B
+  //
+  // A flat array of integers with 3 null arrays, 1 empty array and the rest
+  // of arrays of average size 3:
+  //
+  //  ARRAY 8 rows ARRAY 288B
+  //       Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]
+  //    BIGINT 12 rows FLAT 128B
+  //
+  // A dictionary over map with 4 unique maps:
+  //
+  //  MAP 8 rows DICTIONARY 192B
+  //      Stats: 0 nulls, 4 unique
+  //    MAP 4 rows MAP 160B
+  //        Stats: 0 nulls, 1 empty, sizes: [1...4, avg 2]
+  //      INTEGER 8 rows FLAT 32B
+  //      REAL 8 rows FLAT 32B
+  static std::string summarizeToText(
+      const BaseVector& vector,
+      const Options& options = Options::defaultOptions());
+};
+
 } // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(
   Boost::system
   GTest::gtest
   GTest::gtest_main
+  GTest::gmock
   Folly::folly
   gflags::gflags
   glog::glog

--- a/velox/vector/tests/VectorPrinterTest.cpp
+++ b/velox/vector/tests/VectorPrinterTest.cpp
@@ -17,6 +17,8 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+#include <gmock/gmock.h>
+
 namespace facebook::velox::test {
 
 class VectorPrinterTest : public testing::Test, public VectorTestBase {
@@ -24,10 +26,21 @@ class VectorPrinterTest : public testing::Test, public VectorTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
   }
+
+  static std::vector<std::string> summarizeToLines(
+      const BaseVector& vector,
+      const VectorPrinter::Options& options = {}) {
+    std::vector<std::string> lines;
+    folly::split('\n', VectorPrinter::summarizeToText(vector, options), lines);
+    if (lines.back().empty()) {
+      lines.pop_back();
+    }
+    return lines;
+  }
 };
 
 // Sanity check that printVector doesn't fail or crash.
-TEST_F(VectorPrinterTest, basic) {
+TEST_F(VectorPrinterTest, printVectorFuzz) {
   VectorFuzzer::Options options;
   options.vectorSize = 100;
   options.nullRatio = 0.1;
@@ -50,11 +63,96 @@ TEST_F(VectorPrinterTest, basic) {
   }
 }
 
-TEST_F(VectorPrinterTest, map) {
+TEST_F(VectorPrinterTest, printVectorMap) {
   auto data = makeMapVector<int64_t, int64_t>({
       {},
       {{1, 10}},
   });
   ASSERT_NO_THROW(printVector(*data));
 }
+
+TEST_F(VectorPrinterTest, summarizeToText) {
+  auto data = makeRowVector(
+      {"a", "b", "c", "d"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8}),
+          makeArrayVectorFromJson<int64_t>({
+              "[1, 2, 3]",
+              "[4, 5]",
+              "null",
+              "[6, 7, 8, 9]",
+              "null",
+              "null",
+              "[10, 11, 12]",
+              "[]",
+          }),
+          wrapInDictionary(
+              makeIndices({0, 0, 0, 1, 2, 2, 3, 3}),
+              makeMapVectorFromJson<int32_t, float>({
+                  "{1: 1.0}",
+                  "{3: 3.0, 4: 4.0, 5: 5.0}",
+                  "{}",
+                  "{6: 6.0, 7: 7.0, 8: 8.0, 9: 9.0}",
+              })),
+          makeConstant("hello", 8),
+      });
+
+  EXPECT_THAT(
+      summarizeToLines(*data),
+      ::testing::ElementsAre(
+          ::testing::MatchesRegex("ROW\\(4\\) 8 rows ROW [0-9]+.*"),
+          ::testing::MatchesRegex("   INTEGER 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("   ARRAY 8 rows ARRAY [0-9]+.*"),
+          "         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]",
+          ::testing::MatchesRegex("      BIGINT 12 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("   MAP 8 rows DICTIONARY [0-9]+.*"),
+          "         Stats: 0 nulls, 4 unique",
+          ::testing::MatchesRegex("      MAP 4 rows MAP [0-9]+.*"),
+          "            Stats: 0 nulls, 1 empty, sizes: [1...4, avg 2]",
+          ::testing::MatchesRegex("         INTEGER 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("         REAL 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("   VARCHAR 8 rows CONSTANT [0-9]+.*")));
+
+  EXPECT_THAT(
+      summarizeToLines(
+          *data,
+          {.types = {}, .includeChildNames = true, .includeNodeIds = true}),
+      ::testing::ElementsAre(
+          ::testing::MatchesRegex("0 ROW\\(4\\) 8 rows ROW [0-9]+.*"),
+          ::testing::MatchesRegex("   0.0 INTEGER 8 rows FLAT [0-9]+.* a"),
+          ::testing::MatchesRegex("   0.1 ARRAY 8 rows ARRAY [0-9]+.* b"),
+          "         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]",
+          ::testing::MatchesRegex("      0.1.0 BIGINT 12 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("   0.2 MAP 8 rows DICTIONARY [0-9]+.* c"),
+          "         Stats: 0 nulls, 4 unique",
+          ::testing::MatchesRegex("      0.2.0 MAP 4 rows MAP [0-9]+.*"),
+          "            Stats: 0 nulls, 1 empty, sizes: [1...4, avg 2]",
+          ::testing::MatchesRegex(
+              "         0.2.0.0 INTEGER 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("         0.2.0.1 REAL 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex(
+              "   0.3 VARCHAR 8 rows CONSTANT [0-9]+.* d")));
+
+  EXPECT_THAT(
+      summarizeToLines(*data, {.types = {}, .maxChildren = 2}),
+      ::testing::ElementsAre(
+          ::testing::MatchesRegex("ROW\\(4\\) 8 rows ROW [0-9]+.*"),
+          ::testing::MatchesRegex("   INTEGER 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("   ARRAY 8 rows ARRAY [0-9]+.*"),
+          "         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]",
+          ::testing::MatchesRegex("      BIGINT 12 rows FLAT [0-9]+.*"),
+          "   ...2 more"));
+
+  EXPECT_THAT(
+      summarizeToLines(
+          *data,
+          {.types = {}, .maxChildren = 2, .indent = 2, .skipTopSummary = true}),
+      ::testing::ElementsAre(
+          ::testing::MatchesRegex("         INTEGER 8 rows FLAT [0-9]+.*"),
+          ::testing::MatchesRegex("         ARRAY 8 rows ARRAY [0-9]+.*"),
+          "               Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]",
+          ::testing::MatchesRegex("            BIGINT 12 rows FLAT [0-9]+.*"),
+          "         ...2 more"));
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Introduce VectorPrinter::summarizeToText helper function to generate human-friendly summary of a vector.

The summary shows the overall hierarchy of the vector and annotates each node with data type, number of rows, encoding, and size in memory.

Dictionary nodes include number of unique indices. Array and Map nodes specify number of empty arrays / maps as well as min/max/avg sizes of the arrays / maps.

```
ROW(4) 8 rows ROW 528B
   INTEGER 8 rows FLAT 32B
   ARRAY 8 rows ARRAY 288B
         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]
      BIGINT 12 rows FLAT 128B
   MAP 8 rows DICTIONARY 192B
         Stats: 0 nulls, 4 unique
      MAP 4 rows MAP 160B
            Stats: 0 nulls, 1 empty, sizes: [1...4, avg 2]
         INTEGER 8 rows FLAT 32B
         REAL 8 rows FLAT 32B
   VARCHAR 8 rows CONSTANT 16B
```

The summary optionally includes unique node IDs to allow for easy referencing.

```
0 ROW(4) 8 rows ROW 528B
   0.0 INTEGER 8 rows FLAT 32B
   0.1 ARRAY 8 rows ARRAY 288B
         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]
      0.1.0 BIGINT 12 rows FLAT 128B
   0.2 MAP 8 rows DICTIONARY 192B
         Stats: 0 nulls, 4 unique
      0.2.0 MAP 4 rows MAP 160B
            Stats: 0 nulls, 1 empty, sizes: [1...4, avg 2]
         0.2.0.0 INTEGER 8 rows FLAT 32B
         0.2.0.1 REAL 8 rows FLAT 32B
   0.3 VARCHAR 8 rows CONSTANT 16B
```

The number of RowVector chidren is limited to 5, but can be increased by specifying options.maxChildren:

```
ROW(4) 8 rows ROW 528B
   INTEGER 8 rows FLAT 32B
   ARRAY 8 rows ARRAY 288B
         Stats: 3 nulls, 1 empty, sizes: [2...4, avg 3]
      BIGINT 12 rows FLAT 128B
   ...2 more
```

Differential Revision: D67229321


