### PR TITLE
feat: Add Presto Avg Aggregate for Interval

### DIFF
--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -98,7 +98,12 @@ class AverageAggregateBase : public exec::Aggregate {
       } else {
         clearNull(rawNulls, i);
         auto* sumCount = accumulator(group);
-        rawValues[i] = TResult(sumCount->sum) / sumCount->count;
+        if constexpr (std::is_integral_v<TResult>) {
+          rawValues[i] =
+              static_cast<TResult>(std::round(sumCount->sum / sumCount->count));
+        } else {
+          rawValues[i] = sumCount->sum / sumCount->count;
+        }
       }
     }
   }

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -42,6 +42,15 @@ void registerAverageAggregate(
                              .argumentType(inputType)
                              .build());
   }
+
+  // Interval input type in Presto has special case and returns INTERVAL, not
+  // DOUBLE.
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("interval day to second")
+                           .intermediateType("row(double,bigint)")
+                           .argumentType("interval day to second")
+                           .build());
+
   // Real input type in Presto has special case and returns REAL, not DOUBLE.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .returnType("real")
@@ -82,6 +91,10 @@ void registerAverageAggregate(
               if (inputType->isShortDecimal()) {
                 return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
                     resultType);
+              }
+              if (inputType->isIntervalDayTime()) {
+                return std::make_unique<
+                    AverageAggregateBase<int64_t, double, int64_t>>(resultType);
               }
               return std::make_unique<
                   AverageAggregateBase<int64_t, double, double>>(resultType);

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -594,6 +594,23 @@ TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
   AggregationTestBase::enableTestIncremental();
 }
 
+TEST_F(AverageAggregationTest, avgIntervalWithMultipleRowVectors) {
+  AggregationTestBase::disableTestIncremental();
+
+  auto inputRows = {
+      makeRowVector({makeFlatVector<int64_t>({100, 200}, INTERVAL_DAY_TIME())}),
+      makeRowVector({makeFlatVector<int64_t>({300, 400}, INTERVAL_DAY_TIME())}),
+      makeRowVector({makeFlatVector<int64_t>({500, 845}, INTERVAL_DAY_TIME())}),
+  };
+
+  auto expectedResult = {makeRowVector(
+      {makeFlatVector(std::vector<int64_t>{391}, INTERVAL_DAY_TIME())})};
+
+  testAggregations(inputRows, {}, {"avg(c0)"}, expectedResult);
+
+  AggregationTestBase::enableTestIncremental();
+}
+
 TEST_F(AverageAggregationTest, constantVectorOverflow) {
   auto rows = makeRowVector({makeConstant<int32_t>(1073741824, 100)});
   auto plan = PlanBuilder()


### PR DESCRIPTION
Summary:
Aggregate function signature is not supported: presto.default.avg(INTERVAL DAY TO SECOND).

- Add support for avg() for Interval Day to Second
- Returns long based on Java implementation [IntervalDayToSecondAverageAggregation.java](https://www.internalfb.com/code/fbsource/fbcode/github/presto-deprecated/presto-main/src/main/java/com/facebook/presto/operator/aggregation/IntervalDayToSecondAverageAggregation.java)
- Note: Expected return type is long (the average is rounded to be a valid interval) not double. A Velox Runtime Error is thrown on cluster testing, if attempted to return double.

Differential Revision: D67879726


