### PR TITLE
fix(merge-join): Properly load lazies on right join

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -628,6 +628,11 @@ bool MergeJoin::addToOutputForRightJoin() {
         auto leftEnd = l == numLefts - 1 ? leftMatch_->endIndex : left->size();
 
         if (prepareOutput(left, right)) {
+          // Differently from left joins, for right joins we need to load lazies
+          // (from the left) whenever we detect we have to move to the next
+          // right batch, since this means that we will produce this buffer, but
+          // we may have subsequent matches.
+          loadColumns(left, *operatorCtx_->execCtx());
           output_->resize(outputSize_);
           leftMatch_->setCursor(l, leftStart);
           rightMatch_->setCursor(r, i);


### PR DESCRIPTION
Summary:
When executing a right outer merge join, we cannot produce a buffer
containing LazyVectors if the current left buffer may still participate in
subsequent records. This can cause an issue where the lazy vector is
materialized by an operator downstream only for a few records, and the merge
join code may still try to reference records that were not materialized,
leaving garbage in the output.

To fix it, ensure that whenever we detect we crossed the boundary to the next
right batch and an output batch is produced, that left lazies are loaded.

Differential Revision: D68480018


