### PR TITLE
fix(parquet): Get sessionTimezone from QueryConfig

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -780,14 +780,10 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
         insertTableHandle_->serdeParameters().end());
   }
 
-  options->processConfigs(*hiveConfig_->config(), *connectorSessionProperties);
-
-  const auto& sessionTimeZoneName = connectorQueryCtx_->sessionTimezone();
-  if (!sessionTimeZoneName.empty()) {
-    options->sessionTimezone = tz::locateZone(sessionTimeZoneName);
-  }
+  options->sessionTimezoneName = connectorQueryCtx_->sessionTimezone();
   options->adjustTimestampToTimezone =
       connectorQueryCtx_->adjustTimestampToTimezone();
+  options->processConfigs(*hiveConfig_->config(), *connectorSessionProperties);
 
   // Prevents the memory allocation during the writer creation.
   WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerInfo_.size() - 1);

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -636,7 +636,7 @@ struct WriterOptions {
   std::function<std::unique_ptr<dwio::common::FlushPolicy>()>
       flushPolicyFactory;
 
-  const tz::TimeZone* sessionTimezone{nullptr};
+  std::string sessionTimezoneName;
   bool adjustTimestampToTimezone{false};
 
   // WriterOption implementations can implement this function to specify how to

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -264,6 +264,8 @@ Writer::Writer(
       static_cast<TimestampUnit>(options.parquetWriteTimestampUnit.value_or(
           TimestampPrecision::kNanoseconds));
   options_.timestampTimeZone = options.parquetWriteTimestampTimeZone;
+  common::testutil::TestValue::adjust(
+      "facebook::velox::parquet::Writer::Writer", &options_);
   arrowContext_->properties =
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();
@@ -463,12 +465,7 @@ void WriterOptions::processConfigs(
         : getTimestampUnit(connectorConfig, kParquetSessionWriteTimestampUnit);
   }
   if (!parquetWriteTimestampTimeZone) {
-    parquetWriteTimestampTimeZone =
-        getTimestampTimeZone(session, core::QueryConfig::kSessionTimezone)
-            .has_value()
-        ? getTimestampTimeZone(session, core::QueryConfig::kSessionTimezone)
-        : getTimestampTimeZone(
-              connectorConfig, core::QueryConfig::kSessionTimezone);
+    parquetWriteTimestampTimeZone = parquetWriterOptions->sessionTimezoneName;
   }
 }
 


### PR DESCRIPTION
Session timezone is in 'QueryConfig' and cannot be accessed through 
'sessionProperties' and 'hiveConfig'. This PR retrieves the session timezone 
from the connector query context which stores the 'sessionTimezone' of the 
query config in driver context.