### PR TITLE
feat(fuzzer): Add ability in expression fuzzer to run multiple batches

### DIFF
--- a/velox/expression/fuzzer/FuzzerToolkit.h
+++ b/velox/expression/fuzzer/FuzzerToolkit.h
@@ -43,6 +43,11 @@ struct SignatureTemplate {
   std::unordered_set<std::string> typeVariables;
 };
 
+struct InputTestCase {
+  RowVectorPtr inputVector;
+  SelectivityVector activeRows;
+};
+
 struct ResultOrError {
   RowVectorPtr result;
   std::exception_ptr exceptionPtr;
@@ -123,11 +128,6 @@ struct InputRowMetadata {
   // increasing order)
   std::vector<int> columnsToWrapInCommonDictionary;
 
-  // Dictionary indices and nulls for the common dictionary layer. Buffers are
-  // null if no columns are specified in `columnsToWrapInCommonDictionary`.
-  BufferPtr commonDictionaryIndices;
-  BufferPtr commonDictionaryNulls;
-
   bool empty() const {
     return columnsToWrapInLazy.empty() &&
         columnsToWrapInCommonDictionary.empty();
@@ -138,11 +138,4 @@ struct InputRowMetadata {
       const char* filePath,
       memory::MemoryPool* pool);
 };
-
-// Wraps the columns in the row vector with a common dictionary layer. The
-// column indices to wrap and the wrap itself is specified in
-// `inputRowMetadata`.
-RowVectorPtr applyCommonDictionaryLayer(
-    const RowVectorPtr& rowVector,
-    const InputRowMetadata& inputRowMetadata);
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/tests/FuzzerToolkitTest.cpp
+++ b/velox/expression/fuzzer/tests/FuzzerToolkitTest.cpp
@@ -41,10 +41,7 @@ class FuzzerToolKitTest : public testing::Test,
   bool equals(const InputRowMetadata& lhs, const InputRowMetadata& rhs) {
     return lhs.columnsToWrapInLazy == rhs.columnsToWrapInLazy &&
         lhs.columnsToWrapInCommonDictionary ==
-        rhs.columnsToWrapInCommonDictionary &&
-        compareBuffers(
-               lhs.commonDictionaryIndices, rhs.commonDictionaryIndices) &&
-        compareBuffers(lhs.commonDictionaryNulls, rhs.commonDictionaryNulls);
+        rhs.columnsToWrapInCommonDictionary;
   }
 };
 
@@ -52,38 +49,7 @@ TEST_F(FuzzerToolKitTest, inputRowMetadataRoundTrip) {
   InputRowMetadata metadata;
   metadata.columnsToWrapInLazy = {1, -2, 3, -4, 5};
   metadata.columnsToWrapInCommonDictionary = {1, 2, 3, 4, 5};
-  metadata.commonDictionaryIndices = makeIndicesInReverse(5);
-  metadata.commonDictionaryNulls = makeNulls({true, false, true, false, true});
 
-  {
-    auto path = exec::test::TempFilePath::create();
-    metadata.saveToFile(path->getPath().c_str());
-    auto copy =
-        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
-    ASSERT_TRUE(equals(metadata, copy));
-  }
-
-  metadata.commonDictionaryNulls = nullptr;
-  {
-    auto path = exec::test::TempFilePath::create();
-    metadata.saveToFile(path->getPath().c_str());
-    auto copy =
-        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
-    ASSERT_TRUE(equals(metadata, copy));
-  }
-
-  metadata.columnsToWrapInCommonDictionary.clear();
-  metadata.commonDictionaryIndices = nullptr;
-  {
-    auto path = exec::test::TempFilePath::create();
-    metadata.saveToFile(path->getPath().c_str());
-    auto copy =
-        InputRowMetadata::restoreFromFile(path->getPath().c_str(), pool());
-    ASSERT_TRUE(equals(metadata, copy));
-  }
-
-  metadata.columnsToWrapInLazy.clear();
-  metadata.commonDictionaryIndices = nullptr;
   {
     auto path = exec::test::TempFilePath::create();
     metadata.saveToFile(path->getPath().c_str());

--- a/velox/expression/tests/ExpressionRunner.h
+++ b/velox/expression/tests/ExpressionRunner.h
@@ -31,8 +31,11 @@ namespace facebook::velox::test {
 ///                supported)
 class ExpressionRunner {
  public:
-  /// @param inputPath The path to the on-disk vector that will be used as input
-  ///        to feed to the expression.
+  /// @param inputPaths A comma separated list of paths to the on-disk vectors
+  ///         that will be used as inputs to be fed to the expression.
+  /// @param inputSelectivityVectorPath A comma separated list of paths to the
+  ///        on-disk selectivity vectors that correspond 1-to-1 with the inputs
+  ///        to be fed to the expression.
   /// @param sql Comma-separated SQL expressions.
   /// @param complexConstantsPath The path to on-disk vector that stores complex
   ///        subexpressions that aren't expressable in SQL (if any), used with
@@ -63,7 +66,8 @@ class ExpressionRunner {
   /// User can refer to 'VectorSaver' class to see how to serialize/preserve
   /// vectors to disk.
   static void run(
-      const std::string& inputPath,
+      const std::string& inputPaths,
+      const std::string& inputSelectivityVectorPath,
       const std::string& sql,
       const std::string& complexConstantsPath,
       const std::string& resultPath,

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -28,19 +28,22 @@ namespace facebook::velox::test {
 using exec::test::ReferenceQueryErrorCode;
 
 namespace {
-void logRowVector(const RowVectorPtr& rowVector) {
-  if (rowVector == nullptr) {
-    return;
-  }
-  VLOG(1) << rowVector->childrenSize() << " vectors as input:";
-  for (const auto& child : rowVector->children()) {
-    VLOG(1) << "\t" << child->toString(/*recursive=*/true);
-  }
+void logInputs(const std::vector<fuzzer::InputTestCase>& inputTestCases) {
+  int testCaseIdx = 0;
+  for (const auto& [rowVector, rows] : inputTestCases) {
+    VLOG(1) << "Input test case " << testCaseIdx++ << ": "
+            << rowVector->childrenSize() << " vectors as input:";
+    VLOG(1) << rowVector->childrenSize() << " vectors as input:";
+    for (const auto& child : rowVector->children()) {
+      VLOG(1) << "\t" << child->toString(/*recursive=*/true);
+    }
 
-  VLOG(1) << "RowVector contents (" << rowVector->type()->toString() << "):";
+    VLOG(1) << "RowVector contents (" << rowVector->type()->toString() << "):";
 
-  for (vector_size_t i = 0; i < rowVector->size(); ++i) {
-    VLOG(1) << "\tAt " << i << ": " << rowVector->toString(i);
+    for (vector_size_t i = 0; i < rowVector->size(); ++i) {
+      VLOG(1) << "\tAt " << i << ": " << rowVector->toString(i);
+    }
+    VLOG(1) << "Rows to verify: " << rows.toString(rows.end());
   }
 }
 
@@ -93,17 +96,16 @@ RowVectorPtr reduceToSelectedRows(
 }
 } // namespace
 
-fuzzer::ResultOrError ExpressionVerifier::verify(
+std::vector<fuzzer::ResultOrError> ExpressionVerifier::verify(
     const std::vector<core::TypedExprPtr>& plans,
-    const RowVectorPtr& rowVector,
-    const std::optional<SelectivityVector>& rowsToVerify,
+    const std::vector<fuzzer::InputTestCase>& inputTestCases,
     VectorPtr&& resultVector,
     bool canThrow,
     const InputRowMetadata& inputRowMetadata) {
   for (int i = 0; i < plans.size(); ++i) {
     LOG(INFO) << "Executing expression " << i << " : " << plans[i]->toString();
   }
-  logRowVector(rowVector);
+  logInputs(inputTestCases);
 
   // Store data and expression in case of reproduction.
   VectorPtr copiedResult;
@@ -131,278 +133,311 @@ fuzzer::ResultOrError ExpressionVerifier::verify(
     }
     if (options_.persistAndRunOnce) {
       persistReproInfo(
-          rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
+          inputTestCases,
+          inputRowMetadata,
+          copiedResult,
+          sql,
+          complexConstants);
     }
   }
 
-  // Execute expression plan using both common and simplified evals.
-  std::vector<VectorPtr> commonEvalResult;
-  std::vector<VectorPtr> simplifiedEvalResult;
-  if (resultVector && resultVector->encoding() == VectorEncoding::Simple::ROW) {
-    auto resultRowVector = resultVector->asUnchecked<RowVector>();
-    auto children = resultRowVector->children();
-    commonEvalResult.resize(children.size());
-    simplifiedEvalResult.resize(children.size());
-    for (int i = 0; i < children.size(); ++i) {
-      commonEvalResult[i] = children[i];
-    }
-  } else {
-    // For backwards compatibility where there was a single result and plan.
-    VELOX_CHECK_EQ(plans.size(), 1);
-    commonEvalResult.push_back(resultVector);
-    simplifiedEvalResult.resize(1);
-  }
-  std::exception_ptr exceptionCommonPtr;
-  std::exception_ptr exceptionSimplifiedPtr;
+  std::vector<fuzzer::ResultOrError> results;
+  // Share ExpressionSet between consecutive iterations to simulate its usage in
+  // FilterProject.
+  exec::ExprSet exprSetCommon(
+      plans, execCtx_, !options_.disableConstantFolding);
+  exec::ExprSetSimplified exprSetSimplified(plans, execCtx_);
 
-  VLOG(1) << "Starting common eval execution.";
-  SelectivityVector rows;
-  if (rowsToVerify.has_value()) {
-    rows = *rowsToVerify;
-  } else {
-    rows = SelectivityVector{rowVector ? rowVector->size() : 1};
-  }
-
-  // Execute with common expression eval path. Some columns of the input row
-  // vector will be wrapped in lazy as specified in 'columnsToWrapInLazy'.
-
-  // Whether UNSUPPORTED_INPUT_UNCATCHABLE error is thrown from either the
-  // common or simplified evaluation path. This error is allowed to thrown only
-  // from one evaluation path because it is VeloxRuntimeError, hence cannot be
-  // suppressed by default nulls.
-  bool unsupportedInputUncatchableError{false};
-  // Whether default null behavior takes place in the common evaluation path. If
-  // so, errors from Presto are allowed because Presto doesn't suppress error by
-  // default nulls.
-  bool defaultNull{false};
-  try {
-    exec::ExprSet exprSetCommon(
-        plans, execCtx_, !options_.disableConstantFolding);
-    auto inputRowVector = rowVector;
-    VectorPtr copiedInput;
-    inputRowVector = VectorFuzzer::fuzzRowChildrenToLazy(
-        rowVector, inputRowMetadata.columnsToWrapInLazy);
-    inputRowVector =
-        applyCommonDictionaryLayer(inputRowVector, inputRowMetadata);
-    if (inputRowVector != rowVector) {
-      VLOG(1) << "Modified inputs for common eval path: ";
-      logRowVector(inputRowVector);
-    }
-    if (inputRowMetadata.columnsToWrapInLazy.empty()) {
-      // Copy loads lazy vectors so only do this when there are no lazy inputs.
-      copiedInput = BaseVector::copy(*inputRowVector);
-    }
-
-    exec::EvalCtx evalCtxCommon(execCtx_, &exprSetCommon, inputRowVector.get());
-    exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
-    defaultNull = defaultNullRowsSkipped(exprSetCommon);
-
-    if (copiedInput) {
-      // Flatten the input vector as an optimization if its very deeply nested.
-      fuzzer::compareVectors(
-          copiedInput,
-          BaseVector::copy(*inputRowVector),
-          "Copy of original input",
-          "Input after common",
-          rows);
-    }
-  } catch (const VeloxException& e) {
-    if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
-      unsupportedInputUncatchableError = true;
-    } else if (!(canThrow && e.isUserError())) {
-      if (!canThrow) {
-        LOG(ERROR)
-            << "Common eval wasn't supposed to throw, but it did. Aborting.";
-      } else if (!e.isUserError()) {
-        LOG(ERROR)
-            << "Common eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE error are not allowed.";
-      }
-      persistReproInfoIfNeeded(
-          rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
-      throw;
-    }
-    exceptionCommonPtr = std::current_exception();
-  } catch (...) {
-    LOG(ERROR)
-        << "Common eval: Exceptions other than VeloxUserError or VeloxRuntimeError of UNSUPPORTED_INPUT_UNCATCHABLE are not allowed.";
-    persistReproInfoIfNeeded(
-        rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
-    throw;
-  }
-
-  VLOG(1) << "Starting reference eval execution.";
-
-  if (referenceQueryRunner_ != nullptr) {
-    VLOG(1) << "Execute with reference DB.";
-    auto inputRowVector = rowVector;
-    inputRowVector =
-        applyCommonDictionaryLayer(inputRowVector, inputRowMetadata);
-    inputRowVector = reduceToSelectedRows(rowVector, rows);
-    auto projectionPlan = makeProjectionPlan(inputRowVector, plans);
-    auto referenceResultOrError = computeReferenceResults(
-        projectionPlan, {inputRowVector}, referenceQueryRunner_.get());
-
-    auto referenceEvalResult = referenceResultOrError.first;
-
-    if (referenceResultOrError.second !=
-        ReferenceQueryErrorCode::kReferenceQueryUnsupported) {
-      bool exceptionReference =
-          (referenceResultOrError.second != ReferenceQueryErrorCode::kSuccess);
-      try {
-        // Compare results or exceptions (if any). Fail if anything is
-        // different.
-        if (exceptionCommonPtr || exceptionReference) {
-          // Throws in case only one evaluation path throws exception.
-          // Otherwise, return false to signal that the expression failed.
-          if (!(defaultNull &&
-                referenceQueryRunner_->runnerType() ==
-                    ReferenceQueryRunner::RunnerType::kPrestoQueryRunner) &&
-              !(exceptionCommonPtr && exceptionReference)) {
-            LOG(ERROR) << "Only "
-                       << (exceptionCommonPtr ? "common" : "reference")
-                       << " path threw exception:";
-            if (exceptionCommonPtr) {
-              std::rethrow_exception(exceptionCommonPtr);
-            } else {
-              auto referenceSql = referenceQueryRunner_->toSql(projectionPlan);
-              VELOX_FAIL("Reference path throws for query: {}", *referenceSql);
-            }
-          }
-        } else {
-          // Throws in case output is different.
-          VELOX_CHECK_EQ(commonEvalResult.size(), plans.size());
-          VELOX_CHECK(referenceEvalResult.has_value());
-
-          std::vector<TypePtr> types;
-          for (auto i = 0; i < commonEvalResult.size(); ++i) {
-            types.push_back(commonEvalResult[i]->type());
-          }
-          auto commonEvalResultRow = std::make_shared<RowVector>(
-              execCtx_->pool(),
-              ROW(std::move(types)),
-              nullptr,
-              commonEvalResult[0]->size(),
-              commonEvalResult);
-          commonEvalResultRow = reduceToSelectedRows(commonEvalResultRow, rows);
-          VELOX_CHECK(
-              exec::test::assertEqualResults(
-                  referenceEvalResult.value(),
-                  projectionPlan->outputType(),
-                  {commonEvalResultRow}),
-              "Velox and reference DB results don't match");
-          LOG(INFO) << "Verified results against reference DB";
-        }
-      } catch (...) {
-        persistReproInfoIfNeeded(
-            rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
-        throw;
+  int testCaseItr = 0;
+  for (auto [rowVector, rows] : inputTestCases) {
+    LOG(INFO) << "Executing test case: " << testCaseItr++;
+    // Execute expression plan using both common and simplified evals.
+    std::vector<VectorPtr> commonEvalResult;
+    std::vector<VectorPtr> simplifiedEvalResult;
+    if (resultVector) {
+      VELOX_CHECK(resultVector->encoding() == VectorEncoding::Simple::ROW);
+      auto resultRowVector = resultVector->asUnchecked<RowVector>();
+      auto children = resultRowVector->children();
+      commonEvalResult.resize(children.size());
+      simplifiedEvalResult.resize(children.size());
+      for (int i = 0; i < children.size(); ++i) {
+        commonEvalResult[i] = children[i];
       }
     }
-  } else {
-    VLOG(1) << "Execute with simplified expression eval path.";
+    std::exception_ptr exceptionCommonPtr;
+    std::exception_ptr exceptionSimplifiedPtr;
+
+    VLOG(1) << "Starting common eval execution.";
+
+    // Execute with common expression eval path. Some columns of the input row
+    // vector will be wrapped in lazy as specified in 'columnsToWrapInLazy'.
+
+    // Whether UNSUPPORTED_INPUT_UNCATCHABLE error is thrown from either the
+    // common or simplified evaluation path. This error is allowed to thrown
+    // only from one evaluation path because it is VeloxRuntimeError, hence
+    // cannot be suppressed by default nulls.
+    bool unsupportedInputUncatchableError{false};
+    // Whether default null behavior takes place in the common evaluation path.
+    // If so, errors from Presto are allowed because Presto doesn't suppress
+    // error by default nulls.
+    bool defaultNull{false};
     try {
-      exec::ExprSetSimplified exprSetSimplified(plans, execCtx_);
-      auto inputRowVector =
-          applyCommonDictionaryLayer(rowVector, inputRowMetadata);
-      if (inputRowVector != rowVector) {
-        VLOG(1) << "Modified inputs for simplified eval path: ";
-        logRowVector(inputRowVector);
+      auto inputRowVector = rowVector;
+      VectorPtr copiedInput;
+      inputRowVector = VectorFuzzer::fuzzRowChildrenToLazy(
+          rowVector, inputRowMetadata.columnsToWrapInLazy);
+      if (inputRowMetadata.columnsToWrapInLazy.empty()) {
+        // Copy loads lazy vectors so only do this when there are no lazy
+        // inputs.
+        copiedInput = BaseVector::copy(*inputRowVector);
       }
 
-      exec::EvalCtx evalCtxSimplified(
-          execCtx_, &exprSetSimplified, inputRowVector.get());
+      exec::EvalCtx evalCtxCommon(
+          execCtx_, &exprSetCommon, inputRowVector.get());
+      exprSetCommon.eval(
+          0,
+          exprSetCommon.size(),
+          true /*initialize*/,
+          rows,
+          evalCtxCommon,
+          commonEvalResult);
+      defaultNull = defaultNullRowsSkipped(exprSetCommon);
 
-      auto copy = BaseVector::copy(*inputRowVector);
-      exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
-
-      // Flatten the input vector as an optimization if its very deeply
-      // nested.
-      fuzzer::compareVectors(
-          copy,
-          BaseVector::copy(*inputRowVector),
-          "Copy of original input",
-          "Input after simplified",
-          rows);
+      if (copiedInput) {
+        // Flatten the input vector as an optimization if its very deeply
+        // nested.
+        fuzzer::compareVectors(
+            copiedInput,
+            BaseVector::copy(*inputRowVector),
+            "Copy of original input",
+            "Input after common",
+            rows);
+      }
     } catch (const VeloxException& e) {
       if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
         unsupportedInputUncatchableError = true;
-      } else if (!e.isUserError()) {
-        LOG(ERROR)
-            << "Simplified eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE error are not allowed.";
+      } else if (!(canThrow && e.isUserError())) {
+        if (!canThrow) {
+          LOG(ERROR)
+              << "Common eval wasn't supposed to throw, but it did. Aborting.";
+        } else if (!e.isUserError()) {
+          LOG(ERROR)
+              << "Common eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE error are not allowed.";
+        }
         persistReproInfoIfNeeded(
-            rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
         throw;
       }
-      exceptionSimplifiedPtr = std::current_exception();
+      exceptionCommonPtr = std::current_exception();
     } catch (...) {
       LOG(ERROR)
-          << "Simplified eval: Exceptions other than VeloxUserError or VeloxRuntimeError with UNSUPPORTED_INPUT are not allowed.";
+          << "Common eval: Exceptions other than VeloxUserError or VeloxRuntimeError of UNSUPPORTED_INPUT_UNCATCHABLE are not allowed.";
       persistReproInfoIfNeeded(
-          rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
+          inputTestCases,
+          inputRowMetadata,
+          copiedResult,
+          sql,
+          complexConstants);
       throw;
     }
 
-    try {
-      // Compare results or exceptions (if any). Fail if anything is
-      // different.
-      if (exceptionCommonPtr || exceptionSimplifiedPtr) {
-        // UNSUPPORTED_INPUT_UNCATCHABLE errors are VeloxRuntimeErrors that
-        // cannot
-        // be suppressed by default NULLs. So it may happen that only one of the
-        // common and simplified path throws this error. In this case, we do not
-        // compare the exceptions.
-        if (!unsupportedInputUncatchableError) {
-          // Throws in case exceptions are not compatible. If they are
-          // compatible, return false to signal that the expression failed.
-          fuzzer::compareExceptions(exceptionCommonPtr, exceptionSimplifiedPtr);
-        }
-        return {
-            nullptr,
-            exceptionCommonPtr ? exceptionCommonPtr : exceptionSimplifiedPtr,
-            unsupportedInputUncatchableError};
-      } else {
-        // Throws in case output is different.
-        VELOX_CHECK_EQ(commonEvalResult.size(), plans.size());
-        VELOX_CHECK_EQ(simplifiedEvalResult.size(), plans.size());
-        for (int i = 0; i < plans.size(); ++i) {
-          fuzzer::compareVectors(
-              commonEvalResult[i],
-              simplifiedEvalResult[i],
-              "common path results ",
-              "simplified path results",
-              rows);
+    VLOG(1) << "Starting reference eval execution.";
+
+    if (referenceQueryRunner_ != nullptr) {
+      VLOG(1) << "Execute with reference DB.";
+      auto inputRowVector = reduceToSelectedRows(rowVector, rows);
+      auto projectionPlan = makeProjectionPlan(inputRowVector, plans);
+      auto referenceResultOrError = computeReferenceResults(
+          projectionPlan, {inputRowVector}, referenceQueryRunner_.get());
+
+      auto referenceEvalResult = referenceResultOrError.first;
+
+      if (referenceResultOrError.second !=
+          ReferenceQueryErrorCode::kReferenceQueryUnsupported) {
+        bool exceptionReference =
+            (referenceResultOrError.second !=
+             ReferenceQueryErrorCode::kSuccess);
+        try {
+          // Compare results or exceptions (if any). Fail if anything is
+          // different.
+          if (exceptionCommonPtr || exceptionReference) {
+            // Throws in case only one evaluation path throws exception.
+            // Otherwise, return false to signal that the expression failed.
+            if (!(defaultNull &&
+                  referenceQueryRunner_->runnerType() ==
+                      ReferenceQueryRunner::RunnerType::kPrestoQueryRunner) &&
+                !(exceptionCommonPtr && exceptionReference)) {
+              LOG(ERROR) << "Only "
+                         << (exceptionCommonPtr ? "common" : "reference")
+                         << " path threw exception:";
+              if (exceptionCommonPtr) {
+                std::rethrow_exception(exceptionCommonPtr);
+              } else {
+                auto referenceSql =
+                    referenceQueryRunner_->toSql(projectionPlan);
+                VELOX_FAIL(
+                    "Reference path throws for query: {}", *referenceSql);
+              }
+            }
+          } else {
+            // Throws in case output is different.
+            VELOX_CHECK_EQ(commonEvalResult.size(), plans.size());
+            VELOX_CHECK(referenceEvalResult.has_value());
+
+            std::vector<TypePtr> types;
+            for (auto i = 0; i < commonEvalResult.size(); ++i) {
+              types.push_back(commonEvalResult[i]->type());
+            }
+            auto commonEvalResultRow = std::make_shared<RowVector>(
+                execCtx_->pool(),
+                ROW(std::move(types)),
+                nullptr,
+                commonEvalResult[0]->size(),
+                commonEvalResult);
+            commonEvalResultRow =
+                reduceToSelectedRows(commonEvalResultRow, rows);
+            VELOX_CHECK(
+                exec::test::assertEqualResults(
+                    referenceEvalResult.value(),
+                    projectionPlan->outputType(),
+                    {commonEvalResultRow}),
+                "Velox and reference DB results don't match");
+            LOG(INFO) << "Verified results against reference DB";
+          }
+        } catch (...) {
+          persistReproInfoIfNeeded(
+              inputTestCases,
+              inputRowMetadata,
+              copiedResult,
+              sql,
+              complexConstants);
+          throw;
         }
       }
-    } catch (...) {
-      persistReproInfoIfNeeded(
-          rowVector, inputRowMetadata, copiedResult, sql, complexConstants);
-      throw;
+    } else {
+      VLOG(1) << "Execute with simplified expression eval path.";
+      try {
+        exec::EvalCtx evalCtxSimplified(
+            execCtx_, &exprSetSimplified, rowVector.get());
+
+        auto copy = BaseVector::copy(*rowVector);
+        exprSetSimplified.eval(
+            0,
+            exprSetSimplified.size(),
+            true /*initialize*/,
+            rows,
+            evalCtxSimplified,
+            simplifiedEvalResult);
+
+        // Flatten the input vector as an optimization if its very deeply
+        // nested.
+        fuzzer::compareVectors(
+            copy,
+            BaseVector::copy(*rowVector),
+            "Copy of original input",
+            "Input after simplified",
+            rows);
+      } catch (const VeloxException& e) {
+        if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
+          unsupportedInputUncatchableError = true;
+        } else if (!e.isUserError()) {
+          LOG(ERROR)
+              << "Simplified eval: VeloxRuntimeErrors other than UNSUPPORTED_INPUT_UNCATCHABLE error are not allowed.";
+          persistReproInfoIfNeeded(
+              inputTestCases,
+              inputRowMetadata,
+              copiedResult,
+              sql,
+              complexConstants);
+          throw;
+        }
+        exceptionSimplifiedPtr = std::current_exception();
+      } catch (...) {
+        LOG(ERROR)
+            << "Simplified eval: Exceptions other than VeloxUserError or VeloxRuntimeError with UNSUPPORTED_INPUT are not allowed.";
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
+
+      try {
+        // Compare results or exceptions (if any). Fail if anything is
+        // different.
+        if (exceptionCommonPtr || exceptionSimplifiedPtr) {
+          // UNSUPPORTED_INPUT_UNCATCHABLE errors are VeloxRuntimeErrors that
+          // cannot
+          // be suppressed by default NULLs. So it may happen that only one of
+          // the common and simplified path throws this error. In this case, we
+          // do not compare the exceptions.
+          if (!unsupportedInputUncatchableError) {
+            // Throws in case exceptions are not compatible. If they are
+            // compatible, return false to signal that the expression failed.
+            fuzzer::compareExceptions(
+                exceptionCommonPtr, exceptionSimplifiedPtr);
+          }
+          results.push_back(
+              {nullptr,
+               exceptionCommonPtr ? exceptionCommonPtr : exceptionSimplifiedPtr,
+               unsupportedInputUncatchableError});
+          continue;
+        } else {
+          // Throws in case output is different.
+          VELOX_CHECK_EQ(commonEvalResult.size(), plans.size());
+          VELOX_CHECK_EQ(simplifiedEvalResult.size(), plans.size());
+          for (int i = 0; i < plans.size(); ++i) {
+            fuzzer::compareVectors(
+                commonEvalResult[i],
+                simplifiedEvalResult[i],
+                "common path results ",
+                "simplified path results",
+                rows);
+          }
+        }
+      } catch (...) {
+        persistReproInfoIfNeeded(
+            inputTestCases,
+            inputRowMetadata,
+            copiedResult,
+            sql,
+            complexConstants);
+        throw;
+      }
+    }
+
+    if (!options_.reproPersistPath.empty() && options_.persistAndRunOnce) {
+      // A guard to make sure it runs only once with persistAndRunOnce flag
+      // turned on. It shouldn't reach here normally since the flag is used to
+      // persist repro info for crash failures. But if it hasn't crashed by now,
+      // we still don't want another iteration.
+      LOG(WARNING)
+          << "Iteration succeeded with --persist_and_run_once flag enabled "
+             "(expecting crash failure)";
+      exit(0);
+    }
+
+    if (exceptionCommonPtr) {
+      results.push_back(
+          {nullptr, exceptionCommonPtr, unsupportedInputUncatchableError});
+    } else {
+      results.push_back(
+          {VectorMaker(commonEvalResult[0]->pool()).rowVector(commonEvalResult),
+           nullptr,
+           unsupportedInputUncatchableError});
     }
   }
-
-  if (!options_.reproPersistPath.empty() && options_.persistAndRunOnce) {
-    // A guard to make sure it runs only once with persistAndRunOnce flag
-    // turned on. It shouldn't reach here normally since the flag is used to
-    // persist repro info for crash failures. But if it hasn't crashed by now,
-    // we still don't want another iteration.
-    LOG(WARNING)
-        << "Iteration succeeded with --persist_and_run_once flag enabled "
-           "(expecting crash failure)";
-    exit(0);
-  }
-
-  if (exceptionCommonPtr) {
-    return {nullptr, exceptionCommonPtr, unsupportedInputUncatchableError};
-  } else {
-    return {
-        VectorMaker(commonEvalResult[0]->pool()).rowVector(commonEvalResult),
-        nullptr,
-        unsupportedInputUncatchableError};
-  }
+  return results;
 }
 
 void ExpressionVerifier::persistReproInfoIfNeeded(
-    const VectorPtr& inputVector,
+    const std::vector<fuzzer::InputTestCase>& inputTestCases,
     const InputRowMetadata& inputRowMetadata,
     const VectorPtr& resultVector,
     const std::string& sql,
@@ -411,17 +446,18 @@ void ExpressionVerifier::persistReproInfoIfNeeded(
     LOG(INFO) << "Skipping persistence because repro path is empty.";
   } else if (!options_.persistAndRunOnce) {
     persistReproInfo(
-        inputVector, inputRowMetadata, resultVector, sql, complexConstants);
+        inputTestCases, inputRowMetadata, resultVector, sql, complexConstants);
   }
 }
 
 void ExpressionVerifier::persistReproInfo(
-    const VectorPtr& inputVector,
+    const std::vector<fuzzer::InputTestCase>& inputTestCases,
     const InputRowMetadata& inputRowMetadata,
     const VectorPtr& resultVector,
     const std::string& sql,
     const std::vector<VectorPtr>& complexConstants) {
-  std::string inputPath;
+  std::vector<std::string> inputPaths;
+  std::vector<std::string> inputSelectivityVectorPaths;
   std::string inputRowMetadataPath;
   std::string resultPath;
   std::string sqlPath;
@@ -438,12 +474,30 @@ void ExpressionVerifier::persistReproInfo(
     LOG(INFO) << "Failed to create directory for persisting repro info.";
     return;
   }
-  // Saving input vector
-  inputPath = fmt::format("{}/{}", dirPath->c_str(), kInputVectorFileName);
-  try {
-    saveVectorToFile(inputVector.get(), inputPath.c_str());
-  } catch (std::exception& e) {
-    inputPath = e.what();
+  // Saving input test cases
+  for (int i = 0; i < inputTestCases.size(); i++) {
+    auto filePath = fmt::format(
+        "{}/{}_{}", dirPath->c_str(), kInputVectorFileNamePrefix, i);
+    try {
+      saveVectorToFile(inputTestCases[i].inputVector.get(), filePath.c_str());
+      inputPaths.push_back(filePath);
+    } catch (std::exception& e) {
+      inputPaths.clear();
+      inputPaths.push_back(e.what());
+      break;
+    }
+
+    filePath = fmt::format(
+        "{}/{}_{}", dirPath->c_str(), kInputSelectivityVectorFileNamePrefix, i);
+    try {
+      saveSelectivityVectorToFile(
+          inputTestCases[i].activeRows, filePath.c_str());
+      inputSelectivityVectorPaths.push_back(filePath);
+    } catch (std::exception& e) {
+      inputSelectivityVectorPaths.clear();
+      inputSelectivityVectorPaths.push_back(e.what());
+      break;
+    }
   }
 
   // Saving the list of column indices that are to be wrapped in lazy.
@@ -491,7 +545,9 @@ void ExpressionVerifier::persistReproInfo(
 
   std::stringstream ss;
   ss << "Persisted input: --fuzzer_repro_path " << dirPath.value();
-  ss << " --input_path " << inputPath;
+  ss << " --input_paths " << boost::algorithm::join(inputPaths, ",")
+     << " --input_selectivity_vector_paths "
+     << boost::algorithm::join(inputSelectivityVectorPaths, ",");
   if (resultVector) {
     ss << " --result_path " << resultPath;
   }
@@ -516,14 +572,13 @@ class MinimalSubExpressionFinder {
   // Tries subexpressions of plan until finding the minimal failing subtree.
   void findMinimalExpression(
       core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::optional<SelectivityVector>& rowsToVerify,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata) {
-    if (verifyWithResults(plan, rowVector, rowsToVerify, inputRowMetadata)) {
+    if (verifyWithResults(plan, inputTestCases, inputRowMetadata)) {
       errorExit("Retry should have failed");
     }
     bool minimalFound =
-        findMinimalRecursive(plan, rowVector, rowsToVerify, inputRowMetadata);
+        findMinimalRecursive(plan, inputTestCases, inputRowMetadata);
     if (minimalFound) {
       errorExit("Found minimal failing expression.");
     } else {
@@ -542,16 +597,14 @@ class MinimalSubExpressionFinder {
   // breakpoint inside this to debug failures.
   bool findMinimalRecursive(
       core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::optional<SelectivityVector>& rowsToVerify,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata) {
     bool anyFailed = false;
     for (auto& input : plan->inputs()) {
-      if (!verifyWithResults(
-              input, rowVector, rowsToVerify, inputRowMetadata)) {
+      if (!verifyWithResults(input, inputTestCases, inputRowMetadata)) {
         anyFailed = true;
-        bool minimalFound = findMinimalRecursive(
-            input, rowVector, rowsToVerify, inputRowMetadata);
+        bool minimalFound =
+            findMinimalRecursive(input, inputTestCases, inputRowMetadata);
         if (minimalFound) {
           return true;
         }
@@ -560,10 +613,10 @@ class MinimalSubExpressionFinder {
     if (!anyFailed) {
       LOG(INFO) << "Failed with all children succeeding: " << plan->toString();
       // Re-running the minimum failed. Put breakpoint here to debug.
-      verifyWithResults(plan, rowVector, rowsToVerify, inputRowMetadata);
+      verifyWithResults(plan, inputTestCases, inputRowMetadata);
       if (!inputRowMetadata.columnsToWrapInLazy.empty()) {
         LOG(INFO) << "Trying without lazy:";
-        if (verifyWithResults(plan, rowVector, rowsToVerify, {})) {
+        if (verifyWithResults(plan, inputTestCases, {})) {
           LOG(INFO) << "Minimal failure succeeded without lazy vectors";
         }
       }
@@ -579,17 +632,16 @@ class MinimalSubExpressionFinder {
   // contents in result vector.
   bool verifyWithResults(
       core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::optional<SelectivityVector>& rowsToVerify,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata) {
     VectorPtr result;
     LOG(INFO) << "Running with empty results vector :" << plan->toString();
     bool emptyResult =
-        verifyPlan(plan, rowVector, rowsToVerify, inputRowMetadata, result);
+        verifyPlan(plan, inputTestCases, inputRowMetadata, result);
     LOG(INFO) << "Running with non empty vector :" << plan->toString();
     result = vectorFuzzer_.fuzzFlat(plan->type());
     bool filledResult =
-        verifyPlan(plan, rowVector, rowsToVerify, inputRowMetadata, result);
+        verifyPlan(plan, inputTestCases, inputRowMetadata, result);
     if (emptyResult != filledResult) {
       LOG(ERROR) << fmt::format(
           "Different results for empty vs populated ! Empty result = {} filledResult = {}",
@@ -603,8 +655,7 @@ class MinimalSubExpressionFinder {
   // Returns true if the verification is successful.
   bool verifyPlan(
       core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::optional<SelectivityVector>& rowsToVerify,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata,
       VectorPtr results) {
     // Turn off unnecessary logging.
@@ -614,8 +665,7 @@ class MinimalSubExpressionFinder {
     try {
       verifier_.verify(
           {plan},
-          rowVector,
-          rowsToVerify,
+          inputTestCases,
           results ? BaseVector::copy(*results) : nullptr,
           true, // canThrow
           inputRowMetadata);
@@ -635,8 +685,7 @@ void computeMinimumSubExpression(
     ExpressionVerifier&& minimalVerifier,
     VectorFuzzer& fuzzer,
     const std::vector<core::TypedExprPtr>& plans,
-    const RowVectorPtr& rowVector,
-    const std::optional<SelectivityVector>& rowsToVerify,
+    const std::vector<fuzzer::InputTestCase>& inputTestCases,
     const InputRowMetadata& inputRowMetadata) {
   auto finder = MinimalSubExpressionFinder(std::move(minimalVerifier), fuzzer);
   if (plans.size() > 1) {
@@ -648,8 +697,7 @@ void computeMinimumSubExpression(
   for (auto plan : plans) {
     LOG(INFO) << "============================================";
     LOG(INFO) << "Finding minimal subexpression for plan:" << plan->toString();
-    finder.findMinimalExpression(
-        plan, rowVector, rowsToVerify, inputRowMetadata);
+    finder.findMinimalExpression(plan, inputTestCases, inputRowMetadata);
     LOG(INFO) << "============================================";
   }
 }

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -42,7 +42,10 @@ class ExpressionVerifier {
  public:
   // File names used to persist data required for reproducing a failed test
   // case.
-  static constexpr const std::string_view kInputVectorFileName = "input_vector";
+  static constexpr const std::string_view kInputVectorFileNamePrefix =
+      "input_vector";
+  static constexpr const std::string_view
+      kInputSelectivityVectorFileNamePrefix = "input_selectivity_vector";
   static constexpr const std::string_view kInputRowMetadataFileName =
       "input_row_metadata";
   static constexpr const std::string_view kResultVectorFileName =
@@ -61,25 +64,20 @@ class ExpressionVerifier {
 
   // Executes expressions using common path (all evaluation
   // optimizations) and compares the result with either the simplified path or a
-  // reference query runner. An optional selectivity vector 'rowsToVerify' can
-  // be passed which specifies which rows to evaluate and verify. If its not
-  // provided (by passing std::nullopt) then all rows will be verified.
-  // Additionally, a list of column indices can be passed via
-  // 'columnsToWrapInLazy' which specify the columns/children in the input row
-  // vector that should be wrapped in a lazy layer before running it through the
-  // common evaluation path. The list can contain negative column indices that
-  // represent lazy vectors that should be preloaded before being fed to the
-  // evaluator. This list is sorted on the absolute value of the entries.
+  // reference query runner. This execution is done for each input test cases
+  // where the ExprSet for the common and simplified is reused between test
+  // cases to simulate batches being processed via a ProjectFilter operator.
   // Returns:
+  // A vector of ResultOrError objects, one for each InputTestCase. Each result
+  // contains:
   //  - result of evaluating the expressions if both paths succeeded and
   //  returned the exact same vectors.
   //  - exception thrown by the common path if both paths failed with compatible
   //  exceptions.
   //  - throws otherwise (incompatible exceptions or different results).
-  fuzzer::ResultOrError verify(
+  std::vector<fuzzer::ResultOrError> verify(
       const std::vector<core::TypedExprPtr>& plans,
-      const RowVectorPtr& rowVector,
-      const std::optional<SelectivityVector>& rowsToVerify,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       VectorPtr&& resultVector,
       bool canThrow,
       const InputRowMetadata& inputRowMetadata = {});
@@ -88,7 +86,7 @@ class ExpressionVerifier {
   // Utility method used to serialize the relevant data required to repro a
   // crash.
   void persistReproInfo(
-      const VectorPtr& inputVector,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata,
       const VectorPtr& resultVector,
       const std::string& sql,
@@ -98,7 +96,7 @@ class ExpressionVerifier {
   // options_.reproPersistPath is set and is not persistAndRunOnce. Do nothing
   // otherwise.
   void persistReproInfoIfNeeded(
-      const VectorPtr& inputVector,
+      const std::vector<fuzzer::InputTestCase>& inputTestCases,
       const InputRowMetadata& inputRowMetadata,
       const VectorPtr& resultVector,
       const std::string& sql,
@@ -117,7 +115,6 @@ void computeMinimumSubExpression(
     ExpressionVerifier&& minimalVerifier,
     VectorFuzzer& fuzzer,
     const std::vector<core::TypedExprPtr>& plans,
-    const RowVectorPtr& rowVector,
-    const std::optional<SelectivityVector>& rowsToVerify,
+    const std::vector<fuzzer::InputTestCase>& inputTestCases,
     const InputRowMetadata& inputRowMetadata);
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -113,7 +113,9 @@ TEST_F(ExpressionVerifierUnitTest, persistReproInfo) {
 
     removeDirecrtoryIfExist(localFs, reproPath);
     VELOX_ASSERT_THROW(
-        verifier.verify({plan}, data, std::nullopt, nullptr, false), "");
+        verifier.verify(
+            {plan}, {{data, SelectivityVector(data->size())}}, nullptr, false),
+        "");
     EXPECT_TRUE(localFs->exists(reproPath));
     EXPECT_FALSE(localFs->list(reproPath).empty());
     removeDirecrtoryIfExist(localFs, reproPath);
@@ -144,12 +146,14 @@ TEST_F(ExpressionVerifierUnitTest, subsetOfRowsToVerify) {
     auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
     auto plan = parseExpression("always_throws(c0)", asRowType(data->type()));
     VELOX_ASSERT_THROW(
-        verifier.verify({plan}, data, std::nullopt, nullptr, false), "");
+        verifier.verify(
+            {plan}, {{data, SelectivityVector(data->size())}}, nullptr, false),
+        "");
 
     SelectivityVector rows(data->size());
     rows.setValid(1, false);
     rows.updateBounds();
-    verifier.verify({plan}, data, rows, nullptr, false);
+    verifier.verify({plan}, {{data, rows}}, nullptr, false);
   }
 }
 

--- a/velox/vector/VectorSaver.h
+++ b/velox/vector/VectorSaver.h
@@ -61,20 +61,10 @@ void saveSelectivityVector(const SelectivityVector& rows, std::ostream& out);
 /// the provided input stream.
 SelectivityVector restoreSelectivityVector(std::istream& in);
 
-/// Serializes a BufferPtr into binary format and writes it to the
-/// provided output stream. 'buffer' must be non-null.
-void writeBuffer(const BufferPtr& buffer, std::ostream& out);
+void saveSelectivityVectorToFile(
+    const SelectivityVector& rows,
+    const char* filePath);
 
-/// Serializes a optional BufferPtr into binary format and writes it to the
-/// provided output stream.
-void writeOptionalBuffer(const BufferPtr& buffer, std::ostream& out);
-
-/// Deserializes a BufferPtr serialized by 'writeBuffer' from the provided
-/// input stream.
-BufferPtr readBuffer(std::istream& in, memory::MemoryPool* pool);
-
-/// Deserializes a optional BufferPtr serialized by 'writeOptionalBuffer' from
-/// the provided input stream.
-BufferPtr readOptionalBuffer(std::istream& in, memory::MemoryPool* pool);
+SelectivityVector restoreSelectivityVectorFromFile(const char* filePath);
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
This change adds the ability to run 2 input batches for each
expression fuzzer iteration which will re-use the ExprSet to simulate
its typical usage in actual use-cases like in the ProjectFilter
Operator. The full execution loop of each iteration is modified to
accommodate this change, including input generation and modification,
result verification, re-running input using TRY, finding the minimal
breaking expression tree, and the facility to serialize the input and
repro using the ExpressionRunner utility.

Side note: this exposed a bug in Simplified path where the inputs are
not cleared if during eval of inputs an exception is thrown. The fix is
also a part of this change.

Differential Revision: D67368974


