### PR TITLE
refactor: Remove unused headers and gflags

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -22,6 +22,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <folly/Preprocessor.h>
+#include <glog/logging.h>
 
 #include "velox/common/base/FmtStdFormatters.h"
 #include "velox/common/base/VeloxException.h"

--- a/velox/common/base/SkewedPartitionBalancer.cpp
+++ b/velox/common/base/SkewedPartitionBalancer.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/common/base/SkewedPartitionBalancer.h"
 
+#include <unordered_set>
+
 #include "velox/common/testutil/TestValue.h"
 
 using facebook::velox::common::testutil::TestValue;

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -268,10 +268,10 @@ void VeloxException::State::finalize() const {
     elaborateMessage += "Stack trace has been disabled.";
     if (exceptionType == VeloxException::Type::kSystem) {
       elaborateMessage +=
-          " Use --velox_exception_system_stacktrace_enabled=true to enable it.\n";
+          " Use config::globalConfig.exceptionSystemStacktraceEnabled=true to enable it.\n";
     } else {
       elaborateMessage +=
-          " Use --velox_exception_user_stacktrace_enabled=true to enable it.\n";
+          " Use config::globalConfig.exceptionUserStacktraceEnabled=true to enable it.\n";
     }
   }
 }

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -19,19 +19,10 @@
 #include <exception>
 #include <string>
 
-#include <folly/Exception.h>
 #include <folly/FixedString.h>
-#include <folly/String.h>
 #include <folly/synchronization/CallOnce.h>
-#include <glog/logging.h>
 
 #include "velox/common/process/StackTrace.h"
-
-DECLARE_bool(velox_exception_user_stacktrace_enabled);
-DECLARE_bool(velox_exception_system_stacktrace_enabled);
-
-DECLARE_int32(velox_exception_user_stacktrace_rate_limit_ms);
-DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);
 
 namespace facebook {
 namespace velox {

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -16,11 +16,18 @@
 
 #include <fmt/format.h>
 #include <folly/Random.h>
+#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/config/GlobalConfig.h"
 #include "velox/flag_definitions/flags.h"
+
+DECLARE_bool(velox_exception_user_stacktrace_enabled);
+DECLARE_bool(velox_exception_system_stacktrace_enabled);
+
+DECLARE_int32(velox_exception_user_stacktrace_rate_limit_ms);
+DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);
 
 using namespace facebook::velox;
 

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -23,12 +23,6 @@
 #include "velox/common/config/GlobalConfig.h"
 #include "velox/flag_definitions/flags.h"
 
-DECLARE_bool(velox_exception_user_stacktrace_enabled);
-DECLARE_bool(velox_exception_system_stacktrace_enabled);
-
-DECLARE_int32(velox_exception_user_stacktrace_rate_limit_ms);
-DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);
-
 using namespace facebook::velox;
 
 struct Counter {

--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "folly/Random.h"
+#include "folly/String.h"
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -17,6 +17,8 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 
+#include "folly/String.h"
+
 #include <sys/mman.h>
 
 namespace facebook::velox::memory {

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -22,6 +22,8 @@
 #include <iostream>
 #include <numeric>
 
+#include "folly/String.h"
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -18,6 +18,8 @@
 
 #include <sys/mman.h>
 
+#include "folly/String.h"
+
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/base/StatsReporter.h"

--- a/velox/common/memory/MmapArena.cpp
+++ b/velox/common/memory/MmapArena.cpp
@@ -16,7 +16,10 @@
 
 #include "velox/common/memory/MmapArena.h"
 
+#include "folly/String.h"
+
 #include <sys/mman.h>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/memory/Memory.h"
 

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/common/memory/SharedArbitrator.h"
 #include <folly/system/ThreadName.h>
+#include "folly/String.h"
+
 #include <pthread.h>
 #include <mutex>
 #include "velox/common/base/AsyncSource.h"

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -27,6 +27,7 @@
 #include <fmt/format.h>
 #include <folly/Random.h>
 #include <folly/Range.h>
+#include <folly/String.h>
 #include <gflags/gflags.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>

--- a/velox/common/process/StackTrace.h
+++ b/velox/common/process/StackTrace.h
@@ -16,10 +16,11 @@
 
 #pragma once
 
-#include <folly/synchronization/CallOnce.h>
-
 #include <string>
+#include <unordered_set>
 #include <vector>
+
+#include <folly/synchronization/CallOnce.h>
 
 namespace facebook::velox::process {
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -17,6 +17,8 @@
 
 #include <optional>
 #include <string>
+
+#include "folly/String.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::config {

--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -19,8 +19,8 @@
 #include <bitset>
 
 #include <fmt/core.h>
+#include <folly/String.h>
 #include <folly/container/Array.h>
-
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook {

--- a/velox/dwio/common/encryption/Encryption.h
+++ b/velox/dwio/common/encryption/Encryption.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/String.h>
 #include "folly/Range.h"
 #include "folly/io/IOBuf.h"
 #include "velox/dwio/common/exception/Exception.h"

--- a/velox/dwio/common/exception/Exception.h
+++ b/velox/dwio/common/exception/Exception.h
@@ -16,13 +16,11 @@
 
 #pragma once
 
+#include <folly/String.h>
 #include "velox/common/base/VeloxException.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace exception {
+namespace facebook::velox::dwio {
+namespace common::exception {
 
 class ExceptionLogger {
  public:
@@ -101,8 +99,7 @@ class LoggedException : public velox::VeloxException {
   }
 };
 
-} // namespace exception
-} // namespace common
+} // namespace common::exception
 
 #define DWIO_WARN_IF(e, ...)                                                \
   ({                                                                        \
@@ -256,6 +253,4 @@ containing information about the file, line, and function where it happened.
       "] : ",                           \
       ##__VA_ARGS__);
 
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio

--- a/velox/exec/tests/utils/TempFilePath.cpp
+++ b/velox/exec/tests/utils/TempFilePath.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/tests/utils/TempFilePath.h"
+#include <folly/String.h>
 
 namespace facebook::velox::exec::test {
 

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -17,6 +17,8 @@
 #include "velox/expression/TypeSignature.h"
 #include "velox/common/base/Exceptions.h"
 
+#include "folly/String.h"
+
 namespace facebook::velox::exec {
 void toAppend(
     const facebook::velox::exec::TypeSignature& signature,

--- a/velox/flag_definitions/flags.h
+++ b/velox/flag_definitions/flags.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/// When GFlags are used, they must be translated to
+/// velox::GlobalConfig by invoking translateFlagsToGlobalConfig
 namespace facebook::velox {
 void translateFlagsToGlobalConfig();
 }
@@ -27,3 +29,17 @@ DECLARE_bool(velox_ssd_odirect);
 /// read back and is compared against the entry written.
 /// This is helpful to protect against SSD write corruption.
 DECLARE_bool(velox_ssd_verify_write);
+
+/// Enable the stacktrace for user type of VeloxException
+DECLARE_bool(velox_exception_user_stacktrace_enabled);
+
+/// Enable the stacktrace for system type of VeloxException
+DECLARE_bool(velox_exception_system_stacktrace_enabled);
+
+/// Min time interval in milliseconds between stack traces captured in
+/// user type of VeloxException; off when set to 0 (the default)
+DECLARE_int32(velox_exception_user_stacktrace_rate_limit_ms);
+
+/// Min time interval in milliseconds between stack traces captured in
+/// system type of VeloxException; off when set to 0 (the default)
+DECLARE_int32(velox_exception_system_stacktrace_rate_limit_ms);

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -17,6 +17,8 @@
 #include <gtest/gtest.h>
 #include "velox/type/Tokenizer.h"
 
+#include <unordered_set>
+
 using namespace facebook::velox::common;
 
 std::vector<std::unique_ptr<Subfield::PathElement>> tokenize(


### PR DESCRIPTION
Remove unused headers in `velox/common/base/VeloxException.h`