### PR TITLE
feat(fuzzer): Allow functions to be tested only with sorted input in aggregation fuzzer

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.h
+++ b/velox/exec/fuzzer/AggregationFuzzer.h
@@ -37,6 +37,7 @@ namespace facebook::velox::exec::test {
 void aggregateFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t seed,
+    const std::unordered_set<std::string>& functionsRequireSortedInput,
     const std::unordered_map<std::string, std::shared_ptr<ResultVerifier>>&
         orderDependentFunctions,
     const std::unordered_map<std::string, std::shared_ptr<InputGenerator>>&

--- a/velox/exec/fuzzer/AggregationFuzzerOptions.h
+++ b/velox/exec/fuzzer/AggregationFuzzerOptions.h
@@ -29,6 +29,9 @@ struct AggregationFuzzerOptions {
   /// Set of functions to not test.
   std::unordered_set<std::string> skipFunctions;
 
+  /// Set of functions that should only be tested with sorted input.
+  std::unordered_set<std::string> functionsRequireSortedInput;
+
   /// Set of functions whose results are non-deterministic. These can be
   /// order-dependent functions whose results depend on the order of input
   /// rows, or functions that return complex-typed results containing

--- a/velox/exec/fuzzer/AggregationFuzzerRunner.h
+++ b/velox/exec/fuzzer/AggregationFuzzerRunner.h
@@ -124,6 +124,7 @@ class AggregationFuzzerRunner {
     facebook::velox::exec::test::aggregateFuzzer(
         filteredSignatures,
         seed,
+        options.functionsRequireSortedInput,
         options.customVerificationFunctions,
         options.customInputGenerators,
         aggregationFunctionDataSpecs,

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -133,6 +133,10 @@ int main(int argc, char** argv) {
       "any_value",
   };
 
+  static const std::unordered_set<std::string> functionsRequireSortedInput = {
+      "tdigest_agg",
+  };
+
   using facebook::velox::exec::test::ApproxDistinctResultVerifier;
   using facebook::velox::exec::test::ApproxPercentileResultVerifier;
   using facebook::velox::exec::test::ArbitraryResultVerifier;
@@ -195,6 +199,7 @@ int main(int argc, char** argv) {
   Options options;
   options.onlyFunctions = FLAGS_only;
   options.skipFunctions = skipFunctions;
+  options.functionsRequireSortedInput = functionsRequireSortedInput;
   options.customVerificationFunctions = customVerificationFunctions;
   options.customInputGenerators =
       facebook::velox::exec::test::getCustomInputGenerators();


### PR DESCRIPTION
Summary: The tdigest_agg() function needs to be tested only with input of determined order so that Velox result is comparable with Presto's. This is because different ordering of input values affects the content in TDigest. Therefore, this diff makes it possible to specify a set of functions to be tested only with ordered inputs in aggregation fuzzer. Aggregation fuzzer will then use `order by arg0, arg1, ...` inside the aggregaiton function calls of this function.

Differential Revision: D69886108


