### PR TITLE
build(pyvelox) : Remove VELOX_BUILD_MINIMAL_WITH_DWIO

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,6 @@ class CMakeBuild(build_ext):
             f"-DCMAKE_BUILD_TYPE={cfg}",
             f"-DCMAKE_INSTALL_PREFIX={extdir}",
             "-DCMAKE_VERBOSE_MAKEFILE=ON",
-            "-DVELOX_BUILD_MINIMAL_WITH_DWIO=ON",
             "-DVELOX_BUILD_PYTHON_PACKAGE=ON",
             f"-DPYTHON_EXECUTABLE={exec_path} ",
         ]


### PR DESCRIPTION
Fixes broken pyvelox build. Turns on full set of functionality for pyvelox. In a subsequent PR I will work to reduce the scope of linked features. 