### PR TITLE
misc: Add support for row_constructor and dereference expressions in ToSqlUtil

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -107,6 +107,11 @@ void toCallInputsSql(
         auto concatArg =
             std::dynamic_pointer_cast<const core::ConcatTypedExpr>(input)) {
       sql << toConcatSql(concatArg);
+    } else if (
+        auto dereferenceArg =
+            std::dynamic_pointer_cast<const core::DereferenceTypedExpr>(
+                input)) {
+      sql << toDereferenceSql(dereferenceArg);
     } else {
       VELOX_NYI("Unsupported input expression: {}.", input->toString());
     }
@@ -196,6 +201,10 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql({inputs[1]}, sql);
     sql << " and ";
     toCallInputsSql({inputs[2]}, sql);
+  } else if (call->name() == "row_constructor") {
+    sql << "row(";
+    toCallInputsSql(call->inputs(), sql);
+    sql << ")";
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";
@@ -223,6 +232,13 @@ std::string toConcatSql(const core::ConcatTypedExprPtr& concat) {
   sql << "concat(";
   toCallInputsSql(concat->inputs(), sql);
   sql << ")";
+  return sql.str();
+}
+
+std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference) {
+  std::stringstream sql;
+  toCallInputsSql(dereference->inputs(), sql);
+  sql << "." << dereference->name();
   return sql.str();
 }
 

--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -41,6 +41,9 @@ std::string toCastSql(const core::CastTypedExprPtr& cast);
 /// Convert a concat expression into a SQL string.
 std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
 
+/// Convert a dereference expression into a SQL string.
+std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
+
 /// Convert a constant expression into a SQL string.
 std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
 


### PR DESCRIPTION
Summary:
Support for row_constructor and dereference expressions were never added to ToSqlUtil.  This file is used by
Fuzzer QueryRunners (particularly Presto) to generate SQL to execute. I'm guessing these features were
never used.

This is needed as part of enabling support for custom types not supported in DWRF files in Fuzzers
comparing agains Presto.

Differential Revision: D67310284


