### PR TITLE
fix(HashAgg): Update abandoned Partial Aggregation flag condition

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -330,6 +330,8 @@ RowVectorPtr HashAggregation::getOutput() {
     prepareOutput(input_->size());
     groupingSet_->toIntermediate(input_, output_);
     numOutputRows_ += input_->size();
+    addRuntimeStat(
+        "abandonedPartialAggregationRowCount", RuntimeCounter(input_->size()));
     input_ = nullptr;
     return output_;
   }

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -281,13 +281,11 @@ void HashAggregation::resetPartialOutputIfNeed() {
 
 void HashAggregation::maybeIncreasePartialAggregationMemoryUsage(
     double aggregationPct) {
-  // If more than this many are unique at full memory, give up on partial agg.
-  constexpr int32_t kPartialMinFinalPct = 40;
   VELOX_DCHECK(isPartialOutput_);
   // If size is at max and there still is not enough reduction, abandon partial
   // aggregation.
   if (abandonPartialAggregationEarly(numOutputRows_) ||
-      (aggregationPct > kPartialMinFinalPct &&
+      (aggregationPct > abandonPartialAggregationMinPct_ &&
        maxPartialAggregationMemoryUsage_ >=
            maxExtendedPartialAggregationMemoryUsage_)) {
     groupingSet_->abandonPartialAggregation();


### PR DESCRIPTION
Now, in partial aggregation, if aggregationPct > 40% (hardcoded), abandonedPartialAggregation flag will be set, and more rows will be produced without partial aggregation in partial aggregation operator. We can use config abandonPartialAggregationMinPct here instead of 40%.

abandonPartialAggregationMinPct is 80% in velox, and 90% in gluten, which I think is more reasonable.

Testing with TPCDS q67, the query time went from 109 seconds to 90 seconds.

![image](https://github.com/user-attachments/assets/7f5581ba-d0db-4c57-a315-df9e303ae598)
