### PR TITLE
feat(python): PyVelox bindings for Files

### DIFF
--- a/velox/py/CMakeLists.txt
+++ b/velox/py/CMakeLists.txt
@@ -21,6 +21,15 @@ target_link_libraries(
   type
   PRIVATE velox_py_type_lib)
 
+# velox.py.file library:
+velox_add_library(velox_py_file_lib file/PyFile.cpp)
+velox_link_libraries(velox_py_file_lib velox_dwio_common pybind11::module)
+
+pybind11_add_module(file MODULE file/file.cpp)
+target_link_libraries(
+  file
+  PRIVATE velox_py_file_lib)
+
 # velox.py.vector library:
 velox_add_library(velox_py_vector_lib vector/PyVector.cpp)
 velox_link_libraries(velox_py_vector_lib velox_vector pybind11::module)

--- a/velox/py/file/PyFile.cpp
+++ b/velox/py/file/PyFile.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/py/file/PyFile.h"
+#include <fmt/format.h>
+
+namespace facebook::velox::py {
+
+std::string PyFile::toString() const {
+  return fmt::format("{} ({})", filePath_, fileFormat_);
+}
+
+} // namespace facebook::velox::py

--- a/velox/py/file/PyFile.h
+++ b/velox/py/file/PyFile.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::velox::py {
+
+class PyFile {
+ public:
+  PyFile(const std::string& filePath, dwio::common::FileFormat fileFormat)
+      : filePath_(filePath), fileFormat_(fileFormat) {}
+
+  std::string toString() const;
+
+  static PyFile createParquet(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::PARQUET);
+  }
+
+  static PyFile createDwrf(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::DWRF);
+  }
+
+  static PyFile createNimble(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::NIMBLE);
+  }
+
+  static PyFile createOrc(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::ORC);
+  }
+
+  static PyFile createJson(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::JSON);
+  }
+
+  static PyFile createText(const std::string& filePath) {
+    return PyFile(filePath, dwio::common::FileFormat::TEXT);
+  }
+
+ private:
+  const std::string filePath_;
+  const dwio::common::FileFormat fileFormat_;
+};
+
+} // namespace facebook::velox::py

--- a/velox/py/file/file.cpp
+++ b/velox/py/file/file.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "velox/py/file/PyFile.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(file, m) {
+  using namespace facebook;
+
+  // File wrapper abstraction.
+  py::class_<velox::py::PyFile>(m, "File").def(
+      "__str__", &velox::py::PyFile::toString, py::doc(R"(
+        Returns a short and recursive description of the file.
+      )"));
+
+  m.def("PARQUET", &velox::py::PyFile::createParquet);
+  m.def("DWRF", &velox::py::PyFile::createDwrf);
+  m.def("NIMBLE", &velox::py::PyFile::createNimble);
+  m.def("ORC", &velox::py::PyFile::createOrc);
+  m.def("JSON", &velox::py::PyFile::createJson);
+  m.def("TEXT", &velox::py::PyFile::createText);
+}

--- a/velox/py/file/file.pyi
+++ b/velox/py/file/file.pyi
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+class File: ...
+
+def PARQUET(str) -> File: ...
+def DWRF(str) -> File: ...
+def NIMBLE(str) -> File: ...
+def ORC(str) -> File: ...
+def JSON(str) -> File: ...
+def TEXT(str) -> File: ...

--- a/velox/py/tests/test_file.py
+++ b/velox/py/tests/test_file.py
@@ -1,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from velox.py.file import PARQUET, DWRF, NIMBLE, ORC, JSON, TEXT
+
+
+class TestPyVeloxFile(unittest.TestCase):
+    def test_input_file(self):
+        file_parquet = PARQUET("my_parquet_file")
+        file_nimble = NIMBLE("/tmp/my_nimble")
+        file_dwrf = DWRF("dir/some_file.dwrf")
+        file_orc = ORC("orc_file")
+        file_json = JSON("dir2/other_file.json")
+        file_text = TEXT("a/b/csome_file.txt")
+
+        self.assertEqual(str(file_parquet), "my_parquet_file (parquet)")
+        self.assertEqual(str(file_nimble), "/tmp/my_nimble (nimble)")
+        self.assertEqual(str(file_dwrf), "dir/some_file.dwrf (dwrf)")
+        self.assertEqual(str(file_orc), "orc_file (orc)")
+        self.assertEqual(str(file_json), "dir2/other_file.json (json)")
+        self.assertEqual(str(file_text), "a/b/csome_file.txt (text)")


### PR DESCRIPTION
Summary:
Adding a "file" python abstraction. This will be used by runners to
make it more convenient to define plans without having to necessarily expose
"splits" to clients - since they are often just more boilerplate in most local
debugging cases.
.
Having them in upper case is not strictly pythonic, but follows the pattern
used throughout Velox for types (ROW/MAP, etc)

Differential Revision: D68978813


