### PR TITLE
fix(json_parse): Json_parse to ignore invalid unicode escape sequences

### DIFF
--- a/velox/functions/prestosql/JsonFunctions.cpp
+++ b/velox/functions/prestosql/JsonFunctions.cpp
@@ -320,7 +320,9 @@ class JsonParseFunction : public exec::VectorFunction {
         return value.get_double().error();
       case simdjson::ondemand::json_type::string:
         addOrMergeViews(views_, trimToken(value.raw_json_token()));
-        return value.get_string().error();
+        // We ask simdjson to allow replacements for invalid UTF-8 sequences.
+        // to avoid throwing an exception in line with Presto java.
+        return value.get_string(true).error();
       case simdjson::ondemand::json_type::boolean:
         addOrMergeViews(views_, trimToken(value.raw_json_token()));
         return value.get_bool().error();

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -237,6 +237,12 @@ TEST_F(JsonFunctionsTest, jsonParse) {
 
   // Test bad unicode characters
   testJsonParse("\"Hello \xc0\xaf World\"", "\"Hello �� World\"");
+  // The below tests fail if simdjson.doc.get_string() is called
+  // without specifying replacement for bad characters in simdjson.
+  testJsonParse(R"("\uDE2Dau")", R"("\uDE2Dau")");
+  testJsonParse(
+      R"([{"response": "[\"fusil a peinture\",\"\ufffduD83E\\uDE2Dau bois\"]"}])",
+      R"([{"response":"[\"fusil a peinture\",\"�uD83E\\uDE2Dau bois\"]"}])");
 
   VELOX_ASSERT_THROW(
       jsonParse(R"({"k1":})"), "The JSON document has an improper structure");


### PR DESCRIPTION
Summary:
Certain improperly escaped unicode points like \uDE2Dau throw in json_parse. This happens in simdjson since these are invalid unicode escape sequences (i.e without the surrogate pairs). As Presto java ignores this, we add similar support in Velox. 

```
SELECT json_parse(x) from (values '"\uDE2Dau"') t(x);
-- Returns "\uDE2Dau" in java but throws in Velox
```

Differential Revision: D68176965


