### PR TITLE
Fix: Flakey memory pool already exists failure in TableScanReplayerTest

### DIFF
--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -113,8 +113,9 @@ core::PlanNodePtr OperatorReplayerBase::createPlan() {
 }
 
 std::shared_ptr<core::QueryCtx> OperatorReplayerBase::createQueryCtx() {
+  static std::atomic_uint64_t replayQueryId{0};
   auto queryPool = memory::memoryManager()->addRootPool(
-      fmt::format("{}_replayer_{}", operatorType_, replayQueryId_++),
+      fmt::format("{}_replayer_{}", operatorType_, replayQueryId++),
       queryCapacity_);
   std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
       connectorConfigs;

--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -76,7 +76,6 @@ class OperatorReplayerBase {
       connectorConfigs_;
   core::PlanNodePtr planFragment_;
   core::PlanNodeId replayPlanNodeId_;
-  std::atomic_uint64_t replayQueryId_{0};
 
   void printStats(const std::shared_ptr<exec::Task>& task) const;
 


### PR DESCRIPTION
The `OperatorReplayerBase` creates query context for each replay query,
in which it would create a memory pool, we should add a thread-safe 
auto increase ID in it as CI would run unit tests concurrently, and trigger
the flakey failure.

Resolve #12360 