### PR TITLE
Add capacity() getter to ApproxMostFrequentStreamSummary

### DIFF
--- a/velox/functions/lib/ApproxMostFrequentStreamSummary.h
+++ b/velox/functions/lib/ApproxMostFrequentStreamSummary.h
@@ -68,6 +68,9 @@ struct ApproxMostFrequentStreamSummary {
   /// Return the number of distinct values currently being tracked.
   int size() const;
 
+  // Return the maximum number of distinct values that can be tracked.
+  int capacity() const;
+
   /// Return the pointer to values data.  The number of values equals to size().
   const T* values() const {
     return queue_.values();
@@ -105,6 +108,11 @@ void ApproxMostFrequentStreamSummary<T, A>::setCapacity(int capacity) {
 template <typename T, typename A>
 int ApproxMostFrequentStreamSummary<T, A>::size() const {
   return queue_.size();
+}
+
+template <typename T, typename A>
+int ApproxMostFrequentStreamSummary<T, A>::capacity() const {
+  return capacity_;
 }
 
 template <typename T, typename A>

--- a/velox/functions/lib/tests/ApproxMostFrequentStreamSummaryTest.cpp
+++ b/velox/functions/lib/tests/ApproxMostFrequentStreamSummaryTest.cpp
@@ -184,5 +184,17 @@ TEST(ApproxMostFrequentStreamSummaryTest, mergeSerialized) {
   }
 }
 
+TEST(ApproxMostFrequentStreamSummaryTest, capacity) {
+  constexpr int kCapacity = 30;
+  ApproxMostFrequentStreamSummary<int> summary;
+  summary.setCapacity(kCapacity);
+  ASSERT_EQ(summary.capacity(), 30);
+}
+
+TEST(ApproxMostFrequentStreamSummaryTest, unsetCapacity) {
+  ApproxMostFrequentStreamSummary<int> summary;
+  ASSERT_EQ(summary.capacity(), 0);
+}
+
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
# Context

This diff adds a simple getter to retrieve the capacity parameter (after we hit setCapacity()).

We use this internally to perform some sanity checking when we have potentially two different SteamSummaries and we want to ensure capacities are in a sane spot.

This seems reasonably safe to add, the capacity is set by the user and having something to read back out the set value doesn't seem too dangerous. It's also good for sanity checks and unit tests - e.g. as deserializing a stream summary gives back 0 capacity.

Differential Revision: D68870501


