### PR TITLE
refactor: migrate uses of legacy alias folly::io::CodecType

### DIFF
--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -25,36 +25,36 @@ std::unique_ptr<folly::compression::Codec> compressionKindToCodec(
     CompressionKind kind) {
   switch (static_cast<int32_t>(kind)) {
     case CompressionKind_NONE:
-      return getCodec(folly::io::CodecType::NO_COMPRESSION);
+      return getCodec(folly::compression::CodecType::NO_COMPRESSION);
     case CompressionKind_ZLIB:
-      return getCodec(folly::io::CodecType::ZLIB);
+      return getCodec(folly::compression::CodecType::ZLIB);
     case CompressionKind_SNAPPY:
-      return getCodec(folly::io::CodecType::SNAPPY);
+      return getCodec(folly::compression::CodecType::SNAPPY);
     case CompressionKind_ZSTD:
-      return getCodec(folly::io::CodecType::ZSTD);
+      return getCodec(folly::compression::CodecType::ZSTD);
     case CompressionKind_LZ4:
-      return getCodec(folly::io::CodecType::LZ4);
+      return getCodec(folly::compression::CodecType::LZ4);
     case CompressionKind_GZIP:
-      return getCodec(folly::io::CodecType::GZIP);
+      return getCodec(folly::compression::CodecType::GZIP);
     default:
       VELOX_UNSUPPORTED(
           "Not support {} in folly", compressionKindToString(kind));
   }
 }
 
-CompressionKind codecTypeToCompressionKind(folly::io::CodecType type) {
+CompressionKind codecTypeToCompressionKind(folly::compression::CodecType type) {
   switch (type) {
-    case folly::io::CodecType::NO_COMPRESSION:
+    case folly::compression::CodecType::NO_COMPRESSION:
       return CompressionKind_NONE;
-    case folly::io::CodecType::ZLIB:
+    case folly::compression::CodecType::ZLIB:
       return CompressionKind_ZLIB;
-    case folly::io::CodecType::SNAPPY:
+    case folly::compression::CodecType::SNAPPY:
       return CompressionKind_SNAPPY;
-    case folly::io::CodecType::ZSTD:
+    case folly::compression::CodecType::ZSTD:
       return CompressionKind_ZSTD;
-    case folly::io::CodecType::LZ4:
+    case folly::compression::CodecType::LZ4:
       return CompressionKind_LZ4;
-    case folly::io::CodecType::GZIP:
+    case folly::compression::CodecType::GZIP:
       return CompressionKind_GZIP;
     default:
       VELOX_UNSUPPORTED(

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -36,7 +36,7 @@ enum CompressionKind {
 std::unique_ptr<folly::compression::Codec> compressionKindToCodec(
     CompressionKind kind);
 
-CompressionKind codecTypeToCompressionKind(folly::io::CodecType type);
+CompressionKind codecTypeToCompressionKind(folly::compression::CodecType type);
 
 /// Get the name of the CompressionKind.
 std::string compressionKindToString(CompressionKind kind);

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -38,10 +38,10 @@ TEST_F(CompressionTest, testCompressionNames) {
 
 TEST_F(CompressionTest, compressionKindToCodec) {
   ASSERT_EQ(
-      folly::io::CodecType::NO_COMPRESSION,
+      folly::compression::CodecType::NO_COMPRESSION,
       compressionKindToCodec(CompressionKind::CompressionKind_NONE)->type());
   ASSERT_EQ(
-      folly::io::CodecType::LZ4,
+      folly::compression::CodecType::LZ4,
       compressionKindToCodec(CompressionKind::CompressionKind_LZ4)->type());
   EXPECT_THROW(
       compressionKindToCodec(CompressionKind::CompressionKind_LZO),

--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -170,7 +170,7 @@ FlushSizes flushStreams(
 
 FOLLY_ALWAYS_INLINE bool needCompression(
     const folly::compression::Codec& codec) {
-  return codec.type() != folly::io::CodecType::NO_COMPRESSION;
+  return codec.type() != folly::compression::CodecType::NO_COMPRESSION;
 }
 
 inline int64_t computeChecksum(

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -266,7 +266,7 @@ class RowSerializer : public IterativeVectorSerializer {
   }
 
   bool needCompression() const {
-    return codec_->type() != folly::io::CodecType::NO_COMPRESSION;
+    return codec_->type() != folly::compression::CodecType::NO_COMPRESSION;
   }
 
   void flushUncompressed(int32_t size, OutputStream* stream) {


### PR DESCRIPTION
Differential Revision: D69792285


