### PR TITLE
fix(fuzzer): Filter keys from both join sides instead of just one

### DIFF
--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -1114,14 +1114,12 @@ void JoinFuzzer::verify(core::JoinType joinType) {
   if (withFilter) {
     if (vectorFuzzer_.coinToss(0.5)) {
       keyTypes.push_back(BOOLEAN());
-      filter = vectorFuzzer_.coinToss(0.5)
-          ? fmt::format("t{} = true", keyTypes.size() - 1)
-          : fmt::format("u{} = true", keyTypes.size() - 1);
+      filter = fmt::format("t{0} = true AND u{0} = true", keyTypes.size() - 1);
     } else {
       keyTypes.push_back(INTEGER());
-      filter = vectorFuzzer_.coinToss(0.5)
-          ? fmt::format("t{} % {} = 0", keyTypes.size() - 1, randInt(1, 9))
-          : fmt::format("u{} % {} = 0", keyTypes.size() - 1, randInt(1, 9));
+      int rand = randInt(1, 9);
+      filter = fmt::format(
+          "t{0} % {1} = 0 AND u{0} % {1} = 0", keyTypes.size() - 1, rand);
     }
   }
 


### PR DESCRIPTION
Summary:
Joins operators with filters on one side are not currently supported in Velox. It is expected that such a filter would be pushed down to the table scan and therefore not show up in the join operator.

The fix to support this would be disabling filter pushdown when filtering only one side of a join.

Alternatively, filters within join operators can be checked to ensure that the filter contains keys from both sides, else throw an exception. This change will require testing in production to see if Presto produces such plans.

For now, changing the join fuzzer filter creation to include keys from both sides will avoid this type of failure completely.

Differential Revision: D69079267


