### PR TITLE
fix: Fix a null bit set in left index lookup join

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -453,7 +453,7 @@ RowVectorPtr IndexLookupJoin::produceOutputForLeftJoin() {
       bits::fillBits(
           rawLookupOutputNulls_,
           numOutputRows,
-          numOutputMissedInputRows,
+          numOutputRows + numOutputMissedInputRows,
           bits::kNull);
       for (auto i = 0; i < numOutputMissedInputRows; ++i) {
         rawProbeOutputRowIndices_[numOutputRows++] = ++lastProcessedInputRow;


### PR DESCRIPTION
Summary:
Fix null bit setting in left index lookup join as the bits fill take [start, end) but not {start, length}.
Found in Meta internal tests.

Differential Revision: D68941198


