### PR TITLE
feat: Spark unix_timestamp and to_unix_timestamp function support timestamp and date type

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -311,6 +311,16 @@ These functions support TIMESTAMP and DATE input types.
     Returns null if ``string`` does not match ``format`` or if ``format``
     is invalid.
 
+.. spark:function:: unix_timestamp(timestamp, format) -> integer
+   :noindex:
+
+    Returns the UNIX timestamp of time specified by ``timestamp``.
+
+.. spark:function:: unix_timestamp(date) -> integer
+   :noindex:
+
+    Returns the UNIX timestamp of time specified by ``date``.
+
 .. function:: week_of_year(x) -> integer
 
     Returns the `ISO-Week`_ of the year from x. The value ranges from ``1`` to ``53``.

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -33,6 +33,10 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<UnixSecondsFunction, int64_t, Timestamp>(
       {prefix + "unix_seconds"});
   registerFunction<UnixTimestampFunction, int64_t>({prefix + "unix_timestamp"});
+  registerFunction<UnixTimestampFunction, int64_t, Timestamp, Varchar>(
+      {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<UnixTimestampFunction, int64_t, Date, Varchar>(
+      {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
   registerFunction<UnixTimestampParseFunction, int64_t, Varchar>(
       {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
   registerFunction<


### PR DESCRIPTION
Spark unix_timestamp and to_unix_timestamp function should support timestamp and date type