### PR TITLE
refactor(spill): Only use query config to decide prefix sort enable status

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -75,11 +75,6 @@ struct SpillConfig {
   /// Checks if the given 'startBitOffset' has exceeded the max spill limit.
   bool exceedSpillLevelLimit(uint8_t startBitOffset) const;
 
-  /// Returns true if prefix sort is enabled.
-  bool prefixSortEnabled() const {
-    return prefixSortConfig.has_value();
-  }
-
   /// A callback function that returns the spill directory path. Implementations
   /// can use it to ensure the path exists before returning.
   GetSpillDirectoryPathCB getSpillDirPathCb;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -110,7 +110,7 @@ void HashAggregation::initialize() {
       isRawInput(aggregationNode_->step()),
       aggregationNode_->globalGroupingSets(),
       groupIdChannel,
-      spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
+      spillConfig(),
       &nonReclaimableSection_,
       operatorCtx_.get(),
       &spillStats_);
@@ -136,9 +136,9 @@ void HashAggregation::setupGroupingKeyChannelProjections(
     groupingKeyProjections.emplace_back(
         exprToChannel(groupingKeys[i].get(), inputType), i);
   }
-
+  const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
   const bool reorderGroupingKeys =
-      canSpill() && spillConfig()->prefixSortEnabled();
+      canSpill() && queryConfig.spillPrefixSortEnabled();
   // If prefix sort is enabled, we need to sort the grouping key's layout in the
   // grouping set to maximize the prefix sort acceleration if spill is
   // triggered. The reorder stores the grouping key with smaller prefix sort


### PR DESCRIPTION
Summary:
Right now we have two places for checking whether spill prefixsort is enabled:
1: `QueryConfig::spillPrefixSortEnabled()` that decides based on the worker config
2: `SpillConfig::prefixSortEnabled()` that decides based on `prefixSortConfig.has_value()`


2 depends on 1 based on the assumption that if 1 is false, `prefixSortConfig` is `nullopt`, and this is done through
`DriverCtx::makeSpillConfig()`

It's better that we only have one source of truth instead of two: checking the worker config. Because the dependency logic is not immediately obvious and may easily break in the future without notice.

Differential Revision: D69678186


