### PR TITLE
feat(fuzzer): Add input generator for json_parse in expression fuzzer

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -456,7 +456,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
       usesTypeName(signature, "hyperloglog") ||
-      usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));

--- a/velox/expression/fuzzer/ArgsOverrideFunctions.cpp
+++ b/velox/expression/fuzzer/ArgsOverrideFunctions.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/fuzzer/ArgsOverrideFunctions.h"
+
+#include "velox/common/fuzzer/ConstrainedGenerators.h"
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/core/Expressions.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::fuzzer {
+
+std::vector<core::TypedExprPtr> JsonParseArgValuesGenerator::generate(
+    const CallableSignature& signature,
+    const VectorFuzzer::Options& options,
+    FuzzerGenerator& rng,
+    ExpressionFuzzerState& state) {
+  VELOX_CHECK_EQ(signature.args.size(), 1);
+  std::vector<core::TypedExprPtr> inputExpressions;
+
+  state.inputRowTypes_.emplace_back(signature.args[0]);
+  state.inputRowNames_.emplace_back(
+      fmt::format("c{}", state.inputRowTypes_.size() - 1));
+
+  const auto representedType = facebook::velox::randType(rng, 3);
+  const auto seed = rand<uint32_t>(rng);
+  const auto nullRatio = options.nullRatio;
+  state.customInputGenerators_.emplace_back(
+      std::make_shared<fuzzer::JsonInputGenerator>(
+          seed,
+          signature.args[0],
+          nullRatio,
+          fuzzer::getRandomInputGenerator(seed, representedType, nullRatio),
+          true));
+
+  inputExpressions.push_back(std::make_shared<core::FieldAccessTypedExpr>(
+      signature.args[0], state.inputRowNames_.back()));
+  return inputExpressions;
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ArgsOverrideFunctions.h
+++ b/velox/expression/fuzzer/ArgsOverrideFunctions.h
@@ -13,27 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
-#include "velox/common/fuzzer/ConstrainedGenerators.h"
-#include "velox/vector/BaseVector.h"
+#include "velox/expression/fuzzer/FuzzerToolkit.h"
 
 namespace facebook::velox::fuzzer {
 
-class ConstrainedVectorGenerator {
+class JsonParseArgValuesGenerator : public ArgValuesGenerator {
  public:
-  ConstrainedVectorGenerator() = delete;
+  ~JsonParseArgValuesGenerator() override = default;
 
-  static VectorPtr generateConstant(
-      const AbstractInputGeneratorPtr& customGenerator,
-      vector_size_t size,
-      memory::MemoryPool* pool);
-
-  static VectorPtr generateFlat(
-      const AbstractInputGeneratorPtr& customGenerator,
-      vector_size_t size,
-      memory::MemoryPool* pool);
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
 };
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(
 
 add_library(
   velox_expression_fuzzer
+  ArgsOverrideFunctions.cpp
   ArgumentTypeFuzzer.cpp
   DecimalArgGeneratorBase.cpp
   ExpressionFuzzer.cpp
@@ -38,11 +39,13 @@ target_link_libraries(
   velox_type
   velox_vector_fuzzer
   velox_vector_test_lib
+  velox_constrained_input_generators
   velox_function_registry
   velox_expression_test_utility
   velox_file
   velox_hive_connector
-  velox_fuzzer_util)
+  velox_fuzzer_util
+  velox_common_fuzzer_util)
 
 add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -19,6 +19,8 @@
 
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 #include "velox/expression/fuzzer/ArgGenerator.h"
+#include "velox/expression/fuzzer/ArgsOverrideFunctions.h"
+#include "velox/expression/fuzzer/ExpressionFuzzer.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
 #include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
 #include "velox/functions/prestosql/fuzzer/DivideArgGenerator.h"
@@ -52,7 +54,10 @@ DEFINE_uint32(
 using namespace facebook::velox::exec::test;
 using facebook::velox::exec::test::PrestoQueryRunner;
 using facebook::velox::fuzzer::ArgGenerator;
+using facebook::velox::fuzzer::ArgValuesGenerator;
+using facebook::velox::fuzzer::ExpressionFuzzer;
 using facebook::velox::fuzzer::FuzzerRunner;
+using facebook::velox::fuzzer::JsonParseArgValuesGenerator;
 using facebook::velox::test::ReferenceQueryRunner;
 
 int main(int argc, char** argv) {
@@ -122,6 +127,10 @@ int main(int argc, char** argv) {
           {"map_keys", std::make_shared<SortArrayTransformer>()},
           {"map_values", std::make_shared<SortArrayTransformer>()}};
 
+  std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
+      argsOverrideFuncs = {
+          {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()}};
+
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool{
       facebook::velox::memory::memoryManager()->addRootPool()};
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner{nullptr};
@@ -140,6 +149,7 @@ int main(int argc, char** argv) {
       {{"session_timezone", "America/Los_Angeles"},
        {"adjust_timestamp_to_session_timezone", "true"}},
       argGenerators,
+      argsOverrideFuncs,
       referenceQueryRunner,
       std::make_shared<
           facebook::velox::fuzzer::SpecialFormSignatureGenerator>());

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.h
@@ -55,7 +55,10 @@ class ExpressionFuzzerVerifier {
       size_t initialSeed,
       const Options& options,
       const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
-          argGenerators);
+          argGenerators,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<ArgValuesGenerator>>& argsOverrideFuncs);
 
   // This function starts the test that is performed by the
   // ExpressionFuzzerVerifier which is generating random expressions and
@@ -173,7 +176,8 @@ class ExpressionFuzzerVerifier {
   // 4. Appends a row number column to the input row vector.
   std::pair<std::vector<InputTestCase>, InputRowMetadata> generateInput(
       const RowTypePtr& rowType,
-      VectorFuzzer& vectorFuzzer);
+      VectorFuzzer& vectorFuzzer,
+      const std::vector<AbstractInputGeneratorPtr>& inputGenerators);
 
   /// Randomize initial result vector data to test for correct null and data
   /// setting in functions.

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/expression/fuzzer/FuzzerRunner.h"
+
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
 
 DEFINE_int32(steps, 10, "Number of expressions to generate and execute.");
@@ -236,6 +237,8 @@ int FuzzerRunner::run(
     const std::unordered_map<std::string, std::string>& queryConfigs,
     const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
         argGenerators,
+    const std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>&
+        argsOverrideFuncs,
     std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
     const std::shared_ptr<SpecialFormSignatureGenerator>&
         specialFormSignatureGenerator) {
@@ -245,6 +248,7 @@ int FuzzerRunner::run(
       exprTransformers,
       queryConfigs,
       argGenerators,
+      argsOverrideFuncs,
       referenceQueryRunner,
       specialFormSignatureGenerator);
   return RUN_ALL_TESTS();
@@ -259,6 +263,8 @@ void FuzzerRunner::runFromGtest(
     const std::unordered_map<std::string, std::string>& queryConfigs,
     const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
         argGenerators,
+    const std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>&
+        argsOverrideFuncs,
     std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
     const std::shared_ptr<SpecialFormSignatureGenerator>&
         specialFormSignatureGenerator) {
@@ -271,6 +277,8 @@ void FuzzerRunner::runFromGtest(
   // Insert generated signatures of special forms into the signature map.
   specialFormSignatureGenerator->appendSpecialForms(
       signatures, options.expressionFuzzerOptions.specialForms);
-  ExpressionFuzzerVerifier(signatures, seed, options, argGenerators).go();
+  ExpressionFuzzerVerifier(
+      signatures, seed, options, argGenerators, argsOverrideFuncs)
+      .go();
 }
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/FuzzerRunner.h
+++ b/velox/expression/fuzzer/FuzzerRunner.h
@@ -20,7 +20,6 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <vector>
 
 #include "velox/exec/fuzzer/ExprTransformer.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
@@ -44,6 +43,9 @@ class FuzzerRunner {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
           argGenerators,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<ArgValuesGenerator>>& argsOverrideFuncs,
       std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
       const std::shared_ptr<SpecialFormSignatureGenerator>& signatureGenerator);
 
@@ -56,6 +58,9 @@ class FuzzerRunner {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
           argGenerators,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<ArgValuesGenerator>>& argsOverrideFuncs,
       std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
       const std::shared_ptr<SpecialFormSignatureGenerator>& signatureGenerator);
 };

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -107,6 +107,7 @@ int main(int argc, char** argv) {
       {{}},
       queryConfigs,
       argGenerators,
+      {{}},
       referenceQueryRunner,
       std::make_shared<
           facebook::velox::fuzzer::SparkSpecialFormSignatureGenerator>());

--- a/velox/expression/fuzzer/tests/ExpressionFuzzerUnitTest.cpp
+++ b/velox/expression/fuzzer/tests/ExpressionFuzzerUnitTest.cpp
@@ -143,7 +143,7 @@ TEST_F(ExpressionFuzzerUnitTest, exprBank) {
         0,
         vectorfuzzer,
         makeOptionsWithMaxLevelNesting(maxLevelOfNesting)};
-    ExpressionFuzzer::ExprBank exprBank(seed, maxLevelOfNesting);
+    ExprBank exprBank(seed, maxLevelOfNesting);
     for (int i = 0; i < 5000; ++i) {
       auto expression = fuzzer.fuzzExpression().expressions[0];
       // Verify that if there is a single expression then it is returned
@@ -171,7 +171,7 @@ TEST_F(ExpressionFuzzerUnitTest, exprBank) {
         0,
         vectorfuzzer,
         makeOptionsWithMaxLevelNesting(maxLevelOfNesting)};
-    ExpressionFuzzer::ExprBank exprBank(seed, maxLevelOfNesting);
+    ExprBank exprBank(seed, maxLevelOfNesting);
     for (int i = 0; i < 1000; ++i) {
       auto expression = fuzzer.fuzzExpression().expressions[0];
       exprBank.insert(expression);

--- a/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
+++ b/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
@@ -25,7 +25,7 @@ using exec::VectorWriter;
 
 // static
 VectorPtr ConstrainedVectorGenerator::generateConstant(
-    const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+    const AbstractInputGeneratorPtr& customGenerator,
     vector_size_t size,
     memory::MemoryPool* pool) {
   VELOX_CHECK_NOT_NULL(customGenerator);
@@ -119,7 +119,7 @@ void writeOne<TypeKind::ROW>(const variant& v, GenericWriter& writer) {
 
 // static
 VectorPtr ConstrainedVectorGenerator::generateFlat(
-    const std::shared_ptr<AbstractInputGenerator>& customGenerator,
+    const AbstractInputGeneratorPtr& customGenerator,
     vector_size_t size,
     memory::MemoryPool* pool) {
   VELOX_CHECK_NOT_NULL(customGenerator);

--- a/velox/vector/fuzzer/tests/ConstrainedVectorGeneratorTest.cpp
+++ b/velox/vector/fuzzer/tests/ConstrainedVectorGeneratorTest.cpp
@@ -35,7 +35,7 @@ class ConstrainedVectorGeneratorTest : public testing::Test,
       const variant& excludedValue) {
     using T = typename TypeTraits<KIND>::NativeType;
     const uint32_t kSize = 1000;
-    std::shared_ptr<AbstractInputGenerator> generator =
+    AbstractInputGeneratorPtr generator =
         std::make_shared<NotEqualConstrainedGenerator>(
             0,
             type,
@@ -69,7 +69,7 @@ class ConstrainedVectorGeneratorTest : public testing::Test,
   void testGenerateVectorsComplex(const TypePtr& type) {
     using T = typename TypeTraits<KIND>::ImplType;
     const uint32_t kSize = 1000;
-    std::shared_ptr<AbstractInputGenerator> generator =
+    AbstractInputGeneratorPtr generator =
         std::make_shared<RandomInputGenerator<T>>(0, type, 0.5);
     auto vector =
         ConstrainedVectorGenerator::generateFlat(generator, kSize, pool());


### PR DESCRIPTION
Summary:
Make expression fuzzer generate input vectors of valid JSON strings for the
json_parse function. To test corner cases, the JSON strings may be
randomly truncated or inserted with a space character.

Differential Revision: D67820571


