### PR TITLE
feat: Add Spark array_append function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -15,6 +15,15 @@ Array Functions
 
         SELECT array(1, 2, 3); -- [1,2,3]
 
+.. spark:function:: array_append(array(E), element) -> array(E)
+
+    Add the ``element`` at the end of the input ``array``.
+    Type of ``element`` should be the same to the type of elements in the ``array``.
+    NULL element is also appended into the ``array``. Returns NULL when the input ``array`` is NULL. ::
+
+        SELECT array_append(array(1, 2, 3), 2); -- [1, 2, 3, 2]
+        SELECT array_append(array(1, 2, 3), NULL); -- [1, 2, 3, NULL]
+
 .. spark:function:: array_contains(array(E), value) -> boolean
 
     Returns true if the array contains the value. ::

--- a/velox/functions/sparksql/ArrayAppend.h
+++ b/velox/functions/sparksql/ArrayAppend.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// array_append(array(E), element) -> array(E)
+/// Given an array and another element, append the element at the end of the
+/// array.
+template <typename TExec>
+struct ArrayAppendFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE bool callNullable(
+      out_type<Array<Generic<T1>>>& out,
+      const arg_type<Array<Generic<T1>>>* array,
+      const arg_type<Generic<T1>>* element) {
+    if (array == nullptr) {
+      return false;
+    }
+    out.reserve(array->size() + 1);
+    out.add_items(*array);
+    element ? out.push_back(*element) : out.add_null();
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/lib/Repeat.h"
 #include "velox/functions/lib/Slice.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
+#include "velox/functions/sparksql/ArrayAppend.h"
 #include "velox/functions/sparksql/ArrayFlattenFunction.h"
 #include "velox/functions/sparksql/ArrayInsert.h"
 #include "velox/functions/sparksql/ArrayMinMaxFunction.h"
@@ -141,6 +142,11 @@ void registerArrayFunctions(const std::string& prefix) {
       makeArrayShuffleWithCustomSeed,
       getMetadataForArrayShuffle());
   registerIntegerSliceFunction(prefix);
+  registerFunction<
+      ArrayAppendFunction,
+      Array<Generic<T1>>,
+      Array<Generic<T1>>,
+      Generic<T1>>({prefix + "array_append"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/ArrayAppendTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayAppendTest.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayAppendTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(ArrayAppendTest, intArrays) {
+  const auto arrayVector = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
+  const auto elementVector = makeFlatVector<int64_t>({11, 22, 33, 44});
+
+  VectorPtr expected = makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 11},
+      {3, 4, 5, 22},
+      {7, 8, 9, 33},
+      {10, 20, 30, 44},
+  });
+  testExpression(
+      "array_append(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+TEST_F(ArrayAppendTest, nullArrays) {
+  const auto arrayVector = makeArrayVectorFromJson<int64_t>(
+      {"[1, 2, 3, null]", "[3, 4, 5]", "null", "[10, 20, null]"});
+
+  const auto elementVector = makeNullableFlatVector<int64_t>(
+      {11, std::nullopt, std::nullopt, std::nullopt});
+
+  VectorPtr expected = makeArrayVectorFromJson<int64_t>(
+      {"[1, 2, 3, null, 11]",
+       "[3, 4, 5, null]",
+       "null",
+       "[10, 20, null, null]"});
+  testExpression(
+      "array_append(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
+  ArrayAppendTest.cpp
   ArrayFlattenTest.cpp
   ArrayGetTest.cpp
   ArrayInsertTest.cpp


### PR DESCRIPTION
Given an array and another element, append the element at the end of the array.
Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L5082