### PR TITLE
fix(fuzzer): Stabalize expression fuzzer for nightly run by removing known test failures

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -132,6 +132,7 @@ const std::unordered_map<std::string, std::string>& binaryOperatorMap() {
   static std::unordered_map<std::string, std::string> binaryOperatorMap{
       {"plus", "+"},
       {"subtract", "-"},
+      {"minus", "-"},
       {"multiply", "*"},
       {"divide", "/"},
       {"eq", "="},


### PR DESCRIPTION
Summary: Removes functions already noted as test failures that crash fuzzer run in order to stabalize fuzzer for nightly QA run

Differential Revision: D69337160


