### PR TITLE
fix: JsonStringUtil attempts to serialize bad char* in error message

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -334,8 +334,8 @@ size_t normalizeForJsonParse(const char* input, size_t length, char* output) {
   while (start < end) {
     // Unescape characters that are escaped by \ character.
     if (FOLLY_UNLIKELY(*start == '\\')) {
-      VELOX_USER_CHECK_NE(
-          start + 1, end, "Invalid escape sequence at the end of string");
+      VELOX_USER_CHECK(
+          start + 1 != end, "Invalid escape sequence at the end of string");
       // Presto java implementation only unescapes the / character.
       switch (*(start + 1)) {
         case '/':
@@ -343,8 +343,8 @@ size_t normalizeForJsonParse(const char* input, size_t length, char* output) {
           start += 2;
           continue;
         case 'u': {
-          VELOX_USER_CHECK_LE(
-              start + 5, end, "Invalid escape sequence at the end of string");
+          VELOX_USER_CHECK(
+              start + 5 <= end, "Invalid escape sequence at the end of string");
 
           // Read 4 hex digits.
           auto codePoint = parseHex(std::string_view(start + 2, 4));
@@ -428,16 +428,16 @@ size_t normalizedSizeForJsonParse(const char* input, size_t length) {
   size_t outSize = 0;
   while (start < end) {
     if (FOLLY_UNLIKELY(*start == '\\')) {
-      VELOX_USER_CHECK_NE(
-          start + 1, end, "Invalid escape sequence at the end of string");
+      VELOX_USER_CHECK(
+          start + 1 != end, "Invalid escape sequence at the end of string");
       switch (*(start + 1)) {
         case '/':
           ++outSize;
           start += 2;
           continue;
         case 'u': {
-          VELOX_USER_CHECK_LE(
-              start + 5, end, "Invalid escape sequence at the end of string");
+          VELOX_USER_CHECK(
+              start + 5 <= end, "Invalid escape sequence at the end of string");
           auto codePoint = parseHex(std::string_view(start + 2, 4));
           if (isHighSurrogate(codePoint) || isLowSurrogate(codePoint) ||
               isSpecialCode(codePoint)) {

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -326,6 +326,12 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   } catch (const VeloxUserError& e) {
     ASSERT_EQ(e.context(), "Top-level Expression: json_parse(c0)");
   }
+
+  // Test partial escape sequences.
+  VELOX_ASSERT_USER_THROW(
+      jsonParse("{\"k1\\"), "Invalid escape sequence at the end of string");
+  VELOX_ASSERT_USER_THROW(
+      jsonParse("{\"k1\\u"), "Invalid escape sequence at the end of string");
 }
 
 TEST_F(JsonFunctionsTest, canonicalization) {


### PR DESCRIPTION
Summary:
JsonStringUtil uses VELOX_USER_CHECK_NE/VELOX_USER_CHECK_LE to compare char* to make sure one is 
not at or beyond the end of the string.  The way the macro works, if it fails, it will attempt to serialize the char*
in the error message.  It doesn't not serialize the address but rather a string starting from the pointer (since it's
a char*).  Given this check has already determined the pointer is at or beyond the end of the string this
produces results that are useless at best.

Using VELOX_USER_CHECK avoids this serialization.

Caught via ASAN with expression fuzzer tests.

Differential Revision: D67875678


