### PR TITLE
fix: CacheFuzzer does not respect restartCache when initializing cache bytes

### DIFF
--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -319,8 +319,8 @@ void CacheFuzzer::initializeCache(bool restartCache) {
   // We have up to 20 threads and 16 threads are used for reading so
   // there are some threads left over for SSD background write.
   executor_ = std::make_unique<folly::IOThreadPoolExecutor>(20);
-  const auto memoryCacheBytes = getMemoryCacheBytes();
-  const auto ssdCacheBytes = getSsdCacheBytes();
+  const auto memoryCacheBytes = getMemoryCacheBytes(restartCache);
+  const auto ssdCacheBytes = getSsdCacheBytes(restartCache);
 
   std::unique_ptr<SsdCache> ssdCache;
   if (ssdCacheBytes > 0) {


### PR DESCRIPTION
Summary:
When CacheFuzzer calls initializeCache it may allocate a new cache or restart the existing cache.  When it's
supposed to restart the cache it picks a new value for memoryCacheBytes and ssdCacheBytes.

If when the cache was originally started ssdCacheBytes was 0, then SSD specific settings like ssdCacheShards
won't have values. If ssdCacheBytes > 0 when the cache is restarted it will try to reuse the original value of
those SSD specific settings, which since they were never initialized are arbitrary and can be non-sensical (e.g. <= 0 in the case of shards). This leads to division by 0 and other errors when the cache is initialized.

I think the intention was for the value of the cache bytes to be reused if the cache is restarted like the other
settings (the get methods already take that boolean as a parameter).  That fixes the issue.

Differential Revision: D67909205


