### PR TITLE
fix(json): GetEscapedChar should ignore bad escaped chars

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -264,7 +264,9 @@ int32_t getEscapedChar(std::string_view view, size_t& pos) {
         return '\t';
 
       default:
-        VELOX_USER_FAIL("Bad escape character in view {}", view);
+        // Presto java ignores bad escape sequences.
+        pos += 1;
+        return view[pos];
     }
   }
 


### PR DESCRIPTION
Summary: Fix JsonStringUtils::getEscapedChar to ignore bad escaping and to conform to Presto java behavior. For e.g. previously we would throw when trying to sort keys like '\\&page=20' and with this change we wont.

Differential Revision: D69419721


