### PR TITLE
fix(parquet): Avoid SEGV if table column type does not match file column type

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1258,6 +1258,82 @@ TEST_F(ParquetTableScanTest, singleBooleanRle) {
   assertSelect({"c2"}, "SELECT c2 FROM tmp");
 }
 
+TEST_F(ParquetTableScanTest, intToBigintRead) {
+  vector_size_t kSize = 100;
+  RowVectorPtr intDataFileVectors = makeRowVector(
+      {"c1"}, {makeFlatVector<int32_t>(kSize, [](auto row) { return row; })});
+
+  RowVectorPtr bigintDataFileVectors = makeRowVector(
+      {"c1"}, {makeFlatVector<int64_t>(kSize, [](auto row) { return row; })});
+
+  const std::shared_ptr<exec::test::TempDirectoryPath> dataFileFolder =
+      exec::test::TempDirectoryPath::create();
+  auto filePath = dataFileFolder->getPath() + "/" + "data.parquet";
+  WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  writeToParquetFile(filePath, {intDataFileVectors}, options);
+
+  auto rowType = ROW({"c1"}, {BIGINT()});
+  auto op = PlanBuilder()
+                .startTableScan()
+                .outputType(rowType)
+                .dataColumns(rowType)
+                .endTableScan()
+                .planNode();
+
+  auto split = makeSplit(filePath);
+  auto result = AssertQueryBuilder(op).split(split).copyResults(pool());
+  auto rows = result->as<RowVector>();
+
+  assertEqualVectors(bigintDataFileVectors->childAt(0), rows->childAt(0));
+}
+
+TEST_F(ParquetTableScanTest, shortAndLongDecimalReadWithLargerPrecision) {
+  // decimal.parquet holds two columns (a: DECIMAL(5, 2), b: DECIMAL(20, 5)) and
+  // 20 rows (10 rows per group). Data is in plain uncompressed format:
+  //   a: [100.01 .. 100.20]
+  //   b: [100000000000000.00001 .. 100000000000000.00020]
+  // This test reads the DECIMAL(5, 2)a and DECIMAL(20, 5) file columns
+  // with DECIMAL(8, 2) and DECIMAL(22, 5) row types.
+  vector_size_t kSize = 20;
+  std::vector<int64_t> unscaledShortValues(kSize);
+  std::iota(unscaledShortValues.begin(), unscaledShortValues.end(), 10001);
+  std::vector<int128_t> longDecimalValues;
+  for (int i = 1; i <= kSize; ++i) {
+    if (i < 10) {
+      longDecimalValues.emplace_back(
+          HugeInt::parse(fmt::format("1000000000000000000{}", i)));
+    } else {
+      longDecimalValues.emplace_back(
+          HugeInt::parse(fmt::format("100000000000000000{}", i)));
+    }
+  }
+
+  RowVectorPtr expectedDecimalVectors = makeRowVector(
+      {"c1", "c2"},
+      {makeFlatVector<int64_t>(unscaledShortValues, DECIMAL(8, 2)),
+       makeFlatVector<int128_t>(longDecimalValues, DECIMAL(22, 5))});
+
+  const std::shared_ptr<exec::test::TempDirectoryPath> dataFileFolder =
+      exec::test::TempDirectoryPath::create();
+  auto filePath = getExampleFilePath("decimal.parquet");
+
+  auto rowType = ROW({"c1", "c2"}, {DECIMAL(8, 2), DECIMAL(22, 5)});
+  auto op = PlanBuilder()
+                .startTableScan()
+                .outputType(rowType)
+                .dataColumns(rowType)
+                .endTableScan()
+                .planNode();
+
+  auto split = makeSplit(filePath);
+  auto result = AssertQueryBuilder(op).split(split).copyResults(pool());
+  auto rows = result->as<RowVector>();
+
+  assertEqualVectors(expectedDecimalVectors->childAt(0), rows->childAt(0));
+  assertEqualVectors(expectedDecimalVectors->childAt(1), rows->childAt(1));
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv, false};


### PR DESCRIPTION
If a user defines a table, for example in Hive, where the column types don’t match the file column types SEGV might occur. Specifically, the SEGV has been observed if the parquet file contains a VARCHAR column but the table defines an INTEGER column instead and the data is accessed via TableScan using a basic select * .

The resulting vector is of type string but it doesn’t match the table metadata and can cause a SEGV in the PartitionedOutput operator.

This also prevents issues and error coming from the readers when they encounter types that are not part of the switch, for example, defining a VARCHAR type column when the file column is an INTEGER.

Fixes: https://github.com/facebookincubator/velox/issues/12349