### PR TITLE
fix: Fix nullptr of memory pool in FilterNode::create

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2799,7 +2799,7 @@ folly::dynamic FilterNode::serialize() const {
 PlanNodePtr FilterNode::create(const folly::dynamic& obj, void* context) {
   auto source = deserializeSingleSource(obj, context);
 
-  auto filter = ISerializable::deserialize<ITypedExpr>(obj["filter"]);
+  auto filter = ISerializable::deserialize<ITypedExpr>(obj["filter"], context);
   return std::make_shared<FilterNode>(
       deserializePlanNodeId(obj), filter, std::move(source));
 }


### PR DESCRIPTION
When we trace filter node which contains in expression, the replay
runner will core dump because the memory pool is nullptr. We fix 
it in this PR.
