### PR TITLE
fix: regexp_extract returns match in mismatched group

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -144,8 +144,14 @@ bool re2Extract(
     }
   } else {
     const re2::StringPiece extracted = groups[groupId];
-    result.setNoCopy(row, StringView(extracted.data(), extracted.size()));
-    return !StringView::isInline(extracted.size());
+    // Check if the extracted data is null.
+    if (extracted.data()) {
+      result.setNoCopy(row, StringView(extracted.data(), extracted.size()));
+      return !StringView::isInline(extracted.size());
+    } else {
+      result.setNull(row, true);
+      return false;
+    }
   }
 }
 
@@ -2099,16 +2105,18 @@ PatternMetadata determinePatternKind(
           return PatternMetadata::prefix(
               std::string(unescapedPattern, 0, firstSubPatternLength));
         } else if (lastSubPatternKind == SubPatternKind::kLiteralString) {
-          return PatternMetadata::suffix(std::string(
-              unescapedPattern, lastSubPatternStart, lastSubPatternLength));
+          return PatternMetadata::suffix(
+              std::string(
+                  unescapedPattern, lastSubPatternStart, lastSubPatternLength));
         } else if (
             numSubPatterns == 3 &&
             firstSubPatternKind == SubPatternKind::kAnyCharsWildcard &&
             lastSubPatternKind == SubPatternKind::kAnyCharsWildcard) {
-          return PatternMetadata::substring(std::string(
-              unescapedPattern,
-              subPatternRanges[1].first,
-              subPatternRanges[1].second));
+          return PatternMetadata::substring(
+              std::string(
+                  unescapedPattern,
+                  subPatternRanges[1].first,
+                  subPatternRanges[1].second));
         }
       }
 

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -2105,18 +2105,16 @@ PatternMetadata determinePatternKind(
           return PatternMetadata::prefix(
               std::string(unescapedPattern, 0, firstSubPatternLength));
         } else if (lastSubPatternKind == SubPatternKind::kLiteralString) {
-          return PatternMetadata::suffix(
-              std::string(
-                  unescapedPattern, lastSubPatternStart, lastSubPatternLength));
+          return PatternMetadata::suffix(std::string(
+              unescapedPattern, lastSubPatternStart, lastSubPatternLength));
         } else if (
             numSubPatterns == 3 &&
             firstSubPatternKind == SubPatternKind::kAnyCharsWildcard &&
             lastSubPatternKind == SubPatternKind::kAnyCharsWildcard) {
-          return PatternMetadata::substring(
-              std::string(
-                  unescapedPattern,
-                  subPatternRanges[1].first,
-                  subPatternRanges[1].second));
+          return PatternMetadata::substring(std::string(
+              unescapedPattern,
+              subPatternRanges[1].first,
+              subPatternRanges[1].second));
         }
       }
 

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -369,6 +369,9 @@ void testRe2Extract(F&& regexExtract) {
   EXPECT_EQ(regexExtract(std::nullopt, "\\d+", 0), std::nullopt);
   EXPECT_EQ(regexExtract(" 123 ", std::nullopt, 0), std::nullopt);
   EXPECT_EQ(regexExtract(" 123 ", "\\d+", std::nullopt), std::nullopt);
+  // Group case that mismatch.
+  EXPECT_EQ(
+      regexExtract("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2), std::nullopt);
 }
 
 TEST_F(Re2FunctionsTest, regexExtract) {


### PR DESCRIPTION
The implementation of Re2Extract has a bug, that it might consider a mismatched group as MATCHED empty string "" rather than MISMATCHED std::nullopt.

For example, in the function calling: regexp_extract("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2). 
In this case, for group 2 the result must be std::nullopt because no substring would match pattern `blah(.)`. 
But the current implementation would mistake the matching of group 1 `ra(.)` as a empty match case for group 2, and thus return a empty matching, which is wrong.

See detailed description in https://github.com/facebookincubator/velox/issues/12119.

This PR fix this bug in Re2Extract implementation.

Also note that this bug behavior exists in Re2ExtractAll as well, but this PR doesn't modify in Re2ExtractAll because existing UTs of Re2ExtractAll already rely on this behavior. 