### PR TITLE
fix: GFlags to GlobalConfig change for memoryUseHugepages usage

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -413,7 +413,7 @@ void MemoryAllocator::useHugePages(
     const ContiguousAllocation& data,
     bool enable) {
 #ifdef linux
-  if (config::globalConfig.memoryUseHugepages) {
+  if (!config::globalConfig.memoryUseHugepages) {
     return;
   }
   auto maybeRange = data.hugePageRange();


### PR DESCRIPTION
The change was incorrectly made here https://github.com/facebookincubator/velox/pull/11745/files#r1923767492