### PR TITLE
feat: Add Spark get_struct_field function

### DIFF
--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -21,7 +21,11 @@ Miscellaneous Functions
     The ``input`` must be of row type and nested complex type is allowed.
     The subfield position is specified by ``ordinal``.
     If ``ordinal`` is negative or greater than the children size of ``input``,
-    exception is thrown.
+    exception is thrown. ::
+
+        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 0); -- 1
+        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 1); -- array(1,2,3)
+        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 2); -- throws exception
 
 .. spark:function:: monotonically_increasing_id() -> bigint
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -23,9 +23,8 @@ Miscellaneous Functions
     If ``ordinal`` is negative or greater than the children size of ``input``,
     exception is thrown. ::
 
-        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 0); -- 1
-        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 1); -- array(1,2,3)
-        SELECT get_struct_field(from_json('{"a": 1, "b": [1, 2, 3]}'), 2); -- throws exception
+        SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').a; -- 1
+        SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').b; -- array(1,2,3)
 
 .. spark:function:: monotonically_increasing_id() -> bigint
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -15,6 +15,11 @@ Miscellaneous Functions
         SELECT at_least_n_non_nulls(2, 0, 1.0, NULL);  -- true
         SELECT at_least_n_non_nulls(2, 0, array(NULL), NULL);  -- true
 
+.. spark:function:: get_struct_field(input, ordinal) -> T
+
+    Returns the value of field in the row type `input`.
+    The field position is specified by `ordinal`.
+
 .. spark:function:: monotonically_increasing_id() -> bigint
 
     Returns monotonically increasing 64-bit integers. The generated ID is

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -17,9 +17,9 @@ Miscellaneous Functions
 
 .. spark:function:: get_struct_field(input, ordinal) -> T
 
-    Returns the value of nested field in the ``input``.
-    ``input`` must be of row type and nested complex type is allowed.
-    The field position is specified by ``ordinal``.
+    Returns the value of nested subfield in the ``input`` struct.
+    The ``input`` must be of row type and nested complex type is allowed.
+    The subfield position is specified by ``ordinal``.
     If ``ordinal`` is negative or greater than the children size of ``input``,
     exception is thrown.
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -21,7 +21,7 @@ Miscellaneous Functions
     ``input`` must be of row type and nested complex type is allowed.
     The field position is specified by ``ordinal``.
     If ``ordinal`` is negative or greater than the children size of ``input``,
-    it will throw exception.
+    exception is thrown.
 
 .. spark:function:: monotonically_increasing_id() -> bigint
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -15,12 +15,12 @@ Miscellaneous Functions
         SELECT at_least_n_non_nulls(2, 0, 1.0, NULL);  -- true
         SELECT at_least_n_non_nulls(2, 0, array(NULL), NULL);  -- true
 
-.. spark:function:: get_struct_field(input, ordinal) -> T
+.. spark:function:: get_struct_field(struct, ordinal) -> T
 
-    Returns the value of nested subfield in the ``input`` struct.
-    The ``input`` must be of row type and nested complex type is allowed.
+    Returns the value of nested subfield at position ``ordinal`` in the input ``struct``.
+    The input must be of row type and nested complex type is allowed.
     The subfield position is specified by ``ordinal``.
-    If ``ordinal`` is negative or greater than the children size of ``input``,
+    If ``ordinal`` is negative or greater than the children size of ``struct``,
     exception is thrown. ::
 
         SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').a; -- 1

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -17,8 +17,8 @@ Miscellaneous Functions
 
 .. spark:function:: get_struct_field(input, ordinal) -> T
 
-    Returns the value of field in the row type `input`.
-    The field position is specified by `ordinal`.
+    Returns the value of field in the row type ``input``.
+    The field position is specified by ``ordinal``.
 
 .. spark:function:: monotonically_increasing_id() -> bigint
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -19,9 +19,8 @@ Miscellaneous Functions
 
     Returns the value of nested subfield at position ``ordinal`` in the input ``struct``.
     The input must be of row type and nested complex type is allowed.
-    The subfield position is specified by ``ordinal``.
-    If ``ordinal`` is negative or greater than the children size of ``struct``,
-    exception is thrown. ::
+    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
+    the children size of ``struct``, exception is thrown. ::
 
         SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').a; -- 1
         SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').b; -- array(1,2,3)

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -17,8 +17,11 @@ Miscellaneous Functions
 
 .. spark:function:: get_struct_field(input, ordinal) -> T
 
-    Returns the value of field in the row type ``input``.
+    Returns the value of nested field in the ``input``.
+    ``input`` must be of row type and nested complex type is allowed.
     The field position is specified by ``ordinal``.
+    If ``ordinal`` is negative or greater than the children size of ``input``,
+    it will throw exception.
 
 .. spark:function:: monotonically_increasing_id() -> bigint
 

--- a/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
+++ b/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/sparksql/specialforms/AtLeastNNonNulls.h"
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/functions/sparksql/specialforms/FromJson.h"
+#include "velox/functions/sparksql/specialforms/GetStructField.h"
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
 #include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
 
@@ -48,6 +49,8 @@ void registerSpecialFormGeneralFunctions(const std::string& prefix) {
   exec::registerFunctionCallToSpecialForm(
       FromJsonCallToSpecialForm::kFromJson,
       std::make_unique<FromJsonCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      "get_struct_field", std::make_unique<GetStructFieldCallToSpecialForm>());
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   AtLeastNNonNulls.cpp
   DecimalRound.cpp
   FromJson.cpp
+  GetStructField.cpp
   MakeDecimal.cpp
   SparkCastExpr.cpp
   SparkCastHooks.cpp)

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/functions/sparksql/specialforms/GetStructField.h"
-#include <type/Type.h>
 #include "expression/Expr.h"
 #include "vector/ComplexVector.h"
 #include "vector/ConstantVector.h"

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/GetStructField.h"
+#include <type/Type.h>
+#include "expression/Expr.h"
+#include "vector/ComplexVector.h"
+#include "vector/ConstantVector.h"
+#include "velox/expression/PeeledEncoding.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::functions::sparksql {
+
+void GetStructFieldExpr::evalSpecialForm(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  VectorPtr input;
+  VectorPtr ordinalVector;
+  inputs_[0]->eval(rows, context, input);
+  inputs_[1]->eval(rows, context, ordinalVector);
+  VELOX_USER_CHECK(ordinalVector->isConstantEncoding());
+  auto ordinal =
+      ordinalVector->asUnchecked<ConstantVector<int32_t>>()->valueAt(0);
+  auto resultType = std::const_pointer_cast<const Type>(type_);
+
+  LocalSelectivityVector remainingRows(context, rows);
+  context.deselectErrors(*remainingRows);
+
+  LocalDecodedVector decoded(context, *input, *remainingRows);
+
+  auto* rawNulls = decoded->nulls();
+  if (rawNulls) {
+    remainingRows->deselectNulls(
+        rawNulls, remainingRows->begin(), remainingRows->end());
+  }
+
+  VectorPtr localResult;
+  if (!remainingRows->hasSelections()) {
+    localResult =
+        BaseVector::createNullConstant(resultType, rows.end(), context.pool());
+  } else {
+    auto rowData = decoded->base()->as<RowVector>();
+    if (decoded->isIdentityMapping()) {
+      localResult = rowData->childAt(ordinal);
+    } else {
+      localResult =
+          decoded->wrap(rowData->childAt(ordinal), *input, decoded->size());
+    }
+  }
+
+  context.moveOrCopyResult(localResult, *remainingRows, result);
+  context.releaseVector(localResult);
+
+  VELOX_CHECK_NOT_NULL(result);
+  if (rawNulls || context.errors()) {
+    EvalCtx::addNulls(
+        rows, remainingRows->asRange().bits(), context, resultType, result);
+  }
+
+  context.releaseVector(input);
+  context.releaseVector(ordinalVector);
+}
+
+TypePtr GetStructFieldCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& /*argTypes*/) {
+  VELOX_FAIL("get_struct_field function does not support type resolution.");
+}
+
+ExprPtr GetStructFieldCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& args,
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
+  VELOX_USER_CHECK_EQ(args.size(), 2, "get_struct_field expects two argument.");
+
+  VELOX_USER_CHECK_EQ(
+      args[0]->type()->kind(),
+      TypeKind::ROW,
+      "The first argument of get_struct_field should be of row type.");
+
+  VELOX_USER_CHECK_EQ(
+      args[1]->type()->kind(),
+      TypeKind::INTEGER,
+      "The second argument of get_struct_field should be of integer type.");
+
+  return std::make_shared<GetStructFieldExpr>(
+      type, std::move(args), trackCpuUsage);
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -24,7 +24,7 @@ namespace {
 // The input ``args`` must be of row type and nested complex type is allowed.
 // The field position is specified by ``ordinal``.
 // If ``ordinal`` is negative or greater than the children size of input,
-// it will throw exception.
+// exception is thrown.
 class GetStructFieldFunction : public exec::VectorFunction {
  public:
   GetStructFieldFunction(int32_t ordinal) : ordinal_(ordinal) {}

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -38,6 +38,10 @@ class GetStructFieldFunction : public exec::VectorFunction {
       VectorPtr& result) const override {
     exec::LocalDecodedVector decoded(context, *args[0], rows);
     auto rowData = decoded->base()->as<RowVector>();
+    VELOX_USER_CHECK_LT(
+        ordinal_,
+        rowData->childrenSize(),
+        "Invalid ordinal. Should be smaller than the children size of input row vector.");
     if (decoded->isIdentityMapping()) {
       result = rowData->childAt(ordinal_);
     } else {
@@ -92,11 +96,6 @@ exec::ExprPtr GetStructFieldCallToSpecialForm::constructSpecialForm(
   auto ordinal = constantVector->valueAt(0);
 
   VELOX_USER_CHECK_GE(ordinal, 0, "Invalid ordinal. Should be greater than 0.");
-  VELOX_USER_CHECK_LT(
-      ordinal,
-      args[0]->as<RowVector>()->childrenSize(),
-      "Invalid ordinal. Should be smaller than the children size of input row vector.");
-
   auto getStructFieldFunction =
       std::make_shared<GetStructFieldFunction>(ordinal);
 

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -20,7 +20,7 @@
 namespace facebook::velox::functions::sparksql {
 namespace {
 
-// Returns the value of nested field in the input struct.
+// Returns the value of nested subfield in the input struct.
 // The input must be of row type and nested complex type is allowed.
 // The subfield position is specified by 'ordinal'.
 // If 'ordinal' is negative or greater than the children size of input,

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -20,6 +20,8 @@
 namespace facebook::velox::functions::sparksql {
 namespace {
 
+// Vector function that returns the value of fields in a RowVector.
+// The constructor parameter ordinal controls the field index.
 class GetStructFieldFunction : public exec::VectorFunction {
  public:
   GetStructFieldFunction(int32_t ordinal) : ordinal_(ordinal) {}
@@ -41,6 +43,7 @@ class GetStructFieldFunction : public exec::VectorFunction {
   }
 
  private:
+  // The ordinal to select child from the struct
   const int32_t ordinal_;
 };
 

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -22,7 +22,7 @@ namespace {
 
 // Returns the value of nested field in the input struct.
 // The input must be of row type and nested complex type is allowed.
-// The subfield position is specified by ``ordinal``.
+// The subfield position is specified by 'ordinal'.
 // If 'ordinal' is negative or greater than the children size of input,
 // exception is thrown.
 class GetStructFieldFunction : public exec::VectorFunction {

--- a/velox/functions/sparksql/specialforms/GetStructField.h
+++ b/velox/functions/sparksql/specialforms/GetStructField.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SpecialForm.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::functions::sparksql {
+
+class GetStructFieldExpr : public SpecialForm {
+ public:
+  /// @param type The target type of the returned expression
+  /// @param expr The struct expression to get by field ordinal
+  /// @param trackCpuUsage Whether to track CPU usage
+  GetStructFieldExpr(
+      TypePtr type,
+      std::vector<ExprPtr>&& expr,
+      bool trackCpuUsage)
+      : SpecialForm(type, expr, "get_struct_field", false, trackCpuUsage) {}
+
+  void evalSpecialForm(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result) override;
+
+  void computePropagatesNulls() override {
+    propagatesNulls_ = inputs_[0]->propagatesNulls();
+  }
+};
+
+class GetStructFieldCallToSpecialForm : public exec::FunctionCallToSpecialForm {
+ public:
+  // Throws not supported exception.
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  /// @brief Returns an expression for get_struct_field special form. The
+  /// expression is a regular expression based on a custom VectorFunction
+  /// implementation.
+  /// @param type Result type.
+  /// @param args Two inputs. First input should be a RowVector. Second
+  /// input is the ordinal to get from RowVector, and must be constant
+  /// INTEGER.
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+
+  static constexpr const char* kGetStructField = "get_struct_field";
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetStructField.h
+++ b/velox/functions/sparksql/specialforms/GetStructField.h
@@ -26,12 +26,15 @@ class GetStructFieldExpr : public SpecialForm {
  public:
   /// @param type The target type of the returned expression
   /// @param expr The struct expression to get by field ordinal
+  /// @param ordinal The ordinal to get from struct expression
   /// @param trackCpuUsage Whether to track CPU usage
   GetStructFieldExpr(
       TypePtr type,
       std::vector<ExprPtr>&& expr,
+      int32_t ordinal,
       bool trackCpuUsage)
-      : SpecialForm(type, expr, "get_struct_field", false, trackCpuUsage) {}
+      : SpecialForm(type, expr, "get_struct_field", false, trackCpuUsage),
+        ordinal_(ordinal) {}
 
   void evalSpecialForm(
       const SelectivityVector& rows,
@@ -41,6 +44,9 @@ class GetStructFieldExpr : public SpecialForm {
   void computePropagatesNulls() override {
     propagatesNulls_ = inputs_[0]->propagatesNulls();
   }
+
+ private:
+  const int32_t ordinal_;
 };
 
 class GetStructFieldCallToSpecialForm : public exec::FunctionCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/GetStructField.h
+++ b/velox/functions/sparksql/specialforms/GetStructField.h
@@ -16,38 +16,8 @@
 #pragma once
 
 #include "velox/expression/FunctionCallToSpecialForm.h"
-#include "velox/expression/SpecialForm.h"
-
-using namespace facebook::velox::exec;
 
 namespace facebook::velox::functions::sparksql {
-
-class GetStructFieldExpr : public SpecialForm {
- public:
-  /// @param type The target type of the returned expression
-  /// @param expr The struct expression to get by field ordinal
-  /// @param ordinal The ordinal to get from struct expression
-  /// @param trackCpuUsage Whether to track CPU usage
-  GetStructFieldExpr(
-      TypePtr type,
-      std::vector<ExprPtr>&& expr,
-      int32_t ordinal,
-      bool trackCpuUsage)
-      : SpecialForm(type, expr, "get_struct_field", false, trackCpuUsage),
-        ordinal_(ordinal) {}
-
-  void evalSpecialForm(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      VectorPtr& result) override;
-
-  void computePropagatesNulls() override {
-    propagatesNulls_ = inputs_[0]->propagatesNulls();
-  }
-
- private:
-  const int32_t ordinal_;
-};
 
 class GetStructFieldCallToSpecialForm : public exec::FunctionCallToSpecialForm {
  public:

--- a/velox/functions/sparksql/specialforms/GetStructField.h
+++ b/velox/functions/sparksql/specialforms/GetStructField.h
@@ -28,12 +28,12 @@ class GetStructFieldCallToSpecialForm : public exec::FunctionCallToSpecialForm {
   /// expression is a regular expression based on a custom VectorFunction
   /// implementation.
   /// @param type Result type.
-  /// @param args Two inputs. First input should be a RowVector. Second
-  /// input is the ordinal to get from RowVector, and must be constant
-  /// INTEGER.
+  /// @param args Two inputs. First input should be of row type.
+  /// Second input is the ordinal to select child from the struct,
+  /// and must be constant INTEGER.
   exec::ExprPtr constructSpecialForm(
       const TypePtr& type,
-      std::vector<exec::ExprPtr>&& compiledChildren,
+      std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
 

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   ElementAtTest.cpp
   FromJsonTest.cpp
   GetJsonObjectTest.cpp
+  GetStructFieldTest.cpp
   HashTest.cpp
   InTest.cpp
   JsonArrayLengthTest.cpp

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "functions/sparksql/specialforms/GetStructField.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class GetStructFieldTest : public SparkFunctionBaseTest {
+ protected:
+  void GetStructFieldSimple(
+      const VectorPtr& parameter,
+      const VectorPtr& index,
+      const TypePtr& inputType,
+      const TypePtr& resultType,
+      const VectorPtr& expected = nullptr) {
+    core::TypedExprPtr data =
+        std::make_shared<const core::FieldAccessTypedExpr>(inputType, "c0");
+    core::TypedExprPtr ordinal =
+        std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c1");
+    auto getStructFieldExpr = std::make_shared<const core::CallTypedExpr>(
+        resultType,
+        std::vector<core::TypedExprPtr>{data, ordinal},
+        "get_struct_field");
+    auto result = evaluate(
+        getStructFieldExpr, makeRowVector({"c0", "c1"}, {parameter, index}));
+    if (expected) {
+      ::facebook::velox::test::assertEqualVectors(expected, result);
+    }
+  }
+};
+
+TEST_F(GetStructFieldTest, simpleInteger) {
+  auto dataType = ROW({"k1", "k2", "a"}, {BIGINT(), BIGINT(), BIGINT()});
+  auto data = makeRowVector(
+      {"k1", "k2", "a"},
+      {makeNullableFlatVector<int32_t>({12}),
+       makeNullableFlatVector<int32_t>({2}),
+       makeNullableFlatVector<int32_t>({1})});
+  auto result = makeNullableFlatVector<int32_t>({2});
+  auto index = makeConstant<int32_t>(1, 1);
+  GetStructFieldSimple(data, index, dataType, INTEGER(), result);
+}
+
+TEST_F(GetStructFieldTest, simpleVarchar) {
+  auto dataType = ROW({"k1", "k2", "a"}, {BIGINT(), VARCHAR(), BIGINT()});
+  auto data = makeRowVector(
+      {"k1", "k2", "a"},
+      {makeNullableFlatVector<int32_t>({12}),
+       makeNullableFlatVector<std::string>({"Milly"}),
+       makeNullableFlatVector<int32_t>({1})});
+  auto result = makeNullableFlatVector<std::string>({"Milly"});
+  auto index = makeConstant<int32_t>(1, 1);
+  GetStructFieldSimple(data, index, dataType, VARCHAR(), result);
+}
+
+TEST_F(GetStructFieldTest, simpleNull) {
+  auto dataType = ROW({"k1", "k2", "a"}, {BIGINT(), BIGINT(), BIGINT()});
+  auto data = makeRowVector(
+      {"k1", "k2", "a"},
+      {makeNullableFlatVector<int32_t>({12}),
+       makeNullableFlatVector<int32_t>({std::nullopt}),
+       makeNullableFlatVector<int32_t>({1})});
+  auto result = makeNullableFlatVector<int32_t>({std::nullopt});
+  auto index = makeConstant<int32_t>(1, 1);
+  GetStructFieldSimple(data, index, dataType, INTEGER(), result);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -33,15 +33,12 @@ class GetStructFieldTest : public SparkFunctionBaseTest {
     auto ordinalVector = makeConstant<int32_t>(ordinal, batchSize);
     std::vector<core::TypedExprPtr> inputs = {
         std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c1")
-    };
+        std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c1")};
     auto resultType = expected->type();
     auto expr = std::make_shared<const core::CallTypedExpr>(
-        resultType,
-        std::move(inputs),
-        "get_struct_field");
-    auto result = evaluate(
-        expr, makeRowVector({"c0", "c1"}, {input, ordinalVector}));
+        resultType, std::move(inputs), "get_struct_field");
+    auto result =
+        evaluate(expr, makeRowVector({"c0", "c1"}, {input, ordinalVector}));
     ::facebook::velox::test::assertEqualVectors(expected, result);
   }
 };
@@ -63,20 +60,12 @@ TEST_F(GetStructFieldTest, simpleType) {
 }
 
 TEST_F(GetStructFieldTest, complexType) {
-  auto col0 = makeArrayVector<int32_t>({
-    {1, 2},
-    {3, 4}
-  });
-  auto col1 = makeMapVector<std::string, int32_t>({
-    {{"a", 0}, {"b", 1}},
-    {{"c", 3}, {"d", 4}}
-  });
-  auto col2 = makeRowVector({
-    makeArrayVector<int32_t>({
-      {100, 101}, {200, 202}, {300, 303}
-    }),
-    makeFlatVector<std::string>({"a", "b"})
-  });
+  auto col0 = makeArrayVector<int32_t>({{1, 2}, {3, 4}});
+  auto col1 = makeMapVector<std::string, int32_t>(
+      {{{"a", 0}, {"b", 1}}, {{"c", 3}, {"d", 4}}});
+  auto col2 = makeRowVector(
+      {makeArrayVector<int32_t>({{100, 101}, {200, 202}, {300, 303}}),
+       makeFlatVector<std::string>({"a", "b"})});
   auto data = makeRowVector({col0, col1, col2});
 
   // Get array field

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -112,7 +112,7 @@ TEST_F(GetStructFieldTest, invalidOrdinal) {
   VELOX_ASSERT_THROW(
       testGetStructField(data, 4, colString),
       fmt::format(
-          "Invalid ordinal. Should be smaller than the children size of input row vector."));
+          "(4 vs. 3) Invalid ordinal. Should be smaller than the children size of input row vector."));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -34,13 +34,12 @@ class GetStructFieldTest : public SparkFunctionBaseTest {
     std::vector<core::TypedExprPtr> inputs = {
         std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
         std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal))};
-    auto resultType = expected->type();
     auto expr = std::make_shared<const core::CallTypedExpr>(
-        resultType, std::move(inputs), "get_struct_field");
+        expected->type(), std::move(inputs), "get_struct_field");
 
     // Input is flat.
     auto result = evaluate(expr, makeRowVector({input}));
-    ::facebook::velox::test::assertEqualVectors(expected, result);
+    assertEqualVectors(expected, result);
 
     // Input is dictionary or constant encoding.
     testEncodings(expr, {input}, expected);

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -29,16 +29,13 @@ class GetStructFieldTest : public SparkFunctionBaseTest {
       const VectorPtr& input,
       int ordinal,
       const VectorPtr& expected) {
-    auto batchSize = expected->size();
-    auto ordinalVector = makeConstant<int32_t>(ordinal, batchSize);
     std::vector<core::TypedExprPtr> inputs = {
         std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c1")};
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal))};
     auto resultType = expected->type();
     auto expr = std::make_shared<const core::CallTypedExpr>(
         resultType, std::move(inputs), "get_struct_field");
-    auto result =
-        evaluate(expr, makeRowVector({"c0", "c1"}, {input, ordinalVector}));
+    auto result = evaluate(expr, makeRowVector({input}));
     ::facebook::velox::test::assertEqualVectors(expected, result);
   }
 };

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -112,8 +112,7 @@ TEST_F(GetStructFieldTest, invalidOrdinal) {
   VELOX_ASSERT_THROW(
       testGetStructField(data, 4, colString),
       fmt::format(
-          "Invalid ordinal. Should be small than the children size of input row vector {}.",
-          3));
+          "Invalid ordinal. Should be smaller than the children size of input row vector."));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -63,9 +63,9 @@ TEST_F(GetStructFieldTest, complexType) {
   auto col0 = makeArrayVector<int32_t>({{1, 2}, {3, 4}});
   auto col1 = makeMapVector<std::string, int32_t>(
       {{{"a", 0}, {"b", 1}}, {{"c", 3}, {"d", 4}}});
-  auto col2 = makeRowVector(
-      {makeArrayVector<int32_t>({{100, 101}, {200, 202}, {300, 303}}),
-       makeFlatVector<std::string>({"a", "b"})});
+  auto col2 = makeRowVector({
+    makeArrayVector<int32_t>({{100, 101, 102}, {200, 201, 202}, {300, 301, 302}}),
+    makeFlatVector<std::string>({"a", "b", "c"})});
   auto data = makeRowVector({col0, col1, col2});
 
   // Get array field

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -63,9 +63,10 @@ TEST_F(GetStructFieldTest, complexType) {
   auto col0 = makeArrayVector<int32_t>({{1, 2}, {3, 4}});
   auto col1 = makeMapVector<std::string, int32_t>(
       {{{"a", 0}, {"b", 1}}, {{"c", 3}, {"d", 4}}});
-  auto col2 = makeRowVector({
-    makeArrayVector<int32_t>({{100, 101, 102}, {200, 201, 202}, {300, 301, 302}}),
-    makeFlatVector<std::string>({"a", "b", "c"})});
+  auto col2 = makeRowVector(
+      {makeArrayVector<int32_t>(
+           {{100, 101, 102}, {200, 201, 202}, {300, 301, 302}}),
+       makeFlatVector<std::string>({"a", "b", "c"})});
   auto data = makeRowVector({col0, col1, col2});
 
   // Get array field

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -46,13 +46,13 @@ TEST_F(GetStructFieldTest, simpleType) {
   auto col2 = makeNullableFlatVector<int32_t>({std::nullopt, 12});
   auto data = makeRowVector({col0, col1, col2});
 
-  // Get int field
+  // Get int field.
   testGetStructField(data, 0, col0);
 
-  // Get string field
+  // Get string field.
   testGetStructField(data, 1, col1);
 
-  // Get int field with null
+  // Get int field with null.
   testGetStructField(data, 2, col2);
 }
 
@@ -66,13 +66,13 @@ TEST_F(GetStructFieldTest, complexType) {
        makeFlatVector<std::string>({"a", "b", "c"})});
   auto data = makeRowVector({col0, col1, col2});
 
-  // Get array field
+  // Get array field.
   testGetStructField(data, 0, col0);
 
-  // Get map field
+  // Get map field.
   testGetStructField(data, 1, col1);
 
-  // Get row field
+  // Get row field.
   testGetStructField(data, 2, col2);
 }
 


### PR DESCRIPTION
Returns the value of nested field in the struct.
Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala#L105.