### PR TITLE
feat(json): Add support for $internal$_json_string_to_array/map/cast

### DIFF
--- a/velox/examples/CMakeLists.txt
+++ b/velox/examples/CMakeLists.txt
@@ -19,7 +19,8 @@ target_link_libraries(
   velox_functions_lib
   velox_core
   velox_expression
-  re2::re2)
+  re2::re2
+  simdjson::simdjson)
 
 add_executable(velox_example_expression_eval ExpressionEval.cpp)
 

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -71,6 +71,18 @@ void registerJsonFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, prefix + "json_parse");
+
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_$internal$_json_string_to_array,
+      prefix + "$internal$json_string_to_array_cast");
+
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_$internal$_json_string_to_map,
+      prefix + "$internal$json_string_to_map_cast");
+
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_$internal$_json_string_to_row,
+      prefix + "$internal$json_string_to_row_cast");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/json/SIMDJsonUtil.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
@@ -71,5 +72,47 @@ struct JsonT {
 using Json = CustomType<JsonT>;
 
 void registerJsonType();
+
+/// Custom operator for casts from and to Json type.
+class JsonCastOperator : public exec::CastOperator {
+ public:
+  bool isSupportedFromType(const TypePtr& other) const override;
+
+  bool isSupportedToType(const TypePtr& other) const override;
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override;
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result,
+      const std::shared_ptr<exec::CastHooks>& hooks) const override;
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override;
+
+ private:
+  template <TypeKind kind>
+  void castFromJson(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      BaseVector& result) const;
+
+  mutable folly::once_flag initializeErrors_;
+  mutable std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
+  mutable std::string paddedInput_;
+};
 
 } // namespace facebook::velox


### PR DESCRIPTION
We add support for $internal$_json_string_to_array/map/cast functions. These are used by the presto co-ordinator when we have expressions of the form 
cast( json as array()/map()/row()) . Consider for example cast(json_parse(x) as array(varchar)) ; Currently we will have to parse the json represented by x twice, once in json_parse and a second time in the cast . We currently spend significant CPU canonicalizing these jsons, and this is wasted if we end up casting the result. The presto plan actually tries to invoke $internal$_json_string_to_array/map/cast which is converted to a cast currently in prestissimo (https://github.com/prestodb/presto/blob/master/presto-native-execution/presto_cpp/main/types/PrestoToVeloxExpr.cpp#L233) . Once this is merged , I will submit a PR to prestissimo to fix this in Presto.
Note: At the moment these functions do not behave correctly if the type casted to has a JSON , as that still should be canonicalized. I will be changing PrestoToVeloxExpr.cpp to ensure its only called for non json types.

Differential Revision: D68582388


