### PR TITLE
Add malformed partition component to the exception message

### DIFF
--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -151,7 +151,10 @@ std::string FileUtils::unescapePathName(const std::string& data) {
       std::string tmp{data.data() + i + 1, HEX_WIDTH};
       char* end;
       c = static_cast<char>(std::strtol(tmp.c_str(), &end, 16));
-      DWIO_ENSURE(errno != ERANGE && end == tmp.data() + HEX_WIDTH);
+      DWIO_ENSURE(
+          errno != ERANGE && end == tmp.data() + HEX_WIDTH,
+          "Malformed path component: ",
+          data);
       i += HEX_WIDTH;
     }
     ret.append(1, c);

--- a/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
+++ b/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
@@ -36,6 +36,9 @@ TEST(FileUtilsTests, MakePartName) {
 
 TEST(FileUtilsTests, ParsePartKeyValues) {
   ASSERT_THROW(FileUtils::parsePartKeyValues("ds"), LoggedException);
+  ASSERT_THROW(
+      FileUtils::parsePartKeyValues("ts=2025-01-01+00%3A00%ZZ99"),
+      LoggedException);
 
   ASSERT_THAT(
       FileUtils::parsePartKeyValues(


### PR DESCRIPTION
Summary: Add the malformed partition component to the exception message to facilitate troubleshooting of errors like this https://fburl.com/scuba/xldb_koski_queries/52viv41r

Reviewed By: xiaoxmeng

Differential Revision: D67652803


