### PR TITLE
fix: Fix flaky tsan failure in async data cache

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -518,7 +518,9 @@ void CacheShard::updateStats(CacheStats& stats) {
     if (!entry || !entry->key_.fileNum.hasValue()) {
       ++stats.numEmptyEntries;
       continue;
-    } else if (entry->isExclusive()) {
+    }
+
+    if (entry->isExclusive()) {
       stats.exclusivePinnedBytes +=
           entry->data().byteSize() + entry->tinyData_.capacity();
       ++stats.numExclusive;
@@ -527,10 +529,12 @@ void CacheShard::updateStats(CacheStats& stats) {
           entry->data().byteSize() + entry->tinyData_.capacity();
       ++stats.numShared;
     }
+
     if (entry->isPrefetch_) {
       ++stats.numPrefetch;
       stats.prefetchBytes += entry->size();
     }
+
     ++stats.numEntries;
     stats.tinySize += entry->tinyData_.size();
     stats.tinyPadding += entry->tinyData_.capacity() - entry->tinyData_.size();

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -787,9 +787,15 @@ class AsyncDataCache : public memory::Cache {
   /// Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer)
+  __attribute__((__no_sanitize__("thread")))
+#endif
+#endif
   /// Returns snapshot of the aggregated stats from all shards and the stats of
   /// SSD cache if used.
-  virtual CacheStats refreshStats() const;
+  virtual CacheStats
+  refreshStats() const;
 
   /// If 'details' is true, returns the stats of the backing memory allocator
   /// and ssd cache. Otherwise, only returns the cache stats.


### PR DESCRIPTION
Summary:
Mark refresh stats method to avoid tsan check to see if it can prevent tsan failure. The refresh stats will access the
entries which are under initialization and it is read only has not pointer chasing so it is safe to do so.

Differential Revision: D67378594


