### PR TITLE
fix: Address ipprefix type incompatibility mismatch

### DIFF
--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -578,6 +578,14 @@ void appendNonNull(
           numNonNull,
           values,
           toJavaUuidValue);
+    } else if (stream->isIpAddress()) {
+      copyWordsWithRows(
+          output,
+          rows.data(),
+          nonNullIndices,
+          numNonNull,
+          values,
+          reverseIpAddressByteOrder);
     } else {
       copyWordsWithRows(
           output, rows.data(), nonNullIndices, numNonNull, values);
@@ -608,6 +616,13 @@ void serializeFlatVector(
             output, rows.data(), rows.size(), rawValues, toJavaDecimalValue);
       } else if (stream->isUuid()) {
         copyWords(output, rows.data(), rows.size(), rawValues, toJavaUuidValue);
+      } else if (stream->isIpAddress()) {
+        copyWords(
+            output,
+            rows.data(),
+            rows.size(),
+            rawValues,
+            reverseIpAddressByteOrder);
       } else {
         copyWords(output, rows.data(), rows.size(), rawValues);
       }

--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 #pragma once
+#include <folly/IPAddressV6.h>
 
 #include "velox/common/memory/ByteStream.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
@@ -54,6 +56,10 @@ static inline const std::string_view kRLE{"RLE"};
 static inline const std::string_view kDictionary{"DICTIONARY"};
 
 void initBitsToMapOnce();
+FOLLY_ALWAYS_INLINE int128_t
+reverseIpAddressByteOrder(int128_t currentIpBytes) {
+  return DecimalUtil::bigEndian(currentIpBytes);
+}
 
 FOLLY_ALWAYS_INLINE int128_t toJavaDecimalValue(int128_t value) {
   // Presto Java UnscaledDecimal128 representation uses signed magnitude

--- a/velox/serializers/VectorStream.cpp
+++ b/velox/serializers/VectorStream.cpp
@@ -67,6 +67,7 @@ VectorStream::VectorStream(
       nullsFirst_(opts.nullsFirst),
       isLongDecimal_(type_->isLongDecimal()),
       isUuid_(isUuidType(type_)),
+      isIpAddress_(isIPAddressType(type_)),
       opts_(opts),
       encoding_(getEncoding(encoding, vector)),
       nulls_(streamArena, true, true),
@@ -353,6 +354,8 @@ void VectorStream::append(folly::Range<const int128_t*> values) {
       val = toJavaDecimalValue(value);
     } else if (isUuid_) {
       val = toJavaUuidValue(value);
+    } else if (isIpAddress_) {
+      val = reverseIpAddressByteOrder(value);
     }
     values_.append<int128_t>(folly::Range(&val, 1));
   }

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -180,6 +180,10 @@ class VectorStream {
     return isUuid_;
   }
 
+  bool isIpAddress() const {
+    return isIpAddress_;
+  }
+
   void clear();
 
  private:
@@ -196,6 +200,7 @@ class VectorStream {
   const bool nullsFirst_;
   const bool isLongDecimal_;
   const bool isUuid_;
+  const bool isIpAddress_;
   const PrestoVectorSerde::PrestoOptions opts_;
   std::optional<VectorEncoding::Simple> encoding_;
   int32_t nonNullCount_{0};

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -184,6 +184,10 @@ class VectorStream {
     return isIpAddress_;
   }
 
+  bool isIpPrefix() const {
+    return isIpPrefix_;
+  }
+
   void clear();
 
  private:
@@ -201,6 +205,7 @@ class VectorStream {
   const bool isLongDecimal_;
   const bool isUuid_;
   const bool isIpAddress_;
+  const bool isIpPrefix_;
   const PrestoVectorSerde::PrestoOptions opts_;
   std::optional<VectorEncoding::Simple> encoding_;
   int32_t nonNullCount_{0};

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -20,6 +20,7 @@
 #include <vector>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/ByteStream.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/serializers/PrestoVectorLexer.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -1162,6 +1163,24 @@ TEST_P(PrestoSerializerTest, longDecimal) {
     vector->setNull(i, true);
   }
   testRoundTrip(vector);
+}
+
+TEST_P(PrestoSerializerTest, ipaddress) {
+  auto ipaddress = makeFlatVector<int128_t>(
+      100,
+      [](auto row) {
+        return HugeInt::build(folly::Random::rand64(), folly::Random::rand64());
+      },
+      /* isNullAt */ nullptr,
+      IPADDRESS());
+
+  testRoundTrip(ipaddress);
+
+  // Add some nulls.
+  for (auto i = 0; i < 100; i += 7) {
+    ipaddress->setNull(i, true);
+  }
+  testRoundTrip(ipaddress);
 }
 
 TEST_P(PrestoSerializerTest, uuid) {


### PR DESCRIPTION
Summary:
Java represents ipprefix as 17 byte varchar with the first 16 bytes as BE form ipaddress, and the 17th byte as the prefix length.

In Velox, we represent ipprefix as a struct/row of <IPADRESS, TINYTINY> which is internally represented as a ROW<HUGEINT, TINYINT>. Natively, this is represented as int128_t for the ipaddress in LE form and int8_t for the prefix.

The mismatch in types causes serialization and deserialization issues because the encoding for java is VARIABLE_WIDTH encoding but Velox is sending ROW encoding.

To address this, let's transform the velox representation of IPPREFIX to match that of Java. In other words, transform ROW<IPADDRESS, TINYINT> -> VARIABLE_WIDTH (16 Byte BE form of ip, 1 byte tiny).

Differential Revision: D68285595


