### PR TITLE
fix: Replace crash with failure in exportToArrow for constant vectors of complex type

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1436,6 +1436,11 @@ void exportToArrow(
         0, newArrowSchema("i", "run_ends"), arrowSchema);
     bridgeHolder->setChildAtIndex(1, std::move(valuesChild), arrowSchema);
   } else {
+    if (vec->encoding() == VectorEncoding::Simple::CONSTANT &&
+        options.flattenConstant) {
+      VELOX_CHECK(
+          vec->isScalar(), "Flattening is only supported for scalar types.");
+    }
     arrowSchema.format =
         exportArrowFormatStr(type, options, bridgeHolder->formatBuffer);
     arrowSchema.dictionary = nullptr;

--- a/velox/vector/arrow/Bridge.h
+++ b/velox/vector/arrow/Bridge.h
@@ -34,6 +34,7 @@ enum class TimestampUnit : uint8_t {
 
 struct ArrowOptions {
   bool flattenDictionary{false};
+  // NOTE: flattenConstant is only supported for scalar types.
   bool flattenConstant{false};
   TimestampUnit timestampUnit = TimestampUnit::kNano;
   std::optional<std::string> timestampTimeZone{std::nullopt};
@@ -69,7 +70,6 @@ namespace facebook::velox {
 ///   (use arrowArray)
 ///
 ///   arrowArray.release(&arrowArray);
-///
 void exportToArrow(
     const VectorPtr& vector,
     ArrowArray& arrowArray,

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -294,6 +294,15 @@ TEST_F(ArrowBridgeSchemaExportTest, constant) {
   testConstant(MAP(UNKNOWN(), REAL()), "+m");
   testConstant(ROW({TIMESTAMP(), DOUBLE()}), "+s");
   testConstant(ROW({UNKNOWN(), UNKNOWN()}), "+s");
+  VELOX_ASSERT_THROW(
+      testConstant(ARRAY(INTEGER()), "+l", {false, true}),
+      "Flattening is only supported for scalar types.");
+  VELOX_ASSERT_THROW(
+      testConstant(MAP(BOOLEAN(), REAL()), "+m", {false, true}),
+      "Flattening is only supported for scalar types.");
+  VELOX_ASSERT_THROW(
+      testConstant(ROW({BOOLEAN(), REAL()}), "+s", {false, true}),
+      "Flattening is only supported for scalar types.");
 }
 
 class ArrowBridgeSchemaImportTest : public ArrowBridgeSchemaExportTest {


### PR DESCRIPTION
In `exportToArrow()` method,  when the input vector is a constant vector of complex types and the `ArrowOptions.flattenConstant` is set to true, the velox will crash.
This change replaces crash with a failure: "Flattening is only supported for scalar types" .

Fixes #12066
