### PR TITLE
fix: Fix flaky HashJoinTest.reclaimDuringOutputProcessing

### DIFF
--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -6225,7 +6225,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
           }
           testWaitFlag = false;
           testWait.notifyAll();
-          driverWait.await([&]() { return !testWaitFlag.load(); });
+          driverWait.await([&]() { return !driverWaitFlag.load(); });
         })));
 
     std::thread taskThread([&]() {


### PR DESCRIPTION
Original test mistakenly puts the wrong wait flag to driver thread, causing sometimes driver to finish and close early, ending up with accessing to an invalidated Operator*.