### PR TITLE
fix(sparksql): Respect session timezone when casting varchar to timestamp

### DIFF
--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -31,8 +31,17 @@ SparkCastHooks::SparkCastHooks(const velox::core::QueryConfig& config)
 
 Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
     const StringView& view) const {
-  return util::fromTimestampString(
+  auto conversionResult = util::fromTimestampWithTimezoneString(
       view.data(), view.size(), util::TimestampParseMode::kSparkCast);
+  if (conversionResult.hasError()) {
+    return folly::makeUnexpected(conversionResult.error());
+  }
+
+  auto sessionTimezone = config_.sessionTimezone().empty()
+      ? nullptr
+      : tz::locateZone(config_.sessionTimezone());
+  return util::fromParsedTimestampWithTimeZone(
+      conversionResult.value(), sessionTimezone);
 }
 
 Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -234,11 +234,14 @@ TEST_F(SparkCastExprTest, invalidDate) {
 TEST_F(SparkCastExprTest, stringToTimestamp) {
   std::vector<std::optional<std::string>> input{
       "1970-01-01",
+      "1970-01-01 00:00:00-02:00",
+      "1970-01-01 00:00:00 +02:00",
       "2000-01-01",
       "1970-01-01 00:00:00",
       "2000-01-01 12:21:56",
       std::nullopt,
       "2015-03-18T12:03:17",
+      "2015-03-18T12:03:17Z",
       "2015-03-18 12:03:17",
       "2015-03-18T12:03:17",
       "2015-03-18 12:03:17.123",
@@ -248,10 +251,13 @@ TEST_F(SparkCastExprTest, stringToTimestamp) {
   };
   std::vector<std::optional<Timestamp>> expected{
       Timestamp(0, 0),
+      Timestamp(7200, 0),
+      Timestamp(-7200, 0),
       Timestamp(946684800, 0),
       Timestamp(0, 0),
       Timestamp(946729316, 0),
       std::nullopt,
+      Timestamp(1426680197, 0),
       Timestamp(1426680197, 0),
       Timestamp(1426680197, 0),
       Timestamp(1426680197, 0),
@@ -261,6 +267,18 @@ TEST_F(SparkCastExprTest, stringToTimestamp) {
       Timestamp(1426680197, 456000000),
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
+
+  setTimezone("Asia/Shanghai");
+  testCast<std::string, Timestamp>(
+      "timestamp",
+      {"1970-01-01 00:00:00",
+       "1970-01-01 08:00:00",
+       "1970-01-01 08:00:59",
+       "1970"},
+      {Timestamp(-8 * 3600, 0),
+       Timestamp(0, 0),
+       Timestamp(59, 0),
+       Timestamp(-8 * 3600, 0)});
 }
 
 TEST_F(SparkCastExprTest, intToTimestamp) {

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -66,7 +66,7 @@ void Timestamp::toGMT(const tz::TimeZone& zone) {
     // Invalid argument means we hit a conversion not supported by
     // external/date. Need to throw a RuntimeError so that try() statements do
     // not suppress it.
-    VELOX_FAIL(e.what());
+    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(e.what());
   }
   seconds_ = sysSeconds.count();
 }

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -269,10 +269,17 @@ inline Expected<ParsedTimestampWithTimeZone> fromTimestampWithTimezoneString(
   return fromTimestampWithTimezoneString(str.data(), str.size(), parseMode);
 }
 
+/// Converts ParsedTimestampWithTimeZone to Timestamp according to the
+/// timezone-based adjustment. If no timezone information is available
+/// in the first argument, respects the session timezone if configured.
+Timestamp fromParsedTimestampWithTimeZone(
+    ParsedTimestampWithTimeZone parsed,
+    const tz::TimeZone* sessionTimeZone);
+
 Timestamp fromDatetime(int64_t daysSinceEpoch, int64_t microsSinceMidnight);
 
 /// Returns the number of days since epoch for a given timestamp and optional
 /// time zone.
-int32_t toDate(const Timestamp& timestamp, const tz::TimeZone* timeZone_);
+int32_t toDate(const Timestamp& timestamp, const tz::TimeZone* timeZone);
 
 } // namespace facebook::velox::util

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -469,6 +469,51 @@ TEST(DateTimeUtilTest, fromTimestampWithTimezoneString) {
           Timestamp(0, 0), tz::locateZone("-06:00"), std::nullopt}));
 }
 
+TEST(DateTimeUtilTest, fromParsedTimestampWithTimeZone) {
+  // Based on the parsed timezone.
+  auto input = ParsedTimestampWithTimeZone{
+      Timestamp(0, 0), tz::locateZone("-06:00"), std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, nullptr), Timestamp(21600, 0));
+  input = ParsedTimestampWithTimeZone{
+      Timestamp(0, 0), tz::locateZone("+06:00"), std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, nullptr), Timestamp(-21600, 0));
+  input = ParsedTimestampWithTimeZone{
+      Timestamp(21600, 0), tz::locateZone("+06:00"), std::nullopt};
+  EXPECT_EQ(fromParsedTimestampWithTimeZone(input, nullptr), Timestamp(0, 0));
+  input = ParsedTimestampWithTimeZone{
+      Timestamp(0, 0), tz::locateZone("America/Los_Angeles"), std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, nullptr), Timestamp(28800, 0));
+
+  // Based on the configured session timezone.
+  input = ParsedTimestampWithTimeZone{Timestamp(0, 0), nullptr, std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, tz::locateZone("-06:00")),
+      Timestamp(21600, 0));
+  input = ParsedTimestampWithTimeZone{Timestamp(0, 0), nullptr, std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, tz::locateZone("+06:00")),
+      Timestamp(-21600, 0));
+  input = ParsedTimestampWithTimeZone{Timestamp(0, 0), nullptr, std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(
+          input, tz::locateZone("America/Los_Angeles")),
+      Timestamp(28800, 0));
+
+  // Prioritize using the parsed timezone instead of the configured one.
+  input = ParsedTimestampWithTimeZone{
+      Timestamp(0, 0), tz::locateZone("+06:00"), std::nullopt};
+  EXPECT_EQ(
+      fromParsedTimestampWithTimeZone(input, tz::locateZone("-06:00")),
+      Timestamp(-21600, 0));
+
+  // No timezone, then no adjustment.
+  input = ParsedTimestampWithTimeZone{Timestamp(0, 0), nullptr, std::nullopt};
+  EXPECT_EQ(fromParsedTimestampWithTimeZone(input, nullptr), Timestamp(0, 0));
+}
+
 TEST(DateTimeUtilTest, toGMT) {
   auto* laZone = tz::locateZone("America/Los_Angeles");
 


### PR DESCRIPTION
When casting varchar to timestamp, the timezone embedded in input or the 
oneconfigured by user should be respected in the conversion. The proposed 
changesfor SparkSQL are quite similar to that for Presto, except the parse 
mode. So in thispr, a common function was also extracted for doing timezone-
based adjustment.