### PR TITLE
feat: Add option to negate bits written to ByteOutputStream

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -92,17 +92,18 @@ inline void setBit(T* bits, uint64_t idx, bool value) {
   value ? setBit(bits, idx) : clearBit(bits, idx);
 }
 
-inline void negate(char* bits, int32_t size) {
+inline void negate(uint64_t* bits, int32_t size) {
   int32_t i = 0;
   for (; i + 64 <= size; i += 64) {
-    auto wordPtr = reinterpret_cast<uint64_t*>(bits + (i / 8));
+    auto wordPtr = bits + i / 64;
     *wordPtr = ~*wordPtr;
   }
+  auto* bitsAs8Bit = reinterpret_cast<uint8_t*>(bits);
   for (; i + 8 <= size; i += 8) {
-    bits[i / 8] = ~bits[i / 8];
+    bitsAs8Bit[i / 8] = ~bitsAs8Bit[i / 8];
   }
   for (; i < size; ++i) {
-    bits::setBit(bits, i, !bits::isBitSet(bits, i));
+    bits::setBit(bitsAs8Bit, i, !bits::isBitSet(bits, i));
   }
 }
 

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -547,7 +547,7 @@ TEST_F(BitUtilTest, negate) {
     setBit(data, i, i % 2 == 0);
   }
 
-  negate(data, 64);
+  negate(reinterpret_cast<uint64_t*>(data), 64);
   for (int32_t i = 0; i < 64; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
@@ -555,12 +555,12 @@ TEST_F(BitUtilTest, negate) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 64);
+  negate(reinterpret_cast<uint64_t*>(data), 64);
   for (int32_t i = 0; i < 64; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 72);
+  negate(reinterpret_cast<uint64_t*>(data), 72);
   for (int32_t i = 0; i < 72; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
@@ -568,17 +568,17 @@ TEST_F(BitUtilTest, negate) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 72);
+  negate(reinterpret_cast<uint64_t*>(data), 72);
   for (int32_t i = 0; i < 72; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 100);
+  negate(reinterpret_cast<uint64_t*>(data), 100);
   for (int32_t i = 0; i < 100; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
 
-  negate(data, 100);
+  negate(reinterpret_cast<uint64_t*>(data), 100);
   for (int32_t i = 0; i < 100; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }

--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -296,10 +296,16 @@ void ByteOutputStream::flush(OutputStream* out) {
   for (int32_t i = 0; i < ranges_.size(); ++i) {
     int32_t count = i == ranges_.size() - 1 ? lastRangeEnd_ : ranges_[i].size;
     int32_t bytes = isBits_ ? bits::nbytes(count) : count;
+    if (isBits_ && isNegateBits_ && !isNegated_) {
+      bits::negate(reinterpret_cast<uint64_t*>(ranges_[i].buffer), count);
+    }
     if (isBits_ && isReverseBitOrder_ && !isReversed_) {
       bits::reverseBits(ranges_[i].buffer, bytes);
     }
     out->write(reinterpret_cast<char*>(ranges_[i].buffer), bytes);
+  }
+  if (isBits_ && isNegateBits_) {
+    isNegated_ = true;
   }
   if (isBits_ && isReverseBitOrder_) {
     isReversed_ = true;

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -231,11 +231,15 @@ inline int128_t ByteInputStream::read<int128_t>() {
 class ByteOutputStream {
  public:
   /// For output.
-  ByteOutputStream(
+  explicit ByteOutputStream(
       StreamArena* arena,
       bool isBits = false,
-      bool isReverseBitOrder = false)
-      : arena_(arena), isBits_(isBits), isReverseBitOrder_(isReverseBitOrder) {}
+      bool isReverseBitOrder = false,
+      bool isNegateBits = false)
+      : arena_(arena),
+        isBits_(isBits),
+        isReverseBitOrder_(isReverseBitOrder),
+        isNegateBits_(isNegateBits) {}
 
   ByteOutputStream(const ByteOutputStream& other) = delete;
 
@@ -267,6 +271,7 @@ class ByteOutputStream {
   void startWrite(int32_t initialSize) {
     ranges_.clear();
     isReversed_ = false;
+    isNegated_ = false;
     allocatedBytes_ = 0;
     current_ = nullptr;
     lastRangeEnd_ = 0;
@@ -431,9 +436,15 @@ class ByteOutputStream {
 
   const bool isReverseBitOrder_;
 
+  const bool isNegateBits_;
+
   // True if the bit order in ranges_ has been inverted. Presto requires
   // reverse bit order.
   bool isReversed_ = false;
+
+  // True if the bits in ranges_ have been negated. Presto requires null flags
+  // to be the inverse of Velox.
+  bool isNegated_ = false;
 
   std::vector<ByteRange> ranges_;
   // The total number of bytes allocated from 'arena_' in 'ranges_'.

--- a/velox/functions/lib/IsNull.cpp
+++ b/velox/functions/lib/IsNull.cpp
@@ -57,7 +57,7 @@ class IsNullFunction : public exec::VectorFunction {
             isNull->asMutable<int64_t>(),
             arg->rawNulls(),
             bits::nbytes(rows.end()));
-        bits::negate(isNull->asMutable<char>(), rows.end());
+        bits::negate(isNull->asMutable<uint64_t>(), rows.end());
       }
     } else {
       exec::DecodedArgs decodedArgs(rows, args, context);
@@ -69,7 +69,7 @@ class IsNullFunction : public exec::VectorFunction {
           bits::nbytes(rows.end()));
 
       if (!IsNotNULL) {
-        bits::negate(isNull->asMutable<char>(), rows.end());
+        bits::negate(isNull->asMutable<uint64_t>(), rows.end());
       }
     }
 

--- a/velox/functions/prestosql/Not.cpp
+++ b/velox/functions/prestosql/Not.cpp
@@ -42,7 +42,7 @@ class NotFunction : public exec::VectorFunction {
           AlignedBuffer::allocate<bool>(rows.end(), context.pool(), !value);
     } else {
       negated = AlignedBuffer::allocate<bool>(rows.end(), context.pool());
-      auto rawNegated = negated->asMutable<char>();
+      auto* rawNegated = negated->asMutable<uint64_t>();
 
       auto rawInput = input->asFlatVector<bool>()->rawValues<uint64_t>();
 

--- a/velox/functions/prestosql/window/FirstLastValue.cpp
+++ b/velox/functions/prestosql/window/FirstLastValue.cpp
@@ -115,7 +115,7 @@ class FirstLastValueFunction : public exec::WindowFunction {
 
     // first(last)Value functions return the first(last) non-null values for the
     // frame. Negate the bits in nulls_ so that nonNull bits are set instead.
-    bits::negate(nulls_->asMutable<char>(), frameSize);
+    bits::negate(nulls_->asMutable<uint64_t>(), frameSize);
     auto rawNonNulls = nulls_->as<uint64_t>();
 
     auto rawFrameStarts = frameStarts->as<vector_size_t>();

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -74,7 +74,7 @@ vector_size_t valueCount(
   auto numBytes = bits::nbytes(size);
   source->readBytes(rawNulls, numBytes);
   bits::reverseBits(reinterpret_cast<uint8_t*>(rawNulls), numBytes);
-  bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
+  bits::negate(rawNulls, numBytes * 8);
   if (copy) {
     copy->resize(bits::nwords(size));
     memcpy(copy->data(), rawNulls, numBytes);
@@ -329,7 +329,7 @@ vector_size_t readNulls(
 
   source->readBytes(rawNulls, numBytes);
   bits::reverseBits(rawNulls, numBytes);
-  bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
+  bits::negate(reinterpret_cast<uint64_t*>(rawNulls), numBytes * 8);
   // Add incoming nulls if any.
   if (incomingNulls) {
     bits::scatterBits(


### PR DESCRIPTION
Summary:
In PrestoSerializer we write the null bits to a ByteOutputStream. Presto's serialization format inverts the null
flags from what Velox uses. This change adds an option to ByteOutputStream to do that negation on flush,
rather than requiring the user to negate them when calling append.  This makes it easier to write ranges of null
bits without an additional copy, and reduces the level of mental gymnastics needed to reason about the null 
flags in the serializer. (It's analogous to the option ByteOutputStream already has to reverse the order
of bits within a byte, again because of Presto's serialization format for null flags).

Differential Revision: D67994045


