### PR TITLE
refactor: Simplify the partial full handling for distinct aggregation

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -206,10 +206,9 @@ void HashAggregation::addInput(RowVectorPtr input) {
       // Save input to use for output in getOutput().
       input_ = input;
     } else {
-      // If no new distinct groups (meaning we don't have anything to output),
-      // then we need to ensure we 'need input'. For that we need to reset
-      // the 'partial full' flag.
-      partialFull_ = false;
+      VELOX_CHECK(
+          !partialFull_,
+          "Unexpected partial full when there is no new distincts");
     }
   }
 }


### PR DESCRIPTION
Summary:
The current partial full is cleared when there is no new distinct in add input if it has been set.
The reason for doing this is to avoid distinct partial aggregation hanging problem
as we only reset the grouping set in case of partial full if there is new distinct found in get output.
This is a bit tricky and it is better to handle reset partial full unconditionally in get output for
distinct type of aggregation.

Differential Revision: D67288365


