### PR TITLE
fix(CI): disable mac builds on fork

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -44,6 +44,7 @@ concurrency:
 
 jobs:
   macos-build:
+    if: ${{ github.repository == 'facebookincubator/velox' }}
     name: "${{ matrix.os }}"
     strategy:
       fail-fast: false


### PR DESCRIPTION
This patch disabled the mac build tests on fork, aligning with linux builds
https://github.com/facebookincubator/velox/blob/main/.github/workflows/linux-build-base.yml#L30