### PR TITLE
feat: Support to specify partition key order in TableWrite operator

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -85,7 +85,7 @@ std::vector<column_index_t> getPartitionChannels(
 
   if (insertTableHandle->partitionKeyOrder().size() > 0) {
     auto partitionKeys = insertTableHandle->partitionKeyOrder();
-    for (auto partitionKeyName : partitionKeys) {
+    for (const auto& partitionKeyName : partitionKeys) {
       for (column_index_t j = 0; j < insertTableHandle->inputColumns().size();
            j++) {
         if (insertTableHandle->inputColumns()[j]->name() == partitionKeyName) {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -83,8 +83,8 @@ std::vector<column_index_t> getPartitionChannels(
     const std::shared_ptr<const HiveInsertTableHandle>& insertTableHandle) {
   std::vector<column_index_t> channels;
 
-  if (insertTableHandle->partitionKeys().size() > 0) {
-    auto partitionKeys = insertTableHandle->partitionKeys();
+  if (insertTableHandle->partitionKeyOrder().size() > 0) {
+    auto partitionKeys = insertTableHandle->partitionKeyOrder();
     for (auto partitionKeyName : partitionKeys) {
       for (column_index_t j = 0; j < insertTableHandle->inputColumns().size();
            j++) {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -83,10 +83,23 @@ std::vector<column_index_t> getPartitionChannels(
     const std::shared_ptr<const HiveInsertTableHandle>& insertTableHandle) {
   std::vector<column_index_t> channels;
 
-  for (column_index_t i = 0; i < insertTableHandle->inputColumns().size();
-       i++) {
-    if (insertTableHandle->inputColumns()[i]->isPartitionKey()) {
-      channels.push_back(i);
+  if (insertTableHandle->partitionKeys().size() > 0) {
+    auto partitionKeys = insertTableHandle->partitionKeys();
+    for (auto partitionKeyName : partitionKeys) {
+      for (column_index_t j = 0; j < insertTableHandle->inputColumns().size();
+           j++) {
+        if (insertTableHandle->inputColumns()[j]->name() == partitionKeyName) {
+          channels.push_back(j);
+          break;
+        }
+      }
+    }
+  } else {
+    for (column_index_t i = 0; i < insertTableHandle->inputColumns().size();
+         i++) {
+      if (insertTableHandle->inputColumns()[i]->isPartitionKey()) {
+        channels.push_back(i);
+      }
     }
   }
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -246,13 +246,11 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
           partitionKeyOrder_.begin(), partitionKeyOrder_.end());
       for (const auto& inputColumn : inputColumns_) {
         if (inputColumn->isPartitionKey()) {
-          VELOX_CHECK(partitionKeyNames.erase(inputColumn->name()) == 1);
+          VELOX_CHECK(
+              partitionKeyNames.erase(inputColumn->name()) == 1,
+              "partitionKeyOrder does not contain the partition key.");
         }
       }
-
-      VELOX_CHECK(
-          partitionKeyNames.empty(),
-          "Ensure the partitionKeyOrder contains all the partition keys in inputColumns_");
     }
   }
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -242,18 +242,17 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
     }
 
     if (partitionKeyOrder_.size() > 0) {
-      // Ensure the partitionKeyOrder contains all the partition keys in
-      // inputColumns_.
-      std::string partitionKeyNames;
+      folly::F14FastSet<std::string> partitionKeyNames(
+          partitionKeyOrder_.begin(), partitionKeyOrder_.end());
       for (const auto& inputColumn : inputColumns_) {
         if (inputColumn->isPartitionKey()) {
-          partitionKeyNames.emplace_back(inputColumn->name());
+          VELOX_CHECK(partitionKeyNames.erase(inputColumn->name()) == 1);
         }
       }
 
       VELOX_CHECK(
-          partitionKeyNames.size() == partitionKeyOrder_.size(),
-          "partition key order size is not equal with the partition column size in inputColumns_");
+          partitionKeyNames.empty(),
+          "Ensure the partitionKeyOrder contains all the partition keys in inputColumns_");
     }
   }
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -248,7 +248,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
         if (inputColumn->isPartitionKey()) {
           VELOX_CHECK(
               partitionKeyNames.erase(inputColumn->name()) == 1,
-              "partitionKeyOrder does not contain the partition key.");
+              "partitionKeyOrder does not contain the partition key");
         }
       }
     }

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -209,7 +209,8 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
       // When this option is set the HiveDataSink will always write a file even
       // if there's no data. This is useful when the table is bucketed, but the
       // engine handles ensuring a 1 to 1 mapping from task to bucket.
-      const bool ensureFiles = false)
+      const bool ensureFiles = false,
+      const std::vector<std::string> partitionKeys = {})
       : inputColumns_(std::move(inputColumns)),
         locationHandle_(std::move(locationHandle)),
         storageFormat_(storageFormat),
@@ -217,7 +218,8 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
         compressionKind_(compressionKind),
         serdeParameters_(serdeParameters),
         writerOptions_(writerOptions),
-        ensureFiles_(ensureFiles) {
+        ensureFiles_(ensureFiles),
+        partitionKeys_(partitionKeys) {
     if (compressionKind.has_value()) {
       VELOX_CHECK(
           compressionKind.value() != common::CompressionKind_MAX,
@@ -271,6 +273,10 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
     return ensureFiles_;
   }
 
+  const std::vector<std::string>& partitionKeys() const {
+    return partitionKeys_;
+  }
+
   bool supportsMultiThreading() const override {
     return true;
   }
@@ -300,6 +306,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
   const std::unordered_map<std::string, std::string> serdeParameters_;
   const std::shared_ptr<dwio::common::WriterOptions> writerOptions_;
   const bool ensureFiles_;
+  const std::vector<std::string> partitionKeys_;
 };
 
 /// Parameters for Hive writers.

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2126,108 +2126,122 @@ TEST_P(AllTableWriterTest, commitStrategies) {
 }
 
 TEST_P(PartitionedTableWriterTest, specialPartitionName) {
-  const int32_t numPartitions = 50;
-  const int32_t numBatches = 2;
+  std::function<void(
+      const std::vector<std::string>&, const std::vector<TypePtr>)>
+      testSpecialPartitionName = [&](const std::vector<std::string>&
+                                         partitionKeys,
+                                     const std::vector<TypePtr>
+                                         partitionTypes) {
+        const int32_t numPartitions = 50;
+        const int32_t numBatches = 2;
 
-  const auto rowType =
-      ROW({"c0", "p0", "p1", "c1", "c3", "c5"},
-          {INTEGER(), INTEGER(), VARCHAR(), BIGINT(), REAL(), VARCHAR()});
-  const std::vector<std::string> partitionKeys = {"p0", "p1"};
-  const std::vector<TypePtr> partitionTypes = {INTEGER(), VARCHAR()};
+        const auto rowType =
+            ROW({"c0", "p0", "p1", "c1", "c3", "c5"},
+                {INTEGER(), INTEGER(), VARCHAR(), BIGINT(), REAL(), VARCHAR()});
 
-  const std::vector charsToEscape = {
-      '"',
-      '#',
-      '%',
-      '\'',
-      '*',
-      '/',
-      ':',
-      '=',
-      '?',
-      '\\',
-      '\x7F',
-      '{',
-      '[',
-      ']',
-      '^'};
-  ASSERT_GE(numPartitions, charsToEscape.size());
-  std::vector<RowVectorPtr> vectors = makeBatches(numBatches, [&](auto) {
-    return makeRowVector(
-        rowType->names(),
-        {
-            makeFlatVector<int32_t>(
-                numPartitions, [&](auto row) { return row + 100; }),
-            makeFlatVector<int32_t>(
-                numPartitions, [&](auto row) { return row; }),
-            makeFlatVector<StringView>(
-                numPartitions,
-                [&](auto row) {
-                  // special character
-                  return StringView::makeInline(
-                      fmt::format("str_{}{}", row, charsToEscape.at(row % 15)));
-                }),
-            makeFlatVector<int64_t>(
-                numPartitions, [&](auto row) { return row + 1000; }),
-            makeFlatVector<float>(
-                numPartitions, [&](auto row) { return row + 33.23; }),
-            makeFlatVector<StringView>(
-                numPartitions,
-                [&](auto row) {
-                  return StringView::makeInline(
-                      fmt::format("bucket_{}", row * 3));
-                }),
+        const std::vector charsToEscape = {
+            '"',
+            '#',
+            '%',
+            '\'',
+            '*',
+            '/',
+            ':',
+            '=',
+            '?',
+            '\\',
+            '\x7F',
+            '{',
+            '[',
+            ']',
+            '^'};
+        ASSERT_GE(numPartitions, charsToEscape.size());
+        std::vector<RowVectorPtr> vectors = makeBatches(numBatches, [&](auto) {
+          return makeRowVector(
+              rowType->names(),
+              {
+                  makeFlatVector<int32_t>(
+                      numPartitions, [&](auto row) { return row + 100; }),
+                  makeFlatVector<int32_t>(
+                      numPartitions, [&](auto row) { return row; }),
+                  makeFlatVector<StringView>(
+                      numPartitions,
+                      [&](auto row) {
+                        // special character
+                        return StringView::makeInline(fmt::format(
+                            "str_{}{}", row, charsToEscape.at(row % 15)));
+                      }),
+                  makeFlatVector<int64_t>(
+                      numPartitions, [&](auto row) { return row + 1000; }),
+                  makeFlatVector<float>(
+                      numPartitions, [&](auto row) { return row + 33.23; }),
+                  makeFlatVector<StringView>(
+                      numPartitions,
+                      [&](auto row) {
+                        return StringView::makeInline(
+                            fmt::format("bucket_{}", row * 3));
+                      }),
+              });
         });
-  });
-  createDuckDbTable(vectors);
+        createDuckDbTable(vectors);
 
-  auto inputFilePaths = makeFilePaths(numBatches);
-  for (int i = 0; i < numBatches; i++) {
-    writeToFile(inputFilePaths[i]->getPath(), vectors[i]);
-  }
+        auto inputFilePaths = makeFilePaths(numBatches);
+        for (int i = 0; i < numBatches; i++) {
+          writeToFile(inputFilePaths[i]->getPath(), vectors[i]);
+        }
 
-  auto outputDirectory = TempDirectoryPath::create();
-  auto plan = createInsertPlan(
-      PlanBuilder().tableScan(rowType),
-      rowType,
-      outputDirectory->getPath(),
-      partitionKeys,
-      bucketProperty_,
-      compressionKind_,
-      getNumWriters(),
-      connector::hive::LocationHandle::TableType::kNew,
-      commitStrategy_);
+        auto outputDirectory = TempDirectoryPath::create();
+        auto plan = createInsertPlan(
+            PlanBuilder().tableScan(rowType),
+            rowType,
+            outputDirectory->getPath(),
+            partitionKeys,
+            bucketProperty_,
+            compressionKind_,
+            getNumWriters(),
+            connector::hive::LocationHandle::TableType::kNew,
+            commitStrategy_);
 
-  auto task = assertQuery(plan, inputFilePaths, "SELECT count(*) FROM tmp");
+        auto task =
+            assertQuery(plan, inputFilePaths, "SELECT count(*) FROM tmp");
 
-  std::set<std::string> actualPartitionDirectories =
-      getLeafSubdirectories(outputDirectory->getPath());
+        std::set<std::string> actualPartitionDirectories =
+            getLeafSubdirectories(outputDirectory->getPath());
 
-  std::set<std::string> expectedPartitionDirectories;
-  const std::vector<std::string> expectedCharsAfterEscape = {
-      "%22",
-      "%23",
-      "%25",
-      "%27",
-      "%2A",
-      "%2F",
-      "%3A",
-      "%3D",
-      "%3F",
-      "%5C",
-      "%7F",
-      "%7B",
-      "%5B",
-      "%5D",
-      "%5E"};
-  for (auto i = 0; i < numPartitions; ++i) {
-    // url encoded
-    auto partitionName = fmt::format(
-        "p0={}/p1=str_{}{}", i, i, expectedCharsAfterEscape.at(i % 15));
-    expectedPartitionDirectories.emplace(
-        fs::path(outputDirectory->getPath()) / partitionName);
-  }
-  EXPECT_EQ(actualPartitionDirectories, expectedPartitionDirectories);
+        std::set<std::string> expectedPartitionDirectories;
+        const std::vector<std::string> expectedCharsAfterEscape = {
+            "%22",
+            "%23",
+            "%25",
+            "%27",
+            "%2A",
+            "%2F",
+            "%3A",
+            "%3D",
+            "%3F",
+            "%5C",
+            "%7F",
+            "%7B",
+            "%5B",
+            "%5D",
+            "%5E"};
+        for (auto i = 0; i < numPartitions; ++i) {
+          // url encoded
+          std::string partitionName;
+          if (partitionKeys == std::vector<std::string>{"p0", "p1"}) {
+            partitionName = fmt::format(
+                "p0={}/p1=str_{}{}", i, i, expectedCharsAfterEscape.at(i % 15));
+          } else if (partitionKeys == std::vector<std::string>{"p1", "p0"}) {
+            partitionName = fmt::format(
+                "p1=str_{}{}/p0={}", i, expectedCharsAfterEscape.at(i % 15), i);
+          }
+          expectedPartitionDirectories.emplace(
+              fs::path(outputDirectory->getPath()) / partitionName);
+        }
+        EXPECT_EQ(actualPartitionDirectories, expectedPartitionDirectories);
+      };
+  testSpecialPartitionName({"p0", "p1"}, {VARCHAR(), INTEGER()});
+  testSpecialPartitionName({"p1", "p0"}, {INTEGER(), VARCHAR()});
 }
 
 TEST_P(PartitionedTableWriterTest, multiplePartitions) {

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -285,7 +285,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const dwio::common::FileFormat tableStorageFormat,
     const std::optional<common::CompressionKind> compressionKind,
     const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
-    const bool ensureFiles) {
+    const bool ensureFiles,
+    const std::vector<std::string>& partitionKeyOrder) {
   return makeHiveInsertTableHandle(
       tableColumnNames,
       tableColumnTypes,
@@ -296,7 +297,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
       compressionKind,
       {},
       writerOptions,
-      ensureFiles);
+      ensureFiles,
+      partitionKeyOrder);
 }
 
 // static
@@ -311,7 +313,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters,
     const std::shared_ptr<dwio::common::WriterOptions>& writerOptions,
-    const bool ensureFiles) {
+    const bool ensureFiles,
+    const std::vector<std::string>& partitionKeyOrder) {
   std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
       columnHandles;
   std::vector<std::string> bucketedBy;
@@ -370,7 +373,7 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
       serdeParameters,
       writerOptions,
       ensureFiles,
-      partitionedBy);
+      partitionKeyOrder);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -369,7 +369,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
       compressionKind,
       serdeParameters,
       writerOptions,
-      ensureFiles);
+      ensureFiles,
+      partitionedBy);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -193,7 +193,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::unordered_map<std::string, std::string>& serdeParameters = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
           nullptr,
-      const bool ensureFiles = false);
+      const bool ensureFiles = false,
+      const std::vector<std::string>& partitionKeyOrder = {});
 
   static std::shared_ptr<connector::hive::HiveInsertTableHandle>
   makeHiveInsertTableHandle(
@@ -206,7 +207,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::optional<common::CompressionKind> compressionKind = {},
       const std::shared_ptr<dwio::common::WriterOptions>& writerOptions =
           nullptr,
-      const bool ensureFiles = false);
+      const bool ensureFiles = false,
+      const std::vector<std::string>& partitionKeyOrder = {});
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,


### PR DESCRIPTION
Fix https://github.com/apache/incubator-gluten/issues/8663

The `HiveDataSink `generates partition directories based on the partition index derived from the input `RowVector`. Currently, the partition index is constructed by traversing the `RowVector `to determine if a column is partitioned. This approach can lead to a mismatch in partition key order if it differs from the order in the `RowVector`. For instance, if the input `RowVector `is` (a, b, c)` and the partition key is set as `(b, a)`, Velox will create directories as` (a={}/b={}) `based on the existing logic. This does not align with Spark's partition directory format, which would be `(b={}/a={})`. To address this, we have introduced a partitionKey parameter in the `HiveInsertTableHandle`. This allows us to generate the partition index according to the specified partitionKey order, ensuring alignment with the user's desired partition key sequence.