### PR TITLE
fix: Fix partition filters with timestamp value 

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -93,7 +93,7 @@ bool testFilters(
         partitionKey,
     const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
         partitionKeysHandle,
-    bool asLocalTime = true);
+    bool asLocalTime);
 
 std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
     const FileHandle& fileHandle,

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -92,7 +92,8 @@ bool testFilters(
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,
     const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeysHandle);
+        partitionKeysHandle,
+    bool asLocalTime = true);
 
 std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
     const FileHandle& fileHandle,

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -295,7 +295,9 @@ bool SplitReader::filterOnStats(
           baseReader_.get(),
           hiveSplit_->filePath,
           hiveSplit_->partitionKeys,
-          *partitionKeys_)) {
+          *partitionKeys_,
+          hiveConfig_->readTimestampPartitionValueAsLocalTime(
+              connectorQueryCtx_->sessionProperties()))) {
     return true;
   }
   ++runtimeStats.skippedSplits;

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -40,6 +40,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       baseFilePath_(baseFilePath),
       fileHandleFactory_(fileHandleFactory),
       executor_(executor),
+      connectorQueryCtx_(connectorQueryCtx),
       hiveConfig_(hiveConfig),
       ioStats_(ioStats),
       fsStats_(fsStats),
@@ -114,7 +115,9 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
           deleteReader.get(),
           deleteSplit_->filePath,
           deleteSplit_->partitionKeys,
-          {})) {
+          {},
+          hiveConfig_->readTimestampPartitionValueAsLocalTime(
+              connectorQueryCtx_->sessionProperties()))) {
     // We only count the number of base splits skipped as skippedSplits runtime
     // statistics in Velox.  Skipped delta split is only counted as skipped
     // bytes.

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -65,6 +65,7 @@ class PositionalDeleteFileReader {
   const std::string& baseFilePath_;
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const executor_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;
   const std::shared_ptr<io::IoStatistics> ioStats_;
   const std::shared_ptr<filesystems::File::IoStats> fsStats_;

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2004,7 +2004,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
       {"c0", regularColumn("c0", BIGINT())},
       {"c1", regularColumn("c1", DOUBLE())}};
 
-  auto sql = [&](const std::string& sqlTemplate, bool asLocalTime) {
+  auto sql = [&](const char* sqlTemplate, bool asLocalTime) {
     auto t =
         util::fromTimestampString(
             StringView(partitionValue), util::TimestampParseMode::kPrestoCast)
@@ -2018,7 +2018,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
     return fmt::format(sqlTemplate, partitionValueStr);
   };
 
-  auto expect = [&](PlanNodePtr plan, const std::string& sqlTemplate) {
+  auto expect = [&](PlanNodePtr plan, const char* sqlTemplate) {
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1992,7 +1992,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
   const std::string partitionValue = "2023-10-27 00:12:35";
 
   auto partitionType = TIMESTAMP();
-  // test partition value is null
+  // Test partition value is null.
   testPartitionedTable(filePath->getPath(), partitionType, std::nullopt);
 
   auto split = exec::test::HiveConnectorSplitBuilder(filePath->getPath())
@@ -2073,7 +2073,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
           .planNode(),
       "SELECT c0, c1, {} FROM tmp");
 
-  // select only partition key
+  // Select only partition key.
   expect(
       PlanBuilder()
           .startTableScan()

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2004,7 +2004,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
       {"c0", regularColumn("c0", BIGINT())},
       {"c1", regularColumn("c1", DOUBLE())}};
 
-  auto sql = [&](const std::string& sqlTempl, bool asLocalTime) {
+  auto sql = [&](const std::string& sqlTemplate, bool asLocalTime) {
     auto t =
         util::fromTimestampString(
             StringView(partitionValue), util::TimestampParseMode::kPrestoCast)
@@ -2015,10 +2015,10 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
       t.toGMT(Timestamp::defaultTimezone());
     }
     std::string partitionValueStr = "'" + t.toString() + "'";
-    return fmt::format(sqlTempl, partitionValueStr);
+    return fmt::format(sqlTemplate, partitionValueStr);
   };
 
-  auto expect = [&](PlanNodePtr plan, const std::string& sqlTempl) {
+  auto expect = [&](PlanNodePtr plan, const std::string& sqlTemplate) {
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(
@@ -2027,7 +2027,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
                 kReadTimestampPartitionValueAsLocalTimeSession,
             "true")
         .splits({split})
-        .assertResults(sql(sqlTempl, true));
+        .assertResults(sql(sqlTemplate, true));
 
     // Read timestamp partition value as UTC.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -2037,7 +2037,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
                 kReadTimestampPartitionValueAsLocalTimeSession,
             "false")
         .splits({split})
-        .assertResults(sql(sqlTempl, false));
+        .assertResults(sql(sqlTemplate, false));
   };
 
   expect(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2089,7 +2089,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
     auto planNodeWithSubfilter = [&](bool asLocalTime) {
       auto outputType =
           ROW({"pkey", "c0", "c1"}, {TIMESTAMP(), BIGINT(), DOUBLE()});
-      SubfieldFilters filters;
+      common::SubfieldFilters filters;
       // pkey = 2023-10-27 00:12:35.
       auto lower =
           util::fromTimestampString(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2028,7 +2028,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr char* sqlTemplate = "SELECT {}, * FROM tmp";
+    constexpr std::string sqlTemplate = "SELECT {}, * FROM tmp";
 
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -2061,7 +2061,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr char* sqlTemplate = "SELECT c0, {}, c1 FROM tmp";
+    constexpr std::string sqlTemplate = "SELECT c0, {}, c1 FROM tmp";
 
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -2094,7 +2094,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr char* sqlTemplate = "SELECT c0, c1, {} FROM tmp";
+    constexpr std::string sqlTemplate = "SELECT c0, c1, {} FROM tmp";
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(
@@ -2126,7 +2126,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments({{"pkey", partitionKey("pkey", partitionType)}})
             .endTableScan()
             .planNode();
-    constexpr char* sqlTemplate = "SELECT {} FROM tmp";
+    constexpr std::string sqlTemplate = "SELECT {} FROM tmp";
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2028,7 +2028,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr std::string sqlTemplate = "SELECT {}, * FROM tmp";
+    const char* sqlTemplate = "SELECT {}, * FROM tmp";
 
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -2061,7 +2061,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr std::string sqlTemplate = "SELECT c0, {}, c1 FROM tmp";
+    const char* sqlTemplate = "SELECT c0, {}, c1 FROM tmp";
 
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
@@ -2094,7 +2094,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments(assignments)
             .endTableScan()
             .planNode();
-    constexpr std::string sqlTemplate = "SELECT c0, c1, {} FROM tmp";
+    const char* sqlTemplate = "SELECT c0, c1, {} FROM tmp";
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(
@@ -2126,7 +2126,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
             .assignments({{"pkey", partitionKey("pkey", partitionType)}})
             .endTableScan()
             .planNode();
-    constexpr std::string sqlTemplate = "SELECT {} FROM tmp";
+    const char* sqlTemplate = "SELECT {} FROM tmp";
     // Read timestamp partition value as local time.
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .connectorSessionProperty(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2004,7 +2004,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
       {"c0", regularColumn("c0", BIGINT())},
       {"c1", regularColumn("c1", DOUBLE())}};
 
-  TimeStamp ts =
+  Timestamp ts =
       util::fromTimestampString(
           StringView(partitionValue), util::TimestampParseMode::kPrestoCast)
           .thenOrThrow(folly::identity, [&](const Status& status) {
@@ -2013,7 +2013,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
   // Read timestamp partition value as UTC.
   std::string tsValue = "'" + ts.toString() + "'";
 
-  TimeStamp tsAsLocalTime = ts;
+  Timestamp tsAsLocalTime = ts;
   tsAsLocalTime.toGMT(Timestamp::defaultTimezone());
   // Read timestamp partition value as local time.
   std::string tsValueAsLocal = "'" + tsAsLocalTime.toString() + "'";
@@ -2158,7 +2158,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
     };
 
     auto expect = [&](bool asLocalTime) {
-      AssertQueryBuilder(planWithSubfilter, duckDbQueryRunner_)
+      AssertQueryBuilder(planWithSubfilter(asLocalTime), duckDbQueryRunner_)
           .connectorSessionProperty(
               kHiveConnectorId,
               connector::hive::HiveConfig::

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2065,7 +2065,8 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               "true")
           .splits({split})
           .assertResults(fmt::format(
-              "SELECT {}, * FROM tmp", asLocalTime ? tsValueAsLocal : tsValue));
+              "SELECT c0, {}, c1 FROM tmp",
+              asLocalTime ? tsValueAsLocal : tsValue));
     };
     expect(true);
     expect(false);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2035,7 +2035,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               kHiveConnectorId,
               connector::hive::HiveConfig::
                   kReadTimestampPartitionValueAsLocalTimeSession,
-              "true")
+              asLocalTime ? "true" : "false")
           .splits({split})
           .assertResults(fmt::format(
               "SELECT {}, * FROM tmp", asLocalTime ? tsValueAsLocal : tsValue));
@@ -2062,7 +2062,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               kHiveConnectorId,
               connector::hive::HiveConfig::
                   kReadTimestampPartitionValueAsLocalTimeSession,
-              "true")
+              asLocalTime ? "true" : "false")
           .splits({split})
           .assertResults(fmt::format(
               "SELECT c0, {}, c1 FROM tmp",
@@ -2089,7 +2089,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               kHiveConnectorId,
               connector::hive::HiveConfig::
                   kReadTimestampPartitionValueAsLocalTimeSession,
-              "true")
+              asLocalTime ? "true" : "false")
           .splits({split})
           .assertResults(fmt::format(
               "SELECT c0, c1, {} FROM tmp",
@@ -2116,7 +2116,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               kHiveConnectorId,
               connector::hive::HiveConfig::
                   kReadTimestampPartitionValueAsLocalTimeSession,
-              "true")
+              asLocalTime ? "true" : "false")
           .splits({split})
           .assertResults(fmt::format(
               "SELECT {} FROM tmp", asLocalTime ? tsValueAsLocal : tsValue));
@@ -2164,7 +2164,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
               kHiveConnectorId,
               connector::hive::HiveConfig::
                   kReadTimestampPartitionValueAsLocalTimeSession,
-              "true")
+              asLocalTime ? "true" : "false")
           .splits({split})
           .assertResults(fmt::format(
               "SELECT {}, * FROM tmp", asLocalTime ? tsValueAsLocal : tsValue));


### PR DESCRIPTION
When using partition filters with timestamp value, use configuration
 to control whether to interpret it as local time or UTC.
 
Follow-up for https://github.com/facebookincubator/velox/pull/11957