### PR TITLE
fix: Improve rehash of Wave Group By

### DIFF
--- a/velox/experimental/wave/common/Compile.cu
+++ b/velox/experimental/wave/common/Compile.cu
@@ -141,6 +141,31 @@ std::mutex initMutex;
 std::vector<std::string> waveNvrtcFlags;
 std::vector<const char*> waveNvrtcFlagsString;
 
+  bool readSystemHeaders(std::map<std::string, std::string>& headers) {
+    std::ifstream in("/tmp/wavesystemheaders.txt");
+    std::string  path;
+    while (std::getline(in, path)) {
+      std::string size;
+      getline(in, size);
+      int32_t bytes = atoi(size.c_str());
+      std::string text;
+      text.resize(bytes);
+      in.read(text.data(), bytes);
+      headers[path] = text;
+    }
+    return !headers.empty();
+  }
+
+  void saveSystemHeaders(std::map<std::string, std::string>& map) {
+    std::ofstream out(fmt::format("/tmp/h.{}", getpid()));
+    for (auto& pair : map) {
+      out << pair.first << std::endl << pair.second.size() << std::endl << pair.second;
+    }
+    out.close();
+    system(fmt::format(" mv /tmp/h.{} /tmp/wavesystemheaders.txt", getpid()).c_str());
+  }
+
+  
 // Adds a trailing zero to make the string.data() a C char*.
 void makeNTS(std::string& string) {
   string.resize(string.size() + 1);
@@ -230,12 +255,15 @@ void ensureInit() {
         "--gpu-architecture=compute_{}{}", device->major, device->minor));
   }
   ::jitify::detail::detect_and_add_cuda_arch(waveNvrtcFlags);
-
-  static jitify::JitCache kernel_cache;
-
-  auto program = kernel_cache.program(sampleText, {}, waveNvrtcFlags);
-
-  initializeWaveHeaders(program._impl->_config->sources, "sample");
+  std::map<std::string, std::string> headers;
+  if (!readSystemHeaders(headers)) {
+    static jitify::JitCache kernel_cache;
+    
+    auto program = kernel_cache.program(sampleText, {}, waveNvrtcFlags);
+    headers = program._impl->_config->sources;
+    saveSystemHeaders(headers);
+  }
+  initializeWaveHeaders(headers, "sample");
 
   for (auto& str : waveNvrtcFlags) {
     makeNTS(str);

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -20,6 +20,7 @@
 #include "velox/experimental/wave/common/Cuda.h"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 #include "velox/experimental/wave/common/Exception.h"
+#include "velox/experimental/wave/common/HashTable.h"
 
 #include <assert.h>
 #include <mutex>
@@ -389,6 +390,14 @@ void fillMemory(uint64_t* ptr, int32_t numWords, int32_t seed, bool isDevice) {
   }
 }
 
+  std::string AllocationRange::toString(int32_t rowSize) {
+    return fmt::format("<Range: {} Fixed cap={} rows fixd avail={} rows total cap={}B >", (fixedFull ? "full" : ""), (stringOffset - firstRowOffset) / rowSize,  (rowLimit - rowOffset) / rowSize, capacity);
+  }
+
+  std::string HashPartitionAllocator::toString() {
+    return fmt::format("<allocator avail {} rows : {} {}>", availableFixed() / rowSize, ranges[0].toString(rowSize), ranges[1].toString(rowSize));
+  }
+  
 bool registerKernel(const char* name, const void* func) {
   kernelEntries[numKernelEntries].name = name;
   kernelEntries[numKernelEntries].func = func;

--- a/velox/experimental/wave/common/HashTable.h
+++ b/velox/experimental/wave/common/HashTable.h
@@ -18,6 +18,7 @@
 
 #ifndef __CUDACC_RTC__
 #include <string.h>
+#include <string>
 #endif
 #include <cstdint>
 
@@ -137,6 +138,8 @@ struct AllocationRange {
   bool empty() {
     return capacity == 0;
   }
+
+  std::string toString(int32_t rowSize);
 #endif
   bool fixedFull{true};
   bool variableFull{true};
@@ -190,6 +193,8 @@ struct HashPartitionAllocator {
     target = ranges[0].trimFixed(target);
     ranges[1].trimFixed(target);
   }
+
+  std::string toString();
 #endif
 
   const int32_t rowSize{0};

--- a/velox/experimental/wave/exec/Instruction.h
+++ b/velox/experimental/wave/exec/Instruction.h
@@ -197,7 +197,11 @@ struct AdvanceResult {
   /// Action to run before continue. If the update is visible between
   /// streams/Drivers, use the right sync flag above. No sync needed if e.g.
   /// adding space to a string buffer on the 'stream's' vectors.
-  std::function<void(WaveStream&, AbstractInstruction&)> updateStatus;
+  std::function<void(
+      WaveStream&,
+      const std::vector<WaveStream*>& otherStreams,
+      AbstractInstruction&)>
+      updateStatus;
 
   /// Extra token to mark reason for 'syncDrivers', e.g. the host side
   /// handle to a device hash table to rehash.

--- a/velox/experimental/wave/exec/Project.cpp
+++ b/velox/experimental/wave/exec/Project.cpp
@@ -63,10 +63,13 @@ std::vector<AdvanceResult> Project::canAdvance(WaveStream& stream) {
   return {};
 }
 
-void Project::callUpdateStatus(WaveStream& stream, AdvanceResult& advance) {
+void Project::callUpdateStatus(
+    WaveStream& stream,
+    const std::vector<WaveStream*>& otherStreams,
+    AdvanceResult& advance) {
   if (advance.updateStatus) {
     levels_[advance.nthLaunch][advance.programIdx]->callUpdateStatus(
-        stream, advance);
+        stream, otherStreams, advance);
   }
 }
 

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -65,7 +65,10 @@ class Project : public WaveOperator {
     return computedSet_;
   }
 
-  void callUpdateStatus(WaveStream& stream, AdvanceResult& advance) override;
+  void callUpdateStatus(
+      WaveStream& stream,
+      const std::vector<WaveStream*>& otherStreams,
+      AdvanceResult& advance) override;
 
  private:
   struct ContinueLocation {

--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -38,7 +38,7 @@ DEFINE_bool(wave_trace_stream, false, "Enable trace of streams and drivers");
 
 DEFINE_int32(
     wave_init_group_by_buckets,
-    30000,
+    2048,
     "Initial buckets in group by hash table (4 slots/bucket)");
 
 namespace facebook::velox::wave {
@@ -1201,9 +1201,13 @@ AdvanceResult Program::canAdvance(
   return {};
 }
 
-void Program::callUpdateStatus(WaveStream& stream, AdvanceResult& advance) {
+void Program::callUpdateStatus(
+    WaveStream& stream,
+    const std::vector<WaveStream*>& otherStreams,
+    AdvanceResult& advance) {
   if (advance.updateStatus) {
-    advance.updateStatus(stream, *instructions_[advance.instructionIdx]);
+    advance.updateStatus(
+        stream, otherStreams, *instructions_[advance.instructionIdx]);
   }
 }
 

--- a/velox/experimental/wave/exec/WaveDriver.cpp
+++ b/velox/experimental/wave/exec/WaveDriver.cpp
@@ -159,6 +159,7 @@ void WaveBarrier::maybeReleaseAcquireLocked() {
     auto promise = std::move(exclusivePromises_.back());
     exclusivePromises_.pop_back();
     exclusiveTokens_.pop_back();
+    exclPipelines_.pop_back();
     promise.setValue(true);
   }
 }
@@ -172,7 +173,10 @@ void WaveBarrier::leave() {
   maybeReleaseAcquireLocked();
 }
 
-void WaveBarrier::acquire(void* reason, std::function<void()> preWait) {
+void WaveBarrier::acquire(
+    Pipeline* pipeline,
+    void* reason,
+    std::function<void()> preWait) {
   folly::SemiFuture<bool> future(false);
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -191,6 +195,7 @@ void WaveBarrier::acquire(void* reason, std::function<void()> preWait) {
     future = promise.getSemiFuture();
     exclusivePromises_.push_back(std::move(promise));
     exclusiveTokens_.push_back(reason);
+    exclPipelines_.push_back(pipeline);
     waitingForExcl_.push_back(getTid());
     maybeReleaseAcquireLocked();
   }
@@ -217,6 +222,7 @@ void WaveBarrier::release() {
         promise.setValue();
       }
       waitingForExclDone_.clear();
+      waitingPipelines_.clear();
       promises_.clear();
       return;
     }
@@ -232,7 +238,7 @@ void WaveBarrier::release() {
   VELOX_CHECK_TID(isTidNotIn(waitingForExclDone_, mutex_));
 }
 
-void WaveBarrier::mayYield(std::function<void()> preWait) {
+void WaveBarrier::mayYield(Pipeline* pipeline, std::function<void()> preWait) {
   ContinueFuture waitFuture;
   folly::Promise<bool> exclPromise;
   {
@@ -252,6 +258,7 @@ void WaveBarrier::mayYield(std::function<void()> preWait) {
     promises_.push_back(std::move(promise));
     waitFuture = std::move(future);
     ++numInArrive_;
+    waitingPipelines_.push_back(pipeline);
     waitingForExclDone_.push_back(getTid());
     if (numJoined_ - numInArrive_ == exclusivePromises_.size() &&
         !exclusivePromises_.empty()) {
@@ -259,6 +266,7 @@ void WaveBarrier::mayYield(std::function<void()> preWait) {
       exclPromise = std::move(exclusivePromises_.back());
       exclusivePromises_.pop_back();
       exclusiveTokens_.pop_back();
+      exclPipelines_.pop_back();
       waitingForExcl_.pop_back();
     }
   }
@@ -267,6 +275,21 @@ void WaveBarrier::mayYield(std::function<void()> preWait) {
   }
   waitFor(std::move(waitFuture));
   VELOX_CHECK_TID(isTidNotIn(waitingForExclDone_, mutex_));
+}
+
+std::vector<WaveStream*> WaveBarrier::waitingStreams() const {
+  std::vector<WaveStream*> result;
+  for (auto& pipeline : exclPipelines_) {
+    for (auto& s : pipeline->arrived) {
+      result.push_back(s.get());
+    }
+  }
+  for (auto& pipeline : waitingPipelines_) {
+    for (auto& s : pipeline->arrived) {
+      result.push_back(s.get());
+    }
+  }
+  return result;
 }
 
 WaveDriver::WaveDriver(
@@ -494,20 +517,23 @@ void WaveDriver::prepareAdvance(
       waitForArrival(pipeline);
     } else {
       // No sync, like adding memory to string pool for func.
-      pipeline.operators[from]->callUpdateStatus(stream, advance);
+      std::vector<WaveStream*> empty;
+      pipeline.operators[from]->callUpdateStatus(stream, empty, advance);
     }
   }
   if (driversToken) {
     TR((&stream), "acquire");
-    barrier_->acquire(driversToken, [&]() { waitForArrival(pipeline); });
+    barrier_->acquire(
+        &pipeline, driversToken, [&]() { waitForArrival(pipeline); });
     auto guard = folly::makeGuard([&]() {
       TR((&stream), "release");
       barrier_->release();
     });
 
     waitForArrival(pipeline);
+    auto otherStreams = barrier_->waitingStreams();
     pipeline.operators[from]->callUpdateStatus(
-        stream, advanceVector[exclusiveIndex]);
+        stream, otherStreams, advanceVector[exclusiveIndex]);
   }
 }
 
@@ -517,7 +543,7 @@ void WaveDriver::runOperators(
     int32_t from,
     int32_t numRows) {
   // Pause here if other WaveDrivers need exclusive access.
-  barrier_->mayYield([&]() { waitForArrival(pipeline); });
+  barrier_->mayYield(&pipeline, [&]() { waitForArrival(pipeline); });
   // The stream is in 'host' state for any host to device data
   // transfer, then in parallel state after first kernel launch.
   ++stream.stats().numWaves;

--- a/velox/experimental/wave/exec/WaveDriver.h
+++ b/velox/experimental/wave/exec/WaveDriver.h
@@ -25,6 +25,34 @@ DECLARE_int32(max_streams_per_driver);
 namespace facebook::velox::wave {
 enum class Advance { kBlocked, kResult, kFinished };
 
+struct Pipeline {
+  // Wave operators replacing 'cpuOperators_' on GPU path.
+  std::vector<std::unique_ptr<WaveOperator>> operators;
+
+  // The set of currently pending kernel DAGs for this Pipeline.  If the
+  // source operator can produce multiple consecutive batches before the batch
+  // is executed to completion, multiple such batches can be on device
+  // independently of each other. Limited by max_streams_per_driver.
+  std::vector<std::unique_ptr<WaveStream>> running;
+
+  std::vector<std::unique_ptr<WaveStream>> arrived;
+
+  /// Streams ready to recycle. A stream's device side resources are usually
+  /// reusable for a new batch from the source operator.
+  std::vector<std::unique_ptr<WaveStream>> finished;
+
+  /// True if status copy to host is needed after the last kernel. True if
+  /// returns vectors to host or if can produce multiple batches of output for
+  /// one input.
+  bool needStatus{false};
+  bool sinkFull{false};
+
+  /// True if produces Batches in RowVectors.
+  bool makesHostResult{false};
+  bool canAdvance{false};
+  bool noMoreInput{false};
+};
+
 /// Synchronizes between WaveDrivers on different Drivers of a Task
 /// pipeline. All threads inside WaveDriver::getOutput are the
 /// coordinated set. One or more of these cn acquire the barrier in
@@ -51,7 +79,7 @@ class WaveBarrier {
   /// Gets exclusive access. All other threads in the coordinated set are
   /// stopped wen this returns. If the calling thread will block, 'preWait' is
   /// called first.
-  void acquire(void* reason, std::function<void()> preWait);
+  void acquire(Pipeline* pipeline, void* reason, std::function<void()> preWait);
 
   /// Releases exclusive. The calling thread must have called acquire() first.
   void release();
@@ -62,7 +90,9 @@ class WaveBarrier {
   /// release(). Acquires are continued one by one after all threads
   /// are either blocked in arrive() or acquire(). If the calling thread waits,
   /// 'preWait' is called before the wait.
-  void mayYield(std::function<void()> preWait);
+  void mayYield(Pipeline* pipeline, std::function<void()> preWait);
+
+  std::vector<WaveStream*> waitingStreams() const;
 
   static std::shared_ptr<WaveBarrier>
   get(const std::string& taskId, int32_t driverId, int32_t operatorId);
@@ -81,8 +111,6 @@ class WaveBarrier {
   // arrive or have left.
   void maybeReleaseAcquireLocked();
 
-  void waitForExclDone();
-
   // Serializes all non-static state.
   std::mutex mutex_;
 
@@ -98,12 +126,16 @@ class WaveBarrier {
   /// tids that wait for exclusive section to finish.
   std::vector<int32_t> waitingForExclDone_;
 
+  // Streams waiting for excl. 1:1 to 'exclusiveTokens_'.
+  std::vector<Pipeline*> exclPipelines_;
+
   // Number of threads to coordinate.
   int32_t numJoined_{0};
 
   // Number of threads blocked in mayYield() or release() or enter().
   int32_t numInArrive_{0};
   std::vector<ContinuePromise> promises_;
+  std::vector<Pipeline*> waitingPipelines_;
   std::vector<folly::Promise<bool>> exclusivePromises_;
   std::vector<void*> exclusiveTokens_;
   void* exclusiveToken_{nullptr};
@@ -188,34 +220,6 @@ class WaveDriver : public exec::SourceOperator {
   }
 
  private:
-  struct Pipeline {
-    // Wave operators replacing 'cpuOperators_' on GPU path.
-    std::vector<std::unique_ptr<WaveOperator>> operators;
-
-    // The set of currently pending kernel DAGs for this Pipeline.  If the
-    // source operator can produce multiple consecutive batches before the batch
-    // is executed to completion, multiple such batches can be on device
-    // independently of each other. Limited by max_streams_per_driver.
-    std::vector<std::unique_ptr<WaveStream>> running;
-
-    std::vector<std::unique_ptr<WaveStream>> arrived;
-
-    /// Streams ready to recycle. A stream's device side resources are usually
-    /// reusable for a new batch from the source operator.
-    std::vector<std::unique_ptr<WaveStream>> finished;
-
-    /// True if status copy to host is needed after the last kernel. True if
-    /// returns vectors to host or if can produce multiple batches of output for
-    /// one input.
-    bool needStatus{false};
-    bool sinkFull{false};
-
-    /// True if produces Batches in RowVectors.
-    bool makesHostResult{false};
-    bool canAdvance{false};
-    bool noMoreInput{false};
-  };
-
   // True if all output from 'stream' is fetched.
   bool streamAtEnd(WaveStream& stream);
 

--- a/velox/experimental/wave/exec/WaveOperator.h
+++ b/velox/experimental/wave/exec/WaveOperator.h
@@ -93,7 +93,10 @@ class WaveOperator {
     return false;
   }
 
-  virtual void callUpdateStatus(WaveStream& stream, AdvanceResult& advance) {
+  virtual void callUpdateStatus(
+      WaveStream& stream,
+      const std::vector<WaveStream*>& otherStreams,
+      AdvanceResult& advance) {
     VELOX_FAIL("Only Project supports callUpdateStatus()");
   }
 

--- a/velox/experimental/wave/exec/tests/BarrierTest.cpp
+++ b/velox/experimental/wave/exec/tests/BarrierTest.cpp
@@ -50,7 +50,7 @@ class BarrierTest : public testing::Test {
       if (action % 10 == 0 && threadIdx % 10 < 5) {
         void* reason = reinterpret_cast<void*>(action + 1);
         message(threadIdx, "acq");
-        barrier->acquire(reason, nullptr);
+        barrier->acquire(nullptr, reason, nullptr);
         message(threadIdx, "exc");
         // std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
         ++numAcquired_;
@@ -63,7 +63,7 @@ class BarrierTest : public testing::Test {
         barrier->enter();
       } else {
         message(threadIdx, "mayYield");
-        barrier->mayYield(nullptr);
+        barrier->mayYield(nullptr, nullptr);
         message(threadIdx, "cont");
       }
     }

--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -42,7 +42,7 @@ DEFINE_int32(wt_num_batches, 3, "Number of batches of test data");
 
 DEFINE_int32(wt_batch_size, 20'000, "Batch size  in test data");
 
-DEFINE_bool(extended, false, "Run extra permutations of drivers/streams");
+DEFINE_bool(extended, true, "Run extra permutations of drivers/streams");
 
 using namespace facebook::velox;
 using namespace facebook::velox::core;


### PR DESCRIPTION
Gathers together all the streams that need a rehash or resupply of allocator space together. Allocates the needed space and does the optional rehash for all concerned in bulk.

Caches the set of Cuda headres on first init of Wave JIT as /tmp/wavesystemheaders.txt. Subsequent startups are faster because of not repeating the 5-10s it takes to figur out the includes.