### PR TITLE
fix(table-writer): Allow structs to be written as flat maps

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -975,7 +975,7 @@ void updateDWRFWriterOptions(
       std::dynamic_pointer_cast<dwrf::WriterOptions>(writerOptions);
   VELOX_CHECK_NOT_NULL(
       dwrfWriterOptions, "DWRF writer expected a DWRF WriterOptions object.");
-  std::map<std::string, std::string> configs;
+  std::map<std::string, std::string> configs = writerOptions->serdeParameters;
 
   if (writerOptions->compressionKind.has_value()) {
     configs.emplace(

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -199,6 +199,11 @@ class TableWriter : public Operator {
 
   void updateStats(const connector::DataSink::Stats& stats);
 
+  // Sets type mappings in `inputMapping_`, `mappedInputType_`, and
+  // `mappedOutputType_`.
+  void setTypeMappings(
+      const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
+
   std::string createTableCommitContext(bool lastOutput);
 
   void setConnectorMemoryReclaimer();
@@ -213,8 +218,16 @@ class TableWriter : public Operator {
   std::shared_ptr<connector::Connector> connector_;
   std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::unique_ptr<connector::DataSink> dataSink_;
+
+  // Contains the mappings between input and output columns.
   std::vector<column_index_t> inputMapping_;
-  std::shared_ptr<const RowType> mappedType_;
+
+  // Stores the mapped input and output types. Note that input types must have
+  // the same types as the types receing in addInput(), but they may be in a
+  // different order. Output type may have different types to allow the writer
+  // to convert them (for example, when writing structs as flap maps).
+  std::shared_ptr<const RowType> mappedInputType_;
+  std::shared_ptr<const RowType> mappedOutputType_;
 
   // The blocking future might be set when finish data sink.
   ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};


### PR DESCRIPTION
Summary:
Fixing table writer type mapping to allow output and input types to
differ to enable plans that write structs as flat maps. Also fixing
configurations passing in dwrf not to ignore writerOption serdeParameters.

Differential Revision: D67415905


