### PR TITLE
fix: Fix optimization of re-using inputVector

### DIFF
--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -403,6 +403,7 @@ void SortedAggregations::extractValues(
         const auto numRows =
             extractSingleGroup(groupRows, *aggregate, aggregateInputs);
         if (numRows == 0) {
+          firstInputColumn += aggregateInputs.size();
           // Mask must be false for all 'groupRows'.
           continue;
         }


### PR DESCRIPTION
Summary:
D69567930 introduced an optimization to reuse the inputVector to save cycles and likely memory when extracting data from a group.

However, there is a subtle bug here when we call `extractSingleGroup()`, it can return 0 rows. In this case, we must still update the firstInputColumn, which is a rolling index that represents which inputVectors map to which aggregateInputs.

By not updating this, we may get a mismatch in the reused inputVector and the actual underlying type at this particular column. This is a hidden bug that surfaces if the following conditions are at least satisfied:

1. We've extracted a group with 0 rows
2. We've retried to use an index at a position which has a type that is different that the column index.

Differential Revision: D69625562


