### PR TITLE
build(ci): Use ccache instead of .ccache

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ jobs:
     if: github.repository == 'facebookincubator/velox'
     runs-on: 8-core-ubuntu
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
       LINUX_DISTRO: "ubuntu"
@@ -56,7 +56,7 @@ jobs:
         uses: actions/cache/restore@v3
         id: restore-cache
         with:
-          path: ".ccache"
+          path: "ccache"
           key: ccache-benchmark-${{ github.sha }}
           restore-keys: |
             ccache-benchmark-
@@ -132,7 +132,7 @@ jobs:
         uses: actions/cache/save@v3
         id: cache
         with:
-          path: ".ccache"
+          path: "ccache"
           key: ccache-benchmark-${{ github.sha }}
 
       - name: "Install benchmark dependencies"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -90,12 +90,12 @@ jobs:
           # NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF++ ; print}')
           echo "build_version=${VERSION}a${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
 
-      - run: mkdir -p .ccache
+      - run: mkdir -p ccache
       - name: "Restore ccache"
         uses: actions/cache/restore@v3
         id: restore-cache
         with:
-          path: ".ccache"
+          path: "ccache"
           key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
             ccache-wheels-${{ matrix.os }}-
@@ -126,28 +126,28 @@ jobs:
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output &&
-            cp -R /host${{ github.workspace }}/.ccache /output/.ccache &&
+            cp -R /host${{ github.workspace }}/ccache /output/ccache &&
             ccache -s
           CIBW_ENVIRONMENT_PASS_LINUX: CCACHE_DIR BUILD_VERSION
           CIBW_TEST_EXTRAS: "tests"
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"
-          CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/.ccache"
+          CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/ccache"
           BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         with:
           output-dir: wheelhouse
 
-      - name: "Move .ccache to workspace"
+      - name: "Move ccache to workspace"
         if: matrix.os != 'macos-11'
         run: |
-          mkdir -p .ccache
-          cp -R ./wheelhouse/.ccache/* .ccache
+          mkdir -p ccache
+          cp -R ./wheelhouse/ccache/* ccache
 
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: cache
         with:
-          path: ".ccache"
+          path: "ccache"
           key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
 
       - name: "Rename wheel compatibility tag"

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: 16-core-ubuntu
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "ubuntu"
     steps:
 
@@ -114,7 +114,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -34,7 +34,7 @@ jobs:
       run:
         shell: bash
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       GTest_SOURCE: BUNDLED
       simdjson_SOURCE: BUNDLED
@@ -124,7 +124,7 @@ jobs:
     if: ${{ github.repository == 'facebookincubator/velox' }}
     name: "Ubuntu debug with resolve_dependency"
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/ccache"
       USE_CLANG: "${{ inputs.use-clang && 'true' || 'false' }}"
     defaults:
       run:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -53,7 +53,7 @@ jobs:
         os: [macos-13, macos-14]
     runs-on: ${{ matrix.os }}
     env:
-      CCACHE_DIR: '${{ github.workspace }}/.ccache'
+      CCACHE_DIR: '${{ github.workspace }}/ccache'
       # The arm runners have only 7GB RAM
       BUILD_TYPE: "${{ matrix.os ==  'macos-14' && 'Release' || 'Debug' }}"
       INSTALL_PREFIX: "/tmp/deps-install"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -92,7 +92,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache"
+      CCACHE_DIR: "${{ github.workspace }}/ccache"
       LINUX_DISTRO: "ubuntu"
       MAKEFLAGS: "NUM_THREADS=${{ inputs.numThreads || 16 }} MAX_HIGH_MEM_JOBS=${{ inputs.maxHighMemJobs || 8 }} MAX_LINK_JOBS=${{ inputs.maxLinkJobs || 4 }}"
 
@@ -590,7 +590,7 @@ jobs:
     needs: compile
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 
@@ -755,7 +755,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 
@@ -819,7 +819,7 @@ jobs:
     timeout-minutes: 120
     if: ${{ needs.compile.outputs.presto_bias  == 'true' }}
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 
@@ -907,7 +907,7 @@ jobs:
     timeout-minutes: 120
     if: ${{ needs.compile.outputs.presto_aggregate_bias  == 'true' }}
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 
@@ -1004,7 +1004,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 
@@ -1067,7 +1067,7 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:presto-java
     timeout-minutes: 120
     env:
-      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_DIR: "${{ github.workspace }}/ccache/"
       LINUX_DISTRO: "centos"
     steps:
 


### PR DESCRIPTION
Jacob mentioned that files with the dot prefix are restricted from being uploaded and hence 
the ccache is disabled.