### PR TITLE
fix(driver): Fix isBlockedTiming updating

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -571,7 +571,6 @@ StopReason Driver::runInternal(
               curOperatorId_,
               kOpMethodIsBlocked);
         });
-
         if (blockingReason_ != BlockingReason::kNotBlocked) {
           return blockDriver(self, i, std::move(future), blockingState, guard);
         }
@@ -579,7 +578,7 @@ StopReason Driver::runInternal(
         if (i < numOperators - 1) {
           Operator* nextOp = operators_[i + 1].get();
 
-          withDeltaCpuWallTimer(op, &OperatorStats::isBlockedTiming, [&]() {
+          withDeltaCpuWallTimer(nextOp, &OperatorStats::isBlockedTiming, [&]() {
             CALL_OPERATOR(
                 blockingReason_ = nextOp->isBlocked(&future),
                 nextOp,
@@ -1045,11 +1044,12 @@ void Driver::withDeltaCpuWallTimer(
   // If 'trackOperatorCpuUsage_' is true, create and initialize the timer object
   // to track cpu and wall time of the opFunction.
   if (!trackOperatorCpuUsage_) {
-    return opFunction();
+    opFunction();
+    return;
   }
 
   // The delta CpuWallTiming object would be recorded to the corresponding
-  // opTimingMember upon destruction of the timer when withDeltaCpuWallTimer
+  // 'opTimingMember' upon destruction of the timer when withDeltaCpuWallTimer
   // ends. The timer is created on the stack to avoid heap allocation
   auto f = [op, opTimingMember, this](const CpuWallTiming& elapsedTime) {
     auto elapsedSelfTime = processLazyIoStats(*op, elapsedTime);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1226,7 +1226,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
     EXPECT_EQ(32 * i, operatorStats.outputBytes);
     EXPECT_EQ(3 * i, operatorStats.outputPositions);
     EXPECT_EQ(i, operatorStats.outputVectors);
-    EXPECT_EQ(2 * (i + 1), operatorStats.isBlockedTiming.count);
+    EXPECT_EQ(i + 1, operatorStats.isBlockedTiming.count);
     EXPECT_EQ(0, operatorStats.finishTiming.count);
     EXPECT_EQ(0, operatorStats.backgroundTiming.count);
 
@@ -1253,11 +1253,18 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
   EXPECT_EQ(32 * numBatches, operatorStats.outputBytes);
   EXPECT_EQ(3 * numBatches, operatorStats.outputPositions);
   EXPECT_EQ(numBatches, operatorStats.outputVectors);
-  // isBlocked() should be called at least twice for each batch
-  EXPECT_LE(2 * numBatches, operatorStats.isBlockedTiming.count);
+  // For the first operator, 'isBlocked()' should be called at least once for
+  // each batch.
+  EXPECT_LE(numBatches, operatorStats.isBlockedTiming.count);
   EXPECT_EQ(1, operatorStats.finishTiming.count);
   // No operators with background CPU time yet.
   EXPECT_EQ(0, operatorStats.backgroundTiming.count);
+
+  const auto& secondOperatorStats =
+      finishStats.pipelineStats[0].operatorStats[1];
+  // For non-first operators, 'isBlocked()' should be called at least twice for
+  // each batch.
+  EXPECT_LE(2 * numBatches, secondOperatorStats.isBlockedTiming.count);
 
   EXPECT_NE(0, finishStats.executionEndTimeMs);
   EXPECT_NE(0, finishStats.terminationTimeMs);


### PR DESCRIPTION
Fixes #12173

In the current implementation, the time consumed by calling  
`nextOp->isBlocked()` will be accumulated to the  
previous operator (`op`), which is wrong and should be accumulated to `nextOp`.