### PR TITLE
feat(function): Add MAP() signature for MapFunction.

### DIFF
--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -32,6 +32,22 @@ class MapFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
+    // No arguments case (empty map).
+    if (args.empty()) {
+      auto emptyMapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          nullptr, // nulls
+          rows.end(),
+          allocateOffsets(rows.end(), context.pool()),
+          allocateSizes(rows.end(), context.pool()),
+          BaseVector::create(outputType->childAt(0), 0, context.pool()),
+          BaseVector::create(outputType->childAt(1), 0, context.pool()));
+
+      context.moveOrCopyResult(emptyMapVector, rows, result);
+      return;
+    }
+
     VELOX_CHECK_EQ(args.size(), 2);
 
     auto keys = args[0];
@@ -277,13 +293,19 @@ class MapFunction : public exec::VectorFunction {
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // array(K), array(V) -> map(K,V)
-    return {exec::FunctionSignatureBuilder()
-                .typeVariable("K")
-                .typeVariable("V")
-                .returnType("map(K,V)")
-                .argumentType("array(K)")
-                .argumentType("array(V)")
-                .build()};
+    // () -> map()
+    return {
+        exec::FunctionSignatureBuilder()
+            .typeVariable("K")
+            .typeVariable("V")
+            .returnType("map(K,V)")
+            .argumentType("array(K)")
+            .argumentType("array(V)")
+            .build(),
+        exec::FunctionSignatureBuilder()
+            .returnType("map(unknown,unknown)")
+            .build(),
+    };
   }
 
  private:

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -99,6 +99,25 @@ TEST_F(MapTest, noNulls) {
   assertEqualVectors(expectedMap, result);
 }
 
+TEST_F(MapTest, emptyMap) {
+  const auto numRows = 1'000;
+  // We use unknown types here because no way to specify the output type for the
+  // map() call.
+  auto emptyMapVector = std::make_shared<MapVector>(
+      pool(),
+      MAP(UNKNOWN(), UNKNOWN()),
+      nullptr, // nulls
+      numRows,
+      allocateOffsets(numRows, pool()),
+      allocateSizes(numRows, pool()),
+      BaseVector::create(UNKNOWN(), 0, pool()),
+      BaseVector::create(UNKNOWN(), 0, pool()));
+
+  auto result =
+      evaluate("map()", makeRowVector({makeConstant<int64_t>(1, numRows)}));
+  assertEqualVectors(emptyMapVector, result);
+}
+
 TEST_F(MapTest, someNulls) {
   auto size = 1'000;
 


### PR DESCRIPTION
Summary:
Some queries can fail with the following error:
Scalar function presto.default.map not registered with arguments: ()

MAP() is supported in Presto and works by creating an emtpy map of the output type.
Add the same capability to Velox.

Differential Revision: D68359107


