### PR TITLE
docs: Fix some small typos in documentation

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -230,13 +230,14 @@ toIntermediate
 ^^^^^^^^^^^^^^
 
 The author can optionally define a static method `toIntermediate()` that
-converts a raw input to an intermediate state. If defined, this function is
-used in query plans that abandon the partial aggregation step. If the aggregaiton function has
-default-null behavior, the toIntermediate() function has an out-parameter
-of the type `exec::out_type<IntermediateType>&` followed by in-parameters of
-the type `exec::arg_type<T>` for each `T` wrapped inside InputType . If the
-aggregation function has non-default null behavior, the in-parameters of
-toIntermediate() are of the type `exec::optional_arg_type<T>` instead.
+converts a raw input to an intermediate state. If defined, this function is used
+in query plans that abandon the partial aggregation step. If the aggregation
+function has default-null behavior, the toIntermediate() function has an
+out-parameter of the type `exec::out_type<IntermediateType>&` followed by
+in-parameters of the type `exec::arg_type<T>` for each `T` wrapped inside
+InputType . If the aggregation function has non-default null behavior, the
+in-parameters of toIntermediate() are of the type `exec::optional_arg_type<T>`
+instead.
 
 When `T` is a primitive type except Varchar and Varbinary, `exec::arg_type<T>`
 is simply `T` itself and `exec::out_type<T>` is `T&`. `exec::optional_arg_type<T>`

--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -513,7 +513,7 @@ NullableVariadicView, and NullFreeVariadicView, supports the following:
 
 - VariadicView<T>::Iterator end() : iterator indicating end of iteration.
 
-- bool mayHaveNulls() : a check on the nullity of the arugments (note this takes time proportional to the number of arguments). When it returns false, there are definitely no nulls, a true does not guarantee null existence.
+- bool mayHaveNulls() : a check on the nullity of the arguments (note this takes time proportional to the number of arguments). When it returns false, there are definitely no nulls, a true does not guarantee null existence.
 
 - VariadicView<T>::SkipNullsContainer SkipNulls() : return an iterable container that provides direct access to each argument with a non-null value.
 

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -65,7 +65,7 @@ the timestamp, which is less than 1 second. Valid range of nanoseconds is [0, 10
 Timestamps before the epoch are specified using negative values for the seconds.
 Examples:
 
-* Timestamp(0, 0) represents 1970-01-0 T00:00:00 (epoch).
+* Timestamp(0, 0) represents 1970-01-01 T00:00:00 (epoch).
 * Timestamp(10*24*60*60 + 125, 0) represents 1970-01-11 00:02:05 (10 days 125 seconds after epoch).
 * Timestamp(19524*24*60*60 + 500, 38726411) represents 2023-06-16 08:08:20.038726411
   (19524 days 500 seconds 38726411 nanoseconds after epoch).
@@ -201,7 +201,7 @@ subnet range. This type can be used in IP subnet functions.
 Example:
 
 In this example the first 32 bits(*FFFF:FFFF*) represents the network prefix.
-As a result the IPPREFIX object stores *FFFF:FFFF::* and the length 32 for both of these IPPREFIX objects. 
+As a result the IPPREFIX object stores *FFFF:FFFF::* and the length 32 for both of these IPPREFIX objects.
 
 ::
 


### PR DESCRIPTION
Summary: Several mispellings and one incorrect datetime.

Differential Revision: D69800176


