### PR TITLE
refactor(hive): Remove Parquet dependency from HiveConnectorTestBase

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(
   velox_s3fs
   velox_core
   velox_exec_test_lib
+  velox_dwio_parquet_reader
   velox_dwio_common_exception
   velox_exec
   GTest::gtest
@@ -57,6 +58,8 @@ target_link_libraries(
   velox_s3fs
   velox_core
   velox_exec_test_lib
+  velox_dwio_parquet_writer
+  velox_dwio_parquet_reader
   velox_dwio_common_exception
   velox_exec
   GTest::gtest
@@ -73,6 +76,7 @@ target_link_libraries(
   velox_s3fs
   velox_core
   velox_exec_test_lib
+  velox_dwio_parquet_reader
   velox_dwio_common_exception
   velox_exec
   GTest::gtest
@@ -86,6 +90,8 @@ target_link_libraries(
   velox_s3fs
   velox_core
   velox_exec_test_lib
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_dwio_common_exception
   velox_exec
   GTest::gtest

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
@@ -20,6 +20,8 @@
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 #include "velox/connectors/hive/storage_adapters/test_common/InsertTest.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 
 namespace facebook::velox::filesystems {
 namespace {

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -42,7 +42,7 @@ if(VELOX_ENABLE_PARQUET)
 
   target_include_directories(velox_hive_connector_test
                              PUBLIC ${ARROW_PREFIX}/install/include)
-  target_link_libraries(velox_hive_connector_test
+  target_link_libraries(velox_hive_connector_test velox_dwio_parquet_writer
                         velox_dwio_native_parquet_reader)
 
 endif()

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -43,6 +43,6 @@ if(VELOX_ENABLE_PARQUET)
   target_include_directories(velox_hive_connector_test
                              PUBLIC ${ARROW_PREFIX}/install/include)
   target_link_libraries(velox_hive_connector_test velox_dwio_parquet_writer
-                        velox_dwio_native_parquet_reader)
+                        velox_dwio_parquet_reader)
 
 endif()

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -29,6 +29,8 @@
 #include "velox/dwio/dwrf/writer/Writer.h"
 
 #ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #endif
@@ -48,6 +50,10 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
+#ifdef VELOX_ENABLE_PARQUET
+    parquet::registerParquetReaderFactory();
+    parquet::registerParquetWriterFactory();
+#endif
     Type::registerSerDe();
     HiveSortingColumn::registerSerDe();
     HiveBucketProperty::registerSerDe();

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ set(TEST_LINK_LIBS
     velox_dwio_common_test_utils
     velox_vector_test_lib
     velox_exec_test_lib
+    velox_dwio_parquet_reader
+    velox_dwio_parquet_writer
     velox_temp_path
     GTest::gtest
     GTest::gtest_main
@@ -35,10 +37,6 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   velox_dwio_parquet_tpch_test
-  velox_dwio_parquet_reader
-  velox_exec_test_lib
-  velox_exec
-  velox_hive_connector
   velox_tpch_connector
   velox_aggregates
   velox_tpch_gen

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -90,6 +90,7 @@ add_test(
 target_link_libraries(
   velox_dwio_parquet_table_scan_test
   velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_exec_test_lib
   velox_exec
   velox_hive_connector

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -81,6 +81,7 @@ if(${VELOX_ENABLE_PARQUET})
     velox_sort_benchmark
     velox_exec
     velox_exec_test_lib
+    velox_dwio_parquet_reader
     velox_vector_test_lib
     Folly::follybenchmark
     arrow

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -47,8 +47,6 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
-  velox_dwio_parquet_writer
-  velox_dwio_parquet_reader
   velox_dwio_common_test_utils
   velox_file_test_utils
   velox_type_fbhive
@@ -71,8 +69,6 @@ if(${VELOX_BUILD_RUNNER})
     velox_file_test_utils
     velox_hive_connector
     velox_tpch_connector
-    velox_dwio_parquet_reader
-    velox_dwio_parquet_writer
     velox_local_runner)
 
 endif()

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -24,8 +24,6 @@
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 
 namespace facebook::velox::exec::test {
@@ -51,8 +49,6 @@ void HiveConnectorTestBase::SetUp() {
   dwio::common::registerFileSinks();
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();
-  parquet::registerParquetReaderFactory();
-  parquet::registerParquetWriterFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
@@ -61,8 +57,6 @@ void HiveConnectorTestBase::TearDown() {
   ioExecutor_.reset();
   dwrf::unregisterDwrfReaderFactory();
   dwrf::unregisterDwrfWriterFactory();
-  parquet::unregisterParquetReaderFactory();
-  parquet::unregisterParquetWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
   connector::unregisterConnectorFactory(
       connector::hive::HiveConnectorFactory::kHiveConnectorName);

--- a/velox/functions/sparksql/fuzzer/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/fuzzer/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
     velox_spark_query_runner
     velox_functions_spark
     velox_exec_test_lib
+    velox_dwio_parquet_writer
     velox_parse_utils
     velox_vector_test_lib
     GTest::gtest

--- a/velox/tool/trace/CMakeLists.txt
+++ b/velox/tool/trace/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_hive_connector
   velox_tpch_connector
   velox_memory


### PR DESCRIPTION
Applications must link Parquet where needed.
DWRF will be refactored similarly in a follow-up PR.