### PR TITLE
fix: Flaky test FilterProjectReplayerTest.projectOnly

### DIFF
--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -114,7 +114,8 @@ core::PlanNodePtr OperatorReplayerBase::createPlan() {
 
 std::shared_ptr<core::QueryCtx> OperatorReplayerBase::createQueryCtx() {
   auto queryPool = memory::memoryManager()->addRootPool(
-      fmt::format("{}_replayer", operatorType_), queryCapacity_);
+      fmt::format("{}_replayer_{}", operatorType_, replayQueryId_++),
+      queryCapacity_);
   std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
       connectorConfigs;
   for (auto& [connectorId, configs] : connectorConfigs_) {

--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -76,6 +76,7 @@ class OperatorReplayerBase {
       connectorConfigs_;
   core::PlanNodePtr planFragment_;
   core::PlanNodeId replayPlanNodeId_;
+  std::atomic_uint64_t replayQueryId_{0};
 
   void printStats(const std::shared_ptr<exec::Task>& task) const;
 

--- a/velox/tool/trace/TraceReplayTaskRunner.cpp
+++ b/velox/tool/trace/TraceReplayTaskRunner.cpp
@@ -45,7 +45,9 @@ std::shared_ptr<RowVector> TraceReplayTaskRunner::copy(
     totalRows += result->size();
   }
   auto copyResult = BaseVector::create<RowVector>(
-      results[0]->type(), totalRows, memory::traceMemoryPool());
+      cursorParams_.planNode->outputType(),
+      totalRows,
+      memory::traceMemoryPool());
   auto resultRowOffset = 0;
   for (const auto& result : results) {
     copyResult->copy(result.get(), resultRowOffset, 0, result->size());

--- a/velox/tool/trace/TraceReplayTaskRunner.h
+++ b/velox/tool/trace/TraceReplayTaskRunner.h
@@ -28,6 +28,8 @@ class TraceReplayTaskRunner {
       std::shared_ptr<core::QueryCtx> queryCtx) {
     cursorParams_.planNode = std::move(plan);
     cursorParams_.queryCtx = std::move(queryCtx);
+    VELOX_CHECK_NOT_NULL(cursorParams_.planNode);
+    VELOX_CHECK_NOT_NULL(cursorParams_.queryCtx);
   }
 
   /// Run the replaying task. Return the copied results if 'copyResults' is
@@ -50,8 +52,7 @@ class TraceReplayTaskRunner {
  private:
   void addSplits(exec::Task* task);
 
-  static std::shared_ptr<RowVector> copy(
-      const std::vector<RowVectorPtr>& results);
+  std::shared_ptr<RowVector> copy(const std::vector<RowVectorPtr>& results);
 
   exec::CursorParameters cursorParams_;
   std::unordered_map<core::PlanNodeId, std::vector<exec::Split>> splits_;

--- a/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
+++ b/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
@@ -293,5 +293,31 @@ TEST_F(FilterProjectReplayerTest, projectOnly) {
                               executor_.get())
                               .run();
   assertEqualResults({result}, {replayingResult1, replayingResult2});
+
+  const auto taskTraceDir =
+      exec::trace::getTaskTraceDirectory(traceRoot, *task);
+  const auto opTraceDir =
+      exec::trace::getOpTraceDirectory(taskTraceDir, projectNodeId_, 0, 0);
+  const auto opTraceDataFile = exec::trace::getOpTraceInputFilePath(opTraceDir);
+  auto fs = filesystems::getFileSystem(opTraceDataFile, nullptr);
+  auto file = fs->openFileForWrite(
+      opTraceDataFile,
+      filesystems::FileOptions{
+          .values = {},
+          .fileSize = std::nullopt,
+          .shouldThrowOnFileAlreadyExists = false});
+  file->truncate(0);
+  file->close();
+  auto emptyResult = FilterProjectReplayer(
+                         traceRoot,
+                         task->queryCtx()->queryId(),
+                         task->taskId(),
+                         projectNodeId_,
+                         "FilterProject",
+                         "0",
+                         0,
+                         executor_.get())
+                         .run();
+  ASSERT_EQ(emptyResult->size(), 0);
 }
 } // namespace facebook::velox::tool::trace::test


### PR DESCRIPTION
The trace data file for some drivers might be empty hence the
replaying results of those drivers are empty causing a segment
fault issue when we use `results[0]` to get the output type. We
should use the `TraceReplayTaskRunner::cursorParams_::planNode`.

Fix #12071 