### PR TITLE
feat(types): Dedup types during serialization

### DIFF
--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/exec/PartitionFunction.h"
-#include "velox/exec/WindowFunction.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -56,12 +55,31 @@ class PlanNodeSerdeTest : public testing::Test,
   }
 
   void testSerde(const core::PlanNodePtr& plan) {
-    auto serialized = plan->serialize();
+    {
+      const auto serialized = plan->serialize();
+      const auto copy =
+          velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+      ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
+    }
+    {
+      // Test serde with type cache enabled.
+      auto& cache = serializedTypeCache();
+      cache.enable({.minRowTypeSize = 1});
+      SCOPE_EXIT {
+        cache.disable();
+        cache.clear();
+        deserializedTypeCache().clear();
+      };
 
-    auto copy =
-        velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+      const auto serialized = plan->serialize();
 
-    ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
+      const auto serializedCache = cache.serialize();
+      deserializedTypeCache().deserialize(serializedCache);
+
+      const auto copy =
+          velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+      ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
+    }
   }
 
   std::vector<RowVectorPtr> data_;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2145,6 +2145,95 @@ void toAppend(
 /// Appends type's SQL string to 'out'. Uses DuckDB SQL.
 void toTypeSql(const TypePtr& type, std::ostream& out);
 
+/// Cache of serialized RowType instances. Useful to reduce the size of
+/// serialized expressions and plans. Disabled by default. Not thread safe.
+///
+/// To enable, call 'serializedTypeCache().enable()'. This enables the cache for
+/// the current thread. To disable, call 'serializedTypeCache().disable()'.
+/// While enables, type serialization will use the cache and serialize the types
+/// using IDs stored in the cache. The caller is responsible for saving
+/// serialized types from the cache and using these to hidrate
+/// 'deserializedTypeCache()' before deserializing the types.
+class SerializedTypeCache {
+ public:
+  struct Options {
+    // Caching applies to RowType's with at least this many fields.
+    size_t minRowTypeSize = 10;
+  };
+
+  bool isEnabled() const {
+    return enabled_;
+  }
+
+  const Options& options() const {
+    return options_;
+  }
+
+  void enable(const Options& options = {.minRowTypeSize = 10}) {
+    enabled_ = true;
+    options_ = options;
+  }
+
+  void disable() {
+    enabled_ = false;
+  }
+
+  size_t size() const {
+    return cache_.size();
+  }
+
+  void clear() {
+    cache_.clear();
+  }
+
+  /// Returns the ID of the type if it is in the cache. Returns std::nullopt if
+  /// type is not found in the cache. Cache key is type instance pointer. Hence,
+  /// equal but different instances are stored separately.
+  std::optional<int32_t> get(const Type& type) const;
+
+  /// Stores the type in the cache. Returns the ID of the type. Reports an error
+  /// if type is already present in the cache. IDs are monotonically increasing.
+  /// Serialized type may refer to types stored previously in the cache. When
+  /// deserializing type cache, make sure to deserialize types in the order of
+  /// cache IDs.
+  int32_t put(const Type& type, folly::dynamic serialized);
+
+  /// Serialized the types stored in the cache. Use
+  /// DeserializedTypeCache::deserialize to deserialize.
+  folly::dynamic serialize();
+
+ private:
+  bool enabled_{false};
+  Options options_;
+  folly::F14FastMap<const Type*, std::pair<int32_t, folly::dynamic>> cache_;
+};
+
+/// Thread local cache of serialized RowType instances. Used by
+/// RowType::serialize.
+SerializedTypeCache& serializedTypeCache();
+
+/// Thread local cache of deserialized RowType instances. Used when
+/// deserializing Type objects.
+class DeserializedTypeCache {
+ public:
+  void deserialize(const folly::dynamic& obj);
+
+  size_t size() const {
+    return cache_.size();
+  }
+
+  const TypePtr& get(int32_t id) const;
+
+  void clear() {
+    cache_.clear();
+  }
+
+ private:
+  folly::F14FastMap<int32_t, TypePtr> cache_;
+};
+
+DeserializedTypeCache& deserializedTypeCache();
+
 } // namespace facebook::velox
 
 namespace folly {


### PR DESCRIPTION
Summary:
Serializing plans used in AI/ML produces very large JSONs (multiple GBs). Most of it is taken by large RowTypes serialized repeatedly. This change introduces a cache of serialized types that is used to dedup type instances during serialization. This allows to reduce serialized size 1000x from GBs to MBs.

By default, cache is disabled.

Cache is not thread safe.

To enable the cache, access thread local instance and call 'enable()' API: serializedTypeCache().enable(). Then, serialize types, expressions or plan nodes as usual. Make sure to serialize and store the cache itself using 'serializedTypeCache().serialize()' API. Clear the cache when done.

To deserialize, restore the cache using 'deserializedTypeCache().deserialize()' API. Then, deserialize types, expressions or plan nodes as usual. Clear the cache when done.

See TEST(TypeTest, serdeCache) for an example of usage.

Differential Revision: D69755598


