### PR TITLE
build(ci): Fix artifact handling in Conbench Upload job

### DIFF
--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -42,8 +42,6 @@ jobs:
         path: /tmp/artifacts/
         github-token: ${{ github.token }}
 
-    - run: ls -R /tmp/artifacts/
-
     - name: Set meta data outputs
       id: 'download'
       uses: actions/github-script@v7
@@ -110,7 +108,7 @@ jobs:
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
           --pr_number "${{ steps.extract.outputs.pr_number }}" \
           --sha "${{ steps.download.outputs.contender_sha }}" \
-          --output_dir "/tmp/artifacts/benchmark-results/contender/"
+          --output_dir "/tmp/artifacts/contender/"
 
     - name: "Check the status of the upload"
       # Status functions like failure() only work in `if:`

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -42,6 +42,8 @@ jobs:
         path: /tmp/artifacts/
         github-token: ${{ github.token }}
 
+    - run: ls -R /tmp/artifacts/
+
     - name: Set meta data outputs
       id: 'download'
       uses: actions/github-script@v7


### PR DESCRIPTION
The v4 artifact action handles paths different leading to the 'benchmark-results' dir getting dropped. 

Working run of the fixed workflow: https://github.com/facebookincubator/velox/actions/runs/12994805091/job/36240073932#step:8:26