### PR TITLE
feat: Add BufferedOutputStream

### DIFF
--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1713,7 +1713,7 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST_F(TestReader, testEmptyFile) {
   MemorySink sink{1024, {.pool = pool()}};
   DataBufferHolder holder{*pool(), 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
-  BufferedOutputStream output{holder};
+  facebook::velox::dwio::common::BufferedOutputStream output{holder};
 
   proto::Footer footer;
   footer.set_numberofrows(0);

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -44,7 +44,9 @@ void testInts(std::function<T()> generator) {
       count * (vInt ? folly::kMaxVarintLength64 : sizeof(T));
   MemorySink sink{capacity, {.pool = pool.get()}};
   DataBufferHolder holder{*pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
-  auto output = std::make_unique<BufferedOutputStream>(holder);
+  auto output =
+      std::make_unique<facebook::velox::dwio::common::BufferedOutputStream>(
+          holder);
   auto encoder =
       createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));
 


### PR DESCRIPTION
Summary:
Context:
I plan to update the PrestoBatchVectorSerializer to write directly to the OutputStream rather than going through
VectorStreams as I've seen this can greatly improve the speed.  However, this ends up with many small writes to
the OutputStream, which is typically a ByteOutputStream, so this leads to a lot of small allocations which is
counter productive to the optimization I'm trying to make.

To address this I add a BufferedOutputStream which wraps around another OutputStream, coalesces writes in a 
buffer, and flushes those as large writes to the wrapped OutputStream as the buffer fills up, or as needed.

In my experiments I've seen the cost of the additional copy is far less then the cost of the tiny allocations.

Differential Revision: D67997655


