### PR TITLE
misc: Allow to install shared lib gflags on centos9

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -90,12 +90,12 @@ function install_gflags {
   # Remove an older version if present.
   dnf remove -y gflags
   wget_and_untar https://github.com/gflags/gflags/archive/v2.2.2.tar.gz gflags
-  cmake_install_dir gflags -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64
+  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64
 }
 
 function install_glog {
   wget_and_untar https://github.com/google/glog/archive/v0.6.0.tar.gz glog
-  cmake_install_dir glog -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED"
+  cmake_install_dir glog -DBUILD_SHARED_LIBS=ON
 }
 
 function install_lzo {

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -95,7 +95,7 @@ function install_gflags {
 
 function install_glog {
   wget_and_untar https://github.com/google/glog/archive/v0.6.0.tar.gz glog
-  cmake_install_dir glog -DBUILD_SHARED_LIBS=ON
+  cmake_install_dir glog -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED"
 }
 
 function install_lzo {


### PR DESCRIPTION
This pr just reverts one line of change by #10732. I think it is not necessary to fully align gflags build with velox build. It means we should set `BUILD_SHARED_LIBS=ON` for gflags when `VELOX_BUILD_SHARED=ON`, but it is not necessary to set `BUILD_SHARED_LIBS=OFF` for gflags when `VELOX_BUILD_SHARED=OFF`. We can just make the shared lib always be produced, as I also note `setup-ubuntu.sh` always installs shared gflags from package (see [link](https://github.com/facebookincubator/velox/blob/main/scripts/setup-ubuntu.sh#L120)). Another reason for this fix is, it is better to keep using same lib type (static or shared) for gflags and glog to avoid any potential issues.

Related discussion on this issue: https://github.com/facebookincubator/velox/pull/10732#issuecomment-2295588282