### PR TITLE
misc(fuzzer): Support custom result verifier with compare() API in window fuzzer

### DIFF
--- a/velox/expression/fuzzer/FuzzerToolkit.cpp
+++ b/velox/expression/fuzzer/FuzzerToolkit.cpp
@@ -157,6 +157,23 @@ void compareVectors(
   LOG(INFO) << "Two vectors match.";
 }
 
+RowVectorPtr mergeRowVectors(
+    const std::vector<RowVectorPtr>& results,
+    velox::memory::MemoryPool* pool) {
+  auto totalCount = 0;
+  for (const auto& result : results) {
+    totalCount += result->size();
+  }
+  auto copy =
+      BaseVector::create<RowVector>(results[0]->type(), totalCount, pool);
+  auto copyCount = 0;
+  for (const auto& result : results) {
+    copy->copy(result.get(), copyCount, 0, result->size());
+    copyCount += result->size();
+  }
+  return copy;
+}
+
 void InputRowMetadata::saveToFile(const char* filePath) const {
   std::ofstream outputFile(filePath, std::ofstream::binary);
   saveStdVector(columnsToWrapInLazy, outputFile);

--- a/velox/expression/fuzzer/FuzzerToolkit.h
+++ b/velox/expression/fuzzer/FuzzerToolkit.h
@@ -120,6 +120,11 @@ void compareVectors(
     const std::string& rightName = "right",
     const std::optional<SelectivityVector>& rows = std::nullopt);
 
+// Merges a vector of RowVectors into one RowVector.
+RowVectorPtr mergeRowVectors(
+    const std::vector<RowVectorPtr>& results,
+    velox::memory::MemoryPool* pool);
+
 struct InputRowMetadata {
   // Column indices to wrap in LazyVector (in a strictly increasing order)
   std::vector<int> columnsToWrapInLazy;

--- a/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/AverageResultVerifier.h
@@ -52,6 +52,20 @@ class AverageResultVerifier : public ResultVerifier {
     }
   }
 
+  void initializeWindow(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& /*partitionByKeys*/,
+      const std::vector<SortingKeyAndOrder>& /*sortingKeysAndOrders*/,
+      const core::WindowNode::Function& function,
+      const std::string& /*frame*/,
+      const std::string& windowName) override {
+    if (function.functionCall->type()->isIntervalDayTime()) {
+      projections_ = asRowType(input[0]->type())->names();
+      projections_.push_back(
+          fmt::format("cast(to_milliseconds({}) as double)", windowName));
+    }
+  }
+
   bool compare(const RowVectorPtr& result, const RowVectorPtr& altResult)
       override {
     if (projections_.empty()) {

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileResultVerifier.h"
+#include "velox/functions/prestosql/fuzzer/AverageResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/WindowOffsetInputGenerator.h"
@@ -130,6 +131,7 @@ int main(int argc, char** argv) {
   // TODO: allow custom result verifiers.
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;
   using facebook::velox::exec::test::ApproxPercentileResultVerifier;
+  using facebook::velox::exec::test::AverageResultVerifier;
 
   static const std::unordered_map<
       std::string,
@@ -149,6 +151,7 @@ int main(int argc, char** argv) {
           // https://github.com/facebookincubator/velox/issues/6330
           {"max_data_size_for_stats", nullptr},
           {"sum_data_size_for_stats", nullptr},
+          {"avg", std::make_shared<AverageResultVerifier>()},
       };
 
   static const std::unordered_set<std::string> orderDependentFunctions = {


### PR DESCRIPTION
Summary:
The custom result verifiers of some functions provides a compare() API that can be used to 
compare the expected and actual results after certain transformation. This is needed for 
functions like `avg(interval) -> interval` because the result of this function can have a small 
precision error that should be tolerated. However, the window fuzzer used to only support 
the verify() API of custom result verifiers. This diff makes the window fuzzer to use the 
compare() API as well when available.

Differential Revision: D68507422


