### PR TITLE
docs: Fix display issue related to the <super> tag in TpchBenchmark.rst

### DIFF
--- a/velox/docs/develop/TpchBenchmark.rst
+++ b/velox/docs/develop/TpchBenchmark.rst
@@ -109,8 +109,8 @@ Top Optimization Recommendations
    :header: "Option Name", "Single Process", "Multi-Process"
    :widths: auto
 
-   "num_drivers","max(20, vCPUs<super>*</super> X 3 / 4)","NA"
-   "num_io_threads", "max(16, vCPUs<super>*</super> X 3 / 8)", "vCPUs*"
+   "num_drivers","max(20, vCPUs* X 3 / 4)","NA"
+   "num_io_threads", "max(16, vCPUs* X 3 / 8)", "vCPUs*"
    "cache_gb", "50% System RAM", "NA (default = 0)"
    "num_splits_per_file", "Row Group Size of Data", "Row Group Size of Data"
    "max_coalesced_bytes", "Minimum of 90MB", "Minimum of 90MB"


### PR DESCRIPTION
Fix the issue where the `<super>` tag is displayed as plain text rather than being rendered as superscript in HTML.

**Before Changes**：
![image](https://github.com/user-attachments/assets/2b0421e6-f4ad-4eaa-85e1-1b68a00a52e9)

**After Changes**:
![image](https://github.com/user-attachments/assets/0ec216ee-7ac6-4c3e-a9a3-c8984c4cd4f3)