### PR TITLE
test: Reenable set_agg and set_union in AggregationFuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -132,13 +132,6 @@ int main(int argc, char** argv) {
       "map_union_sum",
       "approx_set",
       "any_value",
-      // Presto 0.288 makes set_agg and set_union not respect order-by on
-      // inputs. Presto 0.289
-      // re-enables the order-by for them. So skip these two functions until we
-      // compare
-      // Velox result against Presto 0.289 or later versions.
-      "set_agg",
-      "set_union",
   };
 
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;


### PR DESCRIPTION
Summary:
set_agg and set_union were disabled in AggregationFuzzer because Velox and Presto 0.288 had
different ordering semantics.  This was fixed in 0.289 and we bumped the version of Presto we
compare against to 0.290 so this is no longer a concern.

Ran a biased AggregationFuzzer run against only set_agg and set_union comparing against 
Presto for 1 hour and didn't see issues.

Differential Revision: D68286084


