### PR TITLE
build(ci): Build metrics job failing due to build type check

### DIFF
--- a/scripts/build-metrics.py
+++ b/scripts/build-metrics.py
@@ -45,8 +45,6 @@ class BinarySizeAdapter(BenchmarkAdapter):
         result_fields_append: Dict[str, Any] = {},
     ) -> None:
         self.size_file = Path(size_file)
-        if build_type not in ["debug", "release"]:
-            raise ValueError(f"Build type '{build_type}' is not valid!")
         self.build_type = build_type
         super().__init__(command, result_fields_override, result_fields_append)
 
@@ -112,8 +110,6 @@ class NinjaLogAdapter(BenchmarkAdapter):
         result_fields_append: Dict[str, Any] = {},
     ) -> None:
         self.ninja_log = Path(ninja_log)
-        if build_type not in ["debug", "release"]:
-            raise ValueError(f"Build type '{build_type}' is not valid!")
         self.build_type = build_type
         super().__init__(command, result_fields_override, result_fields_append)
 


### PR DESCRIPTION
Build metrics job fails since it checks for builds to be 'debug' 'release', these are now 'debug-shared', 'debug-static' etc. 
Going to remove this check so we have more flexibility for the future. 
cc: https://github.com/facebookincubator/velox/actions/runs/12879960789/job/35908254047