### PR TITLE
fix: Fix build failure

### DIFF
--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -552,9 +552,9 @@ PlanNodePtr toVeloxPlan(
 }
 
 namespace {
-std::vector<size_t> columnIndices(std::vector<idx_t> map, int32_t size) {
+std::vector<idx_t> columnIndices(std::vector<idx_t> map, int32_t size) {
   if (size > 0 && map.empty()) {
-    std::vector<size_t> result(size);
+    std::vector<idx_t> result(size);
     std::iota(result.begin(), result.end(), 0);
     return result;
   }


### PR DESCRIPTION
Although `idx_t (aka uint64_t)` and `size_t` have the same underlying representation, they
are still considered different types in the C++ type system.