### PR TITLE
fix: Fix DwrfStreamIdentifier compilation on `operator==`

### DIFF
--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -200,13 +200,18 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
 
   ~DwrfStreamIdentifier() = default;
 
-  bool operator==(const DwrfStreamIdentifier& other) const {
-    // column == other.column may be join the expression if all files
-    // share the same new version that has column field filled
-    return encodingKey_ == other.encodingKey_ && kind_ == other.kind_;
+  bool operator==(const StreamIdentifier& other) const override {
+    if (const auto* otherDwrf =
+            dynamic_cast<const DwrfStreamIdentifier*>(&other)) {
+      // column == other.column may be join the expression if all files
+      // share the same new version that has column field filled.
+      return encodingKey_ == otherDwrf->encodingKey_ &&
+          kind_ == otherDwrf->kind_;
+    }
+    return false;
   }
 
-  std::size_t hash() const {
+  std::size_t hash() const override {
     return encodingKey_.hash() ^ std::hash<uint32_t>()(kind_);
   }
 
@@ -222,7 +227,7 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
     return encodingKey_;
   }
 
-  std::string toString() const {
+  std::string toString() const override {
     return fmt::format(
         "[id={}, node={}, sequence={}, column={}, kind={}]",
         id_,


### PR DESCRIPTION
Fixes DwrfStreamIdentifier compilation by overriding the `operator==` of 
StreamIdentifier.

Fixes https://github.com/facebookincubator/velox/issues/12342.