### PR TITLE
feat: Add single node mode for query trace tool

### DIFF
--- a/velox/common/base/TraceConfig.cpp
+++ b/velox/common/base/TraceConfig.cpp
@@ -25,11 +25,13 @@ TraceConfig::TraceConfig(
     std::unordered_set<std::string> _queryNodeIds,
     std::string _queryTraceDir,
     UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
-    std::string _taskRegExp)
+    std::string _taskRegExp,
+    bool _singleNodeMode)
     : queryNodes(std::move(_queryNodeIds)),
       queryTraceDir(std::move(_queryTraceDir)),
       updateAndCheckTraceLimitCB(std::move(_updateAndCheckTraceLimitCB)),
-      taskRegExp(std::move(_taskRegExp)) {
+      taskRegExp(std::move(_taskRegExp)),
+      singleNodeMode(_singleNodeMode) {
   VELOX_CHECK(!queryNodes.empty(), "Query trace nodes cannot be empty");
 }
 } // namespace facebook::velox::exec::trace

--- a/velox/common/base/TraceConfig.h
+++ b/velox/common/base/TraceConfig.h
@@ -45,11 +45,14 @@ struct TraceConfig {
   UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB;
   /// The trace task regexp.
   std::string taskRegExp;
+  /// Single node mode.
+  bool singleNodeMode;
 
   TraceConfig(
       std::unordered_set<std::string> _queryNodeIds,
       std::string _queryTraceDir,
       UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
-      std::string _taskRegExp);
+      std::string _taskRegExp,
+      bool _singleNodeMode = false);
 };
 } // namespace facebook::velox::exec::trace

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -416,6 +416,11 @@ class QueryConfig {
   static constexpr const char* kQueryTraceTaskRegExp =
       "query_trace_task_reg_exp";
 
+  /// Single Trace node mode. Only write the target trace node metadata if true,
+  /// and the num of query trace nodes must be 1.
+  static constexpr const char* kQueryTraceSingleNodeMode =
+      "query_trace_single_node_mode";
+
   /// Config used to create operator trace directory. This config is provided to
   /// underlying file system and the config is free form. The form should be
   /// defined by the underlying file system.
@@ -786,6 +791,10 @@ class QueryConfig {
   std::string queryTraceTaskRegExp() const {
     // The default query trace task regexp, empty by default.
     return get<std::string>(kQueryTraceTaskRegExp, "");
+  }
+
+  bool queryTraceSingleNodeMode() const {
+    return get<bool>(kQueryTraceSingleNodeMode, false);
   }
 
   std::string opTraceDirectoryCreateConfig() const {

--- a/velox/exec/TaskTraceWriter.cpp
+++ b/velox/exec/TaskTraceWriter.cpp
@@ -66,4 +66,11 @@ void TaskTraceMetadataWriter::write(
   file->close();
 }
 
+void TaskTraceMetadataWriter::write(
+    const std::shared_ptr<core::QueryCtx>& queryCtx,
+    const core::PlanNodePtr& planNode,
+    const core::PlanNodeId& planNodeId) {
+  write(queryCtx, copyTraceNode(planNode, planNodeId));
+}
+
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/TaskTraceWriter.h
+++ b/velox/exec/TaskTraceWriter.h
@@ -29,6 +29,11 @@ class TaskTraceMetadataWriter {
       const std::shared_ptr<core::QueryCtx>& queryCtx,
       const core::PlanNodePtr& planNode);
 
+  void write(
+      const std::shared_ptr<core::QueryCtx>& queryCtx,
+      const core::PlanNodePtr& planNode,
+      const core::PlanNodeId& planNodeId);
+
  private:
   const std::string traceDir_;
   const std::shared_ptr<filesystems::FileSystem> fs_;


### PR DESCRIPTION
The `TaskTraceMetadataWriter` serializes and writes the entire plan
fragment to the task metadata file. Then, the `TaskTraceMetadataReader`
deserializes the task metadata, extracts the target trace node, and constructs
a replay node by using it.

This PR adds a single node mode that `TaskTraceMetadataWriter` only serializes
the mirror node constructed using the target trace node. In this mode, it replaces
its source nodes with `DummySourceNode` to retain the trace node's input types.