### PR TITLE
fix: Bitwise operations on signed integers (Part-2)

### DIFF
--- a/velox/common/hyperloglog/SparseHll.cpp
+++ b/velox/common/hyperloglog/SparseHll.cpp
@@ -31,7 +31,7 @@ inline uint32_t decodeIndex(uint32_t entry) {
 }
 
 inline uint32_t decodeValue(uint32_t entry) {
-  return entry & ((1 << kValueBitLength) - 1);
+  return entry & ((1u << kValueBitLength) - 1);
 }
 
 int searchIndex(
@@ -41,7 +41,7 @@ int searchIndex(
   int high = entries.size() - 1;
 
   while (low <= high) {
-    int middle = (low + high) >> 1;
+    int middle = static_cast<uint32_t>(low + high) >> 1;
 
     auto middleIndex = decodeIndex(entries[middle]);
 
@@ -93,7 +93,7 @@ int64_t SparseHll::cardinality() const {
   // 2^kIndexBitLength buckets available due to the fact that we're
   // recording the raw leading kIndexBitLength of the hash. This produces
   // much better precision while in the sparse regime.
-  static const int kTotalBuckets = 1 << kIndexBitLength;
+  static const int kTotalBuckets = 1u << kIndexBitLength;
 
   int zeroBuckets = kTotalBuckets - entries_.size();
   return std::round(linearCounting(zeroBuckets, kTotalBuckets));


### PR DESCRIPTION
## Bug Summary:

This PR addresses an issue with signed integer literals and operands used in bitwise operations. When dealing with signed integer literals, adding the 'u' suffix to the constant can resolve the issue by explicitly marking the constant as unsigned. Additionally, any operand of signed integer type can be cast to its unsigned equivalent using a C (or C++) cast expression. For signed variables used in bitwise operations, their type should be converted to an unsigned equivalent to avoid undefined behavior and ensure proper operation.

## Changes Made:

Added 'u' suffix to signed integer literals: This explicitly marks the constants as unsigned to ensure correct type handling.
Applied C/C++ cast to operands: All signed integer operands involved in bitwise operations are now cast to unsigned integers to prevent unexpected behavior.
Converted signed variables to unsigned type: For bitwise operations, the type of signed variables has been changed to the unsigned equivalent to maintain correctness and prevent potential overflow or sign extension issues.

## Impact:

These changes will ensure that the code handles integer literals and operands in bitwise expressions correctly, using unsigned types when appropriate, thus preventing bugs related to type conversion and ensuring cross-platform consistency.

This is part 2 of multiple PRs for this fix.