### PR TITLE
refactor: Support parameters in custom type resolving

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -141,7 +141,7 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
     case LogicalTypeId::TIMESTAMP:
       return TIMESTAMP();
     case LogicalTypeId::TIMESTAMP_TZ: {
-      if (auto customType = getCustomType("TIMESTAMP WITH TIME ZONE")) {
+      if (auto customType = getCustomType("TIMESTAMP WITH TIME ZONE", {})) {
         return customType;
       }
       [[fallthrough]];
@@ -182,14 +182,14 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
       return ROW(std::move(names), std::move(types));
     }
     case LogicalTypeId::UUID: {
-      if (auto customType = getCustomType("UUID")) {
+      if (auto customType = getCustomType("UUID", {})) {
         return customType;
       }
       [[fallthrough]];
     }
     case LogicalTypeId::USER: {
       const auto name = ::duckdb::UserType::GetTypeName(type);
-      if (auto customType = getCustomType(name)) {
+      if (auto customType = getCustomType(name, {})) {
         return customType;
       }
       [[fallthrough]];

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -56,7 +56,8 @@ class TypeFactories : public CustomTypeFactories {
  public:
   TypeFactories(const TypePtr& type) : type_(type) {}
 
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return type_;
   }
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -55,7 +55,8 @@ class FancyIntType : public OpaqueType {
 
 class FancyIntTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return FancyIntType::get();
   }
 
@@ -145,7 +146,8 @@ struct FancyPlusFunction {
 
 class AlwaysFailingTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     VELOX_UNSUPPORTED();
   }
 
@@ -256,7 +258,7 @@ TEST_F(CustomTypeTest, nullConstant) {
 
   auto names = getCustomTypeNames();
   for (const auto& name : names) {
-    auto type = getCustomType(name);
+    auto type = getCustomType(name, {});
     auto null = BaseVector::createNullConstant(type, 10, pool());
     EXPECT_TRUE(null->isConstantEncoding());
     EXPECT_TRUE(type->equivalent(*null->type()));

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -81,8 +81,8 @@ std::string typeName(const TypePtr& type) {
       if (isHyperLogLogType(type)) {
         return "HyperLogLog";
       }
-      if (isTDigestType(type)) {
-        return "TDigest";
+      if (*type == *TDIGEST(DOUBLE())) {
+        return "tdigest(double)";
       }
       return "varbinary";
     case TypeKind::TIMESTAMP:

--- a/velox/functions/prestosql/tests/TDigestCastTest.cpp
+++ b/velox/functions/prestosql/tests/TDigestCastTest.cpp
@@ -24,24 +24,24 @@ class TDigestCastTest : public functions::test::CastBaseTest {};
 TEST_F(TDigestCastTest, toTDigest) {
   testCast<StringView, StringView>(
       VARBINARY(),
-      TDIGEST(),
+      TDIGEST(DOUBLE()),
       {"aaa"_sv, ""_sv, std::nullopt},
       {"aaa"_sv, ""_sv, std::nullopt});
   testCast<StringView, StringView>(
       VARBINARY(),
-      TDIGEST(),
+      TDIGEST(DOUBLE()),
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 }
 
 TEST_F(TDigestCastTest, fromTDigest) {
   testCast<StringView, StringView>(
-      TDIGEST(),
+      TDIGEST(DOUBLE()),
       VARBINARY(),
       {"aaa"_sv, ""_sv, std::nullopt},
       {"aaa"_sv, ""_sv, std::nullopt});
   testCast<StringView, StringView>(
-      TDIGEST(),
+      TDIGEST(DOUBLE()),
       VARBINARY(),
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt});

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -57,7 +57,7 @@ TEST_F(TypeOfTest, basic) {
 
   EXPECT_EQ("HyperLogLog", typeOf(HYPERLOGLOG()));
 
-  EXPECT_EQ("TDigest", typeOf(TDIGEST()));
+  EXPECT_EQ("tdigest(double)", typeOf(TDIGEST(DOUBLE())));
 
   EXPECT_EQ("unknown", typeOf(UNKNOWN()));
 

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -73,7 +73,8 @@ using HyperLogLog = CustomType<HyperLogLogT>;
 
 class HyperLogLogTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return HYPERLOGLOG();
   }
 

--- a/velox/functions/prestosql/types/IPAddressType.cpp
+++ b/velox/functions/prestosql/types/IPAddressType.cpp
@@ -258,7 +258,8 @@ class IPAddressTypeFactories : public CustomTypeFactories {
  public:
   IPAddressTypeFactories() = default;
 
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return IPADDRESS();
   }
 

--- a/velox/functions/prestosql/types/IPPrefixType.cpp
+++ b/velox/functions/prestosql/types/IPPrefixType.cpp
@@ -183,7 +183,8 @@ class IPPrefixCastOperator : public exec::CastOperator {
 
 class IPPrefixTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return IPPrefixType::get();
   }
 

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -1248,7 +1248,8 @@ class JsonTypeFactories : public CustomTypeFactories {
  public:
   JsonTypeFactories() = default;
 
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return JSON();
   }
 

--- a/velox/functions/prestosql/types/TDigestType.cpp
+++ b/velox/functions/prestosql/types/TDigestType.cpp
@@ -17,6 +17,18 @@
 
 namespace facebook::velox {
 
+folly::dynamic TDigestType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "Type";
+  obj["type"] = name();
+  folly::dynamic children = folly::dynamic::array;
+  for (auto& param : parameters_) {
+    children.push_back(param.type->serialize());
+  }
+  obj["cTypes"] = children;
+  return obj;
+}
+
 void registerTDigestType() {
   registerCustomType("tdigest", std::make_unique<const TDigestTypeFactories>());
 }

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -151,7 +151,8 @@ using TimestampWithTimezone = CustomType<TimestampWithTimezoneT, true>;
 
 class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return TIMESTAMP_WITH_TIME_ZONE();
   }
 

--- a/velox/functions/prestosql/types/UuidType.cpp
+++ b/velox/functions/prestosql/types/UuidType.cpp
@@ -140,7 +140,8 @@ class UuidTypeFactories : public CustomTypeFactories {
  public:
   UuidTypeFactories() = default;
 
-  TypePtr getType() const override {
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return UUID();
   }
 

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_test(velox_presto_types_test velox_presto_types_test)
 target_link_libraries(
   velox_presto_types_test
   velox_presto_types
+  velox_type_parser
   Folly::folly
   GTest::gtest
   GTest::gtest_main

--- a/velox/functions/prestosql/types/tests/TDigestTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TDigestTypeTest.cpp
@@ -15,8 +15,10 @@
  */
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+#include "velox/type/parser/TypeParser.h"
 
 namespace facebook::velox::test {
+namespace {
 
 class TDigestTypeTest : public testing::Test, public TypeTestBase {
  public:
@@ -26,16 +28,22 @@ class TDigestTypeTest : public testing::Test, public TypeTestBase {
 };
 
 TEST_F(TDigestTypeTest, basic) {
-  ASSERT_STREQ(TDIGEST()->name(), "TDIGEST");
-  ASSERT_STREQ(TDIGEST()->kindName(), "VARBINARY");
-  ASSERT_TRUE(TDIGEST()->parameters().empty());
-  ASSERT_EQ(TDIGEST()->toString(), "TDIGEST");
+  ASSERT_STREQ(TDIGEST(DOUBLE())->name(), "TDIGEST");
+  ASSERT_STREQ(TDIGEST(DOUBLE())->kindName(), "VARBINARY");
+  ASSERT_EQ(TDIGEST(DOUBLE())->parameters().size(), 1);
+  ASSERT_EQ(TDIGEST(DOUBLE())->toString(), "TDIGEST(DOUBLE)");
 
   ASSERT_TRUE(hasType("TDIGEST"));
-  ASSERT_EQ(*getType("TDIGEST", {}), *TDIGEST());
+  ASSERT_EQ(*getType("TDIGEST", {TypeParameter(DOUBLE())}), *TDIGEST(DOUBLE()));
 }
 
 TEST_F(TDigestTypeTest, serde) {
-  testTypeSerde(TDIGEST());
+  testTypeSerde(TDIGEST(DOUBLE()));
 }
+
+TEST_F(TDigestTypeTest, parse) {
+  ASSERT_EQ(*parseType("tdigest(double)"), *TDIGEST(DOUBLE()));
+}
+
+} // namespace
 } // namespace facebook::velox::test

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -87,7 +87,9 @@ class OpaqueCustomTypeRegister {
    public:
     TypeFactory() = default;
 
-    TypePtr getType() const override {
+    TypePtr getType(
+        const std::vector<TypeParameter>& parameters) const override {
+      VELOX_CHECK(parameters.empty());
       return singletonTypePtr();
     }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2024,7 +2024,8 @@ class CustomTypeFactories {
   virtual ~CustomTypeFactories();
 
   /// Returns a shared pointer to the custom type.
-  virtual TypePtr getType() const = 0;
+  virtual TypePtr getType(
+      const std::vector<TypeParameter>& parameters) const = 0;
 
   /// Returns a shared pointer to the custom cast operator. If a custom type
   /// should be treated as its underlying native type during type castings,
@@ -2118,7 +2119,9 @@ std::unordered_set<std::string> getCustomTypeNames();
 
 /// Returns an instance of a custom type with the specified name and specified
 /// child types.
-TypePtr getCustomType(const std::string& name);
+TypePtr getCustomType(
+    const std::string& name,
+    const std::vector<TypeParameter>& parameters);
 
 /// Removes custom type from the registry if exists. Returns true if type was
 /// removed, false if type didn't exist.

--- a/velox/type/parser/ParserUtil.cpp
+++ b/velox/type/parser/ParserUtil.cpp
@@ -37,6 +37,20 @@ TypePtr typeFromString(
   return inferredType;
 }
 
+TypePtr customTypeWithChildren(
+    const std::string& name,
+    const std::vector<TypePtr>& children) {
+  std::vector<TypeParameter> params;
+  params.reserve(children.size());
+  for (auto& child : children) {
+    params.emplace_back(child);
+  }
+  auto type = getType(name, params);
+  VELOX_CHECK_NOT_NULL(
+      type, "Failed to parse custom type with children [{}]", name);
+  return type;
+}
+
 std::pair<std::string, std::shared_ptr<const Type>> inferTypeWithSpaces(
     std::vector<std::string>& words,
     bool cannotHaveFieldName = false) {

--- a/velox/type/parser/ParserUtil.h
+++ b/velox/type/parser/ParserUtil.h
@@ -27,6 +27,10 @@ TypePtr typeFromString(
     const std::string& type,
     bool failIfNotRegistered = true);
 
+TypePtr customTypeWithChildren(
+    const std::string& name,
+    const std::vector<TypePtr>& children);
+
 /// Convert words with spaces to a Velox type.
 /// First check if all the words are a Velox type.
 /// Then check if the first word is a field name and the remaining words are a

--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -39,7 +39,7 @@
 %token YYEOF         0
 
 %nterm <std::shared_ptr<const Type>> type type_single_word 
-%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type
+%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
 %nterm <std::pair<std::string, std::shared_ptr<const Type>>> named_type
@@ -68,6 +68,7 @@ special_type : array_type     { $$ = $1; }
              | function_type  { $$ = $1; }
              | variable_type  { $$ = $1; }
              | decimal_type   { $$ = $1; }
+             | custom_type_with_children { $$ = $1; }
 
 /* 
  * Types with spaces have at least two words. They are joined in an 
@@ -111,6 +112,8 @@ function_type : FUNCTION LPAREN type_list RPAREN { auto returnType = $3.back(); 
 
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = ROW(std::move($3.names), std::move($3.types)); }
          ;
+
+custom_type_with_children : WORD LPAREN type_list RPAREN { $$ = customTypeWithChildren($1, $3); }
 
 /* Consecutive list of types, separated by a comma. */
 type_list : type                   { $$.push_back($1); }

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -46,7 +46,8 @@ class TypeFactories : public CustomTypeFactories {
  public:
   TypeFactories(const TypePtr& type) : type_(type) {}
 
-  TypePtr getType() const override {
+  TypePtr getType(
+      const std::vector<TypeParameter>& /*parameters*/) const override {
     return type_;
   }
 
@@ -155,7 +156,7 @@ TEST_F(TypeParserTest, invalidType) {
   VELOX_ASSERT_THROW(
       parseType("blah()"),
       "Failed to parse type [blah()]. "
-      "syntax error, unexpected LPAREN, expecting WORD");
+      "syntax error, unexpected RPAREN");
 
   VELOX_ASSERT_THROW(parseType("array()"), "Failed to parse type [array()]");
 
@@ -165,9 +166,7 @@ TEST_F(TypeParserTest, invalidType) {
 
   // Ensure this is not treated as a row type.
   VELOX_ASSERT_THROW(
-      parseType("rowxxx(a)"),
-      "Failed to parse type [rowxxx(a)]. "
-      "syntax error, unexpected LPAREN, expecting WORD");
+      parseType("rowxxx(a)"), "Failed to parse type [a]. Type not registered.");
 }
 
 TEST_F(TypeParserTest, rowType) {

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -261,7 +261,7 @@ VectorPtr VectorFuzzer::fuzz(
     vectorSize += rand<uint32_t>(rng_) % 8;
   }
 
-  if (!inputGenerator && getCustomType(type->name())) {
+  if (!inputGenerator && customTypeExists(type->name())) {
     InputGeneratorConfig config{rand<uint32_t>(rng_), opts_.nullRatio};
     inputGenerator = getCustomTypeInputGenerator(type->name(), config);
   }


### PR DESCRIPTION
Summary:
Support `TypeParameter` when creating custom types.  For `tdigest` this
is not absolutely necessary, since the only parameter supported is `double`, but
it would be nice to have this ready so we can use it with `qdigest(T)`.

Differential Revision: D69879669


