### PR TITLE
fix: Remove StringWriter that modifies input in place

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -256,6 +256,12 @@ After applying substr(s, 2) function string in position 1 became short enough
 to fit inside the StringView, hence, it no longer contains a pointer to a
 position in the string buffer.
 
+Allowing these zero-copy implementations of functions that simply change the
+starting position/length of a string, means that we may end up with StringViews
+pointing to overlapping ranges within `stringBuffers_`. For this reason the
+Buffers in `stringBuffers_` should be treated as immutable to prevent
+modifications from unintentionally cascading.
+
 Flat vectors of type TIMESTAMP are represented by FlatVector<Timestamp>.
 Timestamp struct consists of two 64-bit integers: seconds and nanoseconds. Each
 entry uses 16 bytes.

--- a/velox/docs/develop/view-and-writer-types.rst
+++ b/velox/docs/develop/view-and-writer-types.rst
@@ -310,7 +310,7 @@ When a given Ti is primitive, the following is valid.
 Assignable to std::optional<T> allows writing null or value to the primitive. Returned by complex writers when writing nullable
 primitives.
 
-**StringWriter<>**
+**StringWriter**
 
 - void **reserve** (size_t newCapacity) : Reserve a space for the output string with size of at least newCapacity.
 - void **resize** (size_t newCapacity) : Set the size of the string.

--- a/velox/docs/functions/presto/json.rst
+++ b/velox/docs/functions/presto/json.rst
@@ -211,4 +211,4 @@ are similar. To create a JSON-typed vector, one can use
 ``BaseVector::create(JSON(), size, pool)`` that creates a flat vector of
 StringViews, i.e. FlatVector<StringView>. Reading and writing to a JSON-typed
 vector are the same as those for VARCHAR vectors, e.g., via
-VectorReader<StringView> and StringWriter<>.
+VectorReader<StringView> and StringWriter.

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -341,7 +341,7 @@ void CastExpr::applyCastKernel(
     if constexpr (
         ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
       // Write the result output to the output vector
-      auto writer = exec::StringWriter<>(result, row);
+      auto writer = exec::StringWriter(result, row);
       writer.copy_from(output);
       writer.finalize();
     } else {

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -175,7 +175,7 @@ VectorPtr CastExpr::castFromDate(
         try {
           // TODO Optimize to avoid creating an intermediate string.
           auto output = DATE()->toString(inputFlatVector->valueAt(row));
-          auto writer = exec::StringWriter<>(resultFlatVector, row);
+          auto writer = exec::StringWriter(resultFlatVector, row);
           writer.resize(output.size());
           ::memcpy(writer.data(), output.data(), output.size());
           writer.finalize();
@@ -298,7 +298,7 @@ VectorPtr CastExpr::castFromIntervalDayTime(
           // TODO Optimize to avoid creating an intermediate string.
           auto output =
               INTERVAL_DAY_TIME()->valueToString(inputFlatVector->valueAt(row));
-          auto writer = exec::StringWriter<>(resultFlatVector, row);
+          auto writer = exec::StringWriter(resultFlatVector, row);
           writer.resize(output.size());
           ::memcpy(writer.data(), output.data(), output.size());
           writer.finalize();

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -21,7 +21,6 @@
 
 namespace facebook::velox::exec {
 
-template <bool reuseInput>
 class StringWriter;
 
 template <bool nullable, typename V>
@@ -120,14 +119,14 @@ template <>
 struct resolver<Varchar> {
   using in_type = StringView;
   using null_free_in_type = in_type;
-  using out_type = StringWriter<false>;
+  using out_type = StringWriter;
 };
 
 template <>
 struct resolver<Varbinary> {
   using in_type = StringView;
   using null_free_in_type = in_type;
-  using out_type = StringWriter<false>;
+  using out_type = StringWriter;
 };
 
 template <>

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -353,7 +353,7 @@ struct VectorWriter<
     std::enable_if_t<std::is_same_v<T, Varchar> | std::is_same_v<T, Varbinary>>>
     : public VectorWriterBase {
   using vector_t = typename TypeToFlatVector<T>::type;
-  using exec_out_t = StringWriter<>;
+  using exec_out_t = StringWriter;
 
   void init(vector_t& vector, bool uniqueAndMutable = false) {
     proxy_.vector_ = &vector;

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -28,7 +28,7 @@ class StringWriterTest : public functions::test::FunctionBaseTest {};
 
 TEST_F(StringWriterTest, append) {
   auto vector = makeFlatVector<StringView>(2);
-  auto writer = exec::StringWriter<>(vector.get(), 0);
+  auto writer = exec::StringWriter(vector.get(), 0);
   writer.append("1 "_sv);
   writer.append(std::string_view("2 "));
   writer.append("3 "_sv);
@@ -42,7 +42,7 @@ TEST_F(StringWriterTest, append) {
 
 TEST_F(StringWriterTest, plusOperator) {
   auto vector = makeFlatVector<StringView>(1);
-  auto writer = exec::StringWriter<>(vector.get(), 0);
+  auto writer = exec::StringWriter(vector.get(), 0);
   writer += "1 "_sv;
   writer += "2 ";
   writer += std::string_view("3 ");
@@ -57,19 +57,19 @@ TEST_F(StringWriterTest, plusOperator) {
 TEST_F(StringWriterTest, assignment) {
   auto vector = makeFlatVector<StringView>(4);
 
-  auto writer0 = exec::StringWriter<>(vector.get(), 0);
+  auto writer0 = exec::StringWriter(vector.get(), 0);
   writer0 = "string0"_sv;
   writer0.finalize();
 
-  auto writer1 = exec::StringWriter<>(vector.get(), 1);
+  auto writer1 = exec::StringWriter(vector.get(), 1);
   writer1 = std::string("string1");
   writer1.finalize();
 
-  auto writer2 = exec::StringWriter<>(vector.get(), 2);
+  auto writer2 = exec::StringWriter(vector.get(), 2);
   writer2 = std::string_view("string2");
   writer2.finalize();
 
-  auto writer3 = exec::StringWriter<>(vector.get(), 3);
+  auto writer3 = exec::StringWriter(vector.get(), 3);
   writer3 = folly::StringPiece("string3");
   writer3.finalize();
 
@@ -81,7 +81,7 @@ TEST_F(StringWriterTest, assignment) {
 
 TEST_F(StringWriterTest, copyFromStringView) {
   auto vector = makeFlatVector<StringView>(1);
-  auto writer = exec::StringWriter<>(vector.get(), 0);
+  auto writer = exec::StringWriter(vector.get(), 0);
   writer.copy_from("1 2 3 4 5 "_sv);
   writer.finalize();
 
@@ -90,7 +90,7 @@ TEST_F(StringWriterTest, copyFromStringView) {
 
 TEST_F(StringWriterTest, copyFromStdString) {
   auto vector = makeFlatVector<StringView>(1);
-  auto writer = exec::StringWriter<>(vector.get(), 0);
+  auto writer = exec::StringWriter(vector.get(), 0);
   writer.copy_from(std::string("1 2 3 4 5 "));
   writer.finalize();
 
@@ -99,7 +99,7 @@ TEST_F(StringWriterTest, copyFromStdString) {
 
 TEST_F(StringWriterTest, copyFromCString) {
   auto vector = makeFlatVector<StringView>(4);
-  auto writer = exec::StringWriter<>(vector.get(), 0);
+  auto writer = exec::StringWriter(vector.get(), 0);
   writer.copy_from("1 2 3 4 5 ");
   writer.finalize();
 

--- a/velox/expression/tests/VariadicViewTest.cpp
+++ b/velox/expression/tests/VariadicViewTest.cpp
@@ -377,7 +377,7 @@ const auto callNullablePrefix = "callNullable "_sv;
 const auto callAsciiPrefix = "callAscii "_sv;
 
 void writeInputToOutput(
-    StringWriter<>& out,
+    StringWriter& out,
     const VariadicView<true, Varchar>* inputs) {
   for (const auto& input : *inputs) {
     out += input.has_value() ? input.value() : null;

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1424,11 +1424,11 @@ class RegexpReplaceWithLambdaFunction : public exec::VectorFunction {
   // Sections being replaced should not overlap.
   struct Replacer {
     const StringView& original;
-    exec::StringWriter<false>& writer;
+    exec::StringWriter& writer;
     char* result;
     size_t start = 0;
 
-    Replacer(const StringView& _original, exec::StringWriter<false>& _writer)
+    Replacer(const StringView& _original, exec::StringWriter& _writer)
         : original{_original}, writer{_writer}, result{writer.data()} {}
 
     void replace(size_t offset, size_t size, const StringView& replacement) {

--- a/velox/functions/lib/ToHex.h
+++ b/velox/functions/lib/ToHex.h
@@ -23,7 +23,7 @@ namespace facebook::velox::functions {
 struct ToHexUtil {
   FOLLY_ALWAYS_INLINE static void toHex(
       StringView input,
-      exec::StringWriter<false>& result) {
+      exec::StringWriter& result) {
     // Lookup table to translate unsigned char to its hexadecimal format.
     static const char* const kHexTable =
         "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
@@ -49,7 +49,7 @@ struct ToHexUtil {
 
   FOLLY_ALWAYS_INLINE static void toHex(
       uint64_t input,
-      exec::StringWriter<false>& result) {
+      exec::StringWriter& result) {
     static const char* const kHexTable = "0123456789ABCDEF";
     if (input == 0) {
       result = "0";

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -21,8 +21,6 @@
 #include <stdlib.h>
 #include <cstdint>
 #include <cstring>
-#include <sstream>
-#include <string>
 #include <string_view>
 #include <vector>
 #include "folly/CPortability.h"
@@ -62,20 +60,6 @@ FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
         lowerUnicode(output.data(), output.size(), input.data(), input.size());
     output.resize(size);
   }
-  return true;
-}
-
-/// Inplace ascii lower
-template <typename T>
-FOLLY_ALWAYS_INLINE bool lowerAsciiInPlace(T& str) {
-  lowerAscii(str.data(), str.data(), str.size());
-  return true;
-}
-
-/// Inplace ascii upper
-template <typename T>
-FOLLY_ALWAYS_INLINE bool upperAsciiInPlace(T& str) {
-  upperAscii(str.data(), str.data(), str.size());
   return true;
 }
 

--- a/velox/functions/prestosql/FromUtf8.cpp
+++ b/velox/functions/prestosql/FromUtf8.cpp
@@ -95,7 +95,7 @@ class FromUtf8Function : public exec::VectorFunction {
 
     if (constantReplacement) {
       rows.applyToSelected([&](auto row) {
-        exec::StringWriter<false> writer(flatResult, row);
+        exec::StringWriter writer(flatResult, row);
         auto value = decodedInput.valueAt<StringView>(row);
         if (row < firstInvalidRow) {
           writer.append(value);
@@ -109,7 +109,7 @@ class FromUtf8Function : public exec::VectorFunction {
       context.applyToSelectedNoThrow(rows, [&](auto row) {
         auto replacement =
             getReplacementCharacter(args[1]->type(), decodedReplacement, row);
-        exec::StringWriter<false> writer(flatResult, row);
+        exec::StringWriter writer(flatResult, row);
         auto value = decodedInput.valueAt<StringView>(row);
         if (row < firstInvalidRow) {
           writer.append(value);
@@ -261,7 +261,7 @@ class FromUtf8Function : public exec::VectorFunction {
   void fixInvalidUtf8(
       StringView input,
       const std::string& replacement,
-      exec::StringWriter<false>& fixedWriter) const {
+      exec::StringWriter& fixedWriter) const {
     if (input.empty()) {
       fixedWriter.setEmpty();
       return;

--- a/velox/functions/prestosql/Reverse.cpp
+++ b/velox/functions/prestosql/Reverse.cpp
@@ -42,7 +42,7 @@ class ReverseFunction : public exec::VectorFunction {
         const FlatVector<StringView>* input,
         FlatVector<StringView>* result) {
       rows.applyToSelected([&](int row) {
-        auto proxy = exec::StringWriter<>(result, row);
+        auto proxy = exec::StringWriter(result, row);
         stringImpl::reverse<isAscii>(proxy, input->valueAt(row).getString());
         proxy.finalize();
       });
@@ -100,7 +100,7 @@ class ReverseFunction : public exec::VectorFunction {
     if (originalArg->isConstantEncoding()) {
       auto value = originalArg->as<ConstantVector<StringView>>()->valueAt(0);
 
-      auto proxy = exec::StringWriter<>(flatResult, rows.begin());
+      auto proxy = exec::StringWriter(flatResult, rows.begin());
       if (isAscii) {
         stringImpl::reverse<true>(proxy, value.str());
       } else {

--- a/velox/functions/prestosql/StringFunctions.cpp
+++ b/velox/functions/prestosql/StringFunctions.cpp
@@ -19,7 +19,6 @@
 #include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/StringEncodingUtils.h"
-#include "velox/functions/lib/string/StringCore.h"
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/vector/FlatVector.h"
 
@@ -43,7 +42,7 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
         const DecodedVector* decodedInput,
         FlatVector<StringView>* results) {
       rows.applyToSelected([&](int row) {
-        auto proxy = exec::StringWriter<>(results, row);
+        auto proxy = exec::StringWriter(results, row);
         if constexpr (isLower) {
           stringImpl::lower<isAscii>(
               proxy, decodedInput->valueAt<StringView>(row));
@@ -55,25 +54,6 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
       });
     }
   };
-
-  void applyInternalInPlace(
-      const SelectivityVector& rows,
-      DecodedVector* decodedInput,
-      FlatVector<StringView>* results) const {
-    rows.applyToSelected([&](int row) {
-      auto proxy = exec::StringWriter<true /*reuseInput*/>(
-          results,
-          row,
-          decodedInput->valueAt<StringView>(row) /*reusedInput*/,
-          true /*inPlace*/);
-      if constexpr (isLower) {
-        stringImpl::lowerAsciiInPlace(proxy);
-      } else {
-        stringImpl::upperAsciiInPlace(proxy);
-      }
-      proxy.finalize();
-    });
-  }
 
  public:
   void apply(
@@ -91,19 +71,6 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
     auto decodedInput = inputHolder.get();
 
     auto ascii = isAscii(inputStringsVector, rows);
-
-    bool tryInplace = ascii &&
-        (inputStringsVector->encoding() == VectorEncoding::Simple::FLAT);
-
-    // If tryInplace, then call prepareFlatResultsVector(). If the latter
-    // returns true, note that the input arg was moved to result, so that the
-    // buffer can be reused as output.
-    if (tryInplace &&
-        prepareFlatResultsVector(result, rows, context, args.at(0))) {
-      auto* resultFlatVector = result->as<FlatVector<StringView>>();
-      applyInternalInPlace(rows, decodedInput, resultFlatVector);
-      return;
-    }
 
     // Not in place path.
     VectorPtr emptyVectorPtr;
@@ -308,32 +275,13 @@ class Replace : public exec::VectorFunction {
       const SelectivityVector& rows,
       FlatVector<StringView>* results) const {
     rows.applyToSelected([&](int row) {
-      auto proxy = exec::StringWriter<>(results, row);
+      auto proxy = exec::StringWriter(results, row);
       stringImpl::replace(
           proxy,
           stringReader(row),
           searchReader(row),
           replaceReader(row),
           replaceFirst_);
-      proxy.finalize();
-    });
-  }
-
-  template <
-      typename StringReader,
-      typename SearchReader,
-      typename ReplaceReader>
-  void applyInPlace(
-      StringReader stringReader,
-      SearchReader searchReader,
-      ReplaceReader replaceReader,
-      const SelectivityVector& rows,
-      FlatVector<StringView>* results) const {
-    rows.applyToSelected([&](int row) {
-      auto proxy = exec::StringWriter<true /*reuseInput*/>(
-          results, row, stringReader(row) /*reusedInput*/, true /*inPlace*/);
-      stringImpl::replaceInPlace(
-          proxy, searchReader(row), replaceReader(row), replaceFirst_);
       proxy.finalize();
     });
   }
@@ -391,27 +339,6 @@ class Replace : public exec::VectorFunction {
         return decodedReplaceInput->valueAt<StringView>(row);
       }
     };
-
-    // Right now we enable the inplace if 'search' and 'replace' are constants
-    // and 'search' size is larger than or equal to 'replace' and if the input
-    // vector is reused.
-
-    // TODO: analyze other options for enabling inplace i.e.:
-    // 1. Decide per row.
-    // 2. Scan inputs for max lengths and decide based on that. ..etc
-    bool tryInplace = replaceArgValue.has_value() &&
-        searchArgValue.has_value() &&
-        (searchArgValue.value().size() >= replaceArgValue.value().size()) &&
-        (args.at(0)->encoding() == VectorEncoding::Simple::FLAT);
-
-    if (tryInplace) {
-      if (prepareFlatResultsVector(result, rows, context, args.at(0))) {
-        auto* resultFlatVector = result->as<FlatVector<StringView>>();
-        applyInPlace(
-            stringReader, searchReader, replaceReader, rows, resultFlatVector);
-        return;
-      }
-    }
 
     // Not in place path
     VectorPtr emptyVectorPtr;

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -114,7 +114,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       std::reverse(addrBytes.begin(), addrBytes.end());
       folly::IPAddressV6 v6Addr(addrBytes);
 
-      exec::StringWriter<false> result(flatResult, row);
+      exec::StringWriter result(flatResult, row);
       if (v6Addr.isIPv4Mapped()) {
         result.append(v6Addr.createIPv4().str());
       } else {
@@ -165,7 +165,7 @@ class IPAddressCastOperator : public exec::CastOperator {
       memcpy(&addrBytes, &intAddr, ipaddress::kIPAddressBytes);
       std::reverse(addrBytes.begin(), addrBytes.end());
 
-      exec::StringWriter<false> result(flatResult, row);
+      exec::StringWriter result(flatResult, row);
       result.resize(ipaddress::kIPAddressBytes);
       memcpy(result.data(), &addrBytes, ipaddress::kIPAddressBytes);
       result.finalize();

--- a/velox/functions/prestosql/types/IPPrefixType.cpp
+++ b/velox/functions/prestosql/types/IPPrefixType.cpp
@@ -122,7 +122,7 @@ class IPPrefixCastOperator : public exec::CastOperator {
       auto stringRet = fmt::format("{}/{}", ipString, prefixVal);
 
       // Write the string to the result vector
-      exec::StringWriter<false> result(flatResult, row);
+      exec::StringWriter result(flatResult, row);
       result.append(stringRet);
       result.finalize();
     });

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -314,7 +314,7 @@ struct AsJson {
   }
 
   // Appends the json string of the value at i to a string writer.
-  void append(vector_size_t i, exec::StringWriter<>& proxy) const {
+  void append(vector_size_t i, exec::StringWriter& proxy) const {
     if (decoded_->isNullAt(i)) {
       proxy.append("null");
     } else {
@@ -435,7 +435,7 @@ void castToJsonFromArray(
     auto offset = inputArray->offsetAt(row);
     auto size = inputArray->sizeAt(row);
 
-    auto proxy = exec::StringWriter<>(&flatResult, row);
+    auto proxy = exec::StringWriter(&flatResult, row);
 
     proxy.append("["_sv);
     for (int i = offset, end = offset + size; i < end; ++i) {
@@ -529,7 +529,7 @@ void castToJsonFromMap(
     }
     std::sort(sortedKeys.begin(), sortedKeys.end());
 
-    auto proxy = exec::StringWriter<>(&flatResult, row);
+    auto proxy = exec::StringWriter(&flatResult, row);
 
     proxy.append("{"_sv);
     for (auto it = sortedKeys.begin(); it != sortedKeys.end(); ++it) {
@@ -587,7 +587,7 @@ void castToJsonFromRow(
       return;
     }
 
-    auto proxy = exec::StringWriter<>(&flatResult, row);
+    auto proxy = exec::StringWriter(&flatResult, row);
 
     proxy.append("["_sv);
     for (int i = 0; i < childrenSize; ++i) {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -131,7 +131,7 @@ void castToString(
     const auto timeZoneId = unpackZoneKeyId(timestampWithTimezone);
     const auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
 
-    exec::StringWriter<false> result(flatResult, row);
+    exec::StringWriter result(flatResult, row);
 
     const auto maxResultSize = formatter->maxResultSize(timezonePtr);
     result.reserve(maxResultSize);

--- a/velox/functions/prestosql/types/UuidType.cpp
+++ b/velox/functions/prestosql/types/UuidType.cpp
@@ -93,7 +93,7 @@ class UuidCastOperator : public exec::CastOperator {
           "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
           "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
 
-      exec::StringWriter<false> result(flatResult, row);
+      exec::StringWriter result(flatResult, row);
       result.resize(36);
 
       size_t offset = 0;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -17,11 +17,9 @@
 
 #include "folly/ssl/OpenSSLHash.h"
 
-#include <codecvt>
 #include <string>
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
-#include "velox/functions/UDFOutputString.h"
 #include "velox/functions/lib/string/StringCore.h"
 #include "velox/functions/lib/string/StringImpl.h"
 
@@ -683,7 +681,7 @@ struct SubstrFunction {
 struct OverlayFunctionBase {
   template <bool isAscii, bool isVarchar>
   FOLLY_ALWAYS_INLINE void doCall(
-      exec::StringWriter<false>& result,
+      exec::StringWriter& result,
       StringView input,
       StringView replace,
       int32_t pos,
@@ -713,7 +711,7 @@ struct OverlayFunctionBase {
 
   template <bool isAscii, bool isVarchar>
   FOLLY_ALWAYS_INLINE void append(
-      exec::StringWriter<false>& result,
+      exec::StringWriter& result,
       StringView input,
       std::pair<int32_t, int32_t> pair) {
     if constexpr (isVarchar && !isAscii) {


### PR DESCRIPTION
Summary:
StringWriter supports two flavors, one that writes out new strings to a result Vector, and one that
modifies existing strings in place. The latter is only used in two places, providing fast paths for
upper/lower and replace/replace_first. 

I found a related bug with fuzzer that occurs in replace/replace_first that occurs when the StringViews in the first argument's Vector point to overlapping ranges of the same string buffers.
In this case the changes to one row are accidentally applied to multiple rows resulting in
incorrect results.

Since we explicitly allow operations that produce a substring of the original string to do so with
a no-copy implementation, StringViews with overlapping ranges can occur.  E.g. SimpleFunctions
that apply this no-copy optimization on a string argument which could be constant, with other
arguments that determine the range of the original string to take that are non-constant (like 
trim).

I discussed this offline with a few folks and since the above is allowed and this in-place 
optimization is so rarely used, the consensus was to treat the string buffers in a FlatVector as
immutable.

Therefore in this change, I remove the flavor of StringWriter that modifies strings in place. This
fixes the bug in replace/replace_first. upper/lower was using it correctly because the optimization
was only applied to ASCII strings, the function takes a single argument, and the modification is 
idempotent (the value of a byte in the string don't depend on any other bytes in the string or any 
other arguments, and can be reapplied without consequences). Given how precarious this
optimization is (if any of those conditions changed it would result in difficult to detect bugs), and
allowing upper/lower to mutate the string in place would invite others to do so in the future
(potentially leading to more bugs like in replace/replace_first) I think losing this fast path is worth
the added safety.

I also updated the documentation to clarify that the string buffers in a FlatVector should be
treated as immutable.

Differential Revision: D68924324


