### PR TITLE
feat: Support to disable dynamic filter reordering

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -403,7 +403,7 @@ class ConnectorQueryCtx {
   const config::ConfigBase* const sessionProperties_;
   const common::SpillConfig* const spillConfig_;
   const common::PrefixSortConfig prefixSortConfig_;
-  std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
+  const std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
   cache::AsyncDataCache* cache_;
   const std::string scanId_;
   const std::string queryId_;

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -123,8 +123,10 @@ bool HiveConfig::ignoreMissingFiles(const config::ConfigBase* session) const {
   return session->get<bool>(kIgnoreMissingFilesSession, false);
 }
 
-int64_t HiveConfig::maxCoalescedBytes() const {
-  return config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20); // 128MB
+int64_t HiveConfig::maxCoalescedBytes(const config::ConfigBase* session) const {
+  return session->get<int64_t>(
+      kMaxCoalescedBytesSession,
+      config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20)); // 128MB
 }
 
 int32_t HiveConfig::maxCoalescedDistanceBytes(
@@ -147,8 +149,9 @@ int32_t HiveConfig::prefetchRowGroups() const {
   return config_->get<int32_t>(kPrefetchRowGroups, 1);
 }
 
-int32_t HiveConfig::loadQuantum() const {
-  return config_->get<int32_t>(kLoadQuantum, 8 << 20);
+int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
+  return session->get<int32_t>(
+      kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));
 }
 
 int32_t HiveConfig::numCacheFileHandles() const {
@@ -281,6 +284,13 @@ uint8_t HiveConfig::readTimestampUnit(const config::ConfigBase* session) const {
       unit == 3 || unit == 6 /*micro*/ || unit == 9 /*nano*/,
       "Invalid timestamp unit.");
   return unit;
+}
+
+bool HiveConfig::readStatsBasedFilterReorderDisabled(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kReadStatsBasedFilterReorderDisabledSession,
+      config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
 }
 
 bool HiveConfig::cacheNoRetention(const config::ConfigBase* session) const {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -102,6 +102,8 @@ class HiveConfig {
 
   /// The max coalesce bytes for a request.
   static constexpr const char* kMaxCoalescedBytes = "max-coalesced-bytes";
+  static constexpr const char* kMaxCoalescedBytesSession =
+      "max-coalesced-bytes";
 
   /// The max merge distance to combine read requests.
   /// Note: The session property name differs from the constant name for
@@ -116,6 +118,7 @@ class HiveConfig {
   /// The total size in bytes for a direct coalesce request. Up to 8MB load
   /// quantum size is supported when SSD cache is enabled.
   static constexpr const char* kLoadQuantum = "load-quantum";
+  static constexpr const char* kLoadQuantumSession = "load-quantum";
 
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
@@ -206,6 +209,11 @@ class HiveConfig {
   static constexpr const char* kReadTimestampUnitSession =
       "hive.reader.timestamp_unit";
 
+  static constexpr const char* kReadStatsBasedFilterReorderDisabled =
+      "hive.reader.stats_based_filter_reorder_disabaled";
+  static constexpr const char* kReadStatsBasedFilterReorderDisabledSession =
+      "hive.reader.stats_based_filter_reorder_disabaled";
+
   static constexpr const char* kCacheNoRetention = "cache.no_retention";
   static constexpr const char* kCacheNoRetentionSession = "cache.no_retention";
   static constexpr const char* kLocalDataPath = "hive_local_data_path";
@@ -239,13 +247,13 @@ class HiveConfig {
 
   bool ignoreMissingFiles(const config::ConfigBase* session) const;
 
-  int64_t maxCoalescedBytes() const;
+  int64_t maxCoalescedBytes(const config::ConfigBase* session) const;
 
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;
 
-  int32_t loadQuantum() const;
+  int32_t loadQuantum(const config::ConfigBase* session) const;
 
   int32_t numCacheFileHandles() const;
 
@@ -293,6 +301,10 @@ class HiveConfig {
 
   // Returns the timestamp unit used when reading timestamps from files.
   uint8_t readTimestampUnit(const config::ConfigBase* session) const;
+
+  /// Returns true if the stats based filter reorder for read is disabled.
+  bool readStatsBasedFilterReorderDisabled(
+      const config::ConfigBase* session) const;
 
   /// Returns true to evict out a query scanned data out of in-memory cache
   /// right after the access, and also skip staging to the ssd cache. This helps

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -60,6 +60,7 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
         infoColumns,
     const SpecialColumnNames& specialColumns,
+    bool disableStatsBasedFilterReorder,
     memory::MemoryPool* pool);
 
 void configureReaderOptions(

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -195,6 +195,8 @@ HiveDataSource::HiveDataSource(
       partitionKeys_,
       infoColumns_,
       specialColumns_,
+      hiveConfig_->readStatsBasedFilterReorderDisabled(
+          connectorQueryCtx_->sessionProperties()),
       pool_);
   if (remainingFilter) {
     metadataFilter_ = std::make_shared<common::MetadataFilter>(
@@ -260,6 +262,8 @@ std::unique_ptr<HivePartitionFunction> HiveDataSource::setupBucketConversion() {
         partitionKeys_,
         infoColumns_,
         specialColumns_,
+        hiveConfig_->readStatsBasedFilterReorderDisabled(
+            connectorQueryCtx_->sessionProperties()),
         pool_);
     newScanSpec->moveAdaptationFrom(*scanSpec_);
     scanSpec_ = std::move(newScanSpec);

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -35,15 +35,16 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.immutablePartitions(), false);
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
-  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), false);
-  ASSERT_EQ(
-      hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()), false);
+  ASSERT_FALSE(hiveConfig.isOrcUseColumnNames(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()));
 
-  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 128 << 20);
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(emptySession.get()), 128 << 20);
   ASSERT_EQ(
       hiveConfig.maxCoalescedDistanceBytes(emptySession.get()), 512 << 10);
+  ASSERT_FALSE(
+      hiveConfig.readStatsBasedFilterReorderDisabled(emptySession.get()));
   ASSERT_EQ(hiveConfig.numCacheFileHandles(), 20'000);
-  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), true);
+  ASSERT_TRUE(hiveConfig.isFileHandleCacheEnabled());
   ASSERT_EQ(
       hiveConfig.orcWriterMaxStripeSize(emptySession.get()),
       64L * 1024L * 1024L);
@@ -62,14 +63,15 @@ TEST(HiveConfigTest, defaultConfig) {
       hiveConfig.sortWriterMaxOutputBytes(emptySession.get()), 10UL << 20);
   ASSERT_EQ(
       hiveConfig.sortWriterFinishTimeSliceLimitMs(emptySession.get()), 5'000);
-  ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(emptySession.get()), true);
-  ASSERT_EQ(hiveConfig.allowNullPartitionKeys(emptySession.get()), true);
+  ASSERT_TRUE(hiveConfig.isPartitionPathAsLowerCase(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.allowNullPartitionKeys(emptySession.get()));
   ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(emptySession.get()), 1024);
   ASSERT_EQ(
       hiveConfig.orcWriterCompressionLevel(emptySession.get()), std::nullopt);
-  ASSERT_EQ(
-      hiveConfig.orcWriterLinearStripeSizeHeuristics(emptySession.get()), true);
+  ASSERT_TRUE(
+      hiveConfig.orcWriterLinearStripeSizeHeuristics(emptySession.get()));
   ASSERT_FALSE(hiveConfig.cacheNoRetention(emptySession.get()));
+  ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -96,7 +98,9 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristics, "false"},
       {HiveConfig::kOrcWriterMinCompressionSize, "512"},
       {HiveConfig::kOrcWriterCompressionLevel, "1"},
-      {HiveConfig::kCacheNoRetention, "true"}};
+      {HiveConfig::kCacheNoRetention, "true"},
+      {HiveConfig::kReadStatsBasedFilterReorderDisabled, "true"},
+      {HiveConfig::kLoadQuantum, std::to_string(4 << 20)}};
   HiveConfig hiveConfig(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   auto emptySession = std::make_shared<config::ConfigBase>(
@@ -106,18 +110,17 @@ TEST(HiveConfigTest, overrideConfig) {
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
   ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 120);
-  ASSERT_EQ(hiveConfig.immutablePartitions(), true);
+  ASSERT_TRUE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "hey");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "hey");
-  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(emptySession.get()), true);
-  ASSERT_EQ(
-      hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()), true);
-  ASSERT_EQ(hiveConfig.allowNullPartitionKeys(emptySession.get()), false);
-  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 100);
+  ASSERT_TRUE(hiveConfig.isOrcUseColumnNames(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.isFileColumnNamesReadAsLowerCase(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.allowNullPartitionKeys(emptySession.get()));
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(emptySession.get()), 100);
   ASSERT_EQ(
       hiveConfig.maxCoalescedDistanceBytes(emptySession.get()), 100 << 10);
   ASSERT_EQ(hiveConfig.numCacheFileHandles(), 100);
-  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), false);
+  ASSERT_FALSE(hiveConfig.isFileHandleCacheEnabled());
   ASSERT_EQ(
       hiveConfig.orcWriterMaxStripeSize(emptySession.get()),
       100L * 1024L * 1024L);
@@ -142,6 +145,9 @@ TEST(HiveConfigTest, overrideConfig) {
       hiveConfig.orcWriterLinearStripeSizeHeuristics(emptySession.get()),
       false);
   ASSERT_TRUE(hiveConfig.cacheNoRetention(emptySession.get()));
+  ASSERT_TRUE(
+      hiveConfig.readStatsBasedFilterReorderDisabled(emptySession.get()));
+  ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 4 << 20);
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -165,7 +171,9 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kOrcWriterMinCompressionSizeSession, "512"},
       {HiveConfig::kOrcWriterCompressionLevelSession, "1"},
       {HiveConfig::kOrcWriterLinearStripeSizeHeuristicsSession, "false"},
-      {HiveConfig::kCacheNoRetentionSession, "true"}};
+      {HiveConfig::kCacheNoRetentionSession, "true"},
+      {HiveConfig::kReadStatsBasedFilterReorderDisabledSession, "true"},
+      {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)}};
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
   ASSERT_EQ(
@@ -173,36 +181,35 @@ TEST(HiveConfigTest, overrideSession) {
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
   ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(session.get()), 128);
-  ASSERT_EQ(hiveConfig.immutablePartitions(), false);
+  ASSERT_FALSE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
-  ASSERT_EQ(hiveConfig.isOrcUseColumnNames(session.get()), true);
-  ASSERT_EQ(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()), true);
+  ASSERT_TRUE(hiveConfig.isOrcUseColumnNames(session.get()));
+  ASSERT_TRUE(hiveConfig.isFileColumnNamesReadAsLowerCase(session.get()));
 
-  ASSERT_EQ(hiveConfig.maxCoalescedBytes(), 128 << 20);
+  ASSERT_EQ(hiveConfig.maxCoalescedBytes(session.get()), 128 << 20);
   ASSERT_EQ(hiveConfig.maxCoalescedDistanceBytes(session.get()), 3 << 20);
   ASSERT_EQ(hiveConfig.numCacheFileHandles(), 20'000);
-  ASSERT_EQ(hiveConfig.isFileHandleCacheEnabled(), true);
+  ASSERT_TRUE(hiveConfig.isFileHandleCacheEnabled());
   ASSERT_EQ(
       hiveConfig.orcWriterMaxStripeSize(session.get()), 22L * 1024L * 1024L);
   ASSERT_EQ(
       hiveConfig.orcWriterMaxDictionaryMemory(session.get()),
       22L * 1024L * 1024L);
-  ASSERT_EQ(
-      hiveConfig.isOrcWriterIntegerDictionaryEncodingEnabled(session.get()),
-      false);
-  ASSERT_EQ(
-      hiveConfig.isOrcWriterStringDictionaryEncodingEnabled(session.get()),
-      false);
+  ASSERT_FALSE(
+      hiveConfig.isOrcWriterIntegerDictionaryEncodingEnabled(session.get()));
+  ASSERT_FALSE(
+      hiveConfig.isOrcWriterStringDictionaryEncodingEnabled(session.get()));
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(session.get()), 20);
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputBytes(session.get()), 20UL << 20);
   ASSERT_EQ(hiveConfig.sortWriterFinishTimeSliceLimitMs(session.get()), 300);
-  ASSERT_EQ(hiveConfig.isPartitionPathAsLowerCase(session.get()), false);
-  ASSERT_EQ(hiveConfig.allowNullPartitionKeys(session.get()), false);
-  ASSERT_EQ(hiveConfig.ignoreMissingFiles(session.get()), true);
-  ASSERT_EQ(
-      hiveConfig.orcWriterLinearStripeSizeHeuristics(session.get()), false);
+  ASSERT_FALSE(hiveConfig.isPartitionPathAsLowerCase(session.get()));
+  ASSERT_FALSE(hiveConfig.allowNullPartitionKeys(session.get()));
+  ASSERT_TRUE(hiveConfig.ignoreMissingFiles(session.get()));
+  ASSERT_FALSE(hiveConfig.orcWriterLinearStripeSizeHeuristics(session.get()));
   ASSERT_EQ(hiveConfig.orcWriterMinCompressionSize(session.get()), 512);
   ASSERT_EQ(hiveConfig.orcWriterCompressionLevel(session.get()), 1);
   ASSERT_TRUE(hiveConfig.cacheNoRetention(session.get()));
+  ASSERT_TRUE(hiveConfig.readStatsBasedFilterReorderDisabled(session.get()));
+  ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
 }

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -130,8 +130,11 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   performConfigure();
   EXPECT_EQ(readerOptions.fileFormat(), fileFormat);
   EXPECT_TRUE(compareSerDeOptions(readerOptions.serDeOptions(), expectedSerDe));
-  EXPECT_EQ(readerOptions.loadQuantum(), hiveConfig->loadQuantum());
-  EXPECT_EQ(readerOptions.maxCoalesceBytes(), hiveConfig->maxCoalescedBytes());
+  EXPECT_EQ(
+      readerOptions.loadQuantum(), hiveConfig->loadQuantum(&sessionProperties));
+  EXPECT_EQ(
+      readerOptions.maxCoalesceBytes(),
+      hiveConfig->maxCoalescedBytes(&sessionProperties));
   EXPECT_EQ(
       readerOptions.maxCoalesceDistance(),
       hiveConfig->maxCoalescedDistanceBytes(&sessionProperties));
@@ -237,8 +240,11 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   hiveConfig = std::make_shared<hive::HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(customHiveConfigProps)));
   performConfigure();
-  EXPECT_EQ(readerOptions.loadQuantum(), hiveConfig->loadQuantum());
-  EXPECT_EQ(readerOptions.maxCoalesceBytes(), hiveConfig->maxCoalescedBytes());
+  EXPECT_EQ(
+      readerOptions.loadQuantum(), hiveConfig->loadQuantum(&sessionProperties));
+  EXPECT_EQ(
+      readerOptions.maxCoalesceBytes(),
+      hiveConfig->maxCoalescedBytes(&sessionProperties));
   EXPECT_EQ(
       readerOptions.maxCoalesceDistance(),
       hiveConfig->maxCoalescedDistanceBytes(&sessionProperties));

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -526,7 +526,7 @@ Each query can override the config by setting corresponding query session proper
      - 512KB
      - Maximum distance in capacity units between chunks to be fetched that may be coalesced into a single request.
    * - load-quantum
-     -
+     - load-quantum
      - integer
      - 8MB
      - Define the size of each coalesce load request. E.g. in Parquet scan, if it's bigger than rowgroup size then the whole row group can be fetched together. Otherwise, the row group will be fetched column chunk by column chunk
@@ -613,7 +613,14 @@ Each query can override the config by setting corresponding query session proper
        and also skip staging to the ssd cache. This helps to prevent the cache space pollution
        from the one-time table scan by large batch query when mixed running with interactive
        query which has high data locality.
-
+   * - hive.reader.stats_based_filter_reorder_disabaled
+     - hive.reader.stats_based_filter_reorder_disabaled
+     - bool
+     - false
+     - If true, disable the stats based filter reordering during the read processing, and the
+       filter execution order is totally determined by the filter type. Otherwise, the file
+       reader will dynamically adjust the filter execution order based on the past filter
+       execution stats.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -19,10 +19,7 @@
 #include "velox/common/process/TraceContext.h"
 #include "velox/dwio/common/CacheInputStream.h"
 
-DEFINE_int32(
-    cache_prefetch_min_pct,
-    80,
-    "Minimum percentage of actual uses over references to a column for prefetching. No prefetch if > 100");
+DECLARE_int32(cache_prefetch_min_pct);
 
 using ::facebook::velox::common::Region;
 
@@ -189,6 +186,7 @@ void CachedBufferedInput::load(const LogType /*unused*/) {
       storageLoad[loadIndex].push_back(part);
     }
   }
+
   makeLoads(std::move(storageLoad[1]), true);
   makeLoads(std::move(ssdLoad[1]), true);
   makeLoads(std::move(storageLoad[0]), false);

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -370,14 +370,28 @@ class ScanSpec {
     isFlatMapAsStruct_ = value;
   }
 
+  /// Disable stats based filter reordering.
+  void disableStatsBasedFilterReorder() {
+    disableStatsBasedFilterReorder_ = true;
+    for (auto& child : children_) {
+      child->disableStatsBasedFilterReorder();
+    }
+  }
+
+  bool statsBasedFilterReorderDisabled() const {
+    return disableStatsBasedFilterReorder_;
+  }
+
  private:
   void reorder();
 
   void enableFilterInSubTree(bool value);
 
-  static bool compareTimeToDropValue(
+  bool compareTimeToDropValue(
       const std::shared_ptr<ScanSpec>& x,
       const std::shared_ptr<ScanSpec>& y);
+
+  bool disableStatsBasedFilterReorder_{false};
 
   // Serializes stableChildren().
   std::mutex mutex_;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -100,3 +100,8 @@ DEFINE_bool(
     "exception. This is only used by test to control the test error output size");
 
 DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");
+
+DEFINE_int32(
+    cache_prefetch_min_pct,
+    80,
+    "Minimum percentage of actual uses over references to a column for prefetching. No prefetch if > 100");


### PR DESCRIPTION
Summary:
Add config to disable dynamic filter reordering to see if it can help reduce io in favor of small query execution
if io wait could take significant amount when having local ssd. The static reordering solely based on the filter kind.
This should only be used in specific case as dynamic filter reordering is an important scan optimization.

Differential Revision: D67542368
