### PR TITLE
feat: Add spark varchar_writeside_check function for writing to fixed length varchar type

### DIFF
--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -147,6 +147,8 @@ void registerStringFunctions(const std::string& prefix) {
   registerFunctionCallToSpecialForm(
       ConcatWsCallToSpecialForm::kConcatWs,
       std::make_unique<ConcatWsCallToSpecialForm>());
+  registerFunction<VarcharWriteSideCheckFunction, Varchar, Varchar, int32_t>(
+      {prefix + "varchar_writeside_check"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -1055,5 +1055,25 @@ TEST_F(StringTest, empty2Null) {
   EXPECT_EQ(empty2Null(""), std::nullopt);
   EXPECT_EQ(empty2Null("abc"), "abc");
 }
+
+TEST_F(StringTest, VarcharWriteSideCheck) {
+  const auto varcharWriteSideCheck = [&](const std::string& srcStr,
+                                         int32_t length) {
+    return evaluateOnce<std::string>(
+        "varchar_writeside_check(c0, c1)",
+        std::make_optional(srcStr),
+        std::make_optional(length));
+  };
+
+  EXPECT_EQ(varcharWriteSideCheck("", 3), "");
+  EXPECT_EQ(varcharWriteSideCheck(" ", 3), " ");
+  EXPECT_EQ(varcharWriteSideCheck("abc", 3), "abc");
+  EXPECT_EQ(varcharWriteSideCheck("ab ", 3), "ab ");
+  EXPECT_EQ(varcharWriteSideCheck("ab    ", 3), "ab ");
+  EXPECT_EQ(varcharWriteSideCheck("abc    ", 3), "abc");
+  VELOX_ASSERT_USER_THROW(
+      varcharWriteSideCheck("abcd", 3),
+      "Exceeds varchar type length limitation: 3")
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
When spark writing to fixed length varchar type,`StaticInvoke(classOf[CharVarcharCodegenUtils],StringType,"varcharTypeWriteSideCheck",expr :: Literal(length) :: Nil,returnNullable = false)` will be executed, so add spark varchar_writeside_check function to support it