### PR TITLE
fix: Use MemoryManager::testInstance to check the MemoryManager initialization

### DIFF
--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -223,7 +223,7 @@ void TraceReplayRunner::init() {
   VELOX_USER_CHECK(!FLAGS_query_id.empty(), "--query_id must be provided");
   VELOX_USER_CHECK(!FLAGS_node_id.empty(), "--node_id must be provided");
 
-  if (memory::memoryManager() == nullptr) {
+  if (!memory::MemoryManager::testInstance()) {
     memory::initializeMemoryManager({});
   }
   filesystems::registerLocalFileSystem();


### PR DESCRIPTION
Use `MemoryManager::testInstance` to check whether the MemoryManager
is initialized in `TraceReplayRunner.cpp` instead of `memory::memoryManager()`
as it uses `MemoryManager::instance`, which would throw if the MemoryManager
instance is null.
