### PR TITLE
feat: Add combine_hash internal operator

### DIFF
--- a/velox/functions/prestosql/IntegerFunctions.h
+++ b/velox/functions/prestosql/IntegerFunctions.h
@@ -35,4 +35,20 @@ struct XxHash64BigIntFunction {
   }
 };
 
+// combine_hash(bigint, bigint) → bigint
+template <typename T>
+struct CombineHashFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(
+      out_type<int64_t>& result,
+      const arg_type<int64_t>& previousHashValue,
+      const arg_type<int64_t>& input) {
+    result = static_cast<int64_t>(
+        31 * static_cast<uint64_t>(previousHashValue) +
+        static_cast<uint64_t>(input));
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/IntegerFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/IntegerFunctionsRegistration.cpp
@@ -23,6 +23,9 @@ namespace {
 void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<XxHash64BigIntFunction, int64_t, int64_t>(
       {prefix + "xxhash64_internal"});
+
+  registerFunction<CombineHashFunction, int64_t, int64_t, int64_t>(
+      {prefix + "combine_hash_internal"});
 }
 } // namespace
 


### PR DESCRIPTION
Summary: Add combine_hash internal function to unblock join prefilter optimization in Prestissimo.

Differential Revision: D69007969


