### PR TITLE
feat: Add Spark CAST(double/float as timestamp)

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -263,7 +263,7 @@ From floating-point types
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Casting from floating-point input to timestamp type is allowed.
-The input value is treated as the number of seconds since the epoch (1970-01-01 00:00:00 UTC) and converted to microseconds.
+The input value is treated as the number of seconds since the epoch (1970-01-01 00:00:00 UTC) and converted to microseconds by truncating the fractional part.
 
 Valid examples
 

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -263,7 +263,7 @@ From floating-point types
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Casting from floating-point input to timestamp type is allowed.
-The input floating-point multiples 1'000'000 and is treated as the number of microseconds since the epoch (1970-01-01 00:00:00 UTC).
+The input value is treated as the number of seconds since the epoch (1970-01-01 00:00:00 UTC) and converted to microseconds.
 
 Valid examples
 

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -258,4 +258,23 @@ Valid example
   SELECT cast(1727181032 as timestamp); -- 2024-09-24 12:30:32
   SELECT cast(9223372036855 as timestamp); -- 294247-01-10 04:00:54.775807
   SELECT cast(-9223372036855 as timestamp); -- 290308-12-21 19:59:05.224192
+
+From floating-point types
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Casting from floating-point input to timestamp type is allowed.
+The input floating-point multiples 1'000'000 and is treated as the number of microseconds since the epoch (1970-01-01 00:00:00 UTC).
+
+Valid examples
+
+::
+
+  SELECT cast(0.0 as timestamp); -- 1970-01-01 00:00:00
+  SELECT cast(1727181032.0 as timestamp); -- 2024-09-24 12:30:32
+  SELECT cast(-1727181032.0 as timestamp); -- 1915-04-09 11:29:28
+  SELECT cast(cast(9223372036855.999 as double) as timestamp); -- 294247-01-10 04:00:54.775807
+  SELECT cast(cast(-9223372036856.999 as double) as timestamp); -- -290308-12-21 19:59:05.224192
+  SELECT cast(cast(1.79769e+308 as double) as timestamp); -- 294247-01-10 04:00:54.775807
+  SELECT cast(cast('inf' as double) as timestamp); -- NULL
+  SELECT cast(cast('nan' as double) as timestamp); -- NULL
   

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -292,13 +292,13 @@ void CastExpr::applyCastKernel(
       const auto castResult =
           hooks_->castDoubleToTimestamp(static_cast<double>(inputRowValue));
       if (castResult.hasError()) {
-        if (castResult.error().isUserError()) {
-          setError(castResult.error().message());
+        setError(castResult.error().message());
+      } else {
+        if (castResult.value().has_value()) {
+          result->set(row, castResult.value().value());
         } else {
           result->setNull(row, true);
         }
-      } else {
-        result->set(row, castResult.value());
       }
       return;
     }

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -37,7 +37,8 @@ class CastHooks {
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
-  virtual Expected<Timestamp> castDoubleToTimestamp(double seconds) const = 0;
+  virtual Expected<std::optional<Timestamp>> castDoubleToTimestamp(
+      double seconds) const = 0;
 
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -37,6 +37,8 @@ class CastHooks {
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
+  virtual Expected<Timestamp> castDoubleToTimestamp(double seconds) const = 0;
+
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;
 

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -90,7 +90,7 @@ Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t seconds) const {
       Status::UserError("Conversion to Timestamp is not supported"));
 }
 
-Expected<Timestamp> PrestoCastHooks::castDoubleToTimestamp(
+Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(
     double seconds) const {
   return folly::makeUnexpected(
       Status::UserError("Conversion to Timestamp is not supported"));

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -90,6 +90,12 @@ Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(int64_t seconds) const {
       Status::UserError("Conversion to Timestamp is not supported"));
 }
 
+Expected<Timestamp> PrestoCastHooks::castDoubleToTimestamp(
+    double seconds) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion to Timestamp is not supported"));
+}
+
 Expected<int32_t> PrestoCastHooks::castStringToDate(
     const StringView& dateString) const {
   // Cast from string to date allows only complete ISO 8601 formatted strings:

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -32,7 +32,8 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
-  Expected<Timestamp> castDoubleToTimestamp(double seconds) const override;
+  Expected<std::optional<Timestamp>> castDoubleToTimestamp(
+      double seconds) const override;
 
   // Uses standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -32,6 +32,8 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
+  Expected<Timestamp> castDoubleToTimestamp(double seconds) const override;
+
   // Uses standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -60,10 +60,10 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   return castNumberToTimestamp(seconds);
 }
 
-Expected<Timestamp> SparkCastHooks::castDoubleToTimestamp(double value) const {
+Expected<std::optional<Timestamp>> SparkCastHooks::castDoubleToTimestamp(
+    double value) const {
   if (FOLLY_UNLIKELY(std::isnan(value) || std::isinf(value))) {
-    return folly::makeUnexpected(
-        Status::Invalid("Can not convert NaN or Infinity to timestamp"));
+    return std::optional<Timestamp>{};
   }
   return castNumberToTimestamp(value);
 }

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -63,7 +63,7 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
 Expected<std::optional<Timestamp>> SparkCastHooks::castDoubleToTimestamp(
     double value) const {
   if (FOLLY_UNLIKELY(std::isnan(value) || std::isinf(value))) {
-    return std::optional<Timestamp>{};
+    return std::nullopt;
   }
   return castNumberToTimestamp(value);
 }

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -50,6 +50,15 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   return Timestamp(seconds, 0);
 }
 
+Expected<Timestamp> SparkCastHooks::castDoubleToTimestamp(double value) const {
+  if (FOLLY_UNLIKELY(std::isnan(value) || std::isinf(value))) {
+    return folly::makeUnexpected(
+        Status::Invalid("Can not convert NaN or Infinity to timestamp"));
+  }
+  return Timestamp::fromMicrosNoError(
+      static_cast<int64_t>(value * Timestamp::kMicrosecondsInSecond));
+}
+
 Expected<int32_t> SparkCastHooks::castStringToDate(
     const StringView& dateString) const {
   // Allows all patterns supported by Spark:

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -36,24 +36,24 @@ Expected<Timestamp> SparkCastHooks::castStringToTimestamp(
 }
 
 template <typename T>
-Expected<Timestamp> SparkCastHooks::castNumberToTimestamp(T value) const {
+Expected<Timestamp> SparkCastHooks::castNumberToTimestamp(T seconds) const {
   // Spark internally use microsecond precision for timestamp.
   // To avoid overflow, we need to check the range of seconds.
   static constexpr int64_t maxSeconds =
       std::numeric_limits<int64_t>::max() / Timestamp::kMicrosecondsInSecond;
-  if (value > maxSeconds) {
+  if (seconds > maxSeconds) {
     return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::max());
   }
-  if (value < -maxSeconds) {
+  if (seconds < -maxSeconds) {
     return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::min());
   }
 
   if constexpr (std::is_floating_point_v<T>) {
     return Timestamp::fromMicrosNoError(
-        static_cast<int64_t>(value * Timestamp::kMicrosecondsInSecond));
+        static_cast<int64_t>(seconds * Timestamp::kMicrosecondsInSecond));
   }
 
-  return Timestamp(value, 0);
+  return Timestamp(seconds, 0);
 }
 
 Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -34,6 +34,10 @@ class SparkCastHooks : public exec::CastHooks {
   /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
+  /// When casting double as timestamp, the input is treated as
+  /// the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
+  Expected<Timestamp> castDoubleToTimestamp(double value) const override;
+
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
   /// non-standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -68,8 +68,11 @@ class SparkCastHooks : public exec::CastHooks {
   exec::PolicyType getPolicy() const override;
 
  private:
+  /// Casts a number to a timestamp. The number is treated as the number of
+  /// seconds since the epoch (1970-01-01 00:00:00 UTC).
+  /// Supported input types: integer, floating-point.
   template <typename T>
-  Expected<Timestamp> castNumberToTimestamp(T value) const;
+  Expected<Timestamp> castNumberToTimestamp(T seconds) const;
 
   const core::QueryConfig& config_;
 

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -79,5 +79,8 @@ class SparkCastHooks : public exec::CastHooks {
       .skipTrailingZeros = true,
       .zeroPaddingYear = true,
       .dateTimeSeparator = ' '};
+
+  template <typename T>
+  Expected<Timestamp> castNumberToTimestamp(T value) const;
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -36,7 +36,8 @@ class SparkCastHooks : public exec::CastHooks {
 
   /// When casting double as timestamp, the input is treated as
   /// the number of seconds since the epoch (1970-01-01 00:00:00 UTC).
-  Expected<Timestamp> castDoubleToTimestamp(double value) const override;
+  Expected<std::optional<Timestamp>> castDoubleToTimestamp(
+      double value) const override;
 
   /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
   /// non-standard cast mode to cast from string to date.

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -67,6 +67,9 @@ class SparkCastHooks : public exec::CastHooks {
   exec::PolicyType getPolicy() const override;
 
  private:
+  template <typename T>
+  Expected<Timestamp> castNumberToTimestamp(T value) const;
+
   const core::QueryConfig& config_;
 
   /// 1) Does not follow 'isLegacyCast'. 2) The conversion precision is
@@ -79,8 +82,5 @@ class SparkCastHooks : public exec::CastHooks {
       .skipTrailingZeros = true,
       .zeroPaddingYear = true,
       .dateTimeSeparator = ' '};
-
-  template <typename T>
-  Expected<Timestamp> castNumberToTimestamp(T value) const;
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -68,9 +68,9 @@ class SparkCastHooks : public exec::CastHooks {
   exec::PolicyType getPolicy() const override;
 
  private:
-  /// Casts a number to a timestamp. The number is treated as the number of
-  /// seconds since the epoch (1970-01-01 00:00:00 UTC).
-  /// Supported input types: integer, floating-point.
+  // Casts a number to a timestamp. The number is treated as the number of
+  // seconds since the epoch (1970-01-01 00:00:00 UTC).
+  // Supports integer and floating-point types.
   template <typename T>
   Expected<Timestamp> castNumberToTimestamp(T seconds) const;
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -291,6 +291,46 @@ TEST_F(SparkCastExprTest, intToTimestamp) {
   testIntegralToTimestampCast<int32_t>();
 }
 
+TEST_F(SparkCastExprTest, doubleToTimestamp) {
+  testCast(
+      makeNullableFlatVector<double>({
+          0.0,
+          1727181032.0,
+          -1727181032.0,
+          kInf,
+          kNan,
+          -kInf,
+      }),
+      makeNullableFlatVector<Timestamp>({
+          Timestamp(0, 0),
+          Timestamp(1727181032, 0),
+          Timestamp(-1727181032, 0),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+      }));
+}
+
+TEST_F(SparkCastExprTest, floatToTimestamp) {
+  testCast(
+      makeNullableFlatVector<float>({
+          0.0,
+          1727181032.0,
+          -1727181032.0,
+          kInf,
+          kNan,
+          -kInf,
+      }),
+      makeNullableFlatVector<Timestamp>({
+          Timestamp(0, 0),
+          Timestamp(1727181056, 0),
+          Timestamp(-1727181056, 0),
+          std::nullopt,
+          std::nullopt,
+          std::nullopt,
+      }));
+}
+
 TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {
   // To integer.
   {

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -293,10 +293,16 @@ TEST_F(SparkCastExprTest, intToTimestamp) {
 
 TEST_F(SparkCastExprTest, doubleToTimestamp) {
   testCast(
-      makeNullableFlatVector<double>({
+      makeFlatVector<double>({
           0.0,
           1727181032.0,
           -1727181032.0,
+          9223372036855.999,
+          -9223372036856.999,
+          1.79769e+308,
+          std::numeric_limits<double>::max(),
+          -std::numeric_limits<double>::max(),
+          std::numeric_limits<double>::min(),
           kInf,
           kNan,
           -kInf,
@@ -305,6 +311,12 @@ TEST_F(SparkCastExprTest, doubleToTimestamp) {
           Timestamp(0, 0),
           Timestamp(1727181032, 0),
           Timestamp(-1727181032, 0),
+          Timestamp(9223372036854, 775'807'000),
+          Timestamp(-9223372036855, 224'192'000),
+          Timestamp(9223372036854, 775'807'000),
+          Timestamp(9223372036854, 775'807'000),
+          Timestamp(-9223372036855, 224'192'000),
+          Timestamp(0, 0),
           std::nullopt,
           std::nullopt,
           std::nullopt,
@@ -313,10 +325,12 @@ TEST_F(SparkCastExprTest, doubleToTimestamp) {
 
 TEST_F(SparkCastExprTest, floatToTimestamp) {
   testCast(
-      makeNullableFlatVector<float>({
+      makeFlatVector<float>({
           0.0,
           1727181032.0,
           -1727181032.0,
+          std::numeric_limits<float>::max(),
+          std::numeric_limits<float>::min(),
           kInf,
           kNan,
           -kInf,
@@ -325,6 +339,8 @@ TEST_F(SparkCastExprTest, floatToTimestamp) {
           Timestamp(0, 0),
           Timestamp(1727181056, 0),
           Timestamp(-1727181056, 0),
+          Timestamp(9223372036854, 775'807'000),
+          Timestamp(0, 0),
           std::nullopt,
           std::nullopt,
           std::nullopt,

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -81,6 +81,8 @@ struct Timestamp {
  public:
   static constexpr int64_t kMillisecondsInSecond = 1'000;
   static constexpr int64_t kMicrosecondsInMillisecond = 1'000;
+  static constexpr int64_t kMicrosecondsInSecond =
+      kMicrosecondsInMillisecond * kMillisecondsInSecond;
   static constexpr int64_t kNanosecondsInMicrosecond = 1'000;
   static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
   static constexpr int64_t kNanosInSecond =


### PR DESCRIPTION
Add Spark CAST (double/float as timestamp). The input value is treated as the
number of seconds since the epoch (1970-01-01 00:00:00 UTC).

Spark's implementation: https://github.com/apache/spark/blob/fd86f85e181fc2dc0f50a096855acf83a6cc5d9c/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L675