### PR TITLE
refactor(parquet): Use velox parquet reader in StatisticsTest

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -219,6 +219,21 @@ ColumnChunkMetaDataPtr::getColumnStatistics(
       thriftColumnChunkPtr(ptr_)->meta_data.statistics, *type, numRows);
 };
 
+std::string ColumnChunkMetaDataPtr::getColumnMetadataStatsMinValue() {
+  VELOX_CHECK(hasStatistics());
+  return thriftColumnChunkPtr(ptr_)->meta_data.statistics.min_value;
+}
+
+std::string ColumnChunkMetaDataPtr::getColumnMetadataStatsMaxValue() {
+  VELOX_CHECK(hasStatistics());
+  return thriftColumnChunkPtr(ptr_)->meta_data.statistics.max_value;
+}
+
+int64_t ColumnChunkMetaDataPtr::getColumnMetadataStatsNullCount() {
+  VELOX_CHECK(hasStatistics());
+  return thriftColumnChunkPtr(ptr_)->meta_data.statistics.null_count;
+}
+
 int64_t ColumnChunkMetaDataPtr::dataPageOffset() const {
   return thriftColumnChunkPtr(ptr_)->meta_data.data_page_offset;
 }

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -42,6 +42,15 @@ class ColumnChunkMetaDataPtr {
       const TypePtr type,
       int64_t numRows);
 
+  /// Return the Column Metadata Statistics Min Value
+  std::string getColumnMetadataStatsMinValue();
+
+  /// Return the Column Metadata Statistics Max Value
+  std::string getColumnMetadataStatsMaxValue();
+
+  /// Return the Column Metadata Statistics Null Count
+  int64_t getColumnMetadataStatsNullCount();
+
   /// Number of values.
   int64_t numValues() const;
 

--- a/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
@@ -37,7 +37,9 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
   arrow
-  arrow_testing)
+  arrow_testing
+  velox_dwio_native_parquet_reader
+  velox_temp_path)
 
 add_library(
   velox_dwio_arrow_parquet_writer_test_lib


### PR DESCRIPTION
Change Parquet writer tests to use Velox parquet reader instead of Arrow parquet reader.
Once all the tests are migrated, we can remove the Arrow Parquet reader code.