### PR TITLE
feat: Support per-split fine-grained cache control

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -76,7 +76,7 @@ struct ConnectorSplit : public ISerializable {
         "[split: connector id {}, weight {}, cacheable {}]",
         connectorId,
         splitWeight,
-        folly::to<bool>(cacheable));
+        cacheable ? "true" : "false");
   }
 };
 

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -70,41 +70,6 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
 
   std::optional<RowIdProperties> rowIdProperties;
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  HiveConnectorSplit(
-      const std::string& connectorId,
-      const std::string& _filePath,
-      dwio::common::FileFormat _fileFormat,
-      uint64_t _start = 0,
-      uint64_t _length = std::numeric_limits<uint64_t>::max(),
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          _partitionKeys = {},
-      std::optional<int32_t> _tableBucketNumber = std::nullopt,
-      const std::unordered_map<std::string, std::string>& _customSplitInfo = {},
-      const std::shared_ptr<std::string>& _extraFileInfo = {},
-      const std::unordered_map<std::string, std::string>& _serdeParameters = {},
-      int64_t _splitWeight = 0,
-      const std::unordered_map<std::string, std::string>& _infoColumns = {},
-      std::optional<FileProperties> _properties = std::nullopt,
-      std::optional<RowIdProperties> _rowIdProperties = std::nullopt)
-      : HiveConnectorSplit(
-            connectorId,
-            _filePath,
-            _fileFormat,
-            _start,
-            _length,
-            _partitionKeys,
-            _tableBucketNumber,
-            _customSplitInfo,
-            _extraFileInfo,
-            _serdeParameters,
-            _splitWeight,
-            true,
-            _infoColumns,
-            _properties,
-            _rowIdProperties) {}
-#endif
-
   HiveConnectorSplit(
       const std::string& connectorId,
       const std::string& _filePath,

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -538,27 +538,27 @@ std::unique_ptr<dwio::common::SerDeOptions> parseSerdeParameters(
 }
 
 void configureReaderOptions(
-    dwio::common::ReaderOptions& readerOptions,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit) {
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
+    dwio::common::ReaderOptions& readerOptions) {
   configureReaderOptions(
-      readerOptions,
       hiveConfig,
       connectorQueryCtx,
       hiveTableHandle->dataColumns(),
       hiveSplit,
-      hiveTableHandle->tableParameters());
+      hiveTableHandle->tableParameters(),
+      readerOptions);
 }
 
 void configureReaderOptions(
-    dwio::common::ReaderOptions& readerOptions,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const ConnectorQueryCtx* connectorQueryCtx,
     const RowTypePtr& fileSchema,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
-    const std::unordered_map<std::string, std::string>& tableParameters) {
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    dwio::common::ReaderOptions& readerOptions) {
   auto sessionProperties = connectorQueryCtx->sessionProperties();
   readerOptions.setLoadQuantum(hiveConfig->loadQuantum(sessionProperties));
   readerOptions.setMaxCoalesceBytes(
@@ -591,7 +591,7 @@ void configureReaderOptions(
   readerOptions.setFilePreloadThreshold(hiveConfig->filePreloadThreshold());
   readerOptions.setPrefetchRowGroups(hiveConfig->prefetchRowGroups());
   readerOptions.setNoCacheRetention(
-      hiveConfig->cacheNoRetention(sessionProperties));
+      hiveConfig->cacheNoRetention(sessionProperties) || !hiveSplit->cacheable);
   const auto& sessionTzName = connectorQueryCtx->sessionTimezone();
   if (!sessionTzName.empty()) {
     const auto timezone = tz::locateZone(sessionTzName);

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -64,19 +64,19 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     memory::MemoryPool* pool);
 
 void configureReaderOptions(
-    dwio::common::ReaderOptions& readerOptions,
     const std::shared_ptr<const HiveConfig>& config,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit);
+    const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
+    dwio::common::ReaderOptions& readerOptions);
 
 void configureReaderOptions(
-    dwio::common::ReaderOptions& readerOptions,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const ConnectorQueryCtx* connectorQueryCtx,
     const RowTypePtr& fileSchema,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
-    const std::unordered_map<std::string, std::string>& tableParameters = {});
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    dwio::common::ReaderOptions& readerOptions);
 
 void configureRowReaderOptions(
     const std::unordered_map<std::string, std::string>& tableParameters,

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -134,13 +134,14 @@ SplitReader::SplitReader(
 void SplitReader::configureReaderOptions(
     std::shared_ptr<velox::random::RandomSkipTracker> randomSkip) {
   hive::configureReaderOptions(
-      baseReaderOpts_,
       hiveConfig_,
       connectorQueryCtx_,
       hiveTableHandle_,
-      hiveSplit_);
+      hiveSplit_,
+      baseReaderOpts_);
   baseReaderOpts_.setRandomSkip(std::move(randomSkip));
   baseReaderOpts_.setScanSpec(scanSpec_);
+  baseReaderOpts_.setFileFormat(hiveSplit_->fileFormat);
 }
 
 void SplitReader::prepareSplit(

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -26,35 +26,6 @@ struct IcebergDeleteFile;
 struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  HiveIcebergSplit(
-      const std::string& connectorId,
-      const std::string& filePath,
-      dwio::common::FileFormat fileFormat,
-      uint64_t start = 0,
-      uint64_t length = std::numeric_limits<uint64_t>::max(),
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          partitionKeys = {},
-      std::optional<int32_t> tableBucketNumber = std::nullopt,
-      const std::unordered_map<std::string, std::string>& customSplitInfo = {},
-      const std::shared_ptr<std::string>& extraFileInfo = {},
-      const std::unordered_map<std::string, std::string>& infoColumns = {},
-      std::optional<FileProperties> fileProperties = std::nullopt)
-      : HiveIcebergSplit(
-            connectorId,
-            filePath,
-            fileFormat,
-            start,
-            length,
-            partitionKeys,
-            tableBucketNumber,
-            customSplitInfo,
-            extraFileInfo,
-            true,
-            infoColumns,
-            fileProperties) {}
-#endif
-
   HiveIcebergSplit(
       const std::string& connectorId,
       const std::string& filePath,
@@ -70,38 +41,7 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       const std::unordered_map<std::string, std::string>& infoColumns = {},
       std::optional<FileProperties> fileProperties = std::nullopt);
 
-// For tests only
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  HiveIcebergSplit(
-      const std::string& connectorId,
-      const std::string& filePath,
-      dwio::common::FileFormat fileFormat,
-      uint64_t start = 0,
-      uint64_t length = std::numeric_limits<uint64_t>::max(),
-      const std::unordered_map<std::string, std::optional<std::string>>&
-          partitionKeys = {},
-      std::optional<int32_t> tableBucketNumber = std::nullopt,
-      const std::unordered_map<std::string, std::string>& customSplitInfo = {},
-      const std::shared_ptr<std::string>& extraFileInfo = {},
-      std::vector<IcebergDeleteFile> deletes = {},
-      const std::unordered_map<std::string, std::string>& infoColumns = {},
-      std::optional<FileProperties> fileProperties = std::nullopt)
-      : HiveIcebergSplit(
-            connectorId,
-            filePath,
-            fileFormat,
-            start,
-            length,
-            partitionKeys,
-            tableBucketNumber,
-            customSplitInfo,
-            extraFileInfo,
-            true,
-            deletes,
-            infoColumns,
-            fileProperties) {}
-#endif
-
+  // For tests only
   HiveIcebergSplit(
       const std::string& connectorId,
       const std::string& filePath,

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -82,11 +82,12 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
 
   dwio::common::ReaderOptions deleteReaderOpts(pool_);
   configureReaderOptions(
-      deleteReaderOpts,
       hiveConfig_,
       connectorQueryCtx,
       deleteFileSchema,
-      deleteSplit_);
+      deleteSplit_,
+      /*tableParameters=*/{},
+      deleteReaderOpts);
 
   auto deleteFileHandleCachePtr =
       fileHandleFactory_->generate(deleteFile_.filePath);

--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -124,7 +124,7 @@ class TpchSpeedTest {
       task.addSplit(
           scanId,
           exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(
-              kTpchConnectorId_, numSplits, i)));
+              kTpchConnectorId_, /*cacheable=*/true, numSplits, i)));
     }
 
     task.noMoreSplits(scanId);

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1245,20 +1245,6 @@ class LocalPartitionNode : public PlanNode {
 
   static Type typeFromName(const std::string& name);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  LocalPartitionNode(
-      const PlanNodeId& id,
-      Type type,
-      PartitionFunctionSpecPtr partitionFunctionSpec,
-      std::vector<PlanNodePtr> sources)
-      : LocalPartitionNode(
-            id,
-            std::move(type),
-            /*scaleWriter=*/false,
-            std::move(partitionFunctionSpec),
-            std::move(sources)) {}
-#endif
-
   /// If 'scaleWriter' is true, the local partition is used to scale the table
   /// writer prcessing.
   LocalPartitionNode(

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -484,7 +484,10 @@ void Writer::flushStripe(bool close) {
   auto result = layoutPlanner_->plan(encodingManager, getStreamList(context));
   result.iterateIndexStreams(
       [&](const DwrfStreamIdentifier& streamId, DataBufferHolder& content) {
-        VELOX_CHECK(isIndexStream(streamId.kind()), "unexpected stream kind");
+        VELOX_CHECK(
+            isIndexStream(streamId.kind()),
+            "unexpected stream kind {}",
+            streamId.kind());
         indexLength += content.size();
         addStream(streamId, content);
         sink.addBuffers(content);
@@ -494,7 +497,10 @@ void Writer::flushStripe(bool close) {
   sink.setMode(WriterSink::Mode::Data);
   result.iterateDataStreams(
       [&](const DwrfStreamIdentifier& streamId, DataBufferHolder& content) {
-        VELOX_CHECK(!isIndexStream(streamId.kind()), "unexpected stream kind");
+        VELOX_CHECK(
+            !isIndexStream(streamId.kind()),
+            "unexpected stream kind {}",
+            streamId.kind());
         dataLength += content.size();
         addStream(streamId, content);
         sink.addBuffers(content);

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -256,11 +256,13 @@ HiveConnectorTestBase::makeHiveConnectorSplit(
     const std::string& filePath,
     uint64_t start,
     uint64_t length,
-    int64_t splitWeight) {
+    int64_t splitWeight,
+    bool cacheable) {
   return HiveConnectorSplitBuilder(filePath)
       .start(start)
       .length(length)
       .splitWeight(splitWeight)
+      .cacheable(cacheable)
       .build();
 }
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -91,7 +91,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::string& filePath,
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max(),
-      int64_t splitWeight = 0);
+      int64_t splitWeight = 0,
+      bool cacheable = true);
 
   static std::shared_ptr<connector::hive::HiveConnectorSplit>
   makeHiveConnectorSplit(


### PR DESCRIPTION
Summary:
Set no cache retention flag in split reader based on no-cache retention session property plus the cacheable
flag set in connector split. Tests added to verify. This will be used by Prestissimo adhoc use case to support
Presto distributed cache protocol. 

Differential Revision: D67707564


