### PR TITLE
fix(lazy-vector): Load lazies to be able to compare()

### DIFF
--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -150,6 +150,10 @@ class SimpleVector : public BaseVector {
       vector_size_t index,
       vector_size_t otherIndex,
       CompareFlags flags) const override {
+    // By design `this` is not a lazy vector (or it would not be a
+    // SimpleVector), but it may be a dictionary wrapped around a lazy, so we
+    // need to ensure it is loaded.
+    loadedVector();
     other = other->loadedVector();
     DCHECK(dynamic_cast<const SimpleVector<T>*>(other) != nullptr)
         << "Attempting to compare vectors not of the same type";


### PR DESCRIPTION
Summary:
Whenever clients try to .compare() vectors containing lazy vectors,
then need to be loaded first. The existing code ensured that lazies are loaded,
but if lazies were wrapped by a dictionary and on the left side of the
comparison, it would fail and trigger an assertion failure.

Differential Revision: D68515000


