### PR TITLE
test: Disable O_DIRECT in cache fuzzer

### DIFF
--- a/velox/common/file/tests/FaultyFileSystem.h
+++ b/velox/common/file/tests/FaultyFileSystem.h
@@ -47,8 +47,8 @@ class FaultyFileSystem : public FileSystem {
   // Extracts the delegated real file path by removing the faulty file system
   // scheme prefix.
   inline std::string_view extractPath(std::string_view path) const override {
-    VELOX_CHECK_EQ(path.find(scheme()), 0, "");
-    const auto filePath = path.substr(scheme().length());
+    const auto filePath =
+        (path.find(scheme()) == 0) ? path.substr(scheme().length()) : path;
     return getFileSystem(filePath, config_)->extractPath(filePath);
   }
 

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -28,7 +28,6 @@
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
-#include "velox/vector/fuzzer/Utils.h"
 
 DEFINE_int32(steps, 10, "Number of plans to generate and test.");
 
@@ -498,6 +497,12 @@ void CacheFuzzer::go() {
       FLAGS_steps > 0 || FLAGS_duration_sec > 0,
       "Either --steps or --duration_sec needs to be greater than zero.");
 
+  // O_DIRECT requires I/O size to be the same as a disk file block size which
+  // is not handled in SSD cache. Misalignment can lead to EINVAL in some
+  // filesystem and kernel version.
+  //
+  // TODO: add this support if needed later.
+  FLAGS_ssd_odirect = false;
   auto startTime = std::chrono::system_clock::now();
   size_t iteration = 0;
 


### PR DESCRIPTION
Summary:
O_DIRECT requires I/O size needs to be the same as a disk file block size
which is not handled in SSD cache. Misalignment can lead to EINVAL in some
filesystem and kernel version.

Differential Revision: D68562695


