### PR TITLE
fix(s3): Allow custom cacheKey function

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -16,10 +16,21 @@
 
 #pragma once
 
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace facebook::velox::config {
+class ConfigBase;
+}
+
 namespace facebook::velox::filesystems {
 
+using CacheKeyFn = std::function<
+    std::string(std::shared_ptr<const config::ConfigBase>, std::string_view)>;
+
 // Register the S3 filesystem.
-void registerS3FileSystem();
+void registerS3FileSystem(CacheKeyFn cacheKeyFunc = nullptr);
 
 /// Teardown the AWS SDK C++.
 /// Velox users need to manually invoke this before exiting an application.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -21,24 +21,20 @@
 
 namespace facebook::velox::filesystems {
 
-std::string S3Config::identity(
+std::string S3Config::cacheKey(
     std::string_view bucket,
     std::shared_ptr<const config::ConfigBase> config) {
   auto bucketEndpoint = bucketConfigKey(Keys::kEndpoint, bucket);
   if (config->valueExists(bucketEndpoint)) {
-    auto value = config->get<std::string>(bucketEndpoint);
-    if (value.has_value()) {
-      return value.value();
-    }
+    return fmt::format(
+        "{}-{}", config->get<std::string>(bucketEndpoint).value(), bucket);
   }
   auto baseEndpoint = baseConfigKey(Keys::kEndpoint);
   if (config->valueExists(baseEndpoint)) {
-    auto value = config->get<std::string>(baseEndpoint);
-    if (value.has_value()) {
-      return value.value();
-    }
+    return fmt::format(
+        "{}-{}", config->get<std::string>(baseEndpoint).value(), bucket);
   }
-  return kDefaultS3Identity;
+  return std::string(bucket);
 }
 
 S3Config::S3Config(

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -115,10 +115,10 @@ class S3Config {
       std::string_view bucket,
       std::shared_ptr<const config::ConfigBase> config);
 
-  /// Identity is used as a key for the S3FileSystem instance map.
-  /// This will be the bucket endpoint or the base endpoint or the
-  /// default identity in that order.
-  static std::string identity(
+  /// cacheKey is used as a key for the S3FileSystem instance map.
+  /// This will be the bucket endpoint or the base endpoint if they exist plus
+  /// bucket name.
+  static std::string cacheKey(
       std::string_view bucket,
       std::shared_ptr<const config::ConfigBase> config);
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
@@ -20,11 +20,17 @@
 namespace facebook::velox::filesystems {
 namespace {
 
+std::string cacheKeyFunc(
+    std::shared_ptr<const config::ConfigBase> config,
+    std::string_view path) {
+  return config->get<std::string>("hive.s3.endpoint").value();
+}
+
 class S3FileSystemRegistrationTest : public S3Test {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
-    filesystems::registerS3FileSystem();
+    filesystems::registerS3FileSystem(cacheKeyFunc);
   }
 
   static void TearDownTestCase() {
@@ -68,6 +74,15 @@ TEST_F(S3FileSystemRegistrationTest, fileHandle) {
       std::make_unique<FileHandleGenerator>(hiveConfig));
   auto fileHandleCachePtr = factory.generate(s3File);
   readData(fileHandleCachePtr->file.get());
+}
+
+TEST_F(S3FileSystemRegistrationTest, cacheKey) {
+  auto hiveConfig = minioServer_->hiveConfig();
+  auto s3fs = filesystems::getFileSystem(kDummyPath, hiveConfig);
+  std::string_view kDummyPath2 = "s3://dummy2/foo.txt";
+  auto s3fs_new = filesystems::getFileSystem(kDummyPath2, hiveConfig);
+  // The cacheKeyFunc function allows fs caching based on the endpoint value.
+  ASSERT_NE(s3fs, s3fs_new);
 }
 
 TEST_F(S3FileSystemRegistrationTest, finalize) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
@@ -49,7 +49,6 @@ TEST_F(S3FileSystemRegistrationTest, readViaRegistry) {
     LocalWriteFile writeFile(filename);
     writeData(&writeFile);
   }
-  filesystems::registerS3FileSystem();
   auto hiveConfig = minioServer_->hiveConfig();
   {
     auto s3fs = filesystems::getFileSystem(s3File, hiveConfig);
@@ -82,7 +81,7 @@ TEST_F(S3FileSystemRegistrationTest, cacheKey) {
   std::string_view kDummyPath2 = "s3://dummy2/foo.txt";
   auto s3fs_new = filesystems::getFileSystem(kDummyPath2, hiveConfig);
   // The cacheKeyFunc function allows fs caching based on the endpoint value.
-  ASSERT_NE(s3fs, s3fs_new);
+  ASSERT_EQ(s3fs, s3fs_new);
 }
 
 TEST_F(S3FileSystemRegistrationTest, finalize) {


### PR DESCRIPTION
Today, S3FileSystem caches the instances based on the endpoint value.
The endpoint value is not a sufficient key in practice. Usually, the credentials are
per bucket. Presto uses the bucket name as a key as well.
This PR changes the default key to use endpoint + bucket name.
Users can optionally provide a function to define the key
for caching the instances to allow customization.