### PR TITLE
Fix unused-value issue in velox/dwio/dwrf/test/WriterContextTest.cpp +1

### DIFF
--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -143,8 +143,9 @@ TEST_F(WriterContextTest, BuildPhysicalSizeAggregators) {
     EXPECT_NO_THROW(context.getPhysicalSizeAggregator(i));
   }
   for (const auto nodeId : mapNodes) {
-    EXPECT_NO_THROW(dynamic_cast<MapPhysicalSizeAggregator&>(
-        context.getPhysicalSizeAggregator(nodeId)));
+    EXPECT_NO_THROW(
+        std::ignore = dynamic_cast<MapPhysicalSizeAggregator&>(
+            context.getPhysicalSizeAggregator(nodeId)));
   }
 }
 


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-value` which we treat as an error because it's so often diagnostic of a code issue. Unused values often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D69691755


