### PR TITLE
feat: Add HashStringAllocator::InputStream

### DIFF
--- a/velox/common/file/FileInputStream.cpp
+++ b/velox/common/file/FileInputStream.cpp
@@ -52,7 +52,6 @@ FileInputStream::~FileInputStream() {
 
 void FileInputStream::readNextRange() {
   VELOX_CHECK(current_ == nullptr || current_->availableBytes() == 0);
-  ranges_.clear();
   current_ = nullptr;
 
   int32_t readBytes{0};
@@ -77,9 +76,8 @@ void FileInputStream::readNextRange() {
     }
   }
 
-  ranges_.resize(1);
-  ranges_[0] = {buffer()->asMutable<uint8_t>(), readBytes, 0};
-  current_ = ranges_.data();
+  range_ = {buffer()->asMutable<uint8_t>(), readBytes, 0};
+  current_ = &range_;
   fileOffset_ += readBytes;
 
   updateStats(readBytes, readTimeNs);

--- a/velox/common/file/FileInputStream.h
+++ b/velox/common/file/FileInputStream.h
@@ -123,6 +123,8 @@ class FileInputStream : public ByteInputStream {
   folly::SemiFuture<uint64_t> readAheadWait_{
       folly::SemiFuture<uint64_t>::makeEmpty()};
 
+  ByteRange range_;
+
   Stats stats_;
 };
 } // namespace facebook::velox::common

--- a/velox/exec/AddressableNonNullValueList.cpp
+++ b/velox/exec/AddressableNonNullValueList.cpp
@@ -84,13 +84,13 @@ HashStringAllocator::Position AddressableNonNullValueList::appendSerialized(
 
 namespace {
 
-std::unique_ptr<ByteInputStream> prepareRead(
+HashStringAllocator::InputStream prepareRead(
     const AddressableNonNullValueList::Entry& entry) {
   auto header = entry.offset.header;
   auto seek = entry.offset.position - header->begin();
 
-  auto stream = HashStringAllocator::prepareRead(header, entry.size + seek);
-  stream->seekp(seek);
+  HashStringAllocator::InputStream stream(header);
+  stream.seekp(seek);
   return stream;
 }
 } // namespace
@@ -110,7 +110,7 @@ bool AddressableNonNullValueList::equalTo(
   CompareFlags compareFlags =
       CompareFlags::equality(CompareFlags::NullHandlingMode::kNullAsValue);
   return exec::ContainerRowSerde::compare(
-             *leftStream, *rightStream, type.get(), compareFlags) == 0;
+             leftStream, rightStream, type.get(), compareFlags) == 0;
 }
 
 // static
@@ -119,7 +119,7 @@ void AddressableNonNullValueList::read(
     BaseVector& result,
     vector_size_t index) {
   auto stream = prepareRead(position);
-  exec::ContainerRowSerde::deserialize(*stream, index, &result);
+  exec::ContainerRowSerde::deserialize(stream, index, &result);
 }
 
 // static
@@ -127,7 +127,7 @@ void AddressableNonNullValueList::readSerialized(
     const Entry& position,
     char* dest) {
   auto stream = prepareRead(position);
-  stream->readBytes(dest, position.size);
+  stream.ByteInputStream::readBytes(dest, position.size);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1168,7 +1168,7 @@ class RowContainer {
     }
   }
 
-  static std::unique_ptr<ByteInputStream> prepareRead(
+  static HashStringAllocator::InputStream prepareRead(
       const char* row,
       int32_t offset);
 
@@ -1399,7 +1399,7 @@ class RowContainer {
         result->setNull(resultIndex, true);
       } else {
         auto stream = prepareRead(row, offset);
-        ContainerRowSerde::deserialize(*stream, resultIndex, result.get());
+        ContainerRowSerde::deserialize(stream, resultIndex, result.get());
       }
     }
   }

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -51,10 +51,10 @@ struct RowPointers {
   }
 
   void read(folly::Range<char**> rows) {
-    auto stream = HashStringAllocator::prepareRead(firstBlock);
+    HashStringAllocator::InputStream stream(firstBlock);
 
     for (auto i = 0; i < size; ++i) {
-      rows[i] = reinterpret_cast<char*>(stream->read<uintptr_t>());
+      rows[i] = reinterpret_cast<char*>(stream.read<uintptr_t>());
     }
   }
 };

--- a/velox/exec/prefixsort/PrefixSortEncoder.h
+++ b/velox/exec/prefixsort/PrefixSortEncoder.h
@@ -294,9 +294,9 @@ FOLLY_ALWAYS_INLINE void PrefixSortEncoder::encodeNoNulls(
   } else {
     // 'data' is stored in non-contiguous allocation pieces in the row
     // container, we only read prefix size data out.
-    auto stream = HashStringAllocator::prepareRead(
+    HashStringAllocator::InputStream stream(
         HashStringAllocator::headerOf(value.data()));
-    stream->readBytes(dest, copySize);
+    stream.ByteInputStream::readBytes(dest, copySize);
   }
 
   if (value.size() < encodeSize) {

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -81,9 +81,9 @@ class ContainerRowSerdeTest : public testing::Test,
       data->setNull(i, true);
     }
 
-    auto in = HashStringAllocator::prepareRead(position.header);
+    HashStringAllocator::InputStream in(position.header);
     for (auto i = 0; i < numRows; ++i) {
-      ContainerRowSerde::deserialize(*in, i, data.get());
+      ContainerRowSerde::deserialize(in, i, data.get());
     }
     return data;
   }
@@ -112,19 +112,19 @@ class ContainerRowSerdeTest : public testing::Test,
         mode};
 
     for (auto i = 0; i < expected.size(); ++i) {
-      auto stream = HashStringAllocator::prepareRead(positions.at(i).header);
+      HashStringAllocator::InputStream stream(positions.at(i).header);
       if (expected.at(i) == kIndeterminate &&
           mode == CompareFlags::NullHandlingMode::kNullAsIndeterminate &&
           !equalsOnly) {
         VELOX_ASSERT_THROW(
             ContainerRowSerde::compareWithNulls(
-                *stream, decodedVector, i, compareFlags),
+                stream, decodedVector, i, compareFlags),
             "Ordering nulls is not supported");
       } else {
         ASSERT_EQ(
             expected.at(i),
             ContainerRowSerde::compareWithNulls(
-                *stream, decodedVector, i, compareFlags));
+                stream, decodedVector, i, compareFlags));
       }
     }
   }
@@ -146,22 +146,20 @@ class ContainerRowSerdeTest : public testing::Test,
         mode};
 
     for (auto i = 0; i < expected.size(); ++i) {
-      auto leftStream =
-          HashStringAllocator::prepareRead(leftPositions.at(i).header);
-      auto rightStream =
-          HashStringAllocator::prepareRead(rightPositions.at(i).header);
+      HashStringAllocator::InputStream leftStream(leftPositions.at(i).header);
+      HashStringAllocator::InputStream rightStream(rightPositions.at(i).header);
       if (expected.at(i) == kIndeterminate &&
           mode == CompareFlags::NullHandlingMode::kNullAsIndeterminate &&
           !equalsOnly) {
         VELOX_ASSERT_THROW(
             ContainerRowSerde::compareWithNulls(
-                *leftStream, *rightStream, type.get(), compareFlags),
+                leftStream, rightStream, type.get(), compareFlags),
             "Ordering nulls is not supported");
       } else {
         ASSERT_EQ(
             expected.at(i),
             ContainerRowSerde::compareWithNulls(
-                *leftStream, *rightStream, type.get(), compareFlags));
+                leftStream, rightStream, type.get(), compareFlags));
       }
     }
   }
@@ -181,37 +179,34 @@ class ContainerRowSerdeTest : public testing::Test,
 
     for (auto i = 0; i < positionsActual.size(); ++i) {
       // Test comparing reading from a ByteInputStream and a DecodedVector.
-      auto actualStream =
-          HashStringAllocator::prepareRead(positionsActual.at(i).header);
+      HashStringAllocator::InputStream actualStream(
+          positionsActual.at(i).header);
       ASSERT_EQ(
           0,
           ContainerRowSerde::compare(
-              *actualStream, decodedVector, i, compareFlags))
+              actualStream, decodedVector, i, compareFlags))
           << "at " << i << ": " << actual->toString(i) << " "
           << expected->toString(i);
 
       // Test comparing reading from two ByteInputStreams.
       actualStream =
-          HashStringAllocator::prepareRead(positionsActual.at(i).header);
-      auto expectedStream =
-          HashStringAllocator::prepareRead(positionsExpected.at(i).header);
+          HashStringAllocator::InputStream(positionsActual.at(i).header);
+      HashStringAllocator::InputStream expectedStream(
+          positionsExpected.at(i).header);
       ASSERT_EQ(
           0,
           ContainerRowSerde::compare(
-              *actualStream,
-              *expectedStream,
-              actual->type().get(),
-              compareFlags))
+              actualStream, expectedStream, actual->type().get(), compareFlags))
           << "at " << i << ": " << actual->toString(i) << " "
           << expected->toString(i);
 
       // Test comparing hashes.
       actualStream =
-          HashStringAllocator::prepareRead(positionsActual.at(i).header);
+          HashStringAllocator::InputStream(positionsActual.at(i).header);
 
       ASSERT_EQ(
           expected->hashValueAt(i),
-          ContainerRowSerde::hash(*actualStream, actual->type().get()))
+          ContainerRowSerde::hash(actualStream, actual->type().get()))
           << "at " << i << ": " << actual->toString(i) << " "
           << expected->toString(i);
     }

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -41,8 +41,8 @@ void SingleValueAccumulator::read(const VectorPtr& vector, vector_size_t index)
     const {
   VELOX_CHECK_NOT_NULL(start_.header);
 
-  auto stream = HashStringAllocator::prepareRead(start_.header);
-  exec::ContainerRowSerde::deserialize(*stream, index, vector.get());
+  HashStringAllocator::InputStream stream(start_.header);
+  exec::ContainerRowSerde::deserialize(stream, index, vector.get());
 }
 
 bool SingleValueAccumulator::hasValue() const {
@@ -55,9 +55,9 @@ std::optional<int32_t> SingleValueAccumulator::compare(
     CompareFlags compareFlags) const {
   VELOX_CHECK_NOT_NULL(start_.header);
 
-  auto stream = HashStringAllocator::prepareRead(start_.header);
+  HashStringAllocator::InputStream stream(start_.header);
   return exec::ContainerRowSerde::compareWithNulls(
-      *stream, decoded, index, compareFlags);
+      stream, decoded, index, compareFlags);
 }
 
 void SingleValueAccumulator::destroy(HashStringAllocator* allocator) {

--- a/velox/functions/lib/aggregates/ValueList.h
+++ b/velox/functions/lib/aggregates/ValueList.h
@@ -127,8 +127,8 @@ class ValueListReader {
   const vector_size_t size_;
   const vector_size_t lastNullsStart_;
   const uint64_t lastNulls_;
-  std::unique_ptr<ByteInputStream> dataStream_;
-  std::unique_ptr<ByteInputStream> nullsStream_;
+  HashStringAllocator::InputStream dataStream_;
+  HashStringAllocator::InputStream nullsStream_;
   uint64_t nulls_;
   vector_size_t pos_{0};
 };

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -54,8 +54,8 @@ void ValueSet::read(
     const HashStringAllocator::Header* header) const {
   VELOX_CHECK_NOT_NULL(header);
 
-  auto stream = HashStringAllocator::prepareRead(header);
-  exec::ContainerRowSerde::deserialize(*stream, index, vector);
+  HashStringAllocator::InputStream stream(header);
+  exec::ContainerRowSerde::deserialize(stream, index, vector);
 }
 
 void ValueSet::free(HashStringAllocator::Header* header) const {

--- a/velox/row/benchmarks/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmarks/UnsafeRowSerializeBenchmark.cpp
@@ -110,9 +110,9 @@ class SerializeBenchmark {
 
     auto copy = BaseVector::create(rowType, data->size(), pool());
 
-    auto in = HashStringAllocator::prepareRead(position.header);
+    HashStringAllocator::InputStream in(position.header);
     for (auto i = 0; i < data->size(); ++i) {
-      exec::ContainerRowSerde::deserialize(*in, i, copy.get());
+      exec::ContainerRowSerde::deserialize(in, i, copy.get());
     }
 
     VELOX_CHECK_EQ(copy->size(), data->size());


### PR DESCRIPTION
Summary:
When we get `ByteInputStream` from `HashStringAllocator`, we used to
have to materialize all the byte ranges in a vector, which is not efficient.
This change improve the efficiency by creating a `ByteInputStream` directly over
the linked list of a multi-part allocation.

Differential Revision: D69750088


