### PR TITLE
let VeloxPromise move-ctor be noexcept

### DIFF
--- a/velox/common/future/VeloxPromise.h
+++ b/velox/common/future/VeloxPromise.h
@@ -42,7 +42,7 @@ class VeloxPromise : public folly::Promise<T> {
     }
   }
 
-  explicit VeloxPromise(VeloxPromise<T>&& other)
+  explicit VeloxPromise(VeloxPromise<T>&& other) noexcept
       : folly::Promise<T>(std::move(other)),
         context_(std::move(other.context_)) {}
 


### PR DESCRIPTION
Summary: It seems like the intention was for the `VeloxPromise` move-ctor to be `noexcept`.

Differential Revision: D68715056


