### PR TITLE
fix: MemoryManager constructors reliance on a static GlobalConfiguration object

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -37,7 +37,7 @@ MallocAllocator::MallocAllocator(size_t capacity, uint32_t reservationByteLimit)
 
 MallocAllocator::~MallocAllocator() {
   // TODO: Remove the check when memory leak issue is resolved.
-  if (config::globalConfig.memoryLeakCheckEnabled) {
+  if (FLAGS_velox_memory_leak_check_enabled) {
     VELOX_CHECK(
         ((allocatedBytes_ - reservations_.read()) == 0) &&
             (numAllocated_ == 0) && (numMapped_ == 0),

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -24,6 +24,8 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/MmapAllocator.h"
 
+DECLARE_int32(velox_memory_num_shared_leaf_pools);
+
 namespace facebook::velox::memory {
 namespace {
 constexpr std::string_view kSysRootName{"__sys_root__"};
@@ -78,7 +80,7 @@ std::vector<std::shared_ptr<MemoryPool>> createSharedLeafMemoryPools(
   VELOX_CHECK_EQ(sysPool.name(), kSysRootName);
   std::vector<std::shared_ptr<MemoryPool>> leafPools;
   const size_t numSharedPools =
-      std::max(1, config::globalConfig.memoryNumSharedLeafPools);
+      std::max(1, FLAGS_velox_memory_num_shared_leaf_pools);
   leafPools.reserve(numSharedPools);
   for (size_t i = 0; i < numSharedPools; ++i) {
     leafPools.emplace_back(
@@ -129,7 +131,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       sysRoot_->name());
   VELOX_CHECK_EQ(
       sharedLeafPools_.size(),
-      std::max(1, config::globalConfig.memoryNumSharedLeafPools));
+      std::max(1, FLAGS_velox_memory_num_shared_leaf_pools));
 }
 
 MemoryManager::~MemoryManager() {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -40,6 +40,10 @@
 #include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MemoryPool.h"
 
+DECLARE_bool(velox_memory_leak_check_enabled);
+DECLARE_bool(velox_memory_pool_debug_enabled);
+DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
+
 namespace facebook::velox::memory {
 #define VELOX_MEM_LOG_PREFIX "[MEM] "
 #define VELOX_MEM_LOG(severity) LOG(severity) << VELOX_MEM_LOG_PREFIX
@@ -61,18 +65,18 @@ struct MemoryManagerOptions {
 
   /// If true, enable memory usage tracking in the default memory pool.
   bool trackDefaultUsage{
-      config::globalConfig.enableMemoryUsageTrackInDefaultMemoryPool};
+      FLAGS_velox_enable_memory_usage_track_in_default_memory_pool};
 
   /// If true, check the memory pool and usage leaks on destruction.
   ///
   /// TODO: deprecate this flag after all the existing memory leak use cases
   /// have been fixed.
-  bool checkUsageLeak{config::globalConfig.memoryLeakCheckEnabled};
+  bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
 
   /// If true, the memory pool will be running in debug mode to track the
   /// allocation and free call stacks to detect the source of memory leak for
   /// testing purpose.
-  bool debugEnabled{config::globalConfig.memoryPoolDebugEnabled};
+  bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
 
   /// Terminates the process and generates a core file on an allocation failure
   bool coreOnAllocationFailureEnabled{false};

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -29,6 +29,8 @@
 #include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 
+DECLARE_bool(velox_memory_pool_debug_enabled);
+
 namespace facebook::velox::exec {
 class ParallelMemoryReclaimer;
 }
@@ -151,7 +153,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
     /// If true, tracks the allocation and free call stacks to detect the source
     /// of memory leak for testing purpose.
-    bool debugEnabled{config::globalConfig.memoryPoolDebugEnabled};
+    bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
 
     /// Terminates the process and generates a core file on an allocation
     /// failure

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -342,8 +342,8 @@ void setupMemory(
     int64_t allocatorCapacity,
     int64_t arbitratorCapacity,
     bool enableGlobalArbitration) {
-  config::globalConfig.enableMemoryUsageTrackInDefaultMemoryPool = true;
-  config::globalConfig.memoryLeakCheckEnabled = true;
+  FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+  FLAGS_velox_memory_leak_check_enabled = true;
   facebook::velox::memory::SharedArbitrator::registerFactory();
   facebook::velox::memory::MemoryManagerOptions options;
   options.allocatorCapacity = allocatorCapacity;


### PR DESCRIPTION
Summary: Reverting part of #12127 where MemoryManager initialization is referring to static objects and some internal usecases statically initialize the memory manager. Since static initialization order is not defined, this can cause undefined behaviour which we caught using ASAN.

Reviewed By: xiaoxmeng

Differential Revision: D68874619


