### PR TITLE
feat: Add support for double to timestamp cast for Spark

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -286,6 +286,14 @@ void CastExpr::applyCastKernel(
       return;
     }
 
+    if constexpr (
+        (FromKind == TypeKind::DOUBLE) && ToKind == TypeKind::TIMESTAMP) {
+      const auto castResult =
+          hooks_->castDoubleToTimestamp((double)inputRowValue);
+      setResultOrError(castResult, row);
+      return;
+    }
+
     // Optimize empty input strings casting by avoiding throwing exceptions.
     if constexpr (
         FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -58,5 +58,8 @@ class CastHooks {
   virtual bool truncate() const = 0;
 
   virtual PolicyType getPolicy() const = 0;
+
+  // Converts double to timestamp type.
+  virtual Expected<Timestamp> castDoubleToTimestamp(double seconds) const = 0;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -97,6 +97,11 @@ Expected<int32_t> PrestoCastHooks::castStringToDate(
   return util::fromDateString(dateString, util::ParseMode::kPrestoCast);
 }
 
+Expected<Timestamp> PrestoCastHooks::castDoubleToTimestamp(double seconds) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion to Timestamp is not supported"));
+}
+
 namespace {
 
 using double_conversion::StringToDoubleConverter;

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -32,6 +32,8 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
+  Expected<Timestamp> castDoubleToTimestamp(double seconds) const override;
+
   // Uses standard cast mode to cast from string to date.
   Expected<int32_t> castStringToDate(
       const StringView& dateString) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -50,6 +50,23 @@ Expected<Timestamp> SparkCastHooks::castIntToTimestamp(int64_t seconds) const {
   return Timestamp(seconds, 0);
 }
 
+
+Expected<Timestamp> SparkCastHooks::castDoubleToTimestamp(double d) const {
+  double usecsAsDouble = d * 1'000'000.0;
+  constexpr double kMinInt64AsDouble = static_cast<double>(std::numeric_limits<int64_t>::min());
+  constexpr double kMaxInt64AsDouble = static_cast<double>(std::numeric_limits<int64_t>::max());
+
+  if (usecsAsDouble > kMaxInt64AsDouble) {
+    return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::max());
+  }
+  if (usecsAsDouble < kMinInt64AsDouble) {
+    return Timestamp::fromMicrosNoError(std::numeric_limits<int64_t>::min());
+  }
+
+  int64_t micros = static_cast<int64_t>(usecsAsDouble);
+  return Timestamp::fromMicrosNoError(micros);
+}
+
 Expected<int32_t> SparkCastHooks::castStringToDate(
     const StringView& dateString) const {
   // Allows all patterns supported by Spark:

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -52,6 +52,8 @@ class SparkCastHooks : public exec::CastHooks {
   /// whitespaces before cast.
   StringView removeWhiteSpaces(const StringView& view) const override;
 
+  Expected<Timestamp> castDoubleToTimestamp(double seconds) const override;
+
   const TimestampToStringOptions& timestampToStringOptions() const override {
     return timestampToStringOptions_;
   }

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -750,5 +750,49 @@ TEST_F(SparkCastExprTest, bigintToBinary) {
        std::string("\x80\x00\x00\x00\x00\x00\x00\x00", 8)});
 }
 
+
+TEST_F(SparkCastExprTest, doubleToTimestamp) {
+  testCast<double, Timestamp>(
+      "castDoubleToTimestamp",
+      {
+          0.0,
+          1.0,
+          1727181032.0,
+          -1727181032.0,
+          9223372036.855,
+          -9223372036.856,
+          std::numeric_limits<double>::max(),
+          std::numeric_limits<double>::min(),
+          std::nullopt,
+      },
+      {
+          Timestamp(0, 0),
+          Timestamp(1, 0),
+          Timestamp(1727181032, 0),
+          Timestamp(-1727181032, 0),
+          Timestamp(9223372036, 855'000'000),
+          Timestamp(-9223372036, -856'000'000),
+          Timestamp(9223372036, 855'000'000),
+          Timestamp(-9223372036, -856'000'000),
+          std::nullopt,
+      });
+
+  testCast<double, Timestamp>(
+      "castDoubleToTimestamp",
+      {
+          12345.6789,
+          -98765.4321,
+          1.999999,
+          -1.999999,
+          0.123456789,
+      },
+      {
+          Timestamp(12345, 678900000),
+          Timestamp(-98765, 432100000),
+          Timestamp(1, 999999000),
+          Timestamp(-1, -999999000),
+          Timestamp(0, 123456789),
+      });
+}
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
- Add support for double to timestamp cast for Spark
- Replicates the same behaviour as Spark cast for double to timestamp