### PR TITLE
fix(python): Remove .pyi annotations

### DIFF
--- a/velox/py/arrow/arrow.pyi
+++ b/velox/py/arrow/arrow.pyi
@@ -18,10 +18,8 @@
 
 from typing import List
 
-# pyre-fixme[21]: Could not find `velox.py.vector`.
 from velox.py.vector import Vector
 from pyarrow import Array
 
-# pyre-fixme[11]: Annotation `Vector` is not defined as a type.
 def to_velox(array: Array) -> Vector: ...
 def to_arrow(vector: Vector) -> Array: ...

--- a/velox/py/plan_builder/plan_builder.pyi
+++ b/velox/py/plan_builder/plan_builder.pyi
@@ -19,11 +19,8 @@
 from enum import Enum
 from typing import List, Dict, Type
 
-# pyre-fixme[21]: Could not find `velox.py.type`.
-from velox.py.type import Type
-
-# pyre-fixme[21]: Could not find `velox.py.type`.
 from velox.py.file import File
+from velox.py.type import Type
 
 
 class JoinType(Enum):
@@ -37,13 +34,11 @@ class PlanBuilder:
     def __init__(self) -> None: ...
     def table_scan(
         self,
-        # pyre-fixme[11]: Annotation `Type` is not defined as a type.
         output_schema: Type,
         aliases: Dict[str, str] = {},
         subfields: Dict[str, List[int]] = {},
         row_index: str = "",
         connector_id: str = "prism",
-        # pyre-fixme[11]: Annotation `File` is not defined as a type.
         input_files: List[File] = [],
     ) -> PlanBuilder: ...
     def get_plan_node(self) -> PlanBuilder: ...

--- a/velox/py/runner/runner.pyi
+++ b/velox/py/runner/runner.pyi
@@ -18,13 +18,11 @@
 
 from typing import Iterator
 
-# pyre-fixme[21]: Could not find `velox.py.type`.
-from velox.py.cector import Vector
+from velox.py.vector import Vector
 
 
 class LocalRunner:
     def __init__(self, PlanNode) -> None: ...
-    # pyre-fixme[11]: Annotation `Vector` is not defined as a type.
     def execute(self) -> Iterator[Vector]: ...
     def add_file_split(self, plan_id: str, file_path: str) -> None: ...
 


### PR DESCRIPTION
Summary:
Removing .pyi annotations by properly setting interface includes and
dependencies.

Differential Revision: D69538934


