### PR TITLE
feat: Register Spark array_join function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -71,7 +71,7 @@ Array Functions
     Concatenates the elements of the given array using the ``delimiter`` and an optional string to replace nulls.
     If no value is set for ``nullReplacement``, any null value is filtered. ::
 
-        SELECT array_join(array('1', '2', '3'), ','') -- '1,2,3'
+        SELECT array_join(array('1', '2', '3'), ',') -- '1,2,3'
         SELECT array_join(array('1', NULL, '2'), ',') -- '1,2'
         SELECT array_join(array('1', NULL, '2'), ',', '0') -- '1,0,2'
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -66,6 +66,15 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
+.. function:: array_join(x, delimiter, null_replacement) -> varchar
+
+    Concatenates the elements of the given array using the delimiter and an optional string to replace nulls.
+    If no value is set for nullReplacement, any null value is filtered. ::
+
+        SELECT array_join(ARRAY ["1", "2", "3"], ",") -- "1,2,3"
+        SELECT array_join(ARRAY ["1", NULL, "2"], ",") -- "1,2"
+        SELECT array_join(ARRAY ["1", NULL, "2"], ",", "0") -- "1,0,2"
+
 .. spark:function:: array_max(array(E)) -> E
 
     Returns maximum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -66,10 +66,10 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
-.. function:: array_join(x, delimiter, null_replacement) -> varchar
+.. function:: array_join(x, delimiter, nullReplacement) -> varchar
 
-    Concatenates the elements of the given array using the delimiter and an optional string to replace nulls.
-    If no value is set for nullReplacement, any null value is filtered. ::
+    Concatenates the elements of the given array using the ``delimiter`` and an optional string to replace nulls.
+    If no value is set for ``nullReplacement``, any null value is filtered. ::
 
         SELECT array_join(ARRAY ["1", "2", "3"], ",") -- "1,2,3"
         SELECT array_join(ARRAY ["1", NULL, "2"], ",") -- "1,2"

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -71,9 +71,9 @@ Array Functions
     Concatenates the elements of the given array using the ``delimiter`` and an optional string to replace nulls.
     If no value is set for ``nullReplacement``, any null value is filtered. ::
 
-        SELECT array_join(array("1", "2", "3"), ",") -- "1,2,3"
-        SELECT array_join(array("1", NULL, "2"), ",") -- "1,2"
-        SELECT array_join(array("1", NULL, "2"), ",", "0") -- "1,0,2"
+        SELECT array_join(array('1', '2', '3'), ','') -- '1,2,3'
+        SELECT array_join(array('1', NULL, '2'), ',') -- '1,2'
+        SELECT array_join(array('1', NULL, '2'), ',', '0') -- '1,0,2'
 
 .. spark:function:: array_max(array(E)) -> E
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -66,14 +66,14 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
-.. function:: array_join(x, delimiter, nullReplacement) -> varchar
+.. spark:function:: array_join(x, delimiter[, nullReplacement]) -> varchar
 
     Concatenates the elements of the given array using the ``delimiter`` and an optional string to replace nulls.
     If no value is set for ``nullReplacement``, any null value is filtered. ::
 
-        SELECT array_join(ARRAY ["1", "2", "3"], ",") -- "1,2,3"
-        SELECT array_join(ARRAY ["1", NULL, "2"], ",") -- "1,2"
-        SELECT array_join(ARRAY ["1", NULL, "2"], ",", "0") -- "1,0,2"
+        SELECT array_join(array("1", "2", "3"), ",") -- "1,2,3"
+        SELECT array_join(array("1", NULL, "2"), ",") -- "1,2"
+        SELECT array_join(array("1", NULL, "2"), ",", "0") -- "1,0,2"
 
 .. spark:function:: array_max(array(E)) -> E
 

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -47,6 +47,21 @@ void registerSparkArrayFunctions(const std::string& prefix) {
 
 namespace sparksql {
 
+inline void registerArrayJoinFunctions(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<ArrayJoinFunction, Varchar>,
+      Varchar,
+      Array<Varchar>,
+      Varchar>({prefix + "array_join"});
+
+  registerFunction<
+      ParameterBinder<ArrayJoinFunction, Varchar>,
+      Varchar,
+      Array<Varchar>,
+      Varchar,
+      Varchar>({prefix + "array_join"});
+}
+
 template <typename T>
 inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerFunction<ArrayMinFunction, T, Array<T>>({prefix + "array_min"});
@@ -94,6 +109,7 @@ inline void registerArrayRemoveFunctions(const std::string& prefix) {
 }
 
 void registerArrayFunctions(const std::string& prefix) {
+  registerArrayJoinFunctions(prefix);
   registerArrayMinMaxFunctions(prefix);
   registerArrayRemoveFunctions(prefix);
   registerSparkArrayFunctions(prefix);


### PR DESCRIPTION
Gluten removed the registration of Presto sql functions. This PR registers 
Presto array_join function in Spark for reuse.

https://github.com/apache/incubator-gluten/pull/2705
