### PR TITLE
misc: Add support for CustomVectorFuzzers for custom types

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -82,6 +82,7 @@ class AggregationFuzzerBase {
     registerHiveConnector(hiveConfigs);
     dwrf::registerDwrfReaderFactory();
     dwrf::registerDwrfWriterFactory();
+    referenceQueryRunner_->registerCustomVectorFuzzers(vectorFuzzer_);
     seed(initialSeed);
   }
 

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_expression_functions
   velox_presto_types
+  velox_presto_types_fuzzer
   cpr::cpr
   Boost::regex
   velox_type_parser

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -33,6 +33,8 @@
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/fuzzer/TimestampWithTimeZoneFuzzer.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/parser/TypeParser.h"
 
@@ -251,6 +253,13 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
       TIMESTAMP(),
   };
   return kScalarTypes;
+}
+
+void PrestoQueryRunner::registerCustomVectorFuzzers(
+    VectorFuzzer& vectorFuzzer) const {
+  vectorFuzzer.registerCustomVectorFuzzer(
+      TIMESTAMP_WITH_TIME_ZONE(),
+      std::make_unique<TimestampWithTimeZoneVectorFuzzer>());
 }
 
 const std::unordered_map<std::string, DataSpec>&

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -53,6 +53,8 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
 
   const std::vector<TypePtr>& supportedScalarTypes() const override;
 
+  void registerCustomVectorFuzzers(VectorFuzzer& vectorFuzzer) const override;
+
   const std::unordered_map<std::string, DataSpec>&
   aggregationFunctionDataSpecs() const override;
 

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -46,6 +46,12 @@ class ReferenceQueryRunner {
     return defaultScalarTypes();
   }
 
+  /// Register CustomVectorFuzzers specific to the reference query engine, e.g.
+  /// custom types only supported by this engine.
+  virtual void registerCustomVectorFuzzers(VectorFuzzer& vectorFuzzer) const {
+    return;
+  }
+
   virtual const std::unordered_map<std::string, DataSpec>&
   aggregationFunctionDataSpecs() const = 0;
 

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -107,6 +107,11 @@ void toCallInputsSql(
         auto concatArg =
             std::dynamic_pointer_cast<const core::ConcatTypedExpr>(input)) {
       sql << toConcatSql(concatArg);
+    } else if (
+        auto dereferenceArg =
+            std::dynamic_pointer_cast<const core::DereferenceTypedExpr>(
+                input)) {
+      sql << toDereferenceSql(dereferenceArg);
     } else {
       VELOX_NYI("Unsupported input expression: {}.", input->toString());
     }
@@ -196,6 +201,10 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql({inputs[1]}, sql);
     sql << " and ";
     toCallInputsSql({inputs[2]}, sql);
+  } else if (call->name() == "row_constructor") {
+    sql << "row(";
+    toCallInputsSql(call->inputs(), sql);
+    sql << ")";
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";
@@ -223,6 +232,13 @@ std::string toConcatSql(const core::ConcatTypedExprPtr& concat) {
   sql << "concat(";
   toCallInputsSql(concat->inputs(), sql);
   sql << ")";
+  return sql.str();
+}
+
+std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference) {
+  std::stringstream sql;
+  toCallInputsSql(dereference->inputs(), sql);
+  sql << "." << dereference->name();
   return sql.str();
 }
 

--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -41,6 +41,9 @@ std::string toCastSql(const core::CastTypedExprPtr& cast);
 /// Convert a concat expression into a SQL string.
 std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
 
+/// Convert a dereference expression into a SQL string.
+std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
+
 /// Convert a constant expression into a SQL string.
 std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
 

--- a/velox/functions/prestosql/types/fuzzer/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer/CMakeLists.txt
@@ -11,25 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(
-  velox_presto_types
-  HyperLogLogType.cpp
-  JsonType.cpp
-  TimestampWithTimeZoneType.cpp
-  UuidType.cpp
-  IPAddressType.cpp
-  IPPrefixType.cpp)
 
-velox_link_libraries(
-  velox_presto_types
-  velox_memory
-  velox_expression
-  velox_functions_util
-  velox_functions_json
-  velox_functions_lib_date_time_formatter)
+velox_add_library(velox_presto_types_fuzzer TimestampWithTimeZoneFuzzer.h)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
-
-add_subdirectory(fuzzer)
+velox_link_libraries(velox_presto_types_fuzzer velox_vector_fuzzer
+                     velox_presto_types velox_type_tz)

--- a/velox/functions/prestosql/types/fuzzer/TimestampWithTimeZoneFuzzer.h
+++ b/velox/functions/prestosql/types/fuzzer/TimestampWithTimeZoneFuzzer.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/random/uniform_int_distribution.hpp>
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
+#include "velox/vector/fuzzer/CustomVectorFuzzer.h"
+
+namespace facebook::velox {
+/// A CustomVectorFuzzer for TimestampWithTimeZoneType. The millisUtc is random,
+/// and the time zone is selected randomly from the list of known time zones.
+class TimestampWithTimeZoneVectorFuzzer : public CustomVectorFuzzer {
+ public:
+  TimestampWithTimeZoneVectorFuzzer()
+      : CustomVectorFuzzer(), timeZoneIds_(tz::getTimeZoneIDs()) {}
+
+  const VectorPtr fuzzFlat(
+      memory::MemoryPool* pool,
+      const TypePtr& type,
+      vector_size_t size,
+      FuzzerGenerator& rng) override {
+    VELOX_CHECK(isTimestampWithTimeZoneType(type));
+
+    auto result = BaseVector::create(type, size, pool);
+    auto flatResult = result->asFlatVector<int64_t>();
+    for (auto i = 0; i < size; ++i) {
+      int16_t timeZoneId = timeZoneIds_
+          [boost::random::uniform_int_distribution<size_t>()(rng) %
+           timeZoneIds_.size()];
+      flatResult->set(
+          i,
+          pack(
+              boost::random::uniform_int_distribution<int64_t>()(rng),
+              timeZoneId));
+    }
+    return result;
+  }
+
+  const VectorPtr fuzzConstant(
+      memory::MemoryPool* pool,
+      const TypePtr& type,
+      vector_size_t size,
+      FuzzerGenerator& rng) override {
+    VELOX_CHECK(isTimestampWithTimeZoneType(type));
+
+    int16_t timeZoneId = timeZoneIds_
+        [boost::random::uniform_int_distribution<size_t>()(rng) %
+         timeZoneIds_.size()];
+
+    return std::make_shared<ConstantVector<int64_t>>(
+        pool,
+        size,
+        false,
+        type,
+        pack(
+            boost::random::uniform_int_distribution<int64_t>()(rng),
+            timeZoneId));
+  }
+
+ private:
+  const std::vector<int16_t> timeZoneIds_;
+};
+} // namespace facebook::velox

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -424,6 +424,21 @@ int16_t getTimeZoneID(int32_t offsetMinutes) {
   }
 }
 
+std::vector<int16_t> getTimeZoneIDs() {
+  const auto& timeZoneDatabase = getTimeZoneDatabase();
+
+  std::vector<int16_t> ids;
+  ids.reserve(timeZoneDatabase.size());
+
+  for (int16_t i = 0; i < timeZoneDatabase.size(); ++i) {
+    if (timeZoneDatabase[i] != nullptr) {
+      ids.push_back(i);
+    }
+  }
+
+  return ids;
+}
+
 TimeZone::seconds TimeZone::to_sys(
     TimeZone::seconds timestamp,
     TimeZone::TChoose choose) const {

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <string>
+#include <vector>
 
 namespace facebook::velox::date {
 class time_zone;
@@ -62,6 +63,9 @@ int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 /// Returns the timeZoneID for a given offset in minutes. The offset must be in
 /// [-14:00, +14:00] range.
 int16_t getTimeZoneID(int32_t offsetMinutes);
+
+/// Returns all valid time zone IDs.
+std::vector<int16_t> getTimeZoneIDs();
 
 // Validates that the time point can be safely used by the external date
 // library.

--- a/velox/vector/fuzzer/CustomVectorFuzzer.h
+++ b/velox/vector/fuzzer/CustomVectorFuzzer.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/fuzzer/Utils.h"
+
+namespace facebook::velox {
+/// An interface for fuzzing Vectors of a custom type. This is intended for use
+/// when a custom type does not support the full range of values of the backing
+/// physical type.
+///
+/// Implementations of this interface need to be registered in an instance of
+/// VectorFuzzer via registerCustomVectorFuzzer in order for them to be used in
+/// general purpose fuzzing.
+class CustomVectorFuzzer {
+ public:
+  virtual ~CustomVectorFuzzer() = default;
+
+  /// Should return a flat Vector of the given size without nulls.
+  virtual const VectorPtr fuzzFlat(
+      memory::MemoryPool* pool,
+      const TypePtr& type,
+      vector_size_t size,
+      FuzzerGenerator& rng) = 0;
+
+  /// Should return a ConstantVector of the given size backed by a single
+  /// non-null scalar value (complex types do not need to implement this).
+  virtual const VectorPtr fuzzConstant(
+      memory::MemoryPool* pool,
+      const TypePtr& type,
+      vector_size_t size,
+      FuzzerGenerator& rng) = 0;
+};
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
We've seen with Presto a number of custom types that are not supported in other engines, and may not 
support the full range of values of their backing physical type.  This makes testing them in Fuzzers challenging
as we cannot enable these types broadly (they're not supported in DuckDB for example) and if we do we can
end up with a lot of spurious errors due to invalid values, making the tests low signal.

To address these issues, I've added an interface CustomVectorFuzzer.  An implementation can be written for
a custom type which tells the VectorFuzzer how to generate a random flat/constant Vector of the particular
value.  Then the ReferenceQueryRunner can register these CustomVectorFuzzers with VectorFuzzer so that it
can generate random valid values and add the type to its list of known scalar types (to be used when
generating random types for example).

I've added an example here for TimestampWithTimeZone.

This is needed as part of enabling support for custom types not supported in DWRF files in Fuzzers
comparing agains Presto.

Differential Revision: D67344181


