### PR TITLE
fix: Fix failures in TableWriterReplayerTest

### DIFF
--- a/velox/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableScanReplayerTest.cpp
@@ -147,6 +147,7 @@ TEST_F(TableScanReplayerTest, runner) {
 
   FLAGS_root_dir = traceRoot;
   FLAGS_query_id = task->queryCtx()->queryId();
+  FLAGS_task_id = task->taskId();
   FLAGS_node_id = traceNodeId_;
   FLAGS_summary = true;
   {

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -315,6 +315,7 @@ TEST_F(TableWriterReplayerTest, runner) {
 
   FLAGS_root_dir = traceRoot;
   FLAGS_query_id = task->queryCtx()->queryId();
+  FLAGS_task_id = task->taskId();
   FLAGS_node_id = traceNodeId;
   FLAGS_summary = true;
   {


### PR DESCRIPTION
`TableWriterReplayerTest` and `TableScanReplayerTest` use FLAGS_task_id
to specify the replay task ID to locate the related tracing data. We should set
it explicitly in each unit test using `TraceReplayRunner`.