### PR TITLE
fix: regexp_extract_all to not return a match in mismatched group

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1064,8 +1064,13 @@ void re2ExtractAll(
     const re2::StringPiece fullMatch = groups[0];
     const re2::StringPiece subMatch = groups[groupId];
 
-    arrayWriter.add_item().setNoCopy(
-        StringView(subMatch.data(), subMatch.size()));
+    // Check if the subMatch is null.
+    if (subMatch.data()) {
+      arrayWriter.add_item().setNoCopy(
+          StringView(subMatch.data(), subMatch.size()));
+    } else {
+      arrayWriter.add_null();
+    }
     pos = fullMatch.data() + fullMatch.size() - input.data();
     if (UNLIKELY(fullMatch.size() == 0)) {
       ++pos;

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1101,27 +1101,17 @@ TEST_F(Re2FunctionsTest, regexExtractAllConstantPatternConstantGroupId) {
 }
 
 TEST_F(Re2FunctionsTest, regexExtractAllMismatchedGroup) {
-  const auto testRe2ExtractAllMismatchedGroup =
-      [&](const std::string& source,
-          const std::string& pattern,
-          int groupId,
-          const std::vector<std::optional<std::string>>& expected) {
-        auto sourceVector = makeFlatVector<std::string>({source}, VARCHAR());
-        auto patternVector = makeFlatVector<std::string>({pattern}, VARCHAR());
-        auto groupIdVector =
-            makeFlatVector<int>(std::vector{groupId}, INTEGER());
-        // Make the complex vector explicitly, otherwise it would cause template
-        // conflict.
-        auto expectedVector = makeNullableArrayVector<std::string>(
-            std::vector<std::vector<std::optional<std::string>>>{expected});
-        std::string expression = "regexp_extract_all(c0, c1, c2)";
-        auto result = evaluate(
-            expression,
-            makeRowVector({sourceVector, patternVector, groupIdVector}));
-        assertEqualVectors(expectedVector, result);
-      };
-  testRe2ExtractAllMismatchedGroup(
-      "rat cat\nbat dog", "ra(.)|blah(.)(.)", 2, {std::nullopt});
+  auto sourceVector =
+      makeFlatVector<std::string>({"rat cat\nbat dog"}, VARCHAR());
+  auto patternVector =
+      makeFlatVector<std::string>({"ra(.)|blah(.)(.)"}, VARCHAR());
+  auto groupIdVector = makeFlatVector<int>(std::vector{2}, INTEGER());
+  auto expectedVector = makeNullableArrayVector<std::string>(
+      std::vector<std::vector<std::optional<std::string>>>{{std::nullopt}});
+  auto result = evaluate(
+      "regexp_extract_all(c0, c1, c2)",
+      makeRowVector({sourceVector, patternVector, groupIdVector}));
+  assertEqualVectors(expectedVector, result);
 }
 
 TEST_F(Re2FunctionsTest, regexExtractAllConstantPatternVariableGroupId) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -73,12 +73,6 @@ class Re2FunctionsTest : public test::FunctionBaseTest {
       const std::vector<std::optional<T>>& groupIds,
       const std::vector<std::optional<std::vector<std::string>>>& output);
 
-  void testRe2ExtractAll(
-      std::string source,
-      std::string pattern,
-      int idx,
-      std::vector<std::optional<std::string>> expected);
-
   std::string generateString(
       const char* characterSet,
       vector_size_t outputLength = 60) {
@@ -1076,24 +1070,6 @@ void Re2FunctionsTest::testRe2ExtractAll(
   assertEqualVectors(expectedResult, result);
 }
 
-void Re2FunctionsTest::testRe2ExtractAll(
-    std::string source,
-    std::string pattern,
-    int idx,
-    std::vector<std::optional<std::string>> expected) {
-  auto sourceVector = makeFlatVector<std::string>({source}, velox::VARCHAR());
-  auto patternVector = makeFlatVector<std::string>({pattern}, velox::VARCHAR());
-  auto idxVector = makeFlatVector<int>(std::vector<int>{idx}, velox::INTEGER());
-  // Make the complex vector explicitly, otherwise it would cause template
-  // conflict.
-  auto expectedVector = makeNullableArrayVector<std::string>(
-      std::vector<std::vector<std::optional<std::string>>>{expected});
-  std::string expression = "regexp_extract_all(c0, c1, c2)";
-  auto result = evaluate(
-      expression, makeRowVector({sourceVector, patternVector, idxVector}));
-  assertEqualVectors(expectedVector, result);
-}
-
 TEST_F(Re2FunctionsTest, regexExtractAllConstantPatternNoGroupId) {
   const std::vector<std::optional<std::string>> inputs = {
       "  123a   2b   14m  ", "123a 2b     14m", "123a2b14m"};
@@ -1125,7 +1101,27 @@ TEST_F(Re2FunctionsTest, regexExtractAllConstantPatternConstantGroupId) {
 }
 
 TEST_F(Re2FunctionsTest, regexExtractAllMismatchedGroup) {
-  testRe2ExtractAll("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2, {std::nullopt});
+  const auto testRe2ExtractAllMismatchedGroup =
+      [&](const std::string& source,
+          const std::string& pattern,
+          int groupId,
+          const std::vector<std::optional<std::string>>& expected) {
+        auto sourceVector = makeFlatVector<std::string>({source}, VARCHAR());
+        auto patternVector = makeFlatVector<std::string>({pattern}, VARCHAR());
+        auto groupIdVector =
+            makeFlatVector<int>(std::vector{groupId}, INTEGER());
+        // Make the complex vector explicitly, otherwise it would cause template
+        // conflict.
+        auto expectedVector = makeNullableArrayVector<std::string>(
+            std::vector<std::vector<std::optional<std::string>>>{expected});
+        std::string expression = "regexp_extract_all(c0, c1, c2)";
+        auto result = evaluate(
+            expression,
+            makeRowVector({sourceVector, patternVector, groupIdVector}));
+        assertEqualVectors(expectedVector, result);
+      };
+  testRe2ExtractAllMismatchedGroup(
+      "rat cat\nbat dog", "ra(.)|blah(.)(.)", 2, {std::nullopt});
 }
 
 TEST_F(Re2FunctionsTest, regexExtractAllConstantPatternVariableGroupId) {


### PR DESCRIPTION
Fix regexp_extract_all to avoid returning a match in mismatched group.

For example, 

```
regexp_extract_all("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2) 
```

is expected to return {NULL} because the first group `ra(.)` has a match while the second group `blah(.)` has no match. The current buggy implementation returns {""}.

This test case and the expected result is from presto's existing UT, see https://github.com/prestodb/presto/blob/48f2fb1cd0244e8ae1230d27445fcd15d6520597/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestRegexpFunctions.java#L214.

Fixes #12119.