### PR TITLE
feat: Support UNKNOWN type for Spark collect_set aggregate function

### DIFF
--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <type/Type.h>
 #include "velox/functions/lib/aggregates/SetBaseAggregate.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
@@ -88,6 +89,8 @@ void registerCollectSetAggAggregate(
           case TypeKind::ROW:
             return std::make_unique<SparkSetAggAggregate<ComplexType>>(
                 resultType);
+          case TypeKind::UNKNOWN:
+            return std::make_unique<SparkSetAggAggregate<UnknownValue>>(resultType);
           default:
             VELOX_UNSUPPORTED(
                 "Unsupported type {}", mapTypeKindToName(typeKind));

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -89,7 +89,8 @@ void registerCollectSetAggAggregate(
             return std::make_unique<SparkSetAggAggregate<ComplexType>>(
                 resultType);
           case TypeKind::UNKNOWN:
-            return std::make_unique<SparkSetAggAggregate<UnknownValue>>(resultType);
+            return std::make_unique<SparkSetAggAggregate<UnknownValue>>(
+                resultType);
           default:
             VELOX_UNSUPPORTED(
                 "Unsupported type {}", mapTypeKindToName(typeKind));

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <type/Type.h>
 #include "velox/functions/lib/aggregates/SetBaseAggregate.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {

--- a/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -260,7 +260,7 @@ TEST_F(CollectSetAggregateTest, rowWithNestedNull) {
       {data}, {}, {"collect_set(c0)"}, {"spark_array_sort(a0)"}, {expected});
 }
 
-TEST_F(CollectSetAggregateTest, nullType) {
+TEST_F(CollectSetAggregateTest, unknownType) {
   auto data = makeRowVector({
       makeNullConstant(TypeKind::UNKNOWN, 3),
   });

--- a/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -262,15 +262,20 @@ TEST_F(CollectSetAggregateTest, rowWithNestedNull) {
 
 TEST_F(CollectSetAggregateTest, nullType) {
   auto data = makeRowVector({
-    makeNullConstant(TypeKind::UNKNOWN, 3),
+      makeNullConstant(TypeKind::UNKNOWN, 3),
   });
 
   auto expected = makeRowVector({
       makeArrayVectorFromJson<int32_t>({"[]"}),
   });
+  testAggregations({data}, {}, {"collect_set(c0)"}, {}, {expected});
 
-  testAggregations(
-      {data}, {}, {"collect_set(c0)"}, {}, {expected});
+  // with groupby key
+  auto expected2 = makeRowVector({
+      makeNullConstant(TypeKind::UNKNOWN, 1),
+      makeArrayVectorFromJson<int32_t>({"[]"}),
+  });
+  testAggregations({data}, {"c0"}, {"collect_set(c0)"}, {}, {expected2});
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -270,12 +270,12 @@ TEST_F(CollectSetAggregateTest, nullType) {
   });
   testAggregations({data}, {}, {"collect_set(c0)"}, {}, {expected});
 
-  // with groupby key
-  auto expected2 = makeRowVector({
+  // The grouping key is of UNKONWN type.
+  expected = makeRowVector({
       makeNullConstant(TypeKind::UNKNOWN, 1),
       makeArrayVectorFromJson<int32_t>({"[]"}),
   });
-  testAggregations({data}, {"c0"}, {"collect_set(c0)"}, {}, {expected2});
+  testAggregations({data}, {"c0"}, {"collect_set(c0)"}, {}, {expected});
 }
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectSetAggregateTest.cpp
@@ -260,5 +260,18 @@ TEST_F(CollectSetAggregateTest, rowWithNestedNull) {
       {data}, {}, {"collect_set(c0)"}, {"spark_array_sort(a0)"}, {expected});
 }
 
+TEST_F(CollectSetAggregateTest, nullType) {
+  auto data = makeRowVector({
+    makeNullConstant(TypeKind::UNKNOWN, 3),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({"[]"}),
+  });
+
+  testAggregations(
+      {data}, {}, {"collect_set(c0)"}, {}, {expected});
+}
+
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
Gluten maps Spark NullType as UNKNOWN type in Velox. This PR supports the 
UNKNOWN type for the Spark collect_set aggregate function.