### PR TITLE
fix(build): Change to 32-core-ubuntu 

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -89,7 +89,7 @@ jobs:
     name: Build
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
-    runs-on: 16-core-ubuntu
+    runs-on: 32-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:centos9
     timeout-minutes: 120
     env:


### PR DESCRIPTION
The PyVelox build seems to be ooming out. Temporarily increasing the machine specs while we work on reducing the build scope for PyVelox. 