### PR TITLE
fix(unittest): Adjust assertion for random skip to be platform/architecture-dependent

### DIFF
--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -130,9 +130,19 @@ TEST_F(ReaderTest, projectColumnsMutation) {
   random::RandomSkipTracker randomSkip(0.5);
   mutation.randomSkip = &randomSkip;
   actual = RowReader::projectColumns(input, spec, &mutation);
+#if __APPLE__
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 5, 6, 7, 8, 9}),
+  });
+#elif FOLLY_HAVE_EXTRANDOM_SFMT19937
   expected = makeRowVector({
       makeFlatVector<int64_t>({0, 1, 3, 5, 6, 8}),
   });
+#else
+  expected = makeRowVector({
+      makeFlatVector<int64_t>({3, 4, 7, 9}),
+  });
+#endif
   test::assertEqualVectors(expected, actual);
 }
 

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -130,11 +130,11 @@ TEST_F(ReaderTest, projectColumnsMutation) {
   random::RandomSkipTracker randomSkip(0.5);
   mutation.randomSkip = &randomSkip;
   actual = RowReader::projectColumns(input, spec, &mutation);
-#if __APPLE__
+#if FOLLY_HAVE_EXTRANDOM_SFMT19937
   expected = makeRowVector({
       makeFlatVector<int64_t>({1, 5, 6, 7, 8, 9}),
   });
-#elif FOLLY_HAVE_EXTRANDOM_SFMT19937
+#elif __APPLE__
   expected = makeRowVector({
       makeFlatVector<int64_t>({0, 1, 3, 5, 6, 8}),
   });


### PR DESCRIPTION
**Summary**: Adjust assertion in ReaderTest.projectColumnsMutation based on platform. The assertion for the random skip is assuming it is using `__gnu_cxx::sfmt19937`, however if using `std::mt19937` then the result will be different and the unit test will fail due to this. 