### PR TITLE
feat: Add option to  HiveDataSink to always create a file

### DIFF
--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -284,7 +284,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     std::shared_ptr<connector::hive::LocationHandle> locationHandle,
     const dwio::common::FileFormat tableStorageFormat,
     const std::optional<common::CompressionKind> compressionKind,
-    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions) {
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
+    const bool ensureFiles) {
   return makeHiveInsertTableHandle(
       tableColumnNames,
       tableColumnTypes,
@@ -294,7 +295,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
       tableStorageFormat,
       compressionKind,
       {},
-      writerOptions);
+      writerOptions,
+      ensureFiles);
 }
 
 // static
@@ -308,7 +310,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const dwio::common::FileFormat tableStorageFormat,
     const std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters,
-    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions) {
+    const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
+    const bool ensureFiles) {
   std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
       columnHandles;
   std::vector<std::string> bucketedBy;
@@ -365,7 +368,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
       bucketProperty,
       compressionKind,
       serdeParameters,
-      writerOptions);
+      writerOptions,
+      ensureFiles);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -175,6 +175,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param locationHandle Location handle for the table write.
   /// @param compressionKind compression algorithm to use for table write.
   /// @param serdeParameters Table writer configuration parameters.
+  /// @param ensureFiles When this option is set the HiveDataSink will always
+  /// create a file even if there is no data.
   static std::shared_ptr<connector::hive::HiveInsertTableHandle>
   makeHiveInsertTableHandle(
       const std::vector<std::string>& tableColumnNames,
@@ -187,7 +189,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
-          nullptr);
+          nullptr,
+      const bool ensureFiles = false);
 
   static std::shared_ptr<connector::hive::HiveInsertTableHandle>
   makeHiveInsertTableHandle(
@@ -199,7 +202,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
           dwio::common::FileFormat::DWRF,
       const std::optional<common::CompressionKind> compressionKind = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
-          nullptr);
+          nullptr,
+      const bool ensureFiles = false);
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -270,7 +270,8 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       bucketProperty,
       compressionKind_,
       serdeParameters_,
-      options_);
+      options_,
+      ensureFiles_);
 
   auto insertHandle =
       std::make_shared<core::InsertTableHandle>(connectorId_, hiveHandle);
@@ -508,7 +509,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::shared_ptr<dwio::common::WriterOptions>& options,
     const std::string& outputFileName,
     const common::CompressionKind compressionKind,
-    const RowTypePtr& schema) {
+    const RowTypePtr& schema,
+    const bool ensureFiles) {
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)
       .outputFileName(outputFileName)
@@ -523,6 +525,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       .serdeParameters(serdeParameters)
       .options(options)
       .compressionKind(compressionKind)
+      .ensureFiles(ensureFiles)
       .endTableWriter();
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -408,6 +408,13 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param ensureFiles When set the Task will always output a file, even if
+    /// it's empty.
+    TableWriterBuilder& ensureFiles(const bool ensureFiles) {
+      ensureFiles_ = ensureFiles;
+      return *this;
+    }
+
     /// Stop the TableWriterBuilder.
     PlanBuilder& endTableWriter() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -436,6 +443,8 @@ class PlanBuilder {
 
     dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
     common::CompressionKind compressionKind_{common::CompressionKind_NONE};
+
+    bool ensureFiles_{false};
   };
 
   /// Start a TableWriterBuilder.
@@ -629,6 +638,8 @@ class PlanBuilder {
   /// output data files.
   /// @param schema Output schema to be passed to the writer. By default use the
   /// output of the previous operator.
+  /// @param ensureFiles When this option is set the HiveDataSink will always
+  /// create a file even if there is no data.
   PlanBuilder& tableWrite(
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionBy,
@@ -644,7 +655,8 @@ class PlanBuilder {
       const std::shared_ptr<dwio::common::WriterOptions>& options = nullptr,
       const std::string& outputFileName = "",
       const common::CompressionKind = common::CompressionKind_NONE,
-      const RowTypePtr& schema = nullptr);
+      const RowTypePtr& schema = nullptr,
+      const bool ensureFiles = false);
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(


### PR DESCRIPTION
Summary:
This change adds an option to HiveDataSink (plumbed via HiveInsertTableHandle) to always
create a file.  This is useful for query engines that write bucketed tables by running a Task per
output bucket rather than by setting the HiveBucketProperty. In this case, even if there is no data
to process, Velox will still produce an empty file for the output bucket.

Note that this option is not possible to support when the HiveBucketProperty is set or there a
partition keys in the data, as this means that the number of files/directories respectively is
determined at runtime from the input data. Checks for this are enforced at plan generation time.

Differential Revision: D69629165


