### PR TITLE
fix: Fix dual linking of gflags when CMake variable `BUILD_SHARED_LIBS` is cached

### DIFF
--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -51,7 +51,7 @@ endif()
 FetchContent_MakeAvailable(gflags)
 
 # Workaround for https://github.com/gflags/gflags/issues/277
-if(DEFINED CACHED_BUILD_SHARED_LIBS AND NOT DEFINED CACHE{BUILD_SHARED_LIBS})
+if(DEFINED CACHED_BUILD_SHARED_LIBS)
   set(BUILD_SHARED_LIBS
       ${CACHED_BUILD_SHARED_LIBS}
       CACHE BOOL "Restored after setting up gflags")

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -54,7 +54,7 @@ FetchContent_MakeAvailable(gflags)
 if(DEFINED CACHED_BUILD_SHARED_LIBS)
   set(BUILD_SHARED_LIBS
       ${CACHED_BUILD_SHARED_LIBS}
-      CACHE BOOL "Restored after setting up gflags")
+      CACHE BOOL "Restored after setting up gflags" FORCE)
 endif()
 
 # This causes find_package(gflags) in other dependencies to search in the build

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -52,7 +52,7 @@ FetchContent_MakeAvailable(gflags)
 
 # Workaround for https://github.com/gflags/gflags/issues/277
 if (DEFINED CACHED_BUILD_SHARED_LIBS AND NOT DEFINED CACHE{BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS ${CACHED_BUILD_SHARED_LIBS} CACHE BOOL)
+    set(BUILD_SHARED_LIBS ${CACHED_BUILD_SHARED_LIBS} CACHE BOOL "Restored after setting up gflags")
 endif ()
 
 # This causes find_package(gflags) in other dependencies to search in the build

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -43,7 +43,18 @@ set(GFLAGS_IS_SUBPROJECT ON)
 
 # Workaround for https://github.com/gflags/gflags/issues/277
 unset(BUILD_SHARED_LIBS)
+if (DEFINED CACHE{BUILD_SHARED_LIBS})
+    set(CACHED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+    unset(BUILD_SHARED_LIBS CACHE)
+endif ()
+
 FetchContent_MakeAvailable(gflags)
+
+# Workaround for https://github.com/gflags/gflags/issues/277
+if (DEFINED CACHED_BUILD_SHARED_LIBS AND NOT DEFINED CACHE{BUILD_SHARED_LIBS})
+    set(BUILD_SHARED_LIBS ${CACHED_BUILD_SHARED_LIBS} CACHE BOOL)
+endif ()
+
 # This causes find_package(gflags) in other dependencies to search in the build
 # directory and prevents the system gflags from being found when they don't use
 # the target directly (like folly).

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -43,17 +43,19 @@ set(GFLAGS_IS_SUBPROJECT ON)
 
 # Workaround for https://github.com/gflags/gflags/issues/277
 unset(BUILD_SHARED_LIBS)
-if (DEFINED CACHE{BUILD_SHARED_LIBS})
-    set(CACHED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
-    unset(BUILD_SHARED_LIBS CACHE)
-endif ()
+if(DEFINED CACHE{BUILD_SHARED_LIBS})
+  set(CACHED_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
+  unset(BUILD_SHARED_LIBS CACHE)
+endif()
 
 FetchContent_MakeAvailable(gflags)
 
 # Workaround for https://github.com/gflags/gflags/issues/277
-if (DEFINED CACHED_BUILD_SHARED_LIBS AND NOT DEFINED CACHE{BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS ${CACHED_BUILD_SHARED_LIBS} CACHE BOOL "Restored after setting up gflags")
-endif ()
+if(DEFINED CACHED_BUILD_SHARED_LIBS AND NOT DEFINED CACHE{BUILD_SHARED_LIBS})
+  set(BUILD_SHARED_LIBS
+      ${CACHED_BUILD_SHARED_LIBS}
+      CACHE BOOL "Restored after setting up gflags")
+endif()
 
 # This causes find_package(gflags) in other dependencies to search in the build
 # directory and prevents the system gflags from being found when they don't use


### PR DESCRIPTION
This fixes https://github.com/facebookincubator/velox/issues/12358.