### PR TITLE
fix: Optimize ContainerRowSerde deserialization for string, array and map

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -119,23 +119,6 @@ void FlatVector<StringView>::set(vector_size_t idx, StringView value) {
   }
 }
 
-/// For types that requires buffer allocation this should be called only if
-/// value is inlined or if value is already allocated in a buffer within the
-/// vector. Used by StringWriter to allow UDFs to write directly into the
-/// buffers and avoid copying.
-template <>
-void FlatVector<StringView>::setNoCopy(
-    const vector_size_t idx,
-    const StringView& value) {
-  VELOX_DCHECK_LT(idx, BaseVector::length_);
-  ensureValues();
-  VELOX_DCHECK(!values_->isView());
-  if (BaseVector::nulls_) {
-    BaseVector::setNull(idx, false);
-  }
-  rawValues_[idx] = value;
-}
-
 template <>
 void FlatVector<StringView>::acquireSharedStringBuffers(
     const BaseVector* source) {

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -610,10 +610,22 @@ Range<bool> FlatVector<bool>::asRange() const;
 template <>
 void FlatVector<StringView>::set(vector_size_t idx, StringView value);
 
+/// For types that requires buffer allocation this should be called only if
+/// value is inlined or if value is already allocated in a buffer within the
+/// vector. Used by StringWriter to allow UDFs to write directly into the
+/// buffers and avoid copying.
 template <>
-void FlatVector<StringView>::setNoCopy(
+inline void FlatVector<StringView>::setNoCopy(
     const vector_size_t idx,
-    const StringView& value);
+    const StringView& value) {
+  VELOX_DCHECK_LT(idx, BaseVector::length_);
+  ensureValues();
+  VELOX_DCHECK(!values_->isView());
+  if (BaseVector::nulls_) {
+    BaseVector::setNull(idx, false);
+  }
+  rawValues_[idx] = value;
+}
 
 template <>
 void FlatVector<bool>::set(vector_size_t idx, bool value);


### PR DESCRIPTION
Summary:
1. Optimize `deserializeString` in case of inlined strings
2. Optimize `deserializeArray` to avoid heap allocation for intermediate null-like data
3. Inline `FlatVector<StringView>::setNoCopy`

Differential Revision: D69750091


