### PR TITLE
fix: Fix macos build failure

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -40,6 +40,11 @@ namespace {
 struct TestParam {
   VectorSerde::Kind serdeKind;
   common::CompressionKind compressionKind;
+
+  TestParam(
+      VectorSerde::Kind _serdeKind,
+      common::CompressionKind _compressionKind)
+      : serdeKind(_serdeKind), compressionKind(_compressionKind) {}
 };
 
 class MultiFragmentTest : public HiveConnectorTestBase,


### PR DESCRIPTION
Summary: Fix macos build failure and remove a duplicate stats function

Differential Revision: D67525225


