### PR TITLE
feat: Add spatial support

### DIFF
--- a/CMake/resolve_dependency_modules/geos.cmake
+++ b/CMake/resolve_dependency_modules/geos.cmake
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+# GEOS Configuration
+set(VELOX_GEOS_BUILD_VERSION 3.11.1)
+set(VELOX_GEOS_BUILD_SHA256_CHECKSUM
+        6d0eb3cfa9f92d947731cc75f1750356b3bdfc07ea020553daf6af1c768e0be2)
+string(
+        CONCAT
+        VELOX_GEOS_SOURCE_URL "https://download.osgeo.org/geos/"
+        "geos-${VELOX_GEOS_BUILD_VERSION}.tar.bz2")
+
+resolve_dependency_url(GEOS)
+
+FetchContent_Declare(
+        geos
+        URL ${VELOX_GEOS_SOURCE_URL}
+        URL_HASH ${VELOX_GEOS_BUILD_SHA256_CHECKSUM}
+)
+FetchContent_MakeAvailable(geos)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -523,6 +523,17 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS)
   find_package(FBThrift CONFIG REQUIRED)
 endif()
 
+if(VELOX_ENABLE_PRESTO_FUNCTIONS)
+  set_source(geos)
+  resolve_dependhhhency(geos)
+endif()
+
+if(DEFINED FOLLY_BENCHMARK_STATIC_LIB)
+  set(FOLLY_BENCHMARK ${FOLLY_BENCHMARK_STATIC_LIB})
+else()
+  set(FOLLY_BENCHMARK Folly::follybenchmark)
+endif()
+
 if(VELOX_ENABLE_GCS)
   velox_set_source(google_cloud_cpp_storage)
   velox_resolve_dependency(google_cloud_cpp_storage CONFIG 2.22.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,14 +524,8 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS)
 endif()
 
 if(VELOX_ENABLE_PRESTO_FUNCTIONS)
-  set_source(geos)
-  resolve_dependhhhency(geos)
-endif()
-
-if(DEFINED FOLLY_BENCHMARK_STATIC_LIB)
-  set(FOLLY_BENCHMARK ${FOLLY_BENCHMARK_STATIC_LIB})
-else()
-  set(FOLLY_BENCHMARK Folly::follybenchmark)
+  velox_set_source(geos)
+  velox_resolve_dependency(geos)
 endif()
 
 if(VELOX_ENABLE_GCS)

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -22,34 +22,19 @@
 
 namespace facebook::velox::functions {
 
-enum class GeometryType : int {
-  POINT = 0,
-  MULTI_POINT = 1,
-  LINE_STRING = 2,
-  MULTI_LINE_STRING = 3,
-  POLYGON = 4,
-  MULTI_POLYGON = 5,
-  GEOMETRY_COLLECTION = 6,
-  ENVELOPE = 7
-};
-
-template <typename Geometry>
-Geometry deserializeGeometry() {}
-
 template <typename T>
 struct StContainsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE Status call(
+  FOLLY_ALWAYS_INLINE bool call(
       bool& result,
       const arg_type<Geometry>& left,
       const arg_type<Geometry>& right) {
-    auto leftType =
-        static_cast<GeometryType>(*reinterpret_cast<const int*>(left.data()));
-    auto rightType =
-        static_cast<GeometryType>(*reinterpret_cast<const int*>(right.data()));
+    auto leftGeometry = GeosGeometrySerde::deserialize(left);
+    auto rightGeometry = GeosGeometrySerde::deserialize(right);
+    result = leftGeometry->contains(rightGeometry.get());
 
-    // Deserialize based on types
+    return true;
   }
 };
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/UDFOutputString.h"
+#include "velox/functions/prestosql/types/GeometryType.h"
+
+namespace facebook::velox::functions {
+
+enum class GeometryType : int {
+  POINT = 0,
+  MULTI_POINT = 1,
+  LINE_STRING = 2,
+  MULTI_LINE_STRING = 3,
+  POLYGON = 4,
+  MULTI_POLYGON = 5,
+  GEOMETRY_COLLECTION = 6,
+  ENVELOPE = 7
+};
+
+template <typename Geometry>
+Geometry deserializeGeometry() {}
+
+template <typename T>
+struct StContainsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      bool& result,
+      const arg_type<Geometry>& left,
+      const arg_type<Geometry>& right) {
+    auto leftType =
+        static_cast<GeometryType>(*reinterpret_cast<const int*>(left.data()));
+    auto rightType =
+        static_cast<GeometryType>(*reinterpret_cast<const int*>(right.data()));
+
+    // Deserialize based on types
+  }
+};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #pragma once
 
 #include "velox/functions/Macros.h"
@@ -30,11 +29,25 @@ struct StContainsFunction {
       bool& result,
       const arg_type<Geometry>& left,
       const arg_type<Geometry>& right) {
-    auto leftGeometry = GeosGeometrySerde::deserialize(left);
-    auto rightGeometry = GeosGeometrySerde::deserialize(right);
+    auto leftGeometry = GeometryUtils::deserialize(left);
+    auto rightGeometry = GeometryUtils::deserialize(right);
     result = leftGeometry->contains(rightGeometry.get());
 
     return true;
   }
 };
+
+template <typename T>
+struct StPointFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool
+  call(out_type<Geometry>& result, double x, double y) {
+    auto geometry = GeometryUtils::createPoint(x, y);
+    GeometryUtils::serialize(geometry, result);
+
+    return true;
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/GeometryUtils.h
+++ b/velox/functions/prestosql/GeometryUtils.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "geos/geom/CoordinateArraySequence.h"
+
 #include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/GeometryFactory.h>
 #include <geos/geom/LineString.h>
@@ -31,45 +33,13 @@ class GeometryUtils {
       const std::unique_ptr<geos::geom::Geometry>& geometry,
       StringWriter& stringWriter) {
     SliceOutput sliceOutput(stringWriter);
-    switch (geometry->getGeometryTypeId()) {
-      case geos::geom::GEOS_POINT:
-        writePoint(geometry, sliceOutput);
-        break;
-      case geos::geom::GEOS_MULTIPOINT:
-        writeMultiPoint(geometry, sliceOutput);
-        break;
-      case geos::geom::GEOS_LINESTRING:
-      case geos::geom::GEOS_LINEARRING:
-        writePolyline(geometry, sliceOutput, false);
-        break;
-      case geos::geom::GEOS_MULTILINESTRING:
-        writePolyline(geometry, sliceOutput, true);
-        break;
-      default:
-        VELOX_FAIL("Cannot serialize geometry type");
-        break;
-    }
+    serialize(geometry, sliceOutput);
   }
 
   static std::unique_ptr<geos::geom::Geometry> deserialize(
       const StringView& geometryString) {
     SliceInput sliceInput(geometryString.data(), geometryString.size());
-    auto geometryType =
-        static_cast<GeometrySerializationType>(sliceInput.readByte());
-    switch (geometryType) {
-      case GeometrySerializationType::POINT:
-        return readPoint(sliceInput);
-      case GeometrySerializationType::MULTI_POINT:
-        return readMultiPoint(sliceInput);
-      case GeometrySerializationType::LINE_STRING:
-        return readPolyline(sliceInput, false);
-      case GeometrySerializationType::MULTI_LINE_STRING:
-        return readPolyline(sliceInput, true);
-      default:
-        VELOX_FAIL("Cannot deserialize geometry type");
-        break;
-    }
-    return nullptr;
+    return deserialize(sliceInput);
   }
 
   static std::unique_ptr<geos::geom::Geometry> createPoint(double x, double y) {
@@ -186,6 +156,10 @@ class GeometryUtils {
       write<double>(value);
     }
 
+    void writeBytes(const char* data, size_t size) {
+      stringWriter_.append(std::string_view(data, size));
+    }
+
    private:
     template <typename T>
     void write(const T& value) {
@@ -195,6 +169,93 @@ class GeometryUtils {
 
     StringWriter& stringWriter_;
   };
+
+  template <typename T>
+  static void serialize(
+      const std::unique_ptr<geos::geom::Geometry>& geometry,
+      SliceOutput<T>& sliceOutput) {
+    switch (geometry->getGeometryTypeId()) {
+      case geos::geom::GEOS_POINT:
+        writePoint(geometry, sliceOutput);
+        break;
+      case geos::geom::GEOS_MULTIPOINT:
+        writeMultiPoint(geometry, sliceOutput);
+        break;
+      case geos::geom::GEOS_LINESTRING:
+      case geos::geom::GEOS_LINEARRING:
+        writePolyline(geometry, sliceOutput, false);
+        break;
+      case geos::geom::GEOS_MULTILINESTRING:
+        writePolyline(geometry, sliceOutput, true);
+        break;
+      case geos::geom::GEOS_POLYGON:
+        writePolygon(geometry, sliceOutput, false);
+      case geos::geom::GEOS_MULTIPOLYGON:
+        writePolygon(geometry, sliceOutput, true);
+      case geos::geom::GEOS_GEOMETRYCOLLECTION:
+        writeGeometryCollection(geometry, sliceOutput);
+      default:
+        VELOX_FAIL("Cannot serialize geometry type");
+        break;
+    }
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> deserialize(
+      SliceInput& sliceInput) {
+    auto geometryType =
+        static_cast<GeometrySerializationType>(sliceInput.readByte());
+    switch (geometryType) {
+      case GeometrySerializationType::POINT:
+        return readPoint(sliceInput);
+      case GeometrySerializationType::MULTI_POINT:
+        return readMultiPoint(sliceInput);
+      case GeometrySerializationType::LINE_STRING:
+        return readPolyline(sliceInput, false);
+      case GeometrySerializationType::MULTI_LINE_STRING:
+        return readPolyline(sliceInput, true);
+      case GeometrySerializationType::POLYGON:
+        return readPolygon(sliceInput, false);
+      case GeometrySerializationType::MULTI_POLYGON:
+        return readPolygon(sliceInput, true);
+      case GeometrySerializationType::ENVELOPE:
+        return readEnvelope(sliceInput);
+      case GeometrySerializationType::GEOMETRY_COLLECTION:
+        return readGeometryCollection(sliceInput);
+      default:
+        VELOX_FAIL("Cannot deserialize geometry type");
+        break;
+    }
+    return nullptr;
+  }
+
+  static bool isEsriNaN(double d) {
+    auto translateFromAVNaN = [](double value) -> double { return value; };
+    return std::isnan(d) || std::isnan(translateFromAVNaN(d));
+  }
+
+  static bool isClockwise(
+      const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
+      int start,
+      int end) {
+    double sum = 0.0;
+    for (int i = start; i < end - 1; i++) {
+      const auto& p1 = coordinates->getAt(i);
+      const auto& p2 = coordinates->getAt(i + 1);
+      sum += (p2.x - p1.x) * (p2.y + p1.y);
+    }
+    return sum > 0.0;
+  }
+
+  static void reverse(
+      const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
+      int start,
+      int end) {
+    for (int i = 0; i < (end - start) / 2; ++i) {
+      auto temp = coordinates->getAt(start + i);
+      coordinates->setAt(coordinates->getAt(end - 1 - i), start + i);
+      coordinates->setAt(temp, end - 1 - i);
+    }
+  }
 
   template <typename T>
   static void writeEnvelope(
@@ -280,6 +341,135 @@ class GeometryUtils {
       }
     } else {
       writeCoordinates(geometry->getCoordinates(), output);
+    }
+  }
+
+  template <typename T>
+  static void writePolygon(
+      const std::unique_ptr<geos::geom::Geometry>& geometry,
+      SliceOutput<T>& output,
+      bool multitype) {
+    int numGeometries = geometry->getNumGeometries();
+    int numParts = 0;
+    int numPoints = geometry->getNumPoints();
+
+    for (int i = 0; i < numGeometries; i++) {
+      auto polygon =
+          dynamic_cast<const geos::geom::Polygon*>(geometry->getGeometryN(i));
+      if (polygon && polygon->getNumPoints() > 0) {
+        numParts += polygon->getNumInteriorRing() + 1;
+      }
+    }
+
+    if (multitype) {
+      output.writeByte(
+          static_cast<uint8_t>(GeometrySerializationType::MULTI_POLYGON));
+    } else {
+      output.writeByte(
+          static_cast<uint8_t>(GeometrySerializationType::POLYGON));
+    }
+
+    output.writeInt(static_cast<int32_t>(EsriShapeType::POLYGON));
+    writeEnvelope(geometry, output);
+
+    output.writeInt(numParts);
+    output.writeInt(numPoints);
+
+    if (numParts == 0) {
+      return;
+    }
+
+    std::vector<int> partIndexes(numParts);
+    std::vector<bool> shellPart(numParts);
+
+    int currentPart = 0;
+    int currentPoint = 0;
+    for (int i = 0; i < numGeometries; i++) {
+      const geos::geom::Polygon* polygon =
+          dynamic_cast<const geos::geom::Polygon*>(geometry->getGeometryN(i));
+
+      partIndexes[currentPart] = currentPoint;
+      shellPart[currentPart] = true;
+      currentPart++;
+      currentPoint += polygon->getExteriorRing()->getNumPoints();
+
+      int holesCount = polygon->getNumInteriorRing();
+      for (int holeIndex = 0; holeIndex < holesCount; holeIndex++) {
+        partIndexes[currentPart] = currentPoint;
+        shellPart[currentPart] = false;
+        currentPart++;
+        currentPoint += polygon->getInteriorRingN(holeIndex)->getNumPoints();
+      }
+    }
+
+    for (int partIndex : partIndexes) {
+      output.writeInt(partIndex);
+    }
+
+    auto coordinates = geometry->getCoordinates();
+    canonicalizePolygonCoordinates(coordinates, partIndexes, shellPart);
+    writeCoordinates(coordinates, output);
+  }
+
+  static void canonicalizePolygonCoordinates(
+      const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
+      const std::vector<int>& partIndexes,
+      const std::vector<bool>& shellPart) {
+    for (size_t part = 0; part < partIndexes.size() - 1; part++) {
+      canonicalizePolygonCoordinates(
+          coordinates,
+          partIndexes[part],
+          partIndexes[part + 1],
+          shellPart[part]);
+    }
+    if (!partIndexes.empty()) {
+      canonicalizePolygonCoordinates(
+          coordinates,
+          partIndexes.back(),
+          coordinates->size(),
+          shellPart.back());
+    }
+  }
+
+  static void canonicalizePolygonCoordinates(
+      const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
+      int start,
+      int end,
+      bool isShell) {
+    bool isClockwiseFlag = isClockwise(coordinates, start, end);
+
+    if ((isShell && !isClockwiseFlag) || (!isShell && isClockwiseFlag)) {
+      reverse(coordinates, start, end);
+    }
+  }
+
+  template <typename T>
+  static void writeGeometryCollection(
+      const std::unique_ptr<geos::geom::Geometry>& collection,
+      SliceOutput<T>& output) {
+    output.writeByte(
+        static_cast<uint8_t>(GeometrySerializationType::GEOMETRY_COLLECTION));
+
+    for (size_t geometryIndex = 0;
+         geometryIndex < collection->getNumGeometries();
+         ++geometryIndex) {
+      auto* geometry = collection->getGeometryN(geometryIndex);
+      // Wrap the raw pointer into a temporary `std::unique_ptr` without
+      // ownership transfer
+      const std::unique_ptr<geos::geom::Geometry> geometryPtr(
+          const_cast<geos::geom::Geometry*>(geometry),
+          [](geos::geom::Geometry*) {});
+
+      // Use a temporary buffer to serialize the geometry and calculate its
+      // length
+      std::string tempBuffer;
+      SliceOutput tempOutput(tempBuffer);
+
+      serialize(geometryPtr, tempOutput);
+
+      int32_t length = static_cast<int32_t>(tempBuffer.size());
+      output.writeInt(length);
+      output.writeBytes(tempBuffer.data(), tempBuffer.size());
     }
   }
 
@@ -380,6 +570,110 @@ class GeometryUtils {
     }
 
     return std::move(lineStrings[0]);
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> readPolygon(
+      SliceInput& input,
+      bool multiType) {
+    skipEsriType(input);
+    skipEnvelope(input);
+
+    int partCount = input.readInt();
+    if (partCount == 0) {
+      if (multiType) {
+        return GEOMETRY_FACTORY->createMultiPolygon();
+      }
+      return GEOMETRY_FACTORY->createPolygon();
+    }
+
+    int pointCount = input.readInt();
+    std::vector<int> startIndexes(partCount);
+    for (int i = 0; i < partCount; i++) {
+      startIndexes[i] = input.readInt();
+    }
+
+    std::vector<int> partLengths(partCount);
+    if (partCount > 1) {
+      partLengths[0] = startIndexes[1];
+      for (int i = 1; i < partCount - 1; i++) {
+        partLengths[i] = startIndexes[i + 1] - startIndexes[i];
+      }
+    }
+    partLengths[partCount - 1] = pointCount - startIndexes[partCount - 1];
+
+    std::unique_ptr<geos::geom::LinearRing> shell = nullptr;
+    std::vector<std::unique_ptr<geos::geom::LinearRing>> holes;
+    std::vector<std::unique_ptr<geos::geom::Polygon>> polygons;
+
+    for (int i = 0; i < partCount; i++) {
+      auto coordinates = readCoordinates(input, partLengths[i]);
+
+      if (isClockwise(coordinates, 0, coordinates->size())) {
+        if (shell) {
+          polygons.push_back(GEOMETRY_FACTORY->createPolygon(
+              std::move(shell), std::move(holes)));
+          holes.clear();
+        }
+        shell = GEOMETRY_FACTORY->createLinearRing(std::move(coordinates));
+      } else {
+        holes.push_back(
+            GEOMETRY_FACTORY->createLinearRing(std::move(coordinates)));
+      }
+    }
+
+    if (shell) {
+      polygons.push_back(
+          GEOMETRY_FACTORY->createPolygon(std::move(shell), std::move(holes)));
+    }
+
+    if (multiType) {
+      return GEOMETRY_FACTORY->createMultiPolygon(std::move(polygons));
+    }
+
+    if (polygons.size() != 1) {
+      VELOX_USER_FAIL("Expected exactly one polygon, but found multiple.");
+    }
+    return std::move(polygons[0]);
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> readEnvelope(SliceInput& input) {
+    double xMin = input.readDouble();
+    double yMin = input.readDouble();
+    double xMax = input.readDouble();
+    double yMax = input.readDouble();
+
+    if (isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMax) ||
+        isEsriNaN(yMax)) {
+      return GEOMETRY_FACTORY->createPolygon();
+    }
+
+    auto coordinates = std::make_unique<geos::geom::CoordinateArraySequence>();
+    coordinates->add(geos::geom::Coordinate(xMin, yMin));
+    coordinates->add(geos::geom::Coordinate(xMin, yMax));
+    coordinates->add(geos::geom::Coordinate(xMax, yMax));
+    coordinates->add(geos::geom::Coordinate(xMax, yMin));
+    coordinates->add(geos::geom::Coordinate(xMin, yMin)); // Close the ring
+
+    auto shell = GEOMETRY_FACTORY->createLinearRing(std::move(coordinates));
+    return GEOMETRY_FACTORY->createPolygon(std::move(shell), {});
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> readGeometryCollection(
+      SliceInput& input) {
+    std::vector<std::unique_ptr<geos::geom::Geometry>> geometries;
+
+    while (input.remaining() > 0) {
+      // Skip the length field
+      input.readInt();
+      geometries.push_back(deserialize(input));
+    }
+    std::vector<const geos::geom::Geometry*> rawGeometries;
+    for (const auto& geometry : geometries) {
+      rawGeometries.push_back(geometry.get());
+    }
+
+    return std::unique_ptr<geos::geom::GeometryCollection>(
+        GEOMETRY_FACTORY->createGeometryCollection(rawGeometries));
   }
 };
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/GeometryUtils.h
+++ b/velox/functions/prestosql/GeometryUtils.h
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <geos/geom/CoordinateSequenceFactory.h>
+#include <geos/geom/GeometryFactory.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/Point.h>
+
+#include <velox/common/base/Exceptions.h>
+
+namespace facebook::velox::functions {
+
+class GeosGeometrySerde {
+ public:
+  static void serialize(
+      const geos::geom::Geometry* geometry,
+      exec::StringWriter<>& stringWriter) {
+    SliceOutput sliceOutput(stringWriter);
+    switch (geometry->getGeometryTypeId()) {
+      case geos::geom::GEOS_POINT:
+        writePoint(geometry, sliceOutput);
+        break;
+      case geos::geom::GEOS_MULTIPOINT:
+        writeMultiPoint(geometry, sliceOutput);
+        break;
+      case geos::geom::GEOS_LINESTRING:
+      case geos::geom::GEOS_LINEARRING:
+        writePolyline(geometry, sliceOutput, false);
+        break;
+      case geos::geom::GEOS_MULTILINESTRING:
+        writePolyline(geometry, sliceOutput, true);
+        break;
+      default:
+        VELOX_FAIL("Cannot serialize geometry type");
+        break;
+    }
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> deserialize(
+      const StringView& geometryString) {
+    SliceInput sliceInput(geometryString.data(), geometryString.size());
+    auto geometryType =
+        static_cast<GeometrySerializationType>(sliceInput.readByte());
+    switch (geometryType) {
+      case GeometrySerializationType::POINT:
+        return readPoint(sliceInput);
+      case GeometrySerializationType::MULTI_POINT:
+        return readMultiPoint(sliceInput);
+      case GeometrySerializationType::LINE_STRING:
+        return readPolyline(sliceInput, false);
+      case GeometrySerializationType::MULTI_LINE_STRING:
+        return readPolyline(sliceInput, true);
+      default:
+        VELOX_FAIL("Cannot deserialize geometry type");
+        break;
+    }
+    return nullptr;
+  }
+
+ private:
+  enum class GeometrySerializationType : uint8_t {
+    POINT = 0,
+    MULTI_POINT = 1,
+    LINE_STRING = 2,
+    MULTI_LINE_STRING = 3,
+    POLYGON = 4,
+    MULTI_POLYGON = 5,
+    GEOMETRY_COLLECTION = 6,
+    ENVELOPE = 7
+  };
+
+  enum class EsriShapeType : int {
+    POINT = 1,
+    POLYLINE = 3,
+    POLYGON = 5,
+    MULTI_POINT = 8
+  };
+
+  class SliceInput {
+   public:
+    SliceInput(const void* rawData, size_t dataSize)
+        : data_(reinterpret_cast<const uint8_t*>(rawData)),
+          size_(dataSize),
+          position_(0) {}
+
+    uint8_t readByte() {
+      return read<uint8_t>();
+    }
+
+    int16_t readShort() {
+      return read<int16_t>();
+    }
+
+    int32_t readInt() {
+      return read<int32_t>();
+    }
+
+    int32_t readLong() {
+      return read<int64_t>();
+    }
+
+    float readFloat() {
+      return read<float>();
+    }
+
+    double readDouble() {
+      return read<double>();
+    }
+
+    size_t remaining() const {
+      return size_ - position_;
+    }
+
+    void skip(size_t size) {
+      if (position_ + size > size_) {
+        VELOX_USER_FAIL("SliceInput read exceeds buffer size.");
+      }
+      position_ += size;
+    }
+
+   private:
+    template <typename T>
+    T read() {
+      if (position_ + sizeof(T) > size_) {
+        VELOX_USER_FAIL("SliceInput read exceeds buffer size.");
+      }
+      T value;
+      std::memcpy(&value, &data_[position_], sizeof(T));
+      position_ += sizeof(T);
+      return value;
+    }
+
+    const uint8_t* data_;
+    size_t size_;
+    size_t position_;
+  };
+
+  class SliceOutput {
+   public:
+    SliceOutput(exec::StringWriter<>& stringWriter)
+        : stringWriter_(stringWriter) {}
+
+    SliceOutput() = delete;
+
+    void writeByte(uint8_t value) {
+      write<uint8_t>(value);
+    }
+
+    void writeShort(int16_t value) {
+      write<int16_t>(value);
+    }
+
+    void writeInt(int32_t value) {
+      write<int32_t>(value);
+    }
+
+    void writeLong(int64_t value) {
+      write<int64_t>(value);
+    }
+
+    void writeFloat(float value) {
+      write<float>(value);
+    }
+
+    void writeDouble(double value) {
+      write<double>(value);
+    }
+
+   private:
+    template <typename T>
+    void write(const T& value) {
+      stringWriter_.append(
+          std::string_view(reinterpret_cast<const char*>(&value), sizeof(T)));
+    }
+
+    exec::StringWriter<>& stringWriter_;
+  };
+
+  static void writeEnvelope(
+      const geos::geom::Geometry* geometry,
+      SliceOutput& output) {
+    auto envelope = geometry->getEnvelopeInternal();
+    output.writeDouble(envelope->getMinX());
+    output.writeDouble(envelope->getMinY());
+    output.writeDouble(envelope->getMaxX());
+    output.writeDouble(envelope->getMaxY());
+  }
+
+  static void writeCoordinates(
+      const geos::geom::CoordinateSequence* coords,
+      SliceOutput& output) {
+    for (size_t i = 0; i < coords->size(); ++i) {
+      output.writeDouble(coords->getX(i));
+      output.writeDouble(coords->getY(i));
+    }
+  }
+
+  static void writePoint(
+      const geos::geom::Geometry* point,
+      SliceOutput& output) {
+    output.writeByte(static_cast<uint8_t>(GeometrySerializationType::POINT));
+    if (!point->isEmpty()) {
+      writeCoordinates(point->getCoordinates().get(), output);
+    } else {
+      output.writeDouble(std::nan(""));
+      output.writeDouble(std::nan(""));
+    }
+  }
+
+  static void writeMultiPoint(
+      const geos::geom::Geometry* geometry,
+      SliceOutput& output) {
+    output.writeByte(
+        static_cast<uint8_t>(GeometrySerializationType::MULTI_POINT));
+    output.writeInt(static_cast<int32_t>(EsriShapeType::MULTI_POINT));
+    writeEnvelope(geometry, output);
+    output.writeInt(geometry->getNumPoints());
+    writeCoordinates(geometry->getCoordinates().get(), output);
+  }
+
+  static void writePolyline(
+      const geos::geom::Geometry* geometry,
+      SliceOutput& output,
+      bool multiType) {
+    int numParts;
+    int numPoints = geometry->getNumPoints();
+
+    if (multiType) {
+      numParts = geometry->getNumGeometries();
+      output.writeByte(
+          static_cast<uint8_t>(GeometrySerializationType::MULTI_LINE_STRING));
+    } else {
+      numParts = (numPoints > 0) ? 1 : 0;
+      output.writeByte(
+          static_cast<uint8_t>(GeometrySerializationType::LINE_STRING));
+    }
+
+    output.writeInt(static_cast<int32_t>(EsriShapeType::POLYLINE));
+
+    writeEnvelope(geometry, output);
+
+    output.writeInt(numParts);
+    output.writeInt(numPoints);
+
+    int partIndex = 0;
+    for (int i = 0; i < numParts; ++i) {
+      output.writeInt(partIndex);
+      partIndex += geometry->getGeometryN(i)->getNumPoints();
+    }
+
+    if (multiType) {
+      for (int i = 0; i < numParts; ++i) {
+        const auto* part = geometry->getGeometryN(i);
+        writeCoordinates(part->getCoordinates().get(), output);
+      }
+    } else {
+      writeCoordinates(geometry->getCoordinates().get(), output);
+    }
+  }
+
+  inline static auto GEOMETRY_FACTORY = geos::geom::GeometryFactory::create();
+
+  static void skipEsriType(SliceInput& input) {
+    input.skip(4); // Esri type is an integer
+  }
+
+  static void skipEnvelope(SliceInput& input) {
+    input.skip(4 * 8); // Envelopes are 4 doubles (minX, minY, maxX, maxY)
+  }
+
+  static geos::geom::Coordinate readCoordinate(SliceInput& input) {
+    double x = input.readDouble();
+    double y = input.readDouble();
+    return {x, y};
+  }
+
+  static std::unique_ptr<geos::geom::CoordinateSequence> readCoordinates(
+      SliceInput& input,
+      int count) {
+    auto coords =
+        GEOMETRY_FACTORY->getCoordinateSequenceFactory()->create(count, 2);
+    for (int i = 0; i < count; ++i) {
+      coords->setAt(readCoordinate(input), i);
+    }
+    return coords;
+  }
+
+  static std::unique_ptr<geos::geom::Point> readPoint(SliceInput& input) {
+    geos::geom::Coordinate coordinate = readCoordinate(input);
+    if (std::isnan(coordinate.x) || std::isnan(coordinate.y)) {
+      return GEOMETRY_FACTORY->createPoint();
+    }
+    return std::unique_ptr<geos::geom::Point>(
+        GEOMETRY_FACTORY->createPoint(coordinate));
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> readMultiPoint(
+      SliceInput& input) {
+    skipEsriType(input);
+    skipEnvelope(input);
+    int pointCount = input.readInt();
+    auto coords = readCoordinates(input, pointCount);
+    std::vector<std::unique_ptr<geos::geom::Point>> points;
+    for (size_t i = 0; i < coords->size(); ++i) {
+      points.push_back(
+          std::unique_ptr<geos::geom::Point>(GEOMETRY_FACTORY->createPoint(
+              geos::geom::Coordinate(coords->getX(i), coords->getY(i)))));
+    }
+    return GEOMETRY_FACTORY->createMultiPoint(std::move(points));
+  }
+
+  static std::unique_ptr<geos::geom::Geometry> readPolyline(
+      SliceInput& input,
+      bool multiType) {
+    skipEsriType(input);
+    skipEnvelope(input);
+    int partCount = input.readInt();
+
+    if (partCount == 0) {
+      if (multiType) {
+        return GEOMETRY_FACTORY->createMultiLineString();
+      }
+      return GEOMETRY_FACTORY->createLineString();
+    }
+
+    int pointCount = input.readInt();
+    std::vector<int> startIndexes(partCount);
+
+    for (int i = 0; i < partCount; ++i) {
+      startIndexes[i] = input.readInt();
+    }
+
+    std::vector<int> partLengths(partCount);
+    if (partCount > 1) {
+      partLengths[0] = startIndexes[1];
+      for (int i = 1; i < partCount - 1; ++i) {
+        partLengths[i] = startIndexes[i + 1] - startIndexes[i];
+      }
+    }
+    partLengths[partCount - 1] = pointCount - startIndexes[partCount - 1];
+
+    std::vector<std::unique_ptr<geos::geom::LineString>> lineStrings;
+    for (int i = 0; i < partCount; ++i) {
+      lineStrings.push_back(GEOMETRY_FACTORY->createLineString(
+          readCoordinates(input, partLengths[i])));
+    }
+
+    if (multiType) {
+      return GEOMETRY_FACTORY->createMultiLineString(std::move(lineStrings));
+    }
+
+    if (lineStrings.size() != 1) {
+      VELOX_USER_FAIL(
+          "Expected a single LineString for non-multitype polyline.");
+    }
+
+    return std::move(lineStrings[0]);
+  }
+};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
@@ -74,6 +75,8 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARCHAR:
       if (isJsonType(type)) {
         return "json";
+      } else if (isGeometryType(type)) {
+        return "geometry";
       }
       return "varchar";
     case TypeKind::VARBINARY:

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -23,6 +23,7 @@ velox_add_library(
   ComparisonFunctionsRegistration.cpp
   DateTimeFunctionsRegistration.cpp
   GeneralFunctionsRegistration.cpp
+  GeometryFunctionsRegistration.cpp
   HyperLogFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp
   MapFunctionsRegistration.cpp

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/GeometryFunctions.h"
+#include "velox/functions/Registerer.h"
 
 namespace facebook::velox::functions {
 void registerGeometryFunctions(const std::string& prefix) {
   registerGeometryType();
 
-  registerFunction<StContainsFunction, bool, Geometry, Geometry>({
-     {prefix + "ST_Contains"}
-  });
+  registerFunction<StContainsFunction, bool, Geometry, Geometry>(
+      {{prefix + "ST_Contains"}});
+
+  registerFunction<StPointFunction, Geometry, double, double>(
+      {{prefix + "ST_Point"}});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -1,0 +1,29 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/GeometryFunctions.h"
+
+namespace facebook::velox::functions {
+void registerGeometryFunctions(const std::string& prefix) {
+  registerGeometryType();
+
+  registerFunction<StContainsFunction, bool, Geometry, Geometry>({
+     {prefix + "ST_Contains"}
+  });
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -29,6 +29,7 @@ extern void registerComparisonFunctions(const std::string& prefix);
 extern void registerDateTimeFunctions(const std::string& prefix);
 extern void registerGeneralFunctions(const std::string& prefix);
 extern void registerHyperLogFunctions(const std::string& prefix);
+extern void registerGeometryFunctions(const std::string& prefix);
 extern void registerJsonFunctions(const std::string& prefix);
 extern void registerMapFunctions(const std::string& prefix);
 extern void registerStringFunctions(const std::string& prefix);
@@ -66,6 +67,10 @@ void registerJsonFunctions(const std::string& prefix) {
   functions::registerJsonFunctions(prefix);
 }
 
+void registerGeometryFunctions(const std::string& prefix) {
+  functions::registerGeometryFunctions(prefix);
+}
+
 void registerHyperLogFunctions(const std::string& prefix) {
   functions::registerHyperLogFunctions(prefix);
 }
@@ -101,6 +106,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerMapFunctions(prefix);
   registerArrayFunctions(prefix);
   registerJsonFunctions(prefix);
+  registerGeometryFunctions(prefix);
   registerHyperLogFunctions(prefix);
   registerGeneralFunctions(prefix);
   registerDateTimeFunctions(prefix);

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -23,6 +23,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_presto_types
+  GEOS::geos
   velox_memory
   velox_expression
   velox_functions_util

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 velox_add_library(
   velox_presto_types
+  GeometryType.cpp
   HyperLogLogType.cpp
   JsonType.cpp
   TimestampWithTimeZoneType.cpp

--- a/velox/functions/prestosql/types/GeometryType.cpp
+++ b/velox/functions/prestosql/types/GeometryType.cpp
@@ -59,7 +59,7 @@ class GeometryCastOperator : public exec::CastOperator {
       castFromVarbinary(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
-          "Cast from {} to IPAddress not supported", resultType->toString());
+          "Cast from {} to Geometry not supported", resultType->toString());
     }
   }
 
@@ -77,7 +77,7 @@ class GeometryCastOperator : public exec::CastOperator {
       castToVarbinary(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
-          "Cast from IPAddress to {} not supported", resultType->toString());
+          "Cast from Geometry to {} not supported", resultType->toString());
     }
   }
 

--- a/velox/functions/prestosql/types/GeometryType.cpp
+++ b/velox/functions/prestosql/types/GeometryType.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Facebook, Inc. and its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,21 +13,161 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <geos/io/WKBReader.h>
+#include <geos/io/WKBWriter.h>
+#include <geos/io/WKTReader.h>
+#include <geos/io/WKTWriter.h>
 
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
 
+class GeometryCastOperator : public exec::CastOperator {
+ public:
+  bool isSupportedFromType(const TypePtr& other) const override {
+    switch (other->kind()) {
+      case TypeKind::VARBINARY:
+      case TypeKind::VARCHAR:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  bool isSupportedToType(const TypePtr& other) const override {
+    switch (other->kind()) {
+      case TypeKind::VARBINARY:
+      case TypeKind::VARCHAR:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (input.typeKind() == TypeKind::VARCHAR) {
+      castFromString(input, context, rows, *result);
+    } else if (input.typeKind() == TypeKind::VARBINARY) {
+      castFromVarbinary(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to IPAddress not supported", resultType->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+
+    if (resultType->kind() == TypeKind::VARCHAR) {
+      castToString(input, context, rows, *result);
+    } else if (resultType->kind() == TypeKind::VARBINARY) {
+      castToVarbinary(input, context, rows, *result);
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from IPAddress to {} not supported", resultType->toString());
+    }
+  }
+
+ private:
+  static void castToString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* geometries = input.as<SimpleVector<StringView>>();
+    geos::io::WKTWriter writer;
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto geometry = geometries->valueAt(row);
+      auto geosGeometry = functions::GeosGeometrySerde::deserialize(geometry);
+      exec::StringWriter<false> wktString(flatResult, row);
+      wktString.append(writer.write(geosGeometry.get()));
+      wktString.finalize();
+    });
+  }
+
+  static void castFromString(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* geometryStrings = input.as<SimpleVector<StringView>>();
+    geos::io::WKTReader reader;
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto wktString = geometryStrings->valueAt(row);
+      auto geosGeometry = reader.read(wktString);
+      exec::StringWriter<> geometry(flatResult, row);
+      functions::GeosGeometrySerde::serialize(geosGeometry.get(), geometry);
+      geometry.finalize();
+    });
+  }
+
+  static void castToVarbinary(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* geometries = input.as<SimpleVector<StringView>>();
+    geos::io::WKBWriter writer;
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto geometry = geometries->valueAt(row);
+      auto geosGeometry = functions::GeosGeometrySerde::deserialize(geometry);
+      std::ostringstream os;
+      writer.write(*geosGeometry, os);
+      exec::StringWriter<> wkbString(flatResult, row);
+      wkbString.append(os.str()); // append
+      wkbString.finalize();
+    });
+  }
+
+  static void castFromVarbinary(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) {
+    auto* flatResult = result.as<FlatVector<StringView>>();
+    const auto* geometryStrings = input.as<SimpleVector<StringView>>();
+    geos::io::WKBReader reader;
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto wkbString = geometryStrings->valueAt(row);
+      auto geosGeometry = reader.read(
+          reinterpret_cast<const unsigned char*>(wkbString.data()),
+          wkbString.size());
+      exec::StringWriter<> geometry(flatResult, row);
+      functions::GeosGeometrySerde::serialize(geosGeometry.get(), geometry);
+      geometry.finalize();
+    });
+  }
+};
+
 class GeometryTypeFactories : public CustomTypeFactories {
-public:
+ public:
   GeometryTypeFactories() = default;
 
   TypePtr getType() const override {
     return GEOMETRY();
   }
   exec::CastOperatorPtr getCastOperator() const override {
-    throw std::runtime_error("Geometry type does not support casting.");
+    return std::make_shared<GeometryCastOperator>();
   }
 };
 

--- a/velox/functions/prestosql/types/GeometryType.cpp
+++ b/velox/functions/prestosql/types/GeometryType.cpp
@@ -93,7 +93,7 @@ class GeometryCastOperator : public exec::CastOperator {
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto geometry = geometries->valueAt(row);
-      auto geosGeometry = functions::GeosGeometrySerde::deserialize(geometry);
+      auto geosGeometry = functions::GeometryUtils::deserialize(geometry);
       exec::StringWriter<false> wktString(flatResult, row);
       wktString.append(writer.write(geosGeometry.get()));
       wktString.finalize();
@@ -113,7 +113,7 @@ class GeometryCastOperator : public exec::CastOperator {
       const auto wktString = geometryStrings->valueAt(row);
       auto geosGeometry = reader.read(wktString);
       exec::StringWriter<> geometry(flatResult, row);
-      functions::GeosGeometrySerde::serialize(geosGeometry.get(), geometry);
+      functions::GeometryUtils::serialize(geosGeometry, geometry);
       geometry.finalize();
     });
   }
@@ -129,7 +129,7 @@ class GeometryCastOperator : public exec::CastOperator {
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto geometry = geometries->valueAt(row);
-      auto geosGeometry = functions::GeosGeometrySerde::deserialize(geometry);
+      auto geosGeometry = functions::GeometryUtils::deserialize(geometry);
       std::ostringstream os;
       writer.write(*geosGeometry, os);
       exec::StringWriter<> wkbString(flatResult, row);
@@ -153,7 +153,7 @@ class GeometryCastOperator : public exec::CastOperator {
           reinterpret_cast<const unsigned char*>(wkbString.data()),
           wkbString.size());
       exec::StringWriter<> geometry(flatResult, row);
-      functions::GeosGeometrySerde::serialize(geosGeometry.get(), geometry);
+      functions::GeometryUtils::serialize(geosGeometry, geometry);
       geometry.finalize();
     });
   }

--- a/velox/functions/prestosql/types/GeometryType.cpp
+++ b/velox/functions/prestosql/types/GeometryType.cpp
@@ -1,0 +1,40 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/GeometryType.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class GeometryTypeFactories : public CustomTypeFactories {
+public:
+  GeometryTypeFactories() = default;
+
+  TypePtr getType() const override {
+    return GEOMETRY();
+  }
+  exec::CastOperatorPtr getCastOperator() const override {
+    throw std::runtime_error("Geometry type does not support casting.");
+  }
+};
+
+void registerGeometryType() {
+  // Register the geometry type with the type registry.
+  registerCustomType(
+      "geometry", std::make_unique<const GeometryTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/GeometryType.h
+++ b/velox/functions/prestosql/types/GeometryType.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/GeometryUtils.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 

--- a/velox/functions/prestosql/types/GeometryType.h
+++ b/velox/functions/prestosql/types/GeometryType.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/CastExpr.h"
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// Represents Geometry as a string.
+class GeometryType : public VarcharType {
+  GeometryType() = default;
+
+ public:
+  static const std::shared_ptr<const GeometryType>& get() {
+    static const std::shared_ptr<const GeometryType> instance{
+        new GeometryType()};
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "GEOMETRY";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isGeometryType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return GeometryType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const GeometryType> GEOMETRY() {
+  return GeometryType::get();
+}
+
+// Type used for function registration.
+struct GeometryT {
+  using type = Varchar;
+  static constexpr const char* typeName = "geometry";
+};
+
+using Geometry = CustomType<GeometryT>;
+
+void registerGeometryType();
+
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
This draft PR introduces spatial data support (#11814) to Velox, including the following key updates:

+ Added support for geometry types within Velox.
+ Introduced the GEOS library as a dependency for spatial operations.
+ Implemented serialization/deserialization for geometry types using GEOS.
+ Added cast operators to convert between `VARCHAR` (WKT) or `VARBINARY` (WKB) and geometry types.
+ Implemented some spatial functions, including `ST_Point and `ST_Contains`.