### PR TITLE
fix: Bitwise operations on signed integers (Part-3)

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -126,7 +126,7 @@ bool HiveConfig::ignoreMissingFiles(const config::ConfigBase* session) const {
 int64_t HiveConfig::maxCoalescedBytes(const config::ConfigBase* session) const {
   return session->get<int64_t>(
       kMaxCoalescedBytesSession,
-      config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20)); // 128MB
+      config_->get<int64_t>(kMaxCoalescedBytes, 128u << 20)); // 128MB
 }
 
 int32_t HiveConfig::maxCoalescedDistanceBytes(
@@ -151,7 +151,7 @@ int32_t HiveConfig::prefetchRowGroups() const {
 
 int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
   return session->get<int32_t>(
-      kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));
+      kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8u << 20));
 }
 
 int32_t HiveConfig::numCacheFileHandles() const {

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -23,7 +23,7 @@ void mergeHash(bool mix, uint32_t oneHash, uint32_t& aggregateHash) {
 }
 
 int32_t hashInt64(int64_t value) {
-  return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
+  return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ static_cast<uint64_t>(value);
 }
 
 #if defined(__has_feature)
@@ -501,12 +501,12 @@ std::optional<uint32_t> HivePartitionFunction::partition(
     // NOTE: if bucket to partition mapping is empty, then we do
     // identical mapping.
     for (auto i = 0; i < numRows; ++i) {
-      partitions[i] = (hashes[i] & kInt32Max) % numBuckets_;
+      partitions[i] = (hashes[i] & static_cast<uint32_t>(kInt32Max)) % numBuckets_;
     }
   } else {
     for (auto i = 0; i < numRows; ++i) {
       partitions[i] =
-          bucketToPartition_[((hashes[i] & kInt32Max) % numBuckets_)];
+          bucketToPartition_[((hashes[i] & static_cast<uint32_t>(kInt32Max)) % numBuckets_)];
     }
   }
 

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
@@ -28,7 +28,7 @@
 namespace facebook::velox::filesystems {
 
 class AbfsReadFile::Impl {
-  constexpr static uint64_t kNaturalReadSize = 4 << 20; // 4M
+  constexpr static uint64_t kNaturalReadSize = 4UL << 20; // 4M
   constexpr static uint64_t kReadConcurrency = 8;
 
  public:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -161,7 +161,7 @@ class S3ReadFile final : public ReadFile {
   }
 
   uint64_t getNaturalReadSize() const final {
-    return 72 << 20;
+    return 72UL << 20;
   }
 
  private:

--- a/velox/dwio/common/BitPackDecoder.cpp
+++ b/velox/dwio/common/BitPackDecoder.cpp
@@ -283,7 +283,7 @@ void unpack(
     for (auto i_2 = numSafeRows; i_2 < numRows; ++i_2) {
       auto bit = bitOffset + (rows[i_2]) * bitWidth;
       auto byte = bit / 8;
-      auto shift = bit & 7;
+      auto shift = static_cast<uint32_t>(bit) & 7u;
       result[i_2] = safeLoadBits(
                         reinterpret_cast<const char*>(bits) + byte,
                         shift,

--- a/velox/dwio/common/DecoderUtil.cpp
+++ b/velox/dwio/common/DecoderUtil.cpp
@@ -31,18 +31,18 @@ int32_t nonNullRowsFromDense(
 }
 // Returns 8 bits starting at bit 'index'.
 uint8_t load8Bits(const uint64_t* bits, int32_t index) {
-  uint8_t shift = index & 7;
-  uint32_t byte = index >> 3;
+  uint8_t shift = static_cast<uint32_t>(index) & 7u;
+  uint32_t byte = static_cast<uint32_t>(index) >> 3;
   auto asBytes = reinterpret_cast<const uint8_t*>(bits);
-  return (*reinterpret_cast<const int16_t*>(asBytes + byte) >> shift);
+  return (*reinterpret_cast<const uint16_t*>(asBytes + byte) >> shift);
 }
 
 // Loads 'width' bits starting at bit 'index' in 'bits'. 'width is
 // 56 bits or less, so that we can for any index load all the bits
 // in a 64 bit load.
 uint64_t loadUpTo56Bits(const uint64_t* bits, int32_t index, int32_t width) {
-  uint8_t shift = index & 7;
-  uint32_t byte = index >> 3;
+  uint8_t shift = static_cast<uint32_t>(index) & 7u;
+  uint32_t byte = static_cast<uint32_t>(index) >> 3;
   auto asBytes = reinterpret_cast<const uint8_t*>(bits);
   return (*reinterpret_cast<const uint64_t*>(asBytes + byte) >> shift) &
       bits::lowMask(width);
@@ -89,7 +89,7 @@ bool nonNullRowsFromSparse(
     int32_t width = i + kStep > numIn ? numIn - i : kStep;
     int16_t widthMask = bits::lowMask(width);
     if (isDense(rows.data() + i, width)) {
-      uint16_t flags = load8Bits(nulls, rows[i]) & widthMask;
+      uint16_t flags = load8Bits(nulls, rows[i]) & static_cast<uint16_t>(widthMask);
       if (outputNulls) {
         bits::storeBitsToByte<kStep>(flags, resultNullBytes, i);
         anyNull |= flags != widthMask;

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -29,7 +29,7 @@ void printBuffer(std::ostream& out, const char* buffer, uint64_t length) {
     for (uint64_t byte = 0; byte < width && line * width + byte < length;
          ++byte) {
       out << " " << std::setfill('0') << std::setw(2)
-          << static_cast<uint64_t>(0xff & buffer[line * width + byte]);
+          << static_cast<uint64_t>(0xff & static_cast<uint8_t>(buffer[line * width + byte]));
     }
     out << "\n";
   }

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -149,8 +149,8 @@ ZlibDecompressor::ZlibDecompressor(
   zstream_.opaque = Z_NULL;
   zstream_.next_out = Z_NULL;
   zstream_.avail_out = folly::to<uInt>(blockSize);
-  int zlibWindowBits = windowBits;
-  constexpr int GZIP_DETECT_CODE = 32;
+  unsigned int zlibWindowBits = windowBits;
+  constexpr unsigned int GZIP_DETECT_CODE = 32;
   if (isGzip) {
     zlibWindowBits = zlibWindowBits | GZIP_DETECT_CODE;
   }

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -60,7 +60,7 @@ void PagedInputStream::readHeader() {
   if (state_ != State::END) {
     header |= readByte(true) << 8;
     header |= readByte(true) << 16;
-    if (header & 1) {
+    if (header & 1u) {
       state_ = State::ORIGINAL;
     } else {
       state_ = State::START;

--- a/velox/dwio/common/compression/PagedOutputStream.cpp
+++ b/velox/dwio/common/compression/PagedOutputStream.cpp
@@ -65,14 +65,14 @@ void PagedOutputStream::writeHeader(
     char* buffer,
     size_t compressedSize,
     bool original) {
-  VELOX_CHECK_LT(compressedSize, 1 << 23);
+  VELOX_CHECK_LT(compressedSize, 1u << 23);
   buffer[0] = static_cast<char>((compressedSize << 1) + (original ? 1 : 0));
   buffer[1] = static_cast<char>(compressedSize >> 7);
   buffer[2] = static_cast<char>(compressedSize >> 15);
 }
 
 void PagedOutputStream::updateSize(char* buffer, size_t compressedSize) {
-  VELOX_CHECK_LT(compressedSize, 1 << 23);
+  VELOX_CHECK_LT(compressedSize, 1u << 23);
   buffer[0] = ((buffer[0] & 0x01) | static_cast<char>(compressedSize << 1));
   buffer[1] = static_cast<char>(compressedSize >> 7);
   buffer[2] = static_cast<char>(compressedSize >> 15);

--- a/velox/dwio/common/compression/PagedOutputStream.cpp
+++ b/velox/dwio/common/compression/PagedOutputStream.cpp
@@ -73,7 +73,7 @@ void PagedOutputStream::writeHeader(
 
 void PagedOutputStream::updateSize(char* buffer, size_t compressedSize) {
   VELOX_CHECK_LT(compressedSize, 1u << 23);
-  buffer[0] = ((buffer[0] & 0x01) | static_cast<char>(compressedSize << 1));
+  buffer[0] = static_cast<unsigned char>((static_cast<unsigned char>(buffer[0]) & 0x01) |  (static_cast<unsigned char>(compressedSize) << 1));
   buffer[1] = static_cast<char>(compressedSize >> 7);
   buffer[2] = static_cast<char>(compressedSize >> 15);
 }

--- a/velox/dwio/dwrf/common/ByteRLE.cpp
+++ b/velox/dwio/dwrf/common/ByteRLE.cpp
@@ -259,7 +259,7 @@ class BooleanRleEncoderImpl : public ByteRleEncoderImpl {
 
   void writeBool(bool val) {
     --bitsRemained;
-    current |= ((val ? 1 : 0) << bitsRemained);
+    current = static_cast<unsigned char>(current) | (static_cast<uint32_t>(val ? 1 : 0) << bitsRemained);
     if (bitsRemained == 0) {
       writeByte();
     }
@@ -510,7 +510,7 @@ void BooleanRleDecoder::next(
     // need to read new data. Since remainingBits should be less than or equal
     // to 8, therefore nonNulls must be less than 8.
     data[0] =
-        reversedLastByte_ >> (8 - remainingBits_) & 0xff >> (8 - nonNulls);
+        (reversedLastByte_ >> (8 - remainingBits_)) & static_cast<uint8_t>(0xff) >> (8 - nonNulls);
     remainingBits_ -= nonNulls;
   } else {
     // Put the remaining bits, if any, into previousByte.
@@ -537,7 +537,7 @@ void BooleanRleDecoder::next(
         uint64_t tmp = reinterpret_cast<uint64_t*>(data)[i];
         reinterpret_cast<uint64_t*>(data)[i] =
             previousByte | tmp << remainingBits_; // previousByte is LSB
-        previousByte = (tmp >> (64 - remainingBits_)) & 0xff;
+        previousByte = (tmp >> (64 - remainingBits_)) & static_cast<uint64_t>(0xff);
       }
 
       // Shift 8 bits a time for the remaining bits
@@ -558,7 +558,7 @@ void BooleanRleDecoder::next(
 
   // Clear the most significant bits in the last byte which will be processed in
   // the next round.
-  data[outputBytes - 1] &= 0xff >> (outputBytes * 8 - numValues);
+  data[outputBytes - 1] = (static_cast<uint8_t>(data[outputBytes - 1]) &  static_cast<uint8_t>(0xff)) >> (outputBytes * 8 - numValues);
 }
 
 std::unique_ptr<BooleanRleDecoder> createBooleanRleDecoder(

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -139,7 +139,7 @@ void SelectiveTimestampColumnReader::readHelper(
   for (vector_size_t i = 0; i < numValues_; i++) {
     if (!rawNulls || !bits::isBitNull(rawNulls, i)) {
       auto nanos = nanosData[i];
-      uint64_t zeros = nanos & 0x7;
+      uint64_t zeros = nanos & static_cast<uint64_t>(0x7);
       nanos >>= 3;
       if (zeros != 0) {
         for (uint64_t j = 0; j <= zeros; ++j) {

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -237,7 +237,7 @@ class CacheTest : public ::testing::Test {
       const Region region{
           offset + streamStarts_[streamIndex],
           std::min<uint64_t>(
-              (1 << 20) - 11,
+              (1UL << 20) - 11,
               (streamStarts_[streamIndex + 1] - streamStarts_[streamIndex]) /
                   2)};
       auto stream = data->input->enqueue(region, streamIds_[streamIndex].get());
@@ -450,7 +450,7 @@ class CacheTest : public ::testing::Test {
 };
 
 TEST_F(CacheTest, window) {
-  constexpr int32_t kMB = 1 << 20;
+  constexpr int32_t kMB = 1u << 20;
   initializeCache(64 * kMB);
   auto tracker = std::make_shared<ScanTracker>(
       "testTracker",
@@ -510,7 +510,7 @@ TEST_F(CacheTest, window) {
 
 TEST_F(CacheTest, bufferedInput) {
   // Size 160 MB. Frequent evictions and not everything fits in prefetch window.
-  initializeCache(160 << 20);
+  initializeCache(160u << 20);
   readLoop("testfile", 30, 70, 10, 20, 4, /*noCacheRetention=*/false, ioStats_);
   readLoop("testfile", 30, 70, 10, 20, 4, /*noCacheRetention=*/false, ioStats_);
   readLoop(
@@ -523,9 +523,9 @@ TEST_F(CacheTest, bufferedInput) {
 // reading pattern so that half the working set drops out and another half is
 // added. Checks that the working set stabilizes again.
 TEST_F(CacheTest, ssd) {
-  constexpr int64_t kSsdBytes = 256 << 20;
+  constexpr int64_t kSsdBytes = 256UL << 20;
   // 64 RAM, 256MB SSD
-  initializeCache(64 << 20, kSsdBytes);
+  initializeCache(64UL << 20, kSsdBytes);
   testRandomSeek_ = false;
   deterministic_ = true;
 
@@ -584,7 +584,7 @@ TEST_F(CacheTest, ssd) {
 }
 
 TEST_F(CacheTest, singleFileThreads) {
-  initializeCache(1 << 30);
+  initializeCache(1UL << 30);
 
   const int numThreads = 4;
   std::vector<std::thread> threads;
@@ -608,7 +608,7 @@ TEST_F(CacheTest, singleFileThreads) {
 }
 
 TEST_F(CacheTest, ssdThreads) {
-  initializeCache(64 << 20, 1024 << 20);
+  initializeCache(64UL << 20, 1024UL << 20);
   deterministic_ = true;
   constexpr int32_t kNumThreads = 8;
   std::vector<IoStatisticsPtr> stats;
@@ -654,8 +654,8 @@ TEST_F(CacheTest, ssdThreads) {
 
 class FileWithReadAhead {
  public:
-  static constexpr int32_t kFileSize = 21 << 20;
-  static constexpr int64_t kLoadQuantum = 6 << 20;
+  static constexpr int32_t kFileSize = 21u << 20;
+  static constexpr int64_t kLoadQuantum = 6UL << 20;
   FileWithReadAhead(
       const std::string& name,
       cache::AsyncDataCache* cache,
@@ -778,7 +778,7 @@ TEST_F(CacheTest, readAhead) {
 }
 
 TEST_F(CacheTest, noCacheRetention) {
-  const int64_t cacheSize = 1LL << 30;
+  const int64_t cacheSize = 1ULL << 30;
   struct {
     bool noCacheRetention;
     bool hasSsdCache;
@@ -855,12 +855,12 @@ TEST_F(CacheTest, noCacheRetention) {
 }
 
 TEST_F(CacheTest, loadQuotumTooLarge) {
-  initializeCache(64 << 20, 256 << 20);
+  initializeCache(64UL << 20, 256UL << 20);
   auto fileId = std::make_unique<StringIdLease>(fileIds(), "foo");
   auto readFile =
-      std::make_shared<TestReadFile>(fileId->id(), 10 << 20, nullptr);
+      std::make_shared<TestReadFile>(fileId->id(), 10u << 20, nullptr);
   auto readOptions = io::ReaderOptions(pool_.get());
-  readOptions.setLoadQuantum(9 << 20 /*9MB*/);
+  readOptions.setLoadQuantum(9u << 20 /*9MB*/);
   VELOX_ASSERT_THROW(
       std::make_unique<CachedBufferedInput>(
           readFile,
@@ -876,8 +876,8 @@ TEST_F(CacheTest, loadQuotumTooLarge) {
 }
 
 TEST_F(CacheTest, ssdReadVerification) {
-  constexpr int64_t kMemoryBytes = 32 << 20;
-  constexpr int64_t kSsdBytes = 256 << 20;
+  constexpr int64_t kMemoryBytes = 32UL << 20;
+  constexpr int64_t kSsdBytes = 256UL << 20;
   // 32 RAM, 256MB SSD, with checksumWrite/checksumReadVerification enabled.
   initializeCache(kMemoryBytes, kSsdBytes, true);
 
@@ -898,7 +898,7 @@ TEST_F(CacheTest, ssdReadVerification) {
       io::ReaderOptions(pool_.get()));
 
   const auto readData = [&](uint32_t numBytesRead) {
-    const uint64_t kNumBytesPerRead = 4 << 20;
+    const uint64_t kNumBytesPerRead = 4UL << 20;
     for (uint64_t offset = 0; offset < numBytesRead;
          offset += kNumBytesPerRead) {
       auto stream = input->read(offset, kNumBytesPerRead, LogType::TEST);

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -43,7 +43,7 @@ struct TestRegion {
 
 class DirectBufferedInputTest : public testing::Test {
  protected:
-  static constexpr int32_t kLoadQuantum = 8 << 20;
+  static constexpr int32_t kLoadQuantum = 8u << 20;
 
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance({});
@@ -54,7 +54,7 @@ class DirectBufferedInputTest : public testing::Test {
     ioStats_ = std::make_shared<IoStatistics>();
     fileIoStats_ = std::make_shared<IoStatistics>();
     tracker_ = std::make_shared<cache::ScanTracker>("", nullptr, kLoadQuantum);
-    file_ = std::make_shared<TestReadFile>(11, 100 << 20, fileIoStats_);
+    file_ = std::make_shared<TestReadFile>(11, 100u << 20, fileIoStats_);
     opts_ = std::make_unique<dwio::common::ReaderOptions>(pool_.get());
     opts_->setLoadQuantum(kLoadQuantum);
   }


### PR DESCRIPTION
## Bug Summary:

This PR addresses an issue with signed integer literals and operands used in bitwise operations. When dealing with signed integer literals, adding the 'u' suffix to the constant can resolve the issue by explicitly marking the constant as unsigned. Additionally, any operand of signed integer type can be cast to its unsigned equivalent using a C (or C++) cast expression. For signed variables used in bitwise operations, their type should be converted to an unsigned equivalent to avoid undefined behavior and ensure proper operation.

## Changes Made:

Added 'u' suffix to signed integer literals: This explicitly marks the constants as unsigned to ensure correct type handling.
Applied C/C++ cast to operands: All signed integer operands involved in bitwise operations are now cast to unsigned integers to prevent unexpected behavior.
Converted signed variables to unsigned type: For bitwise operations, the type of signed variables has been changed to the unsigned equivalent to maintain correctness and prevent potential overflow or sign extension issues.

## Impact:

These changes will ensure that the code handles integer literals and operands in bitwise expressions correctly, using unsigned types when appropriate, thus preventing bugs related to type conversion and ensuring cross-platform consistency.

This is part 3 of multiple PRs for this fix.