### PR TITLE
feat: Add formatter for dwrf::StreamKind

### DIFF
--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -283,3 +283,15 @@ constexpr int32_t RLE_MAXIMUM_REPEAT = 127 + RLE_MINIMUM_REPEAT;
 constexpr int32_t RLE_MAX_LITERAL_SIZE = 128;
 
 } // namespace facebook::velox::dwrf
+
+namespace fmt {
+template <>
+struct fmt::formatter<facebook::velox::dwrf::StreamKind>
+    : fmt::formatter<std::string> {
+  auto format(
+      const facebook::velox::dwrf::StreamKind& kind,
+      format_context& ctx) const {
+    return formatter<std::string>::format(streamKindToString(kind), ctx);
+  }
+};
+} // namespace fmt


### PR DESCRIPTION
Add formatter for `dwrf::StreamKind` as it used by `fmt::formatter`
in some places like `VELOX_CHECK`.