### PR TITLE
refactor: Remove unused header in functions/Registerer.h

### DIFF
--- a/velox/functions/Registerer.h
+++ b/velox/functions/Registerer.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "velox/core/SimpleFunctionMetadata.h"
-#include "velox/expression/SimpleFunctionAdapter.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/expression/VectorFunction.h"
 


### PR DESCRIPTION
This is causing the xsimd header leak.
See https://github.com/facebookincubator/velox/pull/11439#discussion_r1937756891