### PR TITLE
refactor: Remove ::test namespace from cursor.h

### DIFF
--- a/velox/benchmarks/QueryBenchmarkBase.h
+++ b/velox/benchmarks/QueryBenchmarkBase.h
@@ -86,8 +86,8 @@ class QueryBenchmarkBase {
   virtual ~QueryBenchmarkBase() = default;
   virtual void initialize();
   void shutdown();
-  std::pair<std::unique_ptr<exec::test::TaskCursor>, std::vector<RowVectorPtr>>
-  run(const exec::test::TpchPlan& tpchPlan);
+  std::pair<std::unique_ptr<exec::TaskCursor>, std::vector<RowVectorPtr>> run(
+      const exec::test::TpchPlan& tpchPlan);
 
   virtual std::vector<std::shared_ptr<connector::ConnectorSplit>> listSplits(
       const std::string& path,

--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -94,11 +94,11 @@ class TpchSpeedTest {
     auto startTime = system_clock::now();
     intervalStart_ = startTime;
 
-    CursorParameters params;
+    exec::CursorParameters params;
     params.planNode = plan;
     params.maxDrivers = FLAGS_max_drivers;
 
-    auto taskCursor = TaskCursor::create(params);
+    auto taskCursor = exec::TaskCursor::create(params);
     taskCursor->start();
 
     auto task = taskCursor->task();

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -19,7 +19,7 @@
 
 #include <filesystem>
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::exec {
 
 bool waitForTaskDriversToFinish(exec::Task* task, uint64_t maxWaitMicros) {
   VELOX_USER_CHECK(!task->isRunning());
@@ -460,4 +460,4 @@ bool RowCursor::hasNext() {
   return currentRow_ < numRows_ || cursor_->hasNext();
 }
 
-} // namespace facebook::velox::exec::test
+} // namespace facebook::velox::exec

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -18,7 +18,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Task.h"
 
-namespace facebook::velox::exec::test {
+namespace facebook::velox::exec {
 
 /// Wait up to maxWaitMicros for all the task drivers to finish. The function
 /// returns true if all the drivers have finished, otherwise false.
@@ -186,4 +186,4 @@ class RowCursor {
   vector_size_t numRows_ = 0;
 };
 
-} // namespace facebook::velox::exec::test
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -22,6 +22,7 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 class AssignUniqueIdTest : public OperatorTestBase {

--- a/velox/exec/tests/EnforceSingleRowTest.cpp
+++ b/velox/exec/tests/EnforceSingleRowTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 class EnforceSingleRowTest : public OperatorTestBase {

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 class LimitTest : public HiveConnectorTestBase {};

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 class MergeTest : public OperatorTestBase {

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -22,6 +22,7 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox;
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -4100,14 +4100,14 @@ TEST_F(TableScanTest, addSplitsToFailedTask) {
   writeToFile(filePath->getPath(), {data});
 
   core::PlanNodeId scanNodeId;
-  exec::test::CursorParameters params;
+  CursorParameters params;
   params.planNode = exec::test::PlanBuilder()
                         .tableScan(ROW({"c0"}, {INTEGER()}))
                         .capturePlanNodeId(scanNodeId)
                         .project({"5 / c0"})
                         .planNode();
 
-  auto cursor = exec::test::TaskCursor::create(params);
+  auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit(scanNodeId, makeHiveSplit(filePath->getPath()));
 
   EXPECT_THROW(while (cursor->moveNext()){}, VeloxUserError);

--- a/velox/exec/tests/TaskListenerTest.cpp
+++ b/velox/exec/tests/TaskListenerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 struct TaskCompletedEvent {

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 class UnnestTest : public OperatorTestBase,

--- a/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/utils/AggregationTestBase.cpp
@@ -33,8 +33,8 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/SignatureBinder.h"
 
+using facebook::velox::exec::CursorParameters;
 using facebook::velox::exec::test::AssertQueryBuilder;
-using facebook::velox::exec::test::CursorParameters;
 using facebook::velox::exec::test::PlanBuilder;
 using facebook::velox::test::VectorMaker;
 

--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -61,7 +61,7 @@ void LocalRunner::start() {
   VELOX_CHECK_EQ(state_, State::kInitialized);
   auto lastStage = makeStages();
   params_.planNode = plan_->fragments().back().fragment.planNode;
-  auto cursor = exec::test::TaskCursor::create(params_);
+  auto cursor = exec::TaskCursor::create(params_);
   stages_.push_back({cursor->task()});
   // Add table scan splits to the final gathere stage.
   for (auto& scan : fragments_.back().scans) {

--- a/velox/runner/LocalRunner.h
+++ b/velox/runner/LocalRunner.h
@@ -100,11 +100,11 @@ class LocalRunner : public Runner,
   const std::vector<ExecutableFragment> fragments_;
   const MultiFragmentPlan::Options& options_;
 
-  exec::test::CursorParameters params_;
+  exec::CursorParameters params_;
 
   tsan_atomic<State> state_{State::kInitialized};
 
-  std::unique_ptr<exec::test::TaskCursor> cursor_;
+  std::unique_ptr<exec::TaskCursor> cursor_;
   std::vector<std::vector<std::shared_ptr<exec::Task>>> stages_;
   std::exception_ptr error_;
   std::shared_ptr<SplitSourceFactory> splitSourceFactory_;

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -28,6 +28,7 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::substrait;
 

--- a/velox/tool/trace/TraceReplayTaskRunner.cpp
+++ b/velox/tool/trace/TraceReplayTaskRunner.cpp
@@ -20,7 +20,7 @@ namespace facebook::velox::tool::trace {
 
 std::pair<std::shared_ptr<exec::Task>, RowVectorPtr> TraceReplayTaskRunner::run(
     bool copyResults) {
-  auto cursor = exec::test::TaskCursor::create(cursorParams_);
+  auto cursor = exec::TaskCursor::create(cursorParams_);
   std::vector<RowVectorPtr> results;
   auto* task = cursor->task().get();
   addSplits(task);

--- a/velox/tool/trace/TraceReplayTaskRunner.h
+++ b/velox/tool/trace/TraceReplayTaskRunner.h
@@ -53,7 +53,7 @@ class TraceReplayTaskRunner {
   static std::shared_ptr<RowVector> copy(
       const std::vector<RowVectorPtr>& results);
 
-  exec::test::CursorParameters cursorParams_;
+  exec::CursorParameters cursorParams_;
   std::unordered_map<core::PlanNodeId, std::vector<exec::Split>> splits_;
   bool noMoreSplits_ = false;
 };


### PR DESCRIPTION
Summary: The methods/classes in cusor.h should not be in ::test namespace. Updated the declaration as well as all the references.

Reviewed By: xiaoxmeng

Differential Revision: D67775554


