### PR TITLE
feat(python): Support equality and .child_at in PyVector

### DIFF
--- a/velox/py/arrow/arrow.cpp
+++ b/velox/py/arrow/arrow.cpp
@@ -73,7 +73,7 @@ PYBIND11_MODULE(arrow, m) {
       throw std::runtime_error("Unknown input Arrow structure.");
     }
     return velox::py::PyVector{
-        velox::importFromArrowAsViewer(schema, data, leafPool.get())};
+        velox::importFromArrowAsViewer(schema, data, leafPool.get()), leafPool};
   });
 
   /// Converts a velox.py.vector.Vector to a pyarrow.Array using Velox's arrow

--- a/velox/py/tests/test_vector.py
+++ b/velox/py/tests/test_vector.py
@@ -43,8 +43,19 @@ class TestPyVeloxVector(unittest.TestCase):
         vector1 = to_velox(pyarrow.array(data))
         vector2 = to_velox(to_arrow(vector1))
 
+        # First compare each element.
         for i in range(len(data)):
             self.assertEqual(vector1.compare(vector2, i, i), 0)
+
+        # Then the entire objects at once (__eq__).
+        self.assertEqual(vector1, vector2)
+
+        # Failures.
+        vector3 = to_velox(pyarrow.array([1, 2, 3, 4, 5]))
+        self.assertNotEqual(vector1, vector3)
+
+        vector4 = to_velox(pyarrow.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]))
+        self.assertNotEqual(vector1, vector4)
 
     def test_vector_print(self):
         vector = to_velox(pyarrow.array([1, 2]))
@@ -78,6 +89,14 @@ class TestPyVeloxVector(unittest.TestCase):
         vector = to_velox(pyarrow.array(data, type=struct_type))
         self.assertEqual(
             str(vector), "[ROW ROW<name:VARCHAR,age:INTEGER>: 2 elements, no nulls]"
+        )
+
+        # Validate children.
+        self.assertEqual(
+            str(vector.child_at(0)), "[FLAT VARCHAR: 2 elements, no nulls]"
+        )
+        self.assertEqual(
+            str(vector.child_at(1)), "[FLAT INTEGER: 2 elements, no nulls]"
         )
 
     def test_vector_type(self):

--- a/velox/py/vector/PyVector.cpp
+++ b/velox/py/vector/PyVector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/py/vector/PyVector.h"
+#include "velox/vector/ComplexVector.h"
 #include "velox/vector/VectorPrinter.h"
 
 namespace facebook::velox::py {
@@ -25,6 +26,14 @@ std::string PyVector::summarizeToText() const {
 
 std::string PyVector::printDetailed() const {
   return velox::printVector(*vector_);
+}
+
+PyVector PyVector::childAt(vector_size_t idx) const {
+  if (auto rowVector = std::dynamic_pointer_cast<RowVector>(vector_)) {
+    return PyVector{rowVector->childAt(idx), pool_};
+  }
+  throw std::runtime_error(fmt::format(
+      "Can only call child_at() on RowVector, but got '{}'", toString()));
 }
 
 } // namespace facebook::velox::py

--- a/velox/py/vector/vector.cpp
+++ b/velox/py/vector/vector.cpp
@@ -34,11 +34,21 @@ PYBIND11_MODULE(vector, m) {
       .def("__len__", &velox::py::PyVector::size, py::doc(R"(
         Number of elements in the Vector.
       )"))
+      .def("__eq__", &velox::py::PyVector::equals, py::doc(R"(
+        Returns if two PyVectors have the same size and contents.
+      )"))
       .def("type", &velox::py::PyVector::type, py::doc(R"(
         Returns the Type of the Vector.
       )"))
       .def("size", &velox::py::PyVector::size, py::doc(R"(
         Number of elements in the Vector.
+      )"))
+      .def("child_at", &velox::py::PyVector::childAt, py::doc(R"(
+        Returns the vector's child at position `idx`. Throws if the
+        vector is not a RowVector.
+
+        Args:
+          index: The index of the child element in the RowVector.
       )"))
       .def("null_count", &velox::py::PyVector::nullCount, py::doc(R"(
         Number of null elements in the Vector.


### PR DESCRIPTION
Summary:
Adding new APIs needed to unblock more usage scenarios:
* child_at: to return a child PyVector from a row vector.
* __eq__: to easily compare two PyVectors
* the ability to hold a shared ptr to the pool owning the memory referenced by
  the vector.
The latter is needed as Python relies on garbage collection and sometimes
objects get destructed after modules are unloaded or even after statics are
destructed.

Differential Revision: D69162853


