### PR TITLE
feat: Add new FileFormat::SST to toFileFormat and toString

### DIFF
--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -37,6 +37,8 @@ FileFormat toFileFormat(std::string_view s) {
     return FileFormat::NIMBLE;
   } else if (s == "orc") {
     return FileFormat::ORC;
+  } else if (s == "sst") {
+    return FileFormat::SST;
   }
   return FileFormat::UNKNOWN;
 }
@@ -61,6 +63,8 @@ std::string_view toString(FileFormat fmt) {
       return "nimble";
     case FileFormat::ORC:
       return "orc";
+    case FileFormat::SST:
+      return "sst";
     default:
       return "unknown";
   }


### PR DESCRIPTION
Summary: A new file format FileFormat::SST was introduced, but it was not added to these methods (toFileFormat and toString). Adding a new case statement to the toFileFormat function to return the FileFormat::SST value when the input string is "sst". The toString function is also updated to include a new case statement to return "sst" when the file format is FileFormat::SST. This will allow users to specify the file format as "sst" when working with Velox.

Differential Revision: D68463647


