### PR TITLE
build: Allow options to wget curl cmake during setup

### DIFF
--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -29,6 +29,8 @@ if [[ "$OSTYPE" == darwin* ]]; then
   export INSTALL_PREFIX=${INSTALL_PREFIX:-"$(pwd)/deps-install"}
 fi
 
+WGET_OPTIONS=${WGET_OPTIONS:-""}
+
 function install_aws_deps {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
   local AWS_SDK_VERSION="1.11.321"
@@ -50,7 +52,7 @@ function install_aws_deps {
       # minio will have to approved under the Privacy & Security on MacOS on first use.
       MINIO_OS="darwin"
     fi
-    wget https://dl.min.io/server/minio/release/${MINIO_OS}-${MINIO_ARCH}/archive/minio.RELEASE.2022-05-26T05-48-41Z -O ${MINIO_BINARY}
+    wget ${WGET_OPTIONS} https://dl.min.io/server/minio/release/${MINIO_OS}-${MINIO_ARCH}/archive/minio.RELEASE.2022-05-26T05-48-41Z -O ${MINIO_BINARY}
     chmod +x ./${MINIO_BINARY}
     mv ./${MINIO_BINARY} /usr/local/bin/
   fi
@@ -155,7 +157,7 @@ function install_hdfs_deps {
     # Dependencies for Hadoop testing
     wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-3.3.0/hadoop-3.3.0.tar.gz hadoop
     cp -a ${DEPENDENCY_DIR}/hadoop /usr/local/
-    wget -P /usr/local/hadoop/share/hadoop/common/lib/ https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar
+    wget ${WGET_OPTIONS} -P /usr/local/hadoop/share/hadoop/common/lib/ https://repo1.maven.org/maven2/junit/junit/4.11/junit-4.11.jar
 
     LINUX_DISTRIBUTION=$(. /etc/os-release && echo ${ID})
     if [[ "$LINUX_DISTRIBUTION" == "ubuntu" || "$LINUX_DISTRIBUTION" == "debian" ]]; then

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -20,6 +20,9 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
 OS_CXXFLAGS=""
 NPROC=${BUILD_THREADS:-$(getconf _NPROCESSORS_ONLN)}
 
+CURL_OPTIONS=${CURL_OPTIONS:-""}
+CMAKE_OPTIONS=${CMAKE_OPTIONS:-""}
+
 function run_and_time {
   time "$@" || (echo "Failed to run $* ." ; exit 1 )
   { echo "+ Finished running $*"; } 2> /dev/null
@@ -173,7 +176,7 @@ function wget_and_untar {
   fi
   mkdir -p "${DIR}"
   pushd "${DIR}"
-  curl -L "${URL}" > $2.tar.gz
+  curl ${CURL_OPTIONS} -L "${URL}" > $2.tar.gz
   tar -xz --strip-components=1 -f $2.tar.gz
   popd
   popd
@@ -205,7 +208,7 @@ function cmake_install {
   COMPILER_FLAGS+=${OS_CXXFLAGS}
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
-  cmake -Wno-dev -B"${BINARY_DIR}" \
+  cmake -Wno-dev ${CMAKE_OPTIONS} -B"${BINARY_DIR}" \
     -GNinja \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=17 \


### PR DESCRIPTION
## Description
The current setup scripts generate excessive output, the goal is to reduce the log output by implementing the following changes:

1. Avoid printing the files extracted by tar.
2. Silence the download progress from curl by using an appropriate curl option.
3. Suppress unnecessary CMake messages, logging only warnings instead of info or status messages.
4. Introduce a new environment variable to enable the extensive logging when needed.
5. These changes will help minimize log size while maintaining flexibility for detailed logging when required.