### PR TITLE
test: Deflake MultiFragmentTest.maxBytes

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/OutputBuffer.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Task.h"
 
@@ -475,6 +476,9 @@ bool OutputBuffer::enqueue(
     }
 
     if (bufferedBytes_ >= maxSize_ && future) {
+      common::testutil::TestValue::adjust(
+          "facebook::velox::exec::OutputBuffer::enqueue", this);
+
       promises_.emplace_back("OutputBuffer::enqueue");
       *future = promises_.back().getSemiFuture();
       blocked = true;
@@ -597,6 +601,9 @@ void OutputBuffer::checkIfDone(bool oneDriverFinished) {
           finished.push_back(buffer->getAndClearNotify());
         }
       }
+
+      common::testutil::TestValue::adjust(
+          "facebook::velox::exec::OutputBuffer::checkIfDone", this);
     }
   }
 


### PR DESCRIPTION
Summary:
MultiFragmentTest.maxBytes tests that the maxBytes argument passed to OutputBuffer::getData 
is respected.

It does this by running multiple tasks with the same input data, and calling getData with 
increasing values of maxBytes and verifying that with larger values of maxBytes getData returns 
fewer (i.e. larger) batches.

The size of the batch returned by getData is determined by two factors, maxBytes and the 
number of pages available. The test relies on the fact that the number of pages available is 
always large enough that maxBytes is the decisive factor. This in turn relies on the fact that the 
threads the Tasks' Drivers run in are running fast enough to fill the buffer, which cannot be 
guaranteed (e.g. on a busy host those threads may not get enough time on the CPU).

To fix this I've leveraged the TestValue interface to set boolean flags every time an OutputBuffer 
fills up or an OutputBuffer detects that all upstream Drivers are finished (i.e. that there's no more 
data). I've also modified DataFetcher to wait for one of these flags to be set before calling 
getData. This guarantees that there's always enough data that maxBytes is the decisive factor in 
the size of a packet (except the last packet but that doesn't impact the test). Note that since 
there's only one Driver in each Task we only need the two flags.

Differential Revision: D69288717


