### PR TITLE
fix: Flaky abort exchange test

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -512,6 +512,10 @@ TEST_P(MultiFragmentTest, abortMergeExchange) {
   // Ensure that the threads in the executor can gracefully join
   executor.join();
 
+  /* sleep override */
+  // Wait till all the terminations, closures and destructions are done.
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
   // The references to mergeTask should be two, one for the local variable
   // itself and one reference inside tasks variable.
   EXPECT_EQ(mergeTask.use_count(), 2);


### PR DESCRIPTION
Summary: Similar to other tests in MultiFragmentTest, we need to wait for the terminate functions to execute

Differential Revision: D67636573


