### PR TITLE
fix: Make TPCH dbgen text buffer size consistent with Presto Java

### DIFF
--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -97,11 +97,11 @@ TEST_F(TpchConnectorTest, simple) {
       makeFlatVector<int64_t>({0, 1, 1, 1, 4}),
       // n_comment
       makeFlatVector<StringView>({
-          "furiously regular requests. platelets affix furious",
-          "instructions wake quickly. final deposits haggle. final, silent theodolites ",
-          "asymptotes use fluffily quickly bold instructions. slyly bold dependencies sleep carefully pending accounts",
-          "ss deposits wake across the pending foxes. packages after the carefully bold requests integrate caref",
-          "usly ironic, pending foxes. even, special instructions nag. sly, final foxes detect slyly fluffily ",
+          " haggle. carefully final deposits detect slyly agai",
+          "al foxes promise slyly according to the regular accounts. bold requests alon",
+          "y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special ",
+          "eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold",
+          "y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d",
       }),
   });
   test::assertEqualVectors(expected, output);

--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -37,7 +37,8 @@ class DBGenBackend {
     // structures required by dbgen are populated.
     DBGenContext dbgenCtx;
     load_dists(
-        10 * 1024 * 1024, &dbgenCtx); // 10 MB buffer size for text generation.
+        300 * 1024 * 1024,
+        &dbgenCtx); // 300 MB buffer size for text generation.
   }
   ~DBGenBackend() {
     cleanup_dists();


### PR DESCRIPTION
Changed text buffer size to be 300 MB for Velox's dbgen to match with Java Presto TPCH dbgen's text buffer size. The text buffer size is used in randomly generating offset and length to grab a chunk from the overall text for each row. This fixed the difference in the comment column for the tables in TPCH. 

Java:
https://github.com/trinodb/tpch/blob/master/src/main/java/io/trino/tpch/TextPool.java#L35
```
private static final int DEFAULT_TEXT_POOL_SIZE = 300 * 1024 * 1024;
```

C++:
https://github.com/facebookincubator/velox/blob/main/velox/tpch/gen/DBGenIterator.cpp#L40
```
load_dists(
        10 * 1024 * 1024, &dbgenCtx); // 10 MB buffer size for text generation.
```

Resolves: https://github.com/prestodb/presto/issues/24011