### PR TITLE
fix: Ensure lambda functions fail on oversized array inputs

### DIFF
--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -33,7 +33,11 @@ vector_size_t countElements(
     if (decodedVector.isNullAt(row)) {
       return;
     }
-    count += rawSizes[indices[row]];
+    // In some cases, the array/map vector is wrapped in dictionary encoding
+    // that can explode the cardinality of the underlying elements. This check
+    // helps ensure we fail instead of silently wrapping around and causing
+    // memory corruption or segfaults.
+    count = checkedPlus<vector_size_t>(count, rawSizes[indices[row]]);
   });
   return count;
 }


### PR DESCRIPTION
Summary:
We recently encountered an issue where a lambda function (filter)
having an array as a capture column resulted in creating an oversized
array vector. When inside the lambda eval, the capture is replicated by
wrapping it in a dictionary that aligns each row with each element
of the array that the filter is applied to. It then attempted to
flatten this wrapped vector, where it first calculated the size of the
elements buffer to create which overflowed and resulted in creation
of a buffer much smaller than the required size. Finally when filling
in the values in this elements buffer it ended up writing outside the
bounds of the buffer and caused a seg fault.

This is a bandaid fix for this issue to ensure we fail instead of
crashing.

Differential Revision: D69210640


