### PR TITLE
fix: Fix flaky scaled scan fuzzer test

### DIFF
--- a/velox/exec/ScaledScanController.cpp
+++ b/velox/exec/ScaledScanController.cpp
@@ -76,11 +76,11 @@ void ScaledScanController::updateAndTryScale(
   };
   {
     std::lock_guard<std::mutex> l(lock_);
-    VELOX_CHECK_LT(driverIdx, numRunningDrivers_);
-
     if (closed_) {
       return;
     }
+
+    VELOX_CHECK_LT(driverIdx, numRunningDrivers_);
 
     updateDriverScanUsageLocked(driverIdx, memoryUsage);
 


### PR DESCRIPTION
Summary:
The fuzzer test flakiness is due to the race between test thread and scaled controller close. This PR fixes the issue
by moving the driver index check after the controller close check

Differential Revision: D67727455


