### PR TITLE
refactor(dwio): Rewrite partition file path unescape utility functions using folly::uriUnescape()

### DIFF
--- a/velox/dwio/catalog/fbhive/CMakeLists.txt
+++ b/velox/dwio/catalog/fbhive/CMakeLists.txt
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 velox_add_library(velox_dwio_catalog_fbhive FileUtils.cpp)
-velox_link_libraries(velox_dwio_catalog_fbhive velox_dwio_common_exception
-                     fmt::fmt Folly::folly)
+velox_link_libraries(velox_dwio_catalog_fbhive velox_exception fmt::fmt
+                     Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(test)

--- a/velox/dwio/catalog/fbhive/test/CMakeLists.txt
+++ b/velox/dwio/catalog/fbhive/test/CMakeLists.txt
@@ -17,7 +17,7 @@ add_test(file_utils_test file_utils_test)
 target_link_libraries(
   file_utils_test
   velox_dwio_catalog_fbhive
-  velox_dwio_common_exception
+  velox_exception
   GTest::gtest
   GTest::gtest_main
   GTest::gmock)


### PR DESCRIPTION
Summary:
Refactor the uri unescape utility function using folly:: uriUnescape

NOTE: UriEscape refactor is not part of this PR due to its underlying escape 
char set is only a subset of folly::uriEscape's char set causing slightly 
behavior discrepancy


Differential Revision: D67917130


