### PR TITLE
migrate uses of legacy alias folly::io::Codec (assorted)

### DIFF
--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -21,7 +21,8 @@
 
 namespace facebook::velox::common {
 
-std::unique_ptr<folly::io::Codec> compressionKindToCodec(CompressionKind kind) {
+std::unique_ptr<folly::compression::Codec> compressionKindToCodec(
+    CompressionKind kind) {
   switch (static_cast<int32_t>(kind)) {
     case CompressionKind_NONE:
       return getCodec(folly::io::CodecType::NO_COMPRESSION);

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -33,7 +33,8 @@ enum CompressionKind {
   CompressionKind_MAX = INT64_MAX
 };
 
-std::unique_ptr<folly::io::Codec> compressionKindToCodec(CompressionKind kind);
+std::unique_ptr<folly::compression::Codec> compressionKindToCodec(
+    CompressionKind kind);
 
 CompressionKind codecTypeToCompressionKind(folly::io::CodecType type);
 

--- a/velox/serializers/PrestoBatchVectorSerializer.h
+++ b/velox/serializers/PrestoBatchVectorSerializer.h
@@ -50,7 +50,7 @@ class PrestoBatchVectorSerializer : public BatchVectorSerializer {
       Scratch& scratch);
 
   memory::MemoryPool* const pool_;
-  const std::unique_ptr<folly::io::Codec> codec_;
+  const std::unique_ptr<folly::compression::Codec> codec_;
   const PrestoVectorSerde::PrestoOptions opts_;
 };
 } // namespace facebook::velox::serializer::presto::detail

--- a/velox/serializers/PrestoIterativeVectorSerializer.h
+++ b/velox/serializers/PrestoIterativeVectorSerializer.h
@@ -53,7 +53,7 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
  private:
   const PrestoVectorSerde::PrestoOptions opts_;
   StreamArena* const streamArena_;
-  const std::unique_ptr<folly::io::Codec> codec_;
+  const std::unique_ptr<folly::compression::Codec> codec_;
 
   int32_t numRows_{0};
   std::vector<VectorStream> streams_;

--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -1007,7 +1007,7 @@ void flushSerialization(
 FlushSizes flushCompressed(
     std::vector<VectorStream>& streams,
     const StreamArena& arena,
-    folly::io::Codec& codec,
+    folly::compression::Codec& codec,
     int32_t numRows,
     float minCompressionRatio,
     OutputStream* output,
@@ -1296,7 +1296,7 @@ FlushSizes flushStreams(
     std::vector<VectorStream>& streams,
     int32_t numRows,
     const StreamArena& arena,
-    folly::io::Codec& codec,
+    folly::compression::Codec& codec,
     float minCompressionRatio,
     OutputStream* out) {
   auto listener = dynamic_cast<PrestoOutputStreamListener*>(out->listener());

--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -164,11 +164,12 @@ FlushSizes flushStreams(
     std::vector<VectorStream>& streams,
     int32_t numRows,
     const StreamArena& arena,
-    folly::io::Codec& codec,
+    folly::compression::Codec& codec,
     float minCompressionRatio,
     OutputStream* out);
 
-FOLLY_ALWAYS_INLINE bool needCompression(const folly::io::Codec& codec) {
+FOLLY_ALWAYS_INLINE bool needCompression(
+    const folly::compression::Codec& codec) {
   return codec.type() != folly::io::CodecType::NO_COMPRESSION;
 }
 

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -278,7 +278,7 @@ class RowSerializer : public IterativeVectorSerializer {
   }
 
   const VectorSerde::Options options_;
-  const std::unique_ptr<folly::io::Codec> codec_;
+  const std::unique_ptr<folly::compression::Codec> codec_;
   // Count of forthcoming compressions to skip.
   int32_t numCompressionToSkip_{0};
   CompressionStats stats_;


### PR DESCRIPTION
Differential Revision: D68639721


