### PR TITLE
fix: Added non-avx path for index transposing

### DIFF
--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -533,10 +533,6 @@ TEST_F(OperatorUtilsTest, outputBatchRows) {
 }
 
 TEST_F(OperatorUtilsTest, wrapMany) {
-#if !XSIMD_WITH_AVX2
-  GTEST_SKIP();
-#endif
-
   // Creates a RowVector with nullable and non-null vectors sharing
   // different dictionary wraps. Rewraps these with a new wrap with
   // and without nulls. Checks that the outcome has a single level of


### PR DESCRIPTION
Summary: This diff creates a different transposeIndex path if XSIMD_WITH_AVX2 is not present. Previously it was simply not supported.

Differential Revision: D67659247


