### PR TITLE
fix: Regexp_split fails in empty match pattern

### DIFF
--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1529,6 +1529,17 @@ TEST_F(Re2FunctionsTest, split) {
       {"a", "b"},
   });
   assertEqualVectors(expected, result);
+
+  input = makeRowVector({
+      makeFlatVector<std::string>({
+          "abcd",
+      }),
+  });
+  result = evaluate("regexp_split(c0, '')", input);
+  expected = makeArrayVector<std::string>({
+      {"", "a", "b", "c", "d", ""},
+  });
+  assertEqualVectors(expected, result);
 }
 
 TEST_F(Re2FunctionsTest, parseSubstrings) {


### PR DESCRIPTION
The implementation of Re2RegexpSplit has a bug, that it might fail to split the string when the pattern is a empty string itself.

For example, in the function calling: regexp_split("abcd", "").
The expected result is {"", "a", "b", "c", "d", ""}, but the current implementation would throw error.

This testcase comes from presto https://github.com/prestodb/presto/blob/099bd42eba287b1ea25bf55404c7a18882e0f6d5/presto-main/src/test/java/com/facebook/presto/operator/scalar/AbstractTestRegexpFunctions.java#L231 

See detailed description in https://github.com/facebookincubator/velox/issues/12304.

This PR fix this bug in Re2RegexpSplit implementation.