### PR TITLE
refactor: Minor cleanups for `variant::serialize`

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -497,9 +497,9 @@ folly::dynamic variant::serialize() const {
       break;
     }
     case TypeKind::ARRAY: {
-      auto& row = value<TypeKind::ARRAY>();
+      auto& array = value<TypeKind::ARRAY>();
       folly::dynamic arr = folly::dynamic::array;
-      for (auto& v : row) {
+      for (auto& v : array) {
         arr.push_back(v.serialize());
       }
       objValue = std::move(arr);
@@ -553,7 +553,7 @@ folly::dynamic variant::serialize() const {
     }
     case TypeKind::TIMESTAMP: {
       auto ts = value<TypeKind::TIMESTAMP>();
-      variantObj["value"] = -1; // Not used, but cannot be null.
+      objValue = -1; // Not used, but cannot be null.
       variantObj["seconds"] = ts.getSeconds();
       variantObj["nanos"] = ts.getNanos();
       break;


### PR DESCRIPTION
1. Wrong variable name `row` at line 500 (likely a typo). Correct to `array`.
2. Duplicated reference to `variantObj["value"]`.