### PR TITLE
fix(sparksql): Fix regex_extract on mismatched group

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -138,25 +138,22 @@ bool re2Extract(
     if (emptyNoMatch) {
       result.setNoCopy(row, StringView(nullptr, 0));
       return true;
-    } else {
-      result.setNull(row, true);
-      return false;
     }
+    result.setNull(row, true);
+    return false;
   } else {
     const re2::StringPiece extracted = groups[groupId];
     // Check if the extracted data is null.
     if (extracted.data()) {
       result.setNoCopy(row, StringView(extracted.data(), extracted.size()));
       return !StringView::isInline(extracted.size());
-    } else {
-      if (emptyNoMatch) {
-        result.setNoCopy(row, StringView(nullptr, 0));
-        return true;
-      } else {
-        result.setNull(row, true);
-        return false;
-      }
     }
+    if (emptyNoMatch) {
+      result.setNoCopy(row, StringView(nullptr, 0));
+      return true;
+    }
+    result.setNull(row, true);
+    return false;
   }
 }
 
@@ -369,6 +366,8 @@ class Re2SearchAndExtractConstantPattern final : public exec::VectorFunction {
 
  private:
   RE2 re_;
+  // If true, returns empty string as result for no match case, which is Spark's
+  // behavior. Otherwise, returns null as result, which is Presto's behavior.
   const bool emptyNoMatch_;
 };
 

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -149,8 +149,13 @@ bool re2Extract(
       result.setNoCopy(row, StringView(extracted.data(), extracted.size()));
       return !StringView::isInline(extracted.size());
     } else {
-      result.setNull(row, true);
-      return false;
+      if (emptyNoMatch) {
+        result.setNoCopy(row, StringView(nullptr, 0));
+        return true;
+      } else {
+        result.setNull(row, true);
+        return false;
+      }
     }
   }
 }

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -44,6 +44,13 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
   return makeRe2Extract(name, inputArgs, config, /*emptyNoMatch=*/false);
 }
 
+std::shared_ptr<exec::VectorFunction> makeRegexExtractEmptyNoMatch(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config) {
+  return makeRe2Extract(name, inputArgs, config, /*emptyNoMatch=*/true);
+}
+
 class Re2FunctionsTest : public test::FunctionBaseTest {
  public:
   static void SetUpTestCase() {
@@ -54,6 +61,10 @@ class Re2FunctionsTest : public test::FunctionBaseTest {
         "re2_search", re2SearchSignatures(), makeRe2Search);
     exec::registerStatefulVectorFunction(
         "re2_extract", re2ExtractSignatures(), makeRegexExtract);
+    exec::registerStatefulVectorFunction(
+        "re2_extract_empty_no_match",
+        re2ExtractSignatures(),
+        makeRegexExtractEmptyNoMatch);
     exec::registerStatefulVectorFunction(
         "re2_extract_all", re2ExtractAllSignatures(), makeRe2ExtractAll);
     exec::registerStatefulVectorFunction("like", likeSignatures(), makeLike);
@@ -380,6 +391,21 @@ TEST_F(Re2FunctionsTest, regexExtract) {
                      std::optional<int> group) {
     return evaluateOnce<std::string>(
         "re2_extract(c0, c1, c2)", str, pattern, group);
+  });
+}
+
+template <typename F>
+void testRe2ExtractEmptyNoMatch(F&& regexExtract) {
+  // Group case that mismatch.
+  EXPECT_EQ(regexExtract("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2), "");
+}
+
+TEST_F(Re2FunctionsTest, regexExtract) {
+  testRe2ExtractEmptyNoMatch([&](std::optional<std::string> str,
+                                 std::optional<std::string> pattern,
+                                 std::optional<int> group) {
+    return evaluateOnce<std::string>(
+        "re2_extract_empty_no_match(c0, c1, c2)", str, pattern, group);
   });
 }
 

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -400,7 +400,7 @@ void testRe2ExtractEmptyNoMatch(F&& regexExtract) {
   EXPECT_EQ(regexExtract("rat cat\nbat dog", "ra(.)|blah(.)(.)", 2), "");
 }
 
-TEST_F(Re2FunctionsTest, regexExtract) {
+TEST_F(Re2FunctionsTest, regexExtractEmptyNoMatch) {
   testRe2ExtractEmptyNoMatch([&](std::optional<std::string> str,
                                  std::optional<std::string> pattern,
                                  std::optional<int> group) {


### PR DESCRIPTION
#12109 fixed the mismatched group issue for Presto, but it doesn't meet Spark 
user's expectation.This PR fixes the semantic issue for Spark SQL.