### PR TITLE
fix: Update the filterInput when flatten the right projections

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -331,6 +331,14 @@ void MergeJoin::flattenRightProjections() {
     newFlat->copy(currentVector.get(), 0, 0, outputSize_);
     children[projection.outputChannel] = std::move(newFlat);
   }
+
+  if (filter_ != nullptr && filterInput_ != nullptr) {
+    auto& filterInputChildren = filterInput_->children();
+    for (const auto [filterInputChannel, outputChannel] :
+         filterInputToOutputChannel_) {
+      filterInputChildren[filterInputChannel] = children[outputChannel];
+    }
+  }
   isRightFlattened_ = true;
 }
 


### PR DESCRIPTION
# What changes were proposed in this pull request?

Bug fix for MergeJoin which the join filter is not null. For example, in the tpcds 95, the subquery ws_wh  contains a join filter `ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk`

```sql
SELECT
    ws1.ws_order_number,
    ws1.ws_warehouse_sk wh1,
    ws2.ws_warehouse_sk wh2
  FROM web_sales ws1, web_sales ws2
  WHERE ws1.ws_order_number = ws2.ws_order_number
    AND ws1.ws_warehouse_sk <> ws2.ws_warehouse_sk
```

# How to reproduce this issue:

In tpc95 query, if the right matches contains more than one batch, and these batches are DictionaryVector.
When we `addOutputRow()` from those batches, SMJ join will only copy the Dictionary indices.
And then we decode the incorrect value from the last DictionaryVector.

![image](https://github.com/user-attachments/assets/afe2fbed-ed6a-45ae-b4a9-516644a16e8e)


```c++
void copyRow(
    const RowVectorPtr& source,
    vector_size_t sourceIndex,
    const RowVectorPtr& target,
    vector_size_t targetIndex,
    const std::vector<IdentityProjection>& projections) {
  for (const auto& projection : projections) {
    const auto& sourceChild = source->childAt(projection.inputChannel);
    const auto& targetChild = target->childAt(projection.outputChannel);
    targetChild->copy(sourceChild.get(), targetIndex, sourceIndex, 1);
  }
}
```

# Why are the changes needed?

Fix data quality issue.

# How was this patch tested?

Test with TPCDS 95 query and local query
```sql
SELECT
    ws1.ws_order_number,
    ws1.ws_warehouse_sk wh1,
    ws2.ws_warehouse_sk wh2,
    ws2.ws_warehouse_sk - ws1.ws_warehouse_sk as diff
  FROM web_sales ws1, web_sales ws2
  WHERE ws1.ws_order_number = ws2.ws_order_number
    AND ws1.ws_order_number is not null
    AND ws2.ws_order_number is not null
    AND ws1.ws_warehouse_sk - ws2.ws_warehouse_sk = 0;
```

