### PR TITLE
fix(fuzzer): Allow large error with global aggregation of approx_distinct

### DIFF
--- a/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
@@ -158,7 +158,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
       return largeGaps.size() <= 3;
     }
 
-    return largeGaps.empty();
+    return numGroups == 1 || largeGaps.empty();
   }
 
   // For approx_distinct in window operations, input sets for rows in the same


### PR DESCRIPTION
Summary: The approx_distinct function only guarantees the standard deviation of error distribution when there is a large number of groups. With global aggregation, it should be allowed if approx_distinct produces a large error. This diff relaxes the ApproxDistinctResultVerifier to allow large errors with global aggregations.

Differential Revision: D69611305


