### PR TITLE
fix: Fix ODR violation coming from DuckLogicalOperator.h

### DIFF
--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/parse/QueryPlanner.h"
-#include <duckdb.hpp> // @manual
 #include "velox/duckdb/conversion/DuckConversion.h"
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/parse/DuckLogicalOperator.h"
@@ -28,8 +27,6 @@
 #include <duckdb/planner/expression/bound_constant_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_function_expression.hpp> // @manual
 #include <duckdb/planner/expression/bound_reference_expression.hpp> // @manual
-
-#include <iostream>
 
 namespace facebook::velox::core {
 


### PR DESCRIPTION
Summary:
DuckLogicalOperator.h defines a bunch of DuckDB logical plan nodes that would come from
duckdb-internal.hpp but we can't include that file.

https://github.com/facebookincubator/velox/pull/11930 added LogicalOrder and included a minimal version of
the definition in DuckDB 0.8.1 not including a bunch of fields/functions we don't use. I see minimal versions
of other plan nodes are likewise used in the file, but for whatever reason, this one in particular is tripping up
ODR issue detection during linking when UBSan is enabled.

The fix I offer here is to copy the definition verbatim from duckdb/planner/operator/logical_order.hpp.

I also noticed some unnecessary includes in velox/parse/QueryPlanner.cpp introduced by that PR while 
debugging which I've removed here for cleanliness, they're not critical to the fix.

Differential Revision: D67804092


