### PR TITLE
fix(fuzzer): Skip check of verified iterations in WindowFuzzer when verification is not enabled

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -560,14 +560,17 @@ void WindowFuzzer::go() {
   }
 
   stats_.print(iteration);
-  // Check that at least half of the iterations were verified, either against
-  // the reference DB or through custom result verifiers.
-  // stats_.numVerificationSkipped tracks the number of iterations verified
-  // through custom result verifiers.
-  VELOX_CHECK_GE(
-      (stats_.numVerified + stats_.numVerificationSkipped) / (double)iteration,
-      0.5);
   printSignatureStats();
+  if (FLAGS_enable_window_reference_verification) {
+    // Check that at least half of the iterations were verified, either against
+    // the reference DB or through custom result verifiers.
+    // stats_.numVerificationSkipped tracks the number of iterations verified
+    // through custom result verifiers.
+    VELOX_CHECK_GE(
+        (stats_.numVerified + stats_.numVerificationSkipped) /
+            (double)iteration,
+        0.5);
+  }
 }
 
 void WindowFuzzer::go(const std::string& /*planPath*/) {


### PR DESCRIPTION
Differential Revision: D67497422


