### PR TITLE
feat(python): PyVelox bindings for PlanBuilder and PlanNode

### DIFF
--- a/velox/py/CMakeLists.txt
+++ b/velox/py/CMakeLists.txt
@@ -29,3 +29,22 @@ pybind11_add_module(vector MODULE vector/vector.cpp)
 target_link_libraries(
   vector
   PRIVATE velox_py_vector_lib)
+
+# velox.py.plan_builder library:
+velox_add_library(velox_py_plan_builder_lib plan_builder/PyPlanBuilder.cpp)
+velox_link_libraries(
+  velox_py_plan_builder_lib
+  velox_py_type_lib
+  velox_py_vector_lib
+  velox_vector
+  velox_core
+  velox_cursor
+  velox_hive_connector
+  velox_aggregates
+  velox_functions_prestosql
+  velox_parse_expression
+  velox_exec_test_lib
+  velox_dwio_dwrf_reader
+  velox_dwio_dwrf_writer
+  Folly::folly
+  pybind11::module)

--- a/velox/py/plan_builder/PyPlanBuilder.cpp
+++ b/velox/py/plan_builder/PyPlanBuilder.cpp
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/py/plan_builder/PyPlanBuilder.h"
+
+#include <folly/executors/GlobalExecutor.h>
+#include <pybind11/stl.h>
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/exec/Cursor.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/py/vector/PyVector.h"
+
+namespace facebook::velox::py {
+
+namespace py = pybind11;
+
+folly::once_flag registerOnceFlag;
+
+void registerAllResourcesOnce() {
+  velox::filesystems::registerLocalFileSystem();
+
+  velox::dwrf::registerDwrfWriterFactory();
+  velox::dwrf::registerDwrfReaderFactory();
+
+  velox::parse::registerTypeResolver();
+
+  velox::core::PlanNode::registerSerDe();
+  velox::Type::registerSerDe();
+  velox::common::Filter::registerSerDe();
+  velox::connector::hive::LocationHandle::registerSerDe();
+  velox::connector::hive::HiveSortingColumn::registerSerDe();
+  velox::connector::hive::HiveBucketProperty::registerSerDe();
+  velox::connector::hive::HiveTableHandle::registerSerDe();
+  velox::connector::hive::HiveColumnHandle::registerSerDe();
+  velox::connector::hive::HiveInsertTableHandle::registerSerDe();
+  velox::core::ITypedExpr::registerSerDe();
+
+  // Register functions.
+  // TODO: We should move this to a separate module so that clients could
+  // register only when needed.
+  velox::functions::prestosql::registerAllScalarFunctions();
+  velox::aggregate::prestosql::registerAllAggregateFunctions();
+}
+
+void registerAllResources() {
+  folly::call_once(registerOnceFlag, registerAllResourcesOnce);
+}
+
+PyPlanNode::PyPlanNode(core::PlanNodePtr planNode)
+    : planNode_(std::move(planNode)) {
+  if (planNode_ == nullptr) {
+    throw std::runtime_error("Velox plan node cannot be nullptr.");
+  }
+}
+
+PyPlanBuilder::PyPlanBuilder(
+    const std::shared_ptr<core::PlanNodeIdGenerator>& generator)
+    : planNodeIdGenerator_(
+          generator ? generator
+                    : std::make_shared<core::PlanNodeIdGenerator>()) {
+  auto rootPool = memory::memoryManager()->addRootPool();
+  auto leafPool = rootPool->addLeafChild("py_plan_builder_pool");
+  planBuilder_ = exec::test::PlanBuilder(planNodeIdGenerator_, leafPool.get());
+}
+
+PyPlanBuilder& PyPlanBuilder::tableScan(
+    const velox::py::PyType& output,
+    const py::dict& aliases,
+    const py::dict& subfields,
+    const std::string& rowIndexColumnName,
+    const std::string& connectorId) {
+  using namespace connector::hive;
+  exec::test::PlanBuilder::TableScanBuilder builder(planBuilder_);
+
+  // Try to convert the output type.
+  auto outputRowSchema = asRowType(output.type());
+  if (outputRowSchema == nullptr) {
+    throw std::runtime_error("Output schema must be a ROW().");
+  }
+
+  // If there are any aliases, convert to std container and add to the builder.
+  std::unordered_map<std::string, std::string> aliasMap;
+
+  if (!aliases.empty()) {
+    for (const auto& item : aliases) {
+      if (!py::isinstance<py::str>(item.first) ||
+          !py::isinstance<py::str>(item.second)) {
+        throw std::runtime_error(
+            "Keys and values from aliases map need to be strings.");
+      }
+      aliasMap[item.first.cast<std::string>()] =
+          item.second.cast<std::string>();
+    }
+  }
+
+  // If there are subfields, create the appropriate structures and add to the
+  // scan.
+  if (!subfields.empty() || !rowIndexColumnName.empty()) {
+    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+        assignments;
+
+    for (size_t i = 0; i < outputRowSchema->size(); ++i) {
+      auto name = outputRowSchema->nameOf(i);
+      auto type = outputRowSchema->childAt(i);
+      std::vector<common::Subfield> requiredSubfields;
+
+      py::object key = py::cast(name);
+
+      // Check if the column was aliased by the user.
+      auto it = aliasMap.find(name);
+      auto hiveName = it == aliasMap.end() ? name : it->second;
+
+      if (subfields.contains(key)) {
+        py::handle value = subfields[key];
+        if (!py::isinstance<py::list>(value)) {
+          throw std::runtime_error(
+              "Subfield map value should be a list of integers.");
+        }
+
+        auto values = value.cast<std::vector<int64_t>>();
+
+        // TODO: Assume for now they are fields in a flap map.
+        for (const auto& subfield : values) {
+          requiredSubfields.emplace_back(
+              fmt::format("{}[{}]", hiveName, subfield));
+        }
+      }
+
+      auto columnType = (name == rowIndexColumnName)
+          ? HiveColumnHandle::ColumnType::kRowIndex
+          : HiveColumnHandle::ColumnType::kRegular;
+
+      auto columnHandle = std::make_shared<HiveColumnHandle>(
+          hiveName, columnType, type, type, std::move(requiredSubfields));
+      assignments.insert({name, columnHandle});
+    }
+    builder.assignments(std::move(assignments));
+  }
+
+  builder.outputType(outputRowSchema)
+      .columnAliases(std::move(aliasMap))
+      .connectorId(connectorId)
+      .endTableScan();
+  return *this;
+}
+
+PyPlanBuilder& PyPlanBuilder::values(const std::vector<PyVector>& values) {
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(values.size());
+
+  for (const auto& pyVector : values) {
+    if (auto rowVector =
+            std::dynamic_pointer_cast<RowVector>(pyVector.vector())) {
+      vectors.emplace_back(rowVector);
+    } else {
+      throw std::runtime_error("Values node only takes RowVectors.");
+    }
+  }
+
+  planBuilder_.values(vectors);
+  return *this;
+}
+
+PyPlanBuilder& PyPlanBuilder::project(
+    const std::vector<std::string>& projections) {
+  planBuilder_.project(projections);
+  return *this;
+}
+
+PyPlanBuilder& PyPlanBuilder::filter(const std::string& filter) {
+  planBuilder_.filter(filter);
+  return *this;
+}
+
+PyPlanBuilder& PyPlanBuilder::singleAggregation(
+    const std::vector<std::string>& groupingKeys,
+    const std::vector<std::string>& aggregations) {
+  planBuilder_.singleAggregation(groupingKeys, aggregations);
+  return *this;
+}
+
+PyPlanBuilder& PyPlanBuilder::mergeJoin(
+    const std::vector<std::string>& leftKeys,
+    const std::vector<std::string>& rightKeys,
+    const PyPlanNode& rightPlanSubtree,
+    const std::vector<std::string>& output,
+    const std::string& filter,
+    core::JoinType joinType) {
+  planBuilder_.mergeJoin(
+      leftKeys,
+      rightKeys,
+      rightPlanSubtree.planNode(),
+      filter,
+      output,
+      joinType);
+  return *this;
+}
+
+} // namespace facebook::velox::py

--- a/velox/py/plan_builder/PyPlanBuilder.h
+++ b/velox/py/plan_builder/PyPlanBuilder.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/py/type/PyType.h"
+
+namespace facebook::velox::py {
+
+/// Called when the Python module is loaded/initialized to register Velox
+/// resources like serde functions, type resolver, local filesystem and Presto
+/// functions (scalar and aggregate).
+void registerAllResources();
+
+class PyVector;
+
+/// Thin wrapper class used to expose Velox plan nodes to Python. It is only
+/// used to maintain the internal Velox structure and expose basic string
+/// serialization functionality.
+class PyPlanNode {
+ public:
+  /// Creates a new PyPlanNode wrapper given a Velox plan node. Throws if
+  /// planNode is nullptr.
+  explicit PyPlanNode(core::PlanNodePtr planNode);
+
+  const core::PlanNodePtr& planNode() const {
+    return planNode_;
+  }
+
+  std::string id() const {
+    return std::string{planNode_->id()};
+  }
+
+  std::string serialize() const {
+    return folly::toJson(planNode_->serialize());
+  }
+
+  std::string name() const {
+    return std::string(planNode_->name());
+  }
+
+  std::string toString(bool detailed = false, bool recursive = false) const {
+    return planNode_->toString(detailed, recursive);
+  }
+
+ private:
+  core::PlanNodePtr planNode_;
+};
+
+/// Wrapper class for PlanBuilder. It allows us to avoid exposing all details of
+/// the class to users making it easier to use.
+class PyPlanBuilder {
+ public:
+  /// Constructs a new PyPlanBuilder. If provided, the planNodeIdGenerator is
+  /// used; otherwise a new one is created.
+  PyPlanBuilder(
+      const std::shared_ptr<core::PlanNodeIdGenerator>& generator = nullptr);
+
+  // Returns the plan node at the head of the internal plan builder. If there is
+  // no plan node (plan builder is empty), then std::nullopt will signal pybind
+  // to return None to the Python client.
+  std::optional<PyPlanNode> planNode() const {
+    if (planBuilder_.planNode() != nullptr) {
+      return PyPlanNode(planBuilder_.planNode());
+    }
+    return std::nullopt;
+  }
+
+  // Returns a new builder sharing the plan node id generator, such that the new
+  // builder can safely be used to build other parts/pipelines of the same plan.
+  PyPlanBuilder newBuilder() {
+    DCHECK(planNodeIdGenerator_ != nullptr);
+    return PyPlanBuilder{planNodeIdGenerator_};
+  }
+
+  /// Add table scan node with basic functionality. This API is Hive-connector
+  /// specific.
+  ///
+  /// @param output The schema to be read from the file. Needs to be a RowType.
+  /// @param aliases Aliases to apply, mapping from the desired output name to
+  /// the input name in the file. If there are aliases, OutputSchema should be
+  /// defined based on the aliased names. The Python dict should contain strings
+  /// for keys and values.
+  /// @param subfields Used for projecting subfields from containers (like map
+  /// keys or struct fields), when one does not want to read the entire
+  /// container. It's a dictionary mapping from column name (string) to the list
+  /// of subitems to project from it. For now, a list of integers representing
+  /// the subfields in a flatmap/struct.
+  /// @param rowIndexColumnName If defined, create an output column with that
+  /// name producing $row_ids. This name needs to be part of `output`.
+  /// @param connectorId ID of the connector to use for this scan. By default
+  /// the Python module will specify the default name used to register the
+  /// Hive connector in the first place.
+  ///
+  /// Example (from Python API):
+  ///
+  /// tableScan(
+  ///   output=ROW(
+  ///     names=["row_number", "$row_group_id", "aliased_name"],
+  ///     types=[BIGINT(), VARCHAR(), MAP(INTEGER(), VARCHAR())],
+  ///   ),
+  ///   subfields={"aliased_name": [1234, 5431, 65223]},
+  ///   row_index="row_number",
+  ///   aliases={
+  ///     "aliased_name": "name_in_file",
+  ///    },
+  ///  )
+  PyPlanBuilder& tableScan(
+      const velox::py::PyType& output,
+      const pybind11::dict& aliases,
+      const pybind11::dict& subfields,
+      const std::string& rowIndexColumnName,
+      const std::string& connectorId);
+
+  // Add the provided vectors straight into the operator tree.
+  PyPlanBuilder& values(const std::vector<PyVector>& values);
+
+  // Add a list of projections. Projections are specified as SQL expressions and
+  // currently use DuckDB's parser semantics.
+  PyPlanBuilder& project(const std::vector<std::string>& projections);
+
+  // Add a filter (selection) to the plan. Filters are specified as SQL
+  // expressions and currently use DuckDB's parser semantics.
+  PyPlanBuilder& filter(const std::string& filter);
+
+  // Add a single-stage aggregation given a set of group keys, and aggregations.
+  // Aggregations are specified as SQL expressions and currently use DuckDB's
+  // parser semantics.
+  PyPlanBuilder& singleAggregation(
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregations);
+
+  // Add a merge join node to the plan. Assumes that both left and right
+  // subtrees will produce input sorted in join key order.
+  //
+  // @param leftKeys Set of join keys from the left (current plan builder) plan
+  // subtree.
+  // @param leftKeys Set of join keys from the right plan subtree.
+  // @param rightPlanSubtree Subtree to join to.
+  // @param output List of column names to project in the output of the join.
+  // @param filter An optional filter specified as a SQL expression to be
+  // applied during the join.
+  // @param joinType The type of join (kInner, kLeft, kRight, or kFull)
+  PyPlanBuilder& mergeJoin(
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const PyPlanNode& rightPlanSubtree,
+      const std::vector<std::string>& output,
+      const std::string& filter,
+      core::JoinType joinType);
+
+  // TODO: Add other nodes.
+
+ private:
+  exec::test::PlanBuilder planBuilder_;
+  std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
+};
+
+} // namespace facebook::velox::py

--- a/velox/py/plan_builder/plan_builder.cpp
+++ b/velox/py/plan_builder/plan_builder.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "velox/py/lib/PyInit.h"
+#include "velox/py/plan_builder/PyPlanBuilder.h"
+#include "velox/py/type/PyType.h"
+#include "velox/py/vector/PyVector.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(plan_builder, m) {
+  using namespace facebook;
+
+  velox::py::initializeVeloxMemory();
+  velox::py::registerAllResources();
+
+  // Need types to specify table scan schema output.
+  py::module::import("velox.py.type");
+
+  // PlanNode should not be created from Python directly (no registered
+  // constructor).
+  py::class_<velox::py::PyPlanNode>(m, "PlanNode")
+      .def(
+          "__str__",
+          [](const velox::py::PyPlanNode& planNode) {
+            return planNode.toString(false, true);
+          },
+          py::doc(R"(
+        Returns a short and recursive description of the plan.
+      )"))
+      .def("name", &velox::py::PyPlanNode::name, py::doc(R"(
+        Returns the name of the current plan node.
+      )"))
+      .def(
+          "to_string",
+          [](const velox::py::PyPlanNode& planNode) {
+            return planNode.toString(true, true);
+          },
+          py::doc(R"(
+        Returns a detailed and recursive description of the plan.
+      )"))
+      .def("id", &velox::py::PyPlanNode::id, py::doc(R"(
+        Returns the id of the current plan node.
+      )"));
+
+  // Join type enum for hash, merge and nested loop joins.
+  py::enum_<velox::core::JoinType>(m, "JoinType")
+      .value("INNER", velox::core::JoinType::kInner)
+      .value("LEFT", velox::core::JoinType::kLeft)
+      .value("RIGHT", velox::core::JoinType::kRight)
+      .value("FULL", velox::core::JoinType::kFull);
+
+  py::class_<velox::py::PyPlanBuilder>(m, "PlanBuilder", py::module_local())
+      .def(py::init<>())
+      .def("get_plan_node", &velox::py::PyPlanBuilder::planNode, py::doc(R"(
+        Returns the current plan node.
+      )"))
+      .def("new_builder", &velox::py::PyPlanBuilder::newBuilder, py::doc(R"(
+        Returns a new builder sharing the same plan node id generator,
+        so that they can be safely reused to build different parts of the
+        same plan.
+      )"))
+      .def(
+          "table_scan",
+          &velox::py::PyPlanBuilder::tableScan,
+          py::arg("output") = velox::py::PyType{},
+          py::arg("aliases") = py::dict{},
+          py::arg("subfields") = py::dict{},
+          py::arg("row_index") = "",
+          py::arg("connector_id") = "prism",
+          py::doc(R"(
+        Adds a table scan node to the plan.
+
+        Args:
+          output: A RowType containing the schema to be projected out
+                  of the scan.
+          aliases: An optional map of aliases to apply, from the desired
+                   output name to the name as defined in the file. If
+                   there are aliases, `output` should be specified based
+                   on the aliased name.
+          subfields: Used to project individual items from columns instead
+                     of reading entire containers. It maps from the column
+                     name to a list of items to be projected out.
+          row_index: If defined, creates an output column with this name
+                     producing $row_ids. This name needs to be part of the
+                     `output` as BIGINT.
+          connector_id: ID of the connector to use for this scan.
+      )"))
+      .def(
+          "values",
+          &velox::py::PyPlanBuilder::values,
+          py::arg("values") = std::vector<velox::py::PyVector>{},
+          py::doc(R"(
+        Adds the specified vectors to the operator tree as input. All input
+        vectors need to be RowVectors.
+      )"))
+      .def(
+          "project",
+          &velox::py::PyPlanBuilder::project,
+          py::arg("projections") = std::vector<std::string>{},
+          py::doc(R"(
+        Adds a projection node, calculating expression specified in
+        `projections`. Expressions are specified as SQL expressions.
+      )"))
+      .def(
+          "filter",
+          &velox::py::PyPlanBuilder::filter,
+          py::arg("filter") = "",
+          py::doc(R"(
+        Adds a filter node. The filter expression is specified as a
+        SQL expression.
+      )"))
+      .def(
+          "singleAggregation",
+          &velox::py::PyPlanBuilder::singleAggregation,
+          py::arg("grouping_keys") = std::vector<std::string>{},
+          py::arg("aggregations") = std::vector<std::string>{},
+          py::doc(R"(
+        Adds a single stage aggregation.
+
+        Args:
+          grouping_keys: List of columns to group by.
+          aggregations: List of aggregate expressions.
+      )"))
+      .def(
+          "merge_join",
+          &velox::py::PyPlanBuilder::mergeJoin,
+          py::arg("left_keys"),
+          py::arg("right_keys"),
+          py::arg("right_plan_node"),
+          py::arg("output") = std::vector<std::string>{},
+          py::arg("filter") = "",
+          py::arg("join_type") = velox::core::JoinType::kInner,
+          py::doc(R"(
+        Adds a merge join node.
+
+        Args:
+          left_keys: List of keys from the left table.
+          right_keys: List of keys from the right table.
+          right_plan_node: The plan node defined the subplan to join with.
+          output: List of columns to be projected out of the join.
+          filter: Optional join filter expression.
+      )"));
+}

--- a/velox/py/plan_builder/plan_builder.pyi
+++ b/velox/py/plan_builder/plan_builder.pyi
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+from typing import List, Dict, Type
+
+# pyre-fixme[21]: Could not find `velox.py.type`.
+from velox.py.type import Type
+
+
+class PlanNode: ...
+class PlanBuilder:
+    def __init__(self) -> None: ...
+    def table_scan(
+        self,
+        # pyre-fixme[11]: Annotation `Type` is not defined as a type.
+        output: Type,
+        aliases: Dict[str, str] = {},
+        subfields: Dict[str, List[int]] = {},
+        row_index: str = "",
+    ) -> PlanBuilder: ...
+    def get_plan_node(self) -> PlanBuilder: ...
+    def new_builder(self) -> PlanBuilder: ...
+    def id(self) -> str: ...

--- a/velox/py/tests/test_plan_builder.py
+++ b/velox/py/tests/test_plan_builder.py
@@ -1,0 +1,84 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from velox.py.type import BIGINT, ROW
+from velox.py.plan_builder import PlanBuilder, PlanNode
+
+
+class TestPyVeloxPlanBuidler(unittest.TestCase):
+    def test_plan_builder(self):
+        plan_builder = PlanBuilder()
+        self.assertEqual(plan_builder.get_plan_node(), None)
+
+        # Table scan. Needs at least the output schema and it needs to be a ROW.
+        self.assertRaises(RuntimeError, plan_builder.table_scan)
+        self.assertRaises(RuntimeError, plan_builder.table_scan, BIGINT())
+
+        plan_builder.table_scan(ROW(["c0"], [BIGINT()]))
+        table_scan = plan_builder.get_plan_node()
+        self.assertTrue(isinstance(table_scan, PlanNode))
+        self.assertEqual(table_scan.name(), "TableScan")
+
+        # Project.
+        self.assertRaises(
+            RuntimeError, plan_builder.project, ["c1"]
+        )  # c1 non-existent.
+        plan_builder.project(["c0 + 1 AS d0", "100"])
+        project = plan_builder.get_plan_node()
+        self.assertEqual(project.name(), "Project")
+
+        self.assertNotEqual(table_scan.id(), project.id())
+
+        # Filter.
+        self.assertRaises(
+            RuntimeError, plan_builder.filter, "c0 > 1"
+        )  # c0 non-existent.
+        plan_builder.filter("d0 - 10 > 100")
+        filter_node = plan_builder.get_plan_node()
+        self.assertEqual(filter_node.name(), "Filter")
+
+        self.assertNotEqual(filter_node.id(), project.id())
+
+        self.assertEqual(
+            str(filter_node),
+            "-- Filter[2]\n" "  -- Project[1]\n" "    -- TableScan[0]\n",
+        )
+
+    def test_multiple_plan_builders(self):
+        """
+        Tests that mutliple plan builders (used to create plans with multiple
+        pipelines, like containing joins), generate expected disjoins node ids.
+        """
+        plan_builder1 = PlanBuilder()
+        plan_builder1.table_scan(ROW(["c0"], [BIGINT()]))
+        self.assertEqual(plan_builder1.get_plan_node().id(), "0")
+
+        # A new independent plan builder.
+        plan_builder2 = PlanBuilder()
+        plan_builder2.table_scan(ROW(["c0"], [BIGINT()]))
+        self.assertEqual(plan_builder2.get_plan_node().id(), "0")
+
+        # Chained plan builders.
+        plan_builder1_1 = plan_builder1.new_builder()
+        plan_builder1_1.table_scan(ROW(["c0"], [BIGINT()]))
+        self.assertEqual(plan_builder1_1.get_plan_node().id(), "1")
+
+        plan_builder1_2 = plan_builder1.new_builder()
+        plan_builder1_2.table_scan(ROW(["c0"], [BIGINT()]))
+        self.assertEqual(plan_builder1_2.get_plan_node().id(), "2")
+
+        plan_builder1.project([])
+        self.assertEqual(plan_builder1.get_plan_node().id(), "3")


### PR DESCRIPTION
Summary:
Adding Python bindings to allow plans to be built using PlanBuilder.
Plan builder is still a test dependency, but will be moved out of test soon.

Differential Revision: D68002774


