### PR TITLE
feat: Add cacheable flag in connector split to support fine-grained per-split cache decision

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -52,13 +52,17 @@ class DataSource;
 struct ConnectorSplit : public ISerializable {
   const std::string connectorId;
   const int64_t splitWeight{0};
+  const bool cacheable{true};
 
   std::unique_ptr<AsyncSource<DataSource>> dataSource;
 
   explicit ConnectorSplit(
       const std::string& _connectorId,
-      int64_t _splitWeight = 0)
-      : connectorId(_connectorId), splitWeight(_splitWeight) {}
+      int64_t _splitWeight = 0,
+      bool _cacheable = true)
+      : connectorId(_connectorId),
+        splitWeight(_splitWeight),
+        cacheable(_cacheable) {}
 
   folly::dynamic serialize() const override {
     VELOX_UNSUPPORTED();
@@ -68,7 +72,11 @@ struct ConnectorSplit : public ISerializable {
   virtual ~ConnectorSplit() {}
 
   virtual std::string toString() const {
-    return fmt::format("[split: {}]", connectorId);
+    return fmt::format(
+        "[split: connector id {}, weight {}, cacheable {}]",
+        connectorId,
+        splitWeight,
+        cacheable ? "true" : "false");
   }
 };
 

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -96,4 +96,25 @@ TEST_F(ConnectorTest, getAllConnectors) {
   EXPECT_FALSE(
       unregisterConnectorFactory(TestConnectorFactory::kConnectorFactoryName));
 }
+
+TEST_F(ConnectorTest, connectorSplit) {
+  {
+    const ConnectorSplit split("test", 100, true);
+    ASSERT_EQ(split.connectorId, "test");
+    ASSERT_EQ(split.splitWeight, 100);
+    ASSERT_EQ(split.cacheable, true);
+    ASSERT_EQ(
+        split.toString(),
+        "[split: connector id test, weight 100, cacheable true]");
+  }
+  {
+    const ConnectorSplit split("test", 50, false);
+    ASSERT_EQ(split.connectorId, "test");
+    ASSERT_EQ(split.splitWeight, 50);
+    ASSERT_EQ(split.cacheable, false);
+    ASSERT_EQ(
+        split.toString(),
+        "[split: connector id test, weight 50, cacheable false]");
+  }
+}
 } // namespace facebook::velox::connector


### PR DESCRIPTION
Summary:
Add cacheable flag to support fine-grained per-split cache decision. As Prestissimo might set
cacheable flag in a split (the split context in the protocol) if the split scheduling follow the soft
affinity.

The followup is to add the support in split reader on velox side and set from presto protocol in Prestissimo worker

Differential Revision: D67678409


