### PR TITLE
fix: IPPrefix serialization with null case

### DIFF
--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -810,9 +810,6 @@ void serializeWrapped(
     simd::transpose(indices, rows, innerRows);
     numInner = numRows;
   } else {
-    if (isIPPrefixType(vector->type())) {
-      return serializeIPPrefix(vector, rows, stream);
-    }
     wrapped = &BaseVector::wrappedVectorShared(vector);
     for (int32_t i = 0; i < rows.size(); ++i) {
       if (mayHaveNulls && vector->isNullAt(rows[i])) {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1207,9 +1207,13 @@ TEST_P(PrestoSerializerTest, ipprefix) {
 
   // Test that if the vector is wrapped, we can still properly
   // deserialize the ipprefix type
-  auto oneIndex = makeIndices(100, [](auto) { return 0; });
+  auto oneIndex = makeIndices(100, [](auto row) { return row; });
   auto wrappedVector = makeRowVector({
-      BaseVector::wrapInDictionary(nullptr, oneIndex, 100, vector),
+      BaseVector::wrapInDictionary(
+          makeNulls(100, [](auto row) { return row % 2 == 0; }),
+          oneIndex,
+          100,
+          vector),
   });
   testRoundTrip(wrappedVector);
 }


### PR DESCRIPTION
Summary: We need let `serializeWrapped` handle dealing with nulls for ipprefix. It will deal with the dictionary with `wrappedVectorShared`.

Differential Revision: D69266615


