### PR TITLE
fix: Reuse vector in LocalPartition

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -197,36 +197,6 @@ size_t ByteOutputStream::size() const {
   return total + std::max(ranges_.back().position, lastRangeEnd_);
 }
 
-void ByteOutputStream::appendBool(bool value, int32_t count) {
-  VELOX_DCHECK(isBits_);
-
-  if (count == 1 && current_->size > current_->position) {
-    bits::setBit(
-        reinterpret_cast<uint64_t*>(current_->buffer),
-        current_->position,
-        value);
-    ++current_->position;
-    return;
-  }
-
-  int32_t offset{0};
-  for (;;) {
-    const int32_t bitsFit =
-        std::min(count - offset, current_->size - current_->position);
-    bits::fillBits(
-        reinterpret_cast<uint64_t*>(current_->buffer),
-        current_->position,
-        current_->position + bitsFit,
-        value);
-    current_->position += bitsFit;
-    offset += bitsFit;
-    if (offset == count) {
-      return;
-    }
-    extend(bits::nbytes(count - offset));
-  }
-}
-
 void ByteOutputStream::appendBits(
     const uint64_t* bits,
     int32_t begin,

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -305,7 +305,35 @@ class ByteOutputStream {
     current_->position += sizeof(T) * values.size();
   }
 
-  void appendBool(bool value, int32_t count);
+  inline void appendBool(bool value, int32_t count) {
+    VELOX_DCHECK(isBits_);
+
+    if (count == 1 && current_->size > current_->position) {
+      bits::setBit(
+          reinterpret_cast<uint64_t*>(current_->buffer),
+          current_->position,
+          value);
+      ++current_->position;
+      return;
+    }
+
+    int32_t offset{0};
+    for (;;) {
+      const int32_t bitsFit =
+          std::min(count - offset, current_->size - current_->position);
+      bits::fillBits(
+          reinterpret_cast<uint64_t*>(current_->buffer),
+          current_->position,
+          current_->position + bitsFit,
+          value);
+      current_->position += bitsFit;
+      offset += bitsFit;
+      if (offset == count) {
+        return;
+      }
+      extend(bits::nbytes(count - offset));
+    }
+  }
 
   // A fast path for appending bits into pre-cleared buffers after first extend.
   inline void

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -183,7 +183,8 @@ void ScaleWriterPartitioningLocalPartition::addInput(RowVectorPtr input) {
       auto writerInput = wrapChildren(
           input,
           writerRowCount,
-          std::move(writerAssignmmentIndicesBuffers_[i]));
+          std::move(writerAssignmmentIndicesBuffers_[i]),
+          queues_[i]->getVector());
       ContinueFuture future;
       auto reason = queues_[i]->enqueue(
           writerInput, totalInputBytes * writerRowCount / numInput, &future);

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2609,11 +2609,12 @@ void Task::createLocalExchangeQueuesLocked(
   LocalExchangeState exchange;
   exchange.memoryManager = std::make_shared<LocalExchangeMemoryManager>(
       queryCtx_->queryConfig().maxLocalExchangeBufferSize());
-
+  exchange.vectorPool = std::make_shared<LocalExchangeVectorPool>(
+      queryCtx_->queryConfig().maxLocalExchangeBufferSize());
   exchange.queues.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
-    exchange.queues.emplace_back(
-        std::make_shared<LocalExchangeQueue>(exchange.memoryManager, i));
+    exchange.queues.emplace_back(std::make_shared<LocalExchangeQueue>(
+        exchange.memoryManager, exchange.vectorPool, i));
   }
 
   const auto partitionNode =

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -88,6 +88,7 @@ struct SplitsState {
 /// Stores local exchange queues with the memory manager.
 struct LocalExchangeState {
   std::shared_ptr<LocalExchangeMemoryManager> memoryManager;
+  std::shared_ptr<LocalExchangeVectorPool> vectorPool;
   std::vector<std::shared_ptr<LocalExchangeQueue>> queues;
   std::shared_ptr<common::SkewedPartitionRebalancer>
       scaleWriterPartitionBalancer;
@@ -132,7 +133,7 @@ struct SplitGroupState {
   uint32_t numFinishedOutputDrivers{0};
 
   // True if the state contains structures used for connecting ungrouped
-  // execution pipeline with grouped excution pipeline. In that case we don't
+  // execution pipeline with grouped execution pipeline. In that case we don't
   // want to clean up some of these structures.
   bool mixedExecutionMode{false};
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -691,7 +691,7 @@ class BaseVector {
     VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
-  virtual VectorPtr& valueVector() {
+  virtual void setValueVector(VectorPtr valueVector) {
     VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
@@ -715,8 +715,12 @@ class BaseVector {
 
   /// If 'this' is a wrapper, returns the wrap info, interpretation depends on
   /// encoding.
-  virtual BufferPtr wrapInfo() const {
-    throw std::runtime_error("Vector is not a wrapper");
+  virtual const BufferPtr& wrapInfo() const {
+    VELOX_UNSUPPORTED("Vector is not a wrapper");
+  }
+
+  virtual void setWrapInfo(BufferPtr wrapInfo) {
+    VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
   template <typename T = BaseVector>

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -130,12 +130,16 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_;
   }
 
-  VectorPtr& valueVector() override {
-    return dictionaryValues_;
+  void setValueVector(VectorPtr valueVector) override {
+    setDictionaryValues(std::move(valueVector));
   }
 
-  BufferPtr wrapInfo() const override {
+  const BufferPtr& wrapInfo() const override {
     return indices_;
+  }
+
+  void setWrapInfo(BufferPtr indices) override {
+    indices_ = std::move(indices);
   }
 
   BufferPtr mutableIndices(vector_size_t size) {

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -305,7 +305,7 @@ class LazyVector : public BaseVector {
     return loadedVector()->wrappedIndex(index);
   }
 
-  BufferPtr wrapInfo() const override {
+  const BufferPtr& wrapInfo() const override {
     return loadedVector()->wrapInfo();
   }
 

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -125,10 +125,6 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_;
   }
 
-  VectorPtr& valueVector() override {
-    return sequenceValues_;
-  }
-
   BufferPtr getSequenceLengths() const {
     return sequenceLengths_;
   }
@@ -144,7 +140,7 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_->size();
   }
 
-  BufferPtr wrapInfo() const override {
+  const BufferPtr& wrapInfo() const override {
     return sequenceLengths_;
   }
 


### PR DESCRIPTION
Summary:
More than 10% of the CPU are spent on the destruction of local partition output when the load is high.

Also add some optimizations for serialization.

Differential Revision: D67742489


