### PR TITLE
refactor(trace): Only register Parquet if it's enabled

### DIFF
--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -31,8 +31,6 @@
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/OperatorTraceReader.h"
 #include "velox/exec/PartitionFunction.h"
 #include "velox/exec/TaskTraceReader.h"
@@ -50,6 +48,11 @@
 #include "velox/tool/trace/TableScanReplayer.h"
 #include "velox/tool/trace/TableWriterReplayer.h"
 #include "velox/type/Type.h"
+
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#endif
 
 DEFINE_string(
     root_dir,
@@ -255,8 +258,11 @@ void TraceReplayRunner::init() {
   dwio::common::registerFileSinks();
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();
+
+#ifdef VELOX_ENABLE_PARQUET
   parquet::registerParquetReaderFactory();
   parquet::registerParquetWriterFactory();
+#endif
 
   core::PlanNode::registerSerDe();
   core::ITypedExpr::registerSerDe();


### PR DESCRIPTION
Summary:
Similar to other places in the code, we should only register the Parquet reader/writer if it's
enabled in the Trace tool.

Differential Revision: D69200383


