### PR TITLE
test: Upgrade the version of Presto we compare fuzzers in CI against to 0.290

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,7 +91,7 @@ jobs:
             tags: "ghcr.io/facebookincubator/velox-dev:adapters"
           - name: Presto Java
             file: "scripts/prestojava-container.dockerfile"
-            args: "PRESTO_VERSION=0.288"
+            args: "PRESTO_VERSION=0.290"
             tags: "ghcr.io/facebookincubator/velox-dev:presto-java"
           - name: Spark server
             file: "scripts/spark-container.dockerfile"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
-        - PRESTO_VERSION=0.288
+        - PRESTO_VERSION=0.290
       context: .
       dockerfile: scripts/prestojava-container.dockerfile
     environment:

--- a/scripts/prestojava-container.dockerfile
+++ b/scripts/prestojava-container.dockerfile
@@ -15,7 +15,7 @@
 #
 FROM ghcr.io/facebookincubator/velox-dev:centos9 
 
-ARG PRESTO_VERSION=0.288
+ARG PRESTO_VERSION=0.290
 
 ADD scripts /velox/scripts/
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz


### PR DESCRIPTION
Summary:
We currently run Aggregation, Window, and Writer fuzzers comparing against Presto in CI jobs.
They run Presto at version 0.288. There are known compatibility issues with this older version,
e.g. set_agg and set_union are disabled in AggregationFuzzer because of this.

0.290 appears to be the latest release from Presto and addresses these (we should be able to
enable set_agg and set_union after this).

I ran the Aggregation, Window, and Writer fuzzers against this version of Presto for an hour and
didn't see issues.  We also already run AggregationFuzzer against Presto trunk (or close to it) 
for every PR internally.

Differential Revision: D68280837


