### PR TITLE
fix: ApproxPercentileAggregate Incorrect Handling of Null Values in extract Function

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -525,7 +525,7 @@ class ApproxPercentileAggregate : public exec::Aggregate {
         result->setNull(i, true);
       } else {
         if (rawNulls) {
-          bits::clearBit(rawNulls, i);
+          bits::setNull(rawNulls, i, false);
         }
         extractFunction(accumulator->getSketch(), result, i);
       }


### PR DESCRIPTION
This pull request fixes a bug in the extract function located in `velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp`. The issue arises due to incorrect handling of null values in the `rawNulls` array. Specifically, the original code uses `bits::clearBit(rawNulls, i)` to mark non-null values, but this logic is incorrect. In the `rawNulls` array, a value of 1 represents a non-null value, and a value of 0 represents a null value.

The incorrect usage of `clearBit` was mistakenly setting `rawNulls[i]` to `0` (indicating null), when it should have been setting it to `1 `(indicating a non-null value).

See detailed description in #12122 