### PR TITLE
misc(fuzzer): Allow avg(interval) in aggregation fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -29,6 +29,7 @@
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/ArbitraryResultVerifier.h"
+#include "velox/functions/prestosql/fuzzer/AverageResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MapUnionSumInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.h"
@@ -143,6 +144,7 @@ int main(int argc, char** argv) {
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;
   using facebook::velox::exec::test::ApproxPercentileResultVerifier;
   using facebook::velox::exec::test::ArbitraryResultVerifier;
+  using facebook::velox::exec::test::AverageResultVerifier;
   using facebook::velox::exec::test::MinMaxByResultVerifier;
   using facebook::velox::exec::test::setupReferenceQueryRunner;
   using facebook::velox::exec::test::TransformResultVerifier;
@@ -182,6 +184,7 @@ int main(int argc, char** argv) {
           {"map_union_sum", makeMapVerifier()},
           {"max_by", std::make_shared<MinMaxByResultVerifier>(false)},
           {"min_by", std::make_shared<MinMaxByResultVerifier>(true)},
+          {"avg", std::make_shared<AverageResultVerifier>()},
           {"multimap_agg",
            TransformResultVerifier::create(
                "transform_values({}, (k, v) -> \"$internal$canonicalize\"(v))")},

--- a/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/fuzzer/ResultVerifier.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+// The result of the avg(interval) -> row(double, bigint) -> interval function
+// may have a precision error depending on the ordering of inputs due to the
+// accumulation in the double intermediate state. This verifier convert the
+// interval aggregaiton result to double before comparing the actual and
+// expected results, so that the epsilon comparison for floating-point types in
+// assertEqualResults() can kick in.
+class AverageResultVerifier : public ResultVerifier {
+ public:
+  bool supportsCompare() override {
+    return true;
+  }
+
+  bool supportsVerify() override {
+    return false;
+  }
+
+  void initialize(
+      const std::vector<RowVectorPtr>& /*input*/,
+      const std::vector<std::string>& groupingKeys,
+      const core::AggregationNode::Aggregate& aggregate,
+      const std::string& aggregateName) override {
+    if (aggregate.call->type()->isIntervalDayTime()) {
+      projections_ = groupingKeys;
+      projections_.push_back(
+          fmt::format("cast(to_milliseconds({}) as double)", aggregateName));
+    }
+  }
+
+  bool compare(const RowVectorPtr& result, const RowVectorPtr& altResult)
+      override {
+    if (projections_.empty()) {
+      return assertEqualResults({result}, {altResult});
+    } else {
+      return assertEqualResults({transform(result)}, {transform(altResult)});
+    }
+  }
+
+  bool verify(const RowVectorPtr& /*result*/) override {
+    VELOX_UNSUPPORTED();
+  }
+
+  void reset() override {
+    projections_.clear();
+  }
+
+ private:
+  RowVectorPtr transform(const RowVectorPtr& data) {
+    auto plan = PlanBuilder().values({data}).project(projections_).planNode();
+    return AssertQueryBuilder(plan).copyResults(data->pool());
+  }
+
+  std::vector<std::string> projections_;
+};
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
The avg() function uses `row(double, bigint)` as the intermediate states, so the ordering of 
inputs could cause a small precision error to the double field in the intermediate states and 
hence the final result. https://github.com/facebookincubator/velox/pull/12048 adds a new signature to allow `avg(interval) -> row(double, bigint) -> interval`. 
However, because the `interval` type is an integral type, the imprecision in the aggregation 
result is not tolerated by the assertEqualResults() API, hence causing fuzzer failures, such 
as https://github.com/facebookincubator/velox/actions/runs/12698298641/job/35397706898. 
This diff adds a custom result verifier for avg() that cast the interval results to double before 
calling assertEqualResults(), so that the epsilon-comparison instead of regular comparison is 
used in assertEqualResults().

Differential Revision: D68117666


