### PR TITLE
feat: Add Duck plan transformation for qualified joins and subqueries

### DIFF
--- a/velox/exec/tests/SqlTest.cpp
+++ b/velox/exec/tests/SqlTest.cpp
@@ -93,5 +93,10 @@ TEST_F(SqlTest, tableScan) {
   assertSql("SELECT a, avg(b) FROM t WHERE c > 5 GROUP BY 1");
   assertSql("SELECT * FROM t, u WHERE t.a = u.a");
   assertSql("SELECT t.a, t.b, t.c, u.b FROM t, u WHERE t.a = u.a");
+  assertSql("SELECT t.a, t.b, t.c, u.b FROM t left join u on t.a = u.a");
+  assertSql(
+      "SELECT t.a, t.b, t.c FROM t WHERE EXISTS (SELECT 1 FROM u WHERE t.a = u.a)");
+  assertSql("SELECT t.a, t.b, t.c FROM t WHERE a < (SELECT max(u.a) FROM u)");
 }
+
 } // namespace facebook::velox::exec::test

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "velox/parse/QueryPlanner.h"
+#include <duckdb.hpp> // @manual
 #include "velox/duckdb/conversion/DuckConversion.h"
+#include "velox/expression/ScopedVarSetter.h"
 #include "velox/parse/DuckLogicalOperator.h"
 
 #include <duckdb.hpp> // @manual
@@ -25,6 +28,8 @@
 #include <duckdb/planner/expression/bound_constant_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_function_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_reference_expression.hpp> // @manual
+
+#include <iostream>
 
 namespace facebook::velox::core {
 
@@ -53,6 +58,8 @@ struct QueryContext {
   ColumnNameGenerator columnNameGenerator;
   const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
       inMemoryTables;
+  MakeTableScan makeTableScan;
+  bool isInDelimJoin{false};
 
   QueryContext(const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
                    _inMemoryTables)
@@ -70,7 +77,6 @@ struct QueryContext {
     return columnNameGenerator.next(prefix);
   }
 };
-
 std::string mapScalarFunctionName(const std::string& name) {
   static const std::unordered_map<std::string, std::string> kMapping = {
       {"+", "plus"},
@@ -78,6 +84,8 @@ std::string mapScalarFunctionName(const std::string& name) {
       {"*", "multiply"},
       {"/", "divide"},
       {"%", "mod"},
+      {"~~", "like"},
+      {"!~~", "not_like"},
       {"list_value", "array_constructor"},
   };
 
@@ -142,23 +150,31 @@ PlanNodePtr toVeloxPlan(
   VELOX_CHECK_EQ(logicalGet.function.name, "seq_scan");
   VELOX_CHECK_EQ(0, sources.size());
 
+  std::vector<std::string> columnNames;
   const auto& columnIds = logicalGet.column_ids;
-  std::vector<std::string> names(columnIds.size());
-  std::vector<TypePtr> types(columnIds.size());
-
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  constexpr uint64_t kNone = ~0UL;
   for (auto i = 0; i < columnIds.size(); ++i) {
-    names[i] = queryContext.nextColumnName(logicalGet.names[columnIds[i]]);
-    types[i] = duckdb::toVeloxType(logicalGet.returned_types[columnIds[i]]);
+    if (columnIds[i] == kNone) {
+      continue;
+    }
+    names.push_back(
+        queryContext.nextColumnName(logicalGet.names[columnIds[i]]));
+    types.push_back(
+        duckdb::toVeloxType(logicalGet.returned_types[columnIds[i]]));
+    columnNames.push_back(logicalGet.names[columnIds[i]]);
   }
 
   auto rowType = ROW(std::move(names), std::move(types));
 
   auto tableName = logicalGet.function.to_string(logicalGet.bind_data.get());
   auto it = queryContext.inMemoryTables.find(tableName);
-  VELOX_CHECK(
-      it != queryContext.inMemoryTables.end(),
-      "Can't find in-memory table: {}",
-      tableName);
+
+  if (it == queryContext.inMemoryTables.end()) {
+    return queryContext.makeTableScan(
+        queryContext.nextNodeId(), tableName, rowType, columnNames);
+  }
 
   std::vector<RowVectorPtr> data;
   for (auto& rowVector : it->second) {
@@ -192,6 +208,63 @@ TypedExprPtr toVeloxComparisonExpression(
   return std::make_shared<CallTypedExpr>(BOOLEAN(), std::move(children), name);
 }
 
+namespace {
+struct VeloxColumnProjections {
+  VeloxColumnProjections(QueryContext& context) : context(context) {}
+
+  core::FieldAccessTypedExprPtr toFieldAccess(
+      ::duckdb::Expression& expression,
+      const TypePtr& inputType) {
+    auto expr = toVeloxExpression(expression, inputType);
+    auto column = std::dynamic_pointer_cast<const FieldAccessTypedExpr>(expr);
+    if (column) {
+      columns.push_back(column);
+      exprs.push_back(expr);
+      return column;
+    }
+
+    allIdentity = false;
+    exprs.push_back(expr);
+    const auto name = context.nextColumnName("_p");
+    auto projected =
+        std::make_shared<FieldAccessTypedExpr>(exprs.back()->type(), name);
+    columns.push_back(projected);
+    return projected;
+  }
+
+  void addColumn(const FieldAccessTypedExprPtr& column) {
+    for (auto& existingColumn : columns) {
+      if (column->name() == existingColumn->name()) {
+        return;
+      }
+    }
+    exprs.push_back(column);
+    columns.push_back(column);
+  }
+
+  /// Returns 'input' wrapped in the projections of 'this'. May only be called
+  /// once.
+  PlanNodePtr source(PlanNodePtr input) {
+    if (allIdentity) {
+      return input;
+    }
+
+    std::vector<std::string> names;
+    names.reserve(columns.size());
+    for (auto& column : columns) {
+      names.push_back(column->name());
+    }
+    return std::make_shared<ProjectNode>(
+        context.nextNodeId(), std::move(names), std::move(exprs), input);
+  }
+
+  QueryContext& context;
+  bool allIdentity{true};
+  std::vector<core::TypedExprPtr> exprs;
+  std::vector<core::FieldAccessTypedExprPtr> columns;
+};
+} // namespace
+
 TypedExprPtr toVeloxExpression(
     ::duckdb::Expression& expression,
     const TypePtr& inputType) {
@@ -205,8 +278,17 @@ TypedExprPtr toVeloxExpression(
     }
     case ::duckdb::ExpressionType::COMPARE_EQUAL:
       return toVeloxComparisonExpression("eq", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_NOTEQUAL:
+      return toVeloxComparisonExpression("neq", expression, inputType);
     case ::duckdb::ExpressionType::COMPARE_GREATERTHAN:
       return toVeloxComparisonExpression("gt", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+      return toVeloxComparisonExpression("gte", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_LESSTHAN:
+      return toVeloxComparisonExpression("lt", expression, inputType);
+    case ::duckdb::ExpressionType::COMPARE_LESSTHANOREQUALTO:
+      return toVeloxComparisonExpression("lte", expression, inputType);
+
     case ::duckdb::ExpressionType::OPERATOR_CAST: {
       auto* cast = dynamic_cast<::duckdb::BoundCastExpression*>(&expression);
       return std::make_shared<CastTypedExpr>(
@@ -223,10 +305,21 @@ TypedExprPtr toVeloxExpression(
         children.push_back(toVeloxExpression(*child, inputType));
       }
 
-      return std::make_shared<CallTypedExpr>(
+      auto name = mapScalarFunctionName(func->function.name);
+      bool negate = false;
+      if (name == "not_like") {
+        name = "like";
+        negate = true;
+      }
+      auto call = std::make_shared<CallTypedExpr>(
           duckdb::toVeloxType(func->function.return_type),
           std::move(children),
-          mapScalarFunctionName(func->function.name));
+          name);
+      if (negate) {
+        return std::make_shared<CallTypedExpr>(
+            BOOLEAN(), std::vector<TypedExprPtr>{call}, "not");
+      }
+      return call;
     }
     case ::duckdb::ExpressionType::BOUND_REF: {
       auto* ref =
@@ -262,11 +355,18 @@ PlanNodePtr toVeloxPlan(
     memory::MemoryPool* pool,
     std::vector<PlanNodePtr> sources,
     QueryContext& queryContext) {
-  VELOX_CHECK_EQ(1, logicalFilter.expressions.size());
-  auto filter = toVeloxExpression(
-      *logicalFilter.expressions.front(), sources[0]->outputType());
+  TypedExprPtr veloxFilter;
+  for (auto& expr : logicalFilter.expressions) {
+    auto conjunct = toVeloxExpression(*expr, sources[0]->outputType());
+    if (!veloxFilter) {
+      veloxFilter = conjunct;
+    } else {
+      veloxFilter = std::make_shared<CallTypedExpr>(
+          BOOLEAN(), std::vector<TypedExprPtr>{veloxFilter, conjunct}, "and");
+    }
+  }
   return std::make_shared<FilterNode>(
-      queryContext.nextNodeId(), std::move(filter), std::move(sources[0]));
+      queryContext.nextNodeId(), std::move(veloxFilter), std::move(sources[0]));
 }
 
 PlanNodePtr toVeloxPlan(
@@ -294,6 +394,17 @@ PlanNodePtr toVeloxPlan(
       std::move(sources[0]));
 }
 
+namespace {
+std::string translateAggregateName(const std::string& name) {
+  // first(x) is used to get one element of a set. The closes Velox counterpart
+  // is arbitrary, which usually returns the first value it sees.
+  if (name == "first") {
+    return "arbitrary";
+  }
+  return name;
+}
+} // namespace
+
 PlanNodePtr toVeloxPlan(
     ::duckdb::LogicalAggregate& logicalAggregate,
     memory::MemoryPool* pool,
@@ -308,6 +419,11 @@ PlanNodePtr toVeloxPlan(
   for (auto& expression : logicalAggregate.expressions) {
     auto call = std::dynamic_pointer_cast<const CallTypedExpr>(
         toVeloxExpression(*expression, sources[0]->outputType()));
+    if (expression->return_type.InternalType() ==
+        ::duckdb::PhysicalType::INT128) {
+      call = std::make_shared<CallTypedExpr>(
+          BIGINT(), call->inputs(), call->name());
+    }
     std::vector<TypedExprPtr> fieldInputs;
     std::vector<TypePtr> rawInputTypes;
 
@@ -327,9 +443,9 @@ PlanNodePtr toVeloxPlan(
       }
     }
 
+    auto aggName = translateAggregateName(call->name());
     aggregates.push_back({
-        std::make_shared<CallTypedExpr>(
-            call->type(), fieldInputs, call->name()),
+        std::make_shared<CallTypedExpr>(call->type(), fieldInputs, aggName),
         rawInputTypes,
         nullptr, // mask
         {}, // sortingKeys
@@ -381,6 +497,33 @@ PlanNodePtr toVeloxPlan(
 }
 
 PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalOrder& logicalOrder,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VeloxColumnProjections projections(queryContext);
+  std::vector<FieldAccessTypedExprPtr> keys;
+  std::vector<SortOrder> sortOrder;
+  auto source = sources[0];
+  for (auto& order : logicalOrder.orders) {
+    keys.push_back(
+        projections.toFieldAccess(*order.expression, source->outputType()));
+    sortOrder.push_back(SortOrder(
+        order.type == ::duckdb::OrderType::ASCENDING ||
+            order.type == ::duckdb::OrderType::ORDER_DEFAULT,
+        order.null_order == ::duckdb::OrderByNullType::NULLS_FIRST ||
+            order.null_order == ::duckdb::OrderByNullType::ORDER_DEFAULT));
+  }
+
+  return std::make_shared<OrderByNode>(
+      queryContext.nextNodeId(),
+      keys,
+      sortOrder,
+      /*isPartial=*/false,
+      projections.source(source));
+}
+
+PlanNodePtr toVeloxPlan(
     ::duckdb::LogicalCrossProduct& logicalCrossProduct,
     memory::MemoryPool* pool,
     std::vector<PlanNodePtr> sources,
@@ -408,13 +551,193 @@ PlanNodePtr toVeloxPlan(
       ROW(std::move(names), std::move(types)));
 }
 
+namespace {
+std::vector<size_t> columnIndices(std::vector<idx_t> map, int32_t size) {
+  if (size > 0 && map.empty()) {
+    std::vector<size_t> result(size);
+    std::iota(result.begin(), result.end(), 0);
+    return result;
+  }
+  return map;
+}
+} // namespace
+
+PlanNodePtr toVeloxPlan(
+    ::duckdb::LogicalComparisonJoin& join,
+    memory::MemoryPool* pool,
+    std::vector<PlanNodePtr> sources,
+    QueryContext& queryContext) {
+  VELOX_CHECK_EQ(2, sources.size());
+
+  auto& leftInputType = sources[0]->outputType();
+  auto& rightInputType = sources[1]->outputType();
+
+  VeloxColumnProjections leftProjection(queryContext);
+  VeloxColumnProjections rightProjection(queryContext);
+  JoinType joinType = JoinType::kInner;
+  switch (join.join_type) {
+    case ::duckdb::JoinType::INNER:
+    case ::duckdb::JoinType::SINGLE:
+      joinType = JoinType::kInner;
+      break;
+    case ::duckdb::JoinType::LEFT:
+      joinType = JoinType::kLeft;
+      break;
+    case ::duckdb::JoinType::RIGHT:
+      joinType = JoinType::kRight;
+      break;
+    case ::duckdb::JoinType::OUTER:
+      joinType = JoinType::kFull;
+      break;
+    case ::duckdb::JoinType::SEMI:
+      joinType = JoinType::kLeftSemiFilter;
+      break;
+    case ::duckdb::JoinType::ANTI:
+      joinType = JoinType::kAnti;
+      break;
+    case ::duckdb::JoinType::MARK:
+      joinType = JoinType::kLeftSemiProject;
+      break;
+    default:
+      VELOX_NYI("Bad Duck join type {}", static_cast<int32_t>(join.join_type));
+  }
+
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i :
+       columnIndices(join.left_projection_map, leftInputType->size())) {
+    auto source = std::make_shared<core::FieldAccessTypedExpr>(
+        leftInputType->childAt(i), leftInputType->nameOf(i));
+    leftProjection.addColumn(source);
+    names.push_back(source->name());
+    types.push_back(source->type());
+  }
+  auto joinNodeId = queryContext.nextNodeId();
+  switch (joinType) {
+    case JoinType::kLeftSemiFilter:
+    case JoinType::kAnti:
+      break;
+    case JoinType::kLeftSemiProject:
+      names.push_back(fmt::format("exists{}", joinNodeId));
+      types.push_back(BOOLEAN());
+      break;
+    default:
+      for (auto i :
+           columnIndices(join.right_projection_map, rightInputType->size())) {
+        auto source = std::make_shared<core::FieldAccessTypedExpr>(
+            rightInputType->childAt(i), rightInputType->nameOf(i));
+        rightProjection.addColumn(source);
+        names.push_back(source->name());
+        types.push_back(source->type());
+      }
+  }
+  auto outputType = ROW(std::move(names), std::move(types));
+  TypedExprPtr filter;
+  if (!join.expressions.empty()) {
+    VELOX_CHECK_EQ(join.expressions.size(), 1);
+    filter = toVeloxExpression(*join.expressions.front(), outputType);
+  }
+
+  std::vector<FieldAccessTypedExprPtr> leftKeys;
+  std::vector<FieldAccessTypedExprPtr> rightKeys;
+  for (auto& condition : join.conditions) {
+    VELOX_CHECK(
+        condition.comparison == ::duckdb::ExpressionType::COMPARE_EQUAL ||
+        condition.comparison ==
+            ::duckdb::ExpressionType::COMPARE_NOT_DISTINCT_FROM);
+    leftKeys.push_back(
+        leftProjection.toFieldAccess(*condition.left, leftInputType));
+    rightKeys.push_back(
+        rightProjection.toFieldAccess(*condition.right, rightInputType));
+  }
+
+  return std::make_shared<HashJoinNode>(
+      joinNodeId,
+      joinType,
+      false,
+      std::move(leftKeys),
+      std::move(rightKeys),
+      filter,
+      leftProjection.source(sources[0]),
+      rightProjection.source(sources[1]),
+      outputType);
+}
+
+int32_t getDelimCrossRightSide(
+    ::duckdb::Expression& filter,
+    int32_t numFromDelimGet) {
+  if (filter.type != ::duckdb::ExpressionType::COMPARE_EQUAL) {
+    return -1;
+  }
+  auto& comparison =
+      reinterpret_cast<const ::duckdb::BoundComparisonExpression&>(filter);
+  auto left =
+      dynamic_cast<::duckdb::BoundReferenceExpression*>(comparison.left.get());
+  auto right =
+      dynamic_cast<::duckdb::BoundReferenceExpression*>(comparison.right.get());
+  if (left && right) {
+    if (left->index < numFromDelimGet && right->index >= numFromDelimGet) {
+      return right->index - numFromDelimGet;
+    }
+    if (left->index >= numFromDelimGet && right->index < numFromDelimGet) {
+      return left->index - numFromDelimGet;
+    }
+  }
+  return -1;
+}
+
+// Processesa filter over cross join of delim get and the table in
+// the correlated subq. Some of the filters are joining the delim
+// get and the table in the subquery. The delim get side of the
+// output must be aliases to the corresponding columns on the
+// right. This comes from some of the filters. There can be other
+// filters that pertain to the right side that will be left in
+// place.
+PlanNodePtr processDelimGetJoin(
+    const ::duckdb::LogicalFilter& filter,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext);
+
+PlanNodePtr processDelimGetJoin(
+    const ::duckdb::LogicalComparisonJoin& join,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext);
+
 PlanNodePtr toVeloxPlan(
     ::duckdb::LogicalOperator& plan,
     memory::MemoryPool* pool,
     QueryContext& queryContext) {
   std::vector<PlanNodePtr> sources;
+
+  ScopedVarSetter isDelim(
+      &queryContext.isInDelimJoin, queryContext.isInDelimJoin);
+  if (plan.type == ::duckdb::LogicalOperatorType::LOGICAL_DELIM_JOIN) {
+    queryContext.isInDelimJoin = true;
+  }
+  if (queryContext.isInDelimJoin &&
+      plan.type == ::duckdb::LogicalOperatorType::LOGICAL_FILTER) {
+    auto& filter = dynamic_cast<::duckdb::LogicalFilter&>(plan);
+    if (filter.children[0]->type ==
+            ::duckdb::LogicalOperatorType::LOGICAL_CROSS_PRODUCT &&
+        filter.children[0]->children[1]->type ==
+            ::duckdb::LogicalOperatorType::LOGICAL_DELIM_GET) {
+      return processDelimGetJoin(filter, pool, queryContext);
+    }
+  }
+  if (plan.type == ::duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
+      queryContext.isInDelimJoin &&
+      plan.children[1]->type ==
+          ::duckdb::LogicalOperatorType::LOGICAL_DELIM_GET) {
+    return processDelimGetJoin(
+        dynamic_cast<::duckdb::LogicalComparisonJoin&>(plan),
+        pool,
+        queryContext);
+  }
   for (auto& child : plan.children) {
     sources.push_back(toVeloxPlan(*child, pool, queryContext));
+    if (sources.back() == nullptr) {
+      VELOX_FAIL("null plan for: {}", child->ToString());
+    }
   }
 
   switch (plan.type) {
@@ -451,11 +774,132 @@ PlanNodePtr toVeloxPlan(
           pool,
           std::move(sources),
           queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_ORDER_BY: {
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalOrder&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    }
+    case ::duckdb::LogicalOperatorType::LOGICAL_LIMIT: {
+      auto& limit = dynamic_cast<const ::duckdb::LogicalLimit&>(plan);
+      return std::make_shared<core::LimitNode>(
+          queryContext.nextNodeId(),
+          limit.offset_val,
+          limit.limit_val,
+          false,
+          sources[0]);
+    }
+    case ::duckdb::LogicalOperatorType::LOGICAL_COMPARISON_JOIN:
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalComparisonJoin&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    case ::duckdb::LogicalOperatorType::LOGICAL_DELIM_JOIN: {
+      return toVeloxPlan(
+          dynamic_cast<::duckdb::LogicalComparisonJoin&>(plan),
+          pool,
+          std::move(sources),
+          queryContext);
+    }
+    case ::duckdb::LogicalOperatorType::LOGICAL_DELIM_GET:
+      return nullptr;
     default:
       VELOX_NYI(
           "Plan node is not supported yet: {}",
           ::duckdb::LogicalOperatorToString(plan.type));
   }
+}
+
+PlanNodePtr processDelimGetJoin(
+    const ::duckdb::LogicalFilter& filter,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  auto& cross =
+      dynamic_cast<::duckdb::LogicalCrossProduct&>(*filter.children[0]);
+  int32_t numFromDelimGet = cross.children[1]->types.size();
+  // Column index on the left side for each delim get column.
+  std::vector<int32_t> delimAlias;
+  auto right =
+      toVeloxPlan(*filter.children[0]->children[0], pool, queryContext);
+  auto rightType = right->outputType();
+  std::vector<::duckdb::Expression*> remaining;
+  for (auto& conjunct : filter.expressions) {
+    auto rightSide = getDelimCrossRightSide(*conjunct, numFromDelimGet);
+    if (rightSide >= 0) {
+      delimAlias.push_back(rightSide);
+    } else {
+      remaining.push_back(conjunct.get());
+    }
+  }
+  std::vector<std::string> names;
+  std::vector<TypedExprPtr> exprs;
+  for (auto i = 0; i < numFromDelimGet; ++i) {
+    names.push_back(queryContext.nextColumnName("_delim"));
+    auto rightIndex = delimAlias[i];
+    auto type = rightType->childAt(rightIndex);
+    exprs.push_back(std::make_shared<FieldAccessTypedExpr>(
+        type, rightType->nameOf(rightIndex)));
+  }
+  for (auto i = 0; i < rightType->size(); ++i) {
+    names.push_back(rightType->nameOf(i));
+    auto type = rightType->childAt(i);
+    exprs.push_back(std::make_shared<FieldAccessTypedExpr>(type, names.back()));
+  }
+  auto project = std::make_shared<ProjectNode>(
+      queryContext.nextNodeId(), std::move(names), std::move(exprs), right);
+  if (remaining.empty()) {
+    return project;
+  }
+  TypedExprPtr veloxFilter;
+  for (auto& expr : remaining) {
+    auto conjunct = toVeloxExpression(*expr, project->outputType());
+    if (!veloxFilter) {
+      veloxFilter = conjunct;
+    } else {
+      veloxFilter = std::make_shared<CallTypedExpr>(
+          BOOLEAN(), std::vector<TypedExprPtr>{veloxFilter, conjunct}, "and");
+    }
+  }
+  return std::make_shared<FilterNode>(
+      queryContext.nextNodeId(), veloxFilter, project);
+}
+
+PlanNodePtr processDelimGetJoin(
+    const ::duckdb::LogicalComparisonJoin& join,
+    memory::MemoryPool* pool,
+    QueryContext& queryContext) {
+  int32_t numFromDelimGet = join.children[1]->types.size();
+  // Column index on the right side for each delim get column.
+  std::vector<int32_t> delimAlias(numFromDelimGet);
+  auto right = toVeloxPlan(*join.children[0], pool, queryContext);
+  auto rightType = right->outputType();
+  for (auto& condition : join.conditions) {
+    auto left =
+        dynamic_cast<::duckdb::BoundReferenceExpression*>(condition.left.get());
+    auto right = dynamic_cast<::duckdb::BoundReferenceExpression*>(
+        condition.right.get());
+    VELOX_CHECK(left && right);
+    VELOX_CHECK_LT(left->index, numFromDelimGet);
+    delimAlias[left->index] = right->index;
+  }
+  std::vector<std::string> names;
+  std::vector<TypedExprPtr> exprs;
+  for (auto i = 0; i < numFromDelimGet; ++i) {
+    names.push_back(queryContext.nextColumnName("_delim"));
+    auto rightIndex = delimAlias[i];
+    auto type = rightType->childAt(rightIndex);
+    exprs.push_back(std::make_shared<FieldAccessTypedExpr>(
+        type, rightType->nameOf(rightIndex)));
+  }
+  for (auto i = 0; i < rightType->size(); ++i) {
+    names.push_back(rightType->nameOf(i));
+    auto type = rightType->childAt(i);
+    exprs.push_back(std::make_shared<FieldAccessTypedExpr>(type, names.back()));
+  }
+  return std::make_shared<ProjectNode>(
+      queryContext.nextNodeId(), std::move(names), std::move(exprs), right);
 }
 
 static void customScalarFunction(
@@ -519,7 +963,7 @@ void DuckDbQueryPlanner::registerTable(
     const std::string& name,
     const std::vector<RowVectorPtr>& data) {
   VELOX_CHECK_EQ(
-      0, tables_.count(name), "Table is already registered: {}", name);
+      tables_.count(name), 0, "Table is already registered: {}", name);
 
   auto createTableSql =
       duckdb::makeCreateTableSql(name, *asRowType(data[0]->type()));
@@ -528,6 +972,16 @@ void DuckDbQueryPlanner::registerTable(
       !res->HasError(), "Failed to create DuckDB table: {}", res->GetError());
 
   tables_.insert({name, data});
+}
+
+void DuckDbQueryPlanner::registerTable(
+    const std::string& name,
+    const RowTypePtr& type) {
+  VELOX_CHECK_EQ(
+      tables_.count(name), 0, "Table is already registered: {}", name);
+
+  auto createTableSql = duckdb::makeCreateTableSql(name, *type);
+  auto res = conn_.Query(createTableSql);
 }
 
 void DuckDbQueryPlanner::registerScalarFunction(
@@ -574,6 +1028,7 @@ PlanNodePtr DuckDbQueryPlanner::plan(const std::string& sql) {
   auto plan = conn_.ExtractPlan(sql);
 
   QueryContext queryContext{tables_};
+  queryContext.makeTableScan = makeTableScan_;
   return toVeloxPlan(*plan, pool_, queryContext);
 }
 


### PR DESCRIPTION
DuckDB has a lateral join (DelimJoin) that it introduces into flattened subqueries. This removes the lateral join so that we extract a logical plan that can be used as input to Verax or executed as is.

Adds a way of registering a table to the parser with a type instead of dataset.

This code is strictly a stopgap and will be removed as soon as possible.

TODO: Stop using DuckDB as parser and name resolution.