### PR TITLE
fix: Address incompatibility of ipaddress

### DIFF
--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -578,6 +578,14 @@ void appendNonNull(
           numNonNull,
           values,
           toJavaUuidValue);
+    } else if (stream->isIpAddress()) {
+      copyWordsWithRows(
+          output,
+          rows.data(),
+          nonNullIndices,
+          numNonNull,
+          values,
+          reverseIpAddressByteOrder);
     } else {
       copyWordsWithRows(
           output, rows.data(), nonNullIndices, numNonNull, values);
@@ -608,6 +616,13 @@ void serializeFlatVector(
             output, rows.data(), rows.size(), rawValues, toJavaDecimalValue);
       } else if (stream->isUuid()) {
         copyWords(output, rows.data(), rows.size(), rawValues, toJavaUuidValue);
+      } else if (stream->isIpAddress()) {
+        copyWords(
+            output,
+            rows.data(),
+            rows.size(),
+            rawValues,
+            reverseIpAddressByteOrder);
       } else {
         copyWords(output, rows.data(), rows.size(), rawValues);
       }

--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 #pragma once
+#include <folly/IPAddressV6.h>
 
 #include "velox/common/memory/ByteStream.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
@@ -54,6 +56,10 @@ static inline const std::string_view kRLE{"RLE"};
 static inline const std::string_view kDictionary{"DICTIONARY"};
 
 void initBitsToMapOnce();
+FOLLY_ALWAYS_INLINE int128_t
+reverseIpAddressByteOrder(int128_t currentIpBytes) {
+  return DecimalUtil::bigEndian(currentIpBytes);
+}
 
 FOLLY_ALWAYS_INLINE int128_t toJavaDecimalValue(int128_t value) {
   // Presto Java UnscaledDecimal128 representation uses signed magnitude

--- a/velox/serializers/VectorStream.cpp
+++ b/velox/serializers/VectorStream.cpp
@@ -67,6 +67,7 @@ VectorStream::VectorStream(
       nullsFirst_(opts.nullsFirst),
       isLongDecimal_(type_->isLongDecimal()),
       isUuid_(isUuidType(type_)),
+      isIpAddress_(isIPAddressType(type_)),
       opts_(opts),
       encoding_(getEncoding(encoding, vector)),
       nulls_(streamArena, true, true),
@@ -353,6 +354,8 @@ void VectorStream::append(folly::Range<const int128_t*> values) {
       val = toJavaDecimalValue(value);
     } else if (isUuid_) {
       val = toJavaUuidValue(value);
+    } else if (isIpAddress_) {
+      val = reverseIpAddressByteOrder(value);
     }
     values_.append<int128_t>(folly::Range(&val, 1));
   }

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -180,6 +180,10 @@ class VectorStream {
     return isUuid_;
   }
 
+  bool isIpAddress() const {
+    return isIpAddress_;
+  }
+
   void clear();
 
  private:
@@ -196,6 +200,7 @@ class VectorStream {
   const bool nullsFirst_;
   const bool isLongDecimal_;
   const bool isUuid_;
+  const bool isIpAddress_;
   const PrestoVectorSerde::PrestoOptions opts_;
   std::optional<VectorEncoding::Simple> encoding_;
   int32_t nonNullCount_{0};

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/ByteStream.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/serializers/PrestoVectorLexer.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -1162,6 +1163,24 @@ TEST_P(PrestoSerializerTest, longDecimal) {
     vector->setNull(i, true);
   }
   testRoundTrip(vector);
+}
+
+TEST_P(PrestoSerializerTest, ipaddress) {
+  auto ipaddress = makeFlatVector<int128_t>(
+      100,
+      [](auto row) {
+        return HugeInt::build(folly::Random::rand64(), folly::Random::rand64());
+      },
+      /* isNullAt */ nullptr,
+      IPADDRESS());
+
+  testRoundTrip(ipaddress);
+
+  // Add some nulls.
+  for (auto i = 0; i < 100; i += 7) {
+    ipaddress->setNull(i, true);
+  }
+  testRoundTrip(ipaddress);
 }
 
 TEST_P(PrestoSerializerTest, uuid) {


### PR DESCRIPTION
Summary:
Presto may perform constant folding on queries before sending the fragment to velox workers. However, when the workers receive the fragments, the fragments may contain types which had a different implementation than how velox implemented the type. This incompatibility results in incorrect results.

For example, this PR fixes the type incompatibility between Java coordinator and C++ worker for `ipaddress` types. 
 - Java coordinator, ipaddress is represented as a slice of 16 bytes which if represented as a number, would be big endian. 
- C++ worker, ipaddress is represented as an int128_t, in little endian form.

The discrepancy between these two can be see with on native engine, the result set will be `::ffff:1.2.3.4` represented in reverse byte order
```
SELECT 
  CAST(ip AS ipaddress) as casted_ip 
FROM 
  (
    VALUES 
      ('::ffff:1.2.3.4')
  ) AS t (ip)
```

To address this issue, we can reverse the byte order of the ipaddress type sent from and to Java.

**Note**: 

- This issue is not exclusive to ipaddrss, and other custom types in velox which have different underlying type/implementation than Java may suffer from this issue as well.

- We can likely enhance the fuzzer to help catch cases like this at diff time once custom fuzzer inputs are landed (https://github.com/facebookincubator/velox/pull/11466)

Differential Revision: D68284630


