### PR TITLE
fix: Fix CopyPreserveEncodingsTest.lazyNoNulls

### DIFF
--- a/velox/vector/tests/CopyPreserveEncodingsTest.cpp
+++ b/velox/vector/tests/CopyPreserveEncodingsTest.cpp
@@ -327,10 +327,12 @@ TEST_F(CopyPreserveEncodingsTest, flatNoNulls) {
 TEST_F(CopyPreserveEncodingsTest, lazyNoNulls) {
   auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(
       10, [](vector_size_t row) { return row; });
+  VELOX_ASSERT_THROW(lazyVector->copyPreserveEncodings(), "");
 
-  VELOX_ASSERT_THROW(
-      lazyVector->copyPreserveEncodings(),
-      "copyPreserveEncodings not defined for LazyVector");
+  auto copy = lazyVector->loadedVector()->copyPreserveEncodings();
+  assertEqualVectors(lazyVector, copy);
+  ASSERT_EQ(copy->encoding(), VectorEncoding::Simple::FLAT);
+  ASSERT_EQ(copy->nulls(), nullptr);
 }
 
 TEST_F(CopyPreserveEncodingsTest, sequenceHasNulls) {


### PR DESCRIPTION
Summary: https://github.com/facebookincubator/velox/pull/11855 updated LazyVector:: copyPreserveEncodings() but didn't update the unit test. This diff fixes the failing test.

Differential Revision: D67318403


