### PR TITLE
feat: Support decimal type for Spark floor function

### DIFF
--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -114,6 +114,9 @@ Returns NULL when the actual result cannot be represented with the calculated de
 
 Decimal Functions
 -----------------
+.. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0) 
+
+    Returns ``x`` rounded down to the type ``decimal(min(p - s + 1, 38), 0)``.
 
 .. spark:function:: unaryminus(x: decimal(p, s)) -> r: decimal(p, s)
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -114,7 +114,7 @@ Returns NULL when the actual result cannot be represented with the calculated de
 
 Decimal Functions
 -----------------
-.. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0) 
+.. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0)
 
     Returns ``x`` rounded down to the type ``decimal(min(38, p - s + min(1, s)), 0)``.
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -127,6 +127,7 @@ Decimal Functions
     Returns negated value of x (r = -x). Corresponds to Spark's operator ``-``.
 
     ::
+
         SELECT unaryminus(cast(-9999999999999999999.9999999999999999999 as DECIMAL(38, 19))); -- 9999999999999999999.9999999999999999999
 
 .. spark:function:: unscaled_value(x) -> bigint
@@ -152,6 +153,7 @@ Decimal Special Forms
     After rounding we may need one more digit in the integral part.
     
     ::
+        
         SELECT (round(cast (9.9 as decimal(2, 1)), 0)); -- decimal 10
         SELECT (round(cast (99 as decimal(2, 0)), -1)); -- decimal 100
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -116,7 +116,11 @@ Decimal Functions
 -----------------
 .. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0) 
 
-    Returns ``x`` rounded down to the type ``decimal(38, min({p} - {s} + min(1, {s})), 0)``.
+    Returns ``x`` rounded down to the type ``decimal(38, min(p - s + min(1, s)), 0)``.
+
+    ::
+
+        SELECT floor(cast(1.23 as DECIMAL(3, 2))); -- 1 // Output type: decimal(2,0)
 
 .. spark:function:: unaryminus(x: decimal(p, s)) -> r: decimal(p, s)
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -116,7 +116,7 @@ Decimal Functions
 -----------------
 .. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0) 
 
-    Returns ``x`` rounded down to the type ``decimal(38, min(p - s + min(1, s)), 0)``.
+    Returns ``x`` rounded down to the type ``decimal(min(38, p - s + min(1, s)), 0)``.
 
     ::
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -116,7 +116,7 @@ Decimal Functions
 -----------------
 .. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0) 
 
-    Returns ``x`` rounded down to the type ``decimal(min(p - s + 1, 38), 0)``.
+    Returns ``x`` rounded down to the type ``decimal(38, min({p} - {s} + min(1, {s})), 0)``.
 
 .. spark:function:: unaryminus(x: decimal(p, s)) -> r: decimal(p, s)
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -143,7 +143,7 @@ Mathematical Functions
 .. spark:function:: floor(x) -> [same as x]
 
     Returns ``x`` rounded down to the nearest integer.
-    Supported types are: BIGINT and DOUBLE.
+    Supported types are: BIGINT,  DOUBLE and DECIMAL.
 
 .. spark:function:: hex(x) -> varchar
 

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
+#include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
 #include "velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h"
 #include "velox/functions/sparksql/fuzzer/DivideArgGenerator.h"
 #include "velox/functions/sparksql/fuzzer/MakeTimestampArgGenerator.h"
@@ -92,6 +93,9 @@ int main(int argc, char** argv) {
        {"divide", std::make_shared<DivideArgGenerator>(true)},
        {"divide_deny_precision_loss",
         std::make_shared<DivideArgGenerator>(false)},
+       {"floor",
+        std::make_shared<
+            facebook::velox::exec::test::FloorAndRoundArgGenerator>()},
        {"unscaled_value", std::make_shared<UnscaledValueArgGenerator>()},
        {"make_timestamp", std::make_shared<MakeTimestampArgGenerator>()}};
 

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/Arithmetic.h"
+#include "velox/functions/prestosql/DecimalFunctions.h"
 #include "velox/functions/sparksql/Arithmetic.h"
 #include "velox/functions/sparksql/DecimalArithmetic.h"
 #include "velox/functions/sparksql/Rand.h"
@@ -75,6 +76,7 @@ void registerMathFunctions(const std::string& prefix) {
       {prefix + "floor"});
   registerFunction<sparksql::FloorFunction, int64_t, double>(
       {prefix + "floor"});
+  registerDecimalFloor(prefix);
   registerFunction<HypotFunction, double, double, double>({prefix + "hypot"});
   registerFunction<sparksql::Log2Function, double, double>({prefix + "log2"});
   registerFunction<sparksql::Log10Function, double, double>({prefix + "log10"});


### PR DESCRIPTION
Gluten removed the registration of Presto sql functions. This PR registers
Presto floor function in Spark for reuse.