### PR TITLE
fix(parquet): Add support for weak functions to register parquet readers and writers

### DIFF
--- a/velox/dwio/parquet/CMakeLists.txt
+++ b/velox/dwio/parquet/CMakeLists.txt
@@ -23,8 +23,8 @@ if(VELOX_ENABLE_PARQUET)
   endif()
 endif()
 
-velox_add_library(velox_dwio_parquet_reader RegisterParquetReader.cpp)
-velox_add_library(velox_dwio_parquet_writer RegisterParquetWriter.cpp)
+velox_add_library(velox_dwio_parquet_reader RegisterParquetReaderImpl.cpp)
+velox_add_library(velox_dwio_parquet_writer RegisterParquetWriterImpl.cpp)
 
 if(VELOX_ENABLE_PARQUET)
   velox_link_libraries(velox_dwio_parquet_reader

--- a/velox/dwio/parquet/RegisterParquetReader.cpp
+++ b/velox/dwio/parquet/RegisterParquetReader.cpp
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-#ifdef VELOX_ENABLE_PARQUET
-#include "velox/dwio/parquet/reader/ParquetReader.h" // @manual
-#endif
-
 namespace facebook::velox::parquet {
 
-void registerParquetReaderFactory() {
-#ifdef VELOX_ENABLE_PARQUET
-  dwio::common::registerReaderFactory(std::make_shared<ParquetReaderFactory>());
-#endif
-}
+void registerParquetReaderFactory() {}
 
-void unregisterParquetReaderFactory() {
-#ifdef VELOX_ENABLE_PARQUET
-  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::PARQUET);
-#endif
-}
+void unregisterParquetReaderFactory() {}
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetReaderImpl.cpp
+++ b/velox/dwio/parquet/RegisterParquetReaderImpl.cpp
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-#pragma once
+// This file invokes the Parquet Reader
+
+#include "velox/dwio/parquet/reader/ParquetReader.h"
 
 namespace facebook::velox::parquet {
 
-/// Registers the Parquet reader factory.
-/// Has the weak attribute so that it can be overridden by a custom factory.
-__attribute__((__weak__)) void registerParquetReaderFactory();
+void registerParquetReaderFactory() {
+  dwio::common::registerReaderFactory(std::make_shared<ParquetReaderFactory>());
+}
 
-__attribute__((__weak__)) void unregisterParquetReaderFactory();
+void unregisterParquetReaderFactory() {
+  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::PARQUET);
+}
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetWriter.cpp
+++ b/velox/dwio/parquet/RegisterParquetWriter.cpp
@@ -14,22 +14,10 @@
  * limitations under the License.
  */
 
-#ifdef VELOX_ENABLE_PARQUET
-#include "velox/dwio/parquet/writer/Writer.h" // @manual
-#endif
-
 namespace facebook::velox::parquet {
 
-void registerParquetWriterFactory() {
-#ifdef VELOX_ENABLE_PARQUET
-  dwio::common::registerWriterFactory(std::make_shared<ParquetWriterFactory>());
-#endif
-}
+void registerParquetWriterFactory() {}
 
-void unregisterParquetWriterFactory() {
-#ifdef VELOX_ENABLE_PARQUET
-  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::PARQUET);
-#endif
-}
+void unregisterParquetWriterFactory() {}
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetWriter.h
+++ b/velox/dwio/parquet/RegisterParquetWriter.h
@@ -18,8 +18,10 @@
 
 namespace facebook::velox::parquet {
 
-void registerParquetWriterFactory();
+/// Registers the Parquet writer factory.
+/// Has the weak attribute so that it can be overridden by a custom factory.
+__attribute__((__weak__)) void registerParquetWriterFactory();
 
-void unregisterParquetWriterFactory();
+__attribute__((__weak__)) void unregisterParquetWriterFactory();
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetWriterImpl.cpp
+++ b/velox/dwio/parquet/RegisterParquetWriterImpl.cpp
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "velox/dwio/parquet/writer/Writer.h"
 
 namespace facebook::velox::parquet {
 
-/// Registers the Parquet reader factory.
-/// Has the weak attribute so that it can be overridden by a custom factory.
-__attribute__((__weak__)) void registerParquetReaderFactory();
+void registerParquetWriterFactory() {
+  dwio::common::registerWriterFactory(std::make_shared<ParquetWriterFactory>());
+}
 
-__attribute__((__weak__)) void unregisterParquetReaderFactory();
+void unregisterParquetWriterFactory() {
+  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::PARQUET);
+}
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/dwio/common/tests/utils/DataFiles.h" // @manual
 #include "velox/dwio/parquet/RegisterParquetReader.h" // @manual
 #include "velox/dwio/parquet/reader/PageReader.h" // @manual
-#include "velox/dwio/parquet/reader/ParquetReader.h" // @manual=//velox/connectors/hive:velox_hive_connector_parquet
+#include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h" // @manual
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -29,7 +29,7 @@
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
-#include "velox/connectors/hive/HiveConfig.h" // @manual=//velox/connectors/hive:velox_hive_connector_parquet
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/dwio/parquet/writer/Writer.h" // @manual
 
 using namespace facebook::velox;


### PR DESCRIPTION
Summary:
This diff marks the registerParquet*factory functions with the weak attribute. The weak attribute allows the linker to discard the weaker implementation of the registerParquet*factory functions and in place use the stronger one (See: https://en.wikipedia.org/wiki/Weak_symbol).
This should remove the need to compile the same files with different options,  leading to ODRs when both targets are added as dependencies to the same binary.

Differential Revision: D67301778


