### PR TITLE
refactor: Optimize access to ScanTracker tracking data.

### DIFF
--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -159,7 +159,7 @@ class BufferedInput {
     if (referencedBytes == 0) {
       return 0;
     }
-    const int pct = trackingData.readBytes / referencedBytes * 100;
+    const int pct = ((double)trackingData.readBytes) / referencedBytes * 100;
     VELOX_CHECK_LE(0, pct, "Bad read percentage: {}", pct);
     // It is possible to seek back or clone the stream and read the same data
     // multiple times, or because of unplanned read, so pct could be larger than

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -119,7 +119,7 @@ std::vector<CacheRequest*> makeRequestParts(
   const bool prefetchOne =
       request.trackingId.id() == StreamIdentifier::sequentialFile().id_;
   const auto readDensity =
-      trackingData.readBytes / (1 + trackingData.referencedBytes);
+      ((double)trackingData.readBytes) / (1 + trackingData.referencedBytes);
   const auto readPct = 100 * readDensity;
   const bool prefetch = trackingData.referencedBytes > 0 &&
       isPrefetchPct(readPct) && readDensity >= 0.8;


### PR DESCRIPTION
Summary:
Cloning internal changes by @Yuhta 
The tracking data is protected by a mutex and this blocks both reads and writes. Replace mutex with folly::Synchronized for unblocking parallel reads while blocking write calls.

This change is a part of collection of changes to improve Scan performance.

Reviewed By: joeg

Differential Revision: D67009639


