### PR TITLE
fix(array functions): Add support to array_has_duplicates for input of type json

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -298,6 +298,7 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayHasDuplicatesFunctions<int64_t>(prefix);
   registerArrayHasDuplicatesFunctions<int128_t>(prefix);
   registerArrayHasDuplicatesFunctions<Varchar>(prefix);
+  registerArrayHasDuplicatesFunctions<Json>(prefix);
 
   registerArrayFrequencyFunctions<bool>(prefix);
   registerArrayFrequencyFunctions<int8_t>(prefix);


### PR DESCRIPTION
Summary: Resubmission for adding json support for Presto function array_has_duplicates. Resubmission comes from an investigation into a prior failure discrepancy in Ubuntu/Linux. The issue has since been resolved and we will re-enable the prior functionality following the revert.

Differential Revision: D68860619


