### PR TITLE
feat(s3): Support S3 Region

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
@@ -23,9 +23,9 @@ if(VELOX_ENABLE_S3)
     S3Util.cpp
     S3Config.cpp)
 
-  velox_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
-  velox_link_libraries(velox_s3fs velox_dwio_common Folly::folly
-                       ${AWSSDK_LIBRARIES})
+  velox_include_directories(velox_s3fs PRIVATE ${AWSSDK_INCLUDE_DIRS})
+  velox_link_libraries(velox_s3fs PRIVATE velox_dwio_common Folly::folly
+                                          ${AWSSDK_LIBRARIES})
 
   if(${VELOX_BUILD_TESTING})
     add_subdirectory(tests)

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 
 namespace facebook::velox::filesystems {
 
@@ -72,6 +73,18 @@ S3Config::S3Config(
       }
     }
   }
+}
+
+std::optional<std::string> S3Config::endpointRegion() const {
+  auto region = config_.find(Keys::kEndpointRegion)->second;
+  if (!region.has_value()) {
+    // If region is not set, try inferring from the endpoint.
+    auto endpointValue = endpoint();
+    if (endpointValue.has_value()) {
+      region = parseStandardRegionName(endpointValue.value());
+    }
+  }
+  return region;
 }
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -140,9 +140,7 @@ class S3Config {
   }
 
   /// The S3 storage endpoint region.
-  std::optional<std::string> endpointRegion() const {
-    return config_.find(Keys::kEndpointRegion)->second;
-  }
+  std::optional<std::string> endpointRegion() const;
 
   /// Access key to use.
   std::optional<std::string> accessKey() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -54,6 +54,7 @@ class S3Config {
   enum class Keys {
     kBegin,
     kEndpoint = kBegin,
+    kEndpointRegion,
     kAccessKey,
     kSecretKey,
     kPathStyleAccess,
@@ -80,7 +81,9 @@ class S3Config {
         Keys,
         std::pair<std::string_view, std::optional<std::string_view>>>
         config = {
-            {Keys::kEndpoint, std::make_pair("endpoint", "")},
+            {Keys::kEndpoint, std::make_pair("endpoint", std::nullopt)},
+            {Keys::kEndpointRegion,
+             std::make_pair("endpoint.region", std::nullopt)},
             {Keys::kAccessKey, std::make_pair("aws-access-key", std::nullopt)},
             {Keys::kSecretKey, std::make_pair("aws-secret-key", std::nullopt)},
             {Keys::kPathStyleAccess,
@@ -132,8 +135,13 @@ class S3Config {
 
   /// The S3 storage endpoint server. This can be used to connect to an
   /// S3-compatible storage system instead of AWS.
-  std::string endpoint() const {
-    return config_.find(Keys::kEndpoint)->second.value();
+  std::optional<std::string> endpoint() const {
+    return config_.find(Keys::kEndpoint)->second;
+  }
+
+  /// The S3 storage endpoint region.
+  std::optional<std::string> endpointRegion() const {
+    return config_.find(Keys::kEndpointRegion)->second;
   }
 
   /// Access key to use.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -525,22 +525,12 @@ class S3FileSystem::Impl {
   Impl(const S3Config& s3Config) {
     VELOX_CHECK(getAwsInstance()->isInitialized(), "S3 is not initialized");
     Aws::Client::ClientConfiguration clientConfig;
-    std::string region;
-    if (s3Config.endpointRegion().has_value()) {
-      region = s3Config.endpointRegion().value();
-    }
-
     if (s3Config.endpoint().has_value()) {
       clientConfig.endpointOverride = s3Config.endpoint().value();
-      const std::string_view endpoint = clientConfig.endpointOverride;
-      // If region is not set, try inferring from the endpoint.
-      if (region.empty()) {
-        region = parseStandardRegionName(endpoint);
-      }
     }
 
-    if (!region.empty()) {
-      clientConfig.region = region;
+    if (s3Config.endpointRegion().has_value()) {
+      clientConfig.region = s3Config.endpointRegion().value();
     }
 
     if (s3Config.useProxyFromEnv()) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -158,9 +158,9 @@ std::optional<std::string> parseStandardRegionName(std::string_view endpoint) {
   // Remove the kAmazonHostSuffix.
   std::string_view endpointPrefix = endpoint.substr(0, index);
   const re2::RE2 pattern("^(?:.+\\.)?s3[-.]([a-z0-9-]+)$");
-  std::string bucket, region;
+  std::string region;
   if (re2::RE2::FullMatch(endpointPrefix, pattern, &region)) {
-    // endpointPrefix was 'bucket.s3-[region]' or 'bucket.s3.[region]'
+    // endpointPrefix is 'bucket.s3-[region]' or 'bucket.s3.[region]'
     return region;
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -149,11 +149,11 @@ std::optional<folly::Uri> S3ProxyConfigurationBuilder::build() {
   return proxyUri;
 }
 
-std::string parseStandardRegionName(std::string_view endpoint) {
+std::optional<std::string> parseStandardRegionName(std::string_view endpoint) {
   const std::string_view kAmazonHostSuffix = ".amazonaws.com";
   auto index = endpoint.size() - kAmazonHostSuffix.size();
   if (endpoint.rfind(kAmazonHostSuffix) != index) {
-    return "";
+    return std::nullopt;
   }
   // Remove the kAmazonHostSuffix.
   std::string_view endpointPrefix = endpoint.substr(0, index);
@@ -165,13 +165,13 @@ std::string parseStandardRegionName(std::string_view endpoint) {
   }
 
   index = endpointPrefix.rfind('.');
-  if (index == -1) {
-    // Use default region set by the SDK.
-    return "";
+  if (index != std::string::npos) {
+    // endpointPrefix was 'service.[region]'.
+    return std::string(endpointPrefix.substr(index + 1));
   }
 
-  // endpointPrefix was 'service.[region]'.
-  return std::string(endpointPrefix.substr(index + 1));
+  // Use default region set by the SDK.
+  return std::nullopt;
 }
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -20,6 +20,7 @@
 // (register|generate)ReadFile and (register|generate)WriteFile functions.
 
 #include "folly/IPAddress.h"
+#include "re2/re2.h"
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 
@@ -146,6 +147,31 @@ std::optional<folly::Uri> S3ProxyConfigurationBuilder::build() {
     return std::nullopt;
   }
   return proxyUri;
+}
+
+std::string parseStandardRegionName(std::string_view endpoint) {
+  const std::string_view kAmazonHostSuffix = ".amazonaws.com";
+  auto index = endpoint.size() - kAmazonHostSuffix.size();
+  if (endpoint.rfind(kAmazonHostSuffix) != index) {
+    return "";
+  }
+  // Remove the kAmazonHostSuffix.
+  std::string_view endpointPrefix = endpoint.substr(0, index);
+  const re2::RE2 pattern("^(?:.+\\.)?s3[-.]([a-z0-9-]+)$");
+  std::string bucket, region;
+  if (re2::RE2::FullMatch(endpointPrefix, pattern, &region)) {
+    // endpointPrefix was 'bucket.s3-[region]' or 'bucket.s3.[region]'
+    return region;
+  }
+
+  index = endpointPrefix.rfind('.');
+  if (index == -1) {
+    // Use default region set by the SDK.
+    return "";
+  }
+
+  // endpointPrefix was 'service.[region]'.
+  return std::string(endpointPrefix.substr(index + 1));
 }
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -193,8 +193,8 @@ std::string getNoProxyEnvVar();
 // Adopted from the AWS Java SDK
 // Endpoint can be 'service.[region].amazonaws.com' or
 // 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'
-// Return value is a region value or empty string.
-std::string parseStandardRegionName(std::string_view endpoint);
+// Return value is a region string value if present.
+std::optional<std::string> parseStandardRegionName(std::string_view endpoint);
 
 class S3ProxyConfigurationBuilder {
  public:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -190,6 +190,11 @@ bool isHostExcludedFromProxy(
 std::string getHttpProxyEnvVar();
 std::string getHttpsProxyEnvVar();
 std::string getNoProxyEnvVar();
+// Adopted from the AWS Java SDK
+// Endpoint can be 'service.[region].amazonaws.com' or
+// 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'
+// Return value is a region value or empty string.
+std::string parseStandardRegionName(std::string_view endpoint);
 
 class S3ProxyConfigurationBuilder {
  public:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -190,6 +190,7 @@ bool isHostExcludedFromProxy(
 std::string getHttpProxyEnvVar();
 std::string getHttpsProxyEnvVar();
 std::string getNoProxyEnvVar();
+
 // Adopted from the AWS Java SDK
 // Endpoint can be 'service.[region].amazonaws.com' or
 // 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -19,7 +19,6 @@ target_link_libraries(
   velox_s3file_test
   velox_file
   velox_s3fs
-  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
@@ -33,7 +32,6 @@ target_link_libraries(
   velox_s3registration_test
   velox_file
   velox_s3fs
-  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
@@ -46,7 +44,6 @@ add_test(velox_s3finalize_test velox_s3finalize_test)
 target_link_libraries(
   velox_s3finalize_test
   velox_s3fs
-  velox_hive_config
   velox_file
   velox_core
   GTest::gtest
@@ -58,7 +55,6 @@ target_link_libraries(
   velox_s3insert_test
   velox_file
   velox_s3fs
-  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
@@ -75,7 +71,6 @@ target_link_libraries(
   velox_s3read_test
   velox_file
   velox_s3fs
-  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
@@ -89,7 +84,6 @@ target_link_libraries(
   velox_s3multiendpoints_test
   velox_file
   velox_s3fs
-  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
@@ -28,7 +28,8 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.useVirtualAddressing(), true);
   ASSERT_EQ(s3Config.useSSL(), true);
   ASSERT_EQ(s3Config.useInstanceCredentials(), false);
-  ASSERT_EQ(s3Config.endpoint(), "");
+  ASSERT_EQ(s3Config.endpoint(), std::nullopt);
+  ASSERT_EQ(s3Config.endpointRegion(), std::nullopt);
   ASSERT_EQ(s3Config.accessKey(), std::nullopt);
   ASSERT_EQ(s3Config.secretKey(), std::nullopt);
   ASSERT_EQ(s3Config.iamRole(), std::nullopt);
@@ -41,20 +42,22 @@ TEST(S3ConfigTest, overrideConfig) {
       {S3Config::baseConfigKey(S3Config::Keys::kSSLEnabled), "false"},
       {S3Config::baseConfigKey(S3Config::Keys::kUseInstanceCredentials),
        "true"},
-      {S3Config::baseConfigKey(S3Config::Keys::kEndpoint), "hey"},
-      {S3Config::baseConfigKey(S3Config::Keys::kAccessKey), "hello"},
-      {S3Config::baseConfigKey(S3Config::Keys::kSecretKey), "hello"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "hello"},
+      {S3Config::baseConfigKey(S3Config::Keys::kEndpoint), "endpoint"},
+      {S3Config::baseConfigKey(S3Config::Keys::kEndpointRegion), "region"},
+      {S3Config::baseConfigKey(S3Config::Keys::kAccessKey), "access"},
+      {S3Config::baseConfigKey(S3Config::Keys::kSecretKey), "secret"},
+      {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "iam"},
       {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"}};
   auto s3Config = S3Config(
       "", std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   ASSERT_EQ(s3Config.useVirtualAddressing(), false);
   ASSERT_EQ(s3Config.useSSL(), false);
   ASSERT_EQ(s3Config.useInstanceCredentials(), true);
-  ASSERT_EQ(s3Config.endpoint(), "hey");
-  ASSERT_EQ(s3Config.accessKey(), std::optional("hello"));
-  ASSERT_EQ(s3Config.secretKey(), std::optional("hello"));
-  ASSERT_EQ(s3Config.iamRole(), std::optional("hello"));
+  ASSERT_EQ(s3Config.endpoint(), "endpoint");
+  ASSERT_EQ(s3Config.endpointRegion(), "region");
+  ASSERT_EQ(s3Config.accessKey(), std::optional("access"));
+  ASSERT_EQ(s3Config.secretKey(), std::optional("secret"));
+  ASSERT_EQ(s3Config.iamRole(), std::optional("iam"));
   ASSERT_EQ(s3Config.iamRoleSessionName(), "velox");
 }
 
@@ -65,16 +68,16 @@ TEST(S3ConfigTest, overrideBucketConfig) {
       {S3Config::baseConfigKey(S3Config::Keys::kSSLEnabled), "false"},
       {S3Config::baseConfigKey(S3Config::Keys::kUseInstanceCredentials),
        "true"},
-      {S3Config::baseConfigKey(S3Config::Keys::kEndpoint), "hey"},
+      {S3Config::baseConfigKey(S3Config::Keys::kEndpoint), "endpoint"},
       {S3Config::bucketConfigKey(S3Config::Keys::kEndpoint, bucket),
-       "bucket-hey"},
-      {S3Config::baseConfigKey(S3Config::Keys::kAccessKey), "hello"},
+       "bucket.s3-region.amazonaws.com"},
+      {S3Config::baseConfigKey(S3Config::Keys::kAccessKey), "access"},
       {S3Config::bucketConfigKey(S3Config::Keys::kAccessKey, bucket),
-       "bucket-hello"},
-      {S3Config::baseConfigKey(S3Config::Keys::kSecretKey), "secret-hello"},
+       "bucket-access"},
+      {S3Config::baseConfigKey(S3Config::Keys::kSecretKey), "secret"},
       {S3Config::bucketConfigKey(S3Config::Keys::kSecretKey, bucket),
-       "bucket-secret-hello"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "hello"},
+       "bucket-secret"},
+      {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "iam"},
       {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"}};
   auto s3Config = S3Config(
       bucket,
@@ -82,10 +85,12 @@ TEST(S3ConfigTest, overrideBucketConfig) {
   ASSERT_EQ(s3Config.useVirtualAddressing(), false);
   ASSERT_EQ(s3Config.useSSL(), false);
   ASSERT_EQ(s3Config.useInstanceCredentials(), true);
-  ASSERT_EQ(s3Config.endpoint(), "bucket-hey");
-  ASSERT_EQ(s3Config.accessKey(), std::optional("bucket-hello"));
-  ASSERT_EQ(s3Config.secretKey(), std::optional("bucket-secret-hello"));
-  ASSERT_EQ(s3Config.iamRole(), std::optional("hello"));
+  ASSERT_EQ(s3Config.endpoint(), "bucket.s3-region.amazonaws.com");
+  // Inferred from the endpoint.
+  ASSERT_EQ(s3Config.endpointRegion(), "region");
+  ASSERT_EQ(s3Config.accessKey(), std::optional("bucket-access"));
+  ASSERT_EQ(s3Config.secretKey(), std::optional("bucket-secret"));
+  ASSERT_EQ(s3Config.iamRole(), std::optional("iam"));
   ASSERT_EQ(s3Config.iamRoleSessionName(), "velox");
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
@@ -35,7 +35,7 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.iamRoleSessionName(), "velox-session");
 }
 
-TEST(HiveConfigTest, overrideConfig) {
+TEST(S3ConfigTest, overrideConfig) {
   std::unordered_map<std::string, std::string> configFromFile = {
       {S3Config::baseConfigKey(S3Config::Keys::kPathStyleAccess), "true"},
       {S3Config::baseConfigKey(S3Config::Keys::kSSLEnabled), "false"},
@@ -58,7 +58,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(s3Config.iamRoleSessionName(), "velox");
 }
 
-TEST(HiveConfigTest, overrideBucketConfig) {
+TEST(S3ConfigTest, overrideBucketConfig) {
   std::string_view bucket = "bucket";
   std::unordered_map<std::string, std::string> bucketConfigFromFile = {
       {S3Config::baseConfigKey(S3Config::Keys::kPathStyleAccess), "true"},

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -127,6 +127,20 @@ TEST(S3UtilTest, isDomainExcludedFromProxy) {
   }
 }
 
+TEST(S3UtilTest, parseRegion) {
+  // bucket.s3.[region]
+  EXPECT_EQ(parseStandardRegionName("foo.s3.region.amazonaws.com"), "region");
+  // bucket.s3-[region]
+  EXPECT_EQ(parseStandardRegionName("foo.s3-region.amazonaws.com"), "region");
+  // service.[region]
+  EXPECT_EQ(
+      parseStandardRegionName("foo.a3-region.amazonaws.com"), "a3-region");
+  // Not the right suffix
+  EXPECT_EQ(parseStandardRegionName("foo.a3-region.amazonaw.com"), "");
+  EXPECT_EQ(parseStandardRegionName(""), "");
+  EXPECT_EQ(parseStandardRegionName("velox"), "");
+}
+
 TEST(S3UtilTest, isIpExcludedFromProxy) {
   auto hostname = "127.0.0.1";
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -133,12 +133,11 @@ TEST(S3UtilTest, parseRegion) {
   // bucket.s3-[region]
   EXPECT_EQ(parseStandardRegionName("foo.s3-region.amazonaws.com"), "region");
   // service.[region]
-  EXPECT_EQ(
-      parseStandardRegionName("foo.a3-region.amazonaws.com"), "a3-region");
+  EXPECT_EQ(parseStandardRegionName("foo.a3-reg.amazonaws.com"), "a3-reg");
   // Not the right suffix
-  EXPECT_EQ(parseStandardRegionName("foo.a3-region.amazonaw.com"), "");
-  EXPECT_EQ(parseStandardRegionName(""), "");
-  EXPECT_EQ(parseStandardRegionName("velox"), "");
+  EXPECT_EQ(parseStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
+  EXPECT_EQ(parseStandardRegionName(""), std::nullopt);
+  EXPECT_EQ(parseStandardRegionName("velox"), std::nullopt);
 }
 
 TEST(S3UtilTest, isIpExcludedFromProxy) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -670,8 +670,13 @@ Each query can override the config by setting corresponding query session proper
      - Default AWS secret key to use.
    * - hive.s3.endpoint
      - string
-     - us-east-1
+     - 
      - The S3 storage endpoint server. This can be used to connect to an S3-compatible storage system instead of AWS.
+   * - hive.s3.endpoint.region
+     - string
+     - us-east-1
+     - The S3 storage endpoint server region. Default is set by the AWS SDK. If not configured, region will be attempted
+       to be parsed from the hive.s3.endpoint value. 
    * - hive.s3.path-style-access
      - bool
      - false


### PR DESCRIPTION
We will follow a subset of the Hadoop aws library rules to be consistent with other applications. These rules seem reasonable.
https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/connecting.html#s3_endpoint_region_details

1. Configs hive.s3.endpoint and hive.s3.endpoint.region are used to set values for S3 endpoint and region respectively.
2. If hive.s3.endpoint.region is configured with valid AWS region value, S3FS will use this value.
3. If hive.s3.endpoint.region is not set and hive.s3.endpoint is set with valid endpoint value, S3FS will attempt to parse the region from the endpoint and configure the client to use the region value.
4. If both hive.s3.endpoint and hive.s3.endpoint.region are not set, S3FS will use us-east-2 as default region and enable cross-region access. In this case, S3FS does not attempt to override the endpoint while configuring the S3 client.

Fixes: https://github.com/facebookincubator/velox/issues/11627