### PR TITLE
refactor: Changed RowType::getChildIdx to take a std::string_view instead of string ref

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -421,7 +421,7 @@ bool RowType::containsChild(std::string_view name) const {
   return std::find(names_.begin(), names_.end(), name) != names_.end();
 }
 
-uint32_t RowType::getChildIdx(const std::string& name) const {
+uint32_t RowType::getChildIdx(std::string_view name) const {
   auto index = getChildIdxIfExists(name);
   if (!index.has_value()) {
     VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
@@ -430,7 +430,7 @@ uint32_t RowType::getChildIdx(const std::string& name) const {
 }
 
 std::optional<uint32_t> RowType::getChildIdxIfExists(
-    const std::string& name) const {
+    std::string_view name) const {
   for (uint32_t i = 0; i < names_.size(); i++) {
     if (names_.at(i) == name) {
       return i;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1026,9 +1026,9 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   bool containsChild(std::string_view name) const;
 
-  uint32_t getChildIdx(const std::string& name) const;
+  uint32_t getChildIdx(std::string_view name) const;
 
-  std::optional<uint32_t> getChildIdxIfExists(const std::string& name) const;
+  std::optional<uint32_t> getChildIdxIfExists(std::string_view name) const;
 
   const std::string& nameOf(uint32_t idx) const {
     VELOX_CHECK_LT(idx, names_.size());


### PR DESCRIPTION
Summary:
PROBLEM
`RowType::containsChild()` takes a `string_view` , but if we want to get the index, we need to have a `std::string` .
There isn't any specific reason for mandating the `const std::string&` in the interface, especially when the `findChild` API also uses a StringPiece.

SOLUTION
Change to use `std::string_view`

Differential Revision: D69075102


