### PR TITLE
feat: Support Spark explode outer

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -879,6 +879,9 @@ UnnestNode::UnnestNode(
 }
 
 void UnnestNode::addDetails(std::stringstream& stream) const {
+  if (isOuter_) {
+    stream << "OUTER ";
+  }
   addFields(stream, unnestVariables_);
 }
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -834,7 +834,7 @@ UnnestNode::UnnestNode(
     const std::vector<std::string>& unnestNames,
     const std::optional<std::string>& ordinalityName,
     const PlanNodePtr& source,
-    const bool isOuter)
+    bool isOuter)
     : PlanNode(id),
       replicateVariables_{std::move(replicateVariables)},
       unnestVariables_{std::move(unnestVariables)},

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -833,12 +833,14 @@ UnnestNode::UnnestNode(
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
     const std::vector<std::string>& unnestNames,
     const std::optional<std::string>& ordinalityName,
-    const PlanNodePtr& source)
+    const PlanNodePtr& source,
+    const bool isOuter)
     : PlanNode(id),
       replicateVariables_{std::move(replicateVariables)},
       unnestVariables_{std::move(unnestVariables)},
       withOrdinality_{ordinalityName.has_value()},
-      sources_{source} {
+      sources_{source},
+      isOuter_{isOuter} {
   // Calculate output type. First come "replicate" columns, followed by
   // "unnest" columns, followed by an optional ordinality column.
   std::vector<std::string> names;
@@ -899,6 +901,7 @@ folly::dynamic UnnestNode::serialize() const {
   if (withOrdinality_) {
     obj["ordinalityName"] = outputType()->names().back();
   }
+  obj["isOuter"] = isOuter_;
   return obj;
 }
 
@@ -913,6 +916,7 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("ordinalityName")) {
     ordinalityName = obj["ordinalityName"].asString();
   }
+  bool isOuter = obj["isOuter"].asBool();
 
   return std::make_shared<UnnestNode>(
       deserializePlanNodeId(obj),
@@ -920,7 +924,8 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
       std::move(unnestVariables),
       std::move(unnestNames),
       ordinalityName,
-      std::move(source));
+      std::move(source),
+      isOuter);
 }
 
 AbstractJoinNode::AbstractJoinNode(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1959,16 +1959,7 @@ class UnnestNode : public PlanNode {
       const std::vector<std::string>& unnestNames,
       const std::optional<std::string>& ordinalityName,
       const PlanNodePtr& source,
-      bool isOuter);
-
-  UnnestNode(
-      const PlanNodeId& id,
-      std::vector<FieldAccessTypedExprPtr> replicateVariables,
-      std::vector<FieldAccessTypedExprPtr> unnestVariables,
-      const std::vector<std::string>& unnestNames,
-      const std::optional<std::string>& ordinalityName,
-      const PlanNodePtr& source):
-      UnnestNode(id, replicateVariables, unnestVariables, unnestNames, ordinalityName, source, false) {}
+      bool isOuter = false);
 
   /// The order of columns in the output is: replicated columns (in the order
   /// specified), unnested columns (in the order specified, for maps: key

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1950,8 +1950,8 @@ class UnnestNode : public PlanNode {
   /// names must appear in the same order as unnestVariables.
   /// @param ordinalityName Optional name for the ordinality columns. If not
   /// present, ordinality column is not produced.
-  /// @param isOuter If true, emit null data for empty array/map or array/map
-  /// with null elements. Used in SparkSQL's explode_outer.
+  /// @param isOuter If true, emit null data if the array/map is null or empty.
+  /// Used in SparkSQL's explode_outer.
   UnnestNode(
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1959,7 +1959,7 @@ class UnnestNode : public PlanNode {
       const std::vector<std::string>& unnestNames,
       const std::optional<std::string>& ordinalityName,
       const PlanNodePtr& source,
-      const bool isOuter);
+      bool isOuter);
 
   UnnestNode(
       const PlanNodeId& id,

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1950,13 +1950,25 @@ class UnnestNode : public PlanNode {
   /// names must appear in the same order as unnestVariables.
   /// @param ordinalityName Optional name for the ordinality columns. If not
   /// present, ordinality column is not produced.
+  /// @param isOuter If true, emit null data for empty array/map or array/map
+  /// with null elements. Used in SparkSQL's explode_outer.
   UnnestNode(
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
       const std::vector<std::string>& unnestNames,
       const std::optional<std::string>& ordinalityName,
-      const PlanNodePtr& source);
+      const PlanNodePtr& source,
+      const bool isOuter);
+
+  UnnestNode(
+      const PlanNodeId& id,
+      std::vector<FieldAccessTypedExprPtr> replicateVariables,
+      std::vector<FieldAccessTypedExprPtr> unnestVariables,
+      const std::vector<std::string>& unnestNames,
+      const std::optional<std::string>& ordinalityName,
+      const PlanNodePtr& source):
+      UnnestNode(id, replicateVariables, unnestVariables, unnestNames, ordinalityName, source, false) {}
 
   /// The order of columns in the output is: replicated columns (in the order
   /// specified), unnested columns (in the order specified, for maps: key
@@ -1981,6 +1993,10 @@ class UnnestNode : public PlanNode {
     return withOrdinality_;
   }
 
+  bool isOuter() const {
+    return isOuter_;
+  }
+
   std::string_view name() const override {
     return "Unnest";
   }
@@ -1996,6 +2012,7 @@ class UnnestNode : public PlanNode {
   const std::vector<FieldAccessTypedExprPtr> unnestVariables_;
   const bool withOrdinality_;
   const std::vector<PlanNodePtr> sources_;
+  const bool isOuter_;
   RowTypePtr outputType_;
 };
 

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -98,6 +98,7 @@ class Unnest : public Operator {
 
   // Generate output for 'rowRange' represented rows.
   // @param rowRange Range of rows to process.
+  template <bool isOuter>
   RowVectorPtr generateOutput(const RowRange& rowRange);
 
   // Invoked by generateOutput function above to generate the repeated output
@@ -105,6 +106,9 @@ class Unnest : public Operator {
   void generateRepeatedColumns(
       const RowRange& rowRange,
       std::vector<VectorPtr>& outputs);
+
+  template <bool isOuter>
+  void countMaxNumElementsPerRow(int32_t size);
 
   struct UnnestChannelEncoding {
     BufferPtr indices;
@@ -121,6 +125,7 @@ class Unnest : public Operator {
       const RowRange& rowRange);
 
   // Invoked by generateOutput for the ordinality column.
+  template <bool isOuter>
   VectorPtr generateOrdinalityVector(const RowRange& rowRange);
 
   const bool withOrdinality_;
@@ -142,5 +147,8 @@ class Unnest : public Operator {
 
   // Next 'input_' row to process in getOutput().
   vector_size_t nextInputRow_{0};
+
+  std::vector<bool> rawOrdinalityIsNull_;
+  const bool isOuter_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -108,11 +108,11 @@ class Unnest : public Operator {
       std::vector<VectorPtr>& outputs);
 
   // Calculate the max number of elements of each row after unnested.
-  // @param size The number of input rows
-  // @param isOuter Whether we should generate a null element
-  // if the array/map is null or empty then null is produced
+  // @param numRows The number of input rows.
+  // @param isOuter Whether we should generate a null element.
+  // if the array/map is null or empty then null is produced.
   template <bool isOuter>
-  void countMaxNumElementsPerRow(int32_t size);
+  void countMaxNumElementsPerRow(vector_size_t numRows);
 
   struct UnnestChannelEncoding {
     BufferPtr indices;

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -98,7 +98,6 @@ class Unnest : public Operator {
 
   // Generate output for 'rowRange' represented rows.
   // @param rowRange Range of rows to process.
-  template <bool isOuter>
   RowVectorPtr generateOutput(const RowRange& rowRange);
 
   // Invoked by generateOutput function above to generate the repeated output
@@ -106,12 +105,6 @@ class Unnest : public Operator {
   void generateRepeatedColumns(
       const RowRange& rowRange,
       std::vector<VectorPtr>& outputs);
-
-  // Calculate the max number of elements of each row after unnested.
-  // @param numRows The number of input rows.
-  // @param isOuter If true, emit null data if the array/map is null or empty.
-  template <bool isOuter>
-  void countMaxNumElementsPerRow(vector_size_t numRows);
 
   struct UnnestChannelEncoding {
     BufferPtr indices;
@@ -128,7 +121,6 @@ class Unnest : public Operator {
       const RowRange& rowRange);
 
   // Invoked by generateOutput for the ordinality column.
-  template <bool isOuter>
   VectorPtr generateOrdinalityVector(const RowRange& rowRange);
 
   const bool withOrdinality_;
@@ -151,8 +143,8 @@ class Unnest : public Operator {
   // Next 'input_' row to process in getOutput().
   vector_size_t nextInputRow_{0};
 
-  // Used when 'isOuter_' is true, to denote whether the ordinality vector is null
-  // at each result row.
+  // Used when 'isOuter_' is true, to denote whether the ordinality vector is
+  // null at each result row.
   std::vector<bool> rawOrdinalityIsNull_;
 
   // When true, null is produced for null or empty values in unnested array/map.

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -109,8 +109,7 @@ class Unnest : public Operator {
 
   // Calculate the max number of elements of each row after unnested.
   // @param numRows The number of input rows.
-  // @param isOuter Whether we should generate a null element.
-  // if the array/map is null or empty then null is produced.
+  // @param isOuter If true, emit null data if the array/map is null or empty.
   template <bool isOuter>
   void countMaxNumElementsPerRow(vector_size_t numRows);
 
@@ -152,7 +151,12 @@ class Unnest : public Operator {
   // Next 'input_' row to process in getOutput().
   vector_size_t nextInputRow_{0};
 
+  // Used when 'isOuter_' is true, to denote whether the ordinality vector is null
+  // at each result row.
   std::vector<bool> rawOrdinalityIsNull_;
+
+  // When true, null is produced for null or empty values in unnested array/map.
+  // Otherwise ignore null or empty values.
   const bool isOuter_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -107,6 +107,10 @@ class Unnest : public Operator {
       const RowRange& rowRange,
       std::vector<VectorPtr>& outputs);
 
+  // Calculate the max number of elements of each row after unnested.
+  // @param size The number of input rows
+  // @param isOuter Whether we should generate a null element
+  // if the array/map is null or empty then null is produced
   template <bool isOuter>
   void countMaxNumElementsPerRow(int32_t size);
 

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -477,26 +477,16 @@ TEST_P(UnnestTest, batchSize) {
 TEST_P(UnnestTest, basicArrayWithOuter) {
   auto vector = makeRowVector({
       makeFlatVector<int64_t>({1, 2, 3}),
-      makeNullableArrayVector<int64_t>({
-        {1, 2, std::nullopt},
-        {},
-        {3}
-      }),
+      makeNullableArrayVector<int64_t>({{1, 2, std::nullopt}, {}, {3}}),
   });
 
   createDuckDbTable({vector});
 
-  // isOuter = false
-  auto op1 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ false).planNode();
-  auto params1 = makeCursorParameters(op1);
-  auto expected1 = makeRowVector({
-      makeFlatVector<int64_t>({1, 1, 1, 3}),
-      makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 3}),
-  });
-  assertQuery(params1, expected1);
-
-  // isOuter = true
-  auto op2 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ true).planNode();
+  // isOuter = true.
+  auto op2 = PlanBuilder()
+                 .values({vector})
+                 .unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ true)
+                 .planNode();
   auto params2 = makeCursorParameters(op2);
   auto expected2 = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),
@@ -504,8 +494,11 @@ TEST_P(UnnestTest, basicArrayWithOuter) {
   });
   assertQuery(params2, expected2);
 
-  // ordinal = true && isOuter = true
-  auto op3 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, "ordinal", /* isOuter = */ true).planNode();
+  // ordinal = true && isOuter = true.
+  auto op3 = PlanBuilder()
+                 .values({vector})
+                 .unnest({"c0"}, {"c1"}, "ordinal", /* isOuter = */ true)
+                 .planNode();
   auto params3 = makeCursorParameters(op3);
   auto expected3 = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -483,29 +483,29 @@ TEST_P(UnnestTest, basicArrayWithOuter) {
   createDuckDbTable({vector});
 
   // isOuter = true.
-  auto op2 = PlanBuilder()
-                 .values({vector})
-                 .unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ true)
-                 .planNode();
-  auto params2 = makeCursorParameters(op2);
-  auto expected2 = makeRowVector({
+  auto op = PlanBuilder()
+                .values({vector})
+                .unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ true)
+                .planNode();
+  auto params = makeCursorParameters(op);
+  auto expected = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),
       makeNullableFlatVector<int64_t>({1, 2, std::nullopt, std::nullopt, 3}),
   });
-  assertQuery(params2, expected2);
+  assertQuery(params, expected);
 
   // ordinal = true && isOuter = true.
-  auto op3 = PlanBuilder()
-                 .values({vector})
-                 .unnest({"c0"}, {"c1"}, "ordinal", /* isOuter = */ true)
-                 .planNode();
-  auto params3 = makeCursorParameters(op3);
-  auto expected3 = makeRowVector({
+  op = PlanBuilder()
+           .values({vector})
+           .unnest({"c0"}, {"c1"}, "ordinal", /* isOuter = */ true)
+           .planNode();
+  params = makeCursorParameters(op);
+  expected = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),
       makeNullableFlatVector<int64_t>({1, 2, std::nullopt, std::nullopt, 3}),
       makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt, 1}),
   });
-  assertQuery(params3, expected3);
+  assertQuery(params, expected);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -486,8 +486,8 @@ TEST_P(UnnestTest, basicArrayWithOuter) {
 
   createDuckDbTable({vector});
 
-  // is_outer = false
-  auto op1 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, false /* is_outer */).planNode();
+  // isOuter = false
+  auto op1 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ false).planNode();
   auto params1 = makeCursorParameters(op1);
   auto expected1 = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 3}),
@@ -495,8 +495,8 @@ TEST_P(UnnestTest, basicArrayWithOuter) {
   });
   assertQuery(params1, expected1);
 
-  // is_outer = true
-  auto op2 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, true /* is_outer */).planNode();
+  // isOuter = true
+  auto op2 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, std::nullopt, /* isOuter = */ true).planNode();
   auto params2 = makeCursorParameters(op2);
   auto expected2 = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),
@@ -504,8 +504,8 @@ TEST_P(UnnestTest, basicArrayWithOuter) {
   });
   assertQuery(params2, expected2);
 
-  // ordinal = true && is_outer = true
-  auto op3 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, "ordinal", true /* is_outer */).planNode();
+  // ordinal = true && isOuter = true
+  auto op3 = PlanBuilder().values({vector}).unnest({"c0"}, {"c1"}, "ordinal", /* isOuter = */ true).planNode();
   auto params3 = makeCursorParameters(op3);
   auto expected3 = makeRowVector({
       makeFlatVector<int64_t>({1, 1, 1, 2, 3}),

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1517,7 +1517,8 @@ PlanBuilder& PlanBuilder::nestedLoopJoin(
 PlanBuilder& PlanBuilder::unnest(
     const std::vector<std::string>& replicateColumns,
     const std::vector<std::string>& unnestColumns,
-    const std::optional<std::string>& ordinalColumn) {
+    const std::optional<std::string>& ordinalColumn,
+    bool isOuter) {
   VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
       replicateFields;
@@ -1553,7 +1554,8 @@ PlanBuilder& PlanBuilder::unnest(
       unnestFields,
       unnestNames,
       ordinalColumn,
-      planNode_);
+      planNode_,
+      isOuter);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -956,8 +956,8 @@ class PlanBuilder {
   /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
   /// This column contains the index of the element of the unnested array or
   /// map. If not specified, the output will not contain this column.
-  /// @param isOuter If true, emit null data for empty array/map or array/map
-  /// with null elements. Used in SparkSQL's explode_outer.
+  /// @param isOuter If true, emit null data if the array/map is null or empty.
+  /// Used in SparkSQL's explode_outer.
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -956,10 +956,13 @@ class PlanBuilder {
   /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
   /// This column contains the index of the element of the unnested array or
   /// map. If not specified, the output will not contain this column.
+  /// @param isOuter If true, emit null data for empty array/map or array/map
+  /// with null elements. Used in SparkSQL's explode_outer.
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,
-      const std::optional<std::string>& ordinalColumn = std::nullopt);
+      const std::optional<std::string>& ordinalColumn = std::nullopt,
+      bool isOuter = false);
 
   /// Add a WindowNode to compute one or more windowFunctions.
   /// @param windowFunctions A list of one or more window function SQL like


### PR DESCRIPTION
Support the explode/posexplode with outer semantic. Unlike explode/posexplode, if the array/map is null or empty then null is produced. 

Spark doc: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.explode_outer.html