### PR TITLE
docs: Fix default value of 'query_trace_enabled' property

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -914,7 +914,7 @@ Tracing
      - Description
    * - query_trace_enabled
      - bool
-     - true
+     - false
      - If true, enable query tracing.
    * - query_trace_dir
      - string


### PR DESCRIPTION
`query_trace_enabled` is used for debugging, so its default value
should be `false`. It is correct in the current code, but it is
 wrong in the current documentation.