### PR TITLE
migrate uses of legacy namespace folly::io::zlib (#10283)

### DIFF
--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -33,7 +33,7 @@ using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::dwrf;
 using namespace facebook::velox::memory;
 using namespace facebook::velox;
-using namespace folly::io;
+using namespace folly::compression;
 
 const std::string simpleFile(getExampleFilePath("simple-file.binary"));
 


### PR DESCRIPTION
Summary:


Migrate uses of legacy namespace `folly::io::zlib` to `folly::compression::zlib`.

Reviewed By: michalgr, pedroerp, skrueger

Differential Revision: D58821426


