### PR TITLE
fix: Register SharedArbitrator in WindowPrefixSortBenchmark.cpp

### DIFF
--- a/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
@@ -19,6 +19,7 @@
 #include <folly/init/Init.h>
 #include <string>
 
+#include "velox/common/memory/SharedArbitrator.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -41,6 +42,7 @@ namespace {
 class WindowPrefixSortBenchmark : public HiveConnectorTestBase {
  public:
   explicit WindowPrefixSortBenchmark() {
+    memory::SharedArbitrator::registerFactory();
     HiveConnectorTestBase::SetUp();
     aggregate::prestosql::registerAllAggregateFunctions();
     window::prestosql::registerAllWindowFunctions();


### PR DESCRIPTION
This benchmark class extends `OperatorTestBase` who has `SetUpTestCase` for registering `SharedArbitrator`. However, the `SetUpTestCase` is triggered by GTest when `TEST_F` is used. In this benchmark test, there is no `TEST_F` used. So we may have to explicitly register `SharedArbitrator` to fix the below error.

```
terminate called after throwing an instance of 'facebook::velox::VeloxUserError'
  what():  Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Arbitrator factory for kind SHARED not registered
Retriable: False
Expression: map_.find(kind) != map_.end()
Function: getFactory
File: /root/PHILO/workspace/velox/velox/common/memory/MemoryArbitrator.cpp

```