### PR TITLE
fix: Bitwise operations on signed integers (Part-5)

### DIFF
--- a/velox/dwio/parquet/writer/arrow/util/Crc32.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/Crc32.cpp
@@ -872,7 +872,7 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
   /* process a byte at a time until we hit an alignment boundary (max 3) */
   current_char = reinterpret_cast<const uint8_t*>(data);
   for (; unaligned && length; unaligned--, length--)
-    crc = (crc >> 8) ^ crc32_lookup[0][(crc & 0xFF) ^ *current_char++];
+    crc = (crc >> 8) ^ crc32_lookup[0][(crc & static_cast<uint32_t>(0xFF)) ^ *current_char++];
 
   current = reinterpret_cast<const uint32_t*>(current_char);
 
@@ -891,35 +891,35 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
       uint32_t two = *current++;
       uint32_t three = *current++;
       uint32_t four = *current++;
-      crc = crc32_lookup[0][(four >> 24) & 0xFF] ^
-          crc32_lookup[1][(four >> 16) & 0xFF] ^
-          crc32_lookup[2][(four >> 8) & 0xFF] ^ crc32_lookup[3][four & 0xFF] ^
-          crc32_lookup[4][(three >> 24) & 0xFF] ^
-          crc32_lookup[5][(three >> 16) & 0xFF] ^
-          crc32_lookup[6][(three >> 8) & 0xFF] ^ crc32_lookup[7][three & 0xFF] ^
-          crc32_lookup[8][(two >> 24) & 0xFF] ^
-          crc32_lookup[9][(two >> 16) & 0xFF] ^
-          crc32_lookup[10][(two >> 8) & 0xFF] ^ crc32_lookup[11][two & 0xFF] ^
-          crc32_lookup[12][(one >> 24) & 0xFF] ^
-          crc32_lookup[13][(one >> 16) & 0xFF] ^
-          crc32_lookup[14][(one >> 8) & 0xFF] ^ crc32_lookup[15][one & 0xFF];
+      crc = crc32_lookup[0][(four >> 24) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[1][(four >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[2][(four >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[3][four & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[4][(three >> 24) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[5][(three >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[6][(three >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[7][three & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[8][(two >> 24) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[9][(two >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[10][(two >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[11][two & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[12][(one >> 24) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[13][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[14][(one >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[15][one & static_cast<uint32_t>(0xFF)];
 #else
       uint32_t one = *current++ ^ ::arrow::bit_util::ByteSwap(crc);
       uint32_t two = *current++;
       uint32_t three = *current++;
       uint32_t four = *current++;
-      crc = crc32_lookup[0][four & 0xFF] ^ crc32_lookup[1][(four >> 8) & 0xFF] ^
-          crc32_lookup[2][(four >> 16) & 0xFF] ^
-          crc32_lookup[3][(four >> 24) & 0xFF] ^ crc32_lookup[4][three & 0xFF] ^
-          crc32_lookup[5][(three >> 8) & 0xFF] ^
-          crc32_lookup[6][(three >> 16) & 0xFF] ^
-          crc32_lookup[7][(three >> 24) & 0xFF] ^ crc32_lookup[8][two & 0xFF] ^
-          crc32_lookup[9][(two >> 8) & 0xFF] ^
-          crc32_lookup[10][(two >> 16) & 0xFF] ^
-          crc32_lookup[11][(two >> 24) & 0xFF] ^ crc32_lookup[12][one & 0xFF] ^
-          crc32_lookup[13][(one >> 8) & 0xFF] ^
-          crc32_lookup[14][(one >> 16) & 0xFF] ^
-          crc32_lookup[15][(one >> 24) & 0xFF];
+      crc = crc32_lookup[0][four & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[1][(four >> 8) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[2][(four >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[3][(four >> 24) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[4][three & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[5][(three >> 8) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[6][(three >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[7][(three >> 24) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[8][two & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[9][(two >> 8) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[10][(two >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[11][(two >> 24) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[12][one & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[13][(one >> 8) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[14][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+          crc32_lookup[15][(one >> 24) & static_cast<uint32_t>(0xFF)];
 #endif
     }
 
@@ -932,21 +932,21 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
 #if ARROW_LITTLE_ENDIAN
     uint32_t one = *current++ ^ crc;
     uint32_t two = *current++;
-    crc = crc32_lookup[0][(two >> 24) & 0xFF] ^
-        crc32_lookup[1][(two >> 16) & 0xFF] ^
-        crc32_lookup[2][(two >> 8) & 0xFF] ^ crc32_lookup[3][two & 0xFF] ^
-        crc32_lookup[4][(one >> 24) & 0xFF] ^
-        crc32_lookup[5][(one >> 16) & 0xFF] ^
-        crc32_lookup[6][(one >> 8) & 0xFF] ^ crc32_lookup[7][one & 0xFF];
+    crc = crc32_lookup[0][(two >> 24) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[1][(two >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[2][(two >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[3][two & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[4][(one >> 24) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[5][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[6][(one >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[7][one & static_cast<uint32_t>(0xFF)];
 #else
     uint32_t one = *current++ ^ ::arrow::bit_util::ByteSwap(crc);
     uint32_t two = *current++;
-    crc = crc32_lookup[0][two & 0xFF] ^ crc32_lookup[1][(two >> 8) & 0xFF] ^
-        crc32_lookup[2][(two >> 16) & 0xFF] ^
-        crc32_lookup[3][(two >> 24) & 0xFF] ^ crc32_lookup[4][one & 0xFF] ^
-        crc32_lookup[5][(one >> 8) & 0xFF] ^
-        crc32_lookup[6][(one >> 16) & 0xFF] ^
-        crc32_lookup[7][(one >> 24) & 0xFF];
+    crc = crc32_lookup[0][two & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[1][(two >> 8) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[2][(two >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[3][(two >> 24) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[4][one & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[5][(one >> 8) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[6][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[7][(one >> 24) & static_cast<uint32_t>(0xFF)];
 #endif
 
     length -= 8;
@@ -955,14 +955,14 @@ uint32_t crc32(uint32_t prev, const void* data, size_t length) {
   if (length >= 4) {
 #if ARROW_LITTLE_ENDIAN
     uint32_t one = *current++ ^ crc;
-    crc = crc32_lookup[0][(one >> 24) & 0xFF] ^
-        crc32_lookup[1][(one >> 16) & 0xFF] ^
-        crc32_lookup[2][(one >> 8) & 0xFF] ^ crc32_lookup[3][one & 0xFF];
+    crc = crc32_lookup[0][(one >> 24) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[1][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[2][(one >> 8) & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[3][one & static_cast<uint32_t>(0xFF)];
 #else
     uint32_t one = *current++ ^ ::arrow::bit_util::ByteSwap(crc);
-    crc = crc32_lookup[0][one & 0xFF] ^ crc32_lookup[1][(one >> 8) & 0xFF] ^
-        crc32_lookup[2][(one >> 16) & 0xFF] ^
-        crc32_lookup[3][(one >> 24) & 0xFF];
+    crc = crc32_lookup[0][one & static_cast<uint32_t>(0xFF)] ^ crc32_lookup[1][(one >> 8) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[2][(one >> 16) & static_cast<uint32_t>(0xFF)] ^
+        crc32_lookup[3][(one >> 24) & static_cast<uint32_t>(0xFF)];
 #endif
 
     length -= 4;

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -37,7 +37,7 @@ AssignUniqueId::AssignUniqueId(
       uniqueTaskId,
       kTaskUniqueIdLimit,
       "Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
-  uniqueValueMask_ = static_cast<int64_t>(uniqueTaskId) << 40;
+  uniqueValueMask_ = static_cast<uint64_t>(uniqueTaskId) << 40;
 
   const auto numColumns = planNode->outputType()->size();
   identityProjections_.reserve(numColumns - 1);
@@ -96,7 +96,7 @@ void AssignUniqueId::generateIdColumn(vector_size_t size) {
     const vector_size_t end =
         std::min(static_cast<int64_t>(size), start + numAvailableIds);
     VELOX_CHECK_EQ(
-        (rowIdCounter_ + (end - start)) & uniqueValueMask_,
+        static_cast<uint64_t>(rowIdCounter_ + (end - start)) & static_cast<uint64_t>(uniqueValueMask_),
         0,
         "Ran out of unique IDs at {}. Need {} more.",
         rowIdCounter_,

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -139,7 +139,7 @@ class TypedDistinctAggregations : public DistinctAggregations {
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto i : indices) {
-      groups[i][nullByte_] |= nullMask_;
+      groups[i][nullByte_] = static_cast<uint8_t>(groups[i][nullByte_]) | nullMask_;
       new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
     }
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1024,7 +1024,7 @@ void GroupingSet::spill() {
         spillStats_);
     VELOX_CHECK_EQ(
         inputSpiller_->state().maxPartitions(),
-        1 << spillConfig_->numPartitionBits);
+        1u << spillConfig_->numPartitionBits);
   }
   // Spilling may execute on multiple partitions in parallel, and
   // HashStringAllocator is not thread safe. If any aggregations

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -398,7 +398,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
       bufferManager, "OutputBufferManager was already destructed");
 
   // Limit serialized pages to 1MB.
-  static const uint64_t kMaxPageSize = 1 << 20;
+  static const uint64_t kMaxPageSize = 1UL << 20;
   const uint64_t maxPageSize = std::max<uint64_t>(
       kMinDestinationSize,
       std::min<uint64_t>(kMaxPageSize, maxBufferedBytes_ / numDestinations_));

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -47,7 +47,7 @@ __attribute__((__no_sanitize__("thread")))
 inline void
 setBit(char* bits, uint32_t idx) {
   auto bitsAs8Bit = reinterpret_cast<uint8_t*>(bits);
-  bitsAs8Bit[idx / 8] |= (1 << (idx % 8));
+  bitsAs8Bit[idx / 8] |= (1u << (idx % 8));
 }
 } // namespace
 
@@ -197,7 +197,7 @@ RowContainer::RowContainer(
     // This moves nullOffset to the start of the next byte.
     // This is to guarantee the null and initialized bits for an aggregate
     // always appear in the same byte.
-    nullOffset = (nullOffset + 7) & -8;
+    nullOffset = (nullOffset + 7) & ~7u;
   }
   for (const auto& accumulator : accumulators) {
     // Initialized bit.  Set when the accumulator is initialized.
@@ -861,7 +861,7 @@ void RowContainer::storeComplexType(
     int32_t column) {
   if (decoded.isNullAt(index)) {
     VELOX_DCHECK(nullMask);
-    row[nullByte] |= nullMask;
+    row[nullByte] = static_cast<uint8_t>(row[nullByte]) | nullMask;
     return;
   }
   RowSizeTracker tracker(row[rowSizeOffset_], *stringAllocator_);
@@ -1198,7 +1198,7 @@ int32_t RowContainer::listPartitionRows(
               partitionNumberVector ==
               xsimd::batch<uint8_t>::load_unaligned(runBytes + offsetInRun)) &
           firstBatchMask;
-      firstBatchMask = ~0;
+      firstBatchMask = ~0u;
       bool atEnd = false;
       if (startRow + kBatch >= numRows_) {
         // Clear bits that are for rows past numRows_ - 1.
@@ -1215,7 +1215,7 @@ int32_t RowContainer::listPartitionRows(
           return numResults;
         }
         // Clear last set bit in 'bits'.
-        bits &= bits - 1;
+        bits &= (bits - 1u);d
       }
       startRow += kBatch;
       // The last batch of 32 bytes may have been partly filled. If so, we

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -537,7 +537,7 @@ int main(int argc, char** argv) {
   auto bm = std::make_unique<HashTableListJoinResultBenchmark>();
   std::vector<HashTableBenchmarkResult> results;
 
-  auto hashTableSize = (2L << 20) - 3;
+  auto hashTableSize = (2UL << 20) - 3;
   auto probeRowSize = 100000000L;
 
   TypePtr onlyKeyType{ROW({"k1"}, {BIGINT()})};

--- a/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
@@ -240,7 +240,7 @@ class HashJoinPrepareJoinTableBenchmark : public VectorTestBase {
 void initArrayModeBenchmarkParams(
     std::vector<HashTableBenchmarkParams>& params) {
   TypePtr oneKeyType{ROW({"k1"}, {BIGINT()})};
-  std::vector<int64_t> buildSizeVector = {100000, (2L << 20) - 3};
+  std::vector<int64_t> buildSizeVector = {100000, (2UL << 20) - 3};
   std::vector<int64_t> numTablesVector = {1, 8};
   std::vector<int64_t> dupFactorVector = {1, 8};
   for (auto buildSize : buildSizeVector) {
@@ -260,7 +260,7 @@ void initArrayModeBenchmarkParams(
 void initNormalizedKeyModeBenchmarkParams(
     std::vector<HashTableBenchmarkParams>& params) {
   TypePtr twoKeyType{ROW({"k1", "k2"}, {BIGINT(), BIGINT()})};
-  std::vector<int64_t> buildSizeVector = {100000, (2L << 20) - 3, 2L << 23};
+  std::vector<int64_t> buildSizeVector = {100000, (2UL << 20) - 3, 2UL << 23};
   std::vector<int64_t> numTablesVector = {1, 8};
   std::vector<int64_t> dupFactorVector = {1, 8};
   for (auto buildSize : buildSizeVector) {
@@ -280,7 +280,7 @@ void initNormalizedKeyModeBenchmarkParams(
 void initHashModeBenchmarkParams(
     std::vector<HashTableBenchmarkParams>& params) {
   TypePtr threeKeyType{ROW({"k1", "k2", "k3"}, {BIGINT(), BIGINT(), BIGINT()})};
-  std::vector<int64_t> buildSizeVector = {(2L << 20) - 3, 2L << 23};
+  std::vector<int64_t> buildSizeVector = {(2UL << 20) - 3, 2UL << 23};
   std::vector<int64_t> numTablesVector = {1, 8};
   std::vector<int64_t> dupFactorVector = {1, 8};
   for (auto buildSize : buildSizeVector) {


### PR DESCRIPTION
## Bug Summary:

This PR addresses an issue with signed integer literals and operands used in bitwise operations. When dealing with signed integer literals, adding the 'u' suffix to the constant can resolve the issue by explicitly marking the constant as unsigned. Additionally, any operand of signed integer type can be cast to its unsigned equivalent using a C (or C++) cast expression. For signed variables used in bitwise operations, their type should be converted to an unsigned equivalent to avoid undefined behavior and ensure proper operation.

## Changes Made:

Added 'u' suffix to signed integer literals: This explicitly marks the constants as unsigned to ensure correct type handling.
Applied C/C++ cast to operands: All signed integer operands involved in bitwise operations are now cast to unsigned integers to prevent unexpected behavior.
Converted signed variables to unsigned type: For bitwise operations, the type of signed variables has been changed to the unsigned equivalent to maintain correctness and prevent potential overflow or sign extension issues.

## Impact:

These changes will ensure that the code handles integer literals and operands in bitwise expressions correctly, using unsigned types when appropriate, thus preventing bugs related to type conversion and ensuring cross-platform consistency.

This is part 5 of multiple PRs for this fix.