### PR TITLE
feat: Remote UDF, only serialize and process selected rows

### DIFF
--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -154,6 +154,20 @@ TEST_P(RemoteFunctionTest, simple) {
   auto expected = makeFlatVector<int64_t>({2, 4, 6, 8, 10});
   assertEqualVectors(expected, results);
 }
+TEST_P(RemoteFunctionTest, simpleWithSelectivity) {
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  SelectivityVector rows(inputVector->size());
+  rows.setValid(0, false);
+  rows.setValid(1, false);
+  auto results = evaluate<DictionaryVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}), rows);
+
+  auto expected = makeFlatVector<int64_t>({-1, -1, 6, 8, 10});
+  // The first 2 elements are not evaluated, and should be set as null.
+  expected->setNull(0, true);
+  expected->setNull(1, true);
+  assertEqualVectors(expected, results);
+}
 
 TEST_P(RemoteFunctionTest, string) {
   auto inputVector =


### PR DESCRIPTION
Summary:
- In this diff, we are adding an optimization to Remote UDF, to only serialize and process selected rows.
- This could greatly help in cases where the vector is heavily filtered.
- The previous approach could also potentially have bugs where function would throw exception if it doesn't expect to process un-selected rows (e.g null conditions, unexpected arguments, etc.)

Differential Revision: D69231717


