### PR TITLE
feat: Optimize PrestoBatchVectorSerializer [5/7]: Serialize ConstantVectors

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -92,17 +92,18 @@ inline void setBit(T* bits, uint64_t idx, bool value) {
   value ? setBit(bits, idx) : clearBit(bits, idx);
 }
 
-inline void negate(char* bits, int32_t size) {
+inline void negate(uint64_t* bits, int32_t size) {
   int32_t i = 0;
   for (; i + 64 <= size; i += 64) {
-    auto wordPtr = reinterpret_cast<uint64_t*>(bits + (i / 8));
+    auto wordPtr = bits + i / 64;
     *wordPtr = ~*wordPtr;
   }
+  auto* bitsAs8Bit = reinterpret_cast<uint8_t*>(bits);
   for (; i + 8 <= size; i += 8) {
-    bits[i / 8] = ~bits[i / 8];
+    bitsAs8Bit[i / 8] = ~bitsAs8Bit[i / 8];
   }
   for (; i < size; ++i) {
-    bits::setBit(bits, i, !bits::isBitSet(bits, i));
+    bits::setBit(bitsAs8Bit, i, !bits::isBitSet(bits, i));
   }
 }
 

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -547,7 +547,7 @@ TEST_F(BitUtilTest, negate) {
     setBit(data, i, i % 2 == 0);
   }
 
-  negate(data, 64);
+  negate(reinterpret_cast<uint64_t*>(data), 64);
   for (int32_t i = 0; i < 64; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
@@ -555,12 +555,12 @@ TEST_F(BitUtilTest, negate) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 64);
+  negate(reinterpret_cast<uint64_t*>(data), 64);
   for (int32_t i = 0; i < 64; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 72);
+  negate(reinterpret_cast<uint64_t*>(data), 72);
   for (int32_t i = 0; i < 72; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
@@ -568,17 +568,17 @@ TEST_F(BitUtilTest, negate) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 72);
+  negate(reinterpret_cast<uint64_t*>(data), 72);
   for (int32_t i = 0; i < 72; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }
 
-  negate(data, 100);
+  negate(reinterpret_cast<uint64_t*>(data), 100);
   for (int32_t i = 0; i < 100; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 != 0) << "at " << i;
   }
 
-  negate(data, 100);
+  negate(reinterpret_cast<uint64_t*>(data), 100);
   for (int32_t i = 0; i < 100; i++) {
     EXPECT_EQ(isBitSet(data, i), i % 2 == 0) << "at " << i;
   }

--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -296,10 +296,16 @@ void ByteOutputStream::flush(OutputStream* out) {
   for (int32_t i = 0; i < ranges_.size(); ++i) {
     int32_t count = i == ranges_.size() - 1 ? lastRangeEnd_ : ranges_[i].size;
     int32_t bytes = isBits_ ? bits::nbytes(count) : count;
+    if (isBits_ && isNegateBits_ && !isNegated_) {
+      bits::negate(reinterpret_cast<uint64_t*>(ranges_[i].buffer), count);
+    }
     if (isBits_ && isReverseBitOrder_ && !isReversed_) {
       bits::reverseBits(ranges_[i].buffer, bytes);
     }
     out->write(reinterpret_cast<char*>(ranges_[i].buffer), bytes);
+  }
+  if (isBits_ && isNegateBits_) {
+    isNegated_ = true;
   }
   if (isBits_ && isReverseBitOrder_) {
     isReversed_ = true;

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -279,11 +279,15 @@ inline int128_t ByteInputStream::read<int128_t>() {
 class ByteOutputStream {
  public:
   /// For output.
-  ByteOutputStream(
+  explicit ByteOutputStream(
       StreamArena* arena,
       bool isBits = false,
-      bool isReverseBitOrder = false)
-      : arena_(arena), isBits_(isBits), isReverseBitOrder_(isReverseBitOrder) {}
+      bool isReverseBitOrder = false,
+      bool isNegateBits = false)
+      : arena_(arena),
+        isBits_(isBits),
+        isReverseBitOrder_(isReverseBitOrder),
+        isNegateBits_(isNegateBits) {}
 
   ByteOutputStream(const ByteOutputStream& other) = delete;
 
@@ -315,6 +319,7 @@ class ByteOutputStream {
   void startWrite(int32_t initialSize) {
     ranges_.clear();
     isReversed_ = false;
+    isNegated_ = false;
     allocatedBytes_ = 0;
     current_ = nullptr;
     lastRangeEnd_ = 0;
@@ -479,9 +484,15 @@ class ByteOutputStream {
 
   const bool isReverseBitOrder_;
 
+  const bool isNegateBits_;
+
   // True if the bit order in ranges_ has been inverted. Presto requires
   // reverse bit order.
   bool isReversed_ = false;
+
+  // True if the bits in ranges_ have been negated. Presto requires null flags
+  // to be the inverse of Velox.
+  bool isNegated_ = false;
 
   std::vector<ByteRange> ranges_;
   // The total number of bytes allocated from 'arena_' in 'ranges_'.

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -138,6 +138,45 @@ TEST_F(ByteStreamTest, outputStream) {
   EXPECT_EQ(0, mmapAllocator_->numAllocated());
 }
 
+TEST_F(ByteStreamTest, bufferedOutputStream) {
+  auto arena = newArena();
+  auto out = std::make_unique<IOBufOutputStream>(*pool_, nullptr, 10000);
+  auto buffered =
+      std::make_unique<BufferedOutputStream>(out.get(), arena.get());
+
+  std::stringstream referenceSStream;
+  auto reference = std::make_unique<OStreamOutputStream>(&referenceSStream);
+  for (auto i = 0; i < 1000; ++i) {
+    std::string data;
+    data.resize(10000);
+    std::fill(data.begin(), data.end(), i);
+    buffered->write(data.data(), data.size());
+    reference->write(data.data(), data.size());
+  }
+  buffered->flush();
+  EXPECT_EQ(reference->tellp(), buffered->tellp());
+  EXPECT_EQ(out->tellp(), buffered->tellp());
+
+  for (auto i = 0; i < 100; ++i) {
+    std::string data;
+    data.resize(6000);
+    std::fill(data.begin(), data.end(), i + 10);
+    buffered->seekp(i * 10000 + 5000);
+    reference->seekp(i * 10000 + 5000);
+    buffered->write(data.data(), data.size());
+    reference->write(data.data(), data.size());
+    buffered->flush();
+  }
+
+  auto str = referenceSStream.str();
+  auto iobuf = out->getIOBuf();
+  auto outData = iobuf->coalesce();
+  EXPECT_EQ(
+      str,
+      std::string(
+          reinterpret_cast<const char*>(outData.data()), outData.size()));
+}
+
 TEST_F(ByteStreamTest, newRangeAllocation) {
   const int kPageSize = AllocationTraits::kPageSize;
   struct {

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -301,36 +301,62 @@ TEST_F(ByteStreamTest, bits) {
     bits.push_back(seed * (i + 1));
   }
   auto arena = newArena();
-  ByteOutputStream bitStream(arena.get(), true);
-  bitStream.startWrite(11);
-  int32_t offset = 0;
-  // Odd number of sizes.
-  std::vector<int32_t> bitSizes = {1, 19, 52, 58, 129};
-  int32_t counter = 0;
-  auto totalBits = bits.size() * 64;
-  while (offset < totalBits) {
-    // Every second uses the fast path for aligned source and append only.
-    auto numBits = std::min<int32_t>(
-        totalBits - offset, bitSizes[counter % bitSizes.size()]);
-    if (counter % 1 == 0) {
-      bitStream.appendBits(bits.data(), offset, offset + numBits);
-    } else {
-      uint64_t aligned[10];
-      bits::copyBits(bits.data(), offset, aligned, 0, numBits);
-      bitStream.appendBitsFresh(aligned, 0, numBits);
+
+  struct {
+    bool reversed;
+    bool negated;
+
+    std::string debugString() const {
+      return fmt::format("reversed: {}, negated: {}", reversed, negated);
     }
-    offset += numBits;
-    ++counter;
+  } testSettings[] = {
+      {false, false}, {true, false}, {false, true}, {true, true}};
+
+  for (const auto& settings : testSettings) {
+    SCOPED_TRACE(settings.debugString());
+    ByteOutputStream bitStream(
+        arena.get(), true, settings.reversed, settings.negated);
+    bitStream.startWrite(11);
+    int32_t offset = 0;
+    // Odd number of sizes.
+    std::vector<int32_t> bitSizes = {1, 19, 52, 58, 129};
+    int32_t counter = 0;
+    auto totalBits = bits.size() * 64;
+    while (offset < totalBits) {
+      // Every second uses the fast path for aligned source and append only.
+      auto numBits = std::min<int32_t>(
+          totalBits - offset, bitSizes[counter % bitSizes.size()]);
+      if (counter % 1 == 0) {
+        bitStream.appendBits(bits.data(), offset, offset + numBits);
+      } else {
+        uint64_t aligned[10];
+        bits::copyBits(bits.data(), offset, aligned, 0, numBits);
+        bitStream.appendBitsFresh(aligned, 0, numBits);
+      }
+      offset += numBits;
+      ++counter;
+    }
+    std::stringstream stringStream;
+    OStreamOutputStream out(&stringStream);
+    bitStream.flush(&out);
+
+    auto expected = bits;
+    if (settings.reversed) {
+      bits::reverseBits(
+          reinterpret_cast<uint8_t*>(expected.data()),
+          expected.size() * sizeof(expected[0]));
+    }
+    if (settings.negated) {
+      bits::negate(expected.data(), expected.size() * sizeof(expected[0]) * 8);
+    }
+
+    EXPECT_EQ(
+        0,
+        memcmp(
+            stringStream.str().data(),
+            expected.data(),
+            expected.size() * sizeof(expected[0])));
   }
-  std::stringstream stringStream;
-  OStreamOutputStream out(&stringStream);
-  bitStream.flush(&out);
-  EXPECT_EQ(
-      0,
-      memcmp(
-          stringStream.str().data(),
-          bits.data(),
-          bits.size() * sizeof(bits[0])));
 }
 
 TEST_F(ByteStreamTest, appendWindow) {

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1713,7 +1713,7 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST_F(TestReader, testEmptyFile) {
   MemorySink sink{1024, {.pool = pool()}};
   DataBufferHolder holder{*pool(), 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
-  BufferedOutputStream output{holder};
+  facebook::velox::dwio::common::BufferedOutputStream output{holder};
 
   proto::Footer footer;
   footer.set_numberofrows(0);

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -44,7 +44,9 @@ void testInts(std::function<T()> generator) {
       count * (vInt ? folly::kMaxVarintLength64 : sizeof(T));
   MemorySink sink{capacity, {.pool = pool.get()}};
   DataBufferHolder holder{*pool, capacity, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
-  auto output = std::make_unique<BufferedOutputStream>(holder);
+  auto output =
+      std::make_unique<facebook::velox::dwio::common::BufferedOutputStream>(
+          holder);
   auto encoder =
       createDirectEncoder<isSigned>(std::move(output), vInt, sizeof(T));
 

--- a/velox/functions/lib/IsNull.cpp
+++ b/velox/functions/lib/IsNull.cpp
@@ -57,7 +57,7 @@ class IsNullFunction : public exec::VectorFunction {
             isNull->asMutable<int64_t>(),
             arg->rawNulls(),
             bits::nbytes(rows.end()));
-        bits::negate(isNull->asMutable<char>(), rows.end());
+        bits::negate(isNull->asMutable<uint64_t>(), rows.end());
       }
     } else {
       exec::DecodedArgs decodedArgs(rows, args, context);
@@ -69,7 +69,7 @@ class IsNullFunction : public exec::VectorFunction {
           bits::nbytes(rows.end()));
 
       if (!IsNotNULL) {
-        bits::negate(isNull->asMutable<char>(), rows.end());
+        bits::negate(isNull->asMutable<uint64_t>(), rows.end());
       }
     }
 

--- a/velox/functions/prestosql/Not.cpp
+++ b/velox/functions/prestosql/Not.cpp
@@ -42,7 +42,7 @@ class NotFunction : public exec::VectorFunction {
           AlignedBuffer::allocate<bool>(rows.end(), context.pool(), !value);
     } else {
       negated = AlignedBuffer::allocate<bool>(rows.end(), context.pool());
-      auto rawNegated = negated->asMutable<char>();
+      auto* rawNegated = negated->asMutable<uint64_t>();
 
       auto rawInput = input->asFlatVector<bool>()->rawValues<uint64_t>();
 

--- a/velox/functions/prestosql/window/FirstLastValue.cpp
+++ b/velox/functions/prestosql/window/FirstLastValue.cpp
@@ -115,7 +115,7 @@ class FirstLastValueFunction : public exec::WindowFunction {
 
     // first(last)Value functions return the first(last) non-null values for the
     // frame. Negate the bits in nulls_ so that nonNull bits are set instead.
-    bits::negate(nulls_->asMutable<char>(), frameSize);
+    bits::negate(nulls_->asMutable<uint64_t>(), frameSize);
     auto rawNonNulls = nulls_->as<uint64_t>();
 
     auto rawFrameStarts = frameStarts->as<vector_size_t>();

--- a/velox/serializers/PrestoBatchVectorSerializer.cpp
+++ b/velox/serializers/PrestoBatchVectorSerializer.cpp
@@ -30,7 +30,6 @@ void PrestoBatchVectorSerializer::serialize(
   const auto rowType = vector->type();
   const auto numChildren = vector->childrenSize();
 
-  StreamArena arena(pool_);
   std::vector<VectorStream> streams;
   streams.reserve(numChildren);
   for (int i = 0; i < numChildren; i++) {
@@ -38,7 +37,7 @@ void PrestoBatchVectorSerializer::serialize(
         rowType->childAt(i),
         std::nullopt,
         vector->childAt(i),
-        &arena,
+        &arena_,
         numRows,
         opts_);
 
@@ -48,7 +47,9 @@ void PrestoBatchVectorSerializer::serialize(
   }
 
   flushStreams(
-      streams, numRows, arena, *codec_, opts_.minCompressionRatio, stream);
+      streams, numRows, arena_, *codec_, opts_.minCompressionRatio, stream);
+
+  arena_.clear();
 }
 
 void PrestoBatchVectorSerializer::estimateSerializedSizeImpl(
@@ -177,5 +178,86 @@ void PrestoBatchVectorSerializer::estimateSerializedSizeImpl(
     default:
       VELOX_UNSUPPORTED("Unsupported vector encoding {}", vector->encoding());
   }
+}
+
+void PrestoBatchVectorSerializer::writeHeader(
+    const TypePtr& type,
+    BufferedOutputStream* stream) {
+  auto encoding = typeToEncodingName(type);
+  writeInt32(stream, encoding.size());
+  stream->write(encoding.data(), encoding.size());
+}
+
+template <>
+bool PrestoBatchVectorSerializer::hasNulls(
+    const VectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges) {
+  if (vector->nulls()) {
+    for (auto& range : ranges) {
+      if (!bits::isAllSet(
+              vector->rawNulls(), range.begin, range.begin + range.size)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+template <>
+bool PrestoBatchVectorSerializer::hasNulls(
+    const VectorPtr& vector,
+    const folly::Range<const IndexRangeWithNulls*>& ranges) {
+  if (vector->nulls()) {
+    for (auto& range : ranges) {
+      if (range.isNull ||
+          !bits::isAllSet(
+              vector->rawNulls(), range.begin, range.begin + range.size)) {
+        return true;
+      }
+    }
+  } else {
+    for (auto& range : ranges) {
+      if (range.isNull) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+template <>
+void PrestoBatchVectorSerializer::writeNulls(
+    const VectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
+    vector_size_t numRows,
+    BufferedOutputStream* stream) {
+  nulls_.startWrite(bits::nbytes(numRows));
+  for (auto& range : ranges) {
+    nulls_.appendBits(
+        vector->rawNulls(), range.begin, range.begin + range.size);
+  }
+  nulls_.flush(stream);
+}
+
+template <>
+void PrestoBatchVectorSerializer::writeNulls(
+    const VectorPtr& vector,
+    const folly::Range<const IndexRangeWithNulls*>& ranges,
+    vector_size_t numRows,
+    BufferedOutputStream* stream) {
+  nulls_.startWrite(bits::nbytes(numRows));
+  for (auto& range : ranges) {
+    if (range.isNull) {
+      nulls_.appendBool(bits::kNull, range.size);
+    } else if (vector->mayHaveNulls()) {
+      nulls_.appendBits(
+          vector->rawNulls(), range.begin, range.begin + range.size);
+    } else {
+      nulls_.appendBool(bits::kNotNull, range.size);
+    }
+  }
+  nulls_.flush(stream);
 }
 } // namespace facebook::velox::serializer::presto::detail

--- a/velox/serializers/PrestoBatchVectorSerializer.cpp
+++ b/velox/serializers/PrestoBatchVectorSerializer.cpp
@@ -42,7 +42,8 @@ void PrestoBatchVectorSerializer::serialize(
         opts_);
 
     if (numRows > 0) {
-      serializeColumn(vector->childAt(i), ranges, &streams[i], scratch);
+      velox::serializer::presto::detail::serializeColumn(
+          vector->childAt(i), ranges, &streams[i], scratch);
     }
   }
 
@@ -259,5 +260,194 @@ void PrestoBatchVectorSerializer::writeNulls(
     }
   }
   nulls_.flush(stream);
+}
+
+template <typename RangeType>
+void PrestoBatchVectorSerializer::serializeRowVector(
+    const VectorPtr& vector,
+    const folly::Range<const RangeType*>& ranges,
+    BufferedOutputStream* stream) {
+  const auto* rowVector = vector->as<RowVector>();
+  const auto numRows = rangesTotalSize(ranges);
+
+  // Write out the header.
+  writeHeader(vector->type(), stream);
+
+  const bool hasNulls = this->hasNulls(vector, ranges);
+
+  // The ranges to write of the child Vectors, this is the same as the ranges
+  // of this RowVector to write except positions where the row is null.
+  folly::Range<const IndexRange*> childRanges;
+  // PrestoPage requires us to write out for each row 0 if the row is null or
+  // i if the row is the i'th non-null row. We track these values here.
+  ScratchPtr<int32_t, 64> offsetsHolder(scratch_);
+  int32_t* mutableOffsets = offsetsHolder.get(numRows + 1);
+  // The first offset is always 0, this in addition to the offset per row.
+  mutableOffsets[0] = 0;
+  // The index at which we should write the next value in mutableOffsets.
+  size_t offsetsIndex = 1;
+  // The value of "offset" to write for the next non-null row.
+  int32_t rowOffset = 1;
+
+  // We use this to construct contiguous ranges to write for the children,
+  // excluding any null rows.
+  ScratchPtr<IndexRange, 64> selectedRangesHolder(scratch_);
+
+  if (hasNulls) {
+    IndexRange* mutableSelectedRanges = selectedRangesHolder.get(numRows);
+    // The index in mutableSelectedRanges to write the next range.
+    size_t rangeIndex = 0;
+
+    for (const auto& range : ranges) {
+      if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+        if (range.isNull) {
+          std::fill_n(&mutableOffsets[offsetsIndex], range.size, 0);
+          offsetsIndex += range.size;
+
+          continue;
+        }
+      }
+
+      if (vector->mayHaveNulls() &&
+          !bits::isAllSet(
+              vector->rawNulls(), range.begin, range.begin + range.size)) {
+        // The start of the current contiguous range.
+        int rangeStart = -1;
+        // The length of the current contiguous range.
+        int rangeSize = 0;
+        for (auto i = range.begin; i < range.begin + range.size; ++i) {
+          if (!vector->isNullAt(i)) {
+            mutableOffsets[offsetsIndex++] = rowOffset++;
+
+            // If we aren't already in a contiguous range, mark the beginning.
+            if (rangeStart == -1) {
+              rangeStart = i;
+            }
+            // Continue the contiguous range.
+            rangeSize++;
+          } else {
+            mutableOffsets[offsetsIndex++] = 0;
+
+            // If we were in a contiguous range, write it out to the scratch
+            // buffer and indicate we are no longer in one.
+            if (rangeStart != -1) {
+              mutableSelectedRanges[rangeIndex++] =
+                  IndexRange{rangeStart, rangeSize};
+              rangeStart = -1;
+              rangeSize = 0;
+            }
+          }
+        }
+
+        // If we were in a contigous range, write out the last one.
+        if (rangeStart != -1) {
+          mutableSelectedRanges[rangeIndex++] =
+              IndexRange{rangeStart, rangeSize};
+        }
+      } else {
+        // There are now nulls in this range, write out the offsets and copy
+        // the range to the scratch buffer.
+        std::iota(
+            &mutableOffsets[offsetsIndex],
+            &mutableOffsets[offsetsIndex + range.size],
+            rowOffset);
+        rowOffset += range.size;
+        offsetsIndex += range.size;
+
+        mutableSelectedRanges[rangeIndex++] =
+            IndexRange{range.begin, range.size};
+      }
+    }
+
+    // Lastly update child ranges to exclude any null rows.
+    childRanges =
+        folly::Range<const IndexRange*>(mutableSelectedRanges, rangeIndex);
+  } else {
+    // There are no null rows, so offsets is just an incrementing series and
+    // we can reuse ranges for the children.
+    std::iota(&mutableOffsets[1], &mutableOffsets[numRows + 1], rowOffset);
+
+    if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+      IndexRange* mutableSelectedRanges = selectedRangesHolder.get(numRows);
+      // The index in mutableSelectedRanges to write the next range.
+      size_t rangeIndex = 0;
+      for (const auto& range : ranges) {
+        mutableSelectedRanges[rangeIndex++] = {range.begin, range.size};
+      }
+
+      childRanges =
+          folly::Range<const IndexRange*>(mutableSelectedRanges, ranges.size());
+    } else {
+      childRanges = ranges;
+    }
+  }
+
+  if (opts_.nullsFirst) {
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+    // Write out the hasNull and isNull flags.
+    writeNullsSegment(hasNulls, vector, ranges, numRows, stream);
+  }
+
+  // Write out the number of children.
+  writeInt32(stream, vector->type()->size());
+  // Write out the children.
+  for (int32_t i = 0; i < rowVector->childrenSize(); ++i) {
+    serializeColumn(rowVector->childAt(i), childRanges, stream);
+  }
+
+  if (!opts_.nullsFirst) {
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+    // Write out the offsets.
+    stream->write(
+        reinterpret_cast<char*>(mutableOffsets),
+        (numRows + 1) * sizeof(int32_t));
+    // Write out the hasNull and isNull flags.
+    writeNullsSegment(hasNulls, vector, ranges, numRows, stream);
+  }
+}
+
+template <typename RangeType>
+void PrestoBatchVectorSerializer::serializeColumn(
+    const VectorPtr& vector,
+    const folly::Range<const RangeType*>& ranges,
+    BufferedOutputStream* stream) {
+  switch (vector->encoding()) {
+    case VectorEncoding::Simple::FLAT:
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+          serializeFlatVector, vector->typeKind(), vector, ranges, stream);
+      break;
+    case VectorEncoding::Simple::CONSTANT:
+      // VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      //     serializeConstantVector,
+      //     vector->typeKind(),
+      //     vector,
+      //     ranges,
+      //     stream);
+      break;
+    case VectorEncoding::Simple::DICTIONARY:
+      // VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      //     serializeDictionaryVector,
+      //     vector->typeKind(),
+      //     vector,
+      //     ranges,
+      //     stream);
+      break;
+    case VectorEncoding::Simple::ROW:
+      serializeRowVector(vector, ranges, stream);
+      break;
+    case VectorEncoding::Simple::ARRAY:
+      // serializeArrayVector(vector, ranges, stream);
+      break;
+    case VectorEncoding::Simple::MAP:
+      // serializeMapVector(vector, ranges, stream);
+      break;
+    case VectorEncoding::Simple::LAZY:
+      serializeColumn(BaseVector::loadedVectorShared(vector), ranges, stream);
+      break;
+    default:
+      VELOX_UNSUPPORTED();
+  }
 }
 } // namespace facebook::velox::serializer::presto::detail

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -92,6 +92,12 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
     }
   }
 
+  template <typename RangeType>
+  void serializeColumn(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream);
+
   template <
       TypeKind kind,
       typename RangeType,
@@ -497,6 +503,12 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
     nulls_.appendBool(bits::kNull, numRows);
     nulls_.flush(stream);
   }
+
+  template <typename RangeType>
+  void serializeRowVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream);
 
   StreamArena arena_;
   const std::unique_ptr<folly::io::Codec> codec_;

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -510,6 +510,12 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
       const folly::Range<const RangeType*>& ranges,
       BufferedOutputStream* stream);
 
+  template <typename RangeType>
+  void serializeArrayVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream);
+
   StreamArena arena_;
   const std::unique_ptr<folly::io::Codec> codec_;
   const PrestoVectorSerde::PrestoOptions opts_;

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -18,6 +18,7 @@
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/serializers/PrestoSerializerSerializationUtils.h"
 #include "velox/vector/VectorStream.h"
+#include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox::serializer::presto::detail {
 class PrestoBatchVectorSerializer : public BatchVectorSerializer {
@@ -47,12 +48,46 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
  private:
   static inline constexpr char kZero = 0;
   static inline constexpr char kOne = 1;
+  // The isNull flags to use when there is just a single null at position 0.
+  static inline constexpr char kSingleNull = -128;
 
   void estimateSerializedSizeImpl(
       const VectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch);
+
+  template <TypeKind Kind>
+  void estimateConstantSerializedSize(
+      const VectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes,
+      Scratch& scratch) {
+    VELOX_CHECK(vector->encoding() == VectorEncoding::Simple::CONSTANT);
+    using T = typename KindToFlatVector<Kind>::WrapperType;
+    auto constantVector = vector->as<ConstantVector<T>>();
+    vector_size_t elementSize = 0;
+    if (constantVector->isNullAt(0)) {
+      // There's just a bit mask for the one null.
+      elementSize = 1;
+    } else if (constantVector->valueVector()) {
+      std::vector<IndexRange> newRanges;
+      newRanges.push_back({constantVector->index(), 1});
+      auto* elementSizePtr = &elementSize;
+      estimateSerializedSizeImpl(
+          constantVector->valueVector(), newRanges, &elementSizePtr, scratch);
+    } else if (std::is_same_v<T, StringView>) {
+      auto value = constantVector->valueAt(0);
+      auto string = reinterpret_cast<const StringView*>(&value);
+      elementSize = string->size();
+    } else {
+      elementSize = sizeof(T);
+    }
+
+    for (size_t i = 0; i < ranges.size(); ++i) {
+      *sizes[i] += elementSize;
+    }
+  }
 
   void writeHeader(const TypePtr& type, BufferedOutputStream* stream);
 
@@ -521,6 +556,272 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
       const VectorPtr& vector,
       const folly::Range<const RangeType*>& ranges,
       BufferedOutputStream* stream);
+
+  /// A helper function for getting a value from a ConstantVector that can be
+  /// written to a Presto Stream (mostly just abstracts the complexity needed
+  /// for booleans).
+  template <TypeKind kind>
+  std::conditional_t<
+      kind == TypeKind::BOOLEAN,
+      char,
+      typename KindToFlatVector<kind>::WrapperType>
+  extractConstant(
+      const ConstantVector<typename KindToFlatVector<kind>::WrapperType>*
+          constVector) {
+    if constexpr (kind == TypeKind::BOOLEAN) {
+      return constVector->valueAtFast(0) ? kOne : kZero;
+    } else {
+      return constVector->valueAtFast(0);
+    }
+  }
+
+  /// Helper function for writing a flat stream of any type with a single null
+  /// value.
+  void writeSingleNull(const TypePtr& type, BufferedOutputStream* stream);
+
+  /// Helper function for writing an empty flat stream of any type.
+  void writeEmptyVector(const TypePtr& type, BufferedOutputStream* stream);
+
+  /// Helper function for writing a flat stream with a single primitive value
+  /// `value`. If `withNull` is true a null is written as the first value,
+  /// followed by `value`.
+  template <typename T>
+  void writeSingleValue(
+      const T& value,
+      const TypePtr& type,
+      BufferedOutputStream* stream,
+      bool withNull = false) {
+    VELOX_CHECK(type->isPrimitiveType());
+
+    // Write out the header.
+    writeHeader(type, stream);
+    // Write out the number of rows.
+    writeInt32(stream, withNull ? 2 : 1);
+
+    // Write out the lengths if necessary.
+    if constexpr (std::is_same_v<T, StringView>) {
+      if (withNull) {
+        writeInt32(stream, 0);
+      }
+      writeInt32(stream, value.size());
+    }
+
+    // Write out the hasNull and isNull flags.
+    if (withNull) {
+      stream->write(&kOne, 1);
+      stream->write(&kSingleNull, 1);
+    } else {
+      stream->write(&kZero, 1);
+    }
+
+    // Write out the single non-null value.
+    if constexpr (std::is_same_v<T, StringView>) {
+      // Write out the total length of the values, i.e. the length of the only
+      // value.
+      writeInt32(stream, value.size());
+      stream->write(value.data(), value.size());
+    } else {
+      if constexpr (std::is_same_v<T, Timestamp>) {
+        if (opts_.useLosslessTimestamp) {
+          writeInt64(stream, value.getSeconds());
+          writeInt64(stream, value.getNanos());
+        } else {
+          writeInt64(stream, value.toMillis());
+        }
+      } else {
+        stream->write(reinterpret_cast<const char*>(&value), sizeof(T));
+      }
+    }
+  }
+
+  /// This is specifically for the case where we're flattening a
+  /// DictionaryVector which has a ConstantVector as its values Vector, the
+  /// DictionaryVector introduced nulls, and the type is primitive and small.
+  /// In this case the value is no longer constant and the most efficient way to
+  /// represent it is to flatten it.
+  template <TypeKind kind>
+  void serializeConstantVectorAsFlat(
+      const ConstantVector<typename KindToFlatVector<kind>::WrapperType>*
+          constVector,
+      const folly::Range<const IndexRangeWithNulls*>& ranges,
+      int32_t numRows,
+      BufferedOutputStream* stream) {
+    using T = typename KindToFlatVector<kind>::WrapperType;
+    // If either of these is true, it's more efficient to create a dictionary.
+    static_assert(TypeTraits<kind>::isFixedWidth && sizeof(T) <= 4);
+
+    // Write out the header, in this case we're writing a flat stream according
+    // to the type.
+    const auto encoding = typeToEncodingName(constVector->type());
+    writeInt32(stream, encoding.size());
+    stream->write(encoding.data(), encoding.size());
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    // Write out the hasNulls flag (if we're calling this there must be a null).
+    stream->write(&kOne, 1);
+
+    using ValueType = std::conditional_t<kind == TypeKind::BOOLEAN, char, T>;
+    // We use this to build up the values so we only have to iterate over the
+    // ranges once.
+    ScratchPtr<ValueType, 64> valuesHolder(scratch_);
+    ValueType* mutableValues = valuesHolder.get(numRows);
+    // This tracks where to write the next value in mutableValues.
+    size_t valuesIndex = 0;
+
+    // Extract the constant value from the Vector.
+    const ValueType constValue = extractConstant<kind>(constVector);
+
+    // Write out the isNull flags and build up mutableValues.
+    nulls_.startWrite(bits::nbytes(numRows));
+    for (auto& range : ranges) {
+      if (range.isNull) {
+        nulls_.appendBool(bits::kNull, range.size);
+      } else {
+        nulls_.appendBool(bits::kNotNull, range.size);
+        std::fill_n(mutableValues + valuesIndex, range.size, constValue);
+        valuesIndex += range.size;
+      }
+    }
+
+    nulls_.flush(stream);
+
+    // Write out the non-null constant values.
+    stream->write(
+        reinterpret_cast<char*>(mutableValues), sizeof(T) * valuesIndex);
+  }
+
+  /// This is specifically for the case where we're flattening a
+  /// DictionaryVector which has a ConstantVector as its values Vector, the
+  /// DictionaryVector introduced nulls, and the type is non-primitive or large.
+  /// In this case the value is no longer constant and the most efficient way to
+  /// represent it is as a DictionaryVector with 2 values, null and the constant
+  /// value.
+  template <TypeKind kind>
+  void serializeConstantVectorAsDictionary(
+      const ConstantVector<typename KindToFlatVector<kind>::WrapperType>*
+          constVector,
+      const folly::Range<const IndexRangeWithNulls*>& ranges,
+      int32_t numRows,
+      BufferedOutputStream* stream) {
+    using T = typename KindToFlatVector<kind>::WrapperType;
+    // If both of these are false, it's more efficient just to flatten the data.
+    static_assert(!TypeTraits<kind>::isFixedWidth || sizeof(T) > 4);
+
+    // Write out the header, in this case we're writing a Dictionary encoded
+    // stream.
+    const auto& encoding = kDictionary;
+    writeInt32(stream, encoding.size());
+    stream->write(encoding.data(), encoding.size());
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    // Write out the dictionary values, this is a null at index 0 and the
+    // constant value at index 1.
+    if (constVector->valueVector() != nullptr) {
+      std::vector<IndexRangeWithNulls> selectedRanges;
+      selectedRanges.reserve(2);
+      // Create a range with a single artificial null value.
+      selectedRanges.push_back({0, 1, true});
+      // Create a range with the single constant value.
+      selectedRanges.push_back({constVector->index(), 1, false});
+
+      serializeColumn<IndexRangeWithNulls>(
+          constVector->valueVector(), selectedRanges, stream);
+    } else {
+      const T value = constVector->valueAtFast(0);
+      // Write out a single value with a null preceding it.
+      writeSingleValue(
+          value,
+          constVector->type(),
+          stream,
+          // Inject a null before the value.
+          true);
+    }
+
+    // Used to hold the dictionary indices, these are 0 for nulls inherited from
+    // the dictionary and 1 for non-null values (the constant value).
+    ScratchPtr<int32_t, 64> indicesHolder(scratch_);
+    int32_t* mutableIndices = indicesHolder.get(numRows);
+    // Where to write the next index in mutableIndices.
+    size_t indicesIndex = 0;
+    for (auto& range : ranges) {
+      if (range.isNull) {
+        std::fill_n(mutableIndices + indicesIndex, range.size, 0);
+      } else {
+        std::fill_n(mutableIndices + indicesIndex, range.size, 1);
+      }
+
+      indicesIndex += range.size;
+    }
+    // Write out the indices.
+    stream->write(
+        reinterpret_cast<char*>(mutableIndices),
+        indicesIndex * sizeof(int32_t));
+
+    // Write out the dictionary ID (we don't use this, so just write 0).
+    static const int64_t unused{0};
+    writeInt64(stream, unused);
+    writeInt64(stream, unused);
+    writeInt64(stream, unused);
+  }
+
+  template <TypeKind kind, typename RangeType>
+  void serializeConstantVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    using T = typename KindToFlatVector<kind>::WrapperType;
+    const auto* constVector = vector->as<ConstantVector<T>>();
+    const auto numRows = rangesTotalSize(ranges);
+
+    if (constVector->isNullAt(0)) {
+      // Write a null constant regardless of RangeType.
+      const auto& encoding = kRLE;
+      writeInt32(stream, encoding.size());
+      stream->write(encoding.data(), encoding.size());
+
+      // Write the number of rows.
+      writeInt32(stream, numRows);
+
+      // Write out the constant null value.
+      writeSingleNull(constVector->type(), stream);
+      return;
+    }
+
+    if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+      // If this was wrapped by a dictionary that injected nulls, we either
+      // need to flatten the vector or write it out as a dictionary.
+      if constexpr (TypeTraits<kind>::isFixedWidth && sizeof(T) <= 4) {
+        serializeConstantVectorAsFlat<kind>(
+            constVector, ranges, numRows, stream);
+      } else {
+        serializeConstantVectorAsDictionary<kind>(
+            constVector, ranges, numRows, stream);
+      }
+      return;
+    }
+
+    // Write the header.
+    const auto& encoding = kRLE;
+    writeInt32(stream, encoding.size());
+    stream->write(encoding.data(), encoding.size());
+
+    // Write the number of rows.
+    writeInt32(stream, numRows);
+
+    // Write the single constant value.
+    if (constVector->valueVector() != nullptr) {
+      const IndexRange range{constVector->index(), 1};
+      serializeColumn<IndexRange>(
+          constVector->valueVector(), {&range, 1}, stream);
+    } else {
+      writeSingleValue(
+          extractConstant<kind>(constVector), constVector->type(), stream);
+    }
+  }
 
   StreamArena arena_;
   const std::unique_ptr<folly::io::Codec> codec_;

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -516,6 +516,12 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
       const folly::Range<const RangeType*>& ranges,
       BufferedOutputStream* stream);
 
+  template <typename RangeType>
+  void serializeMapVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream);
+
   StreamArena arena_;
   const std::unique_ptr<folly::io::Codec> codec_;
   const PrestoVectorSerde::PrestoOptions opts_;

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/PrestoSerializerSerializationUtils.h"
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::serializer::presto::detail {
@@ -24,9 +25,10 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
   PrestoBatchVectorSerializer(
       memory::MemoryPool* pool,
       const PrestoVectorSerde::PrestoOptions& opts)
-      : pool_(pool),
+      : arena_(pool),
         codec_(common::compressionKindToCodec(opts.compressionKind)),
-        opts_(opts) {}
+        opts_(opts),
+        nulls_(&arena_, true, true, true) {}
 
   void serialize(
       const RowVectorPtr& vector,
@@ -43,14 +45,471 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
   }
 
  private:
+  static inline constexpr char kZero = 0;
+  static inline constexpr char kOne = 1;
+
   void estimateSerializedSizeImpl(
       const VectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
       vector_size_t** sizes,
       Scratch& scratch);
 
-  memory::MemoryPool* const pool_;
+  void writeHeader(const TypePtr& type, BufferedOutputStream* stream);
+
+  /// Are there any nulls in the Vector or introduced artificially in the
+  /// ranges. Does not look recursively at values Vectors or children.
+  template <typename RangeType>
+  bool hasNulls(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges);
+
+  /// Write out the null flags to the streams.
+  template <typename RangeType>
+  void writeNulls(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      vector_size_t numRows,
+      BufferedOutputStream* stream);
+
+  /// Write out all the null information needed by the PrestoPage, both the
+  /// hasNulls and isNull flags.
+  template <typename RangeType>
+  inline void writeNullsSegment(
+      bool hasNulls,
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      vector_size_t numRows,
+      BufferedOutputStream* stream) {
+    if (hasNulls) {
+      // Has-nulls flag.
+      stream->write(&kOne, 1);
+
+      // Nulls flags.
+      writeNulls(vector, ranges, numRows, stream);
+    } else {
+      // Has-nulls flag.
+      stream->write(&kZero, 1);
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<
+          kind != TypeKind::TIMESTAMP && kind != TypeKind::BOOLEAN &&
+              kind != TypeKind::OPAQUE && kind != TypeKind::UNKNOWN &&
+              !std::
+                  is_same_v<typename TypeTraits<kind>::NativeType, StringView>,
+          bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    using T = typename TypeTraits<kind>::NativeType;
+    const auto* flatVector = vector->as<FlatVector<T>>();
+    const auto* rawValues = flatVector->rawValues();
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    if (this->hasNulls(vector, ranges)) {
+      // Write out the has-nulls flag.
+      stream->write(&kOne, 1);
+
+      // Write out the nulls flags.
+      writeNulls(vector, ranges, numRows, stream);
+
+      // Write out the values.
+      // This logic merges consecutive ranges of non-null values so we can make
+      // long consecutive writes to the stream. A range ends when we detect a
+      // discontinuity between ranges, a null, or the end of the ranges. When
+      // this happens we write out the range.
+
+      // Tracks the beginning of the current range.
+      int firstNonNull = -1;
+      // Tracks the end of the current range.
+      int lastNonNull = -1;
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (static_cast<const IndexRangeWithNulls&>(range).isNull) {
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!flatVector->isNullAt(i)) {
+            if (firstNonNull == -1) {
+              // We're at the beginning of a new range.
+              firstNonNull = i;
+              lastNonNull = i;
+            } else if (i == lastNonNull + 1) {
+              // We're continuing the current range.
+              lastNonNull = i;
+            } else {
+              // We've reached a discontinuity (either because the previous
+              // value was null or because the ranges are discontinuous).
+              // Write out the current range and start a new one.
+              const size_t rangeSize = (1 + lastNonNull - firstNonNull);
+              stream->write(
+                  reinterpret_cast<const char*>(&rawValues[firstNonNull]),
+                  rangeSize * sizeof(T));
+              firstNonNull = i;
+              lastNonNull = i;
+            }
+          }
+        }
+      }
+      // There's no more data, if we had a range waiting to be written out, do
+      // so.
+      if (firstNonNull != -1) {
+        const size_t rangeSize = (1 + lastNonNull - firstNonNull);
+        stream->write(
+            reinterpret_cast<const char*>(&rawValues[firstNonNull]),
+            rangeSize * sizeof(T));
+      }
+    } else {
+      // Write out the has-nulls flag.
+      stream->write(&kZero, 1);
+
+      // Write out the values. Since there are no nulls, we optimistically
+      // assume the ranges are long enough that the overhead of merging
+      // consecutive ranges is not worth it.
+      for (auto& range : ranges) {
+        stream->write(
+            reinterpret_cast<const char*>(&rawValues[range.begin]),
+            range.size * sizeof(T));
+      }
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<kind == TypeKind::TIMESTAMP, bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    const auto* flatVector = vector->as<FlatVector<Timestamp>>();
+    const auto* rawValues = flatVector->rawValues();
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    if (this->hasNulls(vector, ranges)) {
+      // Write out the has-nulls flag.
+      stream->write(&kOne, 1);
+
+      // Write out the nulls flags.
+      writeNulls(vector, ranges, numRows, stream);
+
+      // Write out the values.
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (static_cast<const IndexRangeWithNulls&>(range).isNull) {
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!flatVector->isNullAt(i)) {
+            if (opts_.useLosslessTimestamp) {
+              writeInt64(stream, rawValues[i].getSeconds());
+              writeInt64(stream, rawValues[i].getNanos());
+            } else {
+              writeInt64(stream, rawValues[i].toMillis());
+            }
+          }
+        }
+      }
+    } else {
+      // Write out the has-nulls flag.
+      stream->write(&kZero, 1);
+
+      // Write out the values.
+      for (auto& range : ranges) {
+        if (opts_.useLosslessTimestamp) {
+          for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+            writeInt64(stream, rawValues[i].getSeconds());
+            writeInt64(stream, rawValues[i].getNanos());
+          }
+        } else {
+          for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+            writeInt64(stream, rawValues[i].toMillis());
+          }
+        }
+      }
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<
+          std::is_same_v<typename TypeTraits<kind>::NativeType, StringView>,
+          bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    const auto* flatVector = vector->as<FlatVector<StringView>>();
+    const auto* rawValues = flatVector->rawValues();
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    if (this->hasNulls(vector, ranges)) {
+      // The total number of bytes we'll write out for the strings.
+      int32_t numBytes = 0;
+
+      // Write out the offsets.
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (range.isNull) {
+            // If it's a range of nulls, we just write the last offset out n
+            // times.
+            for (int i = 0; i < range.size; i++) {
+              writeInt32(stream, numBytes);
+            }
+
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!flatVector->isNullAt(i)) {
+            numBytes += rawValues[i].size();
+          }
+          writeInt32(stream, numBytes);
+        }
+      }
+
+      // Write out the has-nulls flag.
+      stream->write(&kOne, 1);
+
+      // Write out the nulls flags.
+      writeNulls(vector, ranges, numRows, stream);
+
+      // Write out the total number of bytes.
+      writeInt32(stream, numBytes);
+
+      // Write out the values.
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (static_cast<const IndexRangeWithNulls&>(range).isNull) {
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!flatVector->isNullAt(i)) {
+            stream->write(rawValues[i].data(), rawValues[i].size());
+          }
+        }
+      }
+    } else {
+      // Write out the offsets.
+      int32_t numBytes = 0;
+      for (const auto& range : ranges) {
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          numBytes += rawValues[i].size();
+          writeInt32(stream, numBytes);
+        }
+      }
+
+      // Write out the has-nulls flag.
+      stream->write(&kZero, 1);
+
+      // Write out the total number of bytes.
+      writeInt32(stream, numBytes);
+
+      // Write out the values.
+      for (auto& range : ranges) {
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          stream->write(rawValues[i].data(), rawValues[i].size());
+        }
+      }
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<kind == TypeKind::BOOLEAN, bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    const auto* flatVector = vector->as<FlatVector<bool>>();
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    if (this->hasNulls(vector, ranges)) {
+      // Write out the has-nulls flag.
+      stream->write(&kOne, 1);
+
+      // Write out the nulls flags.
+      writeNulls(vector, ranges, numRows, stream);
+
+      // Write out the values.
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (static_cast<const IndexRangeWithNulls&>(range).isNull) {
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!vector->isNullAt(i)) {
+            stream->write(flatVector->valueAtFast(i) ? &kOne : &kZero, 1);
+          }
+        }
+      }
+    } else {
+      // Write out the has-nulls flag.
+      stream->write(&kZero, 1);
+
+      // Write out the values.
+      for (const auto& range : ranges) {
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          stream->write(flatVector->valueAtFast(i) ? &kOne : &kZero, 1);
+        }
+      }
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<kind == TypeKind::OPAQUE, bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    const auto* flatVector = vector->as<FlatVector<std::shared_ptr<void>>>();
+    const auto* rawValues = flatVector->rawValues();
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    int32_t numBytes = 0;
+
+    // To avoid serializng the values twice, we hold the serialized data here
+    // until we reach the point in the stream where we can write it out.
+    ScratchPtr<std::string, 64> valuesHolder(scratch_);
+    std::string* mutableValues = valuesHolder.get(numRows);
+    size_t valuesIndex = 0;
+
+    auto serializer = vector->type()->asOpaque().getSerializeFunc();
+
+    const bool hasNulls = flatVector->rawValues();
+
+    // Write out the offsets and serialize the values.
+    if (hasNulls) {
+      for (const auto& range : ranges) {
+        if constexpr (std::is_same_v<RangeType, IndexRangeWithNulls>) {
+          if (range.isNull) {
+            for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+              writeInt32(stream, numBytes);
+            }
+            continue;
+          }
+        }
+
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          if (!flatVector->isNullAt(i)) {
+            mutableValues[valuesIndex] = serializer(rawValues[i]);
+            numBytes += mutableValues[valuesIndex].size();
+            valuesIndex++;
+          }
+
+          writeInt32(stream, numBytes);
+        }
+      }
+    } else {
+      for (const auto& range : ranges) {
+        for (int32_t i = range.begin; i < range.begin + range.size; ++i) {
+          mutableValues[valuesIndex] = serializer(rawValues[i]);
+          numBytes += mutableValues[valuesIndex].size();
+          valuesIndex++;
+
+          writeInt32(stream, numBytes);
+        }
+      }
+    }
+
+    // Write out the nulls flag and nulls.
+    writeNullsSegment(hasNulls, vector, ranges, numRows, stream);
+
+    // Write out the total number of bytes.
+    writeInt32(stream, numBytes);
+
+    // Write out the serialized values.
+    for (size_t i = 0; i < valuesIndex; ++i) {
+      stream->write(mutableValues[i].data(), mutableValues[i].size());
+    }
+  }
+
+  template <
+      TypeKind kind,
+      typename RangeType,
+      typename std::enable_if_t<kind == TypeKind::UNKNOWN, bool> = true>
+  void serializeFlatVector(
+      const VectorPtr& vector,
+      const folly::Range<const RangeType*>& ranges,
+      BufferedOutputStream* stream) {
+    VELOX_CHECK_NOT_NULL(vector->rawNulls());
+
+    const auto numRows = rangesTotalSize(ranges);
+
+    // Write out the header.
+    writeHeader(vector->type(), stream);
+
+    // Write out the number of rows.
+    writeInt32(stream, numRows);
+
+    // Write out the has-nulls flag.
+    stream->write(&kOne, 1);
+
+    // Write out the nulls.
+    nulls_.startWrite(bits::nbytes(numRows));
+    nulls_.appendBool(bits::kNull, numRows);
+    nulls_.flush(stream);
+  }
+
+  StreamArena arena_;
   const std::unique_ptr<folly::io::Codec> codec_;
   const PrestoVectorSerde::PrestoOptions opts_;
+
+  // A scratch space for writing null bits, this is a frequent operation that
+  // the OutputStream interface is not well suited for.
+  //
+  // Since this is shared/reused, it is important that the usage of nulls_
+  // once started when serializing a Vector is finished before serializing any
+  // children. This can be guaranteed by using the writeNullsSegment or
+  // writeNulls functions.
+  ByteOutputStream nulls_;
+  Scratch scratch_;
 };
 } // namespace facebook::velox::serializer::presto::detail

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -74,7 +74,7 @@ vector_size_t valueCount(
   auto numBytes = bits::nbytes(size);
   source->readBytes(rawNulls, numBytes);
   bits::reverseBits(reinterpret_cast<uint8_t*>(rawNulls), numBytes);
-  bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
+  bits::negate(rawNulls, numBytes * 8);
   if (copy) {
     copy->resize(bits::nwords(size));
     memcpy(copy->data(), rawNulls, numBytes);
@@ -329,7 +329,7 @@ vector_size_t readNulls(
 
   source->readBytes(rawNulls, numBytes);
   bits::reverseBits(rawNulls, numBytes);
-  bits::negate(reinterpret_cast<char*>(rawNulls), numBytes * 8);
+  bits::negate(reinterpret_cast<uint64_t*>(rawNulls), numBytes * 8);
   // Add incoming nulls if any.
   if (incomingNulls) {
     bits::scatterBits(

--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -82,7 +82,8 @@ inline void writeInt64(OutputStream* out, int64_t value) {
 
 std::string_view typeToEncodingName(const TypePtr& type);
 
-inline int32_t rangesTotalSize(const folly::Range<const IndexRange*>& ranges) {
+template <typename RangeType>
+inline int32_t rangesTotalSize(const folly::Range<const RangeType*>& ranges) {
   int32_t total = 0;
   for (auto& range : ranges) {
     total += range.size;

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -33,6 +33,18 @@ struct IndexRange {
   vector_size_t size;
 };
 
+// A flavor of IndexRange that allows us to add artificial nulls. This is useful
+// when for example, when flatteneing a DictionaryVector, the DictionaryVector
+// may introduce nulls that do not exist in the values Vector, and so need to
+// get introduced artificially.
+struct IndexRangeWithNulls {
+  vector_size_t begin;
+  vector_size_t size;
+
+  // Whether we should "pretend" the values in this range are null.
+  bool isNull;
+};
+
 namespace row {
 class CompactRow;
 class UnsafeRowFast;


### PR DESCRIPTION
Summary:
Context:
This is a series of diffs in which I reimplement PrestoBatchVectorSerializer to write directly to the output stream,
rather than the indirect route it currently uses via VectorStreams. Reusing VectorStreams and much of the code
for PrestoIterativeVectorSerializer prevented us from capturing all of the performance benefits of writing data in
batches rather than row by row. These changes combined will speed up PrestoBatchVectorSerializer 2-3x (as
measured in Presto queries and other use cases).

In the final diff I will integrate the new serialization functions into PrestoBatchVectorSerializer's serialize
function which will switch it to the new optimized writing path, therefore I will land these changes as a stack.

In this diff:
I provide the implementations for serializing ConstantVectors.

Differential Revision: D68114215
