### PR TITLE
fix: Fix config name for stats-based-filter-reorder-disabaled

### DIFF
--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -165,7 +165,7 @@ class HiveConfig {
       "hive.reader.timestamp_unit";
 
   static constexpr const char* kReadStatsBasedFilterReorderDisabled =
-      "hive.reader.stats_based_filter_reorder_disabaled";
+      "hive.reader.stats-based-filter-reorder-disabaled";
   static constexpr const char* kReadStatsBasedFilterReorderDisabledSession =
       "hive.reader.stats_based_filter_reorder_disabaled";
 


### PR DESCRIPTION
Summary: For hive connector, the naming convention is that config delimiter is -, and session property is _

Differential Revision: D68110440


