### PR TITLE
fix(fuzzer): Catch errors during reference DB query execution

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -652,6 +652,10 @@ PrestoQueryRunner::executeAndReturnVector(const core::PlanNodePtr& plan) {
       LOG(WARNING) << "Query failed in Presto";
       return std::make_pair(
           std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
+    } catch (...) {
+      LOG(WARNING) << "Query failed in Presto";
+      return std::make_pair(
+          std::nullopt, ReferenceQueryErrorCode::kReferenceQueryFail);
     }
   }
 


### PR DESCRIPTION
Summary:
The aggregation fuzzer test started failing after we removed the catch-all block in https://github.com/facebookincubator/velox/pull/12135. 
Now it fails with an uncatched folly::json::parse_error. This is likely due to the fuzzer occasionally 
receives broken response from Presto server. (Unfortunately, I'm not able to reproduce the error 
locally.) So this diff adds the catch-all block back.

Differential Revision: D68570790


