### PR TITLE
fix[RowContainer]: Fix bug in RowContainer::extractValuesWithNulls

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -828,7 +828,7 @@ class RowContainer {
   /// invalidated. Any row erase operations will invalidate column stats.
   std::optional<RowColumn::Stats> columnStats(int32_t columnIndex) const;
 
-  uint32_t columnNullCount(int32_t columnIndex) {
+  uint32_t columnNullCount(int32_t columnIndex) const {
     return rowColumnsStats_[columnIndex].nullCount();
   }
 
@@ -1108,7 +1108,7 @@ class RowContainer {
     auto maxRows = numRows + resultOffset;
     VELOX_DCHECK_LE(maxRows, result->size());
 
-    BufferPtr& nullBuffer = result->mutableNulls(maxRows);
+    BufferPtr& nullBuffer = result->mutableNulls(maxRows, true);
     auto nulls = nullBuffer->asMutable<uint64_t>();
     BufferPtr valuesBuffer = result->mutableValues(maxRows);
     [[maybe_unused]] auto values = valuesBuffer->asMutableRange<T>();

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -256,8 +256,12 @@ class BaseVector {
     return const_cast<uint64_t*>(rawNulls_);
   }
 
-  BufferPtr& mutableNulls(vector_size_t size) {
-    ensureNullsCapacity(size);
+  /// Ensures the vector has capacity for the nulls and returns the shared
+  /// pointer to the buffer containing them.
+  /// Optional parameter 'setNotNull' is passed to ensureNullsCapacity() and is
+  /// used to ensure all the rows will be 'not nulls' if set to true.
+  BufferPtr& mutableNulls(vector_size_t size, bool setNotNull = false) {
+    ensureNullsCapacity(size, setNotNull);
     return nulls_;
   }
 


### PR DESCRIPTION
Summary:
Bug happens when:
We have a target (result) vector which has some rows and not a single null
(null buffer is not allocated).
We extract to that target vector a column from a RowContainer and that column
has null in at least one row.

Bug manifests in all rows that the target vector had before extracting our
RowContainer into it becoming nulls.

This is because the null buffer was allocated with 'setNotNull' set to false.

We fix it by supplying true when 'resultOffset' is positive (meaning that
target vector already has some rows).

Differential Revision: D69445179


