### PR TITLE
Add SerDe code for member field HiveTableHandle::tableParameters_

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -145,6 +145,20 @@ std::string HiveTableHandle::toString() const {
   if (dataColumns_) {
     out << ", data columns: " << dataColumns_->toString();
   }
+  if (!tableParameters_.empty()) {
+    std::map<std::string, std::string> orderedTableParameters{
+        tableParameters_.begin(), tableParameters_.end()};
+    out << ", table parameters: [";
+    bool notFirstParam = false;
+    for (const auto& param : orderedTableParameters) {
+      if (notFirstParam) {
+        out << ", ";
+      }
+      out << param.first << ":" << param.second;
+      notFirstParam = true;
+    }
+    out << "]";
+  }
   return out.str();
 }
 
@@ -168,6 +182,11 @@ folly::dynamic HiveTableHandle::serialize() const {
   if (dataColumns_) {
     obj["dataColumns"] = dataColumns_->serialize();
   }
+  folly::dynamic tableParameters = folly::dynamic::object;
+  for (const auto& param : tableParameters_) {
+    tableParameters[param.first] = param.second;
+  }
+  obj["tableParameters"] = tableParameters;
 
   return obj;
 }
@@ -200,13 +219,21 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     dataColumns = ISerializable::deserialize<RowType>(it->second, context);
   }
 
+  std::unordered_map<std::string, std::string> tableParameters{};
+  folly::dynamic tableParametersObj = obj["tableParameters"];
+  for (const auto& key : tableParametersObj.keys()) {
+    const auto& value = tableParametersObj[key];
+    tableParameters.emplace(key.asString(), value.asString());
+  }
+
   return std::make_shared<const HiveTableHandle>(
       connectorId,
       tableName,
       filterPushdownEnabled,
       std::move(subfieldFilters),
       remainingFilter,
-      dataColumns);
+      dataColumns,
+      tableParameters);
 }
 
 void HiveTableHandle::registerSerDe() {

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 
@@ -128,7 +129,9 @@ TEST_F(HiveConnectorSerDeTest, hiveTableHandle) {
           .build(),
       parseExpr("c1 > c4 and c3 = true", rowType),
       "hive_table",
-      ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
+      ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
+      true,
+      {{dwio::common::TableParameter::kSkipHeaderLineCount, "1"}});
   testSerde(*tableHandle);
 }
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -120,14 +120,17 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table",
       const RowTypePtr& dataColumns = nullptr,
-      bool filterPushdownEnabled = true) {
+      bool filterPushdownEnabled = true,
+      const std::unordered_map<std::string, std::string>& tableParameters =
+          {}) {
     return std::make_shared<connector::hive::HiveTableHandle>(
         kHiveConnectorId,
         tableName,
         filterPushdownEnabled,
         std::move(subfieldFilters),
         remainingFilter,
-        dataColumns);
+        dataColumns,
+        tableParameters);
   }
 
   /// @param name Column name.


### PR DESCRIPTION
SerDe code for the field `HiveTableHandle::tableParameters_` is missing. The patch adds it.

Related to #6710 