### PR TITLE
fix: Do not use index transpose in production code path

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -313,7 +313,7 @@ VectorPtr wrapOne(
   auto it = wrapState.transposeResults.find(baseIndices.get());
   if (it != wrapState.transposeResults.end()) {
     return BaseVector::wrapInDictionary(
-        wrapNulls, BufferPtr(it->second), wrapSize, baseValues);
+        wrapNulls, it->second, wrapSize, baseValues);
   }
 
   auto newIndices =
@@ -325,7 +325,7 @@ VectorPtr wrapOne(
       newIndices->asMutable<vector_size_t>());
   // If another column has the same wrapping and does not add nulls, we can use
   // the same transposed indices.
-  wrapState.transposeResults[baseIndices.get()] = newIndices.get();
+  wrapState.transposeResults[baseIndices.get()] = newIndices;
   return BaseVector::wrapInDictionary(
       wrapNulls, newIndices, wrapSize, baseValues);
 }
@@ -367,9 +367,8 @@ RowVectorPtr wrap(
   }
   std::vector<VectorPtr> wrappedChildren;
   wrappedChildren.reserve(childVectors.size());
-  WrapState state;
   for (auto& child : childVectors) {
-    wrappedChildren.emplace_back(wrapOne(size, mapping, child, nullptr, state));
+    wrappedChildren.emplace_back(wrapChild(size, mapping, child));
   }
   return std::make_shared<RowVector>(
       pool, rowType, nullptr, size, wrappedChildren);

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -100,7 +100,7 @@ struct WrapState {
   // Set of distinct wrappers in input, each mapped to the wrap
   // indices combining the former with the new wrap.
 
-  folly::F14FastMap<Buffer*, Buffer*> transposeResults;
+  folly::F14FastMap<Buffer*, BufferPtr> transposeResults;
 };
 
 /// Wraps 'inputVector' with 'wrapIndices' and


### PR DESCRIPTION
The newly added utility code in OperatorUtils was accidentally used in production code. The intention was not to use them due to uncompleted testings. It has caused Meta's internal production queries to crash due to the bug in the piece. This PR:
* Disables the newly added utility to be used in production code path.
* Fixes the uncovered bug in the utility. 