### PR TITLE
fix: Add the missing 'u' field in SimpleDateFormat

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -2043,6 +2043,9 @@ Expected<std::shared_ptr<DateTimeFormatter>> buildSimpleDateTimeFormatter(
         case 'S':
           builder.appendFractionOfSecond(count);
           break;
+        case 'u':
+          builder.appendDayOfWeek1Based(count);
+          break;
         case 'w':
           builder.appendWeekOfWeekYear(count);
           break;


### PR DESCRIPTION
'U' in SimpleDateFormat represents day of week. Related issue https://github.com/facebookincubator/velox/issues/10354.