### PR TITLE
fix: Support for Sum Aggregation Signature with Interval

### DIFF
--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -48,7 +48,12 @@ exec::AggregateRegistrationResult registerSum(
           .build(),
   };
 
-  for (const auto& inputType : {"tinyint", "smallint", "integer", "bigint"}) {
+  for (const auto& inputType :
+       {"tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        INTERVAL_DAY_TIME()->name()}) {
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .returnType("bigint")
                              .intermediateType("bigint")
@@ -102,7 +107,6 @@ exec::AggregateRegistrationResult registerSum(
             // type is either int128_t or
             // UnscaledLongDecimalWithOverflowState.
             return std::make_unique<DecimalSumAggregate<int128_t>>(resultType);
-
           default:
             VELOX_UNREACHABLE(
                 "Unknown input type for {} aggregation {}",

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -75,6 +75,25 @@ TEST_F(SumTest, sumTinyint) {
       "SELECT sum(c1) FROM tmp WHERE c0 % 2 = 0");
 }
 
+TEST_F(SumTest, sumIntervalDayToSecond) {
+  auto inputRows = {
+      makeRowVector(
+          {makeFlatVector<int64_t>({1, 4}, INTERVAL_DAY_TIME()),
+           makeFlatVector<int64_t>({1, 2}, INTERVAL_DAY_TIME())}),
+
+  };
+  auto expectedResult = {
+      makeRowVector(
+          {makeFlatVector<int64_t>(
+               std::vector<int64_t>{5}, INTERVAL_DAY_TIME()),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{3}, INTERVAL_DAY_TIME())}),
+  };
+
+  testAggregations(inputRows, {}, {"sum(c0)", "sum(c1)"}, expectedResult);
+  AggregationTestBase::enableTestIncremental();
+}
+
 TEST_F(SumTest, sumFloat) {
   auto data = makeRowVector({makeFlatVector<float>({2.00, 1.00})});
   createDuckDbTable({data});


### PR DESCRIPTION
Summary: Implemented the Aggregate function signature for  presto.default.sum(INTERVAL DAY TO SECOND. This fix enables support for queries like SUM(timestamp1 - timestamp2). As a result, when users execute queries such as Query 20241121_072936_03749_2ynq4, they can expect successful results

Reviewed By: kewang1024

Differential Revision: D67468718


