### PR TITLE
feat: Add config to throw exception for duplicate keys in Spark map_concat function

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -505,6 +505,12 @@ class QueryConfig {
   static constexpr const char* kShuffleCompressionKind =
       "shuffle_compression_codec";
 
+  /// If a key is found in multiple given maps, by default that key's value in
+  /// the resulting map comes from the last one of those maps. When true, throw
+  /// exception on duplicate map key.
+  static constexpr const char* kThrowExceptionOnDuplicateMapKeys =
+      "throw_exception_on_duplicate_map_keys";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -928,6 +934,10 @@ class QueryConfig {
 
   std::string shuffleCompressionKind() const {
     return get<std::string>(kShuffleCompressionKind, "none");
+  }
+
+  bool throwExceptionOnDuplicateMapKeys() const {
+    return get<bool>(kThrowExceptionOnDuplicateMapKeys, false);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -161,6 +161,11 @@ Generic Configuration
      - Specifies the compression algorithm type to compress the shuffle data to
        trade CPU for network IO efficiency. The supported compression codecs
        are: zlib, snappy, lzo, zstd, lz4 and gzip. none means no compression.
+   * - throw_exception_on_duplicate_map_keys
+     - bool
+     - false
+     - By default, if a key is found in multiple given maps, that key's value in the resulting map comes from the last one of those maps.
+       If true, throws exception when duplicate keys are found. This configuration is needed by Spark functions `CreateMap`, `MapFromArrays`, `MapFromEntries`, `StringToMap`, `MapConcat`, `TransformKeys`.
 
 .. _expression-evaluation-conf:
 

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -14,6 +14,19 @@ Map Functions
 
         SELECT map(array(1, 2), array(3, 4)); -- {[1, 2] -> [3, 4]}
 
+.. spark:function:: map_concat(map1(K,V), map2(K,V), ..., mapN(K,V)) -> map(K,V)
+
+    Returns the union of all the given maps. If a key is found in multiple given maps,
+    by default that key's value in the resulting map comes from the last one of those maps.
+    If configuration `throw_exception_on_duplicate_map_keys` is set true, throws exception
+    for duplicate keys. Allows single map input.  ::
+
+        SELECT map_concat(map(1, 'a', 2, 'b'), map(3, 'c')); -- {1 -> 'a', 2 -> 'b', 3 -> 'c'}
+        SELECT map_concat(map(1, 'a', 2, 'b'), map(3, NULL)); -- {1 -> 'a', 2 -> 'b', 3 -> NULL}
+        SELECT map_concat(map(1, 'a', 2, 'b')); -- {1 -> 'a', 2 -> 'b'}
+        SELECT map_concat(map(1, 'a', 2, 'b'), map(3, 'c', 2, 'd')); -- {1 -> 'a', 2 -> 'd', 3 -> 'c'} (LAST_WIN behavior)
+        SELECT map_concat(map(1, 'a', 2, 'b'), map(3, 'c', 2, 'd')); --  "Duplicate map key 2 was found" (EXCEPTION behavior)
+
 .. spark:function:: map_entries(map(K,V)) -> array(row(K,V))
 
     Returns an array of all entries in the given map. ::

--- a/velox/functions/lib/MapConcat.h
+++ b/velox/functions/lib/MapConcat.h
@@ -22,6 +22,8 @@ namespace facebook::velox::functions {
 
 void registerMapConcatFunction(const std::string& name);
 
+void registerMapConcatAllowSingleArg(const std::string& name);
+
 void registerMapConcatEmptyNullsFunction(const std::string& name);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/lib/MapConcat.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/sparksql/Size.h"
 
@@ -31,6 +32,8 @@ void registerSparkMapFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, prefix + "map_keys");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, prefix + "map_values");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, prefix + "map_zip_with");
+
+  registerMapConcatAllowSingleArg(prefix + "map_concat");
 }
 
 namespace sparksql {

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   LeastGreatestTest.cpp
   MakeDecimalTest.cpp
   MakeTimestampTest.cpp
+  MapConcatTest.cpp
   MapTest.cpp
   MaskTest.cpp
   MightContainTest.cpp

--- a/velox/functions/sparksql/tests/MapConcatTest.cpp
+++ b/velox/functions/sparksql/tests/MapConcatTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class MapConcatTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename TKey, typename TValue>
+  static std::vector<TKey> mapKeys(const std::map<TKey, TValue>& m) {
+    std::vector<TKey> keys;
+    keys.reserve(m.size());
+    for (const auto& [key, value] : m) {
+      keys.push_back(key);
+    }
+    return keys;
+  }
+
+  template <typename TKey, typename TValue>
+  static std::vector<TValue> mapValues(const std::map<TKey, TValue>& m) {
+    std::vector<TValue> values;
+    values.reserve(m.size());
+    for (const auto& [key, value] : m) {
+      values.push_back(value);
+    }
+    return values;
+  }
+
+  MapVectorPtr makeMapVector(
+      vector_size_t size,
+      const std::map<std::string, int32_t>& m,
+      std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
+    std::vector<std::string> keys = mapKeys(m);
+    std::vector<int32_t> values = mapValues(m);
+    return vectorMaker_.mapVector<StringView, int32_t>(
+        size,
+        [&](vector_size_t /*row*/) { return keys.size(); },
+        [&](vector_size_t /*mapRow*/, vector_size_t row) {
+          return StringView(keys[row]);
+        },
+        [&](vector_size_t mapRow, vector_size_t row) {
+          return mapRow % 11 + values[row];
+        },
+        isNullAt);
+  }
+
+  template <typename TKey, typename TValue>
+  std::map<TKey, TValue> concat(
+      const std::map<TKey, TValue>& a,
+      const std::map<TKey, TValue>& b) {
+    std::map<TKey, TValue> result;
+    result.insert(b.begin(), b.end());
+    result.insert(a.begin(), a.end());
+    return result;
+  }
+};
+
+TEST_F(MapConcatTest, duplicateKeys) {
+  vector_size_t size = 1'000;
+
+  std::map<std::string, int32_t> a = {
+      {"a1", 1}, {"a2", 2}, {"a3", 3}, {"a4", 4}};
+  std::map<std::string, int32_t> b = {
+      {"b1", 1}, {"b2", 2}, {"b3", 3}, {"b4", 4}, {"a2", -1}};
+  auto aMap = makeMapVector(size, a);
+  auto bMap = makeMapVector(size, b);
+
+  // By default, if a key is found in multiple given maps, that key's value in
+  // the resulting map comes from the last one of those maps.
+  std::map<std::string, int32_t> ab = concat(a, b);
+  auto expectedMap = makeMapVector(size, ab);
+  auto result =
+      evaluate<MapVector>("map_concat(c0, c1)", makeRowVector({aMap, bMap}));
+  velox::test::assertEqualVectors(expectedMap, result);
+
+  std::map<std::string, int32_t> ba = concat(b, a);
+  expectedMap = makeMapVector(size, ba);
+  result =
+      evaluate<MapVector>("map_concat(c1, c0)", makeRowVector({aMap, bMap}));
+  velox::test::assertEqualVectors(expectedMap, result);
+
+  result =
+      evaluate<MapVector>("map_concat(c0, c1)", makeRowVector({aMap, aMap}));
+  velox::test::assertEqualVectors(aMap, result);
+
+  // Throws exception when duplicate keys are found.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kThrowExceptionOnDuplicateMapKeys, "true"},
+  });
+  VELOX_ASSERT_USER_THROW(
+      evaluate<MapVector>("map_concat(c0, c1)", makeRowVector({aMap, bMap})),
+      "Duplicate map key a2 was found");
+}
+
+TEST_F(MapConcatTest, singleArg) {
+  vector_size_t size = 1'000;
+
+  std::map<std::string, int32_t> a = {{"a1", 1}, {"a2", 2}, {"a3", 3}};
+  auto aMap = makeMapVector(size, a, nullEvery(5));
+
+  auto expectedMap =
+      makeMapVector(size, a, [](vector_size_t row) { return row % 5 == 0; });
+
+  auto result = evaluate<MapVector>("map_concat(c0)", makeRowVector({aMap}));
+  velox::test::assertEqualVectors(expectedMap, result);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Spark has two policies `EXCEPTION` and `LAST_WIN` to deal with duplicate keys 
in map functions like CreateMap, MapFromArrays, MapFromEntries, StringToMap, 
MapConcat and TransformKeys.

EXCEPTION behaviour: throws exception when a  duplicate key is found in map.
LAST_WIN behaviour: the result value comes from the last inserted element.

Velox by default treats duplicates keys as `LAST_WIN` policy. This PR adds 
config  `throw_exception_on_duplicate_map_keys` to enable/disable the 
behaviour of throwing exception when duplicate keys are found in map. 

Currently, this flag is being utilised in MapConcat function,  and single map input
is allowed for Spark.

Based on https://github.com/facebookincubator/velox/pull/9562 from @Surbhi-Vijay.