### PR TITLE
fix: Fix writer reclaim failure by clearing dict chained buffers during arbitration

### DIFF
--- a/velox/docs/develop/debugging/tracing.rst
+++ b/velox/docs/develop/debugging/tracing.rst
@@ -368,5 +368,5 @@ Here is a full list of supported command line arguments.
 * ``--hiveConnectorExecutorHwMultiplier``: Hardware multiplier for hive connector.
 * ``--driver_cpu_executor_hw_multiplier``: Hardware multipler for driver cpu executor.
 * ``--memory_arbitrator_type``: Specify the memory arbitrator type.
-* ``--query_memory_capacity_gb``: Specify the query memory capacity limit in GB. If it is zero, then there is no limit.
+* ``--query_memory_capacity_mb``: Specify the query memory capacity limit in MB. If it is zero, then there is no limit.
 * ``--copy_results``: If true, copy the replaying result.

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -38,7 +38,7 @@ class DataBuffer {
             pool_->allocateZeroFilled(1, sizeInBytes(size)))),
         size_(size),
         capacity_(size) {
-    DWIO_ENSURE(buf_ != nullptr || size_ == 0);
+    VELOX_CHECK(buf_ != nullptr || size_ == 0);
   }
 
   DataBuffer(DataBuffer&& other) noexcept
@@ -87,7 +87,7 @@ class DataBuffer {
   // Get with range check introduces significant overhead. Use index operator[]
   // when possible
   const T& at(uint64_t i) const {
-    DWIO_ENSURE_LT(i, size_, "Accessing index out of range");
+    VELOX_CHECK_LT(i, size_, "Accessing index out of range");
     return data()[i];
   }
 
@@ -136,7 +136,7 @@ class DataBuffer {
       uint64_t srcOffset,
       uint64_t items) {
     // Does src have insufficient data
-    DWIO_ENSURE_GE(src.size(), srcOffset + items);
+    VELOX_CHECK_GE(src.size(), srcOffset + items);
     append(offset, src.data() + srcOffset, items);
   }
 

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -17,6 +17,7 @@
 #include <glog/logging.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/DataBuffer.h"
 
@@ -81,7 +82,7 @@ TEST_F(DataBufferTest, At) {
     EXPECT_EQ(i, buffer.at(i));
   }
   for (auto i = 8; i != 42; ++i) {
-    EXPECT_THROW(buffer.at(i), exception::LoggedException);
+    VELOX_ASSERT_THROW(buffer.at(i), "Accessing index out of range");
   }
 }
 

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -92,7 +92,7 @@ DEFINE_string(
     "shared",
     "Specify the memory arbitrator type.");
 DEFINE_uint64(
-    query_memory_capacity_gb,
+    query_memory_capacity_mb,
     0,
     "Specify the query memory capacity limit in GB. If it is zero, then there is no limit.");
 DEFINE_bool(copy_results, false, "Copy the replaying results.");
@@ -312,6 +312,7 @@ TraceReplayRunner::createReplayer() const {
       exec::trace::getTaskTraceMetaFilePath(taskTraceDir),
       fs_,
       memory::MemoryManager::getInstance()->tracePool());
+  const auto queryCapacityBytes = (1ULL * FLAGS_query_memory_capacity_mb) << 20;
   if (traceNodeName == "TableWrite") {
     VELOX_USER_CHECK(
         !FLAGS_table_writer_output_dir.empty(),
@@ -323,7 +324,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_node_id,
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get(),
         FLAGS_table_writer_output_dir);
   } else if (traceNodeName == "Aggregation") {
@@ -334,7 +335,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_node_id,
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get());
   } else if (traceNodeName == "PartitionedOutput") {
     replayer = std::make_unique<tool::trace::PartitionedOutputReplayer>(
@@ -345,7 +346,7 @@ TraceReplayRunner::createReplayer() const {
         getVectorSerdeKind(),
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get());
   } else if (traceNodeName == "TableScan") {
     replayer = std::make_unique<tool::trace::TableScanReplayer>(
@@ -355,7 +356,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_node_id,
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get());
   } else if (traceNodeName == "Filter" || traceNodeName == "Project") {
     replayer = std::make_unique<tool::trace::FilterProjectReplayer>(
@@ -365,7 +366,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_node_id,
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get());
   } else if (traceNodeName == "HashJoin") {
     replayer = std::make_unique<tool::trace::HashJoinReplayer>(
@@ -375,7 +376,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_node_id,
         traceNodeName,
         FLAGS_driver_ids,
-        (1ULL * FLAGS_query_memory_capacity_gb) << 30,
+        queryCapacityBytes,
         cpuExecutor_.get());
   } else {
     VELOX_UNSUPPORTED("Unsupported operator type: {}", traceNodeName);

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -33,7 +33,7 @@ DECLARE_string(driver_ids);
 DECLARE_string(table_writer_output_dir);
 DECLARE_double(hive_connector_executor_hw_multiplier);
 DECLARE_int32(shuffle_serialization_format);
-DECLARE_uint64(query_memory_capacity_gb);
+DECLARE_uint64(query_memory_capacity_mb);
 DECLARE_double(driver_cpu_executor_hw_multiplier);
 DECLARE_string(memory_arbitrator_type);
 DECLARE_bool(copy_results);


### PR DESCRIPTION
Summary:
We run into writer memory reclaim failure that after writer memory reclamation and the memory usage is
higher than before the memory reclamation. By digging into the actual memory consumption, the problem is
due to the internal memory buffering by the dictionary in case of wide table write which has 4000 columns. And after
each stripe flush, the chained buffer used to hold the dictionary index doesn't free any memory as it only holds
on page internally, and chained buffer clear only clears the non-first page. This pretty much doesn't free any memory
from the general memory pool.

This PR fixes this issue by supporting clear all the pages from chained buffer pool in case of memory arbitration as
well as dictionary abandon. The latter also doesn't clear any memory from that. With this change, the writer trace
replay shows that after reclaim the general memory pool usage dropped from 64MB to 6MB and without this
change it says at 50-60MB. Also production query can run through without memory reclaim check failure.

Differential Revision: D67666669


