### PR TITLE
Fix DWRF flat map writes with string keys

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -288,6 +288,7 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   uint64_t writeRow(const VectorPtr& slice, const common::Ranges& ranges);
 
   void clearNodes();
+  StringView cacheStringKey(const StringView& key);
 
   // Map of value writers for each key in the dictionary. Needs referential
   // stability because a member variable is captured by reference by lambda
@@ -314,6 +315,9 @@ class FlatMapColumnWriter : public BaseColumnWriter {
   // Stores column keys if writing with RowVector input
   std::vector<KeyType> structKeys_;
   const bool collectMapStats_;
+
+  // Stores data backing non-compact string keys referenced in valueWriters_
+  std::vector<BufferPtr> cachedStringKeys_;
 };
 
 template <>


### PR DESCRIPTION
Summary:
DWRF flat map writer fails when writing a map column with long string keys.
The reason is that the flat map writer holds references to the individual value writers
using StringView as a key. 

StringView inlines short strings and there is no problem when the backing object is gone,
but for long strings it does not do inlining and when the backing object is gone the
StringView turns into garbage. 

This change copies non-inlined string keys into a temporary buffer that has the same
life cycle as the individual field writers, which keeps the StringView keys alive.

Differential Revision: D69494007


