### PR TITLE
feat(python): PyVelox bindings for Vectors and Arrow Conversion

### DIFF
--- a/velox/py/arrow/arrow.cpp
+++ b/velox/py/arrow/arrow.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arrow/array.h>
+#include <arrow/c/abi.h>
+#include <arrow/c/bridge.h>
+#include <arrow/python/pyarrow.h>
+#include <arrow/record_batch.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "velox/py/lib/PyInit.h"
+#include "velox/py/vector/PyVector.h"
+#include "velox/vector/arrow/Bridge.h"
+
+namespace py = pybind11;
+
+/// This module adds two functions `to_velox()` and `to_arrow()` that allow the
+/// conversion between Velox Vectors and Arrow Arrays from a Python program. It
+/// works by extracting the Arrow C structures from the Arrow C++ Array, then
+/// using Velox's Arrow bridge to convert it to a Velox Vector (and vice-versa).
+PYBIND11_MODULE(arrow, m) {
+  using namespace facebook;
+
+  py::module::import("velox.py.vector");
+
+  arrow::py::import_pyarrow();
+  velox::py::initializeVeloxMemory();
+
+  static auto rootPool = velox::memory::memoryManager()->addRootPool();
+  static auto leafPool = rootPool->addLeafChild("py_velox_arrow_pool");
+
+  /// Converts a pyarrow.Array into a velox.py.vector.Vector using Velox's arrow
+  /// bridge.
+  m.def("to_velox", [](py::object& batchObject) {
+    ArrowSchema schema;
+    ArrowArray data;
+    std::shared_ptr<arrow::Array> array;
+    std::shared_ptr<arrow::RecordBatch> batch;
+
+    if (arrow::py::is_array(batchObject.ptr())) {
+      array = *arrow::py::unwrap_array(batchObject.ptr());
+      auto statusType = arrow::ExportType(*array->type(), &schema);
+      auto statusArray = arrow::ExportArray(*array, &data);
+
+      if (!statusArray.ok() || !statusType.ok()) {
+        throw std::runtime_error("Unable to convert Arrow Array to C ABI.");
+      }
+    } else if (arrow::py::is_batch(batchObject.ptr())) {
+      batch = *arrow::py::unwrap_batch(batchObject.ptr());
+      auto statusType = arrow::ExportSchema(*batch->schema(), &schema);
+      auto statusArray = arrow::ExportRecordBatch(*batch, &data);
+
+      if (!statusArray.ok() || !statusType.ok()) {
+        throw std::runtime_error(
+            "Unable to convert Arrow RecorBatch to C ABI.");
+      }
+    } else {
+      throw std::runtime_error("Unknown input Arrow structure.");
+    }
+    return velox::py::PyVector{
+        velox::importFromArrowAsViewer(schema, data, leafPool.get())};
+  });
+
+  /// Converts a velox.py.vector.Vector to a pyarrow.Array using Velox's arrow
+  /// bridge.
+  m.def("to_arrow", [](velox::py::PyVector& vector) {
+    ArrowSchema schema;
+    ArrowArray data;
+
+    velox::exportToArrow(vector.vector(), schema);
+    velox::exportToArrow(vector.vector(), data, leafPool.get());
+
+    auto arrowType = *arrow::ImportType(&schema);
+    auto arrowArray = *arrow::ImportArray(&data, arrowType);
+    return py::reinterpret_steal<py::object>(arrow::py::wrap_array(arrowArray));
+  });
+}

--- a/velox/py/arrow/arrow.pyi
+++ b/velox/py/arrow/arrow.pyi
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# velox.py.type library:
-velox_add_library(velox_py_type_lib type/PyType.cpp)
-velox_link_libraries(velox_py_type_lib velox_type pybind11::module)
+# pyre-unsafe
 
-pybind11_add_module(type MODULE type/type.cpp)
-target_link_libraries(
-  type
-  PRIVATE velox_py_type_lib)
+from typing import List
 
-# velox.py.vector library:
-velox_add_library(velox_py_vector_lib vector/PyVector.cpp)
-velox_link_libraries(velox_py_vector_lib velox_vector pybind11::module)
+# pyre-fixme[21]: Could not find `velox.py.vector`.
+from velox.py.vector import Vector
+from pyarrow import Array
 
-pybind11_add_module(vector MODULE vector/vector.cpp)
-target_link_libraries(
-  vector
-  PRIVATE velox_py_vector_lib)
+# pyre-fixme[11]: Annotation `Vector` is not defined as a type.
+def to_velox(array: Array) -> Vector: ...
+def to_arrow(vector: Vector) -> Array: ...

--- a/velox/py/lib/PyInit.cpp
+++ b/velox/py/lib/PyInit.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/py/lib/PyInit.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::velox::py {
+
+folly::once_flag initOnceFlag;
+
+void initializeVeloxMemoryOnce() {
+  // Enable full Velox stack trace when exceptions are thrown.
+  FLAGS_velox_exception_user_stacktrace_enabled = true;
+
+  velox::memory::initializeMemoryManager({});
+}
+
+void initializeVeloxMemory() {
+  // Initialize Velox once per process.
+  folly::call_once(initOnceFlag, initializeVeloxMemoryOnce);
+}
+
+} // namespace facebook::velox::py

--- a/velox/py/lib/PyInit.h
+++ b/velox/py/lib/PyInit.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::py {
+
+// Initializes Velox memory manager. Safe to be called multiple times and
+// concurrently.
+void initializeVeloxMemory();
+
+} // namespace facebook::velox::py

--- a/velox/py/tests/test_arrow.py
+++ b/velox/py/tests/test_arrow.py
@@ -1,0 +1,48 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pyarrow
+
+from velox.py.arrow import to_velox, to_arrow
+from velox.py.vector import Vector
+
+
+class TestPyVeloxArrow(unittest.TestCase):
+    def test_vector_simple(self):
+        array = pyarrow.array([1, 2, 3, 4, 5, 6])
+        vector = to_velox(array)
+
+        self.assertTrue(isinstance(vector, Vector))
+        self.assertEqual(len(vector), 6)
+
+        # TODO: For now we only return the values as strings for printing.
+        for i in range(len(array)):
+            self.assertEqual(vector[i], str(array[i]))
+
+    def test_roundtrip(self):
+        array = pyarrow.array([2, 2, 3, 4, 4, 0])
+        array2 = to_arrow(to_velox(array))
+
+        self.assertTrue(isinstance(array2, pyarrow.Array))
+        self.assertEqual(array, array2)
+
+    def test_empty(self):
+        # TODO: Velox's arrow bridge does not allow missing buffers (even if
+        # there are no rows):
+        #   https://github.com/facebookincubator/velox/issues/12082
+
+        # vector = to_velox(pyarrow.array([]))
+        # self.assertEqual(vector.size(), 0)
+        pass

--- a/velox/py/tests/test_vector.py
+++ b/velox/py/tests/test_vector.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pyarrow
+
+from velox.py.arrow import to_velox, to_arrow
+from velox.py.type import DOUBLE
+
+
+class TestPyVeloxVector(unittest.TestCase):
+    def test_vector_size(self):
+        vector = to_velox(pyarrow.array([1, 2, 3, 4, 5, 6]))
+        self.assertEqual(len(vector), 6)
+        self.assertEqual(vector.size(), 6)
+
+    def test_vector_nulls(self):
+        data = [1, 2, None, 4, 5, 6, None, 9, 10]
+        vector = to_velox(pyarrow.array(data))
+        self.assertEqual(vector.null_count(), 2)
+
+        self.assertTrue(vector.is_null_at(2))
+        self.assertTrue(vector.is_null_at(6))
+        self.assertFalse(vector.is_null_at(0))
+        self.assertFalse(vector.is_null_at(3))
+        self.assertFalse(vector.is_null_at(8))
+
+    def test_vector_compare(self):
+        data = [1, 2, 3, 4, 5, 6, 7, 9, 10]
+        vector1 = to_velox(pyarrow.array(data))
+        vector2 = to_velox(to_arrow(vector1))
+
+        for i in range(len(data)):
+            self.assertEqual(vector1.compare(vector2, i, i), 0)
+
+    def test_vector_print(self):
+        vector = to_velox(pyarrow.array([1, 2]))
+
+        expected_header = "[FLAT BIGINT: 2 elements, no nulls]"
+        self.assertEqual(str(vector), expected_header)
+        self.assertTrue(vector.print_detailed().startswith(expected_header))
+
+        self.assertEqual(vector.print_all(), "0: 1\n1: 2")
+        self.assertEqual(vector.summarize_to_text(), "BIGINT 2 rows FLAT 16B\n")
+
+    def test_vector_complex(self):
+        # Array/lists.
+        data = [[1, 2, 3], [4, None, 6], None, [7]]
+        vector = to_velox(pyarrow.array(data))
+        self.assertEqual(str(vector), "[ARRAY ARRAY<BIGINT>: 4 elements, 1 nulls]")
+
+        # Maps.
+        data = [[{"key": "a", "value": 1}, {"key": "b", "value": 2}]]
+        map_type = pyarrow.map_(pyarrow.string(), pyarrow.int32())
+        vector = to_velox(pyarrow.array(data, type=map_type))
+        self.assertEqual(
+            str(vector), "[MAP MAP<VARCHAR,INTEGER>: 1 elements, no nulls]"
+        )
+
+        # Row/structs.
+        struct_type = pyarrow.struct(
+            [("name", pyarrow.string()), ("age", pyarrow.int32())]
+        )
+        data = [{"name": "John", "age": 23}, {"name": "Mike", "age": 32}]
+        vector = to_velox(pyarrow.array(data, type=struct_type))
+        self.assertEqual(
+            str(vector), "[ROW ROW<name:VARCHAR,age:INTEGER>: 2 elements, no nulls]"
+        )
+
+    def test_vector_type(self):
+        data = [1.9, 2.45]
+        vector = to_velox(pyarrow.array(data))
+        self.assertEqual(vector.type(), DOUBLE())

--- a/velox/py/vector/PyVector.cpp
+++ b/velox/py/vector/PyVector.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/py/vector/PyVector.h"
+#include "velox/vector/VectorPrinter.h"
+
+namespace facebook::velox::py {
+
+std::string PyVector::summarizeToText() const {
+  return velox::VectorPrinter::summarizeToText(*vector_);
+}
+
+std::string PyVector::printDetailed() const {
+  return velox::printVector(*vector_);
+}
+
+} // namespace facebook::velox::py

--- a/velox/py/vector/PyVector.h
+++ b/velox/py/vector/PyVector.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/embed.h>
+#include "velox/py/type/PyType.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::py {
+
+class PyVector {
+ public:
+  explicit PyVector(const VectorPtr& vector) : vector_(vector) {}
+
+  // Returns a wrapper to the Vector type.
+  PyType type() const {
+    return PyType{vector_->type()};
+  }
+
+  // TODO: This is only for printing/debugging for now as it returns the
+  // value at idx converted to a string.
+  std::string operator[](int32_t idx) const {
+    return vector_->toString(idx);
+  }
+
+  // Returns a string summarizing the vector type, encoding and size, e.g:
+  //
+  //   [FLAT BIGINT: 2 elements, no nulls]
+  std::string toString() const {
+    return vector_->toString(true);
+  }
+
+  // Returns a string containing the values for each record, e.g:
+  //
+  //   0: 1
+  //   1: 2
+  //   ...
+  std::string printAll() const {
+    return vector_->toString(0, vector_->size());
+  }
+
+  // Prints a long descriptive string of the vector and its values.
+  std::string printDetailed() const;
+
+  // Prints a human-readable summary of the vector.
+  std::string summarizeToText() const;
+
+  size_t size() const {
+    return vector_->size();
+  }
+
+  // Number of nulls in the vector.
+  size_t nullCount() const {
+    return BaseVector::countNulls(vector_->nulls(), 0, size());
+  }
+
+  // If vector is null at `idx`.
+  bool isNullAt(vector_size_t idx) const {
+    return vector_->isNullAt(idx);
+  }
+
+  int32_t compare(const PyVector& other, int32_t index, int32_t otherIndex)
+      const {
+    return vector_->compare(other.vector_.get(), index, otherIndex);
+  }
+
+  VectorPtr vector() const {
+    return vector_;
+  }
+
+ private:
+  VectorPtr vector_;
+};
+
+} // namespace facebook::velox::py

--- a/velox/py/vector/vector.cpp
+++ b/velox/py/vector/vector.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "velox/py/vector/PyVector.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(vector, m) {
+  using namespace facebook;
+
+  py::class_<velox::py::PyVector>(m, "Vector")
+      .def("__str__", &velox::py::PyVector::toString, py::doc(R"(
+        Returns a summarized description of the Vector and its type.
+      )"))
+      .def("__getitem__", &velox::py::PyVector::operator[], py::doc(R"(
+        Returns a the value of an element serialized as a string.
+      )"))
+      .def("__len__", &velox::py::PyVector::size, py::doc(R"(
+        Number of elements in the Vector.
+      )"))
+      .def("type", &velox::py::PyVector::type, py::doc(R"(
+        Returns the Type of the Vector.
+      )"))
+      .def("size", &velox::py::PyVector::size, py::doc(R"(
+        Number of elements in the Vector.
+      )"))
+      .def("null_count", &velox::py::PyVector::nullCount, py::doc(R"(
+        Number of null elements in the Vector.
+      )"))
+      .def("is_null_at", &velox::py::PyVector::isNullAt, py::doc(R"(
+        If the Vector has a null element at `idx`.
+
+        Args:
+          index: The vector element to check.
+      )"))
+      .def("print_all", &velox::py::PyVector::printAll, py::doc(R"(
+        Returns a string containg all elements in the Vector.
+      )"))
+      .def("print_detailed", &velox::py::PyVector::printDetailed, py::doc(R"(
+        Returns a descriptive string containing details about the
+        Vector and all its elements.
+      )"))
+      .def(
+          "summarize_to_text",
+          &velox::py::PyVector::summarizeToText,
+          py::doc(R"(
+        Returns a human-readable summarize of the Vector.
+      )"))
+      .def(
+          "compare",
+          &velox::py::PyVector::compare,
+          py::arg("other"),
+          py::arg("index"),
+          py::arg("other_index"),
+          py::doc(R"(
+        Compares elements across Vectors.
+
+        Args:
+          index: Index on the current Vector to compare.
+          other: Vector to compare to.
+          other_index: Index on `other` to compare to.
+
+        Returns:
+          0 if elements are the same, non-zero otherwise.
+      )"));
+}

--- a/velox/py/vector/vector.pyi
+++ b/velox/py/vector/vector.pyi
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,20 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# velox.py.type library:
-velox_add_library(velox_py_type_lib type/PyType.cpp)
-velox_link_libraries(velox_py_type_lib velox_type pybind11::module)
+# pyre-unsafe
 
-pybind11_add_module(type MODULE type/type.cpp)
-target_link_libraries(
-  type
-  PRIVATE velox_py_type_lib)
+from typing import List
 
-# velox.py.vector library:
-velox_add_library(velox_py_vector_lib vector/PyVector.cpp)
-velox_link_libraries(velox_py_vector_lib velox_vector pybind11::module)
 
-pybind11_add_module(vector MODULE vector/vector.cpp)
-target_link_libraries(
-  vector
-  PRIVATE velox_py_vector_lib)
+class Vector:
+    def size(self) -> int: ...
+    def print_all(self) -> str: ...
+    def print_detailed(self) -> str: ...
+    def summarize_to_text(self) -> str: ...
+    def null_count(self) -> int: ...
+    def is_null_at(self, idx: int) -> bool: ...


### PR DESCRIPTION
Summary:
Adding python bindings for Vector and Arrow conversion. Vector
bindings are not supposed to allow users to manipulate vectors; only basic
operations like checking size and potentially comparing rows. To allow for
tests (and in the future deeper pyarrow integration), also adding a
velox.py.arrow to allow Python users to convert velox.py.Vector<->pyarrow.Array

With this diff/PR, one can simply, from a Python interpreter:

```
import pyarrow
from velox.py.arrow import to_velox, to_arrow

array = pyarrow.array([1, 2, 3, 4, 5, 6])
vector = to_velox(array)
print(vector)

# also the opposite
other_array = to_arrow(vector)
```

Differential Revision: D67978010

Depends on https://github.com/facebookincubator/velox/pull/12040


