### PR TITLE
fix: Avoid redownload coalesced region gap twice in buffered inputs

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -205,15 +205,23 @@ class DirectBufferedInput : public BufferedInput {
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
 
-  // Sorts requests and makes CoalescedLoads for nearby requests. If 'prefetch'
-  // is true, starts background loading.
-  void makeLoads(std::vector<LoadRequest*> requests, bool prefetch);
+  std::vector<int32_t> groupRequests(
+      const std::vector<LoadRequest*>& requests,
+      bool prefetch) const;
 
   // Makes a CoalescedLoad for 'requests' to be read together, coalescing IO if
   // appropriate. If 'prefetch' is set, schedules the CoalescedLoad on
   // 'executor_'. Links the CoalescedLoad  to all DirectInputStreams that it
   // covers.
-  void readRegion(std::vector<LoadRequest*> requests, bool prefetch);
+  void readRegion(const std::vector<LoadRequest*>& requests, bool prefetch);
+
+  // Read coalesced regions.  Regions are grouped together using `groupEnds'.
+  // For example if there are 5 regions, 1 and 2 are coalesced together and 3,
+  // 4, 5 are coalesced together, we will have {2, 5} in `groupEnds'.
+  void readRegions(
+      const std::vector<LoadRequest*>& requests,
+      bool prefetch,
+      const std::vector<int32_t>& groupEnds);
 
   const uint64_t fileNum_;
   const std::shared_ptr<cache::ScanTracker> tracker_;

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -39,6 +39,7 @@ using IoStatisticsPtr = std::shared_ptr<IoStatistics>;
 struct TestRegion {
   int32_t offset;
   int32_t length;
+  bool read = true;
 };
 
 class DirectBufferedInputTest : public testing::Test {
@@ -92,7 +93,7 @@ class DirectBufferedInputTest : public testing::Test {
     }
     input->load(LogType::FILE);
     for (auto i = 0; i < regions.size(); ++i) {
-      if (regions[i].length > 0) {
+      if (regions[i].read && regions[i].length > 0) {
         checkRead(streams[i].get(), regions[i]);
       }
     }
@@ -185,4 +186,9 @@ TEST_F(DirectBufferedInputTest, basic) {
   // The first reads in 2 parts and does not coalesce to the second, which reads
   // in one part.
   testLoads({{1000, 9000000}, {9010000, 1000000}}, 3);
+}
+
+TEST_F(DirectBufferedInputTest, noRedownloadCoalescedPrefetch) {
+  testLoads({{100, 100}, {201, 1, false}, {202, 100}}, 1);
+  testLoads({{100, 100}, {201, 1, true}, {202, 100}}, 1);
 }


### PR DESCRIPTION
Summary:
In the current `DirectBufferedInput` and `CachedBufferedInput`, when we
coalesce some regions during prefetch, the gap between regions are not marked as
available, and if they are needed in adhoc streams, we would issue separate IOs
for them, resulting in unnecessary IOs.  This change fixes this by rearranging
the regions and loads generation logic, first generate and group the prefetch
regions, then we can compare the coalesced regions to the adhoc regions and move
those already coalesced to the prefetch loads, reducing the number of adhoc IOs.

Differential Revision: D67810195


