### PR TITLE
fix: Add configuration for reading timestamp partition value

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -207,6 +207,13 @@ uint8_t HiveConfig::readTimestampUnit(const config::ConfigBase* session) const {
   return unit;
 }
 
+bool HiveConfig::readTimestampPartitionValueAsLocalTime(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kReadTimestampPartitionValueAsLocalTimeSession,
+      config_->get<bool>(kReadTimestampPartitionValueAsLocalTime, true));
+}
+
 bool HiveConfig::readStatsBasedFilterReorderDisabled(
     const config::ConfigBase* session) const {
   return session->get<bool>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -164,6 +164,11 @@ class HiveConfig {
   static constexpr const char* kReadTimestampUnitSession =
       "hive.reader.timestamp_unit";
 
+  static constexpr const char* kReadTimestampPartitionValueAsLocalTime =
+      "hive.reader.timestamp-partition-value-as-local-time";
+  static constexpr const char* kReadTimestampPartitionValueAsLocalTimeSession =
+      "hive.reader.timestamp_partition_value_as_local_time";
+
   static constexpr const char* kReadStatsBasedFilterReorderDisabled =
       "hive.reader.stats-based-filter-reorder-disabled";
   static constexpr const char* kReadStatsBasedFilterReorderDisabledSession =
@@ -229,6 +234,11 @@ class HiveConfig {
 
   // Returns the timestamp unit used when reading timestamps from files.
   uint8_t readTimestampUnit(const config::ConfigBase* session) const;
+
+  // Whether to read timestamp partition value as local time. If false, read as
+  // UTC.
+  bool readTimestampPartitionValueAsLocalTime(
+      const config::ConfigBase* session) const;
 
   /// Returns true if the stats based filter reorder for read is disabled.
   bool readStatsBasedFilterReorderDisabled(

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -587,6 +587,11 @@ Each query can override the config by setting corresponding query session proper
        filter execution order is totally determined by the filter type. Otherwise, the file
        reader will dynamically adjust the filter execution order based on the past filter
        execution stats.
+   * - hive.reader.timestamp-partition-value-as-local-time
+     - hive.reader.timestamp_partition_value_as_local_time
+     - bool
+     - true
+     - Reads timestamp partition value as local time if true. Otherwise, reads as UTC.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Adds a hive configuration to control whether to read timestamp partition value 
as local time or UTC.
Follow-up for: https://github.com/facebookincubator/velox/commit/e09a927dfbbc9bff9ceb0199a176d724aab81d9a.
