### PR TITLE
feat: Add fast path for single bit in ByteOutputStream::appendBits

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -234,6 +234,16 @@ void ByteOutputStream::appendBits(
   VELOX_DCHECK(isBits_);
 
   const int32_t count = end - begin;
+
+  if (count == 1 && current_->size > current_->position) {
+    bits::setBit(
+        reinterpret_cast<uint64_t*>(current_->buffer),
+        current_->position,
+        bits::isBitSet(bits, begin));
+    ++current_->position;
+    return;
+  }
+
   int32_t offset = 0;
   for (;;) {
     const int32_t bitsFit =


### PR DESCRIPTION
Summary:
While working on speeding up the PrestoBatchVectorSerializer I noticed that sometimes we write a single bit to
ByteOutputStreams (e.g. when writing a single null or the null flag).  ByteOutputStream::appendBool has a fast path for this
case, which ByteOutputStream::appendBits is missing, this provides a minor speed up that adds up over time.

Differential Revision: D67988365


