### PR TITLE
misc: Add support for TimestampWithTimeZone in AggregationFuzzer

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -86,6 +86,13 @@ class AggregationFuzzerBase {
     registerHiveConnector(hiveConfigs);
     dwrf::registerDwrfReaderFactory();
     dwrf::registerDwrfWriterFactory();
+
+    for (const auto& type : referenceQueryRunner_->supportedScalarTypes()) {
+      if (!type->isReal() && !type->isDouble()) {
+        supportedKeyTypes_.push_back(type);
+      }
+    }
+
     seed(initialSeed);
   }
 
@@ -282,6 +289,7 @@ class AggregationFuzzerBase {
   std::shared_ptr<memory::MemoryPool> writerPool_{
       rootPool_->addAggregateChild("aggregationFuzzerWriter")};
   VectorFuzzer vectorFuzzer_;
+  std::vector<TypePtr> supportedKeyTypes_;
 };
 
 // Returns true if the elapsed time is greater than or equal to

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(
   PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
   PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
   FuzzerUtil.cpp
-  PrestoSql.cpp)
+  PrestoSql.cpp
+  PrestoQueryRunnerIntermediateTypeTransforms.cpp)
 
 target_link_libraries(
   velox_fuzzer_util

--- a/velox/exec/fuzzer/DuckQueryRunner.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunner.cpp
@@ -26,7 +26,6 @@
 namespace facebook::velox::exec::test {
 
 namespace {
-
 std::unordered_set<std::string> getAggregateFunctions() {
   std::string sql =
       "SELECT distinct on(function_name) function_name "

--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -186,7 +186,18 @@ void DuckQueryRunnerToSqlPlanNodeVisitor::visit(
     sql << " as " << node.names()[i];
   }
 
-  sql << " FROM (" << sourceSql.value() << ")";
+  sql << " FROM ";
+
+  // DuckDB doesn't support wrapping table names in parentheses.
+  if (std::dynamic_pointer_cast<const core::ValuesNode>(node.sources()[0]) ==
+          nullptr &&
+      std::dynamic_pointer_cast<const core::TableScanNode>(node.sources()[0]) ==
+          nullptr) {
+    sql << "(" << sourceSql.value() << ")";
+  } else {
+    sql << sourceSql.value();
+  }
+
   visitorContext.sql = sql.str();
 }
 

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -54,6 +54,9 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
 
   static bool isSupportedDwrfType(const TypePtr& type);
 
+  std::pair<std::vector<RowVectorPtr>, std::vector<core::ExprPtr>>
+  inputProjections(const std::vector<RowVectorPtr>& input) const override;
+
   const std::unordered_map<std::string, DataSpec>&
   aggregationFunctionDataSpecs() const override;
 

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -88,7 +88,8 @@ void PrestoQueryRunnerToSqlPlanNodeVisitor::visit(
     visitorContext.sql = std::nullopt;
     return;
   }
-  sql << " FROM " << *source;
+
+  sql << " FROM (" << *source << ")";
 
   if (!groupingKeys.empty()) {
     sql << " GROUP BY " << folly::join(", ", groupingKeys);
@@ -388,7 +389,8 @@ void PrestoQueryRunnerToSqlPlanNodeVisitor::visit(
     visitorContext.sql = std::nullopt;
     return;
   }
-  sql << " FROM " << *source;
+
+  sql << " FROM (" << *source << ")";
 
   visitorContext.sql = sql.str();
 }

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -22,6 +22,8 @@
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/core/PlanNode.h"
 #include "velox/expression/FunctionSignature.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/IExpr.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::exec::test {
@@ -69,6 +71,27 @@ class ReferenceQueryRunner {
   // candidates when generating random types for fuzzers.
   virtual const std::vector<TypePtr>& supportedScalarTypes() const {
     return defaultScalarTypes();
+  }
+
+  /// Given a vector of batches, returns a pair of updated input batches and
+  /// expressions to be run as a projection. This is used to convert
+  /// intermediate only types (types not supported in the input) in input to
+  /// types allowed in the input, and the projections will handle converting
+  /// those values back into intermediate only types.
+  virtual std::pair<std::vector<RowVectorPtr>, std::vector<core::ExprPtr>>
+  inputProjections(const std::vector<RowVectorPtr>& input) const {
+    if (input.empty()) {
+      return {input, {}};
+    }
+
+    std::vector<core::ExprPtr> projections;
+
+    for (const auto& name : input[0]->type()->asRow().names()) {
+      projections.push_back(
+          std::make_shared<core::FieldAccessExpr>(name, name));
+    }
+
+    return std::make_pair(input, projections);
   }
 
   virtual const std::unordered_map<std::string, DataSpec>&

--- a/velox/exec/fuzzer/ResultVerifier.h
+++ b/velox/exec/fuzzer/ResultVerifier.h
@@ -51,6 +51,7 @@ class ResultVerifier {
   /// re-use its results for multiple 'verify' calls.
   virtual void initialize(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) = 0;
@@ -61,6 +62,7 @@ class ResultVerifier {
   /// that will store the window function results.
   virtual void initializeWindow(
       const std::vector<RowVectorPtr>& /*input*/,
+      const std::vector<core::ExprPtr>& /* projections */,
       const std::vector<std::string>& /*partitionByKeys*/,
       const std::vector<SortingKeyAndOrder>& /*sortingKeysAndOrders*/,
       const core::WindowNode::Function& /*function*/,

--- a/velox/exec/fuzzer/TransformResultVerifier.h
+++ b/velox/exec/fuzzer/TransformResultVerifier.h
@@ -52,6 +52,7 @@ class TransformResultVerifier : public ResultVerifier {
 
   void initialize(
       const std::vector<RowVectorPtr>& /*input*/,
+      const std::vector<core::ExprPtr>& /*projections*/,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& /*aggregate*/,
       const std::string& aggregateName) override {

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -199,6 +199,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::string& frameClause,
       const std::string& functionCall,
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       bool customVerification,
       const std::shared_ptr<ResultVerifier>& customVerifier,
       bool enableWindowVerification,
@@ -210,6 +211,7 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::string& frame,
       const std::string& functionCall,
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       bool customVerification,
       const std::shared_ptr<ResultVerifier>& customVerifier,
       const velox::fuzzer::ResultOrError& expected);

--- a/velox/exec/tests/PrestoQueryRunnerTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTest.cpp
@@ -203,7 +203,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
     EXPECT_EQ(
         queryRunner->toSql(plan),
         fmt::format(
-            "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 ASC NULLS LAST {}) FROM tmp",
+            "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 ASC NULLS LAST {}) FROM (tmp)",
             frameClause));
 
     const auto firstValueFrame =
@@ -222,7 +222,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
     EXPECT_EQ(
         queryRunner->toSql(plan),
         fmt::format(
-            "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST {}), last_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST {}) FROM tmp",
+            "SELECT c0, c1, c2, first_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST {}), last_value(c0) OVER (PARTITION BY c1 ORDER BY c2 DESC NULLS FIRST {}) FROM (tmp)",
             firstValueFrame,
             lastValueFrame));
   }
@@ -235,7 +235,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
                     .planNode();
     EXPECT_EQ(
         queryRunner->toSql(plan),
-        "SELECT c1, avg(c0) as a0 FROM tmp GROUP BY c1");
+        "SELECT c1, avg(c0) as a0 FROM (tmp) GROUP BY c1");
 
     plan = PlanBuilder()
                .tableScan("tmp", dataType)
@@ -244,7 +244,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
                .planNode();
     EXPECT_EQ(
         queryRunner->toSql(plan),
-        "SELECT (a0 + c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM tmp GROUP BY c1)");
+        "SELECT (a0 + c1) as p0 FROM (SELECT c1, sum(c0) as a0 FROM (tmp) GROUP BY c1)");
 
     plan = PlanBuilder()
                .tableScan("tmp", dataType)
@@ -252,7 +252,7 @@ TEST_F(PrestoQueryRunnerTest, toSql) {
                .planNode();
     EXPECT_EQ(
         queryRunner->toSql(plan),
-        "SELECT avg(c0) filter (where c2) as a0, avg(c1) as a1 FROM tmp");
+        "SELECT avg(c0) filter (where c2) as a0, avg(c1) as a1 FROM (tmp)");
   }
 
   // Test dereference queries.

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
@@ -130,11 +130,11 @@ void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
 }
 
 TypePtr ArgumentTypeFuzzer::randType() {
-  return velox::randType(rng_, 2);
+  return velox::randType(rng_, scalarTypes_, 2);
 }
 
 TypePtr ArgumentTypeFuzzer::randOrderableType() {
-  return velox::randOrderableType(rng_, 2);
+  return velox::randOrderableType(rng_, scalarTypes_, 2);
 }
 
 bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.h
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.h
@@ -15,13 +15,11 @@
  */
 #pragma once
 
-#include <random>
 #include <unordered_map>
 
 #include "velox/expression/FunctionSignature.h"
-#include "velox/expression/SignatureBinder.h"
 #include "velox/type/Type.h"
-#include "velox/vector/fuzzer/Utils.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::fuzzer {
 
@@ -34,14 +32,19 @@ class ArgumentTypeFuzzer {
  public:
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
-      FuzzerGenerator& rng)
-      : ArgumentTypeFuzzer(signature, nullptr, rng) {}
+      FuzzerGenerator& rng,
+      const std::vector<TypePtr>& scalarTypes = velox::defaultScalarTypes())
+      : ArgumentTypeFuzzer(signature, nullptr, rng, scalarTypes) {}
 
   ArgumentTypeFuzzer(
       const exec::FunctionSignature& signature,
       const TypePtr& returnType,
-      FuzzerGenerator& rng)
-      : signature_{signature}, returnType_{returnType}, rng_{rng} {}
+      FuzzerGenerator& rng,
+      const std::vector<TypePtr>& scalarTypes = velox::defaultScalarTypes())
+      : signature_{signature},
+        returnType_{returnType},
+        rng_{rng},
+        scalarTypes_(scalarTypes) {}
 
   /// Generate random argument types. If the desired returnType has been
   /// specified, checks that it can be bound to the return type of signature_.
@@ -112,6 +115,9 @@ class ArgumentTypeFuzzer {
 
   /// RNG to generate random types for unbounded type variables when necessary.
   FuzzerGenerator& rng_;
+
+  /// The set of scalar types that can be used in random argument types.
+  const std::vector<TypePtr> scalarTypes_;
 };
 
 /// Return the kind name of type in lower case. This is expected to match the

--- a/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
@@ -47,12 +47,14 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
   // Compute count(distinct x) over 'input'.
   void initialize(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) override {
     auto plan =
         PlanBuilder()
             .values(input)
+            .projectExpressions(projections)
             .singleAggregation(groupingKeys, {makeCountDistinctCall(aggregate)})
             .planNode();
 
@@ -66,6 +68,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
   // Compute count_distinct(x) over 'input' over 'frame'.
   void initializeWindow(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       const std::vector<std::string>& partitionByKeys,
       const std::vector<SortingKeyAndOrder>& /*sortingKeysAndOrders*/,
       const core::WindowNode::Function& function,
@@ -73,6 +76,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
       const std::string& windowName) override {
     auto plan = PlanBuilder()
                     .values(input)
+                    .projectExpressions(projections)
                     .window({makeCountDistinctWindowCall(function, frame)})
                     .planNode();
 

--- a/velox/functions/prestosql/fuzzer/ArbitraryResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ArbitraryResultVerifier.h
@@ -38,6 +38,7 @@ class ArbitraryResultVerifier : public ResultVerifier {
 
   void initialize(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) override {
@@ -58,6 +59,7 @@ class ArbitraryResultVerifier : public ResultVerifier {
     auto plan =
         PlanBuilder(planNodeIdGenerator, input[0]->pool())
             .values(input)
+            .projectExpressions(projections)
             .singleAggregation(groupingKeys, {makeArrayAggCall(aggregate)})
             .project(projectColumns)
             .planNode();

--- a/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
@@ -42,6 +42,7 @@ class AverageResultVerifier : public ResultVerifier {
 
   void initialize(
       const std::vector<RowVectorPtr>& /*input*/,
+      const std::vector<core::ExprPtr>& /*projections*/,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) override {
@@ -54,6 +55,7 @@ class AverageResultVerifier : public ResultVerifier {
 
   void initializeWindow(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& /*projections*/,
       const std::vector<std::string>& /*partitionByKeys*/,
       const std::vector<SortingKeyAndOrder>& /*sortingKeysAndOrders*/,
       const core::WindowNode::Function& function,

--- a/velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.cpp
+++ b/velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.cpp
@@ -20,6 +20,7 @@ namespace facebook::velox::exec::test {
 
 void MinMaxByResultVerifier::initialize(
     const std::vector<RowVectorPtr>& input,
+    const std::vector<core::ExprPtr>& projections,
     const std::vector<std::string>& groupingKeys,
     const core::AggregationNode::Aggregate& aggregate,
     const std::string& aggregateName) {
@@ -95,7 +96,9 @@ void MinMaxByResultVerifier::initialize(
   // GROUP BY
   //     b
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan = PlanBuilder(planNodeIdGenerator, input[0]->pool()).values(input);
+  auto plan = PlanBuilder(planNodeIdGenerator, input[0]->pool())
+                  .values(input)
+                  .projectExpressions(projections);
   // Filter out masked rows first so that groups with all rows filtered out
   // won't take a row_number during the filtering later.
   if (aggregate.mask != nullptr) {

--- a/velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.h
@@ -58,6 +58,7 @@ class MinMaxByResultVerifier : public ResultVerifier {
 
   void initialize(
       const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
       const std::vector<std::string>& groupingKeys,
       const core::AggregationNode::Aggregate& aggregate,
       const std::string& aggregateName) override;

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
@@ -22,6 +22,41 @@
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::fuzzer {
+namespace {
+// We exclude certain time zones that may be inconsistent between Presto and
+// Velox. These are primarily time zones that have been downgraded to links or
+// otherwise had their histories corrected/updated, or have had recent updates
+// (e.g. no longer using daylight savings time). The time zone information in
+// the versions of Java and Joda may not have gotten these updates.
+std::vector<int16_t> excludeProblematicTimeZoneIds(
+    std::vector<int16_t> timeZoneIds) {
+  static const std::unordered_set<int16_t> kExcludedTimeZones = {
+      1682, 1683, 1685, 1686, 1687, 1688, 1689, 1691, 1692, 1693, 1697, 1698,
+      1699, 1700, 1701, 1703, 1704, 1705, 1707, 1708, 1710, 1711, 1713, 1714,
+      1715, 1716, 1717, 1718, 1719, 1720, 1721, 1722, 1726, 1727, 1728, 1729,
+      1730, 1731, 1737, 1738, 1753, 1754, 1755, 1762, 1773, 1776, 1780, 1786,
+      1796, 1797, 1798, 1816, 1822, 1827, 1831, 1845, 1846, 1860, 1879, 1881,
+      1882, 1883, 1883, 1884, 1891, 1893, 1900, 1903, 1906, 1907, 1908, 1909,
+      1910, 1919, 1924, 1926, 1933, 1955, 1957, 1962, 1963, 1969, 1994, 2005,
+      2007, 2009, 2049, 2060, 2063, 2065, 2067, 2071, 2073, 2078, 2081, 2089,
+      2091, 2093, 2098, 2104, 2107, 2111, 2116, 2109, 2110, 2112, 2113, 2117,
+      2124, 2130, 2140, 2142, 2150, 2151, 2154, 2159, 2160, 2161, 2162, 2179,
+      2176, 2177, 2181, 2188, 2195, 2197, 2202, 2209, 2210,
+  };
+
+  timeZoneIds.erase(
+      std::remove_if(
+          timeZoneIds.begin(),
+          timeZoneIds.end(),
+          [](int16_t timeZoneId) {
+            return kExcludedTimeZones.count(timeZoneId) > 0;
+          }),
+      timeZoneIds.end());
+
+  return timeZoneIds;
+}
+} // namespace
+
 TimestampWithTimeZoneInputGenerator::TimestampWithTimeZoneInputGenerator(
     const size_t seed,
     const double nullRatio)
@@ -30,7 +65,7 @@ TimestampWithTimeZoneInputGenerator::TimestampWithTimeZoneInputGenerator(
           TIMESTAMP_WITH_TIME_ZONE(),
           nullptr,
           nullRatio),
-      timeZoneIds_(tz::getTimeZoneIDs()) {}
+      timeZoneIds_(excludeProblematicTimeZoneIds(tz::getTimeZoneIDs())) {}
 
 variant TimestampWithTimeZoneInputGenerator::generate() {
   if (coinToss(rng_, nullRatio_)) {


### PR DESCRIPTION
Summary:
This change adds support for TimestampWithTimeZone in AggregationFuzzer as partition keys (it cannot be a
sorting key as it does not support +/-) with PrestoQueryRunner.

The primary challenge is that PrestoQueryRunner does not support TimestampWithTimeZone as an input (it's
not supported in DWRF).  To address this the general strategy is when we see a TimestampWithTimeZone in
the input types we convert it to a BIGINT millisUtc and VARCHAR time_zone and then call from_unixtime as
part of an initial projection in the query to produce TimestampWithTimeZone values.

More concretely I added a general purpose utility library PrestoQueryRunnerIntermediateTypeTransforms to
handle converting Vectors of intermediate only types (custom types not supported in the input) to Vectors of
types supported in the input, and to generate expressions to do the conversion back to the intermediate only
type as part of the query.  This is supported when the types are nested in complex types as well.

I added a function inputProjections to ReferenceQueryRunner which takes in the input batch and does this
conversion and generates the expressions.

The rest of this change is just plumbing these projections into all plans throughout AggregationFuzzer, as well
as the plans generated in the ResultVerifiers.

If this approach is acceptable, it's straight forward to then support custom types like
TimestampWithTimeZone as arguments to aggregates in the fuzzer, as well as add support in other fuzzers
like JoinFuzzer.

Differential Revision: D67346942
