### PR TITLE
build(cmake): Remove unused targets

### DIFF
--- a/velox/dwio/text/writer/CMakeLists.txt
+++ b/velox/dwio/text/writer/CMakeLists.txt
@@ -14,11 +14,4 @@
 
 velox_add_library(velox_dwio_text_writer TextWriter.cpp BufferedWriterSink.cpp)
 
-velox_link_libraries(
-  velox_dwio_text_writer
-  velox_dwio_arrow_parquet_writer_lib
-  velox_dwio_arrow_parquet_writer_util_lib
-  velox_dwio_common
-  velox_arrow_bridge
-  arrow
-  fmt::fmt)
+velox_link_libraries(velox_dwio_text_writer velox_dwio_common fmt::fmt)


### PR DESCRIPTION
libarrow is used as a dependency that is not enabled. This is causing Prestissimo build to fail.