### PR TITLE
fix: Classification functions should return [] instead null

### DIFF
--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
@@ -491,7 +491,7 @@ class ClassificationAggregation : public exec::Aggregate {
       auto* accumulator = value<Accumulator<type>>(group);
       const auto size = accumulator->size();
       if (isNull(group)) {
-        vector->setNull(i, true);
+        clearNull(rawNulls, i);
         continue;
       }
 

--- a/velox/functions/prestosql/aggregates/tests/ClassificationAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ClassificationAggregationTest.cpp
@@ -117,8 +117,7 @@ TEST_F(ClassificationAggregationTest, basic) {
   });
 
   expected = makeRowVector({makeNullableArrayVector<double>(
-      std::vector<std::optional<std::vector<std::optional<double>>>>{
-          {std::nullopt}})});
+      std::vector<std::optional<std::vector<std::optional<double>>>>{{{}}})});
   runTest("classification_fall_out(5, c0, c1)", input, expected);
   runTest("classification_precision(5, c0, c1)", input, expected);
   runTest("classification_recall(5, c0, c1)", input, expected);


### PR DESCRIPTION
Summary:
To be consistent with Java behavior,  values that may produce non-sensible results should return [] instead of NULL just like in Java.

See failed fuzzer
```
10 of extra rows:
	43958 | null | 1.614066005835391E308 | null | 56 | null
	43958 | null | 1.249509044542672E308 | null | 73 | null
	43958 | null | 1.0352077108850509E308 | null | 133 | null
	43958 | null | 1.4197168072885737E308 | null | 222 | null
	43958 | null | 1.5812716007918045E308 | null | 251 | null
	43958 | null | 1.2735686950279541E308 | null | 256 | null
	43958 | null | 3.911438594915475E307 | null | 257 | null
	43958 | null | 1.2969345942976502E307 | null | 258 | null
	43958 | null | 1.2608837131771955E308 | null | 273 | null
	43958 | null | 1.7284583913651944E308 | null | 275 | null

10 of missing rows:
	43958 | null | 1.614066005835391E308 | null | 56 | []
	43958 | null | 1.249509044542672E308 | null | 73 | []
	43958 | null | 1.0352077108850509E308 | null | 133 | []
	43958 | null | 1.4197168072885737E308 | null | 222 | []
	43958 | null | 1.5812716007918045E308 | null | 251 | []
	43958 | null | 1.2735686950279541E308 | null | 256 | []
	43958 | null | 3.911438594915475E307 | null | 257 | []
	43958 | null | 1.2969345942976502E307 | null | 258 | []
	43958 | null | 1.2608837131771955E308 | null | 273 | []
	43958 | null | 1.7284583913651944E308 | null | 275 | []
```

This was discovered as a task to me after the original diff landed; however, the original diff had green signal on the window fuzzer.

Differential Revision: D67246837


