### PR TITLE
refactor: Update columnStats to return non-optional result

### DIFF
--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -356,7 +356,7 @@ class HashProbe : public Operator {
   // NOTE: The column stats is collected by default for hash join table but it
   // could be invalidated in case of spilling. But we should never expect usage
   // of an invalidated table as we always spill the entire table.
-  std::optional<RowColumn::Stats> columnStats(int32_t columnIndex) const;
+  RowColumn::Stats columnStats(int32_t columnIndex) const;
 
   // TODO: Define batch size as bytes based on RowContainer row sizes.
   const vector_size_t outputBatchSize_;

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -187,8 +187,8 @@ class PrefixSort {
       if (keyTypes[i]->kind() == TypeKind::VARBINARY ||
           keyTypes[i]->kind() == TypeKind::VARCHAR) {
         const auto stats = rowContainer->columnStats(i);
-        if (stats.has_value()) {
-          maxStringLength = stats.value().maxBytes();
+        if (stats.minMaxColumnStatsValid()) {
+          maxStringLength = stats.maxBytes();
         }
       }
       maxStringLengths.emplace_back(maxStringLength);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -520,15 +520,12 @@ RowColumn::Stats RowColumn::Stats::merge(
     mergedStats.nullCount_ += stats.nullCount_;
     mergedStats.nonNullCount_ += stats.nonNullCount_;
     mergedStats.sumBytes_ += stats.sumBytes_;
+    mergedStats.minMaxStatsValid_ &= stats.minMaxStatsValid_;
   }
   return mergedStats;
 }
 
-std::optional<RowColumn::Stats> RowContainer::columnStats(
-    int32_t columnIndex) const {
-  if (rowColumnsStats_.empty()) {
-    return std::nullopt;
-  }
+RowColumn::Stats RowContainer::columnStats(int32_t columnIndex) const {
   return rowColumnsStats_[columnIndex];
 }
 
@@ -537,11 +534,6 @@ void RowContainer::updateColumnStats(
     vector_size_t rowIndex,
     char* row,
     int32_t columnIndex) {
-  if (rowColumnsStats_.empty()) {
-    // Column stats have been invalidated.
-    return;
-  }
-
   auto& columnStats = rowColumnsStats_[columnIndex];
   if (decoded.isNullAt(rowIndex)) {
     columnStats.addNullCell();

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -824,9 +824,8 @@ class RowContainer {
   }
 
   /// Returns the aggregated column stats of the column with given
-  /// 'columnIndex'. nullopt will be returned if the column stats was previous
-  /// invalidated. Any row erase operations will invalidate column stats.
-  std::optional<RowColumn::Stats> columnStats(int32_t columnIndex) const;
+  /// 'columnIndex'.
+  RowColumn::Stats columnStats(int32_t columnIndex) const;
 
   uint32_t columnNullCount(int32_t columnIndex) const {
     return rowColumnsStats_[columnIndex].nullCount();
@@ -838,8 +837,8 @@ class RowContainer {
 
   /// Returns true if specified column has nulls, false otherwise.
   inline bool columnHasNulls(int32_t columnIndex) const {
-    return columnStats(columnIndex)->numCells() > 0 &&
-        columnStats(columnIndex)->nullCount() > 0;
+    return columnStats(columnIndex).numCells() > 0 &&
+        columnStats(columnIndex).nullCount() > 0;
   }
 
   const std::vector<Accumulator>& accumulators() const {


### PR DESCRIPTION
As `rowColumnsStats_` should not be empty after https://github.com/facebookincubator/velox/commit/7a3099846d269e0230442dbbd67c5a26e9a33a29, update function `columnStats` to 
return `RowColumn::Stats` instead of `std::optional<RowColumn::Stats>`