### PR TITLE
fix: Use the correct index when doing comparison in custom view

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1030,13 +1030,14 @@ class RowView
       const RowView& other,
       const CompareFlags flags) const {
     if constexpr (Is < sizeof...(T)) {
-      auto result = std::get<Is>(*childReaders_)
-                        ->baseVector()
-                        ->compare(
-                            std::get<Is>(*other.childReaders_)->baseVector(),
-                            offset_,
-                            other.offset_,
-                            flags);
+      auto result =
+          std::get<Is>(*childReaders_)
+              ->baseVector()
+              ->compare(
+                  std::get<Is>(*other.childReaders_)->baseVector(),
+                  std::get<Is>(*childReaders_)->index(offset_),
+                  std::get<Is>(*other.childReaders_)->index(other.offset_),
+                  flags);
       if (!result.has_value()) {
         return std::nullopt;
       }

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -52,6 +52,10 @@ struct VectorReader {
   explicit VectorReader(const VectorReader<T>&) = delete;
   VectorReader<T>& operator=(const VectorReader<T>&) = delete;
 
+  vector_size_t index(vector_size_t idx) const {
+    return decoded_.index(idx);
+  }
+
   exec_in_t operator[](size_t offset) const {
     return decoded_.template valueAt<exec_in_t>(offset);
   }


### PR DESCRIPTION
Summary: We need to use the correct index inside the decoded vector when doing comparison.

Differential Revision: D67354078


