### PR TITLE
feat(python): TPC-H dbgen

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -108,8 +108,9 @@ PlanBuilder& PlanBuilder::tableScan(
 
 PlanBuilder& PlanBuilder::tpchTableScan(
     tpch::Table table,
-    std::vector<std::string>&& columnNames,
-    double scaleFactor) {
+    std::vector<std::string> columnNames,
+    double scaleFactor,
+    std::string_view connectorId) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignmentsMap;
   std::vector<TypePtr> outputTypes;
@@ -127,7 +128,7 @@ PlanBuilder& PlanBuilder::tpchTableScan(
   return TableScanBuilder(*this)
       .outputType(rowType)
       .tableHandle(std::make_shared<connector::tpch::TpchTableHandle>(
-          std::string(kTpchDefaultConnectorId), table, scaleFactor))
+          std::string(connectorId), table, scaleFactor))
       .assignments(assignmentsMap)
       .endTableScan();
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -178,10 +178,12 @@ class PlanBuilder {
   /// and scale factor.
   /// @param columnNames The columns to be returned from that table.
   /// @param scaleFactor The TPC-H scale factor.
+  /// @param connectorId The TPC-H connector id.
   PlanBuilder& tpchTableScan(
       tpch::Table table,
-      std::vector<std::string>&& columnNames,
-      double scaleFactor = 1);
+      std::vector<std::string> columnNames,
+      double scaleFactor = 1,
+      std::string_view connectorId = kTpchDefaultConnectorId);
 
   /// Helper class to build a custom TableScanNode.
   /// Uses a planBuilder instance to get the next plan id, memory pool, and

--- a/velox/py/plan_builder/plan_builder.cpp
+++ b/velox/py/plan_builder/plan_builder.cpp
@@ -175,5 +175,30 @@ PYBIND11_MODULE(plan_builder, m) {
           right_plan_node: The plan node defined the subplan to join with.
           output: List of columns to be projected out of the join.
           filter: Optional join filter expression.
+      )"))
+      .def(
+          "tpch_gen",
+          &velox::py::PyPlanBuilder::tpchGen,
+          py::arg("table_name"),
+          py::arg("columns") = std::vector<std::string>{},
+          py::arg("scale_factor") = 1,
+          py::arg("num_parts") = 1,
+          py::arg("connector_id") = "tpch",
+          py::doc(R"(
+        Generates TPC-H data on the fly using dbgen. Note that generating data
+        on the fly is not terribly efficient, so for performance evaluation one
+        should generate data using this node, write it to output storage files,
+        (Parquet, ORC, or similar), then benchmark a query plan that reads
+        those files.
+
+        Args:
+          table_name: The TPC-H table name to generate data for.
+          columns: The columns from `table_name` to generate data for. If
+                   empty (the default), generate data for all columns.
+          scale_factor: TPC-H scale factor to use - controls the amount of
+                        data generated.
+          num_parts: How many splits to generate. This controls the parallelism
+                     and the number of output files to be generated.
+          connector_id: ID of the connector to use for this scan.
       )"));
 }

--- a/velox/py/runner/PyLocalRunner.cpp
+++ b/velox/py/runner/PyLocalRunner.cpp
@@ -95,9 +95,9 @@ py::iterator PyLocalRunner::execute() {
   }
 
   // Add any files passed by the client during plan building.
-  for (const auto& [scanId, scanPair] : *scanFiles_) {
-    for (const auto& inputFile : scanPair.second) {
-      addFileSplit(inputFile, scanId, scanPair.first);
+  for (auto& [scanId, splits] : *scanFiles_) {
+    for (auto& split : splits) {
+      cursor_->task()->addSplit(scanId, exec::Split(std::move(split)));
     }
     cursor_->task()->noMoreSplits(scanId);
   }


### PR DESCRIPTION
Summary:
Support generation of TPC-H datasets using the Python API. The idea is
to use this as a pre-step that generates datasets in the target file format,
then use the generates file for benchmarks.

Differential Revision: D69809891


