### PR TITLE
build(cmake): Fix protobuf error during build when using Velox as a subproject

### DIFF
--- a/velox/dwio/dwrf/proto/CMakeLists.txt
+++ b/velox/dwio/dwrf/proto/CMakeLists.txt
@@ -31,13 +31,13 @@ set(PROTO_OUTPUT_FILES ${PROTO_HDRS} ${PROTO_SRCS})
 set_source_files_properties(${PROTO_OUTPUT_FILES} PROPERTIES GENERATED TRUE)
 
 # Ensure that the option --proto_path is not given an empty argument
-foreach(PROTO_PATH ${CMAKE_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS})
+foreach(PROTO_PATH ${PROJECT_SOURCE_DIR} ${Protobuf_INCLUDE_DIRS})
   list(APPEND PROTO_PATH_ARGS --proto_path=${PROTO_PATH})
 endforeach()
 
 add_custom_command(
   OUTPUT ${PROTO_OUTPUT_FILES}
-  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${CMAKE_BINARY_DIR}
+  COMMAND protobuf::protoc ${PROTO_PATH_ARGS} --cpp_out ${PROJECT_BINARY_DIR}
           ${PROTO_FILES_FULL}
   DEPENDS protobuf::protoc
   COMMENT "Running PROTO compiler"


### PR DESCRIPTION
Error message:

```
.../cmake-build-debug/_deps/velox-src/velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.cpp:37:10: fatal error: velox/dwio/dwrf/proto/dwrf_proto.pb.cc: No such file or directory
   37 | #include "velox/dwio/dwrf/proto/dwrf_proto.pb.cc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated
```

This is because the generated `protoc` command relies on the root CMake project path so the command will be messed up when Velox is used as a module of nother CMake project.

The patch fixes the issue.