### PR TITLE
fix(vector): Add error logic to DictionaryVector's toString for logging uninitialized lazy loaded vectors

### DIFF
--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -190,6 +190,9 @@ class DictionaryVector : public SimpleVector<T> {
   }
 
   std::string toString(vector_size_t index) const override {
+    VELOX_CHECK(
+        initialized_,
+        "Cannot convert to string because current DictionaryVector is not properly initialized yet.");
     if (BaseVector::isNullAt(index)) {
       return "null";
     }


### PR DESCRIPTION
Currently, the Dictionary Vector's toString method fails to check whether it is loaded before proceeding to access values from the underlying vector. If this vector is lazy, it may be loaded as a result, causing the Dictionary Vector to enter an invalid state where it remains uninitialized despite having a loaded underlying vector.

To mitigate this issue, we should have a consistent behavior for data accessing and logging functions. This diff contains an addition to DictionaryVector's toString method to implement the same precheck as other functions, noting the user to initialize the vector before the toString method can be called.

(fixes https://github.com/facebookincubator/velox/issues/10594)
Pull Request resolved: https://github.com/facebookincubator/velox/pull/12025