### PR TITLE
refactor: Optimize IndexedPriorityQueue::addOrUpdate 20 times faster

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -18,6 +18,8 @@
 
 #include "velox/common/base/Exceptions.h"
 
+#include <folly/CPortability.h>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -26,6 +28,20 @@
 
 #ifdef __BMI2__
 #include <x86intrin.h>
+#endif
+
+// Remove once we upgrade folly.
+#ifndef FOLLY_BUILTIN_MEMCPY
+#if FOLLY_HAS_BUILTIN(__builtin_memcpy_inline)
+#define FOLLY_BUILTIN_MEMCPY(dest, src, size) \
+  void(__builtin_memcpy_inline((dest), (src), (size)))
+#elif FOLLY_HAS_BUILTIN(__builtin_memcpy)
+#define FOLLY_BUILTIN_MEMCPY(dest, src, size) \
+  void(__builtin_memcpy((dest), (src), (size)))
+#else
+#define FOLLY_BUILTIN_MEMCPY(dest, src, size) \
+  void(::std::memcpy((dest), (src), (size)))
+#endif
 #endif
 
 namespace facebook {

--- a/velox/common/base/SkewedPartitionBalancer.h
+++ b/velox/common/base/SkewedPartitionBalancer.h
@@ -113,9 +113,9 @@ class SkewedPartitionRebalancer {
   uint64_t calculateTaskDataSizeSinceLastRebalance(
       const IndexedPriorityQueue<uint32_t, MaxQueue>& maxPartitions) {
     uint64_t estimatedDataBytesSinceLastRebalance{0};
-    for (uint32_t partition : maxPartitions) {
+    for (int i = 0; i < maxPartitions.size(); ++i) {
       estimatedDataBytesSinceLastRebalance +=
-          partitionBytesSinceLastRebalancePerTask_[partition];
+          partitionBytesSinceLastRebalancePerTask_[maxPartitions.values()[i]];
     }
     return estimatedDataBytesSinceLastRebalance;
   }
@@ -132,7 +132,7 @@ class SkewedPartitionRebalancer {
   // 'maxTaskId'.
   std::vector<uint32_t> findSkewedMinTasks(
       uint32_t maxTaskId,
-      const IndexedPriorityQueue<uint32_t, false>& minTasks) const;
+      IndexedPriorityQueue<uint32_t, false>& minTasks) const;
 
   // Tries to assign 'targetTaskId' to 'rebalancePartition' for rebalancing.
   // Returns true if rebalanced, otherwise false.

--- a/velox/common/base/benchmarks/CMakeLists.txt
+++ b/velox/common/base/benchmarks/CMakeLists.txt
@@ -24,3 +24,11 @@ target_link_libraries(
   velox_common_stringsearch_benchmarks
   PUBLIC Folly::follybenchmark
   PRIVATE velox_common_base Folly::folly)
+
+add_executable(velox_common_indexed_priority_queue_benchmark
+               IndexedPriorityQueueBenchmark.cpp)
+
+target_link_libraries(
+  velox_common_indexed_priority_queue_benchmark
+  PUBLIC Folly::follybenchmark
+  PRIVATE velox_common_base Folly::folly)

--- a/velox/common/base/benchmarks/IndexedPriorityQueueBenchmark.cpp
+++ b/velox/common/base/benchmarks/IndexedPriorityQueueBenchmark.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/IndexedPriorityQueue.h"
+
+#include <folly/Benchmark.h>
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+
+#define VELOX_BENCHMARK(_type, _name, ...) \
+  [[maybe_unused]] _type _name(FOLLY_PP_STRINGIZE(_name), __VA_ARGS__)
+
+namespace facebook::velox {
+namespace {
+
+template <typename T>
+class IndexedPriorityQueueBenchmark {
+ public:
+  IndexedPriorityQueueBenchmark(const char* name, int numValues)
+      : values_(numValues), priorities_(2 * numValues) {
+    generateValues();
+    for (int i = 0; i < 2 * numValues; ++i) {
+      priorities_[i] = folly::Random::rand32();
+    }
+    folly::addBenchmark(__FILE__, fmt::format("{}_add", name), [this] {
+      IndexedPriorityQueue<T, true> queue;
+      return add(queue);
+    });
+    folly::addBenchmark(__FILE__, fmt::format("{}_update", name), [this] {
+      IndexedPriorityQueue<T, true> queue;
+      BENCHMARK_SUSPEND {
+        add(queue);
+      }
+      return update(queue);
+    });
+    folly::addBenchmark(__FILE__, fmt::format("{}_pop", name), [this] {
+      IndexedPriorityQueue<T, true> queue;
+      BENCHMARK_SUSPEND {
+        add(queue);
+        update(queue);
+      }
+      return pop(queue);
+    });
+  }
+
+ private:
+  void generateValues();
+
+  unsigned add(IndexedPriorityQueue<T, true>& queue) const {
+    for (int i = 0; i < values_.size(); ++i) {
+      queue.addOrUpdate(values_[i], priorities_[i]);
+    }
+    return values_.size();
+  }
+
+  unsigned update(IndexedPriorityQueue<T, true>& queue) const {
+    for (int i = 0; i < values_.size(); ++i) {
+      queue.addOrUpdate(values_[i], priorities_[i + values_.size()]);
+    }
+    return values_.size();
+  }
+
+  unsigned pop(IndexedPriorityQueue<T, true>& queue) const {
+    while (!queue.empty()) {
+      queue.pop();
+    }
+    return values_.size();
+  }
+
+  std::vector<T> values_;
+  std::vector<uint32_t> priorities_;
+};
+
+template <>
+void IndexedPriorityQueueBenchmark<int64_t>::generateValues() {
+  std::iota(values_.begin(), values_.end(), 0);
+}
+
+} // namespace
+} // namespace facebook::velox
+
+int main(int argc, char* argv[]) {
+  using namespace facebook::velox;
+  folly::Init follyInit(&argc, &argv);
+  VELOX_BENCHMARK(IndexedPriorityQueueBenchmark<int64_t>, int64_1000, 1000);
+  VELOX_BENCHMARK(IndexedPriorityQueueBenchmark<int64_t>, int64_10000, 10'000);
+  VELOX_BENCHMARK(
+      IndexedPriorityQueueBenchmark<int64_t>, int64_100000, 100'000);
+  VELOX_BENCHMARK(
+      IndexedPriorityQueueBenchmark<int64_t>, int64_1000000, 1'000'000);
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
Optimize `IndexedPriorityQueue` to use more compact data structures (binary heap) to leverage cache locality and avoid unnecessary memory allocations.  `addOrUpdate` is now about 20 times faster for large data (~1 million elements).  This allows us to replace the custom heap implementation in `ApproxMostFrequentStreamSummary` with `IndexedPriorityQueue`.

Note that `pop` becomes about twice slower in the new version.  This is expected because we shift some of the reordering cost from insertion time to pop time. This shall be good because for each `pop`, we have at least one corresponding `addOrUpdate` which guarantees net performance gain, and in most of the case we do
not even have `pop` on critical path (e.g. in case of `ApproxMostFrequentStreamSummary`).

Differential Revision: D67626564


