### PR TITLE
feat: Handle errors during constant folding in expression compilation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -505,6 +505,11 @@ class QueryConfig {
   static constexpr const char* kShuffleCompressionKind =
       "shuffle_compression_codec";
 
+  /// Specifies whether the expression compiler should ignore errors encountered
+  /// during constant folding or return a FailFunction instead.
+  static constexpr const char* kConstantFoldErrorWithFailFunction =
+      "constant_fold_error_with_fail_function";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -928,6 +933,10 @@ class QueryConfig {
 
   std::string shuffleCompressionKind() const {
     return get<std::string>(kShuffleCompressionKind, "none");
+  }
+
+  bool constantFoldErrorWithFailFunction() const {
+    return get<bool>(kConstantFoldErrorWithFailFunction, false);
   }
 
   template <typename T>


### PR DESCRIPTION
Expression compilation currently ignores any errors encountered during constant folding. This change enables the expression compiler to return a `FailFunction` in place of the constant expression which throws a `VeloxException` when evaluated. This is consistent with the behavior of Presto's expression compiler, please see [this issue](https://github.com/prestodb/presto/issues/24591) for more context.

Resolves https://github.com/facebookincubator/velox/issues/12414. 