### PR TITLE
fix: Add support for scalar only jsons to json_extract

### DIFF
--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -255,7 +255,7 @@ struct JsonExtractScalarFunction {
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
     bool isDefinitePath = true;
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
+    SIMDJSON_TRY(extractor.extract(json, consumer, isDefinitePath));
 
     if (resultStr.has_value()) {
       result.copy_from(*resultStr);
@@ -323,7 +323,7 @@ struct JsonExtractFunction {
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
     bool isDefinitePath = true;
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
+    SIMDJSON_TRY(extractor.extract(json, consumer, isDefinitePath));
 
     if (resultSize == 0) {
       if (isDefinitePath) {
@@ -395,7 +395,7 @@ struct JsonSizeFunction {
 
     auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
     bool isDefinitePath = true;
-    SIMDJSON_TRY(simdJsonExtract(json, extractor, consumer, isDefinitePath));
+    SIMDJSON_TRY(extractor.extract(json, consumer, isDefinitePath));
 
     if (resultCount == 0) {
       // If the path didn't map to anything in the JSON object, return null.

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -32,9 +32,8 @@ simdjson::error_code simdJsonExtract(
     TConsumer&& consumer) {
   auto& extractor = SIMDJsonExtractor::getInstance(path);
   bool isDefinitePath = true;
-  return simdJsonExtract(
+  return extractor.extract(
       velox::StringView(json),
-      extractor,
       std::forward<TConsumer>(consumer),
       isDefinitePath);
 }

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -976,6 +976,16 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
 
   // Calling wildcard on a scalar
   EXPECT_EQ("[]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.b.[0].[*]"));
+  EXPECT_EQ("[]", jsonExtract("1", "$.*"));
+
+  // Scalar json
+  EXPECT_EQ("1", jsonExtract("1", "$"));
+  EXPECT_EQ(std::nullopt, jsonExtract("1", "$.foo"));
+  EXPECT_EQ(std::nullopt, jsonExtract("1", "$.[0]"));
+  // Scalar 'null' json
+  EXPECT_EQ("null", jsonExtract("null", "$"));
+  EXPECT_EQ(std::nullopt, jsonExtract("null", "$.foo"));
+  EXPECT_EQ(std::nullopt, jsonExtract("null", "$.[0]"));
 
   // non-definite paths that end up being evaluated vs. not evaluated
   EXPECT_EQ(


### PR DESCRIPTION
Summary:
Currently, for scalar only json like '1' or 'null', json_extract
returns NULL for any json path except the root only path '$'.
This change ensure it properly supports these jsons.

Differential Revision: D69337714


