### PR TITLE
fix: Revert array_has_duplicates unit test due to Linux/Ubuntu test mismatch

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -298,7 +298,6 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayHasDuplicatesFunctions<int64_t>(prefix);
   registerArrayHasDuplicatesFunctions<int128_t>(prefix);
   registerArrayHasDuplicatesFunctions<Varchar>(prefix);
-  registerArrayHasDuplicatesFunctions<Json>(prefix);
 
   registerArrayFrequencyFunctions<bool>(prefix);
   registerArrayFrequencyFunctions<int8_t>(prefix);

--- a/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayHasDuplicatesTest.cpp
@@ -16,7 +16,6 @@
 
 #include <optional>
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
-#include "velox/functions/prestosql/types/JsonType.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -145,43 +144,4 @@ TEST_F(ArrayHasDuplicatesTest, nullFreeStrings) {
       });
   auto expected = makeFlatVector<bool>({false, true, false, true});
   testExpr(expected, "array_has_duplicates(C0)", {array});
-}
-
-TEST_F(ArrayHasDuplicatesTest, json) {
-  auto result = evaluate(
-      "array_has_duplicates(C0)",
-      makeRowVector({makeNullableArrayVector<StringView>(
-          {{R"({"key":"value"})", R"({"key":"value"})"}}, ARRAY(JSON()))}));
-  assertEqualVectors(makeFlatVector<bool>(true), result);
-
-  result = evaluate(
-      "array_has_duplicates(C0)",
-      makeRowVector({makeNullableArrayVector<StringView>(
-          {{R"({"key":"value"})", R"({"key":"another_value"})"},
-           {R"({"key":"value"})"},
-           {R"({"key":"same_value"})",
-            R"({"key":"another_value"})",
-            R"({"key":"same_value"})"},
-           {std::nullopt, std::nullopt},
-           {R"({"key":"value"})",
-            R"({"key":"another_value"})",
-            R"({"another_key":"value"})"},
-           {R"({"key": "value\with\backslash"})",
-            R"({"key": "value\with\backslash"})"},
-           {R"({"key": "value\nwith\nnewline"})",
-            R"({"key": "value\nwith\nnewline"})"},
-           {R"({"key": "value with \u00A9 and \u20AC"})",
-            R"({"key": "value with \u00A9 and \u20AC"})"},
-           {R"({"key": "!@#$%^&*()_+-={}:<>?,./~`"})",
-            R"({"key": "!@#$%^&*()_+-={}:<>?,./~`"})"},
-           {R"({"key":"value"})",
-            std::nullopt,
-            R"({"key":"another_value"})",
-            R"({"another_key":"value"})",
-            std::nullopt}},
-          ARRAY(JSON()))}));
-  assertEqualVectors(
-      makeFlatVector<bool>(
-          {false, false, true, true, false, true, true, true, true, true}),
-      result);
 }


### PR DESCRIPTION
Summary: New unit test for array_has_duplicates fails on Linux but not Ubuntu. Undoing the addition temporarily while we investigate the issue in case it's a result of added Json functionality

Differential Revision: D68845988
