### PR TITLE
build(cmake): Make monolithic libs be built inside Velox's own binary directory when being used as a subproject

### DIFF
--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -77,9 +77,9 @@ function(velox_add_library TARGET)
       # Create the target if this is the first invocation.
       add_library(velox ${_type} ${ARGN})
       set_target_properties(velox PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-                                             ${CMAKE_BINARY_DIR}/lib)
+                                             ${PROJECT_BINARY_DIR}/lib)
       set_target_properties(velox PROPERTIES ARCHIVE_OUTPUT_DIRECTORY
-                                             ${CMAKE_BINARY_DIR}/lib)
+                                             ${PROJECT_BINARY_DIR}/lib)
       install(TARGETS velox DESTINATION lib/velox)
     endif()
     # create alias for compatability


### PR DESCRIPTION
Similar to https://github.com/facebookincubator/velox/pull/12128, currently when Velox is imported as a subproject of another project, the monolithic libs `libvelox.a` / `libvelox.so` will be generated in root project's binary directory which is sub-optimal.

The patch fixes the issue so the libs will be generated inside Velox's binary directory.