### PR TITLE
fix: Reduce fuzzer expression depth due to bias run failure

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -992,6 +992,7 @@ jobs:
                 --stderrthreshold=2 \
                 --log_dir=/tmp/presto_only_bias_function_fuzzer_repro/logs \
                 --repro_persist_path=/tmp/presto_only_bias_function_fuzzer_repro \
+                --velox_fuzzer_max_level_of_nesting=4 \
           && echo -e "\n\nPresto Fuzzer run finished successfully."
       - name: Archive Presto only-bias-function expression fuzzer production artifacts
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Summary: Reduce bias run fuzzer depth due to a recent failure caused by array_top_n merge. The error is a result of byte limitation imposed by JVM that C++ doesn't have, which causes fuzzer tests to failure for nested calls.

Differential Revision: D69674802


