### PR TITLE
fix: Bitwise operations on signed integers (Part-1)

### DIFF
--- a/velox/common/base/BigintIdMap.cpp
+++ b/velox/common/base/BigintIdMap.cpp
@@ -42,7 +42,7 @@ void BigintIdMap::resize(int64_t newCapacity) {
     if (*ptr == kEmptyMarker) {
       continue;
     }
-    auto newIndex = indexOfEntry(*ptr);
+    auto newIndex = static_cast<uint64_t>(indexOfEntry(*ptr));
     auto newPtr = valuePtr(table_, newIndex);
     while (*newPtr != kEmptyMarker) {
       newIndex = (newIndex + 1) & sizeMask_;

--- a/velox/common/base/SimdUtil.cpp
+++ b/velox/common/base/SimdUtil.cpp
@@ -71,7 +71,7 @@ void initByteSetBits() {
     int32_t* entry = detail::byteSetBits[i];
     int32_t fill = 0;
     for (auto b = 0; b < 8; ++b) {
-      if (i & (1 << b)) {
+      if (i & (1u << b)) {
         entry[fill++] = b;
       }
     }
@@ -86,7 +86,7 @@ void initPermute4x64Indices() {
     int32_t* result = detail::permute4x64Indices[i];
     int32_t fill = 0;
     for (int bit = 0; bit < 4; ++bit) {
-      if (i & (1 << bit)) {
+      if (i & (1u << bit)) {
         result[fill++] = bit * 2;
         result[fill++] = bit * 2 + 1;
       }

--- a/velox/common/base/benchmarks/SimdUtilBenchmark.cpp
+++ b/velox/common/base/benchmarks/SimdUtilBenchmark.cpp
@@ -48,7 +48,7 @@ class LeadingMask {
     return kSize;
   }
 
-  static constexpr int kSize = 4 << 10;
+  static constexpr int kSize = 4u << 10;
   int8_t inputs_[kSize];
 };
 
@@ -74,7 +74,7 @@ class FromBitMask {
     return kSize;
   }
 
-  static constexpr int kSize = 2 << 10;
+  static constexpr int kSize = 2u << 10;
   uint64_t inputs_[kSize];
 };
 

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -880,7 +880,7 @@ bool AsyncDataCache::canTryAllocate(
 
 void AsyncDataCache::backoff(int32_t counter) {
   size_t seed = folly::hasher<uint16_t>()(++backoffCounter_);
-  const auto usecs = (seed & 0xfff) * (counter & 0x1f);
+  const auto usecs = (seed & 0xfff) * (static_cast<unsigned int>(counter) & 0x1f);
   VELOX_CACHE_LOG_EVERY_MS(INFO, 1'000)
       << "Backoff in allocation contention for " << succinctMicros(usecs);
 

--- a/velox/common/compression/LzoDecompressor.cpp
+++ b/velox/common/compression/LzoDecompressor.cpp
@@ -91,7 +91,7 @@ uint64_t lzoDecompress(
       if (input >= inputLimit) {
         throw MalformedInputException(input - inputAddress);
       }
-      uint32_t command = *(input++) & 0xFF;
+      uint32_t command = static_cast<uint32_t>(*(input++)) & 0xFF;
       if (command == 0x11) {
         break;
       }
@@ -104,8 +104,8 @@ uint64_t lzoDecompress(
       // M: part of match length
       // ?: see documentation in command decoder
 
-      int32_t matchLength;
-      int32_t matchOffset;
+      uint32_t matchLength;
+      uint32_t matchOffset;
       uint32_t literalLength;
       if ((command & 0xf0) == 0) {
         if (lastLiteralLength == 0) {
@@ -126,7 +126,7 @@ uint64_t lzoDecompress(
             literalLength = 0xf;
 
             uint32_t nextByte = 0;
-            while (input < inputLimit && (nextByte = *(input++) & 0xFF) == 0) {
+            while (input < inputLimit && (nextByte = static_cast<uint32_t>(*(input++)) & 0xFF) == 0) {
               literalLength += 0xff;
             }
             literalLength += nextByte;
@@ -148,7 +148,7 @@ uint64_t lzoDecompress(
             throw MalformedInputException(input - inputAddress);
           }
           matchOffset = (command & 0xc) >> 2;
-          matchOffset |= (*(input++) & 0xFF) << 2;
+          matchOffset |= (static_cast<uint32_t>(*(input++)) & 0xFF) << 2;
           matchOffset |= 0x800;
 
           // literal length :: 2 bits :: valid range [0..3]
@@ -168,7 +168,7 @@ uint64_t lzoDecompress(
             throw MalformedInputException(input - inputAddress);
           }
           matchOffset = (command & 0xc) >> 2;
-          matchOffset |= (*(input++) & 0xFF) << 2;
+          matchOffset |= (static_cast<uint32_t>(*(input++)) & 0xFF) << 2;
 
           // literal length :: 2 bits :: valid range [0..3]
           //   [0..1] from command [0..1]
@@ -188,8 +188,8 @@ uint64_t lzoDecompress(
         if (matchLength == 0) {
           matchLength = 0x7;
 
-          int32_t nextByte = 0;
-          while (input < inputLimit && (nextByte = *(input++) & 0xFF) == 0) {
+          uint32_t nextByte = 0;
+          while (input < inputLimit && (nextByte = static_cast<uint32_t>(*(input++)) & 0xFF) == 0) {
             matchLength += 0xff;
           }
           matchLength += nextByte;
@@ -244,11 +244,11 @@ uint64_t lzoDecompress(
 
         // copy offset :: 14 bits :: valid range [0..16383]
         //  [0..13] from trailer [2..15]
-        matchOffset = trailer >> 2;
+        matchOffset = static_cast<uint32_t>(trailer) >> 2;
 
         // literal length :: 2 bits :: valid range [0..3]
         //   [0..1] from trailer [0..1]
-        literalLength = trailer & 0x3;
+        literalLength = static_cast<uint32_t>(trailer) & 0x3;
       } else if ((command & 0xc0) != 0) {
         // 0bMMMP_PPLL 0bPPPP_PPPP
 
@@ -265,7 +265,7 @@ uint64_t lzoDecompress(
           throw MalformedInputException(input - inputAddress);
         }
         matchOffset = (command & 0x1c) >> 2;
-        matchOffset |= (*(input++) & 0xFF) << 3;
+        matchOffset |= (static_cast<uint32_t>(*(input++)) & 0xFF) << 3;
 
         // literal length :: 2 bits :: valid range [0..3]
         //   [0..1] from command [0..1]

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -215,9 +215,9 @@ void Base64::encodeImpl(
   // For each group of 3 bytes (24 bits) in the input, split that into
   // 4 groups of 6 bits and encode that using the supplied charset lookup
   for (; inputSize > 2; inputSize -= 3) {
-    uint32_t inputBlock = static_cast<uint8_t>(*inputIterator++) << 16;
-    inputBlock |= static_cast<uint8_t>(*inputIterator++) << 8;
-    inputBlock |= static_cast<uint8_t>(*inputIterator++);
+    uint32_t inputBlock = static_cast<uint32_t>(*inputIterator++) << 16;
+    inputBlock |= static_cast<uint32_t>(*inputIterator++) << 8;
+    inputBlock |= static_cast<uint32_t>(*inputIterator++);
 
     *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
     *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
@@ -229,10 +229,10 @@ void Base64::encodeImpl(
     // We have either 1 or 2 input bytes left.  Encode this similar to the
     // above (assuming 0 for all other bytes).  Optionally append the '='
     // character if it is requested.
-    uint32_t inputBlock = static_cast<uint8_t>(*inputIterator++) << 16;
+    uint32_t inputBlock = static_cast<uint32_t>(*inputIterator++) << 16;
     *outputPointer++ = charset[(inputBlock >> 18) & 0x3f];
     if (inputSize > 1) {
-      inputBlock |= static_cast<uint8_t>(*inputIterator) << 8;
+      inputBlock |= static_cast<uint32_t>(*inputIterator) << 8;
       *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
       *outputPointer++ = charset[(inputBlock >> 6) & 0x3f];
       if (includePadding) {


### PR DESCRIPTION
## Bug Summary:

This PR addresses an issue with signed integer literals and operands used in bitwise operations. When dealing with signed integer literals, adding the 'u' suffix to the constant can resolve the issue by explicitly marking the constant as unsigned. Additionally, any operand of signed integer type can be cast to its unsigned equivalent using a C (or C++) cast expression. For signed variables used in bitwise operations, their type should be converted to an unsigned equivalent to avoid undefined behavior and ensure proper operation.

## Changes Made:

Added 'u' suffix to signed integer literals: This explicitly marks the constants as unsigned to ensure correct type handling.
Applied C/C++ cast to operands: All signed integer operands involved in bitwise operations are now cast to unsigned integers to prevent unexpected behavior.
Converted signed variables to unsigned type: For bitwise operations, the type of signed variables has been changed to the unsigned equivalent to maintain correctness and prevent potential overflow or sign extension issues.

## Impact:

These changes will ensure that the code handles integer literals and operands in bitwise expressions correctly, using unsigned types when appropriate, thus preventing bugs related to type conversion and ensuring cross-platform consistency.

This is part 1 of multiple PRs for this fix.