### PR TITLE
fix: Fix NullHandlingMode for Spark min/max agg function

### DIFF
--- a/velox/functions/lib/aggregates/Compare.cpp
+++ b/velox/functions/lib/aggregates/Compare.cpp
@@ -22,14 +22,8 @@ int32_t compare(
     const SingleValueAccumulator* accumulator,
     const DecodedVector& decoded,
     vector_size_t index,
-    CompareFlags::NullHandlingMode nullHandlingMode) {
-  static const CompareFlags kCompareFlags{
-      true, // nullsFirst
-      true, // ascending
-      false, // equalsOnly
-      nullHandlingMode};
-
-  auto result = accumulator->compare(decoded, index, kCompareFlags);
+    CompareFlags compareFlags) {
+  auto result = accumulator->compare(decoded, index, compareFlags);
   VELOX_USER_CHECK(
       result.has_value(),
       fmt::format(

--- a/velox/functions/lib/aggregates/Compare.h
+++ b/velox/functions/lib/aggregates/Compare.h
@@ -36,5 +36,5 @@ int32_t compare(
     const velox::functions::aggregate::SingleValueAccumulator* accumulator,
     const DecodedVector& decoded,
     vector_size_t index,
-    CompareFlags::NullHandlingMode nullHandlingMode);
+    CompareFlags compareFlags);
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -396,6 +396,12 @@ class MinMaxAggregateBase : public exec::Aggregate {
       return;
     }
 
+    static const CompareFlags kCompareFlags{
+        true, // nullsFirst
+        true, // ascending
+        false, // equalsOnly
+        nullHandlingMode};
+
     rows.applyToSelected([&](vector_size_t i) {
       if (velox::functions::checkNestedNulls(
               decoded, indices, i, throwOnNestedNulls_)) {
@@ -404,7 +410,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(groups[i]);
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, i, nullHandlingMode))) {
+          compareTest(compare(accumulator, decoded, i, kCompareFlags))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
@@ -421,6 +427,11 @@ class MinMaxAggregateBase : public exec::Aggregate {
     DecodedVector decoded(*arg, rows, true);
     auto indices = decoded.indices();
     auto baseVector = decoded.base();
+    static const CompareFlags kCompareFlags{
+        true, // nullsFirst
+        true, // ascending
+        false, // equalsOnly
+        nullHandlingMode};
 
     if (decoded.isConstantMapping()) {
       if (velox::functions::checkNestedNulls(
@@ -430,7 +441,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(group);
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, 0, nullHandlingMode))) {
+          compareTest(compare(accumulator, decoded, 0, kCompareFlags))) {
         accumulator->write(baseVector, indices[0], allocator_);
       }
       return;
@@ -443,7 +454,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
         return;
       }
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, i, nullHandlingMode))) {
+          compareTest(compare(accumulator, decoded, i, kCompareFlags))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });

--- a/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp
@@ -396,7 +396,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
       return;
     }
 
-    static const CompareFlags kCompareFlags{
+    const CompareFlags compareFlags{
         true, // nullsFirst
         true, // ascending
         false, // equalsOnly
@@ -410,7 +410,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(groups[i]);
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, i, kCompareFlags))) {
+          compareTest(compare(accumulator, decoded, i, compareFlags))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
@@ -427,7 +427,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
     DecodedVector decoded(*arg, rows, true);
     auto indices = decoded.indices();
     auto baseVector = decoded.base();
-    static const CompareFlags kCompareFlags{
+    const CompareFlags compareFlags{
         true, // nullsFirst
         true, // ascending
         false, // equalsOnly
@@ -441,7 +441,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(group);
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, 0, kCompareFlags))) {
+          compareTest(compare(accumulator, decoded, 0, compareFlags))) {
         accumulator->write(baseVector, indices[0], allocator_);
       }
       return;
@@ -454,7 +454,7 @@ class MinMaxAggregateBase : public exec::Aggregate {
         return;
       }
       if (!accumulator->hasValue() ||
-          compareTest(compare(accumulator, decoded, i, kCompareFlags))) {
+          compareTest(compare(accumulator, decoded, i, compareFlags))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
@@ -68,20 +68,19 @@ struct Comparator {
       bool /* isFirstValue */) {
     // SingleValueAccumulator::compare has the semantics of accumulator value
     // is less than vector value.
+    static const CompareFlags kCompareFlags{
+        true, // nullsFirst
+        true, // ascending
+        false, // equalsOnly
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate};
     if constexpr (greaterThan) {
       return !accumulator->hasValue() ||
           functions::aggregate::compare(
-              accumulator,
-              newComparisons,
-              index,
-              CompareFlags::NullHandlingMode::kNullAsIndeterminate) < 0;
+              accumulator, newComparisons, index, kCompareFlags) < 0;
     } else {
       return !accumulator->hasValue() ||
           functions::aggregate::compare(
-              accumulator,
-              newComparisons,
-              index,
-              CompareFlags::NullHandlingMode::kNullAsIndeterminate) > 0;
+              accumulator, newComparisons, index, kCompareFlags) > 0;
     }
   }
 };

--- a/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxAggregationTest.cpp
@@ -195,17 +195,17 @@ TEST_F(MinMaxAggregationTest, array) {
   auto data = makeRowVector({
       makeNullableArrayVector<int64_t>({
           {1, 2, 3},
-          {2, std::nullopt},
-          {6, 7, 8},
+          {1, std::nullopt},
+          {1, 7, 8},
       }),
   });
 
   auto expected = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
+      makeNullableArrayVector<int64_t>({
+          {1, std::nullopt},
       }),
       makeArrayVector<int64_t>({
-          {6, 7, 8},
+          {1, 7, 8},
       }),
   });
 
@@ -214,8 +214,16 @@ TEST_F(MinMaxAggregationTest, array) {
   data = makeRowVector({
       makeNullableArrayVector<int64_t>({
           {1, 2, 3},
-          {3, 2},
-          {6, 7, 8},
+          {2, 3},
+          {3, 7, 8},
+      }),
+  });
+  expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int64_t>({
+          {3, 7, 8},
       }),
   });
   testAggregations({data}, {}, {min("c0"), max("c0")}, {expected});


### PR DESCRIPTION
This issue occurs because `kCompareFlags` in `compare` function is initialized with `kNullAsIndeterminate`.
https://github.com/facebookincubator/velox/blob/d118b1ed4309511b2a8a7730976f55800bf8f46d/velox/functions/lib/aggregates/MinMaxAggregateBase.cpp#L610
The fuzzer detects this issue when min(string) is evaluated before min(array_with_nulls).
UT is updated to reflect this case.
Fix: #11601.