### PR TITLE
feat: Add DecodedVector::sharedBase()

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -104,7 +104,7 @@ void PeeledEncoding::setDictionaryWrapping(
     wrapNulls_ = firstWrapper.nulls();
     return;
   }
-  auto wrapping = decoded.dictionaryWrapping(firstWrapper, rows.end());
+  auto wrapping = decoded.dictionaryWrapping(*firstWrapper.pool(), rows.end());
   wrap_ = std::move(wrapping.indices);
   wrapNulls_ = std::move(wrapping.nulls);
 }

--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -24,6 +24,7 @@ namespace facebook::velox {
 uint64_t DecodedVector::constantNullMask_{0};
 
 namespace {
+
 std::vector<vector_size_t> makeConsecutiveIndices(size_t size) {
   std::vector<vector_size_t> consecutiveIndices(size);
   for (vector_size_t i = 0; i < consecutiveIndices.size(); ++i) {
@@ -31,6 +32,23 @@ std::vector<vector_size_t> makeConsecutiveIndices(size_t size) {
   }
   return consecutiveIndices;
 }
+
+const VectorPtr& getLoadedVector(const VectorPtr& vector) {
+  return BaseVector::loadedVectorShared(vector);
+}
+
+const BaseVector* getLoadedVector(const BaseVector* vector) {
+  return vector->loadedVector();
+}
+
+const VectorPtr& getValueVector(const VectorPtr& vector) {
+  return vector->valueVector();
+}
+
+const BaseVector* getValueVector(const BaseVector* vector) {
+  return vector->valueVector().get();
+}
+
 } // namespace
 
 const std::vector<vector_size_t>& DecodedVector::consecutiveIndices() {
@@ -44,21 +62,22 @@ const std::vector<vector_size_t>& DecodedVector::zeroIndices() {
   return indices;
 }
 
-void DecodedVector::decode(
-    const BaseVector& vector,
+template <typename T>
+VectorPtr DecodedVector::decodeImpl(
+    const T& vector,
     const SelectivityVector* rows,
     bool loadLazy) {
-  reset(end(vector.size(), rows));
+  reset(end(vector->size(), rows));
   partialRowsDecoded_ = rows != nullptr;
   loadLazy_ = loadLazy;
-  const bool isTopLevelLazyAndLoaded =
-      vector.isLazy() && vector.asUnchecked<LazyVector>()->isLoaded();
-  if (isTopLevelLazyAndLoaded || (loadLazy_ && isLazyNotLoaded(vector))) {
-    decode(*vector.loadedVector(), rows, loadLazy);
-    return;
+  const bool isTopLevelLazyAndLoaded = vector->isLazy() &&
+      vector->template asUnchecked<LazyVector>()->isLoaded();
+  if (isTopLevelLazyAndLoaded || (loadLazy_ && isLazyNotLoaded(*vector))) {
+    return decodeImpl(getLoadedVector(vector), rows, loadLazy);
   }
 
-  const auto encoding = vector.encoding();
+  VectorPtr sharedBase;
+  const auto encoding = vector->encoding();
   switch (encoding) {
     case VectorEncoding::Simple::FLAT:
     case VectorEncoding::Simple::BIASED:
@@ -67,22 +86,25 @@ void DecodedVector::decode(
     case VectorEncoding::Simple::MAP:
     case VectorEncoding::Simple::LAZY:
       isIdentityMapping_ = true;
-      setBaseData(vector, rows);
-      return;
+      setBaseData(vector, rows, sharedBase);
+      break;
     case VectorEncoding::Simple::CONSTANT: {
       isConstantMapping_ = true;
-      if (isLazyNotLoaded(vector)) {
-        baseVector_ = vector.valueVector().get();
-        constantIndex_ = vector.wrapInfo()->as<vector_size_t>()[0];
+      if (isLazyNotLoaded(*vector)) {
+        if constexpr (std::is_same_v<T, VectorPtr>) {
+          sharedBase = vector->valueVector();
+        }
+        baseVector_ = vector->valueVector().get();
+        constantIndex_ = vector->wrapInfo()->template as<vector_size_t>()[0];
         mayHaveNulls_ = true;
       } else {
-        setBaseData(vector, rows);
+        setBaseData(vector, rows, sharedBase);
       }
       break;
     }
     case VectorEncoding::Simple::DICTIONARY:
     case VectorEncoding::Simple::SEQUENCE: {
-      combineWrappers(&vector, rows);
+      combineWrappers(vector, rows, sharedBase);
       break;
     }
     default:
@@ -90,6 +112,37 @@ void DecodedVector::decode(
           "Unsupported vector encoding: {}",
           VectorEncoding::mapSimpleToName(encoding));
   }
+  return sharedBase;
+}
+
+DecodedVector::DecodedVector(
+    const BaseVector& vector,
+    const SelectivityVector& rows,
+    bool loadLazy) {
+  decodeImpl(&vector, &rows, loadLazy);
+}
+
+DecodedVector::DecodedVector(const BaseVector& vector, bool loadLazy) {
+  decodeImpl(&vector, nullptr, loadLazy);
+}
+
+void DecodedVector::decode(
+    const BaseVector& vector,
+    const SelectivityVector& rows,
+    bool loadLazy) {
+  decodeImpl(&vector, &rows, loadLazy);
+}
+
+void DecodedVector::decode(const BaseVector& vector, bool loadLazy) {
+  decodeImpl(&vector, nullptr, loadLazy);
+}
+
+VectorPtr DecodedVector::decodeAndGetBase(
+    const VectorPtr& vector,
+    bool loadLazy) {
+  auto sharedBase = decodeImpl(vector, nullptr, loadLazy);
+  VELOX_CHECK(sharedBase.get() == baseVector_);
+  return sharedBase;
 }
 
 void DecodedVector::makeIndices(
@@ -101,7 +154,8 @@ void DecodedVector::makeIndices(
   }
 
   reset(end(vector.size(), rows));
-  combineWrappers(&vector, rows, numLevels);
+  VectorPtr sharedPtr;
+  combineWrappers(&vector, rows, sharedPtr, numLevels);
 }
 
 void DecodedVector::reset(vector_size_t size) {
@@ -133,15 +187,17 @@ void DecodedVector::copyNulls(vector_size_t size) {
   nulls_ = copiedNulls_.data();
 }
 
+template <typename T>
 void DecodedVector::combineWrappers(
-    const BaseVector* vector,
+    const T& vector,
     const SelectivityVector* rows,
+    VectorPtr& sharedBase,
     int numLevels) {
   auto topEncoding = vector->encoding();
-  BaseVector* values = nullptr;
+  T values;
   if (topEncoding == VectorEncoding::Simple::DICTIONARY) {
-    indices_ = vector->wrapInfo()->as<vector_size_t>();
-    values = vector->valueVector().get();
+    indices_ = vector->wrapInfo()->template as<vector_size_t>();
+    values = getValueVector(vector);
     nulls_ = vector->rawNulls();
     if (nulls_) {
       hasExtraNulls_ = true;
@@ -155,14 +211,19 @@ void DecodedVector::combineWrappers(
   int32_t levelCounter = 0;
   for (;;) {
     if (numLevels != -1 && ++levelCounter == numLevels) {
-      baseVector_ = values;
+      if constexpr (std::is_same_v<T, VectorPtr>) {
+        // We get the shared base vector only in case numLevels == -1.
+        VELOX_UNREACHABLE();
+      } else {
+        baseVector_ = values;
+      }
       return;
     }
 
     auto encoding = values->encoding();
     if (isLazy(encoding) &&
-        (loadLazy_ || values->asUnchecked<LazyVector>()->isLoaded())) {
-      values = values->loadedVector();
+        (loadLazy_ || values->template asUnchecked<LazyVector>()->isLoaded())) {
+      values = getLoadedVector(values);
       encoding = values->encoding();
     }
 
@@ -174,13 +235,12 @@ void DecodedVector::combineWrappers(
       case VectorEncoding::Simple::ROW:
       case VectorEncoding::Simple::ARRAY:
       case VectorEncoding::Simple::MAP:
-        setBaseData(*values, rows);
+        setBaseData(values, rows, sharedBase);
         return;
-      case VectorEncoding::Simple::DICTIONARY: {
+      case VectorEncoding::Simple::DICTIONARY:
         applyDictionaryWrapper(*values, rows);
-        values = values->valueVector().get();
+        values = getValueVector(values);
         break;
-      }
       default:
         VELOX_CHECK(false, "Unsupported vector encoding");
     }
@@ -226,7 +286,7 @@ void DecodedVector::applyDictionaryWrapper(
   });
 }
 
-void DecodedVector::fillInIndices() {
+void DecodedVector::fillInIndices() const {
   if (isConstantMapping_) {
     if (size_ > zeroIndices().size() || constantIndex_ != 0) {
       copiedIndices_.resize(size_);
@@ -284,60 +344,72 @@ void DecodedVector::setFlatNulls(
   }
 }
 
+template <typename T>
 void DecodedVector::setBaseData(
-    const BaseVector& vector,
-    const SelectivityVector* rows) {
-  auto encoding = vector.encoding();
-  baseVector_ = &vector;
+    const T& vector,
+    const SelectivityVector* rows,
+    VectorPtr& sharedBase) {
+  auto encoding = vector->encoding();
+  if constexpr (std::is_same_v<T, VectorPtr>) {
+    sharedBase = vector;
+    baseVector_ = vector.get();
+  } else {
+    baseVector_ = vector;
+  }
   switch (encoding) {
     case VectorEncoding::Simple::LAZY:
       break;
-    case VectorEncoding::Simple::FLAT: {
+    case VectorEncoding::Simple::FLAT:
       // values() may be nullptr if 'vector' is all nulls.
-      data_ = vector.values() ? vector.values()->as<void>() : nullptr;
-      setFlatNulls(vector, rows);
+      data_ =
+          vector->values() ? vector->values()->template as<void>() : nullptr;
+      setFlatNulls(*vector, rows);
       break;
-    }
     case VectorEncoding::Simple::ROW:
     case VectorEncoding::Simple::ARRAY:
-    case VectorEncoding::Simple::MAP: {
-      setFlatNulls(vector, rows);
+    case VectorEncoding::Simple::MAP:
+      setFlatNulls(*vector, rows);
       break;
-    }
-    case VectorEncoding::Simple::CONSTANT: {
-      setBaseDataForConstant(vector, rows);
+    case VectorEncoding::Simple::CONSTANT:
+      setBaseDataForConstant(vector, rows, sharedBase);
       break;
-    }
     default:
       VELOX_UNREACHABLE();
   }
 }
 
+template <typename T>
 void DecodedVector::setBaseDataForConstant(
-    const BaseVector& vector,
-    const SelectivityVector* rows) {
-  if (!vector.isScalar()) {
-    baseVector_ = vector.wrappedVector();
-    constantIndex_ = vector.wrappedIndex(0);
+    const T& vector,
+    const SelectivityVector* rows,
+    VectorPtr& sharedBase) {
+  if (!vector->isScalar()) {
+    if constexpr (std::is_same_v<T, VectorPtr>) {
+      sharedBase = BaseVector::wrappedVectorShared(vector);
+      baseVector_ = sharedBase.get();
+    } else {
+      baseVector_ = vector->wrappedVector();
+    }
+    constantIndex_ = vector->wrappedIndex(0);
   }
-  if (!hasExtraNulls_ || vector.isNullAt(0)) {
+  if (!hasExtraNulls_ || vector->isNullAt(0)) {
     // A mapping over a constant is constant except if the
     // mapping adds nulls and the constant is not null.
     isConstantMapping_ = true;
     hasExtraNulls_ = false;
     indices_ = nullptr;
-    nulls_ = vector.isNullAt(0) ? &constantNullMask_ : nullptr;
+    nulls_ = vector->isNullAt(0) ? &constantNullMask_ : nullptr;
   } else {
     makeIndicesMutable();
 
     applyToRows(rows, [this](vector_size_t row) {
       copiedIndices_[row] = constantIndex_;
     });
-    setFlatNulls(vector, rows);
+    setFlatNulls(*vector, rows);
   }
-  data_ = vector.valuesAsVoid();
+  data_ = vector->valuesAsVoid();
   if (!nulls_) {
-    nulls_ = vector.isNullAt(0) ? &constantNullMask_ : nullptr;
+    nulls_ = vector->isNullAt(0) ? &constantNullMask_ : nullptr;
   }
   mayHaveNulls_ = hasExtraNulls_ || nulls_;
 }
@@ -374,25 +446,23 @@ BufferPtr copyNullsBuffer(
 } // namespace
 
 DecodedVector::DictionaryWrapping DecodedVector::dictionaryWrapping(
-    const BaseVector& wrapper,
+    memory::MemoryPool& pool,
     vector_size_t size) const {
-  VELOX_CHECK(!isIdentityMapping_);
-  VELOX_CHECK(!isConstantMapping_);
   VELOX_CHECK_LE(size, size_);
 
   // Make a copy of the indices and nulls buffers.
-  BufferPtr indices = copyIndicesBuffer(indices_, size, wrapper.pool());
+  BufferPtr indices = copyIndicesBuffer(this->indices(), size, &pool);
   // Only copy nulls if we have nulls coming from one of the wrappers, don't
   // do it if nulls are missing or from the base vector.
   // TODO: remove the check for hasExtraNulls_ after #3553 is merged.
   BufferPtr nulls =
-      hasExtraNulls_ ? copyNullsBuffer(nulls_, size, wrapper.pool()) : nullptr;
+      hasExtraNulls_ ? copyNullsBuffer(nulls_, size, &pool) : nullptr;
   return {std::move(indices), std::move(nulls)};
 }
 
 VectorPtr DecodedVector::wrap(
     VectorPtr data,
-    const BaseVector& wrapper,
+    memory::MemoryPool& pool,
     vector_size_t size) {
   if (isConstantMapping_) {
     if (isNullAt(0)) {
@@ -406,7 +476,7 @@ VectorPtr DecodedVector::wrap(
     return BaseVector::wrapInConstant(size, constantIndex_, data);
   }
 
-  auto wrapping = dictionaryWrapping(wrapper, size);
+  auto wrapping = dictionaryWrapping(pool, size);
   return BaseVector::wrapInDictionary(
       std::move(wrapping.nulls),
       std::move(wrapping.indices),

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -107,26 +107,22 @@ class DecodedVector {
   DecodedVector(
       const BaseVector& vector,
       const SelectivityVector& rows,
-      bool loadLazy = true) {
-    decode(vector, &rows, loadLazy);
-  }
+      bool loadLazy = true);
 
-  DecodedVector(const BaseVector& vector, bool loadLazy = true) {
-    decode(vector, nullptr, loadLazy);
-  }
+  explicit DecodedVector(const BaseVector& vector, bool loadLazy = true);
 
   /// Resets the internal state and decodes 'vector' for 'rows'. See
   /// constructor.
   void decode(
       const BaseVector& vector,
       const SelectivityVector& rows,
-      bool loadLazy = true) {
-    decode(vector, &rows, loadLazy);
-  }
+      bool loadLazy = true);
 
-  void decode(const BaseVector& vector, bool loadLazy = true) {
-    decode(vector, nullptr, loadLazy);
-  }
+  void decode(const BaseVector& vector, bool loadLazy = true);
+
+  /// Same as other `decode`, but allow us to get shared ownership of the base
+  /// vector via the return value.
+  VectorPtr decodeAndGetBase(const VectorPtr& vector, bool loadLazy = true);
 
   /// Returns the values buffer for the base vector. Assumes the vector is of
   /// scalar type and has been already decoded. Use indices() to access
@@ -156,7 +152,7 @@ class DecodedVector {
 
   /// Returns the mapping from top-level rows to rows in the base vector or
   /// data() buffer.
-  const vector_size_t* indices() {
+  const vector_size_t* indices() const {
     if (!indices_) {
       fillInIndices();
     }
@@ -259,13 +255,25 @@ class DecodedVector {
   /// have been previously decoded by 'this'. This is used when 'data'
   /// is a component of the base vector of 'wrapper' and must be used
   /// in the same context, thus with the same indirections.
-  VectorPtr wrap(VectorPtr data, const BaseVector& wrapper, vector_size_t size);
+  VectorPtr wrap(VectorPtr data, memory::MemoryPool& pool, vector_size_t size);
+
+  VectorPtr wrap(
+      VectorPtr data,
+      memory::MemoryPool& pool,
+      const SelectivityVector& rows) {
+    return wrap(std::move(data), pool, rows.end());
+  }
+
+  VectorPtr
+  wrap(VectorPtr data, const BaseVector& wrapper, vector_size_t size) {
+    return wrap(std::move(data), *wrapper.pool(), size);
+  }
 
   VectorPtr wrap(
       VectorPtr data,
       const BaseVector& wrapper,
       const SelectivityVector& rows) {
-    return wrap(std::move(data), wrapper, rows.end());
+    return wrap(std::move(data), *wrapper.pool(), rows.end());
   }
 
   struct DictionaryWrapping {
@@ -274,20 +282,20 @@ class DecodedVector {
   };
 
   /// Returns 'indices' and 'nulls' buffers that represent the combined
-  /// dictionary wrapping of the decoded vector. Requires
-  /// isIdentityMapping() == false and isConstantMapping() == false.
+  /// dictionary wrapping of the decoded vector.
+  ///
   /// NOTE: The nulls buffer returned will also have nulls from the base()
   /// combined into it. To control which levels are combined, please make sure
   /// to use makeIndices() instead of decoded() when initializing the
   /// DecodedVector.
   DictionaryWrapping dictionaryWrapping(
-      const BaseVector& wrapper,
+      memory::MemoryPool& pool,
       vector_size_t size) const;
 
   DictionaryWrapping dictionaryWrapping(
-      const BaseVector& wrapper,
+      memory::MemoryPool& pool,
       const SelectivityVector& rows) const {
-    return dictionaryWrapping(wrapper, rows.end());
+    return dictionaryWrapping(pool, rows.end());
   }
 
   /// END: Members that must only be used by PeeledEncoding
@@ -300,14 +308,13 @@ class DecodedVector {
   DecodedVector(
       const BaseVector& vector,
       const SelectivityVector* rows,
-      bool loadLazy = true) {
-    decode(vector, rows, loadLazy);
+      bool loadLazy) {
+    decodeImpl(&vector, rows, loadLazy);
   }
 
-  void decode(
-      const BaseVector& vector,
-      const SelectivityVector* rows,
-      bool loadLazy = true);
+  template <typename T>
+  VectorPtr
+  decodeImpl(const T& vector, const SelectivityVector* rows, bool loadLazy);
 
   void makeIndices(
       const BaseVector& vector,
@@ -330,9 +337,11 @@ class DecodedVector {
 
   void makeIndicesMutable();
 
+  template <typename T>
   void combineWrappers(
-      const BaseVector* vector,
+      const T& vector,
       const SelectivityVector* rows,
+      VectorPtr& sharedBase,
       int numLevels = -1);
 
   void applyDictionaryWrapper(
@@ -341,13 +350,19 @@ class DecodedVector {
 
   void copyNulls(vector_size_t size);
 
-  void fillInIndices();
+  void fillInIndices() const;
 
-  void setBaseData(const BaseVector& vector, const SelectivityVector* rows);
+  template <typename T>
+  void setBaseData(
+      const T& vector,
+      const SelectivityVector* rows,
+      VectorPtr& sharedBase);
 
+  template <typename T>
   void setBaseDataForConstant(
-      const BaseVector& vector,
-      const SelectivityVector* rows);
+      const T& vector,
+      const SelectivityVector* rows,
+      VectorPtr& sharedBase);
 
   void reset(vector_size_t size);
 
@@ -373,7 +388,7 @@ class DecodedVector {
   // The indices into 'data_' or 'baseVector_' for the rows in
   // 'rows' given to decode(). Only positions that are in
   // 'selection' are guaranteed to have valid values.
-  const vector_size_t* indices_ = nullptr;
+  mutable const vector_size_t* indices_ = nullptr;
 
   // The base array of 'vector' given to decode(), nullptr if vector is of
   // complex type.
@@ -419,7 +434,7 @@ class DecodedVector {
 
   // Holds indices if an array of indices needs to be materialized,
   // e.g. when combining nested dictionaries.
-  std::vector<vector_size_t> copiedIndices_;
+  mutable std::vector<vector_size_t> copiedIndices_;
 
   // Used as backing for 'nulls_' when null-ness is combined from
   // dictionary and base values.


### PR DESCRIPTION
Summary: Sometimes we need to take shared ownership of the base value vector of a dictionary.  The current `DecodedVector` only keeps reference to a raw pointer so there is no way to get hold of the `shared_ptr`.  We add `DecodedVector::sharedBase()` and overload of `DecodedVector::decode` to take `shared_ptr` so that we can get the shared ownership.

Differential Revision: D69081492


