### PR TITLE
feat(fuzzer): Add custom special form signatures for Presto and Spark

### DIFF
--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -28,8 +28,9 @@ add_library(
   ArgumentTypeFuzzer.cpp
   DecimalArgGeneratorBase.cpp
   ExpressionFuzzer.cpp
+  ExpressionFuzzerVerifier.cpp
   FuzzerRunner.cpp
-  ExpressionFuzzerVerifier.cpp)
+  SpecialFormSignatureGenerator.cpp)
 
 target_link_libraries(
   velox_expression_fuzzer
@@ -54,7 +55,9 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main)
 
-add_executable(spark_expression_fuzzer_test SparkExpressionFuzzerTest.cpp)
+add_executable(
+  spark_expression_fuzzer_test SparkExpressionFuzzerTest.cpp
+                               SparkSpecialFormSignatureGenerator.cpp)
 
 target_link_libraries(
   spark_expression_fuzzer_test

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 #include "velox/expression/fuzzer/ArgGenerator.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
+#include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
 #include "velox/functions/prestosql/fuzzer/DivideArgGenerator.h"
 #include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ModulusArgGenerator.h"
@@ -139,5 +140,7 @@ int main(int argc, char** argv) {
       {{"session_timezone", "America/Los_Angeles"},
        {"adjust_timestamp_to_session_timezone", "true"}},
       argGenerators,
-      referenceQueryRunner);
+      referenceQueryRunner,
+      std::make_shared<
+          facebook::velox::fuzzer::SpecialFormSignatureGenerator>());
 }

--- a/velox/expression/fuzzer/FuzzerRunner.h
+++ b/velox/expression/fuzzer/FuzzerRunner.h
@@ -25,6 +25,7 @@
 #include "velox/exec/fuzzer/ExprTransformer.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/expression/fuzzer/ExpressionFuzzerVerifier.h"
+#include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
 #include "velox/functions/FunctionRegistry.h"
 
 namespace facebook::velox::fuzzer {
@@ -34,6 +35,7 @@ using facebook::velox::exec::test::ExprTransformer;
 /// FuzzerRunner leverages ExpressionFuzzerVerifier to create a gtest unit test.
 class FuzzerRunner {
  public:
+  /// @param signatureGenerator Generates valid signatures for special forms.
   static int run(
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
@@ -42,8 +44,10 @@ class FuzzerRunner {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
           argGenerators,
-      std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner);
+      std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
+      const std::shared_ptr<SpecialFormSignatureGenerator>& signatureGenerator);
 
+  /// @param signatureGenerator Generates valid signatures for special forms.
   static void runFromGtest(
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
@@ -52,7 +56,8 @@ class FuzzerRunner {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::shared_ptr<ArgGenerator>>&
           argGenerators,
-      std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner);
+      std::shared_ptr<exec::test::ReferenceQueryRunner> referenceQueryRunner,
+      const std::shared_ptr<SpecialFormSignatureGenerator>& signatureGenerator);
 };
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/SparkExpressionFuzzerTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
+#include "velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.h"
 #include "velox/functions/prestosql/fuzzer/FloorAndRoundArgGenerator.h"
 #include "velox/functions/sparksql/fuzzer/AddSubtractArgGenerator.h"
 #include "velox/functions/sparksql/fuzzer/DivideArgGenerator.h"
@@ -106,5 +107,7 @@ int main(int argc, char** argv) {
       {{}},
       queryConfigs,
       argGenerators,
-      referenceQueryRunner);
+      referenceQueryRunner,
+      std::make_shared<
+          facebook::velox::fuzzer::SparkSpecialFormSignatureGenerator>());
 }

--- a/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.cpp
+++ b/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.h"
+
+namespace facebook::velox::fuzzer {
+
+std::vector<exec::FunctionSignaturePtr>
+SparkSpecialFormSignatureGenerator::getSignaturesForCast() const {
+  std::vector<exec::FunctionSignaturePtr> signatures =
+      SpecialFormSignatureGenerator::getSignaturesForCast();
+
+  // Cast tinyint/smallint/integer/bigint as varbinary is supported in Spark.
+  for (auto fromType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(makeCastSignature(fromType, "varbinary"));
+  }
+
+  // Cast tinyint/smallint/integer/bigint as timestamp is supported in Spark.
+  for (auto fromType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(makeCastSignature(fromType, "timestamp"));
+  }
+  return signatures;
+}
+
+const std::unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>&
+SparkSpecialFormSignatureGenerator::getSignatures() const {
+  const static std::
+      unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>
+          kSpecialForms{
+              {"and", getSignaturesForAnd()},
+              {"or", getSignaturesForOr()},
+              {"coalesce", getSignaturesForCoalesce()},
+              {"if", getSignaturesForIf()},
+              {"switch", getSignaturesForSwitch()},
+              {"cast", getSignaturesForCast()},
+              {"concat_ws", getSignaturesForConcatWs()}};
+  return kSpecialForms;
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SparkSpecialFormSignatureGenerator::getSignaturesForConcatWs() const {
+  // Signature: concat_ws (separator, input, ...) -> output:
+  // varchar, varchar, varchar, ... -> varchar
+  return {facebook::velox::exec::FunctionSignatureBuilder()
+              .argumentType("varchar")
+              .variableArity("varchar")
+              .returnType("varchar")
+              .build()};
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.h
+++ b/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
+
+namespace facebook::velox::fuzzer {
+
+/// Generates signatures of special forms for the Spark expression fuzzer test
+/// to use.
+class SparkSpecialFormSignatureGenerator
+    : public SpecialFormSignatureGenerator {
+ protected:
+  std::vector<exec::FunctionSignaturePtr> getSignaturesForCast() const override;
+
+  const std::
+      unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>&
+      getSignatures() const override;
+
+ private:
+  std::vector<exec::FunctionSignaturePtr> getSignaturesForConcatWs() const;
+};
+
+} // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/SpecialFormSignatureGenerator.cpp
+++ b/velox/expression/fuzzer/SpecialFormSignatureGenerator.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
+#include "velox/expression/signature_parser/ParseUtil.h"
+
+namespace facebook::velox::fuzzer {
+
+void SpecialFormSignatureGenerator::appendSpecialForms(
+    FunctionSignatureMap& signatureMap,
+    const std::string& specialForms) const {
+  auto specialFormNames = exec::splitNames(specialForms);
+  for (const auto& [name, signatures] : getSignatures()) {
+    if (specialFormNames.count(name) == 0) {
+      LOG(INFO) << "Skipping special form: " << name;
+      continue;
+    }
+    std::vector<const exec::FunctionSignature*> rawSignatures;
+    for (const auto& signature : signatures) {
+      rawSignatures.push_back(signature.get());
+    }
+    signatureMap.insert({name, std::move(rawSignatures)});
+  }
+}
+
+void SpecialFormSignatureGenerator::addCastFromIntegralSignatures(
+    const std::string& toType,
+    std::vector<exec::FunctionSignaturePtr>& signatures) const {
+  for (const auto& fromType : kIntegralTypes_) {
+    signatures.push_back(makeCastSignature(fromType, toType));
+  }
+}
+
+void SpecialFormSignatureGenerator::addCastFromFloatingPointSignatures(
+    const std::string& toType,
+    std::vector<exec::FunctionSignaturePtr>& signatures) const {
+  for (const auto& fromType : kFloatingPointTypes_) {
+    signatures.push_back(makeCastSignature(fromType, toType));
+  }
+}
+
+void SpecialFormSignatureGenerator::addCastFromVarcharSignature(
+    const std::string& toType,
+    std::vector<exec::FunctionSignaturePtr>& signatures) const {
+  signatures.push_back(makeCastSignature("varchar", toType));
+}
+
+void SpecialFormSignatureGenerator::addCastFromTimestampSignature(
+    const std::string& toType,
+    std::vector<exec::FunctionSignaturePtr>& signatures) const {
+  signatures.push_back(makeCastSignature("timestamp", toType));
+}
+
+void SpecialFormSignatureGenerator::addCastFromDateSignature(
+    const std::string& toType,
+    std::vector<exec::FunctionSignaturePtr>& signatures) const {
+  signatures.push_back(makeCastSignature("date", toType));
+}
+
+const std::unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>&
+SpecialFormSignatureGenerator::getSignatures() const {
+  const static std::
+      unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>
+          kSpecialForms{
+              {"and", getSignaturesForAnd()},
+              {"or", getSignaturesForOr()},
+              {"coalesce", getSignaturesForCoalesce()},
+              {"if", getSignaturesForIf()},
+              {"switch", getSignaturesForSwitch()},
+              {"cast", getSignaturesForCast()}};
+  return kSpecialForms;
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForAnd() const {
+  // Signature: and (condition,...) -> output:
+  // boolean, boolean,.. -> boolean
+  return {exec::FunctionSignatureBuilder()
+              .argumentType("boolean")
+              .variableArity("boolean")
+              .returnType("boolean")
+              .build()};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForOr() const {
+  // Signature: or (condition,...) -> output:
+  // boolean, boolean,.. -> boolean
+  return {exec::FunctionSignatureBuilder()
+              .argumentType("boolean")
+              .variableArity("boolean")
+              .returnType("boolean")
+              .build()};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForCoalesce() const {
+  // Signature: coalesce (input,...) -> output:
+  // T, T,.. -> T
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .argumentType("T")
+              .variableArity("T")
+              .returnType("T")
+              .build()};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForIf() const {
+  // Signature: if (condition, then) -> output:
+  // boolean, T -> T
+  const auto ifThen = exec::FunctionSignatureBuilder()
+                          .typeVariable("T")
+                          .argumentType("boolean")
+                          .argumentType("T")
+                          .returnType("T")
+                          .build();
+  // Signature: if (condition, then, else) -> output:
+  // boolean, T, T -> T
+  const auto ifThenElse = exec::FunctionSignatureBuilder()
+                              .typeVariable("T")
+                              .argumentType("boolean")
+                              .argumentType("T")
+                              .argumentType("T")
+                              .returnType("T")
+                              .build();
+  return {ifThen, ifThenElse};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForSwitch() const {
+  // Signature: Switch (condition, then) -> output:
+  // boolean, T -> T
+  // This is only used to bind to a randomly selected type for the
+  // output, then while generating arguments, an override is used
+  // to generate inputs that can create variation of multiple
+  // cases and may or may not include a final else clause.
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .argumentType("boolean")
+              .argumentType("T")
+              .returnType("T")
+              .build()};
+}
+
+std::vector<exec::FunctionSignaturePtr>
+SpecialFormSignatureGenerator::getSignaturesForCast() const {
+  std::vector<exec::FunctionSignaturePtr> signatures;
+
+  // To integral types.
+  for (const auto& toType : kIntegralTypes_) {
+    addCastFromIntegralSignatures(toType, signatures);
+    addCastFromFloatingPointSignatures(toType, signatures);
+    addCastFromVarcharSignature(toType, signatures);
+  }
+
+  // To floating-point types.
+  for (const auto& toType : kFloatingPointTypes_) {
+    addCastFromIntegralSignatures(toType, signatures);
+    addCastFromFloatingPointSignatures(toType, signatures);
+    addCastFromVarcharSignature(toType, signatures);
+  }
+
+  // To varchar type.
+  addCastFromIntegralSignatures("varchar", signatures);
+  addCastFromFloatingPointSignatures("varchar", signatures);
+  addCastFromVarcharSignature("varchar", signatures);
+  addCastFromDateSignature("varchar", signatures);
+  addCastFromTimestampSignature("varchar", signatures);
+
+  // To timestamp type.
+  addCastFromVarcharSignature("timestamp", signatures);
+  addCastFromDateSignature("timestamp", signatures);
+
+  // To date type.
+  addCastFromVarcharSignature("date", signatures);
+  addCastFromTimestampSignature("date", signatures);
+
+  // For each supported translation pair T --> U, add signatures of array(T) -->
+  // array(U), map(varchar, T) --> map(varchar, U), row(T) --> row(U).
+  auto size = signatures.size();
+  for (auto i = 0; i < size; ++i) {
+    auto from = signatures[i]->argumentTypes()[0].baseName();
+    auto to = signatures[i]->returnType().baseName();
+
+    signatures.push_back(makeCastSignature(
+        fmt::format("array({})", from), fmt::format("array({})", to)));
+
+    signatures.push_back(makeCastSignature(
+        fmt::format("map(varchar, {})", from),
+        fmt::format("map(varchar, {})", to)));
+
+    signatures.push_back(makeCastSignature(
+        fmt::format("row({})", from), fmt::format("row({})", to)));
+  }
+  return signatures;
+}
+
+exec::FunctionSignaturePtr SpecialFormSignatureGenerator::makeCastSignature(
+    const std::string& fromType,
+    const std::string& toType) const {
+  return exec::FunctionSignatureBuilder()
+      .argumentType(fromType)
+      .returnType(toType)
+      .build();
+}
+} // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
+++ b/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/FunctionRegistry.h"
+
+namespace facebook::velox::fuzzer {
+
+// Generates signatures of special forms for the expression fuzzer test to use.
+class SpecialFormSignatureGenerator {
+ public:
+  virtual ~SpecialFormSignatureGenerator() {}
+
+  /// Generates valid signatures for the specified special forms and append them
+  /// to the signature map.
+  /// @param specialForms Specifies a list of special form names delimited by
+  /// comma.
+  void appendSpecialForms(
+      FunctionSignatureMap& signatureMap,
+      const std::string& specialForms) const;
+
+ protected:
+  /// Generates signatures for cast from integral types to the given type and
+  /// adds them to signatures.
+  void addCastFromIntegralSignatures(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  /// Generates signatures for cast from floating-point types to the given type
+  /// and adds them to signatures.
+  void addCastFromFloatingPointSignatures(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  /// Generates signatures for cast from varchar to the given type and adds them
+  /// to signatures.
+  void addCastFromVarcharSignature(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  /// Generates signatures for cast from timestamp to the given type and adds
+  /// them to signatures.
+  void addCastFromTimestampSignature(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  /// Generates signatures for cast from date to the given type and adds them to
+  /// signatures.
+  void addCastFromDateSignature(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  // Returns the map of special form names to their signatures.
+  virtual const std::
+      unordered_map<std::string, std::vector<exec::FunctionSignaturePtr>>&
+      getSignatures() const;
+
+  // Returns the signatures for the 'and' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForAnd() const;
+
+  // Returns the signatures for the 'or' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForOr() const;
+
+  // Returns the signatures for the 'coalesce' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForCoalesce()
+      const;
+
+  // Returns the signatures for the 'if' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForIf() const;
+
+  // Returns the signatures for the 'switch' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForSwitch()
+      const;
+
+  // Returns the signatures for the 'cast' special form.
+  virtual std::vector<exec::FunctionSignaturePtr> getSignaturesForCast() const;
+
+  // Creates a signature for the cast(fromType as toType).
+  exec::FunctionSignaturePtr makeCastSignature(
+      const std::string& fromType,
+      const std::string& toType) const;
+
+  const std::vector<std::string> kIntegralTypes_{
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "boolean"};
+
+  const std::vector<std::string> kFloatingPointTypes_{"real", "double"};
+};
+
+} // namespace facebook::velox::fuzzer

--- a/velox/expression/signature_parser/ParseUtil.cpp
+++ b/velox/expression/signature_parser/ParseUtil.cpp
@@ -34,4 +34,18 @@ TypeSignaturePtr inferTypeWithSpaces(
       allWords.data() + fieldName.size() + 1, {}, fieldName));
 }
 
+std::unordered_set<std::string> splitNames(const std::string& names) {
+  // Parse, lower case and trim it.
+  std::vector<folly::StringPiece> nameList;
+  folly::split(',', names, nameList);
+  std::unordered_set<std::string> nameSet;
+
+  for (const auto& it : nameList) {
+    auto str = folly::trimWhitespace(it).toString();
+    folly::toLowerAscii(str);
+    nameSet.insert(str);
+  }
+  return nameSet;
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/signature_parser/ParseUtil.h
+++ b/velox/expression/signature_parser/ParseUtil.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
 #include "velox/expression/TypeSignature.h"
 
 namespace facebook::velox::exec {
@@ -28,5 +29,9 @@ namespace facebook::velox::exec {
 TypeSignaturePtr inferTypeWithSpaces(
     const std::vector<std::string>& words,
     bool canHaveFieldName = false);
+
+/// Extract names from an input string by splitting on commas, trimming and
+/// lower casing.
+std::unordered_set<std::string> splitNames(const std::string& names);
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
The signatures of special forms used in the expression fuzzer are different 
between Presto and Spark. This PR adds 'SpecialFormSignatureGenerator' and 
'SparkSpecialFormSignatureGenerator' for Presto and Spark respectively. Custom 
signatures for Spark cast and concat_ws function were added.