### PR TITLE
feat(cursor): Enable TaskCursor to take a memory pool

### DIFF
--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -219,7 +219,9 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
         queryCtx_->isExecutorSupplied(),
         "Executor should be set in parallel task cursor");
 
-    queue_ = std::make_shared<TaskQueue>(params.bufferedBytes);
+    queue_ =
+        std::make_shared<TaskQueue>(params.bufferedBytes, params.outputPool);
+
     // Captured as a shared_ptr by the consumer callback of task_.
     auto queue = queue_;
     task_ = Task::create(


### PR DESCRIPTION
Summary:
When task cursor runs in multi-threaded mode, vectors are copied from
the input memory pool to an output one created by the TaskCursor object. Adding
a configuration parameter to enable clients of this API to manually pass a
custom pool and allow them to control their lifetime.

Differential Revision: D69163034


