### PR TITLE
fix(HashJoin): Stop HashProbe filter evaluation when filter input has no selections

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1431,11 +1431,11 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
     prepareFilterRowsForNullAwareJoin(
         filterInput, numRows, filterPropagateNulls);
   }
-
-  EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput.get());
-  filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
-
-  decodedFilterResult_.decode(*filterResult_[0], filterInputRows_);
+  if (filterInputRows_.hasSelections()) {
+    EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput.get());
+    filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
+    decodedFilterResult_.decode(*filterResult_[0], filterInputRows_);
+  }
 
   int32_t numPassed = 0;
   if (isLeftJoin(joinType_) || isFullJoin(joinType_)) {


### PR DESCRIPTION
Summary:
This change stops filter evaluation when filterInputRows_ has no selections. Evaluating the filter when filterInputRows_ has no selections can result in filterResult_ being in an invalid state and cause index out of range errors when attempting to access it.


```
Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (128 vs. 128) Dictionary index must be less than base vector's size. Index: 128.
Retriable: False
Expression: rawIndices_[i] < dictionaryValues_->size()
Context: Top-level Expression: gt(cast((t_k1) as BIGINT), 1000:BIGINT)
Additional Context: Operator: HashProbe[2] 1
Function: validate
File: buck-out/v2/gen/fbcode/16b07710e10499f0/velox/vector/__velox_vector__/buck-headers/velox/vector/DictionaryVector-inl.h
Line: 215
```

Differential Revision: D67420798


