### PR TITLE
misc: Enable trace tool test

### DIFF
--- a/velox/tool/trace/tests/CMakeLists.txt
+++ b/velox/tool/trace/tests/CMakeLists.txt
@@ -22,13 +22,12 @@ add_executable(
   TableScanReplayerTest.cpp
   TableWriterReplayerTest.cpp)
 
-# Disabling this test temporarily due to issue :
-# https://github.com/facebookincubator/velox/issues/12071
+add_test(
+  NAME velox_tool_trace_test
+  COMMAND velox_tool_trace_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# add_test( NAME velox_tool_trace_test COMMAND velox_tool_trace_test
-# WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-
-# set_tests_properties(velox_tool_trace_test PROPERTIES TIMEOUT 3000)
+set_tests_properties(velox_tool_trace_test PROPERTIES TIMEOUT 3000)
 
 target_link_libraries(
   velox_tool_trace_test


### PR DESCRIPTION
Enable the Velox trace tool test as the flakey issue described in #12071 was fixed and merged.

Details in #12136 and #12124 
