### PR TITLE
fix(plan-builder): Avoid advancing plan id on error

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -440,10 +440,9 @@ PlanBuilder& PlanBuilder::optionalFilter(const std::string& optionalFilter) {
 
 PlanBuilder& PlanBuilder::filter(const std::string& filter) {
   VELOX_CHECK_NOT_NULL(planNode_, "Filter cannot be the source node");
-  planNode_ = std::make_shared<core::FilterNode>(
-      nextPlanNodeId(),
-      parseExpr(filter, planNode_->outputType(), options_, pool_),
-      planNode_);
+  auto expr = parseExpr(filter, planNode_->outputType(), options_, pool_);
+  planNode_ =
+      std::make_shared<core::FilterNode>(nextPlanNodeId(), expr, planNode_);
   return *this;
 }
 


### PR DESCRIPTION
Summary:
Avoid advancing plan id on error for filter() method. This is not
necessarily a bug, but it makes the ids non-sequential and less intuitive to
reason about if one uses an invalid expression.

Reviewed By: xiaoxmeng

Differential Revision: D68002662


