### PR TITLE
feat: Register Spark date_format function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -36,7 +36,7 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: date_format(timestamp, dateFormat) -> string
 
-    Converts `timestamp` to a string in the format specified by `dateFormat`.
+    Converts ``timestamp`` to a string in the format specified by ``dateFormat``.
     The format follows Spark's
     `Datetime patterns
     <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -34,6 +34,13 @@ These functions support TIMESTAMP and DATE input types.
     deducted from ``start_date``.
     Supported types for ``num_days`` are: TINYINT, SMALLINT, INTEGER.
 
+.. spark:function:: date_format(timestamp, dateFormat) -> string
+
+    Converts `timestamp` to a string in the format specified by `dateFormat`.
+
+        SELECT date_format('2020-01-29', 'yyyy'); -- '2020'
+        SELECT date_format('2024-05-30 08:00:00', 'yyyy-MM-dd'); -- '2024-05-30'
+
 .. spark:function:: date_from_unix_date(integer) -> date
 
     Creates date from the number of days since 1970-01-01 in either direction. Returns null when input is null.

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -37,6 +37,9 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: date_format(timestamp, dateFormat) -> string
 
     Converts `timestamp` to a string in the format specified by `dateFormat`.
+    The format follows Spark's
+    `Datetime patterns
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
 
         SELECT date_format('2020-01-29', 'yyyy'); -- '2020'
         SELECT date_format('2024-05-30 08:00:00', 'yyyy-MM-dd'); -- '2024-05-30'

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -52,6 +52,8 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<DateAddFunction, Date, Date, int8_t>({prefix + "date_add"});
   registerFunction<DateAddFunction, Date, Date, int16_t>({prefix + "date_add"});
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
+  registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
+      {prefix + "date_format"});
   registerFunction<DateFromUnixDateFunction, Date, int32_t>(
       {prefix + "date_from_unix_date"});
   registerFunction<DateSubFunction, Date, Date, int8_t>({prefix + "date_sub"});


### PR DESCRIPTION
This PR registers the existing `FormatDateTimeFunction` for Spark SQL to use.