### PR TITLE
fix: Fix and improve table scan tracing and make to e2e work

### DIFF
--- a/velox/exec/OperatorTraceReader.cpp
+++ b/velox/exec/OperatorTraceReader.cpp
@@ -80,8 +80,16 @@ OperatorTraceSummary OperatorTraceSummaryReader::read() const {
   folly::dynamic summaryObj = folly::parseJson(summaryStr);
   OperatorTraceSummary summary;
   summary.opType = summaryObj[OperatorTraceTraits::kOpTypeKey].asString();
+  if (summary.opType == "TableScan") {
+    summary.numSplits = summaryObj[OperatorTraceTraits::kNumSplitsKey].asInt();
+  }
   summary.peakMemory = summaryObj[OperatorTraceTraits::kPeakMemoryKey].asInt();
   summary.inputRows = summaryObj[OperatorTraceTraits::kInputRowsKey].asInt();
+  summary.inputBytes = summaryObj[OperatorTraceTraits::kInputBytesKey].asInt();
+  summary.rawInputRows =
+      summaryObj[OperatorTraceTraits::kRawInputRowsKey].asInt();
+  summary.rawInputBytes =
+      summaryObj[OperatorTraceTraits::kRawInputBytesKey].asInt();
   return summary;
 }
 

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -65,7 +65,6 @@ class OperatorTraceInputWriter {
   const UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB_;
 
   std::unique_ptr<WriteFile> traceFile_;
-  TypePtr dataType_;
   std::unique_ptr<VectorStreamGroup> batch_;
   bool limitExceeded_{false};
   bool finished_{false};

--- a/velox/exec/Trace.cpp
+++ b/velox/exec/Trace.cpp
@@ -18,15 +18,33 @@
 
 #include <fmt/core.h>
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::velox::exec::trace {
 
 std::string OperatorTraceSummary::toString() const {
-  return fmt::format(
-      "opType {}, inputRows {}, peakMemory {}",
-      opType,
-      inputRows,
-      succinctBytes(peakMemory));
+  if (numSplits.has_value()) {
+    VELOX_CHECK_EQ(opType, "TableScan");
+    return fmt::format(
+        "opType {}, numSplits {}, inputRows {}, inputBytes {}, rawInputRows {}, rawInputBytes {}, peakMemory {}",
+        opType,
+        numSplits.value(),
+        inputRows,
+        succinctBytes(inputBytes),
+        rawInputRows,
+        succinctBytes(rawInputBytes),
+        succinctBytes(peakMemory));
+  } else {
+    VELOX_CHECK_NE(opType, "TableScan");
+    return fmt::format(
+        "opType {}, inputRows {},  inputBytes {}, rawInputRows {}, rawInputBytes {}, peakMemory {}",
+        opType,
+        inputRows,
+        succinctBytes(inputBytes),
+        rawInputRows,
+        succinctBytes(rawInputBytes),
+        succinctBytes(peakMemory));
+  }
 }
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/Trace.h
+++ b/velox/exec/Trace.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 
 namespace facebook::velox::exec::trace {
@@ -24,7 +25,6 @@ namespace facebook::velox::exec::trace {
 struct TraceTraits {
   static inline const std::string kPlanNodeKey = "planNode";
   static inline const std::string kQueryConfigKey = "queryConfig";
-  static inline const std::string kDataTypeKey = "rowType";
   static inline const std::string kConnectorPropertiesKey =
       "connectorProperties";
 
@@ -40,13 +40,23 @@ struct OperatorTraceTraits {
   static inline const std::string kOpTypeKey = "opType";
   static inline const std::string kPeakMemoryKey = "peakMemory";
   static inline const std::string kInputRowsKey = "inputRows";
-  static inline const std::string kNumSplits = "numSplits";
+  static inline const std::string kInputBytesKey = "inputBytes";
+  static inline const std::string kRawInputRowsKey = "rawInputRows";
+  static inline const std::string kRawInputBytesKey = "rawInputBytes";
+  static inline const std::string kNumSplitsKey = "numSplits";
 };
 
 /// Contains the summary of an operator trace.
 struct OperatorTraceSummary {
   std::string opType;
+  /// The number of splits processed by a table scan operator, nullopt for the
+  /// other operator types.
+  std::optional<uint32_t> numSplits{std::nullopt};
+
   uint64_t inputRows{0};
+  uint64_t inputBytes{0};
+  uint64_t rawInputRows{0};
+  uint64_t rawInputBytes{0};
   uint64_t peakMemory{0};
 
   std::string toString() const;

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -233,6 +233,10 @@ TEST_F(OperatorTraceTest, traceData) {
     ASSERT_EQ(summary.opType, "Aggregation");
     ASSERT_GT(summary.peakMemory, 0);
     ASSERT_EQ(summary.inputRows, testData.numTracedBatches * 16);
+    ASSERT_GT(summary.inputBytes, 0);
+    ASSERT_EQ(summary.rawInputRows, 0);
+    ASSERT_EQ(summary.rawInputBytes, 0);
+    ASSERT_FALSE(summary.numSplits.has_value());
 
     const auto reader = OperatorTraceInputReader(opTraceDir, dataType_, pool());
     RowVectorPtr actual;

--- a/velox/exec/tests/TraceUtilTest.cpp
+++ b/velox/exec/tests/TraceUtilTest.cpp
@@ -89,7 +89,15 @@ TEST_F(TraceUtilTest, OperatorTraceSummary) {
   summary.inputRows = 100;
   summary.peakMemory = 200;
   ASSERT_EQ(
-      summary.toString(), "opType summary, inputRows 100, peakMemory 200B");
+      summary.toString(),
+      "opType summary, inputRows 100,  inputBytes 0B, rawInputRows 0, rawInputBytes 0B, peakMemory 200B");
+  summary.numSplits = 10;
+  summary.rawInputBytes = 222;
+  VELOX_ASSERT_THROW(summary.toString(), "summary vs. TableScan");
+  summary.opType = "TableScan";
+  ASSERT_EQ(
+      summary.toString(),
+      "opType TableScan, numSplits 10, inputRows 100, inputBytes 0B, rawInputRows 0, rawInputBytes 222B, peakMemory 200B");
 }
 
 TEST_F(TraceUtilTest, traceDirectoryLayoutUtilities) {

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -50,7 +50,7 @@ class TraceReplayRunner {
   /// Runs the trace replay with a set of gflags passed from replayer tool.
   virtual void run();
 
- private:
+ protected:
   std::unique_ptr<tool::trace::OperatorReplayerBase> createReplayer() const;
 
   const std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;


### PR DESCRIPTION
Summary:
Make table scan tracing e2e work in Meta and fix issues found in existing table scan tracing
plus improvement such as adding more stats to help analysis.
This PR also add e2e testing for trace replay runner.

Differential Revision: D67258161


