### PR TITLE
fix: Bitwise operations on signed integers (Part-4)

### DIFF
--- a/velox/dwio/dwrf/test/TestByteRle.cpp
+++ b/velox/dwio/dwrf/test/TestByteRle.cpp
@@ -72,7 +72,7 @@ TEST(ByteRle, nullTest) {
   rle->next(result, sizeof(result), nulls);
   for (size_t i = 0; i < sizeof(result); ++i) {
     if (i >= 10) {
-      EXPECT_EQ((i - 10) & 0xff, static_cast<int32_t>(result[i]) & 0xff)
+      EXPECT_EQ((i - 10) & static_cast<uint32_t>(0xff), static_cast<uint32_t>(result[i]) & static_cast<uint32_t>(0xff))
           << "Output wrong at " << i;
     }
   }
@@ -134,7 +134,7 @@ TEST(ByteRle, simpleRuns) {
   for (size_t i = 0; i < 3; ++i) {
     rle->next(data.data(), data.size(), nullptr);
     for (size_t j = 0; j < data.size(); ++j) {
-      EXPECT_EQ(static_cast<char>(-1 - static_cast<int32_t>(i)), data[j])
+      EXPECT_EQ(static_cast<unsigned char>(-1 - static_cast<uint32_t>(i)), data[j])
           << "Output wrong at " << (16 * i + j);
     }
   }
@@ -419,7 +419,7 @@ TEST(ByteRle, testSkip) {
   std::vector<char> data(1);
   for (size_t i = 0; i < 2048; i += 10) {
     rle->next(data.data(), data.size(), nullptr);
-    EXPECT_EQ(static_cast<char>(i < 1024 ? i / 16 : i & 0xff), data[0])
+    EXPECT_EQ(static_cast<char>(i < 1024 ? i / 16 : i & static_cast<uint64_t>(0xff)), data[0])
         << "Output wrong at " << i;
     if (i < 2038) {
       rle->skip(9);
@@ -901,7 +901,7 @@ TEST(ByteRle, testSeek) {
     PositionProvider location(positions[i]);
     rle->seekToRowGroup(location);
     rle->next(data.data(), 1, nullptr);
-    EXPECT_EQ(static_cast<char>(i < 1024 ? i / 4 : i & 0xff), data[0])
+    EXPECT_EQ(static_cast<char>(i < 1024 ? i / 4 : i & static_cast<uint64_t>(0xff)), data[0])
         << "Output wrong at " << i;
   } while (i != 0);
 
@@ -932,8 +932,8 @@ TEST(BooleanRle, simpleTest) {
   for (size_t i = 0; i < 16; ++i) {
     rle->next(data.data(), data.size(), nullptr);
     for (size_t j = 0; j < data.size(); ++j) {
-      const int32_t bitPosn = static_cast<int32_t>(50 * i + j);
-      EXPECT_EQ((bitPosn & 0x4) == 0 ? 1 : 0, bits::isBitSet(data.data(), j))
+      const uint32_t bitPosn = static_cast<int32_t>(50 * i + j);
+      EXPECT_EQ((bitPosn & static_cast<uint32_t>(0x4)) == 0 ? 1 : 0, bits::isBitSet(data.data(), j))
           << "Output wrong at " << i << ", " << j;
     }
   }
@@ -1094,7 +1094,7 @@ TEST(BooleanRle, skipTest) {
   std::vector<char> data(1);
   for (size_t i = 0; i < 16384; i += 5) {
     rle->next(data.data(), data.size(), nullptr);
-    EXPECT_EQ(i < 8192 ? i & 1 : (i / 3) & 1, bits::isBitSet(data.data(), 0))
+    EXPECT_EQ(i < 8192 ? i & 1UL : (i / 3) & 1UL, bits::isBitSet(data.data(), 0))
         << "Output wrong at " << i;
     if (i < 16379) {
       rle->skip(4);
@@ -1204,14 +1204,14 @@ TEST(BooleanRle, skipTestWithNulls) {
   std::unique_ptr<ByteRleDecoder> rle = createBooleanDecoder(std::move(stream));
   raw_vector<char> data;
   data.resize(3);
-  std::vector<uint64_t> someNull(1, ~0x0505050505050505);
+  std::vector<uint64_t> someNull(1, ~static_cast<uint64_t>(0x0505050505050505));
   std::vector<uint64_t> allNull(1, bits::kNull64);
   for (size_t i = 0; i < 16384; i += 5) {
     std::fill(data.begin(), data.end(), -1);
     rle->next(data.data(), data.size(), someNull.data());
     EXPECT_EQ(0, bits::isBitSet(data.data(), 0)) << "Output wrong at " << i;
     EXPECT_EQ(0, bits::isBitSet(data.data(), 2)) << "Output wrong at " << i;
-    EXPECT_EQ(i < 8192 ? i & 1 : (i / 3) & 1, bits::isBitSet(data.data(), 1))
+    EXPECT_EQ(i < 8192 ? i & 1UL : (i / 3) & 1UL, bits::isBitSet(data.data(), 1))
         << "Output wrong at " << i;
     if (i < 16379) {
       rle->skip(4);
@@ -1521,7 +1521,7 @@ TEST(BooleanRle, seekTestWithNulls) {
   rle->next(data.data(), data.size(), noNull.data());
   ASSERT_EQ(getNumReadBytes(), VELOX_ARRAY_SIZE(buffer));
   for (size_t i = 0; i < data.size(); ++i) {
-    EXPECT_EQ(i < 8192 ? i & 1 : (i / 3) & 1, bits::isBitSet(data.data(), i))
+    EXPECT_EQ(i < 8192 ? i & 1UL : (i / 3) & 1UL, bits::isBitSet(data.data(), i))
         << "Output wrong at " << i;
   }
   // set up all of the positions
@@ -1548,7 +1548,7 @@ TEST(BooleanRle, seekTestWithNulls) {
     char readByte;
     rle->next(&readByte, 1, noNull.data());
     ASSERT_GT(getNumReadBytes(), 0);
-    EXPECT_EQ(i < 8192 ? i & 1 : (i / 3) & 1, readByte & 1)
+    EXPECT_EQ(i < 8192 ? i & 1UL : (i / 3) & 1UL, readByte & 1)
         << "Output wrong at " << i;
     bits::setBit(&readByte, 0, 1);
     rle->next(&readByte, 1, allNull.data());

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -644,7 +644,7 @@ class CompressBuffer {
   }
 
   void writeUncompressedHeader(size_t compressedSize) {
-    buf[0] = static_cast<char>(compressedSize << 1) | 1;
+    buf[0] = static_cast<unsigned char>(compressedSize << 1) | 1u;
     buf[1] = static_cast<char>(compressedSize >> 7);
     buf[2] = static_cast<char>(compressedSize >> 15);
   }

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -184,7 +184,7 @@ TEST_F(DirectTest, vIntSignedLong) {
     auto mod = ++count % 33;
     auto numBytes = mod < 9 ? 1 : mod < 14 ? 2 : mod < 17 ? 3 : mod % 9;
     auto value = folly::Random::rand64(rng) & ((1UL << (7 * numBytes)) - 1);
-    return folly::Random::rand32(rng) & 1 ? -value : value;
+    return folly::Random::rand32(rng) & 1u ? -value : value;
   });
 }
 

--- a/velox/dwio/parquet/reader/RleBpDecoder.cpp
+++ b/velox/dwio/parquet/reader/RleBpDecoder.cpp
@@ -29,9 +29,9 @@ void RleBpDecoder::skip(uint64_t numValues) {
     remainingValues_ -= count;
     numValues -= count;
     if (!repeating_) {
-      auto numBits = bitWidth_ * count + bitOffset_;
+      auto numBits = static_cast<uint64_t>(bitWidth_) * count + static_cast<uint64_t>(bitOffset_);
       bufferStart_ += numBits >> 3;
-      bitOffset_ = numBits & 7;
+      bitOffset_ = numBits & 7UL;
     }
   }
 }
@@ -72,9 +72,9 @@ void RleBpDecoder::readBits(
           outputBuffer,
           numWritten,
           consumed);
-      int64_t offset = bitOffset_ + consumed;
+      uint64_t offset = static_cast<uint64_t>(bitOffset_) + static_cast<uint64_t>(consumed);
       bufferStart_ += offset >> 3;
-      bitOffset_ = offset & 7;
+      bitOffset_ = offset & 7UL;
     }
     numWritten += consumed;
     toRead -= consumed;
@@ -96,7 +96,7 @@ void RleBpDecoder::readHeader() {
   bufferStart_ = reinterpret_cast<const char*>(headerRange.begin());
 
   // 0 in low bit means repeating.
-  repeating_ = (indicator & 1) == 0;
+  repeating_ = (indicator & 1u) == 0;
   uint32_t count = indicator >> 1;
   if (repeating_) {
     remainingValues_ = count;

--- a/velox/dwio/parquet/writer/arrow/EncryptionInternal.cpp
+++ b/velox/dwio/parquet/writer/arrow/EncryptionInternal.cpp
@@ -287,10 +287,10 @@ int AesEncryptor::AesEncryptorImpl::GcmEncrypt(
   // Copying the buffer size, nonce and tag to ciphertext
   uint32_t buffer_size = kNonceLength + ciphertext_len + kGcmTagLength;
   if (length_buffer_length_ > 0) {
-    ciphertext[3] = static_cast<uint8_t>(0xff & (buffer_size >> 24));
-    ciphertext[2] = static_cast<uint8_t>(0xff & (buffer_size >> 16));
-    ciphertext[1] = static_cast<uint8_t>(0xff & (buffer_size >> 8));
-    ciphertext[0] = static_cast<uint8_t>(0xff & (buffer_size));
+    ciphertext[3] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 24));
+    ciphertext[2] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 16));
+    ciphertext[1] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 8));
+    ciphertext[0] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size));
   }
   std::copy(nonce, nonce + kNonceLength, ciphertext + length_buffer_length_);
   std::copy(
@@ -352,10 +352,10 @@ int AesEncryptor::AesEncryptorImpl::CtrEncrypt(
   // Copying the buffer size and nonce to ciphertext
   uint32_t buffer_size = kNonceLength + ciphertext_len;
   if (length_buffer_length_ > 0) {
-    ciphertext[3] = static_cast<uint8_t>(0xff & (buffer_size >> 24));
-    ciphertext[2] = static_cast<uint8_t>(0xff & (buffer_size >> 16));
-    ciphertext[1] = static_cast<uint8_t>(0xff & (buffer_size >> 8));
-    ciphertext[0] = static_cast<uint8_t>(0xff & (buffer_size));
+    ciphertext[3] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 24));
+    ciphertext[2] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 16));
+    ciphertext[1] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size >> 8));
+    ciphertext[0] = static_cast<uint8_t>(static_cast<uint32_t>(0xff) & (buffer_size));
   }
   std::copy(nonce, nonce + kNonceLength, ciphertext + length_buffer_length_);
 
@@ -607,9 +607,9 @@ int AesDecryptor::AesDecryptorImpl::GcmDecrypt(
 
   if (length_buffer_length_ > 0) {
     // Extract ciphertext length
-    uint32_t written_ciphertext_len = ((ciphertext[3] & 0xff) << 24) |
-        ((ciphertext[2] & 0xff) << 16) | ((ciphertext[1] & 0xff) << 8) |
-        ((ciphertext[0] & 0xff));
+    uint32_t written_ciphertext_len = ((ciphertext[3] & static_cast<uint32_t>(0xff)) << 24) |
+        ((ciphertext[2] & static_cast<uint32_t>(0xff)) << 16) | ((ciphertext[1] & static_cast<uint32_t>(0xff)) << 8) |
+        ((ciphertext[0] & static_cast<uint32_t>(0xff)));
 
     if (ciphertext_len > 0 &&
         ciphertext_len != (written_ciphertext_len + length_buffer_length_)) {
@@ -684,9 +684,9 @@ int AesDecryptor::AesDecryptorImpl::CtrDecrypt(
 
   if (length_buffer_length_ > 0) {
     // Extract ciphertext length
-    uint32_t written_ciphertext_len = ((ciphertext[3] & 0xff) << 24) |
-        ((ciphertext[2] & 0xff) << 16) | ((ciphertext[1] & 0xff) << 8) |
-        ((ciphertext[0] & 0xff));
+    uint32_t written_ciphertext_len = ((ciphertext[3] & static_cast<uint32_t>(0xff)) << 24) |
+        ((ciphertext[2] & static_cast<uint32_t>(0xff)) << 16) | ((ciphertext[1] & static_cast<uint32_t>(0xff)) << 8) |
+        ((ciphertext[0] & static_cast<uint32_t>(0xff)));
 
     if (ciphertext_len > 0 &&
         ciphertext_len != (written_ciphertext_len + length_buffer_length_)) {
@@ -762,8 +762,8 @@ static std::string ShortToBytesLe(int16_t input) {
   int8_t output[2];
   memset(output, 0, 2);
   uint16_t in = static_cast<uint16_t>(input);
-  output[1] = static_cast<int8_t>(0xff & (in >> 8));
-  output[0] = static_cast<int8_t>(0xff & (in));
+  output[1] = static_cast<int8_t>(static_cast<uint16_t>(0xff) & (in >> 8));
+  output[0] = static_cast<int8_t>(static_cast<uint16_t>(0xff) & (in));
 
   return std::string(reinterpret_cast<char const*>(output), 2);
 }

--- a/velox/dwio/parquet/writer/arrow/util/CompressionZlib.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionZlib.cpp
@@ -76,7 +76,7 @@ int DecompressionWindowBitsForFormat(GZipFormat format, int window_bits) {
     return -window_bits;
   } else {
     /* If not deflate, autodetect format from header */
-    return window_bits | DETECT_CODEC;
+    return static_cast<uint32_t>(window_bits) | static_cast<uint32_t>(DETECT_CODEC);
   }
 }
 


### PR DESCRIPTION
## Bug Summary:

This PR addresses an issue with signed integer literals and operands used in bitwise operations. When dealing with signed integer literals, adding the 'u' suffix to the constant can resolve the issue by explicitly marking the constant as unsigned. Additionally, any operand of signed integer type can be cast to its unsigned equivalent using a C (or C++) cast expression. For signed variables used in bitwise operations, their type should be converted to an unsigned equivalent to avoid undefined behavior and ensure proper operation.

## Changes Made:

Added 'u' suffix to signed integer literals: This explicitly marks the constants as unsigned to ensure correct type handling.
Applied C/C++ cast to operands: All signed integer operands involved in bitwise operations are now cast to unsigned integers to prevent unexpected behavior.
Converted signed variables to unsigned type: For bitwise operations, the type of signed variables has been changed to the unsigned equivalent to maintain correctness and prevent potential overflow or sign extension issues.

## Impact:

These changes will ensure that the code handles integer literals and operands in bitwise expressions correctly, using unsigned types when appropriate, thus preventing bugs related to type conversion and ensuring cross-platform consistency.

This is part 4 of multiple PRs for this fix.