### PR TITLE
fix(windowfuzzer): Reduce complexElementsMaxSize for Window Fuzzers

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -67,7 +67,8 @@ class AggregationFuzzerBase {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::string>& hiveConfigs,
       bool orderableGroupKeys,
-      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner,
+      std::optional<VectorFuzzer::Options> fuzzerOptions = std::nullopt)
       : customVerificationFunctions_{customVerificationFunctions},
         customInputGenerators_{customInputGenerators},
         queryConfigs_{queryConfigs},
@@ -75,7 +76,10 @@ class AggregationFuzzerBase {
         persistAndRunOnce_{FLAGS_persist_and_run_once},
         reproPersistPath_{FLAGS_repro_persist_path},
         referenceQueryRunner_{std::move(referenceQueryRunner)},
-        vectorFuzzer_{getFuzzerOptions(timestampPrecision), pool_.get()} {
+        vectorFuzzer_{
+            fuzzerOptions.has_value() ? fuzzerOptions.value()
+                                      : getFuzzerOptions(timestampPrecision),
+            pool_.get()} {
     filesystems::registerLocalFileSystem();
     connector::registerConnectorFactory(
         std::make_shared<connector::hive::HiveConnectorFactory>());
@@ -104,6 +108,17 @@ class AggregationFuzzerBase {
     /// Number of times generated query plan failed.
     size_t numFailed{0};
   };
+
+  static VectorFuzzer::Options getFuzzerOptions(
+      VectorFuzzer::Options::TimestampPrecision timestampPrecision) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = FLAGS_batch_size;
+    opts.stringVariableLength = true;
+    opts.stringLength = 4'000;
+    opts.nullRatio = FLAGS_null_ratio;
+    opts.timestampPrecision = timestampPrecision;
+    return opts;
+  }
 
  protected:
   struct Stats {
@@ -149,17 +164,6 @@ class AggregationFuzzerBase {
       const CallableSignature& signature);
 
   PlanWithSplits deserialize(const folly::dynamic& obj);
-
-  static VectorFuzzer::Options getFuzzerOptions(
-      VectorFuzzer::Options::TimestampPrecision timestampPrecision) {
-    VectorFuzzer::Options opts;
-    opts.vectorSize = FLAGS_batch_size;
-    opts.stringVariableLength = true;
-    opts.stringLength = 4'000;
-    opts.nullRatio = FLAGS_null_ratio;
-    opts.timestampPrecision = timestampPrecision;
-    return opts;
-  }
 
   void seed(size_t seed) {
     currentSeed_ = seed;

--- a/velox/exec/fuzzer/WindowFuzzer.h
+++ b/velox/exec/fuzzer/WindowFuzzer.h
@@ -43,8 +43,9 @@ class WindowFuzzer : public AggregationFuzzerBase {
       const std::unordered_map<std::string, std::string>& queryConfigs,
       const std::unordered_map<std::string, std::string>& hiveConfigs,
       bool orderableGroupKeys,
-      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner)
-      : AggregationFuzzerBase{seed, customVerificationFunctions, customInputGenerators, timestampPrecision, queryConfigs, hiveConfigs, orderableGroupKeys, std::move(referenceQueryRunner)},
+      std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner,
+      VectorFuzzer::Options vectorFuzzerOptions)
+      : AggregationFuzzerBase{seed, customVerificationFunctions, customInputGenerators, timestampPrecision, queryConfigs, hiveConfigs, orderableGroupKeys, std::move(referenceQueryRunner), vectorFuzzerOptions},
         orderDependentFunctions_{orderDependentFunctions},
         functionDataSpec_{functionDataSpec} {
     VELOX_CHECK(


### PR DESCRIPTION
Summary:
The window fuzzer often runs into OOMs when generating complex types nested inside other complex types.
 For e.g if we were to run map_union on a MAP<MAP<INT, TIMESTAMP>, ARRAY<>>,
 Then currently with the worst case the inner map can have upto 10k entries  as that is the limit set by complexElementsMaxSize.
 Window vector sizes can be 1000 rows, and each row will have the associated map_union result with the inner elements vector worst case complexElementsMaxSize size. This leads to very fat vectors (1000 * 10k) when materializing. A large percentage of time just is spent in creation of the MaterializedViews and subsequently when comparing them sorting inner map vectors again and again. The latter inefficiency will be addressed in another diff. Currently since the creation of these large nested vectors is not feasable for window fuzzer , we reduce the size of complexElementsMaxSize.

Differential Revision: D68049056


