### PR TITLE
fix: Wildcard support in json extract using simdjson

### DIFF
--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -254,7 +254,8 @@ struct JsonExtractScalarFunction {
     };
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer));
+    bool isDefinitePath = true;
+    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
 
     if (resultStr.has_value()) {
       result.copy_from(*resultStr);
@@ -321,16 +322,17 @@ struct JsonExtractFunction {
     };
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer));
+    bool isDefinitePath = true;
+    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
 
     if (resultSize == 0) {
-      if (extractor.isDefinitePath()) {
+      if (isDefinitePath) {
         // If the path didn't map to anything in the JSON object, return null.
         return simdjson::NO_SUCH_FIELD;
       }
 
       result.copy_from("[]");
-    } else if (resultSize == 1 && extractor.isDefinitePath()) {
+    } else if (resultSize == 1 && isDefinitePath) {
       // If there was only one value mapped to by the path, don't wrap it in an
       // array.
       result.copy_from(results);
@@ -392,7 +394,8 @@ struct JsonSizeFunction {
     };
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer));
+    bool isDefinitePath = true;
+    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
 
     if (resultCount == 0) {
       // If the path didn't map to anything in the JSON object, return null.

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -31,8 +31,12 @@ simdjson::error_code simdJsonExtract(
     const std::string& path,
     TConsumer&& consumer) {
   auto& extractor = SIMDJsonExtractor::getInstance(path);
+  bool isDefinitePath = true;
   return simdJsonExtract(
-      velox::StringView(json), extractor, std::forward<TConsumer>(consumer));
+      velox::StringView(json),
+      extractor,
+      std::forward<TConsumer>(consumer),
+      isDefinitePath);
 }
 
 class SIMDJsonExtractorTest : public testing::Test {
@@ -177,6 +181,17 @@ TEST_F(SIMDJsonExtractorTest, generalJsonTest) {
   testExtract(json, "$[\"e mail\"]", "\"amy@only_for_json_udf_test.net\"");
   testExtract(json, "$.owner", "\"amy\"");
 
+  // Wildcard over object's value elements
+  testExtract(
+      json,
+      "$.store.book[0].[*]",
+      std::vector<std::string>{
+          "\"Nigel Rees\"",
+          "\"ayings of the Century\"",
+          "\"reference\"",
+          "8.95"});
+  testExtract(json, "$.store.[*].price", std::vector<std::string>{"19.95"});
+
   testExtract("[[1.1,[2.1,2.2]],2,{\"a\":\"b\"}]", "$[0][1][1]", "2.2");
 
   json = "[1,2,{\"a\":\"b\"}]";
@@ -190,6 +205,7 @@ TEST_F(SIMDJsonExtractorTest, generalJsonTest) {
 
   testExtract("{\"a\":\"b\"}", " $ ", "{\"a\":\"b\"}");
 
+  // Wildcard over array elements
   json =
       "[[{\"key\": 1, \"value\": 2},"
       "{\"key\": 2, \"value\": 4}],"

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -916,6 +916,19 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   EXPECT_EQ("[]", jsonExtract(R"({"a": [{"b": 123}]})", "$.a[*].c"));
   EXPECT_EQ(std::nullopt, jsonExtract(R"({"a": [{"b": 123}]})", "$.a[0].c"));
 
+  // Wildcard on empty object and array
+  EXPECT_EQ("[]", jsonExtract("{\"a\": {}", "$.a.[*]"));
+  EXPECT_EQ("[]", jsonExtract("{\"a\": []}", "$.a.[*]"));
+
+  // Calling wildcard on a scalar
+  EXPECT_EQ("[]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.b.[0].[*]"));
+
+  // non-definite paths that end up being evaluated vs. not evaluated
+  EXPECT_EQ(
+      "[123,456]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.b[*]"));
+  EXPECT_EQ(
+      std::nullopt, jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.c[*]"));
+
   // TODO The following paths are supported by Presto via Jayway, but do not
   // work in Velox yet. Figure out how to add support for these.
   VELOX_ASSERT_THROW(jsonExtract(kJson, "$..price"), "Invalid JSON path");


### PR DESCRIPTION
Summary:
This change addresses 2 bugs in the wildcard support of json_extract:

Bug 1: Failure to iterate on values inside an object, resulting in
empty arrays.
For eg: calling JSON_EXTRACT(
   JSON '{"foo": {"a" : {"c": 1 , "d": 3} }, "b": 2}', '$.foo.a.[*]')
will return an empty array whereas we expect [1, 3]

Bug 2: Inconsistent handling of indefinite results, always returning a
JSON array even when the token is not evaluated.
or eg: JSON_EXTRACT('({"a": {"b": [123, 456]}})', '$.a.c[*]') should
return NULL instead of [] as the key 'c' does not exist.

Differential Revision: D69281233


