### PR TITLE
feat: Add Spark json_array_length function

### DIFF
--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -33,6 +33,15 @@ JSON Functions
         SELECT get_json_object('{"a"-3}'', '$.a'); -- NULL (malformed JSON string)
         SELECT get_json_object('{"a":3}'', '.a'); -- NULL (malformed JSON path)
 
+.. spark:function:: json_array_length(jsonString) -> integer
+
+    Returns the number of elements in the outermost JSON array from ``jsonString``.
+    If ``jsonString`` is not a valid JSON array or NULL, the function returns null. ::
+
+        SELECT json_array_length('[1,2,3,4]'); -- 4
+        SELECT json_array_length('[1,2,3,{"f1":1,"f2":[5,6]},4]'); -- 5
+        SELECT json_array_length('[1,2'); -- NULL
+
 .. spark:function:: json_object_keys(jsonString) -> array(string)
 
     Returns all the keys of the outermost JSON object as an array if a valid JSON object is given.
@@ -44,12 +53,3 @@ JSON Functions
         SELECT json_object_keys(''); -- NULL
         SELECT json_object_keys(1); -- NULL
         SELECT json_object_keys('"hello"'); -- NULL
-
-.. spark:function:: json_array_length(jsonString) -> integer
-
-    Returns the number of elements in the outermost JSON array.
-    If jsonArray is not a valid JSON string or NULL, the function returns null. ::
-
-        SELECT json_array_length('[1,2,3,4]'); -- 4
-        SELECT json_array_length('[1,2,3,{"f1":1,"f2":[5,6]},4]'); -- 5
-        SELECT json_array_length('[1,2'); -- NULL

--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -44,3 +44,12 @@ JSON Functions
         SELECT json_object_keys(''); -- NULL
         SELECT json_object_keys(1); -- NULL
         SELECT json_object_keys('"hello"'); -- NULL
+
+.. spark:function:: json_array_length(jsonString) -> integer
+
+    Returns the number of elements in the outermost JSON array.
+    If jsonArray is not a valid JSON string or NULL, the function returns null. ::
+
+        SELECT json_array_length('[1,2,3,4]'); -- 4
+        SELECT json_array_length('[1,2,3,{"f1":1,"f2":[5,6]},4]'); -- 5
+        SELECT json_array_length('[1,2'); -- NULL

--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -36,7 +36,7 @@ JSON Functions
 .. spark:function:: json_array_length(jsonString) -> integer
 
     Returns the number of elements in the outermost JSON array from ``jsonString``.
-    If ``jsonString`` is not a valid JSON array or NULL, the function returns null. ::
+    If ``jsonString`` is not a valid JSON array or NULL, the function returns NULL. ::
 
         SELECT json_array_length('[1,2,3,4]'); -- 4
         SELECT json_array_length('[1,2,3,{"f1":1,"f2":[5,6]},4]'); -- 5

--- a/velox/functions/lib/JsonArrayLength.h
+++ b/velox/functions/lib/JsonArrayLength.h
@@ -17,14 +17,19 @@
 #pragma once
 
 #include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/json/JsonPathTokenizer.h"
+#include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
+#include "velox/functions/prestosql/json/SIMDJsonWrapper.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 
-namespace facebook::velox::functions::sparksql {
+namespace facebook::velox::functions {
 
 template <typename T>
 struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int32_t& len, const arg_type<Varchar>& json) {
+  template <typename TOUTPUT>
+  FOLLY_ALWAYS_INLINE bool call(TOUTPUT& len, const arg_type<Json>& json) {
     simdjson::ondemand::document jsonDoc;
 
     simdjson::padded_string paddedJson(json.data(), json.size());
@@ -48,5 +53,5 @@ struct JsonArrayLengthFunction {
     return true;
   }
 };
-}  // namespace facebook::velox::functions::sparksql
+}  // namespace facebook::velox::functions
 

--- a/velox/functions/lib/JsonArrayLength.h
+++ b/velox/functions/lib/JsonArrayLength.h
@@ -28,9 +28,10 @@ namespace facebook::velox::functions {
 ///
 /// Returns the array length of json if a valid json string is given.
 /// Returns null if the input json string is invalid.
-/// It is used both in SparkSQL and Presto, See documentation at
-/// Presto: https://prestodb.io/docs/current/functions/json.html#json_array_length-json-bigint
-/// SparkSQL: https://spark.apache.org/docs/latest/api/sql/index.html#json_array_length
+/// Presto:
+/// https://prestodb.io/docs/current/functions/json.html#json_array_length-json-bigint
+/// SparkSQL:
+/// https://spark.apache.org/docs/latest/api/sql/index.html#json_array_length
 template <typename T>
 struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -56,14 +57,15 @@ struct JsonArrayLengthFunction {
       return false;
     }
 
-    VELOX_USER_CHECK(numElements <= std::numeric_limits<TOutput>::max(),
-      "The json array length {} is bigger than the max value of output type {}.",
-      numElements,
-      std::numeric_limits<TOutput>::max());
+    VELOX_USER_CHECK_LE(
+        numElements,
+        std::numeric_limits<TOutput>::max(),
+        "The json array length {} is bigger than the max value of output type {}.",
+        numElements,
+        std::numeric_limits<TOutput>::max());
 
     len = numElements;
     return true;
   }
 };
-}  // namespace facebook::velox::functions
-
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/JsonArrayLength.h
+++ b/velox/functions/lib/JsonArrayLength.h
@@ -56,6 +56,11 @@ struct JsonArrayLengthFunction {
       return false;
     }
 
+    VELOX_USER_CHECK(numElements <= std::numeric_limits<TOutput>::max(),
+      "The json array length {} is bigger than the max value of output type {}.",
+      numElements,
+      std::numeric_limits<TOutput>::max());
+
     len = numElements;
     return true;
   }

--- a/velox/functions/lib/JsonArrayLength.h
+++ b/velox/functions/lib/JsonArrayLength.h
@@ -26,8 +26,8 @@ namespace facebook::velox::functions {
 
 /// json_array_length(jsonString) -> length
 ///
-/// Returns the array length of json if a valid json string is given.
-/// Returns null if the input json string is invalid.
+/// Returns the number of elements in the outermost JSON array from jsonString.
+/// If jsonString is not a valid JSON array or NULL, the function returns null.
 /// Presto:
 /// https://prestodb.io/docs/current/functions/json.html#json_array_length-json-bigint
 /// SparkSQL:

--- a/velox/functions/lib/JsonArrayLength.h
+++ b/velox/functions/lib/JsonArrayLength.h
@@ -24,12 +24,19 @@
 
 namespace facebook::velox::functions {
 
+/// json_array_length(jsonString) -> length
+///
+/// Returns the array length of json if a valid json string is given.
+/// Returns null if the input json string is invalid.
+/// It is used both in SparkSQL and Presto, See documentation at
+/// Presto: https://prestodb.io/docs/current/functions/json.html#json_array_length-json-bigint
+/// SparkSQL: https://spark.apache.org/docs/latest/api/sql/index.html#json_array_length
 template <typename T>
 struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  template <typename TOUTPUT>
-  FOLLY_ALWAYS_INLINE bool call(TOUTPUT& len, const arg_type<Json>& json) {
+  template <typename TOutput>
+  FOLLY_ALWAYS_INLINE bool call(TOutput& len, const arg_type<Json>& json) {
     simdjson::ondemand::document jsonDoc;
 
     simdjson::padded_string paddedJson(json.data(), json.size());

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -124,35 +124,6 @@ struct JsonArrayContainsFunction {
   }
 };
 
-template <typename T>
-struct JsonArrayLengthFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  FOLLY_ALWAYS_INLINE bool call(int64_t& len, const arg_type<Json>& json) {
-    simdjson::ondemand::document jsonDoc;
-
-    simdjson::padded_string paddedJson(json.data(), json.size());
-    if (simdjsonParse(paddedJson).get(jsonDoc)) {
-      return false;
-    }
-    if (jsonDoc.type().error()) {
-      return false;
-    }
-
-    if (jsonDoc.type() != simdjson::ondemand::json_type::array) {
-      return false;
-    }
-
-    size_t numElements;
-    if (jsonDoc.count_elements().get(numElements)) {
-      return false;
-    }
-
-    len = numElements;
-    return true;
-  }
-};
-
 template <typename TExec>
 struct JsonArrayGetFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -21,6 +21,7 @@
 #include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/lib/JsonArrayLength.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/json/JsonExtractor.h"
 #include "velox/functions/prestosql/types/JsonType.h"

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -20,8 +20,8 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
-#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/lib/JsonArrayLength.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/json/JsonExtractor.h"
 #include "velox/functions/prestosql/types/JsonType.h"

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/Registerer.h"
+#include "velox/functions/lib/JsonArrayLength.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/sparksql/JsonArrayLength.h
+++ b/velox/functions/sparksql/JsonArrayLength.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "velox/functions/Macros.h"
-#include "velox/functions/prestosql/types/JsonType.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -25,7 +24,7 @@ template <typename T>
 struct JsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int32_t& len, const arg_type<Json>& json) {
+  FOLLY_ALWAYS_INLINE bool call(int32_t& len, const arg_type<Varchar>& json) {
     simdjson::ondemand::document jsonDoc;
 
     simdjson::padded_string paddedJson(json.data(), json.size());

--- a/velox/functions/sparksql/JsonArrayLength.h
+++ b/velox/functions/sparksql/JsonArrayLength.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::functions::sparksql {
+
+template <typename T>
+struct JsonArrayLengthFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(int32_t& len, const arg_type<Json>& json) {
+    simdjson::ondemand::document jsonDoc;
+
+    simdjson::padded_string paddedJson(json.data(), json.size());
+    if (simdjsonParse(paddedJson).get(jsonDoc)) {
+      return false;
+    }
+    if (jsonDoc.type().error()) {
+      return false;
+    }
+
+    if (jsonDoc.type() != simdjson::ondemand::json_type::array) {
+      return false;
+    }
+
+    size_t numElements;
+    if (jsonDoc.count_elements().get(numElements)) {
+      return false;
+    }
+
+    len = numElements;
+    return true;
+  }
+};
+}  // namespace facebook::velox::functions::sparksql
+

--- a/velox/functions/sparksql/registration/RegisterJson.cpp
+++ b/velox/functions/sparksql/registration/RegisterJson.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/sparksql/GetJsonObject.h"
+#include "velox/functions/sparksql/JsonArrayLength.h"
 #include "velox/functions/sparksql/JsonObjectKeys.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -24,6 +25,8 @@ void registerJsonFunctions(const std::string& prefix) {
       {prefix + "get_json_object"});
   registerFunction<JsonObjectKeysFunction, Array<Varchar>, Varchar>(
       {prefix + "json_object_keys"});
+  registerFunction<JsonArrayLengthFunction, int32_t, Varchar>(
+      {prefix + "json_array_length"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterJson.cpp
+++ b/velox/functions/sparksql/registration/RegisterJson.cpp
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "velox/functions/lib/JsonArrayLength.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/sparksql/GetJsonObject.h"
-#include "velox/functions/sparksql/JsonArrayLength.h"
 #include "velox/functions/sparksql/JsonObjectKeys.h"
 
 namespace facebook::velox::functions::sparksql {

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(
   GetJsonObjectTest.cpp
   HashTest.cpp
   InTest.cpp
+  JsonArrayLengthTest.cpp
   JsonObjectKeysTest.cpp
   LeastGreatestTest.cpp
   MakeDecimalTest.cpp

--- a/velox/functions/sparksql/tests/JsonArrayLengthTest.cpp
+++ b/velox/functions/sparksql/tests/JsonArrayLengthTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class JsonArrayLengthTest : public SparkFunctionBaseTest {
+ protected:
+  VectorPtr jsonArrayLength(const std::string& json) {
+    auto varcharVector = makeFlatVector<std::string>({json});
+    return evaluate("json_array_length(c0)", makeRowVector({varcharVector}));
+  }
+};
+
+TEST_F(JsonArrayLengthTest, basic) {
+  auto expected = makeConstant<int32_t>(4, 1);
+  assertEqualVectors(expected, jsonArrayLength(R"([1,2,3,4])"));
+
+  expected = makeConstant<int32_t>(5, 1);
+  assertEqualVectors(expected, jsonArrayLength(R"([1,2,3,{"f1":1,"f2":[5,6]},4])"));
+
+  expected = makeNullConstant(TypeKind::INTEGER, 1);
+  assertEqualVectors(expected, jsonArrayLength(R"([1,2)"));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
The 'json_array_length' functions of Presto and Spark are similar, however 
Presto returns int64_t, while Spark returns int32_t. In this PR, the 
'JsonArrayLengthFunction' implementation is extracted to 'velox/functions/lib' 
and registered with differenct return types for Presto and Spark.

Spark doc: https://spark.apache.org/docs/latest/api/sql/#json_array_length