### PR TITLE
feat: Add Geometry Presto type

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -173,6 +173,7 @@ TIMESTAMP WITH TIME ZONE  BIGINT
 UUID                      HUGEINT
 IPADDRESS                 HUGEINT
 IPPREFIX                  ROW(HUGEINT,TINYINT)
+GEOMETRY                  VARBINARY
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -231,7 +231,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "IPADDRESS",
           "IPPREFIX",
           "BINGTILE",
-          "TDIGEST"}),
+          "TDIGEST",
+          "GEOMETRY"}),
       names);
 
   ASSERT_TRUE(registerCustomType(
@@ -248,7 +249,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "IPPREFIX",
           "BINGTILE",
           "FANCY_INT",
-          "TDIGEST"}),
+          "TDIGEST",
+          "GEOMETRY"}),
       names);
 
   ASSERT_TRUE(unregisterCustomType("fancy_int"));

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
+#include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
@@ -84,6 +85,9 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARBINARY:
       if (isHyperLogLogType(type)) {
         return "HyperLogLog";
+      }
+      if (isGeometryType(type)) {
+        return "geometry";
       }
       if (*type == *TDIGEST(DOUBLE())) {
         return "tdigest(double)";

--- a/velox/functions/prestosql/registration/GeospatialFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeospatialFunctionsRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/prestosql/GeospatialFunctions.h"
 #include "velox/functions/prestosql/types/BingTileRegistration.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
+#include "velox/functions/prestosql/types/GeometryRegistration.h"
 #include "velox/type/SimpleFunctionApi.h"
 
 namespace facebook::velox::functions {
@@ -43,6 +44,7 @@ void registerBingTileFunctions(const std::string& prefix) {
 
 void registerGeospatialFunctions(const std::string& prefix) {
   registerBingTileType();
+  registerGeometryType();
 
   registerBingTileFunctions(prefix);
 }

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -15,6 +15,7 @@ velox_add_library(
   velox_presto_types
   BingTileRegistration.cpp
   BingTileType.cpp
+  GeometryRegistration.cpp
   HyperLogLogRegistration.cpp
   IPAddressRegistration.cpp
   IPPrefixRegistration.cpp

--- a/velox/functions/prestosql/types/GeometryRegistration.cpp
+++ b/velox/functions/prestosql/types/GeometryRegistration.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/GeometryRegistration.h"
+
+#include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/types/GeometryType.h"
+
+namespace facebook::velox {
+
+namespace {
+class GeometryTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
+    return GEOMETRY();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+} // namespace
+
+void registerGeometryType() {
+  // Register the geometry type with the type registry.
+  registerCustomType(
+      "geometry", std::make_unique<const GeometryTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/GeometryRegistration.h
+++ b/velox/functions/prestosql/types/GeometryRegistration.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+namespace facebook::velox {
+
+void registerGeometryType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/GeometryType.h
+++ b/velox/functions/prestosql/types/GeometryType.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastExpr.h"
+#include "velox/type/SimpleFunctionApi.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class GeometryType : public VarbinaryType {
+  GeometryType() = default;
+
+ public:
+  static const std::shared_ptr<const GeometryType>& get() {
+    static const std::shared_ptr<const GeometryType> instance{
+        new GeometryType()};
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "GEOMETRY";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isGeometryType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return GeometryType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const GeometryType> GEOMETRY() {
+  return GeometryType::get();
+}
+
+// Type used for function registration.
+struct GeometryT {
+  using type = Varbinary;
+  static constexpr const char* typeName = "geometry";
+};
+
+using Geometry = CustomType<GeometryT>;
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_presto_types_test
   BingTileTypeTest.cpp
+  GeometryTypeTest.cpp
   HyperLogLogTypeTest.cpp
   JsonTypeTest.cpp
   TimestampWithTimeZoneTypeTest.cpp

--- a/velox/functions/prestosql/types/tests/GeometryTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/GeometryTypeTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/GeometryType.h"
+#include "velox/functions/prestosql/types/GeometryRegistration.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class GeometryTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  GeometryTypeTest() {
+    registerGeometryType();
+  }
+};
+
+TEST_F(GeometryTypeTest, basic) {
+  ASSERT_EQ(GEOMETRY()->name(), "GEOMETRY");
+  ASSERT_EQ(GEOMETRY()->kindName(), "VARBINARY");
+  ASSERT_TRUE(GEOMETRY()->parameters().empty());
+  ASSERT_EQ(GEOMETRY()->toString(), "GEOMETRY");
+
+  ASSERT_TRUE(hasType("GEOMETRY"));
+  ASSERT_EQ(*getType("GEOMETRY", {}), *GEOMETRY());
+}
+
+TEST_F(GeometryTypeTest, serde) {
+  testTypeSerde(GEOMETRY());
+}
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary

This PR is a split of #12053 to introduce Geometry Presto type in Velox. It focuses on the type declaration without serde code. As suggested, it uses Varbinary as the underlying type. Cast operators can be added later if needed, as Presto Java handles the conversion by functions `ST_GeometryFromText`(`ST_GeomFromBinary`), and `ST_AsText` (`ST_AsBinary`).