### PR TITLE
feat: Add Global Config in place of gflags for expressions

### DIFF
--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -718,7 +718,7 @@ TEST_P(AsyncDataCacheTest, pin) {
 
 TEST_P(AsyncDataCacheTest, replace) {
   constexpr int64_t kMaxBytes = 64 << 20;
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  config::globalConfig.exceptionUserStacktraceEnabled = false;
   initializeCache(kMaxBytes);
   // Load 10x the max size, inject an error every 21 batches.
   loadLoop(0, kMaxBytes * 10, 21);
@@ -736,7 +736,7 @@ TEST_P(AsyncDataCacheTest, replace) {
 
 TEST_P(AsyncDataCacheTest, evictAccounting) {
   constexpr int64_t kMaxBytes = 64 << 20;
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  config::globalConfig.exceptionUserStacktraceEnabled = false;
   initializeCache(kMaxBytes);
   auto pool = manager_->addLeafPool("test");
 
@@ -760,7 +760,7 @@ TEST_P(AsyncDataCacheTest, evictAccounting) {
 TEST_P(AsyncDataCacheTest, largeEvict) {
   constexpr int64_t kMaxBytes = 256 << 20;
   constexpr int32_t kNumThreads = 24;
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  config::globalConfig.exceptionUserStacktraceEnabled = false;
   initializeCache(kMaxBytes);
   // Load 10x the max size, inject an allocation of 1/8 the capacity every 4
   // batches.
@@ -839,7 +839,7 @@ TEST_P(AsyncDataCacheTest, DISABLED_ssd) {
   constexpr uint64_t kRamBytes = 32 << 20;
   constexpr uint64_t kSsdBytes = 512UL << 20;
 #endif
-  FLAGS_velox_exception_user_stacktrace_enabled = false;
+  config::globalConfig.exceptionUserStacktraceEnabled = false;
   initializeCache(kRamBytes, kSsdBytes);
   cache_->setVerifyHook(
       [&](const AsyncDataCacheEntry& entry) { checkContents(entry); });

--- a/velox/common/config/GlobalConfig.h
+++ b/velox/common/config/GlobalConfig.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 namespace facebook::velox::config {
 
@@ -53,6 +54,29 @@ struct GlobalConfiguration {
   /// Min time interval in milliseconds between stack traces captured in
   /// system type of VeloxException; off when set to 0 (the default).
   int32_t exceptionSystemStacktraceRateLimitMs{0};
+  /// Whether to overwrite queryCtx and force the use of simplified expression
+  /// evaluation path.
+  bool forceEvalSimplified{false};
+  /// This is an experimental flag only to be used for debugging purposes. If
+  /// set to true, serializes the input vector data and all the SQL expressions
+  /// in the ExprSet that is currently executing, whenever a fatal signal is
+  /// encountered. Enabling this flag makes the signal handler async signal
+  /// unsafe, so it should only be used for debugging purposes. The vector and
+  /// SQLs are serialized to files in directories specified by either
+  /// 'saveInputOnExpressionAnyFailurePath' or
+  /// 'saveInputOnExpressionSystemFailurePath'
+  bool experimentalSaveInputOnFatalSignal{false};
+  /// Used to enable saving input vector and expression SQL on disk in case
+  /// of any (user or system) error during expression evaluation. The value
+  /// specifies a path to a directory where the vectors will be saved. That
+  /// directory must exist and be writable.
+  std::string saveInputOnExpressionAnyFailurePath;
+  /// Used to enable saving input vector and expression SQL on disk in case
+  /// of a system error during expression evaluation. The value specifies a path
+  /// to a directory where the vectors will be saved. That directory must exist
+  /// and be writable. This flag is ignored if
+  /// saveInputOnExpressionAnyFailurePath flag is set.
+  std::string saveInputOnExpressionSystemFailurePath;
 };
 
 extern GlobalConfiguration globalConfig;

--- a/velox/dwio/common/tests/LoggedExceptionTest.cpp
+++ b/velox/dwio/common/tests/LoggedExceptionTest.cpp
@@ -40,8 +40,8 @@ void testTraceCollectionSwitchControl(bool enabled) {
     SCOPED_TRACE(fmt::format(
         "enabled: {}, user flag: {}, sys flag: {}",
         enabled,
-        FLAGS_velox_exception_user_stacktrace_enabled,
-        FLAGS_velox_exception_system_stacktrace_enabled));
+        config::globalConfig.exceptionUserStacktraceEnabled,
+        config::globalConfig.exceptionSystemStacktraceEnabled));
     ASSERT_TRUE(e.exceptionType() == VeloxException::Type::kSystem);
     ASSERT_EQ(enabled, e.stackTrace() != nullptr);
   }

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -29,19 +29,6 @@
 #include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
 
-/// GFlag used to enable saving input vector and expression SQL on disk in case
-/// of any (user or system) error during expression evaluation. The value
-/// specifies a path to a directory where the vectors will be saved. That
-/// directory must exist and be writable.
-DECLARE_string(velox_save_input_on_expression_any_failure_path);
-
-/// GFlag used to enable saving input vector and expression SQL on disk in case
-/// of a system error during expression evaluation. The value specifies a path
-/// to a directory where the vectors will be saved. That directory must exist
-/// and be writable. This flag is ignored if
-/// velox_save_input_on_expression_any_failure_path flag is set.
-DECLARE_string(velox_save_input_on_expression_system_failure_path);
-
 namespace facebook::velox::exec {
 
 class ExprSet;

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -133,7 +133,7 @@ class ExprEncodingsTest
 
   void SetUp() override {
     // This test throws a lot of exceptions, so turn off stack trace capturing.
-    FLAGS_velox_exception_user_stacktrace_enabled = false;
+    config::globalConfig.exceptionUserStacktraceEnabled = false;
 
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2408,9 +2408,8 @@ TEST_P(ParameterizedExprTest, exceptionContext) {
   registerFunction<TestingAlwaysThrowsFunction, int32_t, int32_t>(
       {"always_throws"});
 
-  // Disable saving vector and expression SQL on error.
-  FLAGS_velox_save_input_on_expression_any_failure_path = "";
-  FLAGS_velox_save_input_on_expression_system_failure_path = "";
+  config::globalConfig.saveInputOnExpressionAnyFailurePath = "";
+  config::globalConfig.saveInputOnExpressionSystemFailurePath = "";
 
   try {
     evaluate("always_throws(c0) + c1", data);
@@ -2444,7 +2443,7 @@ TEST_P(ParameterizedExprTest, exceptionContext) {
 
   // Enable saving vector and expression SQL for system errors only.
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  FLAGS_velox_save_input_on_expression_system_failure_path =
+  config::globalConfig.saveInputOnExpressionSystemFailurePath =
       tempDirectory->getPath();
 
   try {
@@ -2480,9 +2479,9 @@ TEST_P(ParameterizedExprTest, exceptionContext) {
   }
 
   // Enable saving vector and expression SQL for all errors.
-  FLAGS_velox_save_input_on_expression_any_failure_path =
+  config::globalConfig.saveInputOnExpressionAnyFailurePath =
       tempDirectory->getPath();
-  FLAGS_velox_save_input_on_expression_system_failure_path = "";
+  config::globalConfig.saveInputOnExpressionSystemFailurePath = "";
 
   try {
     evaluate("always_throws(c0) + c1", data);

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -76,6 +76,25 @@ DEFINE_string(
     "vectors and expression SQL strings. This flag is ignored if "
     "velox_save_input_on_expression_any_failure_path is set.");
 
+DEFINE_bool(
+    force_eval_simplified,
+    false,
+    "Whether to overwrite queryCtx and force the "
+    "use of simplified expression evaluation path.");
+
+DEFINE_bool(
+    velox_experimental_save_input_on_fatal_signal,
+    false,
+    "This is an experimental flag only to be used for debugging "
+    "purposes. If set to true, serializes the input vector data and "
+    "all the SQL expressions in the ExprSet that is currently "
+    "executing, whenever a fatal signal is encountered. Enabling "
+    "this flag makes the signal handler async signal unsafe, so it "
+    "should only be used for debugging purposes. The vector and SQLs "
+    "are serialized to files in directories specified by either "
+    "'velox_save_input_on_expression_any_failure_path' or "
+    "'velox_save_input_on_expression_system_failure_path'");
+
 // TODO: deprecate this once all the memory leak issues have been fixed in
 // existing meta internal use cases.
 DEFINE_bool(
@@ -138,5 +157,12 @@ void translateFlagsToGlobalConfig() {
       FLAGS_velox_exception_user_stacktrace_enabled;
   config::globalConfig.exceptionUserStacktraceRateLimitMs =
       FLAGS_velox_exception_user_stacktrace_rate_limit_ms;
+  config::globalConfig.forceEvalSimplified = FLAGS_force_eval_simplified;
+  config::globalConfig.experimentalSaveInputOnFatalSignal =
+      FLAGS_velox_experimental_save_input_on_fatal_signal;
+  config::globalConfig.saveInputOnExpressionAnyFailurePath =
+      FLAGS_velox_save_input_on_expression_any_failure_path;
+  config::globalConfig.saveInputOnExpressionSystemFailurePath =
+      FLAGS_velox_save_input_on_expression_system_failure_path;
 }
 } // namespace facebook::velox


### PR DESCRIPTION
This is continuing the previous work of removing GFlags in place of using global config