### PR TITLE
docs: Update Presto functions coverage map

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -62,91 +62,99 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     :widths: auto
     :class: rows
 
-    ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================
-    Scalar Functions                                                                                                            Aggregate Functions                         Window Functions
-    ======================================================================================================================  ==  ======================================  ==  ======================================
-    :func:`abs`                             :func:`find_first_index`                :func:`plus`                                :func:`any_value`                           :func:`cume_dist`
-    :func:`acos`                            :func:`flatten`                         :func:`poisson_cdf`                         :func:`approx_distinct`                     :func:`dense_rank`
-    :func:`all_keys_match`                  :func:`floor`                           :func:`pow`                                 :func:`approx_most_frequent`                :func:`first_value`
-    :func:`all_match`                       :func:`format_datetime`                 :func:`power`                               :func:`approx_percentile`                   :func:`lag`
-    :func:`any_keys_match`                  :func:`from_base`                       :func:`quarter`                             :func:`approx_set`                          :func:`last_value`
-    :func:`any_match`                       :func:`from_base64`                     :func:`radians`                             :func:`arbitrary`                           :func:`lead`
-    :func:`any_values_match`                :func:`from_base64url`                  :func:`rand`                                :func:`array_agg`                           :func:`nth_value`
-    :func:`array_average`                   :func:`from_big_endian_32`              :func:`random`                              :func:`avg`                                 :func:`ntile`
-    :func:`array_constructor`               :func:`from_big_endian_64`              :func:`reduce`                              :func:`bitwise_and_agg`                     :func:`percent_rank`
-    :func:`array_distinct`                  :func:`from_hex`                        :func:`regexp_extract`                      :func:`bitwise_or_agg`                      :func:`rank`
-    :func:`array_duplicates`                :func:`from_ieee754_32`                 :func:`regexp_extract_all`                  :func:`bitwise_xor_agg`                     :func:`row_number`
-    :func:`array_except`                    :func:`from_ieee754_64`                 :func:`regexp_like`                         :func:`bool_and`
-    :func:`array_frequency`                 :func:`from_iso8601_date`               :func:`regexp_replace`                      :func:`bool_or`
-    :func:`array_has_duplicates`            :func:`from_unixtime`                   :func:`remove_nulls`                        :func:`checksum`
-    :func:`array_intersect`                 :func:`from_utf8`                       :func:`repeat`                              :func:`corr`
-    :func:`array_join`                      :func:`gamma_cdf`                       :func:`replace`                             :func:`count`
-    :func:`array_max`                       :func:`greatest`                        :func:`reverse`                             :func:`count_if`
-    :func:`array_min`                       :func:`gt`                              :func:`round`                               :func:`covar_pop`
-    :func:`array_normalize`                 :func:`gte`                             :func:`rpad`                                :func:`covar_samp`
-    :func:`array_position`                  :func:`hamming_distance`                :func:`rtrim`                               :func:`entropy`
-    :func:`array_remove`                    :func:`hmac_md5`                        :func:`second`                              :func:`every`
-    :func:`array_sort`                      :func:`hmac_sha1`                       :func:`sequence`                            :func:`geometric_mean`
-    :func:`array_sort_desc`                 :func:`hmac_sha256`                     :func:`sha1`                                :func:`histogram`
-    :func:`array_sum`                       :func:`hmac_sha512`                     :func:`sha256`                              :func:`kurtosis`
-    :func:`array_union`                     :func:`hour`                            :func:`sha512`                              :func:`map_agg`
-    :func:`arrays_overlap`                  in                                      :func:`shuffle`                             :func:`map_union`
-    :func:`asin`                            :func:`infinity`                        :func:`sign`                                :func:`map_union_sum`
-    :func:`atan`                            :func:`inverse_beta_cdf`                :func:`sin`                                 :func:`max`
-    :func:`atan2`                           :func:`is_finite`                       :func:`slice`                               :func:`max_by`
-    :func:`beta_cdf`                        :func:`is_infinite`                     :func:`split`                               :func:`max_data_size_for_stats`
-    :func:`between`                         :func:`is_json_scalar`                  :func:`split_part`                          :func:`merge`
-    :func:`binomial_cdf`                    :func:`is_nan`                          :func:`split_to_map`                        :func:`min`
-    :func:`bit_count`                       :func:`is_null`                         :func:`spooky_hash_v2_32`                   :func:`min_by`
-    :func:`bitwise_and`                     :func:`json_array_contains`             :func:`spooky_hash_v2_64`                   :func:`multimap_agg`
-    :func:`bitwise_arithmetic_shift_right`  :func:`json_array_length`               :func:`sqrt`                                :func:`reduce_agg`
-    :func:`bitwise_left_shift`              :func:`json_extract`                    :func:`starts_with`                         :func:`regr_avgx`
-    :func:`bitwise_logical_shift_right`     :func:`json_extract_scalar`             :func:`strpos`                              :func:`regr_avgy`
-    :func:`bitwise_not`                     :func:`json_format`                     :func:`strrpos`                             :func:`regr_count`
-    :func:`bitwise_or`                      :func:`json_parse`                      :func:`subscript`                           :func:`regr_intercept`
-    :func:`bitwise_right_shift`             :func:`json_size`                       :func:`substr`                              :func:`regr_r2`
-    :func:`bitwise_right_shift_arithmetic`  :func:`laplace_cdf`                     :func:`tan`                                 :func:`regr_slope`
-    :func:`bitwise_shift_left`              :func:`last_day_of_month`               :func:`tanh`                                :func:`regr_sxx`
-    :func:`bitwise_xor`                     :func:`least`                           :func:`timezone_hour`                       :func:`regr_sxy`
-    :func:`cardinality`                     :func:`length`                          :func:`timezone_minute`                     :func:`regr_syy`
-    :func:`cauchy_cdf`                      :func:`levenshtein_distance`            :func:`to_base`                             :func:`set_agg`
-    :func:`cbrt`                            :func:`like`                            :func:`to_base64`                           :func:`set_union`
-    :func:`ceil`                            :func:`ln`                              :func:`to_base64url`                        :func:`skewness`
-    :func:`ceiling`                         :func:`log10`                           :func:`to_big_endian_32`                    :func:`stddev`
-    :func:`chi_squared_cdf`                 :func:`log2`                            :func:`to_big_endian_64`                    :func:`stddev_pop`
-    :func:`chr`                             :func:`lower`                           :func:`to_hex`                              :func:`stddev_samp`
-    :func:`clamp`                           :func:`lpad`                            :func:`to_ieee754_32`                       :func:`sum`
-    :func:`codepoint`                       :func:`lt`                              :func:`to_ieee754_64`                       :func:`sum_data_size_for_stats`
-    :func:`combinations`                    :func:`lte`                             :func:`to_unixtime`                         :func:`var_pop`
-    :func:`concat`                          :func:`ltrim`                           :func:`to_utf8`                             :func:`var_samp`
-    :func:`contains`                        :func:`map`                             :func:`transform`                           :func:`variance`
-    :func:`cos`                             :func:`map_concat`                      :func:`transform_keys`
-    :func:`cosh`                            :func:`map_entries`                     :func:`transform_values`
-    :func:`cosine_similarity`               :func:`map_filter`                      :func:`trim`
-    :func:`crc32`                           :func:`map_from_entries`                :func:`trim_array`
-    :func:`current_date`                    :func:`map_keys`                        :func:`truncate`
-    :func:`date`                            :func:`map_normalize`                   :func:`typeof`
-    :func:`date_add`                        :func:`map_subset`                      :func:`upper`
-    :func:`date_diff`                       :func:`map_top_n`                       :func:`url_decode`
-    :func:`date_format`                     :func:`map_values`                      :func:`url_encode`
-    :func:`date_parse`                      :func:`map_zip_with`                    :func:`url_extract_fragment`
-    :func:`date_trunc`                      :func:`md5`                             :func:`url_extract_host`
-    :func:`day`                             :func:`millisecond`                     :func:`url_extract_parameter`
-    :func:`day_of_month`                    :func:`minus`                           :func:`url_extract_path`
-    :func:`day_of_week`                     :func:`minute`                          :func:`url_extract_port`
-    :func:`day_of_year`                     :func:`mod`                             :func:`url_extract_protocol`
-    :func:`degrees`                         :func:`month`                           :func:`url_extract_query`
-    :func:`distinct_from`                   :func:`multimap_from_entries`           :func:`week`
-    :func:`divide`                          :func:`multiply`                        :func:`week_of_year`
-    :func:`dow`                             :func:`nan`                             :func:`weibull_cdf`
-    :func:`doy`                             :func:`negate`                          :func:`width_bucket`
-    :func:`e`                               :func:`neq`                             :func:`wilson_interval_lower`
-    :func:`element_at`                      :func:`ngrams`                          :func:`wilson_interval_upper`
-    :func:`empty_approx_set`                :func:`no_keys_match`                   :func:`xxhash64`
-    :func:`ends_with`                       :func:`no_values_match`                 :func:`year`
-    :func:`eq`                              :func:`none_match`                      :func:`year_of_week`
-    :func:`exp`                             :func:`normal_cdf`                      :func:`yow`
-    :func:`f_cdf`                           not                                     :func:`zip`
-    :func:`filter`                          :func:`parse_datetime`                  :func:`zip_with`
-    :func:`find_first`                      :func:`pi`
-    ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================
+    ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
+    Scalar Functions                                                                                                                  Aggregate Functions                           Window Functions
+    ============================================================================================================================  ==  ========================================  ==  ========================================
+    :func:`$internal$split_to_map`            :func:`format_datetime`                   :func:`plus`                                  :func:`any_value`                             :func:`cume_dist`
+    :func:`abs`                               :func:`from_base`                         :func:`poisson_cdf`                           :func:`approx_distinct`                       :func:`dense_rank`
+    :func:`acos`                              :func:`from_base64`                       :func:`pow`                                   :func:`approx_most_frequent`                  :func:`first_value`
+    :func:`all_keys_match`                    :func:`from_base64url`                    :func:`power`                                 :func:`approx_percentile`                     :func:`lag`
+    :func:`all_match`                         :func:`from_big_endian_32`                :func:`quarter`                               :func:`approx_set`                            :func:`last_value`
+    :func:`any_keys_match`                    :func:`from_big_endian_64`                :func:`radians`                               :func:`arbitrary`                             :func:`lead`
+    :func:`any_match`                         :func:`from_hex`                          :func:`rand`                                  :func:`array_agg`                             :func:`nth_value`
+    :func:`any_values_match`                  :func:`from_ieee754_32`                   :func:`random`                                :func:`avg`                                   :func:`ntile`
+    :func:`array_average`                     :func:`from_ieee754_64`                   :func:`reduce`                                :func:`bitwise_and_agg`                       :func:`percent_rank`
+    :func:`array_constructor`                 :func:`from_iso8601_date`                 :func:`regexp_extract`                        :func:`bitwise_or_agg`                        :func:`rank`
+    :func:`array_cum_sum`                     :func:`from_iso8601_timestamp`            :func:`regexp_extract_all`                    :func:`bitwise_xor_agg`                       :func:`row_number`
+    :func:`array_distinct`                    :func:`from_unixtime`                     :func:`regexp_like`                           :func:`bool_and`
+    :func:`array_duplicates`                  :func:`from_utf8`                         :func:`regexp_replace`                        :func:`bool_or`
+    :func:`array_except`                      :func:`gamma_cdf`                         :func:`regexp_split`                          :func:`checksum`
+    :func:`array_frequency`                   :func:`greatest`                          :func:`remove_nulls`                          :func:`classification_fall_out`
+    :func:`array_has_duplicates`              :func:`gt`                                :func:`repeat`                                :func:`classification_miss_rate`
+    :func:`array_intersect`                   :func:`gte`                               :func:`replace`                               :func:`classification_precision`
+    :func:`array_join`                        :func:`hamming_distance`                  :func:`replace_first`                         :func:`classification_recall`
+    :func:`array_max`                         :func:`hmac_md5`                          :func:`reverse`                               :func:`classification_thresholds`
+    :func:`array_min`                         :func:`hmac_sha1`                         :func:`round`                                 :func:`corr`
+    :func:`array_normalize`                   :func:`hmac_sha256`                       :func:`rpad`                                  :func:`count`
+    :func:`array_position`                    :func:`hmac_sha512`                       :func:`rtrim`                                 :func:`count_if`
+    :func:`array_remove`                      :func:`hour`                              :func:`second`                                :func:`covar_pop`
+    :func:`array_sort`                        in                                        :func:`secure_rand`                           :func:`covar_samp`
+    :func:`array_sort_desc`                   :func:`infinity`                          :func:`secure_random`                         :func:`entropy`
+    :func:`array_sum`                         :func:`inverse_beta_cdf`                  :func:`sequence`                              :func:`every`
+    :func:`array_sum_propagate_element_null`  :func:`inverse_cauchy_cdf`                :func:`sha1`                                  :func:`geometric_mean`
+    :func:`array_union`                       :func:`inverse_laplace_cdf`               :func:`sha256`                                :func:`histogram`
+    :func:`arrays_overlap`                    :func:`inverse_normal_cdf`                :func:`sha512`                                :func:`kurtosis`
+    :func:`asin`                              :func:`inverse_weibull_cdf`               :func:`shuffle`                               :func:`map_agg`
+    :func:`at_timezone`                       :func:`ip_prefix`                         :func:`sign`                                  :func:`map_union`
+    :func:`atan`                              :func:`is_finite`                         :func:`sin`                                   :func:`map_union_sum`
+    :func:`atan2`                             :func:`is_infinite`                       :func:`slice`                                 :func:`max`
+    :func:`beta_cdf`                          :func:`is_json_scalar`                    :func:`split`                                 :func:`max_by`
+    :func:`between`                           :func:`is_nan`                            :func:`split_part`                            :func:`max_data_size_for_stats`
+    :func:`binomial_cdf`                      :func:`is_null`                           :func:`split_to_map`                          :func:`merge`
+    :func:`bit_count`                         :func:`json_array_contains`               :func:`spooky_hash_v2_32`                     :func:`min`
+    :func:`bitwise_and`                       :func:`json_array_get`                    :func:`spooky_hash_v2_64`                     :func:`min_by`
+    :func:`bitwise_arithmetic_shift_right`    :func:`json_array_length`                 :func:`sqrt`                                  :func:`multimap_agg`
+    :func:`bitwise_left_shift`                :func:`json_extract`                      :func:`starts_with`                           :func:`reduce_agg`
+    :func:`bitwise_logical_shift_right`       :func:`json_extract_scalar`               :func:`strpos`                                :func:`regr_avgx`
+    :func:`bitwise_not`                       :func:`json_format`                       :func:`strrpos`                               :func:`regr_avgy`
+    :func:`bitwise_or`                        :func:`json_parse`                        :func:`subscript`                             :func:`regr_count`
+    :func:`bitwise_right_shift`               :func:`json_size`                         :func:`substr`                                :func:`regr_intercept`
+    :func:`bitwise_right_shift_arithmetic`    :func:`laplace_cdf`                       :func:`tan`                                   :func:`regr_r2`
+    :func:`bitwise_shift_left`                :func:`last_day_of_month`                 :func:`tanh`                                  :func:`regr_slope`
+    :func:`bitwise_xor`                       :func:`least`                             :func:`timezone_hour`                         :func:`regr_sxx`
+    :func:`cardinality`                       :func:`length`                            :func:`timezone_minute`                       :func:`regr_sxy`
+    :func:`cauchy_cdf`                        :func:`levenshtein_distance`              :func:`to_base`                               :func:`regr_syy`
+    :func:`cbrt`                              :func:`like`                              :func:`to_base64`                             :func:`set_agg`
+    :func:`ceil`                              :func:`ln`                                :func:`to_base64url`                          :func:`set_union`
+    :func:`ceiling`                           :func:`log10`                             :func:`to_big_endian_32`                      :func:`skewness`
+    :func:`chi_squared_cdf`                   :func:`log2`                              :func:`to_big_endian_64`                      :func:`stddev`
+    :func:`chr`                               :func:`lower`                             :func:`to_hex`                                :func:`stddev_pop`
+    :func:`clamp`                             :func:`lpad`                              :func:`to_ieee754_32`                         :func:`stddev_samp`
+    :func:`codepoint`                         :func:`lt`                                :func:`to_ieee754_64`                         :func:`sum`
+    :func:`combinations`                      :func:`lte`                               :func:`to_iso8601`                            :func:`sum_data_size_for_stats`
+    :func:`concat`                            :func:`ltrim`                             :func:`to_milliseconds`                       :func:`var_pop`
+    :func:`contains`                          :func:`map`                               :func:`to_unixtime`                           :func:`var_samp`
+    :func:`cos`                               :func:`map_concat`                        :func:`to_utf8`                               :func:`variance`
+    :func:`cosh`                              :func:`map_entries`                       :func:`trail`
+    :func:`cosine_similarity`                 :func:`map_filter`                        :func:`transform`
+    :func:`crc32`                             :func:`map_from_entries`                  :func:`transform_keys`
+    :func:`current_date`                      :func:`map_key_exists`                    :func:`transform_values`
+    :func:`date`                              :func:`map_keys`                          :func:`trim`
+    :func:`date_add`                          :func:`map_normalize`                     :func:`trim_array`
+    :func:`date_diff`                         :func:`map_remove_null_values`            :func:`truncate`
+    :func:`date_format`                       :func:`map_subset`                        :func:`typeof`
+    :func:`date_parse`                        :func:`map_top_n`                         :func:`upper`
+    :func:`date_trunc`                        :func:`map_top_n_keys`                    :func:`url_decode`
+    :func:`day`                               :func:`map_values`                        :func:`url_encode`
+    :func:`day_of_month`                      :func:`map_zip_with`                      :func:`url_extract_fragment`
+    :func:`day_of_week`                       :func:`md5`                               :func:`url_extract_host`
+    :func:`day_of_year`                       :func:`millisecond`                       :func:`url_extract_parameter`
+    :func:`degrees`                           :func:`minus`                             :func:`url_extract_path`
+    :func:`distinct_from`                     :func:`minute`                            :func:`url_extract_port`
+    :func:`divide`                            :func:`mod`                               :func:`url_extract_protocol`
+    :func:`dow`                               :func:`month`                             :func:`url_extract_query`
+    :func:`doy`                               :func:`multimap_from_entries`             :func:`uuid`
+    :func:`e`                                 :func:`multiply`                          :func:`week`
+    :func:`element_at`                        :func:`nan`                               :func:`week_of_year`
+    :func:`empty_approx_set`                  :func:`negate`                            :func:`weibull_cdf`
+    :func:`ends_with`                         :func:`neq`                               :func:`width_bucket`
+    :func:`eq`                                :func:`ngrams`                            :func:`wilson_interval_lower`
+    :func:`exp`                               :func:`no_keys_match`                     :func:`wilson_interval_upper`
+    :func:`f_cdf`                             :func:`no_values_match`                   :func:`word_stem`
+    :func:`fail`                              :func:`none_match`                        :func:`xxhash64`
+    :func:`filter`                            :func:`normal_cdf`                        :func:`year`
+    :func:`find_first`                        :func:`normalize`                         :func:`year_of_week`
+    :func:`find_first_index`                  not                                       :func:`yow`
+    :func:`flatten`                           :func:`parse_datetime`                    :func:`zip`
+    :func:`floor`                             :func:`pi`                                :func:`zip_with`
+    ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -2,7 +2,7 @@
 Function Coverage
 =================
 
-Here is a list of all scalar and aggregate Presto functions with functions that are available in Velox highlighted.
+Here is a list of all scalar, aggregate, and window functions from Presto, with functions that are available in Velox highlighted.
 
 .. raw:: html
 
@@ -13,7 +13,6 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage td:nth-child(8) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(1) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(9) {background-color: #6BA81E;}
@@ -37,19 +36,22 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(4) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(6) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(7) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(7) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(9) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(8) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(1) {background-color: #6BA81E;}
@@ -66,74 +68,79 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(11) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(16) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(17) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(20) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(21) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(21) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(22) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
@@ -141,108 +148,113 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(32) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(33) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(34) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(35) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(36) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(43) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(43) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(44) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(45) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(46) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(50) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(51) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(54) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
@@ -253,57 +265,70 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(62) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(64) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(64) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(66) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(67) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(68) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(70) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(70) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(70) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(71) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(72) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(73) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(75) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(76) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(77) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(77) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(77) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(5) {background-color: #6BA81E;}
     </style>
 
 .. table::
@@ -313,82 +338,83 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_diff`                         :func:`is_finite`                         :func:`regexp_extract`                    st_overlaps                                   :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_format`                       :func:`is_infinite`                       :func:`regexp_extract_all`                st_point                                      :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_parse`                        :func:`is_json_scalar`                    :func:`regexp_like`                       st_pointn                                     :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_nan`                            :func:`regexp_replace`                    st_points                                     :func:`approx_set`                            :func:`lag`
-    :func:`any_match`                         :func:`day`                               is_subnet_of                              regexp_split                              st_polygon                                    :func:`arbitrary`                             :func:`last_value`
-    :func:`any_values_match`                  :func:`day_of_month`                      jaccard_index                             regress                                   st_relate                                     :func:`array_agg`                             :func:`lead`
-    :func:`array_average`                     :func:`day_of_week`                       :func:`json_array_contains`               reidentification_potential                st_startpoint                                 :func:`avg`                                   :func:`nth_value`
-    array_cum_sum                             :func:`day_of_year`                       json_array_get                            :func:`remove_nulls`                      st_symdifference                              :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_length`                 render                                    st_touches                                    :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_duplicates`                  :func:`dow`                               :func:`json_extract`                      :func:`repeat`                            st_union                                      :func:`bool_and`                              :func:`rank`
-    :func:`array_except`                      :func:`doy`                               :func:`json_extract_scalar`               :func:`replace`                           st_within                                     :func:`bool_or`                               :func:`row_number`
-    :func:`array_frequency`                   :func:`e`                                 :func:`json_format`                       replace_first                             st_x                                          :func:`checksum`
-    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_parse`                        :func:`reverse`                           st_xmax                                       :func: `classification_fall_out`
-    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_size`                         rgb                                       st_xmin                                       :func: `classification_miss_rate`
-    :func:`array_join`                        :func:`ends_with`                         key_sampling_percent                      :func:`round`                             st_y                                          :func: `classification_precision`
-    array_least_frequent                      enum_key                                  :func:`laplace_cdf`                       :func:`rpad`                              st_ymax                                       :func: `classification_recall`
-    :func:`array_max`                         :func:`exp`                               :func:`last_day_of_month`                 :func:`rtrim`                             st_ymin                                       :func: `classification_thresholds`
-    array_max_by                              expand_envelope                           :func:`least`                             scale_qdigest                             :func:`starts_with`                           convex_hull_agg
-    :func:`array_min`                         :func:`f_cdf`                             :func:`length`                            :func:`second`                            :func:`strpos`                                :func:`corr`
-    array_min_by                              features                                  :func:`levenshtein_distance`              secure_rand                               :func:`strrpos`                               :func:`count`
-    :func:`array_normalize`                   :func:`filter`                            line_interpolate_point                    secure_random                             :func:`substr`                                :func:`count_if`
-    :func:`array_position`                    :func:`filter`                            line_locate_point                         :func:`sequence`                          :func:`tan`                                   :func:`covar_pop`
-    :func:`array_remove`                      :func:`find_first`                        :func:`ln`                                :func:`sha1`                              :func:`tanh`                                  :func:`covar_samp`
-    :func:`array_sort`                        :func:`find_first_index`                  localtime                                 :func:`sha256`                            tdigest_agg                                   differential_entropy
-    :func:`array_sort_desc`                   :func:`flatten`                           localtimestamp                            :func:`sha512`                            :func:`timezone_hour`                         :func:`entropy`
-    :func:`array_sum`                         flatten_geometry_collections              :func:`log10`                             :func:`shuffle`                           :func:`timezone_minute`                       evaluate_classifier_predictions
-    array_top_n                               :func:`floor`                             :func:`log2`                              :func:`sign`                              :func:`to_base`                               :func:`every`
-    :func:`array_union`                       fnv1_32                                   :func:`lower`                             simplify_geometry                         to_base32                                     :func:`geometric_mean`
-    :func:`arrays_overlap`                    fnv1_64                                   :func:`lpad`                              :func:`sin`                               :func:`to_base64`                             geometry_union_agg
-    :func:`asin`                              fnv1a_32                                  :func:`ltrim`                             :func:`slice`                             :func:`to_base64url`                          :func:`histogram`
-    :func:`atan`                              fnv1a_64                                  :func:`map`                               spatial_partitions                        :func:`to_big_endian_32`                      khyperloglog_agg
-    :func:`atan2`                             :func:`format_datetime`                   :func:`map_concat`                        :func:`split`                             :func:`to_big_endian_64`                      :func:`kurtosis`
-    bar                                       :func:`from_base`                         :func:`map_entries`                       :func:`split_part`                        to_geometry                                   learn_classifier
-    :func:`beta_cdf`                          from_base32                               :func:`map_filter`                        :func:`split_to_map`                      :func:`to_hex`                                learn_libsvm_classifier
-    bing_tile                                 :func:`from_base64`                       :func:`map_from_entries`                  split_to_multimap                         :func:`to_ieee754_32`                         learn_libsvm_regressor
-    bing_tile_at                              :func:`from_base64url`                    :func:`map_keys`                          :func:`spooky_hash_v2_32`                 :func:`to_ieee754_64`                         learn_regressor
-    bing_tile_children                        :func:`from_big_endian_32`                map_keys_by_top_n_values                  :func:`spooky_hash_v2_64`                 to_iso8601                                    make_set_digest
-    bing_tile_coordinates                     :func:`from_big_endian_64`                :func:`map_normalize`                     :func:`sqrt`                              to_milliseconds                               :func:`map_agg`
-    bing_tile_parent                          :func:`from_hex`                          map_remove_null_values                    st_area                                   to_spherical_geography                        :func:`map_union`
-    bing_tile_polygon                         :func:`from_ieee754_32`                   :func:`map_subset`                        st_asbinary                               :func:`to_unixtime`                           :func:`map_union_sum`
-    bing_tile_quadkey                         :func:`from_ieee754_64`                   :func:`map_top_n`                         st_astext                                 :func:`to_utf8`                               :func:`max`
-    bing_tile_zoom_level                      :func:`from_iso8601_date`                 map_top_n_keys                            st_boundary                               trail                                         :func:`max_by`
-    bing_tiles_around                         from_iso8601_timestamp                    map_top_n_values                          st_buffer                                 :func:`transform`                             :func:`merge`
-    :func:`binomial_cdf`                      :func:`from_unixtime`                     :func:`map_values`                        st_centroid                               :func:`transform_keys`                        merge_set_digest
-    :func:`bit_count`                         :func:`from_utf8`                         :func:`map_zip_with`                      st_contains                               :func:`transform_values`                      :func:`min`
-    :func:`bitwise_and`                       :func:`gamma_cdf`                         :func:`md5`                               st_convexhull                             :func:`trim`                                  :func:`min_by`
-    :func:`bitwise_arithmetic_shift_right`    geometry_as_geojson                       merge_hll                                 st_coorddim                               :func:`trim_array`                            :func:`multimap_agg`
-    :func:`bitwise_left_shift`                geometry_from_geojson                     merge_khll                                st_crosses                                :func:`truncate`                              noisy_avg_gaussian
-    :func:`bitwise_logical_shift_right`       geometry_invalid_reason                   :func:`millisecond`                       st_difference                             :func:`typeof`                                noisy_count_gaussian
-    :func:`bitwise_not`                       geometry_nearest_points                   :func:`minute`                            st_dimension                              uniqueness_distribution                       noisy_count_if_gaussian
-    :func:`bitwise_or`                        geometry_to_bing_tiles                    :func:`mod`                               st_disjoint                               :func:`upper`                                 noisy_sum_gaussian
-    :func:`bitwise_right_shift`               geometry_to_dissolved_bing_tiles          :func:`month`                             st_distance                               :func:`url_decode`                            numeric_histogram
-    :func:`bitwise_right_shift_arithmetic`    geometry_union                            :func:`multimap_from_entries`             st_endpoint                               :func:`url_encode`                            qdigest_agg
-    :func:`bitwise_shift_left`                great_circle_distance                     murmur3_x64_128                           st_envelope                               :func:`url_extract_fragment`                  :func:`reduce_agg`
-    :func:`bitwise_xor`                       :func:`greatest`                          myanmar_font_encoding                     st_envelopeaspts                          :func:`url_extract_host`                      :func:`regr_avgx`
-    :func:`cardinality`                       :func:`hamming_distance`                  myanmar_normalize_unicode                 st_equals                                 :func:`url_extract_parameter`                 :func:`regr_avgy`
-    :func:`cauchy_cdf`                        hash_counts                               :func:`nan`                               st_exteriorring                           :func:`url_extract_path`                      :func:`regr_count`
-    :func:`cbrt`                              :func:`hmac_md5`                          :func:`ngrams`                            st_geometries                             :func:`url_extract_port`                      :func:`regr_intercept`
-    :func:`ceil`                              :func:`hmac_sha1`                         :func:`no_keys_match`                     st_geometryfromtext                       :func:`url_extract_protocol`                  :func:`regr_r2`
-    :func:`ceiling`                           :func:`hmac_sha256`                       :func:`no_values_match`                   st_geometryn                              :func:`url_extract_query`                     :func:`regr_slope`
-    :func:`chi_squared_cdf`                   :func:`hmac_sha512`                       :func:`none_match`                        st_geometrytype                           uuid                                          :func:`regr_sxx`
-    :func:`chr`                               :func:`hour`                              :func:`normal_cdf`                        st_geomfrombinary                         value_at_quantile                             :func:`regr_sxy`
-    classify                                  :func:`infinity`                          normalize                                 st_interiorringn                          values_at_quantiles                           :func:`regr_syy`
-    :func:`codepoint`                         intersection_cardinality                  now                                       st_interiorrings                          :func:`week`                                  :func:`set_agg`
-    color                                     :func:`inverse_beta_cdf`                  :func:`parse_datetime`                    st_intersection                           :func:`week_of_year`                          :func:`set_union`
-    :func:`combinations`                      inverse_binomial_cdf                      parse_duration                            st_intersects                             :func:`weibull_cdf`                           :func:`skewness`
-    :func:`concat`                            inverse_cauchy_cdf                        parse_presto_data_size                    st_isclosed                               :func:`width_bucket`                          spatial_partitioning
-    :func:`contains`                          inverse_chi_squared_cdf                   :func:`pi`                                st_isempty                                :func:`wilson_interval_lower`                 :func:`stddev`
-    :func:`cos`                               inverse_f_cdf                             pinot_binary_decimal_to_double            st_isring                                 :func:`wilson_interval_upper`                 :func:`stddev_pop`
-    :func:`cosh`                              inverse_gamma_cdf                         :func:`poisson_cdf`                       st_issimple                               word_stem                                     :func:`stddev_samp`
-    :func:`cosine_similarity`                 inverse_laplace_cdf                       :func:`pow`                               st_isvalid                                :func:`xxhash64`                              :func:`sum`
-    :func:`crc32`                             inverse_normal_cdf                        :func:`power`                             st_length                                 :func:`year`                                  tdigest_agg
-    :func:`current_date`                      inverse_poisson_cdf                       quantile_at_value                         st_linefromtext                           :func:`year_of_week`                          :func:`var_pop`
-    current_time                              inverse_weibull_cdf                       :func:`quarter`                           st_linestring                             :func:`yow`                                   :func:`var_samp`
-    current_timestamp                         ip_prefix                                 :func:`radians`                           st_multipoint                             :func:`zip`                                   :func:`variance`
-    current_timezone                          ip_subnet_max                             :func:`rand`                              st_numgeometries                          :func:`zip_with`
-    :func:`date`                              ip_subnet_min                             :func:`random`                            st_numinteriorring
-    :func:`date_add`                          ip_subnet_range                           :func:`reduce`                            st_numpoints
+    :func:`abs`                               :func:`date_diff`                         ip_subnet_range                           :func:`random`                            st_numgeometries                              :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_format`                       :func:`is_finite`                         :func:`reduce`                            st_numinteriorring                            :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`date_parse`                        :func:`is_infinite`                       :func:`regexp_extract`                    st_numpoints                                  :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_json_scalar`                    :func:`regexp_extract_all`                st_overlaps                                   :func:`approx_set`                            :func:`lag`
+    :func:`any_match`                         :func:`day`                               :func:`is_nan`                            :func:`regexp_like`                       st_point                                      :func:`arbitrary`                             :func:`last_value`
+    :func:`any_values_match`                  :func:`day_of_month`                      is_private_ip                             :func:`regexp_replace`                    st_pointn                                     :func:`array_agg`                             :func:`lead`
+    :func:`array_average`                     :func:`day_of_week`                       is_subnet_of                              :func:`regexp_split`                      st_points                                     :func:`avg`                                   :func:`nth_value`
+    :func:`array_cum_sum`                     :func:`day_of_year`                       jaccard_index                             regress                                   st_polygon                                    :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_contains`               reidentification_potential                st_relate                                     :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      st_startpoint                                 :func:`bool_and`                              :func:`rank`
+    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    st_symdifference                              :func:`bool_or`                               :func:`row_number`
+    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            st_touches                                    :func:`checksum`
+    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           st_union                                      :func:`classification_fall_out`
+    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     st_within                                     :func:`classification_miss_rate`
+    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           st_x                                          :func:`classification_precision`
+    array_least_frequent                      enum_key                                  :func:`json_size`                         rgb                                       st_xmax                                       :func:`classification_recall`
+    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             st_xmin                                       :func:`classification_thresholds`
+    array_max_by                              expand_envelope                           :func:`laplace_cdf`                       :func:`rpad`                              st_y                                          convex_hull_agg
+    :func:`array_min`                         :func:`f_cdf`                             :func:`last_day_of_month`                 :func:`rtrim`                             st_ymax                                       :func:`corr`
+    array_min_by                              features                                  :func:`least`                             scale_qdigest                             st_ymin                                       :func:`count`
+    :func:`array_normalize`                   :func:`filter`                            :func:`length`                            :func:`second`                            :func:`starts_with`                           :func:`count_if`
+    :func:`array_position`                    :func:`filter`                            :func:`levenshtein_distance`              :func:`secure_rand`                       :func:`strpos`                                :func:`covar_pop`
+    :func:`array_remove`                      :func:`find_first`                        line_interpolate_point                    :func:`secure_random`                     :func:`strrpos`                               :func:`covar_samp`
+    :func:`array_sort`                        :func:`find_first_index`                  line_locate_point                         :func:`sequence`                          :func:`substr`                                differential_entropy
+    :func:`array_sort_desc`                   :func:`flatten`                           :func:`ln`                                :func:`sha1`                              :func:`tan`                                   :func:`entropy`
+    array_split_into_chunks                   flatten_geometry_collections              localtime                                 :func:`sha256`                            :func:`tanh`                                  evaluate_classifier_predictions
+    :func:`array_sum`                         :func:`floor`                             localtimestamp                            :func:`sha512`                            tdigest_agg                                   :func:`every`
+    array_top_n                               fnv1_32                                   :func:`log10`                             :func:`shuffle`                           :func:`timezone_hour`                         :func:`geometric_mean`
+    :func:`array_union`                       fnv1_64                                   :func:`log2`                              :func:`sign`                              :func:`timezone_minute`                       geometry_union_agg
+    :func:`arrays_overlap`                    fnv1a_32                                  :func:`lower`                             simplify_geometry                         :func:`to_base`                               :func:`histogram`
+    :func:`asin`                              fnv1a_64                                  :func:`lpad`                              :func:`sin`                               to_base32                                     khyperloglog_agg
+    :func:`atan`                              :func:`format_datetime`                   :func:`ltrim`                             sketch_kll_quantile                       :func:`to_base64`                             :func:`kurtosis`
+    :func:`atan2`                             :func:`from_base`                         :func:`map`                               sketch_kll_rank                           :func:`to_base64url`                          learn_classifier
+    bar                                       from_base32                               :func:`map_concat`                        :func:`slice`                             :func:`to_big_endian_32`                      learn_libsvm_classifier
+    :func:`beta_cdf`                          :func:`from_base64`                       :func:`map_entries`                       spatial_partitions                        :func:`to_big_endian_64`                      learn_libsvm_regressor
+    bing_tile                                 :func:`from_base64url`                    :func:`map_filter`                        :func:`split`                             to_geometry                                   learn_regressor
+    bing_tile_at                              :func:`from_big_endian_32`                :func:`map_from_entries`                  :func:`split_part`                        :func:`to_hex`                                make_set_digest
+    bing_tile_children                        :func:`from_big_endian_64`                :func:`map_keys`                          :func:`split_to_map`                      :func:`to_ieee754_32`                         :func:`map_agg`
+    bing_tile_coordinates                     :func:`from_hex`                          map_keys_by_top_n_values                  split_to_multimap                         :func:`to_ieee754_64`                         :func:`map_union`
+    bing_tile_parent                          :func:`from_ieee754_32`                   :func:`map_normalize`                     :func:`spooky_hash_v2_32`                 :func:`to_iso8601`                            :func:`map_union_sum`
+    bing_tile_polygon                         :func:`from_ieee754_64`                   :func:`map_remove_null_values`            :func:`spooky_hash_v2_64`                 :func:`to_milliseconds`                       :func:`max`
+    bing_tile_quadkey                         :func:`from_iso8601_date`                 :func:`map_subset`                        :func:`sqrt`                              to_spherical_geography                        :func:`max_by`
+    bing_tile_zoom_level                      :func:`from_iso8601_timestamp`            :func:`map_top_n`                         st_area                                   :func:`to_unixtime`                           :func:`merge`
+    bing_tiles_around                         :func:`from_unixtime`                     :func:`map_top_n_keys`                    st_asbinary                               :func:`to_utf8`                               merge_set_digest
+    :func:`binomial_cdf`                      :func:`from_utf8`                         map_top_n_keys_by_value                   st_astext                                 :func:`trail`                                 :func:`min`
+    :func:`bit_count`                         :func:`gamma_cdf`                         map_top_n_values                          st_boundary                               :func:`transform`                             :func:`min_by`
+    :func:`bitwise_and`                       geometry_as_geojson                       :func:`map_values`                        st_buffer                                 :func:`transform_keys`                        :func:`multimap_agg`
+    :func:`bitwise_arithmetic_shift_right`    geometry_from_geojson                     :func:`map_zip_with`                      st_centroid                               :func:`transform_values`                      noisy_avg_gaussian
+    :func:`bitwise_left_shift`                geometry_invalid_reason                   :func:`md5`                               st_contains                               :func:`trim`                                  noisy_count_gaussian
+    :func:`bitwise_logical_shift_right`       geometry_nearest_points                   merge_hll                                 st_convexhull                             :func:`trim_array`                            noisy_count_if_gaussian
+    :func:`bitwise_not`                       geometry_to_bing_tiles                    merge_khll                                st_coorddim                               :func:`truncate`                              noisy_sum_gaussian
+    :func:`bitwise_or`                        geometry_to_dissolved_bing_tiles          :func:`millisecond`                       st_crosses                                :func:`typeof`                                numeric_histogram
+    :func:`bitwise_right_shift`               geometry_union                            :func:`minute`                            st_difference                             uniqueness_distribution                       qdigest_agg
+    :func:`bitwise_right_shift_arithmetic`    great_circle_distance                     :func:`mod`                               st_dimension                              :func:`upper`                                 :func:`reduce_agg`
+    :func:`bitwise_shift_left`                :func:`greatest`                          :func:`month`                             st_disjoint                               :func:`url_decode`                            :func:`regr_avgx`
+    :func:`bitwise_xor`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             st_distance                               :func:`url_encode`                            :func:`regr_avgy`
+    :func:`cardinality`                       hash_counts                               murmur3_x64_128                           st_endpoint                               :func:`url_extract_fragment`                  :func:`regr_count`
+    :func:`cauchy_cdf`                        :func:`hmac_md5`                          myanmar_font_encoding                     st_envelope                               :func:`url_extract_host`                      :func:`regr_intercept`
+    :func:`cbrt`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 st_envelopeaspts                          :func:`url_extract_parameter`                 :func:`regr_r2`
+    :func:`ceil`                              :func:`hmac_sha256`                       :func:`nan`                               st_equals                                 :func:`url_extract_path`                      :func:`regr_slope`
+    :func:`ceiling`                           :func:`hmac_sha512`                       :func:`ngrams`                            st_exteriorring                           :func:`url_extract_port`                      :func:`regr_sxx`
+    :func:`chi_squared_cdf`                   :func:`hour`                              :func:`no_keys_match`                     st_geometries                             :func:`url_extract_protocol`                  :func:`regr_sxy`
+    :func:`chr`                               :func:`infinity`                          :func:`no_values_match`                   st_geometryfromtext                       :func:`url_extract_query`                     :func:`regr_syy`
+    classify                                  intersection_cardinality                  :func:`none_match`                        st_geometryn                              :func:`uuid`                                  reservoir_sample
+    :func:`codepoint`                         :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        st_geometrytype                           value_at_quantile                             :func:`set_agg`
+    color                                     inverse_binomial_cdf                      :func:`normalize`                         st_geomfrombinary                         values_at_quantiles                           :func:`set_union`
+    :func:`combinations`                      :func:`inverse_cauchy_cdf`                now                                       st_interiorringn                          :func:`week`                                  sketch_kll
+    :func:`concat`                            inverse_chi_squared_cdf                   :func:`parse_datetime`                    st_interiorrings                          :func:`week_of_year`                          sketch_kll_with_k
+    :func:`contains`                          inverse_f_cdf                             parse_duration                            st_intersection                           :func:`weibull_cdf`                           :func:`skewness`
+    :func:`cos`                               inverse_gamma_cdf                         parse_presto_data_size                    st_intersects                             :func:`width_bucket`                          spatial_partitioning
+    :func:`cosh`                              :func:`inverse_laplace_cdf`               :func:`pi`                                st_isclosed                               :func:`wilson_interval_lower`                 :func:`stddev`
+    :func:`cosine_similarity`                 :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            st_isempty                                :func:`wilson_interval_upper`                 :func:`stddev_pop`
+    :func:`crc32`                             inverse_poisson_cdf                       :func:`poisson_cdf`                       st_isring                                 :func:`word_stem`                             :func:`stddev_samp`
+    :func:`current_date`                      :func:`inverse_weibull_cdf`               :func:`pow`                               st_issimple                               :func:`xxhash64`                              :func:`sum`
+    current_time                              :func:`ip_prefix`                         :func:`power`                             st_isvalid                                :func:`year`                                  tdigest_agg
+    current_timestamp                         ip_prefix_collapse                        quantile_at_value                         st_length                                 :func:`year_of_week`                          :func:`var_pop`
+    current_timezone                          ip_prefix_subnets                         :func:`quarter`                           st_linefromtext                           :func:`yow`                                   :func:`var_samp`
+    :func:`date`                              ip_subnet_max                             :func:`radians`                           st_linestring                             :func:`zip`                                   :func:`variance`
+    :func:`date_add`                          ip_subnet_min                             :func:`rand`                              st_multipoint                             :func:`zip_with`
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/functions/prestosql/coverage/data/all_aggregate_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_aggregate_functions.txt
@@ -61,8 +61,11 @@ regr_slope
 regr_sxx
 regr_sxy
 regr_syy
+reservoir_sample
 set_agg
 set_union
+sketch_kll
+sketch_kll_with_k
 skewness
 spatial_partitioning
 stddev

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -21,6 +21,7 @@ array_min_by
 array_normalize
 array_position
 array_remove
+array_split_into_chunks
 array_sort
 array_sort_desc
 array_sum
@@ -151,6 +152,8 @@ inverse_normal_cdf
 inverse_poisson_cdf
 inverse_weibull_cdf
 ip_prefix
+ip_prefix_collapse
+ip_prefix_subnets
 ip_subnet_max
 ip_subnet_min
 ip_subnet_range
@@ -158,6 +161,7 @@ is_finite
 is_infinite
 is_json_scalar
 is_nan
+is_private_ip
 is_subnet_of
 jaccard_index
 json_array_contains
@@ -196,6 +200,7 @@ map_remove_null_values
 map_subset
 map_top_n
 map_top_n_keys
+map_top_n_keys_by_value
 map_top_n_values
 map_values
 map_zip_with
@@ -261,6 +266,8 @@ shuffle
 sign
 simplify_geometry
 sin
+sketch_kll_quantile
+sketch_kll_rank
 slice
 spatial_partitions
 split


### PR DESCRIPTION
Updated the complete list of Presto scalar and aggregate functions using output from 
Presto `SHOW FUNCTIONS`.

Re-generated coverage maps with instructions from `velox/functions/prestosql/coverage/README.md`.