### PR TITLE
feat(python): PyVelox bindings for LocalRunner

### DIFF
--- a/velox/py/CMakeLists.txt
+++ b/velox/py/CMakeLists.txt
@@ -58,3 +58,29 @@ velox_link_libraries(
   velox_dwio_dwrf_writer
   Folly::folly
   pybind11::module)
+
+pybind11_add_module(plan_builder MODULE plan_builder/plan_builder.cpp)
+target_link_libraries(
+  plan_builder
+  PRIVATE velox_py_plan_builder_lib)
+
+# velox.py.runner library:
+velox_add_library(velox_py_local_runner_lib runner/PyLocalRunner.cpp)
+velox_link_libraries(
+  velox_py_local_runner_lib
+  velox_py_type_lib
+  velox_py_vector_lib
+  velox_vector
+  velox_core
+  velox_cursor
+  velox_hive_connector
+  velox_exec_test_lib
+  velox_dwio_dwrf_reader
+  velox_dwio_dwrf_common
+  velox_dwio_dwrf_writer
+  pybind11::module)
+
+pybind11_add_module(runner MODULE runner/runner.cpp)
+target_link_libraries(
+  runner
+  PRIVATE velox_py_local_runner_lib)

--- a/velox/py/file/PyFile.h
+++ b/velox/py/file/PyFile.h
@@ -28,6 +28,14 @@ class PyFile {
 
   std::string toString() const;
 
+  std::string filePath() const {
+    return filePath_;
+  }
+
+  dwio::common::FileFormat fileFormat() const {
+    return fileFormat_;
+  }
+
   static PyFile createParquet(const std::string& filePath) {
     return PyFile(filePath, dwio::common::FileFormat::PARQUET);
   }

--- a/velox/py/plan_builder/plan_builder.cpp
+++ b/velox/py/plan_builder/plan_builder.cpp
@@ -79,17 +79,18 @@ PYBIND11_MODULE(plan_builder, m) {
       .def(
           "table_scan",
           &velox::py::PyPlanBuilder::tableScan,
-          py::arg("output") = velox::py::PyType{},
+          py::arg("output_schema") = velox::py::PyType{},
           py::arg("aliases") = py::dict{},
           py::arg("subfields") = py::dict{},
           py::arg("row_index") = "",
           py::arg("connector_id") = "prism",
+          py::arg("input_files") = std::nullopt,
           py::doc(R"(
         Adds a table scan node to the plan.
 
         Args:
-          output: A RowType containing the schema to be projected out
-                  of the scan.
+          output_schema: A RowType containing the schema to be projected out
+                         of the scan.
           aliases: An optional map of aliases to apply, from the desired
                    output name to the name as defined in the file. If
                    there are aliases, `output` should be specified based
@@ -101,6 +102,8 @@ PYBIND11_MODULE(plan_builder, m) {
                      producing $row_ids. This name needs to be part of the
                      `output` as BIGINT.
           connector_id: ID of the connector to use for this scan.
+          input_files: If defined, uses as the input files so that no splits
+                      will need to be added later.
       )"))
       .def(
           "values",

--- a/velox/py/runner/PyLocalRunner.cpp
+++ b/velox/py/runner/PyLocalRunner.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/py/runner/PyLocalRunner.h"
+
+#include <pybind11/stl.h>
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/py/vector/PyVector.h"
+
+namespace facebook::velox::py {
+namespace {
+
+std::list<std::weak_ptr<exec::Task>>& taskRegistry() {
+  static std::list<std::weak_ptr<exec::Task>> registry;
+  return registry;
+}
+
+std::mutex& taskRegistryLock() {
+  static std::mutex lock;
+  return lock;
+}
+
+} // namespace
+
+namespace py = pybind11;
+
+PyVector PyTaskIterator::Iterator::operator*() const {
+  return PyVector{vector_};
+}
+
+void PyTaskIterator::Iterator::advance() {
+  if (cursor_ && cursor_->moveNext()) {
+    vector_ = cursor_->current();
+  } else {
+    vector_ = nullptr;
+  }
+}
+
+PyLocalRunner::PyLocalRunner(
+    const PyPlanNode& pyPlanNode,
+    const std::shared_ptr<memory::MemoryPool>& pool,
+    const std::shared_ptr<folly::CPUThreadPoolExecutor>& executor)
+    : pool_(pool),
+      executor_(executor),
+      planNode_(pyPlanNode.planNode()),
+      scanFiles_(pyPlanNode.scanFiles()) {
+  // TODO: Make these configurable.
+  std::unordered_map<std::string, std::string> configs = {
+      {"selective_nimble_reader_enabled", "true"}};
+
+  auto queryCtx = core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig(configs),
+      {},
+      cache::AsyncDataCache::getInstance(),
+      pool_);
+
+  cursor_ = exec::TaskCursor::create({
+      .planNode = planNode_,
+      .queryCtx = queryCtx,
+  });
+}
+
+void PyLocalRunner::addFileSplit(
+    const PyFile& pyFile,
+    const std::string& planId,
+    const std::string& connectorId) {
+  auto split =
+      velox::exec::Split(std::make_shared<connector::hive::HiveConnectorSplit>(
+          connectorId, pyFile.filePath(), pyFile.fileFormat()));
+  cursor_->task()->addSplit(planId, std::move(split));
+}
+
+py::iterator PyLocalRunner::execute() {
+  if (pyIterator_) {
+    throw std::runtime_error("PyLocalRunner can only be executed once.");
+  }
+
+  // Add any files passed by the client during plan building.
+  for (const auto& [scanId, scanPair] : *scanFiles_) {
+    for (const auto& inputFile : scanPair.second) {
+      addFileSplit(inputFile, scanId, scanPair.first);
+    }
+    cursor_->task()->noMoreSplits(scanId);
+  }
+
+  {
+    std::lock_guard<std::mutex> guard(taskRegistryLock());
+    taskRegistry().push_back(cursor_->task());
+  }
+
+  pyIterator_ = std::make_shared<PyTaskIterator>(cursor_);
+  return py::make_iterator(pyIterator_->begin(), pyIterator_->end());
+}
+
+void drainAllTasks() {
+  auto& executor = folly::QueuedImmediateExecutor::instance();
+  std::lock_guard<std::mutex> guard(taskRegistryLock());
+
+  auto it = taskRegistry().begin();
+  while (it != taskRegistry().end()) {
+    // Try to acquire a shared_ptr from the weak_ptr (in case the task has
+    // already finished).
+    if (auto task = it->lock()) {
+      if (!task->isFinished()) {
+        task->requestAbort();
+      }
+      auto future = task->taskCompletionFuture()
+                        .within(std::chrono::seconds(1))
+                        .via(&executor);
+      future.wait();
+    }
+    it = taskRegistry().erase(it);
+  }
+}
+
+} // namespace facebook::velox::py

--- a/velox/py/runner/PyLocalRunner.h
+++ b/velox/py/runner/PyLocalRunner.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <pybind11/embed.h>
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Cursor.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/py/plan_builder/PyPlanBuilder.h"
+#include "velox/py/type/PyType.h"
+
+namespace facebook::velox::py {
+
+class PyTaskIterator;
+
+/// A C++ wrapper to allow Python clients to execute plans using TaskCursor.
+///
+/// @param pyPlanNode The plan to be executed (created using
+/// velox.py.plan_builder).
+/// @param pool The memory pool to pass to the task.
+/// @param executor The executor that will be used by drivers.
+class PyLocalRunner {
+ public:
+  explicit PyLocalRunner(
+      const PyPlanNode& pyPlanNode,
+      const std::shared_ptr<memory::MemoryPool>& pool,
+      const std::shared_ptr<folly::CPUThreadPoolExecutor>& executor);
+
+  /// Add a split to scan an entire file.
+  ///
+  /// @param pyFile The Python File object describin the file path and format.
+  /// @param planId The plan node ID of the scan.
+  /// @param connectorId The connector used by the scan.
+  void addFileSplit(
+      const PyFile& pyFile,
+      const std::string& planId,
+      const std::string& connectorId);
+
+  /// Execute the task and returns an iterable to the output vectors.
+  pybind11::iterator execute();
+
+ private:
+  friend class PyTaskIterator;
+
+  // Memory pool and thread pool to be used by queryCtx.
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+
+  // The plan node to be executed (created using velox.py.plan_builder).
+  core::PlanNodePtr planNode_;
+
+  // The task cursor that executed the Velox Task.
+  std::shared_ptr<exec::TaskCursor> cursor_;
+
+  // The Python iterator that exposes output vectors.
+  std::shared_ptr<PyTaskIterator> pyIterator_;
+
+  const TScanFilesPtr scanFiles_;
+};
+
+// Iterator class that wraps around a PyLocalRunner and provides an iterable API
+// for Python. It needs to provide a .begin() and .end() methods, and the object
+// returned by them needs to be comparable and incrementable.
+class PyTaskIterator {
+ public:
+  explicit PyTaskIterator(const std::shared_ptr<exec::TaskCursor>& cursor)
+      : cursor_(cursor) {}
+
+  class Iterator {
+   public:
+    Iterator() {}
+
+    explicit Iterator(const std::shared_ptr<exec::TaskCursor>& cursor)
+        : cursor_(cursor) {
+      // Advance to the first batch.
+      advance();
+    }
+
+    PyVector operator*() const;
+
+    void advance();
+
+    Iterator& operator++() {
+      advance();
+      return *this;
+    }
+
+    bool operator!=(const Iterator& other) const {
+      return vector_ != other.vector_;
+    }
+
+    bool operator==(const Iterator& other) const {
+      return vector_ == other.vector_;
+    }
+
+   private:
+    std::shared_ptr<exec::TaskCursor> cursor_;
+    RowVectorPtr vector_{nullptr};
+  };
+
+  Iterator begin() const {
+    return Iterator(cursor_);
+  }
+
+  Iterator end() const {
+    return Iterator();
+  }
+
+ private:
+  std::shared_ptr<exec::TaskCursor> cursor_;
+};
+
+/// To avoid desctruction order issues during shutdown, this function will
+/// iterate over any pending tasks created by this module and wait for their
+/// task and drivers to finish.
+void drainAllTasks();
+
+} // namespace facebook::velox::py

--- a/velox/py/runner/runner.cpp
+++ b/velox/py/runner/runner.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "velox/py/lib/PyInit.h"
+
+#include "velox/py/runner/PyLocalRunner.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(runner, m) {
+  using namespace facebook;
+  velox::py::initializeVeloxMemory();
+
+  // The executor and root pool need to outlive all vectors returned by this
+  // module, so we make them static so they only get destructed when the process
+  // is about to exit.
+  static auto rootPool = velox::memory::memoryManager()->addRootPool();
+  static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
+      std::thread::hardware_concurrency());
+
+  // execute() returns an iterator to Vectors.
+  py::module::import("velox.py.vector");
+
+  py::class_<velox::py::PyLocalRunner>(m, "LocalRunner")
+      // Only expose the plan node through the Python API.
+      .def(py::init([](const velox::py::PyPlanNode& planNode) {
+        return velox::py::PyLocalRunner{planNode, rootPool, executor};
+      }))
+      .def("execute", &velox::py::PyLocalRunner::execute)
+      .def(
+          "add_file_split",
+          &velox::py::PyLocalRunner::addFileSplit,
+          py::arg("file"),
+          py::arg("plan_id"),
+          py::arg("connector_id") = "prism",
+          py::doc(R"(
+        Add a split to scan a file, and associate it to the plan node
+        described by plan_id.
+
+        Args:
+          file: A file object describing the file path and format.
+          plan_id: The plan node id of the scan to associate this
+                   file/split with.
+          connector_id: The id of the connector used by the scan.
+          )"));
+
+  // Ensure all tasks created by this module have finished.
+  m.add_object("_cleanup", py::capsule(&velox::py::drainAllTasks));
+}

--- a/velox/py/runner/runner.pyi
+++ b/velox/py/runner/runner.pyi
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+from typing import Iterator
+
+
+class Vector:
+    def size(self) -> int: ...
+
+class LocalRunner:
+    def __init__(self, PlanNode) -> None: ...
+    def execute(self) -> Iterator[Vector]: ...
+    def add_file_split(self, plan_id: str, file_path: str) -> None: ...

--- a/velox/py/tests/test_runner.py
+++ b/velox/py/tests/test_runner.py
@@ -1,0 +1,82 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import pyarrow
+
+from velox.py.arrow import to_velox
+from velox.py.runner import LocalRunner
+from velox.py.plan_builder import PlanBuilder
+
+
+class TestPyVeloxRunner(unittest.TestCase):
+    def test_runner_empty(self):
+        plan_builder = PlanBuilder().values()
+        runner = LocalRunner(plan_builder.get_plan_node())
+        total_size = 0
+
+        for vector in runner.execute():
+            total_size += vector.size()
+        self.assertEqual(total_size, 0)
+
+    def test_runner_not_executed(self):
+        # Ensure it won't hang on destruction when it was not executed.
+        plan_builder = PlanBuilder().values()
+        LocalRunner(plan_builder.get_plan_node())
+
+    def test_runner_executed_twice(self):
+        # Ensure the runner fails if it is executed twice.
+        plan_builder = PlanBuilder().values()
+        runner = LocalRunner(plan_builder.get_plan_node())
+        runner.execute()
+        self.assertRaises(RuntimeError, runner.execute)
+
+    def test_runner_with_values(self):
+        vectors = []
+        batch_size = 10
+        num_batches = 10
+
+        for i in range(num_batches):
+            array = pyarrow.array(list(range(i * batch_size, (i + 1) * batch_size)))
+            batch = pyarrow.record_batch([array], names=["c0"])
+            vectors.append(to_velox(batch))
+
+        plan_builder = PlanBuilder().values(vectors)
+        runner = LocalRunner(plan_builder.get_plan_node())
+        total_size = 0
+
+        for vector in runner.execute():
+            total_size += vector.size()
+        self.assertEqual(total_size, 100)
+
+    def test_runner_with_join(self):
+        batch_size = 10
+        array = pyarrow.array([42] * batch_size)
+        batch = to_velox(pyarrow.record_batch([array], names=["c0"]))
+
+        plan_builder = PlanBuilder()
+        plan_builder.values([batch]).merge_join(
+            left_keys=["c0"],
+            right_keys=["c0"],
+            right_plan_node=(
+                plan_builder.new_builder().values([batch]).get_plan_node()
+            ),
+        )
+
+        runner = LocalRunner(plan_builder.get_plan_node())
+        total_size = 0
+
+        for vector in runner.execute():
+            total_size += vector.size()
+        self.assertEqual(total_size, batch_size * batch_size)


### PR DESCRIPTION
Summary:
Adding Python bindings for a local runner that simply takes a plan
node and runs it locally using TaskCursor. It exposes a Python iterator that
can be used to fetch the output vectors produced by the plan.
.
The split API requires a little more iterations; for now just adding a basic
implementation to prove the concept.

The basic API consists of:

```
plan_builder = PlanBuilder()
... [add stuff to builder]
runner = LocalRunner(plan_builder.get_plan_node())

for vector in runner.execute():
    ... [process vector]
```

Differential Revision: D68048427


