### PR TITLE
fix: Set_agg should not throw on nested nulls

### DIFF
--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -111,7 +111,7 @@ class CountDistinctAggregate
   explicit CountDistinctAggregate(
       const TypePtr& resultType,
       const TypePtr& inputType)
-      : Base(resultType, false), inputType_{inputType} {}
+      : Base(resultType), inputType_{inputType} {}
 
   bool supportsToIntermediate() const override {
     return false;
@@ -264,7 +264,6 @@ void registerSetAggAggregate(
         const TypePtr& inputType =
             isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
         const TypeKind typeKind = inputType->kind();
-        const bool throwOnNestedNulls = isRawInput;
 
         if (inputType->providesCustomComparison()) {
           return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
@@ -302,8 +301,7 @@ void registerSetAggAggregate(
           case TypeKind::MAP:
             [[fallthrough]];
           case TypeKind::ROW:
-            return std::make_unique<SetAggAggregate<ComplexType>>(
-                resultType, throwOnNestedNulls);
+            return std::make_unique<SetAggAggregate<ComplexType>>(resultType);
           default:
             VELOX_UNREACHABLE(
                 "Unexpected type {}", mapTypeKindToName(typeKind));

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -86,10 +86,8 @@ void registerCollectSetAggAggregate(
           case TypeKind::ARRAY:
             [[fallthrough]];
           case TypeKind::ROW:
-            // Nested nulls are allowed by setting 'throwOnNestedNulls' as
-            // false.
             return std::make_unique<SparkSetAggAggregate<ComplexType>>(
-                resultType, false);
+                resultType);
           default:
             VELOX_UNSUPPORTED(
                 "Unsupported type {}", mapTypeKindToName(typeKind));


### PR DESCRIPTION
Summary:
Velox's implementation of set_agg throws when it detects nulls nested inside complex types,
while Presto Java tolerates them.

set_agg was changed to throw on nested nulls as part of this issue which discovered that Velox
and Presto Java had different semantics when it came to nested nulls in a variety of
aggregations.
https://github.com/facebookincubator/velox/issues/6314

After this was done, Presto Java changed the semantics of some aggregations/UDFs to be like "distinct
from" rather than equals (i.e. treat null as a value and don't throw). 
https://github.com/prestodb/presto/issues/22900

set_agg was one of these, and it doesn't look like anyone went back and undid the change in
Velox so we allow nested nulls.

We should check the rest of the functions mentioned in that issue, but I think most weren't
implemented in Velox when the Presto Java change was made, so they were likely done correctly 
from the beginning.

Differential Revision: D68226492


