### PR TITLE
fix: Update the Description of map_top_n

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -112,7 +112,7 @@ Map Functions
     ``n`` must be a non-negative BIGINT value.::
 
         SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[2, 3, 1]), 2) --- {'b' -> 3, 'a' -> 2}
-        SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[NULL, 3, NULL]), 2) --- {'b' -> 3, 'a' -> NULL}
+        SELECT map_top_n(map(ARRAY['a', 'b', 'c'], ARRAY[NULL, 3, NULL]), 2) --- {'b' -> 3, 'c' -> NULL}
 
 .. function:: map_top_n_keys(map(K,V), n) -> array(K)
 

--- a/velox/functions/prestosql/tests/MapTopNTest.cpp
+++ b/velox/functions/prestosql/tests/MapTopNTest.cpp
@@ -129,6 +129,16 @@ TEST_F(MapTopNTest, equalValues) {
   auto expectedResults = makeMapVector({0, 3}, expectedKeys, expectedValues);
 
   assertEqualVectors(expectedResults, result);
+
+  auto dataWithStrKey =
+      makeRowVector({makeMapVectorFromJson<std::string, int64_t>(
+          {R"({"a":2, "b":3, "c":1})", R"({"a":null, "b":3, "c":null})"})});
+
+  auto resultWithStrKey = evaluate("map_top_n(c0, 2)", dataWithStrKey);
+
+  auto expectedWithStrKey = makeMapVectorFromJson<std::string, int64_t>(
+      {R"({"b":3, "a":2})", R"({"b":3, "c":null})"});
+  assertEqualVectors(expectedWithStrKey, resultWithStrKey);
 }
 
 TEST_F(MapTopNTest, timestampWithTimeZone) {


### PR DESCRIPTION
Summary:
Update the description of map_top_n

map function **map_top_n** returns a new map containing only the top N elements, sorted in descending order by value. In cases where values are tied, the function sorts the tied elements in lexicographical descending order by key.

Since both 'a' and 'c' have null values, 'c' is included in the top 2 results along with 'b',

Differential Revision: D68913230


