### PR TITLE
fix: Reduce range of buckets in ClassificationAggregationInputGenerator

### DIFF
--- a/velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h
@@ -44,7 +44,7 @@ class ClassificationAggregationInputGenerator : public InputGenerator {
     /// buckets are capped to 50'000 to prevent OOM-ing issues. The minimum is
     /// 2 since that is the minimum valid bucket count.
     if (!bucket_.has_value()) {
-      bucket_ = boost::random::uniform_int_distribution<int64_t>(2, 50000)(rng);
+      bucket_ = boost::random::uniform_int_distribution<int64_t>(2, 500)(rng);
     }
     const auto size = fuzzer.getOptions().vectorSize;
     velox::test::VectorMaker vectorMaker{pool};


### PR DESCRIPTION
Summary:
In the AggregationFuzzer we see plans that use the classification_precision aggregation taking upwards of 2
minutes to execute.  The problem seems to be in sorting the results for the purposes of comparison.  The
aggregate produces arrays with size number of buckets and the cost of comparing large arrays of variants is
quite high.

Given we execute 40+ variations of a plan this causes the AggregationFuzzer to run for over an hour on a single
query using this aggregate.

As a quick fix, this change lowers the maximum value of buckets from 50,000 to 500. With this change
executing a single plan takes closer to 10 seconds.

We should probably look at further optimizations in the future, e.g. executing plans in parallel, evaluating sorting 
the Vectors instead of the variants, use a hash based approach.

Differential Revision: D67872087


