### PR TITLE
Add optional HLL for distinct value count to StatisticsBuilder

### DIFF
--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -81,11 +81,13 @@ class ColumnStatistics {
       std::optional<uint64_t> valueCount,
       std::optional<bool> hasNull,
       std::optional<uint64_t> rawSize,
-      std::optional<uint64_t> size)
+      std::optional<uint64_t> size,
+      std::optional<int64_t> numDistinct = std::nullopt)
       : valueCount_(valueCount),
         hasNull_(hasNull),
         rawSize_(rawSize),
-        size_(size) {}
+        size_(size),
+        numDistinct_(numDistinct) {}
 
   virtual ~ColumnStatistics() = default;
 
@@ -123,6 +125,16 @@ class ColumnStatistics {
     return size_;
   }
 
+  std::optional<uint64_t> numDistinct() const {
+    return numDistinct_;
+  }
+
+  void setNumDistinct(int64_t count) {
+    VELOX_CHECK(
+        !numDistinct_.has_value(), "numDistinct_ can be set only once.");
+    numDistinct_ = count;
+  }
+
   /**
    * return string representation of this stats object
    */
@@ -145,6 +157,7 @@ class ColumnStatistics {
   std::optional<bool> hasNull_;
   std::optional<uint64_t> rawSize_;
   std::optional<uint64_t> size_;
+  std::optional<uint64_t> numDistinct_;
 };
 
 /**

--- a/velox/dwio/dwrf/writer/CMakeLists.txt
+++ b/velox/dwio/dwrf/writer/CMakeLists.txt
@@ -28,6 +28,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_dwio_dwrf_writer
+  velox_common_hyperloglog
   velox_dwio_common
   velox_dwio_dwrf_common
   velox_dwio_dwrf_utils

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <velox/common/base/Exceptions.h>
+#include <velox/common/hyperloglog/SparseHll.h>
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/dwio/dwrf/common/Statistics.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
@@ -76,11 +77,22 @@ inline dwio::common::KeyInfo constructKey(const dwrf::proto::KeyInfo& keyInfo) {
 struct StatisticsBuilderOptions {
   explicit StatisticsBuilderOptions(
       uint32_t stringLengthLimit,
-      std::optional<uint64_t> initialSize = std::nullopt)
-      : stringLengthLimit{stringLengthLimit}, initialSize{initialSize} {}
+      std::optional<uint64_t> initialSize = std::nullopt,
+      bool countDistincts = false,
+      HashStringAllocator* allocator = nullptr)
+      : stringLengthLimit{stringLengthLimit},
+        initialSize{initialSize},
+        countDistincts(countDistincts),
+        allocator(allocator) {}
 
   uint32_t stringLengthLimit;
   std::optional<uint64_t> initialSize;
+  bool countDistincts{false};
+  HashStringAllocator* allocator;
+
+  StatisticsBuilderOptions withoutNumDistinct() const {
+    return StatisticsBuilderOptions(stringLengthLimit, initialSize);
+  }
 
   static StatisticsBuilderOptions fromConfig(const Config& config) {
     return StatisticsBuilderOptions{config.get(Config::STRING_STATS_LIMIT)};
@@ -90,9 +102,12 @@ struct StatisticsBuilderOptions {
 /*
  * Base class for stats builder. Stats builder is used in writer and file merge
  * to collect and merge stats.
+ * It can also be used for gathering stats in ad hoc sampling. In this case it
+ * may also count distinct values if enabled in 'options'.
  */
 class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
  public:
+  /// Constructs with 'options'.
   explicit StatisticsBuilder(const StatisticsBuilderOptions& options)
       : options_{options} {
     init();
@@ -130,6 +145,18 @@ class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
     if (LIKELY(size_.has_value())) {
       addWithOverflowCheck(size_, size, /*count=*/1);
     }
+  }
+
+  template <typename T>
+  void addHash(const T& data) {
+    if (hll_) {
+      hll_->insertHash(folly::hasher<T>()(data));
+    }
+  }
+
+  int64_t cardinality() const {
+    VELOX_CHECK_NOT_NULL(hll_);
+    return hll_->cardinality();
   }
 
   /*
@@ -170,17 +197,21 @@ class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
     hasNull_ = false;
     rawSize_ = 0;
     size_ = options_.initialSize;
+    if (options_.countDistincts) {
+      hll_ = std::make_shared<common::hll::SparseHll>(options_.allocator);
+    }
   }
 
  protected:
   StatisticsBuilderOptions options_;
+  std::shared_ptr<common::hll::SparseHll> hll_;
 };
 
 class BooleanStatisticsBuilder : public StatisticsBuilder,
                                  public dwio::common::BooleanColumnStatistics {
  public:
   explicit BooleanStatisticsBuilder(const StatisticsBuilderOptions& options)
-      : StatisticsBuilder{options} {
+      : StatisticsBuilder{options.withoutNumDistinct()} {
     init();
   }
 
@@ -229,6 +260,7 @@ class IntegerStatisticsBuilder : public StatisticsBuilder,
       max_ = value;
     }
     addWithOverflowCheck(sum_, value, count);
+    addHash(value);
   }
 
   void merge(
@@ -278,6 +310,7 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
     if (max_.has_value() && value > max_.value()) {
       max_ = value;
     }
+    addHash(value);
     // value * count sometimes is not same as adding values (count) times. So
     // add in a loop
     if (sum_.has_value()) {
@@ -342,6 +375,7 @@ class StringStatisticsBuilder : public StatisticsBuilder,
         max_ = value;
       }
     }
+    addHash(value);
 
     addWithOverflowCheck<uint64_t>(length_, value.size(), count);
   }
@@ -375,7 +409,7 @@ class BinaryStatisticsBuilder : public StatisticsBuilder,
                                 public dwio::common::BinaryColumnStatistics {
  public:
   explicit BinaryStatisticsBuilder(const StatisticsBuilderOptions& options)
-      : StatisticsBuilder{options} {
+      : StatisticsBuilder{options.withoutNumDistinct()} {
     init();
   }
 
@@ -412,6 +446,7 @@ class MapStatisticsBuilder : public StatisticsBuilder,
       : StatisticsBuilder{options},
         valueType_{type.as<velox::TypeKind::MAP>().valueType()} {
     init();
+    hll_.reset();
   }
 
   ~MapStatisticsBuilder() override = default;


### PR DESCRIPTION
Adds an optional HLL counter for distinct values to StatisticsBuilder. This is used in Verax sampling to estimate column cardinalities for scalar types.