### PR TITLE
fix: Returns null for invalid inputs in Spark make_date function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -139,7 +139,7 @@ These functions support TIMESTAMP and DATE input types.
 
     Returns the date from year, month and day fields.
     ``year``, ``month`` and ``day`` must be ``INTEGER``.
-    Throws an error if inputs are not valid.
+    Returns NULL if inputs are not valid. (ANSI mode is off by default.)
 
     The valid inputs need to meet the following conditions,
     ``month`` need to be from 1 (January) to 12 (December).

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -139,7 +139,7 @@ These functions support TIMESTAMP and DATE input types.
 
     Returns the date from year, month and day fields.
     ``year``, ``month`` and ``day`` must be ``INTEGER``.
-    Returns NULL if inputs are not valid. (ANSI mode is off by default.)
+    Returns NULL if inputs are not valid.
 
     The valid inputs need to meet the following conditions,
     ``month`` need to be from 1 (January) to 12 (December).

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -449,25 +449,21 @@ template <typename T>
 struct MakeDateFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(
+  FOLLY_ALWAYS_INLINE bool call(
       out_type<Date>& result,
       const int32_t year,
       const int32_t month,
       const int32_t day) {
     Expected<int64_t> expected = util::daysSinceEpochFromDate(year, month, day);
     if (expected.hasError()) {
-      VELOX_DCHECK(expected.error().isUserError());
-      VELOX_USER_FAIL(expected.error().message());
+      return false;
     }
     int64_t daysSinceEpoch = expected.value();
-    VELOX_USER_CHECK_EQ(
-        daysSinceEpoch,
-        (int32_t)daysSinceEpoch,
-        "Integer overflow in make_date({}, {}, {})",
-        year,
-        month,
-        day);
+    if (daysSinceEpoch != (int32_t)daysSinceEpoch) {
+      return false;
+    }
     result = daysSinceEpoch;
+    return true;
   }
 };
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -459,7 +459,7 @@ struct MakeDateFunction {
       return false;
     }
     int64_t daysSinceEpoch = expected.value();
-    if (daysSinceEpoch != (int32_t)daysSinceEpoch) {
+    if (daysSinceEpoch != static_cast<int32_t>(daysSinceEpoch)) {
       return false;
     }
     result = daysSinceEpoch;

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -337,19 +337,18 @@ TEST_F(DateTimeFunctionsTest, makeDate) {
   EXPECT_EQ(makeDate(1920, 1, 25), parseDate("1920-01-25"));
   EXPECT_EQ(makeDate(-10, 1, 30), parseDate("-0010-01-30"));
 
-  auto errorMessage = fmt::format("Date out of range: {}-12-15", kMax);
-  VELOX_ASSERT_THROW(makeDate(kMax, 12, 15), errorMessage);
+  EXPECT_EQ(makeDate(kMax, 12, 15), std::nullopt);
 
   constexpr const int32_t kJodaMaxYear{292278994};
-  VELOX_ASSERT_THROW(makeDate(kJodaMaxYear - 10, 12, 15), "Integer overflow");
+  EXPECT_EQ(makeDate(kJodaMaxYear - 10, 12, 15), std::nullopt);
 
-  VELOX_ASSERT_THROW(makeDate(2021, 13, 1), "Date out of range: 2021-13-1");
-  VELOX_ASSERT_THROW(makeDate(2022, 3, 35), "Date out of range: 2022-3-35");
+  EXPECT_EQ(makeDate(2021, 13, 1), std::nullopt);
+  EXPECT_EQ(makeDate(2022, 3, 35), std::nullopt);
 
-  VELOX_ASSERT_THROW(makeDate(2023, 4, 31), "Date out of range: 2023-4-31");
+  EXPECT_EQ(makeDate(2023, 4, 31), std::nullopt);
   EXPECT_EQ(makeDate(2023, 3, 31), parseDate("2023-03-31"));
 
-  VELOX_ASSERT_THROW(makeDate(2023, 2, 29), "Date out of range: 2023-2-29");
+  EXPECT_EQ(makeDate(2023, 2, 29), std::nullopt);
   EXPECT_EQ(makeDate(2023, 3, 29), parseDate("2023-03-29"));
 }
 


### PR DESCRIPTION
Spark make_date function used to throw error for invalid inputs. This PR 
changes to return null to conform to Spark ANSI off mode.