### PR TITLE
fix: Avoid running the fuzzer if there are no functions to fuzz

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -354,6 +354,11 @@ void ExpressionFuzzerVerifier::go() {
       0,
       "--max_expression_trees_per_step needs to be greater than zero.");
 
+  if (expressionFuzzer_.supportedFunctions().empty()) {
+    LOG(WARNING) << "No functions to fuzz.";
+    return;
+  }
+
   auto startTime = std::chrono::system_clock::now();
   size_t i = 0;
   size_t numFailed = 0;


### PR DESCRIPTION
Summary:
There are edge cases when the input to the fuzzer results in no signatures to fuzz due to combination of skipped functions and skipped input types. This causes the fuzzer to fail when it tries to generate an expression, specifically failing in `ExpressionFuzzer::fuzzReturnType()`, at VELOX_CHECK(!signatures_.empty(), "No function signature available.");. 

Instead of failing the fuzzer at fuzzing time, let's exit the fuzzer with a warning that there were no functions to even fuzz.

Differential Revision: D67153128


