### PR TITLE
misc(json): Add jsoncons as a vendored library

### DIFF
--- a/velox/external/jsoncons/allocator_holder.hpp
+++ b/velox/external/jsoncons/allocator_holder.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_ALLOCATOR_HOLDER_HPP
+#define JSONCONS_ALLOCATOR_HOLDER_HPP
+
+namespace facebook::velox::jsoncons {
+
+template <typename Allocator>
+class allocator_holder
+{
+public:
+    using allocator_type = Allocator;
+private:
+    allocator_type alloc_;
+public:
+    allocator_holder() = default;
+    allocator_holder(const allocator_holder&)  = default;
+    allocator_holder(allocator_holder&&)  = default;
+    allocator_holder& operator=(const allocator_holder&) = delete;
+    allocator_holder(const allocator_type& alloc)
+        : alloc_(alloc)
+        {}
+    ~allocator_holder() = default;
+    
+    allocator_type get_allocator() const
+    {
+        return alloc_;
+    }
+};
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_ALLOCATOR_HOLDER_HPP

--- a/velox/external/jsoncons/allocator_set.hpp
+++ b/velox/external/jsoncons/allocator_set.hpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_ALLOCATOR_SET_HPP
+#define JSONCONS_ALLOCATOR_SET_HPP
+
+#include <memory>
+
+#include "velox/external/jsoncons/tag_type.hpp"
+
+namespace facebook::velox::jsoncons {
+
+template <typename Allocator,typename TempAllocator >
+class allocator_set
+{
+    Allocator result_alloc_;
+    TempAllocator temp_alloc_;
+public:
+    using allocator_type = Allocator;
+    using temp_allocator_type = TempAllocator;
+
+    allocator_set(const Allocator& alloc=Allocator(), 
+        const TempAllocator& temp_alloc=TempAllocator())
+        : result_alloc_(alloc), temp_alloc_(temp_alloc)
+    {
+    }
+
+    allocator_set(const allocator_set&)  = default;
+    allocator_set(allocator_set&&)  = default;
+    allocator_set& operator=(const allocator_set&)  = delete;
+    allocator_set& operator=(allocator_set&&)  = delete;
+    ~allocator_set() = default;
+
+    Allocator get_allocator() const {return result_alloc_;}
+    TempAllocator get_temp_allocator() const {return temp_alloc_;}
+};
+
+inline
+allocator_set<std::allocator<char>,std::allocator<char>> combine_allocators()
+{
+    return allocator_set<std::allocator<char>,std::allocator<char>>(std::allocator<char>(), std::allocator<char>());
+}
+
+template <typename Allocator>
+allocator_set<Allocator,std::allocator<char>> combine_allocators(const Allocator& alloc)
+{
+    return allocator_set<Allocator,std::allocator<char>>(alloc, std::allocator<char>());
+}
+
+template <typename Allocator,typename TempAllocator >
+allocator_set<Allocator,TempAllocator> combine_allocators(const Allocator& alloc, const TempAllocator& temp_alloc)
+{
+    return allocator_set<Allocator,TempAllocator>(alloc, temp_alloc);
+}
+
+template <typename TempAllocator >
+allocator_set<std::allocator<char>,TempAllocator> temp_allocator_only(const TempAllocator& temp_alloc)
+{
+    return allocator_set<std::allocator<char>,TempAllocator>(std::allocator<char>(), temp_alloc);
+}
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_ALLOCATOR_SET_HPP

--- a/velox/external/jsoncons/basic_json.hpp
+++ b/velox/external/jsoncons/basic_json.hpp
@@ -1,0 +1,4771 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_BASIC_JSON_HPP
+#define JSONCONS_BASIC_JSON_HPP
+
+#include <algorithm> // std::swap
+#include <cstring>
+#include <cstdint>
+#include <functional>
+#include <initializer_list> // std::initializer_list
+#include <istream> // std::basic_istream
+#include <limits> // std::numeric_limits
+#include <memory> // std::allocator
+#include <ostream> 
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <type_traits> // std::enable_if
+#include <typeinfo>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/allocator_set.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/version.hpp"
+#include "velox/external/jsoncons/json_array.hpp"
+#include "velox/external/jsoncons/json_decoder.hpp"
+#include "velox/external/jsoncons/json_encoder.hpp"
+#include "velox/external/jsoncons/json_error.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_fwd.hpp"
+#include "velox/external/jsoncons/json_object.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_reader.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/pretty_print.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/source.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/utility/heap_string.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+#if defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR)
+#include <memory_resource> // std::poymorphic_allocator
+#endif
+
+namespace facebook::velox::jsoncons { 
+
+    namespace extension_traits {
+
+        template <typename Container>
+        using 
+        container_array_iterator_type_t = decltype(Container::array_iterator_type);
+        template <typename Container>
+        using 
+        container_const_array_iterator_type_t = decltype(Container::const_array_iterator_type);
+        template <typename Container>
+        using 
+        container_object_iterator_type_t = decltype(Container::object_iterator_type);
+        template <typename Container>
+        using 
+        container_const_object_iterator_type_t = decltype(Container::const_object_iterator_type);
+
+        namespace detail {
+
+            template <typename T>
+            using
+            basic_json_t = basic_json<typename T::char_type,typename T::policy_type,typename T::allocator_type>;
+
+        } // namespace detail
+
+        template <typename T,typename Enable = void>
+        struct is_basic_json : std::false_type {};
+
+        template <typename T>
+        struct is_basic_json<T,
+            typename std::enable_if<extension_traits::is_detected<detail::basic_json_t,typename std::decay<T>::type>::value>::type
+        > : std::true_type {};
+
+    } // namespace extension_traits
+
+    namespace detail {
+
+        template <typename Iterator,typename Enable = void>
+        class random_access_iterator_wrapper
+        {
+        };
+
+        template <typename Iterator>
+        class random_access_iterator_wrapper<Iterator,
+                 typename std::enable_if<std::is_same<typename std::iterator_traits<Iterator>::iterator_category, 
+                                                      std::random_access_iterator_tag>::value>::type> 
+        { 
+            Iterator it_; 
+            bool has_value_;
+
+            template <typename Iter,typename Enable> 
+            friend class random_access_iterator_wrapper;
+        public:
+            using iterator_category = std::random_access_iterator_tag;
+
+            using value_type = typename std::iterator_traits<Iterator>::value_type;
+            using difference_type = typename std::iterator_traits<Iterator>::difference_type;
+            using pointer = typename std::iterator_traits<Iterator>::pointer;
+            using reference = typename std::iterator_traits<Iterator>::reference;
+        
+            random_access_iterator_wrapper() : it_(), has_value_(false) 
+            { 
+            }
+
+            explicit random_access_iterator_wrapper(Iterator ptr) : it_(ptr), has_value_(true)  
+            {
+            }
+
+            random_access_iterator_wrapper(const random_access_iterator_wrapper&) = default;
+            random_access_iterator_wrapper(random_access_iterator_wrapper&&) = default;
+            random_access_iterator_wrapper& operator=(const random_access_iterator_wrapper&) = default;
+            random_access_iterator_wrapper& operator=(random_access_iterator_wrapper&&) = default;
+
+            template <typename Iter,
+                      class=typename std::enable_if<!std::is_same<Iter,Iterator>::value && std::is_convertible<Iter,Iterator>::value>::type>
+            random_access_iterator_wrapper(const random_access_iterator_wrapper<Iter>& other)
+                : it_(other.it_), has_value_(other.has_value_)
+            {
+            }
+
+            operator Iterator() const
+            { 
+                return it_; 
+            }
+
+            reference operator*() const 
+            {
+                return *it_;
+            }
+
+            pointer operator->() const 
+            {
+                return &(*it_);
+            }
+
+            random_access_iterator_wrapper& operator++() 
+            {
+                ++it_;
+                return *this;
+            }
+
+            random_access_iterator_wrapper operator++(int) 
+            {
+                random_access_iterator_wrapper temp = *this;
+                ++*this;
+                return temp;
+            }
+
+            random_access_iterator_wrapper& operator--() 
+            {
+                --it_;
+                return *this;
+            }
+
+            random_access_iterator_wrapper operator--(int) 
+            {
+                random_access_iterator_wrapper temp = *this;
+                --*this;
+                return temp;
+            }
+
+            random_access_iterator_wrapper& operator+=(const difference_type offset) 
+            {
+                it_ += offset;
+                return *this;
+            }
+
+            random_access_iterator_wrapper operator+(const difference_type offset) const 
+            {
+                random_access_iterator_wrapper temp = *this;
+                return temp += offset;
+            }
+
+            random_access_iterator_wrapper& operator-=(const difference_type offset) 
+            {
+                return *this += -offset;
+            }
+
+            random_access_iterator_wrapper operator-(const difference_type offset) const 
+            {
+                random_access_iterator_wrapper temp = *this;
+                return temp -= offset;
+            }
+
+            difference_type operator-(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                return it_ - rhs.it_;
+            }
+
+            reference operator[](const difference_type offset) const noexcept
+            {
+                return *(*this + offset);
+            }
+
+            bool operator==(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                if (!has_value_ || !rhs.has_value_)
+                {
+                    return has_value_ == rhs.has_value_ ? true : false;
+                }
+                else
+                {
+                    return it_ == rhs.it_;
+                }
+            }
+
+            bool operator!=(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                return !(*this == rhs);
+            }
+
+            bool operator<(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                if (!has_value_ || !rhs.has_value_)
+                {
+                    return has_value_ == rhs.has_value_ ? false :(has_value_ ? false : true);
+                }
+                else
+                {
+                    return it_ < rhs.it_;
+                }
+            }
+
+            bool operator>(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                return rhs < *this;
+            }
+
+            bool operator<=(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                return !(rhs < *this);
+            }
+
+            bool operator>=(const random_access_iterator_wrapper& rhs) const noexcept
+            {
+                return !(*this < rhs);
+            }
+
+            inline 
+            friend random_access_iterator_wrapper<Iterator> operator+(
+                difference_type offset, random_access_iterator_wrapper<Iterator> next) 
+            {
+                return next += offset;
+            }
+
+            bool has_value() const
+            {
+                return has_value_;
+            }
+        };
+    } // namespace detail
+
+    struct sorted_policy 
+    {
+        template <typename KeyT,typename Json>
+        using object = sorted_json_object<KeyT,Json,std::vector>;
+
+        template <typename Json>
+        using array = json_array<Json,std::vector>;
+        
+        template <typename CharT,typename CharTraits,typename Allocator>
+        using member_key = std::basic_string<CharT, CharTraits, Allocator>;
+    };
+
+    struct order_preserving_policy
+    {
+        template <typename KeyT,typename Json>
+        using object = order_preserving_json_object<KeyT,Json,std::vector>;
+
+        template <typename Json>
+        using array = json_array<Json,std::vector>;
+        
+        template <typename CharT,typename CharTraits,typename Allocator>
+        using member_key = std::basic_string<CharT, CharTraits, Allocator>;
+    };
+
+    template <typename Policy,typename KeyT,typename Json,typename Enable=void>
+    struct object_iterator_typedefs
+    {
+    };
+
+    template <typename Policy,typename KeyT,typename Json>
+    struct object_iterator_typedefs<Policy, KeyT, Json,typename std::enable_if<
+        !extension_traits::is_detected<extension_traits::container_object_iterator_type_t, Policy>::value ||
+        !extension_traits::is_detected<extension_traits::container_const_object_iterator_type_t, Policy>::value>::type>
+    {
+        using object_iterator_type = jsoncons::detail::random_access_iterator_wrapper<typename Policy::template object<KeyT,Json>::iterator>;                    
+        using const_object_iterator_type = jsoncons::detail::random_access_iterator_wrapper<typename Policy::template object<KeyT,Json>::const_iterator>;
+    };
+
+    template <typename Policy,typename KeyT,typename Json>
+    struct object_iterator_typedefs<Policy, KeyT, Json,typename std::enable_if<
+        extension_traits::is_detected<extension_traits::container_object_iterator_type_t, Policy>::value &&
+        extension_traits::is_detected<extension_traits::container_const_object_iterator_type_t, Policy>::value>::type>
+    {
+        using object_iterator_type = jsoncons::detail::random_access_iterator_wrapper<typename Policy::template object_iterator<KeyT,Json>>;
+        using const_object_iterator_type = jsoncons::detail::random_access_iterator_wrapper<typename Policy::template const_object_iterator<KeyT,Json>>;
+    };
+
+    template <typename Policy,typename KeyT,typename Json,typename Enable=void>
+    struct array_iterator_typedefs
+    {
+    };
+
+    template <typename Policy,typename KeyT,typename Json>
+    struct array_iterator_typedefs<Policy, KeyT, Json,typename std::enable_if<
+        !extension_traits::is_detected<extension_traits::container_array_iterator_type_t, Policy>::value ||
+        !extension_traits::is_detected<extension_traits::container_const_array_iterator_type_t, Policy>::value>::type>
+    {
+        using array_iterator_type = typename Policy::template array<Json>::iterator;
+        using const_array_iterator_type = typename Policy::template array<Json>::const_iterator;
+    };
+
+    template <typename Policy,typename KeyT,typename Json>
+    struct array_iterator_typedefs<Policy, KeyT, Json,typename std::enable_if<
+        extension_traits::is_detected<extension_traits::container_array_iterator_type_t, Policy>::value &&
+        extension_traits::is_detected<extension_traits::container_const_array_iterator_type_t, Policy>::value>::type>
+    {
+        using array_iterator_type = typename Policy::template array_iterator_type<Json>;
+        using const_array_iterator_type = typename Policy::template const_array_iterator_type<Json>;
+    };
+
+    template <typename IteratorT,typename ConstIteratorT>
+    class range 
+    {
+    public:
+        using iterator = IteratorT;
+        using const_iterator = ConstIteratorT;
+        using reverse_iterator = std::reverse_iterator<IteratorT>;
+        using const_reverse_iterator = std::reverse_iterator<ConstIteratorT>;
+    private:
+        iterator first_;
+        iterator last_;
+    public:
+        range(const IteratorT& first, const IteratorT& last)
+            : first_(first), last_(last)
+        {
+        }
+
+        iterator begin() const noexcept
+        {
+            return first_;
+        }
+        iterator end() const noexcept
+        {
+            return last_;
+        }
+        const_iterator cbegin() const noexcept
+        {
+            return first_;
+        }
+        const_iterator cend() const noexcept
+        {
+            return last_;
+        }
+        reverse_iterator rbegin() const noexcept
+        {
+            return reverse_iterator(last_);
+        }
+        reverse_iterator rend() const noexcept
+        {
+            return reverse_iterator(first_);
+        }
+        const_reverse_iterator crbegin() const noexcept
+        {
+            return reverse_iterator(last_);
+        }
+        const_reverse_iterator crend() const noexcept
+        {
+            return reverse_iterator(first_);
+        }
+    };
+
+    template <typename CharT,typename Policy,typename Allocator>
+    class basic_json
+    {
+    public:
+        static_assert(std::allocator_traits<Allocator>::is_always_equal::value || extension_traits::is_propagating_allocator<Allocator>::value,
+                      "Regular stateful allocators must be wrapped with std::scoped_allocator_adaptor");
+
+        using allocator_type = Allocator; 
+
+        using policy_type = Policy;
+
+        using char_type = CharT;
+        using char_traits_type = std::char_traits<char_type>;
+        using string_view_type = jsoncons::basic_string_view<char_type,char_traits_type>;
+
+        using char_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<char_type>;
+
+        using string_type = std::basic_string<char_type,char_traits_type,char_allocator_type>;
+
+        using key_type = typename policy_type::template member_key<char_type,char_traits_type,char_allocator_type>;
+
+
+        using reference = basic_json&;
+        using const_reference = const basic_json&;
+        using pointer = basic_json*;
+        using const_pointer = const basic_json*;
+
+        using key_value_type = key_value<key_type,basic_json>;
+
+        using array = typename policy_type::template array<basic_json>;
+
+        using key_value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<key_value_type>;                       
+
+        using object = typename policy_type::template object<key_type,basic_json>;
+
+        using object_iterator = typename object_iterator_typedefs<policy_type,key_type,basic_json>::object_iterator_type;                    
+        using const_object_iterator = typename object_iterator_typedefs<policy_type,key_type,basic_json>::const_object_iterator_type;                    
+        using array_iterator = typename array_iterator_typedefs<policy_type,key_type,basic_json>::array_iterator_type;                    
+        using const_array_iterator = typename array_iterator_typedefs<policy_type,key_type,basic_json>::const_array_iterator_type;
+
+        using object_range_type = range<object_iterator, const_object_iterator>;
+        using const_object_range_type = range<const_object_iterator, const_object_iterator>;
+        using array_range_type = range<array_iterator, const_array_iterator>;
+        using const_array_range_type = range<const_array_iterator, const_array_iterator>;
+
+    private:
+
+        static constexpr uint8_t major_type_shift = 0x04;
+        static constexpr uint8_t additional_information_mask = (1U << 4) - 1;
+
+    public:
+        struct common_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+        };
+
+        struct null_storage 
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+
+            null_storage(semantic_tag tag = semantic_tag::none)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::null)), short_str_length_(0), tag_(tag)
+            {
+            }
+        };
+
+        struct empty_object_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+
+            empty_object_storage(semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::empty_object)), short_str_length_(0), tag_(tag)
+            {
+            }
+        };  
+
+        struct bool_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            bool val_;
+
+            bool_storage(bool val, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::boolean)), short_str_length_(0), tag_(tag),
+                  val_(val)
+            {
+            }
+
+            bool value() const
+            {
+                return val_;
+            }
+
+        };
+
+        struct int64_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            int64_t val_;
+
+            int64_storage(int64_t val, 
+                       semantic_tag tag = semantic_tag::none)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::int64)), short_str_length_(0), tag_(tag),
+                  val_(val)
+            {
+            }
+
+            int64_t value() const
+            {
+                return val_;
+            }
+        };
+
+        struct uint64_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            uint64_t val_;
+
+            uint64_storage(uint64_t val, 
+                        semantic_tag tag = semantic_tag::none)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::uint64)), short_str_length_(0), tag_(tag),
+                  val_(val)
+            {
+            }
+
+            uint64_t value() const
+            {
+                return val_;
+            }
+        };
+
+        struct half_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            uint16_t val_;
+
+            half_storage(uint16_t val, semantic_tag tag = semantic_tag::none)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::half_float)), short_str_length_(0), tag_(tag),
+                  val_(val)
+            {
+            }
+
+            uint16_t value() const
+            {
+                return val_;
+            }
+        };
+
+        struct double_storage
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            double val_;
+
+            double_storage(double val, 
+                           semantic_tag tag = semantic_tag::none)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::float64)), short_str_length_(0), tag_(tag),
+                  val_(val)
+            {
+            }
+
+            double value() const
+            {
+                return val_;
+            }
+        };
+
+        struct short_string_storage
+        {
+            static constexpr size_t capacity = (2*sizeof(uint64_t) - 2*sizeof(uint8_t))/sizeof(char_type);
+            static constexpr size_t max_length = capacity - 1;
+
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            char_type data_[capacity];
+
+            short_string_storage(const char_type* p, uint8_t length, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::short_str)), short_str_length_(length), tag_(tag)
+            {
+                JSONCONS_ASSERT(length <= max_length);
+                std::memcpy(data_,p,length*sizeof(char_type));
+                data_[length] = 0;
+            }
+
+            short_string_storage(const short_string_storage& other)
+                : storage_kind_(other.storage_kind_), short_str_length_(other.short_str_length_), tag_(other.tag_)
+            {
+                std::memcpy(data_,other.data_,other.short_str_length_*sizeof(char_type));
+                data_[short_str_length_] = 0;
+            }
+           
+            short_string_storage& operator=(const short_string_storage& other) = delete;
+
+            uint8_t length() const
+            {
+                return short_str_length_;
+            }
+
+            const char_type* data() const
+            {
+                return data_;
+            }
+
+            const char_type* c_str() const
+            {
+                return data_;
+            }
+        };
+
+        // long_string_storage
+        struct long_string_storage
+        {
+            using heap_string_factory_type = jsoncons::utility::heap_string_factory<char_type,null_type,Allocator>;
+            using pointer = typename heap_string_factory_type::pointer;
+
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            pointer ptr_;
+
+            long_string_storage(pointer ptr, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::long_str)), short_str_length_(0), tag_(tag), ptr_(ptr)
+            {
+            }
+
+            long_string_storage(const long_string_storage& other)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::long_str)), short_str_length_(0), tag_(other.tag_), ptr_(other.ptr_)
+            {
+            }
+            
+            long_string_storage& operator=(const long_string_storage& other) = delete;
+
+            semantic_tag tag() const
+            {
+                return tag_;
+            }
+
+            const char_type* data() const
+            {
+                return ptr_->data();
+            }
+
+            const char_type* c_str() const
+            {
+                return ptr_->c_str();
+            }
+
+            std::size_t length() const
+            {
+                return ptr_->length();
+            }
+        
+            Allocator get_allocator() const
+            {
+                return ptr_->get_allocator();
+            }
+        };
+
+        // byte_string_storage
+        struct byte_string_storage 
+        {
+            using heap_string_factory_type = jsoncons::utility::heap_string_factory<uint8_t,uint64_t,Allocator>;
+            using pointer = typename heap_string_factory_type::pointer;
+
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            pointer ptr_;
+
+            byte_string_storage(pointer ptr, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::byte_str)), short_str_length_(0), tag_(tag), ptr_(ptr)
+            {
+            }
+
+            byte_string_storage(const byte_string_storage& other)
+                : storage_kind_(other.storage_kind_), short_str_length_(0), tag_(other.tag_), ptr_(other.ptr_)
+            {
+            }
+
+            byte_string_storage& operator=(const byte_string_storage& other) = delete;
+
+            semantic_tag tag() const
+            {
+                return tag_;
+            }
+
+            const uint8_t* data() const
+            {
+                return ptr_->data();
+            }
+
+            std::size_t length() const
+            {
+                return ptr_->length();
+            }
+
+            uint64_t ext_tag() const
+            {
+                return ptr_->extra();
+            }
+
+            Allocator get_allocator() const
+            {
+                return ptr_->get_allocator();
+            }
+        };
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+
+        struct array_storage
+        {
+            using allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<array>;
+            using pointer = typename std::allocator_traits<allocator_type>::pointer;
+
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            pointer ptr_;
+
+            array_storage(pointer ptr, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::array)), short_str_length_(0), tag_(tag), ptr_(ptr)
+            {
+            }
+
+            array_storage(const array_storage& other)
+                : storage_kind_(other.storage_kind_), short_str_length_(0), tag_(other.tag_), ptr_(other.ptr_)
+            {
+            }
+
+            void assign(const array_storage& other)
+            {
+                tag_ = other.tag_;
+                *ptr_ = *(other.ptr_);
+            }
+
+            array_storage& operator=(const array_storage& other) = delete;
+
+            semantic_tag tag() const
+            {
+                return tag_;
+            }
+
+            Allocator get_allocator() const
+            {
+                return ptr_->get_allocator();
+            }
+
+            array& value()
+            {
+                return *ptr_;
+            }
+
+            const array& value() const
+            {
+                return *ptr_;
+            }
+        };
+
+        // object_storage
+        struct object_storage
+        {
+            using allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<object>;
+            using pointer = typename std::allocator_traits<allocator_type>::pointer;
+
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            pointer ptr_;
+
+            object_storage(pointer ptr, semantic_tag tag)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::object)), short_str_length_(0), tag_(tag), ptr_(ptr)
+            {
+            }
+
+            explicit object_storage(const object_storage& other)
+                : storage_kind_(other.storage_kind_), short_str_length_(0), tag_(other.tag_), ptr_(other.ptr_)
+            {
+            }
+
+            void assign(const object_storage& other)
+            {
+                tag_ = other.tag_;
+                *ptr_ = *(other.ptr_);
+            }
+
+            object_storage& operator=(const object_storage& other) = delete;
+
+            semantic_tag tag() const
+            {
+                return tag_;
+            }
+
+            object& value()
+            {
+                JSONCONS_ASSERT(ptr_ != nullptr);
+                return *ptr_;
+            }
+
+            const object& value() const
+            {
+                JSONCONS_ASSERT(ptr_ != nullptr);
+                return *ptr_;
+            }
+
+            Allocator get_allocator() const
+            {
+                JSONCONS_ASSERT(ptr_ != nullptr);
+                return ptr_->get_allocator();
+            }
+        };
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic pop
+#endif
+
+    private:
+        struct json_const_reference_storage 
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            std::reference_wrapper<const basic_json> ref_;
+
+            json_const_reference_storage(const basic_json& ref)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::json_const_reference)), short_str_length_(0), tag_(ref.tag()),
+                  ref_(ref)
+            {
+            }
+
+            const basic_json& value() const
+            {
+                return ref_.get();
+            }
+        };
+
+        struct json_reference_storage 
+        {
+            uint8_t storage_kind_:4;
+            uint8_t short_str_length_:4;
+            semantic_tag tag_;
+            std::reference_wrapper<basic_json> ref_;
+
+            json_reference_storage(basic_json& ref)
+                : storage_kind_(static_cast<uint8_t>(json_storage_kind::json_reference)), short_str_length_(0), tag_(ref.tag()),
+                  ref_(ref)
+            {
+            }
+
+            basic_json& value() 
+            {
+                return ref_.get();
+            }
+
+            const basic_json& value() const
+            {
+                return ref_.get();
+            }
+        };
+
+        union 
+        {
+            common_storage common_;
+            null_storage null_;
+            bool_storage boolean_;
+            int64_storage int64_;
+            uint64_storage uint64_;
+            half_storage half_float_;
+            double_storage float64_;
+            short_string_storage short_str_;
+            long_string_storage long_str_;
+            byte_string_storage byte_str_;
+            array_storage array_;
+            object_storage object_;
+            empty_object_storage empty_object_;
+            json_const_reference_storage json_const_pointer_;
+            json_reference_storage json_ref_;
+        };
+
+        void destroy()
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::long_str:
+                {
+                    if (cast<long_string_storage>().ptr_ != nullptr)
+                    {
+                        long_string_storage::heap_string_factory_type::destroy(cast<long_string_storage>().ptr_);
+                    }
+                    break;
+                }
+                case json_storage_kind::byte_str:
+                    if (cast<byte_string_storage>().ptr_ != nullptr)
+                    {
+                        byte_string_storage::heap_string_factory_type::destroy(cast<byte_string_storage>().ptr_);
+                    }
+                    break;
+                case json_storage_kind::array:
+                {
+                    if (cast<array_storage>().ptr_ != nullptr)
+                    {
+                        auto& storage = cast<array_storage>();
+                        typename array_storage::allocator_type alloc{storage.ptr_->get_allocator()};
+                        std::allocator_traits<typename array_storage::allocator_type>::destroy(alloc, extension_traits::to_plain_pointer(storage.ptr_));
+                        std::allocator_traits<typename array_storage::allocator_type>::deallocate(alloc, storage.ptr_,1);
+                    }
+                    break;
+                }
+                case json_storage_kind::object:
+                {
+                    if (cast<object_storage>().ptr_ != nullptr)
+                    {
+                        auto& storage = cast<object_storage>();
+                        typename object_storage::allocator_type alloc{storage.ptr_->get_allocator()};
+                        std::allocator_traits<typename object_storage::allocator_type>::destroy(alloc, extension_traits::to_plain_pointer(storage.ptr_));
+                        std::allocator_traits<typename object_storage::allocator_type>::deallocate(alloc, storage.ptr_,1);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        typename long_string_storage::pointer create_long_string(const allocator_type& alloc, const char_type* data, std::size_t length)
+        {
+            using heap_string_factory_type = jsoncons::utility::heap_string_factory<char_type,null_type,Allocator>;
+            return heap_string_factory_type::create(data, length, null_type(), alloc); 
+        }
+
+        typename byte_string_storage::pointer create_byte_string(const allocator_type& alloc, const uint8_t* data, std::size_t length,
+            uint64_t ext_tag)
+        {
+            using heap_string_factory_type = jsoncons::utility::heap_string_factory<uint8_t,uint64_t,Allocator>;
+            return heap_string_factory_type::create(data, length, ext_tag, alloc); 
+        }
+        
+        template <typename... Args>
+        typename array_storage::pointer create_array(const allocator_type& alloc, Args&& ... args)
+        {
+            using stor_allocator_type = typename array_storage::allocator_type;
+            stor_allocator_type stor_alloc(alloc);
+            auto ptr = std::allocator_traits<stor_allocator_type>::allocate(stor_alloc, 1);
+            JSONCONS_TRY
+            {
+                std::allocator_traits<stor_allocator_type>::construct(stor_alloc, extension_traits::to_plain_pointer(ptr), 
+                    std::forward<Args>(args)...);
+            }
+            JSONCONS_CATCH(...)
+            {
+                std::allocator_traits<stor_allocator_type>::deallocate(stor_alloc, ptr,1);
+                JSONCONS_RETHROW;
+            }
+            return ptr;
+        }
+
+        template <typename... Args>
+        typename object_storage::pointer create_object(const allocator_type& alloc, Args&& ... args)
+        {
+            using stor_allocator_type = typename object_storage::allocator_type;
+            stor_allocator_type stor_alloc(alloc);
+            auto ptr = std::allocator_traits<stor_allocator_type>::allocate(stor_alloc, 1);
+            JSONCONS_TRY
+            {
+                std::allocator_traits<stor_allocator_type>::construct(stor_alloc, extension_traits::to_plain_pointer(ptr), 
+                    std::forward<Args>(args)...);
+            }
+            JSONCONS_CATCH(...)
+            {
+                std::allocator_traits<stor_allocator_type>::deallocate(stor_alloc, ptr,1);
+                JSONCONS_RETHROW;
+            }
+            return ptr;
+        }
+
+        template <typename StorageType,typename... Args>
+        void construct(Args&&... args)
+        {
+            ::new (&cast<StorageType>()) StorageType(std::forward<Args>(args)...);
+        }
+
+        template <typename T>
+        struct identity { using type = T*; };
+    public:
+        template <typename T> 
+        T& cast()
+        {
+            return cast(identity<T>());
+        }
+
+        template <typename T> 
+        const T& cast() const
+        {
+            return cast(identity<T>());
+        }
+    private:
+        null_storage& cast(identity<null_storage>) 
+        {
+            return null_;
+        }
+
+        const null_storage& cast(identity<null_storage>) const
+        {
+            return null_;
+        }
+
+        empty_object_storage& cast(identity<empty_object_storage>) 
+        {
+            return empty_object_;
+        }
+
+        const empty_object_storage& cast(identity<empty_object_storage>) const
+        {
+            return empty_object_;
+        }
+
+        bool_storage& cast(identity<bool_storage>) 
+        {
+            return boolean_;
+        }
+
+        const bool_storage& cast(identity<bool_storage>) const
+        {
+            return boolean_;
+        }
+
+        int64_storage& cast(identity<int64_storage>) 
+        {
+            return int64_;
+        }
+
+        const int64_storage& cast(identity<int64_storage>) const
+        {
+            return int64_;
+        }
+
+        uint64_storage& cast(identity<uint64_storage>) 
+        {
+            return uint64_;
+        }
+
+        const uint64_storage& cast(identity<uint64_storage>) const
+        {
+            return uint64_;
+        }
+
+        half_storage& cast(identity<half_storage>)
+        {
+            return half_float_;
+        }
+
+        const half_storage& cast(identity<half_storage>) const
+        {
+            return half_float_;
+        }
+
+        double_storage& cast(identity<double_storage>) 
+        {
+            return float64_;
+        }
+
+        const double_storage& cast(identity<double_storage>) const
+        {
+            return float64_;
+        }
+
+        short_string_storage& cast(identity<short_string_storage>)
+        {
+            return short_str_;
+        }
+
+        const short_string_storage& cast(identity<short_string_storage>) const
+        {
+            return short_str_;
+        }
+
+        long_string_storage& cast(identity<long_string_storage>)
+        {
+            return long_str_;
+        }
+
+        const long_string_storage& cast(identity<long_string_storage>) const
+        {
+            return long_str_;
+        }
+
+        byte_string_storage& cast(identity<byte_string_storage>)
+        {
+            return byte_str_;
+        }
+
+        const byte_string_storage& cast(identity<byte_string_storage>) const
+        {
+            return byte_str_;
+        }
+
+        object_storage& cast(identity<object_storage>)
+        {
+            return object_;
+        }
+
+        const object_storage& cast(identity<object_storage>) const
+        {
+            return object_;
+        }
+
+        array_storage& cast(identity<array_storage>)
+        {
+            return array_;
+        }
+
+        const array_storage& cast(identity<array_storage>) const
+        {
+            return array_;
+        }
+
+        json_const_reference_storage& cast(identity<json_const_reference_storage>) 
+        {
+            return json_const_pointer_;
+        }
+
+        json_reference_storage& cast(identity<json_reference_storage>) 
+        {
+            return json_ref_;
+        }
+
+        const json_const_reference_storage& cast(identity<json_const_reference_storage>) const
+        {
+            return json_const_pointer_;
+        }
+
+        const json_reference_storage& cast(identity<json_reference_storage>) const
+        {
+            return json_ref_;
+        }
+
+        template <typename TypeL,typename TypeR>
+        void swap_l_r(basic_json& other) noexcept
+        {
+            swap_l_r(identity<TypeL>(), identity<TypeR>(), other);
+        }
+
+        template <typename TypeL,typename TypeR>
+        void swap_l_r(identity<TypeL>,identity<TypeR>,basic_json& other) noexcept
+        {
+            TypeR temp{other.cast<TypeR>()};
+            other.construct<TypeL>(cast<TypeL>());
+            construct<TypeR>(temp);
+        }
+
+        template <typename TypeL>
+        void swap_l(basic_json& other) noexcept
+        {
+            switch (other.storage_kind())
+            {
+                case json_storage_kind::null         : swap_l_r<TypeL, null_storage>(other); break;
+                case json_storage_kind::empty_object : swap_l_r<TypeL, empty_object_storage>(other); break;
+                case json_storage_kind::boolean         : swap_l_r<TypeL, bool_storage>(other); break;
+                case json_storage_kind::int64        : swap_l_r<TypeL, int64_storage>(other); break;
+                case json_storage_kind::uint64       : swap_l_r<TypeL, uint64_storage>(other); break;
+                case json_storage_kind::half_float         : swap_l_r<TypeL, half_storage>(other); break;
+                case json_storage_kind::float64       : swap_l_r<TypeL, double_storage>(other); break;
+                case json_storage_kind::short_str : swap_l_r<TypeL, short_string_storage>(other); break;
+                case json_storage_kind::long_str  : swap_l_r<TypeL, long_string_storage>(other); break;
+                case json_storage_kind::byte_str  : swap_l_r<TypeL, byte_string_storage>(other); break;
+                case json_storage_kind::array        : swap_l_r<TypeL, array_storage>(other); break;
+                case json_storage_kind::object       : swap_l_r<TypeL, object_storage>(other); break;
+                case json_storage_kind::json_const_reference : swap_l_r<TypeL, json_const_reference_storage>(other); break;
+                case json_storage_kind::json_reference : swap_l_r<TypeL, json_reference_storage>(other); break;
+                default:
+                    JSONCONS_UNREACHABLE();
+                    break;
+            }
+        }
+
+        void uninitialized_copy(const basic_json& other)
+        {
+            if (is_trivial_storage(other.storage_kind()))
+            {
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else
+            {
+                switch (other.storage_kind())
+                {
+                    case json_storage_kind::long_str:
+                    {
+                        const auto& storage = other.cast<long_string_storage>();
+                        auto ptr = create_long_string(std::allocator_traits<Allocator>::select_on_container_copy_construction(storage.get_allocator()),
+                            storage.data(), storage.length());
+                        construct<long_string_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::byte_str:
+                    {
+                        const auto& storage = other.cast<byte_string_storage>();
+                        auto ptr = create_byte_string(std::allocator_traits<Allocator>::select_on_container_copy_construction(storage.get_allocator()),
+                            storage.data(), storage.length(), storage.ext_tag());
+                        construct<byte_string_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::array:
+                    {
+                        auto ptr = create_array(
+                            std::allocator_traits<Allocator>::select_on_container_copy_construction(other.cast<array_storage>().get_allocator()), 
+                            other.cast<array_storage>().value());
+                        construct<array_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::object:
+                    {
+                        auto ptr = create_object(
+                            std::allocator_traits<Allocator>::select_on_container_copy_construction(other.cast<object_storage>().get_allocator()), 
+                            other.cast<object_storage>().value());
+                        construct<object_storage>(ptr, other.tag());
+                        break;
+                    }
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+        }
+
+        void uninitialized_copy_a(const basic_json& other, const Allocator& alloc)
+        {
+            if (is_trivial_storage(other.storage_kind()))
+            {
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else
+            {
+                switch (other.storage_kind())
+                {
+                    case json_storage_kind::long_str:
+                    {
+                        const auto& storage = other.cast<long_string_storage>();
+                        auto ptr = create_long_string(alloc, storage.data(), storage.length());
+                        construct<long_string_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::byte_str:
+                    {
+                        const auto& storage = other.cast<byte_string_storage>();
+                        auto ptr = create_byte_string(alloc, storage.data(), storage.length(), storage.ext_tag());
+                        construct<byte_string_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::array:
+                    {
+                        auto ptr = create_array(alloc, other.cast<array_storage>().value());
+                        construct<array_storage>(ptr, other.tag());
+                        break;
+                    }
+                    case json_storage_kind::object:
+                    {
+                        auto ptr = create_object(alloc, other.cast<object_storage>().value());
+                        construct<object_storage>(ptr, other.tag());
+                        break;
+                    }
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+        }
+
+        void uninitialized_move(basic_json&& other) noexcept
+        {
+            if (is_trivial_storage(other.storage_kind()))
+            {
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else
+            {
+                switch (other.storage_kind())
+                {
+                    case json_storage_kind::long_str:
+                        construct<long_string_storage>(other.cast<long_string_storage>());
+                        other.construct<null_storage>();
+                        break;
+                    case json_storage_kind::byte_str:
+                        construct<byte_string_storage>(other.cast<byte_string_storage>());
+                        other.construct<null_storage>();
+                        break;
+                    case json_storage_kind::array:
+                        construct<array_storage>(other.cast<array_storage>());
+                        other.construct<null_storage>();
+                        break;
+                    case json_storage_kind::object:
+                        construct<object_storage>(other.cast<object_storage>());
+                        other.construct<null_storage>();
+                        break;
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+        }
+
+        void uninitialized_move_a(std::true_type /* stateless allocator */, 
+            basic_json&& other, const Allocator&) noexcept
+        {
+            uninitialized_move(std::move(other));
+        }
+
+        void uninitialized_move_a(std::false_type /* stateful allocator */, 
+            basic_json&& other, const Allocator& alloc) noexcept
+        {
+            if (is_trivial_storage(other.storage_kind()))
+            {
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else
+            {
+                uninitialized_copy_a(other, alloc);
+            }
+        }
+
+        void copy_assignment(const basic_json& other)
+        {
+            if (is_trivial_storage(other.storage_kind()))
+            {
+                destroy();
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else if (storage_kind() == other.storage_kind())
+            {
+                switch (other.storage_kind())
+                {
+                    case json_storage_kind::long_str:
+                    {
+                        auto alloc = cast<long_string_storage>().get_allocator();
+                        destroy();
+                        uninitialized_copy_a(other, alloc);
+                        break;
+                    }
+                    case json_storage_kind::byte_str:
+                    {
+                        auto alloc = cast<byte_string_storage>().get_allocator();
+                        destroy();
+                        uninitialized_copy_a(other, alloc);
+                        break;
+                    }
+                    case json_storage_kind::array:
+                        cast<array_storage>().assign(other.cast<array_storage>());
+                        break;
+                    case json_storage_kind::object:
+                        cast<object_storage>().assign(other.cast<object_storage>());
+                        break;
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+            else if (is_trivial_storage(storage_kind())) // rhs is not trivial storage
+            {
+                destroy();
+                uninitialized_copy(other);
+            }
+            else // lhs and rhs are not trivial storage
+            {
+                auto alloc = get_allocator();
+                destroy();
+                uninitialized_copy_a(other, alloc);
+            }
+        }
+
+        void move_assignment(basic_json&& other) noexcept
+        {
+            if (is_trivial_storage(storage_kind()) && is_trivial_storage(other.storage_kind()))
+            {
+                std::memcpy(static_cast<void*>(this), &other, sizeof(basic_json));
+            }
+            else
+            {
+                swap(other);
+            }
+        }
+
+        basic_json& evaluate_with_default() 
+        {
+            return *this;
+        }
+
+        basic_json& evaluate(const string_view_type& name) 
+        {
+            return at(name);
+        }
+
+        const basic_json& evaluate(const string_view_type& name) const
+        {
+            return at(name);
+        }
+
+    public:
+
+        basic_json& evaluate() 
+        {
+            return *this;
+        }
+
+        const basic_json& evaluate() const
+        {
+            return *this;
+        }
+
+        basic_json& operator=(const basic_json& other)
+        {
+            if (this != &other)
+            {
+                copy_assignment(other);
+            }
+            return *this;
+        }
+
+        basic_json& operator=(basic_json&& other) noexcept
+        {
+            if (this != &other)
+            {
+                move_assignment(std::move(other));
+            }
+            return *this;
+        }
+
+        json_storage_kind storage_kind() const
+        {
+            // It is legal to access 'common_.storage_kind_' even though 
+            // common_ is not the active member of the union because 'storage_kind_' 
+            // is a part of the common initial sequence of all union members
+            // as defined in 11.4-25 of the Standard.
+            return static_cast<json_storage_kind>(common_.storage_kind_);
+        }
+
+        json_type type() const
+        {
+            switch(storage_kind())
+            {
+                case json_storage_kind::null:
+                    return json_type::null_value;
+                case json_storage_kind::boolean:
+                    return json_type::bool_value;
+                case json_storage_kind::int64:
+                    return json_type::int64_value;
+                case json_storage_kind::uint64:
+                    return json_type::uint64_value;
+                case json_storage_kind::half_float:
+                    return json_type::half_value;
+                case json_storage_kind::float64:
+                    return json_type::double_value;
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    return json_type::string_value;
+                case json_storage_kind::byte_str:
+                    return json_type::byte_string_value;
+                case json_storage_kind::array:
+                    return json_type::array_value;
+                case json_storage_kind::empty_object:
+                case json_storage_kind::object:
+                    return json_type::object_value;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().type();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().type();
+                default:
+                    JSONCONS_UNREACHABLE();
+                    break;
+            }
+        }
+
+        semantic_tag tag() const
+        {
+            // It is legal to access 'common_.tag_' even though 
+            // common_ is not the active member of the union because 'tag_' 
+            // is a part of the common initial sequence of all union members
+            // as defined in 11.4-25 of the Standard.
+            switch(storage_kind())
+            {
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().tag();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().tag();
+                default:
+                    return common_.tag_;
+            }
+        }
+
+        std::size_t size() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().size();
+                case json_storage_kind::empty_object:
+                    return 0;
+                case json_storage_kind::object:
+                    return cast<object_storage>().value().size();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().size();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().size();
+                default:
+                    return 0;
+            }
+        }
+
+        string_view_type as_string_view() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                    return string_view_type(cast<short_string_storage>().data(),cast<short_string_storage>().length());
+                case json_storage_kind::long_str:
+                    return string_view_type(cast<long_string_storage>().data(),cast<long_string_storage>().length());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_string_view();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_string_view();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a string"));
+            }
+        }
+
+        template <typename BAllocator=std::allocator<uint8_t>>
+        basic_byte_string<BAllocator> as_byte_string() const
+        {
+            using byte_string_type = basic_byte_string<BAllocator>;
+            std::error_code ec;
+
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    value_converter<jsoncons::string_view, byte_string_type> converter;
+                    byte_string_type v = converter.convert(as_string_view(),tag(), ec);
+                    if (ec)
+                    {
+                        JSONCONS_THROW(ser_error(ec));
+                    }
+                    return v;
+                }
+                case json_storage_kind::byte_str:
+                    return basic_byte_string<BAllocator>(cast<byte_string_storage>().data(),cast<byte_string_storage>().length());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_byte_string();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_byte_string();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a byte string"));
+            }
+        }
+
+        byte_string_view as_byte_string_view() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::byte_str:
+                    return byte_string_view(cast<byte_string_storage>().data(),cast<byte_string_storage>().length());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_byte_string_view();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_byte_string_view();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a byte string"));
+            }
+        }
+
+        int compare(const basic_json& rhs) const noexcept
+        {
+            if (this == &rhs)
+            {
+                return 0;
+            }
+            switch (storage_kind())
+            {
+                case json_storage_kind::json_const_reference:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::json_const_reference:
+                            return cast<json_const_reference_storage>().value().compare(rhs.cast<json_const_reference_storage>().value());
+                        default:
+                            return cast<json_const_reference_storage>().value().compare(rhs);
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::json_reference:
+                            return cast<json_reference_storage>().value().compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return cast<json_reference_storage>().value().compare(rhs);
+                    }
+                    break;
+                case json_storage_kind::null:
+                    return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                case json_storage_kind::empty_object:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            return 0;
+                        case json_storage_kind::object:
+                            return rhs.empty() ? 0 : -1;
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::boolean:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::boolean:
+                            return static_cast<int>(cast<bool_storage>().value()) - static_cast<int>(rhs.cast<bool_storage>().value());
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::int64:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::int64:
+                        {
+                            if (cast<int64_storage>().value() == rhs.cast<int64_storage>().value())
+                                return 0;
+                            return cast<int64_storage>().value() < rhs.cast<int64_storage>().value() ? -1 : 1;
+                        }
+                        case json_storage_kind::uint64:
+                            if (cast<int64_storage>().value() < 0) 
+                                return -1;
+                            else if (static_cast<uint64_t>(cast<int64_storage>().value()) == rhs.cast<uint64_storage>().value()) 
+                                return 0;
+                            else
+                                return static_cast<uint64_t>(cast<int64_storage>().value()) < rhs.cast<uint64_storage>().value() ? -1 : 1;
+                        case json_storage_kind::float64:
+                        {
+                            double r = static_cast<double>(cast<int64_storage>().value()) - rhs.cast<double_storage>().value();
+                            return r == 0.0 ? 0 : (r < 0.0 ? -1 : 1);
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::uint64:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::int64:
+                            if (rhs.cast<int64_storage>().value() < 0) 
+                                return 1;
+                            else if (cast<uint64_storage>().value() == static_cast<uint64_t>(rhs.cast<int64_storage>().value()))
+                                return 0;
+                            else
+                                return cast<uint64_storage>().value() < static_cast<uint64_t>(rhs.cast<int64_storage>().value()) ? -1 : 1;
+                        case json_storage_kind::uint64:
+                            if (cast<uint64_storage>().value() == static_cast<uint64_t>(rhs.cast<int64_storage>().value()))
+                                return 0;
+                            else
+                                return cast<uint64_storage>().value() < static_cast<uint64_t>(rhs.cast<int64_storage>().value()) ? -1 : 1;
+                        case json_storage_kind::float64:
+                        {
+                            auto r = static_cast<double>(cast<uint64_storage>().value()) - rhs.cast<double_storage>().value();
+                            return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::float64:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::int64:
+                        {
+                            auto r = cast<double_storage>().value() - static_cast<double>(rhs.cast<int64_storage>().value());
+                            return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                        }
+                        case json_storage_kind::uint64:
+                        {
+                            auto r = cast<double_storage>().value() - static_cast<double>(rhs.cast<uint64_storage>().value());
+                            return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                        }
+                        case json_storage_kind::float64:
+                        {
+                            auto r = cast<double_storage>().value() - rhs.cast<double_storage>().value();
+                            return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            if (is_string_storage(rhs.storage_kind()) && is_number_tag(rhs.tag()))
+                            {
+                                double val1 = as_double();
+                                double val2 = rhs.as_double();
+                                auto r = val1 - val2;
+                                return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                            }
+                            else
+                            {
+                                return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                            }
+                    }
+                    break;
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    if (is_number_tag(tag()))
+                    {
+                        double val1 = as_double(); 
+                        switch (rhs.storage_kind())
+                        {
+                            case json_storage_kind::int64:
+                            {
+                                auto r = val1 - static_cast<double>(rhs.cast<int64_storage>().value());
+                                return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                            }
+                            case json_storage_kind::uint64:
+                            {
+                                auto r = val1 - static_cast<double>(rhs.cast<uint64_storage>().value());
+                                return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                            }
+                            case json_storage_kind::float64:
+                            {
+                                auto r = val1 - rhs.cast<double_storage>().value();
+                                return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                            }
+                            case json_storage_kind::json_const_reference:
+                                return compare(rhs.cast<json_const_reference_storage>().value());
+                            case json_storage_kind::json_reference:
+                                return compare(rhs.cast<json_reference_storage>().value());
+                            default:
+                                if (is_string_storage(rhs.storage_kind()))
+                                {
+                                    double val2 = rhs.as_double();
+                                    auto r = val1 - val2; 
+                                    return r == 0 ? 0 : (r < 0.0 ? -1 : 1);
+                                }
+                                else
+                                {
+                                    return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                                }
+                        }
+                    }
+                    else
+                    {
+                        // compare regular text
+                        switch (rhs.storage_kind())
+                        {
+                            case json_storage_kind::short_str:
+                                return as_string_view().compare(rhs.as_string_view());
+                            case json_storage_kind::long_str:
+                                return as_string_view().compare(rhs.as_string_view());
+                            case json_storage_kind::json_const_reference:
+                                return compare(rhs.cast<json_const_reference_storage>().value());
+                            case json_storage_kind::json_reference:
+                                return compare(rhs.cast<json_reference_storage>().value());
+                            default:
+                                return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                        }
+                    }
+                    break;
+                case json_storage_kind::byte_str:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::byte_str:
+                        {
+                            return as_byte_string_view().compare(rhs.as_byte_string_view());
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::array:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::array:
+                        {
+                            if (cast<array_storage>().value() == rhs.cast<array_storage>().value())
+                                return 0; 
+                            else 
+                                return cast<array_storage>().value() < rhs.cast<array_storage>().value() ? -1 : 1;
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                case json_storage_kind::object:
+                    switch (rhs.storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            return empty() ? 0 : 1;
+                        case json_storage_kind::object:
+                        {
+                            if (cast<object_storage>().value() == rhs.cast<object_storage>().value())
+                                return 0; 
+                            else 
+                                return cast<object_storage>().value() < rhs.cast<object_storage>().value() ? -1 : 1;
+                        }
+                        case json_storage_kind::json_const_reference:
+                            return compare(rhs.cast<json_const_reference_storage>().value());
+                        case json_storage_kind::json_reference:
+                            return compare(rhs.cast<json_reference_storage>().value());
+                        default:
+                            return static_cast<int>(storage_kind()) - static_cast<int>(rhs.storage_kind());
+                    }
+                    break;
+                default:
+                    JSONCONS_UNREACHABLE();
+                    break;
+            }
+        }
+
+        void swap(basic_json& other) noexcept
+        {
+            if (this == &other)
+            {
+                return;
+            }
+            if (is_trivial_storage(storage_kind()) && is_trivial_storage(other.storage_kind()))
+            {
+                basic_json temp;               
+                std::memcpy(static_cast<void*>(&temp), static_cast<void*>(&other), sizeof(basic_json));
+                std::memcpy(static_cast<void*>(&other), static_cast<void*>(this), sizeof(basic_json));
+                std::memcpy(static_cast<void*>(this), static_cast<void*>(&temp), sizeof(basic_json));
+            }
+            else
+            {
+                switch (storage_kind())
+                {
+                    case json_storage_kind::null: swap_l<null_storage>(other); break;
+                    case json_storage_kind::empty_object : swap_l<empty_object_storage>(other); break;
+                    case json_storage_kind::boolean: swap_l<bool_storage>(other); break;
+                    case json_storage_kind::int64: swap_l<int64_storage>(other); break;
+                    case json_storage_kind::uint64: swap_l<uint64_storage>(other); break;
+                    case json_storage_kind::half_float: swap_l<half_storage>(other); break;
+                    case json_storage_kind::float64: swap_l<double_storage>(other); break;
+                    case json_storage_kind::short_str: swap_l<short_string_storage>(other); break;
+                    case json_storage_kind::long_str: swap_l<long_string_storage>(other); break;
+                    case json_storage_kind::byte_str: swap_l<byte_string_storage>(other); break;
+                    case json_storage_kind::array: swap_l<array_storage>(other); break;
+                    case json_storage_kind::object: swap_l<object_storage>(other); break;
+                    case json_storage_kind::json_const_reference: swap_l<json_const_reference_storage>(other); break;
+                    case json_storage_kind::json_reference: swap_l<json_reference_storage>(other); break;
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+        }
+        // from string
+
+        template <typename Source>
+        static
+         typename std::enable_if<extension_traits::is_sequence_of<Source,char_type>::value,basic_json>::type
+            parse(const Source& source, 
+              const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_parser<char_type> parser(options);
+
+            auto r = unicode_traits::detect_encoding_from_bom(source.data(), source.size());
+            if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+            {
+                JSONCONS_THROW(ser_error(json_errc::illegal_unicode_character,parser.line(),parser.column()));
+            }
+            std::size_t offset = (r.ptr - source.data());
+            parser.update(source.data()+offset,source.size()-offset);
+            parser.parse_some(decoder);
+            parser.finish_parse(decoder);
+            parser.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json string"));
+            }
+            return decoder.get_result();
+        }
+
+        template <typename Source,typename TempAllocator >
+        static
+         typename std::enable_if<extension_traits::is_sequence_of<Source,char_type>::value,basic_json>::type
+            parse(const allocator_set<allocator_type,TempAllocator>& alloc_set, const Source& source, 
+              const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            json_decoder<basic_json> decoder(alloc_set.get_allocator(), alloc_set.get_temp_allocator());
+            basic_json_parser<char_type,TempAllocator> parser(options, alloc_set.get_temp_allocator());
+
+            auto r = unicode_traits::detect_encoding_from_bom(source.data(), source.size());
+            if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+            {
+                JSONCONS_THROW(ser_error(json_errc::illegal_unicode_character,parser.line(),parser.column()));
+            }
+            std::size_t offset = (r.ptr - source.data());
+            parser.update(source.data()+offset,source.size()-offset);
+            parser.parse_some(decoder);
+            parser.finish_parse(decoder);
+            parser.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json string"));
+            }
+            return decoder.get_result();
+        }
+
+        static basic_json parse(const char_type* str, std::size_t length, 
+            const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            return parse(jsoncons::string_view(str,length), options);
+        }
+
+        static basic_json parse(const char_type* source, 
+            const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            return parse(jsoncons::basic_string_view<char_type>(source), options);
+        }
+
+        template <typename TempAllocator >
+        static basic_json parse(const allocator_set<allocator_type,TempAllocator>& alloc_set, const char_type* source, 
+            const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            return parse(alloc_set, jsoncons::basic_string_view<char_type>(source), options);
+        }
+
+        template <typename TempAllocator >
+        static basic_json parse(const allocator_set<allocator_type,TempAllocator>& alloc_set, 
+            const char_type* str, std::size_t length,
+            const basic_json_decode_options<char_type>& options = basic_json_options<char_type>())
+        {
+            return parse(alloc_set, jsoncons::basic_string_view<char_type>(str, length), options);
+        }
+
+        // from stream
+
+        static basic_json parse(std::basic_istream<char_type>& is, 
+            const basic_json_decode_options<char_type>& options = basic_json_options<CharT>())
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_reader<char_type,stream_source<char_type>,Allocator> reader(is, decoder, options);
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json stream"));
+            }
+            return decoder.get_result();
+        }
+
+        template <typename TempAllocator >
+        static basic_json parse(const allocator_set<allocator_type,TempAllocator>& alloc_set, std::basic_istream<char_type>& is, 
+            const basic_json_decode_options<char_type>& options = basic_json_options<CharT>())
+        {
+            json_decoder<basic_json> decoder(alloc_set.get_allocator(), alloc_set.get_temp_allocator());
+            basic_json_reader<char_type,stream_source<char_type>,Allocator> reader(is, decoder, options, alloc_set.get_temp_allocator());
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json stream"));
+            }
+            return decoder.get_result();
+        }
+
+        // from iterator
+
+        template <typename InputIt>
+        static basic_json parse(InputIt first, InputIt last, 
+                                const basic_json_decode_options<char_type>& options = basic_json_options<CharT>())
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_reader<char_type,iterator_source<InputIt>,Allocator> reader(iterator_source<InputIt>(std::forward<InputIt>(first),
+                std::forward<InputIt>(last)), decoder, options);
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json from iterator pair"));
+            }
+            return decoder.get_result();
+        }
+
+        template <typename InputIt,typename TempAllocator >
+        static basic_json parse(const allocator_set<allocator_type,TempAllocator>& alloc_set, InputIt first, InputIt last, 
+                                const basic_json_decode_options<char_type>& options = basic_json_options<CharT>())
+        {
+            json_decoder<basic_json> decoder(alloc_set.get_allocator(), alloc_set.get_temp_allocator());
+            basic_json_reader<char_type,iterator_source<InputIt>,Allocator> reader(iterator_source<InputIt>(std::forward<InputIt>(first),
+                std::forward<InputIt>(last)), 
+                decoder, options, alloc_set.get_temp_allocator());
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json from iterator pair"));
+            }
+            return decoder.get_result();
+        }
+
+#if !defined(JSONCONS_NO_DEPRECATED)
+
+        static basic_json parse(const char_type* s, 
+            const basic_json_decode_options<char_type>& options, 
+            std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            return parse(jsoncons::basic_string_view<char_type>(s), options, err_handler);
+        }
+
+        static basic_json parse(const char_type* s, 
+                                std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            return parse(jsoncons::basic_string_view<char_type>(s), basic_json_decode_options<char_type>(), err_handler);
+        }
+
+        static basic_json parse(std::basic_istream<char_type>& is, 
+            const basic_json_decode_options<char_type>& options, 
+            std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_reader<char_type,stream_source<char_type>> reader(is, decoder, options, err_handler);
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json stream"));
+            }
+            return decoder.get_result();
+        }
+
+        static basic_json parse(std::basic_istream<char_type>& is, std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            return parse(is, basic_json_decode_options<CharT>(), err_handler);
+        }
+
+        template <typename InputIt>
+        static basic_json parse(InputIt first, InputIt last, 
+                                const basic_json_decode_options<char_type>& options, 
+                                std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_reader<char_type,iterator_source<InputIt>> reader(iterator_source<InputIt>(std::forward<InputIt>(first),std::forward<InputIt>(last)), decoder, options, err_handler);
+            reader.read_next();
+            reader.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json from iterator pair"));
+            }
+            return decoder.get_result();
+        }
+
+        template <typename Source>
+        static
+        typename std::enable_if<extension_traits::is_sequence_of<Source,char_type>::value,basic_json>::type
+        parse(const Source& source, 
+              const basic_json_decode_options<char_type>& options, 
+              std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            json_decoder<basic_json> decoder;
+            basic_json_parser<char_type> parser(options,err_handler);
+
+            auto r = unicode_traits::detect_encoding_from_bom(source.data(), source.size());
+            if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+            {
+                JSONCONS_THROW(ser_error(json_errc::illegal_unicode_character,parser.line(),parser.column()));
+            }
+            std::size_t offset = (r.ptr - source.data());
+            parser.update(source.data()+offset,source.size()-offset);
+            parser.parse_some(decoder);
+            parser.finish_parse(decoder);
+            parser.check_done();
+            if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(json_errc::source_error, "Failed to parse json string"));
+            }
+            return decoder.get_result();
+        }
+
+        template <typename Source>
+        static
+        typename std::enable_if<extension_traits::is_sequence_of<Source,char_type>::value,basic_json>::type
+        parse(const Source& source, 
+            std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            return parse(source, basic_json_decode_options<CharT>(), err_handler);
+        }
+
+        template <typename InputIt>
+        static basic_json parse(InputIt first, InputIt last, 
+                                std::function<bool(json_errc,const ser_context&)> err_handler)
+        {
+            return parse(first, last, basic_json_decode_options<CharT>(), err_handler);
+        }
+#endif
+        static basic_json make_array()
+        {
+            return basic_json(array());
+        }
+
+        static basic_json make_array(const array& alloc)
+        {
+            return basic_json(alloc);
+        }
+
+        static basic_json make_array(const array& a, allocator_type alloc)
+        {
+            return basic_json(a, semantic_tag::none, alloc);
+        }
+
+        static basic_json make_array(std::initializer_list<basic_json> init, const Allocator& alloc = Allocator())
+        {
+            return array(std::move(init),alloc);
+        }
+
+        static basic_json make_array(std::size_t n, const Allocator& alloc = Allocator())
+        {
+            return array(n,alloc);
+        }
+
+        template <typename T>
+        static basic_json make_array(std::size_t n, const T& val, const Allocator& alloc = Allocator())
+        {
+            return basic_json::array(n, val,alloc);
+        }
+
+        template <std::size_t dim>
+        static typename std::enable_if<dim==1,basic_json>::type make_array(std::size_t n)
+        {
+            return array(n);
+        }
+
+        template <std::size_t dim,typename T>
+        static typename std::enable_if<dim==1,basic_json>::type make_array(std::size_t n, const T& val, const Allocator& alloc = Allocator())
+        {
+            return array(n,val,alloc);
+        }
+
+        template <std::size_t dim,typename... Args>
+        static typename std::enable_if<(dim>1),basic_json>::type make_array(std::size_t n, Args... args)
+        {
+            const size_t dim1 = dim - 1;
+
+            basic_json val = make_array<dim1>(std::forward<Args>(args)...);
+            val.resize(n);
+            for (std::size_t i = 0; i < n; ++i)
+            {
+                val[i] = make_array<dim1>(std::forward<Args>(args)...);
+            }
+            return val;
+        }
+
+        static const basic_json& null()
+        {
+            static const basic_json a_null = basic_json(null_arg, semantic_tag::none);
+            return a_null;
+        }
+
+        basic_json() 
+        {
+            construct<empty_object_storage>(semantic_tag::none);
+        }
+
+        explicit basic_json(const Allocator& alloc) 
+        {
+            auto ptr = create_object(alloc);
+            construct<object_storage>(ptr, semantic_tag::none);
+        }
+
+        basic_json(semantic_tag tag, const Allocator& alloc) 
+        {
+            auto ptr = create_object(alloc);
+            construct<object_storage>(ptr, tag);
+        }
+
+        basic_json(semantic_tag tag) 
+        {
+            construct<empty_object_storage>(tag);
+        }
+
+        basic_json(const basic_json& other)
+        {
+            uninitialized_copy(other);
+        }
+
+        basic_json(const basic_json& other, const Allocator& alloc)
+        {
+            uninitialized_copy_a(other,alloc);
+        }
+
+        basic_json(basic_json&& other) noexcept
+        {
+            uninitialized_move(std::move(other));
+        }
+
+        template <typename U = Allocator>
+        basic_json(basic_json&& other, const Allocator& alloc) noexcept
+        {
+            uninitialized_move_a(typename std::allocator_traits<U>::is_always_equal(), std::move(other), alloc);
+        }
+
+        explicit basic_json(json_object_arg_t, 
+                            semantic_tag tag,
+                            const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_object(alloc);
+            construct<object_storage>(ptr, tag);
+        }
+
+        explicit basic_json(json_object_arg_t, const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_object(alloc);
+            construct<object_storage>(ptr, semantic_tag::none);
+        }
+
+        template <typename InputIt>
+        basic_json(json_object_arg_t, 
+                   InputIt first, InputIt last, 
+                   semantic_tag tag = semantic_tag::none,
+                   const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_object(alloc, first, last);
+            construct<object_storage>(ptr, tag);
+        }
+
+        basic_json(json_object_arg_t, 
+                   std::initializer_list<std::pair<std::basic_string<char_type>,basic_json>> init, 
+                   semantic_tag tag = semantic_tag::none, 
+                   const Allocator& alloc = Allocator()) 
+        {
+            //construct<object_storage>(object(init,alloc), tag);
+            auto ptr = create_object(alloc, init);
+            construct<object_storage>(ptr, tag);
+        }
+
+        explicit basic_json(json_array_arg_t, const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_array(alloc);
+            construct<array_storage>(ptr, semantic_tag::none);
+        }
+
+        basic_json(json_array_arg_t, std::size_t count, const basic_json& value,
+            semantic_tag tag = semantic_tag::none, const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_array(alloc, count, value);
+            construct<array_storage>(ptr, tag);
+        }
+
+        basic_json(json_array_arg_t, 
+            semantic_tag tag, 
+            const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_array(alloc);
+            construct<array_storage>(ptr, tag);
+        }
+
+        template <typename InputIt>
+        basic_json(json_array_arg_t, 
+                   InputIt first, InputIt last, 
+                   semantic_tag tag = semantic_tag::none, 
+                   const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_array(alloc, first, last);
+            construct<array_storage>(ptr, tag);
+        }
+
+        basic_json(json_array_arg_t, 
+                   std::initializer_list<basic_json> init, 
+                   semantic_tag tag = semantic_tag::none, 
+                   const Allocator& alloc = Allocator()) 
+        {
+            auto ptr = create_array(alloc, init);
+            construct<array_storage>(ptr, tag);
+        }
+
+        basic_json(json_const_pointer_arg_t, const basic_json* ptr) noexcept 
+        {
+            if (ptr == nullptr)
+            {
+                construct<null_storage>(semantic_tag::none);
+            }
+            else
+            {
+                construct<json_const_reference_storage>(*ptr);
+            }
+        }
+
+        basic_json(json_pointer_arg_t, basic_json* ptr) noexcept 
+        {
+            if (ptr == nullptr)
+            {
+                construct<null_storage>(semantic_tag::none);
+            }
+            else
+            {
+                construct<json_reference_storage>(*ptr);
+            }
+        }
+
+        basic_json(const array& val, semantic_tag tag = semantic_tag::none)
+        {
+            auto ptr = create_array(
+                std::allocator_traits<Allocator>::select_on_container_copy_construction(val.get_allocator()), 
+                val);
+            construct<array_storage>(ptr, tag);
+        }
+
+        basic_json(array&& val, semantic_tag tag = semantic_tag::none)
+        {
+            auto alloc = val.get_allocator();
+            auto ptr = create_array(alloc, std::move(val));
+            construct<array_storage>(ptr, tag);
+        }
+
+        basic_json(const object& val, semantic_tag tag = semantic_tag::none)
+        {
+            auto ptr = create_object(
+                std::allocator_traits<Allocator>::select_on_container_copy_construction(val.get_allocator()), 
+                val);
+            construct<object_storage>(ptr, tag);
+        }
+
+        basic_json(object&& val, semantic_tag tag = semantic_tag::none)
+        {
+            auto alloc = val.get_allocator();
+            auto ptr = create_object(alloc, std::move(val));
+            construct<object_storage>(ptr, tag);
+        }
+
+        template <typename T,
+                  class = typename std::enable_if<!extension_traits::is_basic_json<T>::value>::type>
+        basic_json(const T& val)
+            : basic_json(json_type_traits<basic_json,T>::to_json(val))
+        {
+        }
+
+        template <typename T,
+                  class = typename std::enable_if<!extension_traits::is_basic_json<T>::value>::type>
+        basic_json(const T& val, const Allocator& alloc)
+            : basic_json(json_type_traits<basic_json,T>::to_json(val,alloc))
+        {
+        }
+
+        basic_json(const string_type& s)
+            : basic_json(s.data(), s.size(), semantic_tag::none, s.get_allocator())
+        {
+        }
+
+        basic_json(const string_view_type& s, const allocator_type& alloc = allocator_type())
+            : basic_json(s.data(), s.size(), semantic_tag::none, alloc)
+        {
+        }
+
+        basic_json(const string_type& s, semantic_tag tag)
+            : basic_json(s.data(), s.size(), tag, s.get_allocator())
+        {
+        }
+
+        basic_json(const string_type& s, semantic_tag tag, const allocator_type& alloc)
+            : basic_json(s.data(), s.size(), tag, alloc)
+        {
+        }
+
+        basic_json(const char_type* s, semantic_tag tag = semantic_tag::none)
+            : basic_json(s, char_traits_type::length(s), tag)
+        {
+        }
+
+        basic_json(const char_type* s, semantic_tag tag, const allocator_type& alloc)
+            : basic_json(s, char_traits_type::length(s), tag, alloc)
+        {
+        }
+
+        basic_json(const char_type* s, const Allocator& alloc)
+            : basic_json(s, char_traits_type::length(s), semantic_tag::none, alloc)
+        {
+        }
+
+        basic_json(const char_type* s, std::size_t length, semantic_tag tag = semantic_tag::none)
+        {
+            if (length <= short_string_storage::max_length)
+            {
+                construct<short_string_storage>(s, static_cast<uint8_t>(length), tag);
+            }
+            else
+            {
+                auto ptr = create_long_string(allocator_type{}, s, length);
+                construct<long_string_storage>(ptr, tag);
+            }
+        }
+
+        basic_json(const char_type* s, std::size_t length, semantic_tag tag, const Allocator& alloc)
+        {
+            if (length <= short_string_storage::max_length)
+            {
+                construct<short_string_storage>(s, static_cast<uint8_t>(length), tag);
+            }
+            else
+            {
+                auto ptr = create_long_string(alloc, s, length);
+                construct<long_string_storage>(ptr, tag);
+            }
+        }
+
+        basic_json(half_arg_t, uint16_t val, semantic_tag tag = semantic_tag::none)
+        {
+            construct<half_storage>(val, tag);
+        }
+
+        basic_json(half_arg_t, uint16_t val, semantic_tag tag, const allocator_type&)
+        {
+            construct<half_storage>(val, tag);
+        }
+
+        basic_json(double val, semantic_tag tag)
+        {
+            construct<double_storage>(val, tag);
+        }
+
+        basic_json(double val, semantic_tag tag, const allocator_type&)
+        {
+            construct<double_storage>(val, tag);
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag tag, 
+                   typename std::enable_if<extension_traits::is_unsigned_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(uint64_t), int>::type = 0)
+        {
+            construct<uint64_storage>(val, tag);
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag tag, Allocator, 
+                   typename std::enable_if<extension_traits::is_unsigned_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(uint64_t), int>::type = 0)
+        {
+            construct<uint64_storage>(val, tag);
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag, const Allocator& alloc = Allocator(),
+                   typename std::enable_if<extension_traits::is_unsigned_integer<IntegerType>::value && sizeof(uint64_t) < sizeof(IntegerType), int>::type = 0)
+        {
+            std::basic_string<CharT> s;
+            jsoncons::detail::from_integer(val, s);
+            if (s.length() <= short_string_storage::max_length)
+            {
+                construct<short_string_storage>(s.data(), static_cast<uint8_t>(s.length()), semantic_tag::bigint);
+            }
+            else
+            {
+                auto ptr = create_long_string(alloc, s.data(), s.length());
+                construct<long_string_storage>(ptr, semantic_tag::bigint);
+            }
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag tag,
+                   typename std::enable_if<extension_traits::is_signed_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(int64_t),int>::type = 0)
+        {
+            construct<int64_storage>(val, tag);
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag tag, Allocator,
+                   typename std::enable_if<extension_traits::is_signed_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(int64_t),int>::type = 0)
+        {
+            construct<int64_storage>(val, tag);
+        }
+
+        template <typename IntegerType>
+        basic_json(IntegerType val, semantic_tag, const Allocator& alloc = Allocator(),
+                   typename std::enable_if<extension_traits::is_signed_integer<IntegerType>::value && sizeof(int64_t) < sizeof(IntegerType),int>::type = 0)
+        {
+            std::basic_string<CharT> s;
+            jsoncons::detail::from_integer(val, s);
+            if (s.length() <= short_string_storage::max_length)
+            {
+                construct<short_string_storage>(s.data(), static_cast<uint8_t>(s.length()), semantic_tag::bigint);
+            }
+            else
+            {
+                auto ptr = create_long_string(alloc, s.data(), s.length());
+                construct<long_string_storage>(ptr, semantic_tag::bigint);
+            }
+        }
+
+        basic_json(null_type, semantic_tag tag)
+        {
+            construct<null_storage>(tag);
+        }
+
+        basic_json(null_type, semantic_tag tag, const Allocator&)
+        {
+            construct<null_storage>(tag);
+        }
+
+        basic_json(bool val, semantic_tag tag)
+        {
+            construct<bool_storage>(val,tag);
+        }
+
+        basic_json(bool val, semantic_tag tag, const Allocator&)
+        {
+            construct<bool_storage>(val,tag);
+        }
+
+        basic_json(const string_view_type& sv, semantic_tag tag, const allocator_type& alloc = allocator_type())
+            : basic_json(sv.data(), sv.length(), tag, alloc)
+        {
+        }
+
+        template <typename Source>
+        basic_json(byte_string_arg_t, const Source& source, 
+                   semantic_tag tag = semantic_tag::none,
+                   const Allocator& alloc = Allocator(),
+                   typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            auto bytes = jsoncons::span<const uint8_t>(reinterpret_cast<const uint8_t*>(source.data()), source.size());
+            
+            auto ptr = create_byte_string(alloc, bytes.data(), bytes.size(), 0);
+            construct<byte_string_storage>(ptr, tag);
+        }
+
+        template <typename Source>
+        basic_json(byte_string_arg_t, const Source& source, 
+                   uint64_t ext_tag,
+                   const Allocator& alloc = Allocator(),
+                   typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            auto bytes = jsoncons::span<const uint8_t>(reinterpret_cast<const uint8_t*>(source.data()), source.size());
+
+            auto ptr = create_byte_string(alloc, bytes.data(), bytes.size(), ext_tag);
+            construct<byte_string_storage>(ptr, semantic_tag::ext);
+        }
+
+        ~basic_json() noexcept
+        {
+             destroy();
+        }
+
+        template <typename T>
+        basic_json& operator=(const T& val)
+        {
+            *this = json_type_traits<basic_json,T>::to_json(val);
+            return *this;
+        }
+
+        basic_json& operator=(const char_type* s)
+        {
+            *this = basic_json(s, char_traits_type::length(s), semantic_tag::none);
+            return *this;
+        }
+
+        basic_json& operator[](std::size_t i)
+        {
+            return at(i);
+        }
+
+        const basic_json& operator[](std::size_t i) const
+        {
+            return at(i);
+        }
+
+        basic_json& operator[](const string_view_type& key)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object: 
+                    return try_emplace(key, basic_json{}).first->value();
+                case json_storage_kind::object:
+                {           
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it == cast<object_storage>().value().end())
+                    {
+                        return try_emplace(key, basic_json{}).first->value();
+                    }
+                    else
+                    {
+                        return (*it).value();
+                    }
+                    break;
+                }
+                case json_storage_kind::json_reference: 
+                    return cast<json_reference_storage>().value()[key];
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }               
+        }
+
+        const basic_json& operator[](const string_view_type& key) const
+        {
+            static const basic_json an_empty_object = basic_json();
+
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object: 
+                    return an_empty_object;
+                case json_storage_kind::object:
+                {           
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it == cast<object_storage>().value().end())
+                    {
+                        return an_empty_object;
+                    }
+                    else
+                    {
+                        return (*it).value();
+                    }
+                    break;
+                }
+                case json_storage_kind::json_const_reference: 
+                    return cast<json_const_reference_storage>().value().at(key);
+                case json_storage_kind::json_reference: 
+                    return cast<json_reference_storage>().value()[key];
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont,
+             const basic_json_encode_options<char_type>& options = basic_json_options<CharT>(),
+             indenting indent = indenting::no_indent) const
+        {
+            std::error_code ec;
+            dump(cont, options, indent, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump_pretty(CharContainer& cont,
+            const basic_json_encode_options<char_type>& options = basic_json_options<CharT>()) const
+        {
+            std::error_code ec;
+            dump_pretty(cont, options, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+            const basic_json_encode_options<char_type>& options = basic_json_options<CharT>(),
+            indenting indent = indenting::no_indent) const
+        {
+            std::error_code ec;
+            dump(os, options, indent, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump_pretty(CharContainer& cont,
+            const basic_json_encode_options<char_type>& options, 
+            std::error_code& ec) const
+        {
+            basic_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            dump(encoder, ec);
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump_pretty(CharContainer& cont, 
+            std::error_code& ec) const
+        {
+            dump_pretty(cont, basic_json_encode_options<char_type>(), ec);
+        }
+
+        void dump_pretty(std::basic_ostream<char_type>& os, 
+            const basic_json_encode_options<char_type>& options = basic_json_options<CharT>()) const
+        {
+            std::error_code ec;
+            dump_pretty(os, options, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        void dump_pretty(std::basic_ostream<char_type>& os, 
+            const basic_json_encode_options<char_type>& options, 
+            std::error_code& ec) const
+        {
+            basic_json_encoder<char_type> encoder(os, options);
+            dump(encoder, ec);
+        }
+
+        void dump_pretty(std::basic_ostream<char_type>& os, 
+            std::error_code& ec) const
+        {
+            dump_pretty(os, basic_json_encode_options<char_type>(), ec);
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont, indenting indent) const
+        {
+            std::error_code ec;
+
+            dump(cont, indent, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+                  indenting indent) const
+        {
+            std::error_code ec;
+
+            dump(os, indent, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        void dump(basic_json_visitor<char_type>& visitor) const
+        {
+            std::error_code ec;
+            dump(visitor, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec));
+            }
+        }
+
+        // dump
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont,
+                  const basic_json_encode_options<char_type>& options, 
+                  std::error_code& ec) const
+        {
+            basic_compact_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            dump(encoder, ec);
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont, 
+                  std::error_code& ec) const
+        {
+            basic_compact_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont);
+            dump(encoder, ec);
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+                  const basic_json_encode_options<char_type>& options,
+                  std::error_code& ec) const
+        {
+            basic_compact_json_encoder<char_type> encoder(os, options);
+            dump(encoder, ec);
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+                  std::error_code& ec) const
+        {
+            basic_compact_json_encoder<char_type> encoder(os);
+            dump(encoder, ec);
+        }
+
+        // legacy
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont,
+                  const basic_json_encode_options<char_type>& options, 
+                  indenting indent,
+                  std::error_code& ec) const
+        {
+            if (indent == indenting::indent)
+            {
+                dump_pretty(cont, options, ec);
+            }
+            else
+            {
+                dump(cont, options, ec);
+            }
+        }
+
+        template <typename CharContainer>
+        typename std::enable_if<extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+        dump(CharContainer& cont, 
+                  indenting indent,
+                  std::error_code& ec) const
+        {
+            if (indent == indenting::indent)
+            {
+                dump_pretty(cont, ec);
+            }
+            else
+            {
+                dump(cont, ec);
+            }
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+                  const basic_json_encode_options<char_type>& options, 
+                  indenting indent,
+                  std::error_code& ec) const
+        {
+            if (indent == indenting::indent)
+            {
+                dump_pretty(os, options, ec);
+            }
+            else
+            {
+                dump(os, options, ec);
+            }
+        }
+
+        void dump(std::basic_ostream<char_type>& os, 
+                  indenting indent,
+                  std::error_code& ec) const
+        {
+            if (indent == indenting::indent)
+            {
+                dump_pretty(os, ec);
+            }
+            else
+            {
+                dump(os, ec);
+            }
+        }
+    // end legacy
+
+        void dump(basic_json_visitor<char_type>& visitor, 
+                  std::error_code& ec) const
+        {
+            dump_noflush(visitor, ec);
+            if (ec)
+            {
+                return;
+            }
+            visitor.flush();
+        }
+
+        bool is_null() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::null:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_null();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_null();
+                default:
+                    return false;
+            }
+        }
+
+        allocator_type get_default_allocator(std::false_type) const
+        {
+            JSONCONS_THROW(json_runtime_error<std::domain_error>("No default allocator if allocator is not default constructible."));
+        }
+
+        allocator_type get_default_allocator(std::true_type) const
+        {
+            return allocator_type{};
+        }
+
+        template <typename U=Allocator>
+        allocator_type get_allocator() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::long_str:
+                    return cast<long_string_storage>().get_allocator();
+                case json_storage_kind::byte_str:
+                    return cast<byte_string_storage>().get_allocator();
+                case json_storage_kind::array:
+                    return cast<array_storage>().get_allocator();
+                case json_storage_kind::object:
+                    return cast<object_storage>().get_allocator();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().get_allocator();
+                default:
+                    return get_default_allocator(typename std::allocator_traits<U>::is_always_equal());
+            }
+        }
+
+        uint64_t ext_tag() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::byte_str:
+                {
+                    return cast<byte_string_storage>().ext_tag();
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().ext_tag();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().ext_tag();
+                default:
+                    return 0;
+            }
+        }
+
+        bool contains(const string_view_type& key) const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    return it != cast<object_storage>().value().end();
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().contains(key);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().contains(key);
+                default:
+                    return false;
+            }
+        }
+
+        std::size_t count(const string_view_type& key) const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it == cast<object_storage>().value().end())
+                    {
+                        return 0;
+                    }
+                    std::size_t count = 0;
+                    while (it != cast<object_storage>().value().end()&& (*it).key() == key)
+                    {
+                        ++count;
+                        ++it;
+                    }
+                    return count;
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().count(key);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().count(key);
+                default:
+                    return 0;
+            }
+        }
+
+        template <typename T,typename... Args>
+        bool is(Args&&... args) const noexcept
+        {
+            return json_type_traits<basic_json,T>::is(*this,std::forward<Args>(args)...);
+        }
+
+        bool is_string() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_string();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_string();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_string_view() const noexcept
+        {
+            return is_string();
+        }
+
+        bool is_byte_string() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::byte_str:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_byte_string();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_byte_string();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_byte_string_view() const noexcept
+        {
+            return is_byte_string();
+        }
+
+        bool is_bignum() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    return jsoncons::detail::is_base10(as_string_view().data(), as_string_view().length());
+                case json_storage_kind::int64:
+                case json_storage_kind::uint64:
+                    return true;
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_bignum();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_bool() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::boolean:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_bool();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_bool();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_object() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                case json_storage_kind::object:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_object();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_object();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_array() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_array();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_array();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_int64() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::int64:
+                    return true;
+                case json_storage_kind::uint64:
+                    return as_integer<uint64_t>() <= static_cast<uint64_t>((std::numeric_limits<int64_t>::max)());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_int64();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_int64();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_uint64() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::uint64:
+                    return true;
+                case json_storage_kind::int64:
+                    return as_integer<int64_t>() >= 0;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_uint64();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_uint64();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_half() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::half_float:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_half();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_half();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_double() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::float64:
+                    return true;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_double();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_double();
+                default:
+                    return false;
+            }
+        }
+
+        bool is_number() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::int64:
+                case json_storage_kind::uint64:
+                case json_storage_kind::half_float:
+                case json_storage_kind::float64:
+                    return true;
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    return tag() == semantic_tag::bigint ||
+                           tag() == semantic_tag::bigdec ||
+                           tag() == semantic_tag::bigfloat;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().is_number();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().is_number();
+                default:
+                    return false;
+            }
+        }
+
+        bool empty() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::byte_str:
+                    return cast<byte_string_storage>().length() == 0;
+                    break;
+                case json_storage_kind::short_str:
+                    return cast<short_string_storage>().length() == 0;
+                case json_storage_kind::long_str:
+                    return cast<long_string_storage>().length() == 0;
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().empty();
+                case json_storage_kind::empty_object:
+                    return true;
+                case json_storage_kind::object:
+                    return cast<object_storage>().value().empty();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().empty();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().empty();
+                default:
+                    return false;
+            }
+        }
+
+        std::size_t capacity() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().capacity();
+                case json_storage_kind::object:
+                    return cast<object_storage>().value().capacity();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().capacity();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().capacity();
+                default:
+                    return 0;
+            }
+        }
+
+        template <typename U=Allocator>
+        void create_object_implicitly()
+        {
+            create_object_implicitly(typename std::allocator_traits<U>::is_always_equal());
+        }
+
+        void create_object_implicitly(std::false_type)
+        {
+            JSONCONS_THROW(json_runtime_error<std::domain_error>("Cannot create object implicitly - allocator is stateful."));
+        }
+
+        void create_object_implicitly(std::true_type)
+        {
+            *this = basic_json(json_object_arg, tag());
+        }
+
+        void reserve(std::size_t n)
+        {
+            if (n > 0)
+            {
+                switch (storage_kind())
+                {
+                    case json_storage_kind::array:
+                        cast<array_storage>().value().reserve(n);
+                        break;
+                    case json_storage_kind::empty_object:
+                        create_object_implicitly();
+                        cast<object_storage>().value().reserve(n);
+                        break;
+                    case json_storage_kind::object:
+                        cast<object_storage>().value().reserve(n);
+                        break;
+                    case json_storage_kind::json_reference:
+                        cast<json_reference_storage>().value().reserve(n);
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+        void resize(std::size_t n)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().resize(n);
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().resize(n);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        template <typename T>
+        void resize(std::size_t n, T val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().resize(n, val);
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().resize(n, val);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        template <typename T>
+        typename std::enable_if<is_json_type_traits_specialized<basic_json,T>::value,T>::type
+        as() const
+        {
+            T val = json_type_traits<basic_json,T>::as(*this);
+            return val;
+        }
+
+        template <typename T>
+        typename std::enable_if<(!extension_traits::is_string<T>::value && 
+                                 extension_traits::is_back_insertable_byte_container<T>::value) ||
+                                 extension_traits::is_basic_byte_string<T>::value,T>::type
+        as(byte_string_arg_t, semantic_tag hint) const
+        {
+            std::error_code ec;
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    switch (tag())
+                    {
+                        case semantic_tag::base16:
+                        case semantic_tag::base64:
+                        case semantic_tag::base64url:
+                        {
+                            value_converter<jsoncons::basic_string_view<char_type>,T> converter;
+                            T v = converter.convert(as_string_view(),tag(), ec);
+                            if (ec)
+                            {
+                                JSONCONS_THROW(ser_error(ec));
+                            }
+                            return v;
+                        }
+                        default:
+                        {
+                            value_converter<jsoncons::basic_string_view<char_type>, T> converter;
+                            T v = converter.convert(as_string_view(), hint, ec);
+                            if (ec)
+                            {
+                                JSONCONS_THROW(ser_error(ec));
+                            }
+                            return T(v.begin(),v.end());
+                        }
+                        break;
+                    }
+                    break;
+                }
+                case json_storage_kind::byte_str:
+                    return T(as_byte_string_view().begin(), as_byte_string_view().end());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template as<T>(byte_string_arg, hint);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template as<T>(byte_string_arg, hint);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a byte string"));
+            }
+        }
+
+        bool as_bool() const 
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::boolean:
+                    return cast<bool_storage>().value();
+                case json_storage_kind::int64:
+                    return cast<int64_storage>().value() != 0;
+                case json_storage_kind::uint64:
+                    return cast<uint64_storage>().value() != 0;
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_bool();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_bool();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a bool"));
+            }
+        }
+
+        template <typename IntegerType>
+        IntegerType as_integer() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    IntegerType val;
+                    auto result = jsoncons::detail::to_integer(as_string_view().data(), as_string_view().length(), val);
+                    if (!result)
+                    {
+                        JSONCONS_THROW(json_runtime_error<std::runtime_error>(result.error_code().message()));
+                    }
+                    return val;
+                }
+                case json_storage_kind::half_float:
+                    return static_cast<IntegerType>(cast<half_storage>().value());
+                case json_storage_kind::float64:
+                    return static_cast<IntegerType>(cast<double_storage>().value());
+                case json_storage_kind::int64:
+                    return static_cast<IntegerType>(cast<int64_storage>().value());
+                case json_storage_kind::uint64:
+                    return static_cast<IntegerType>(cast<uint64_storage>().value());
+                case json_storage_kind::boolean:
+                    return static_cast<IntegerType>(cast<bool_storage>().value() ? 1 : 0);
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template as_integer<IntegerType>();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template as_integer<IntegerType>();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an integer"));
+            }
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_signed_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(int64_t),bool>::type
+        is_integer() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::int64:
+                    return (as_integer<int64_t>() >= (extension_traits::integer_limits<IntegerType>::lowest)()) && (as_integer<int64_t>() <= (extension_traits::integer_limits<IntegerType>::max)());
+                case json_storage_kind::uint64:
+                    return as_integer<uint64_t>() <= static_cast<uint64_t>((extension_traits::integer_limits<IntegerType>::max)());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template is_integer<IntegerType>();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template is_integer<IntegerType>();
+                default:
+                    return false;
+            }
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_signed_integer<IntegerType>::value && sizeof(int64_t) < sizeof(IntegerType),bool>::type
+        is_integer() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    IntegerType val;
+                    auto result = jsoncons::detail::to_integer(as_string_view().data(), as_string_view().length(), val);
+                    return result ? true : false;
+                }
+                case json_storage_kind::int64:
+                    return (as_integer<int64_t>() >= (extension_traits::integer_limits<IntegerType>::lowest)()) && (as_integer<int64_t>() <= (extension_traits::integer_limits<IntegerType>::max)());
+                case json_storage_kind::uint64:
+                    return as_integer<uint64_t>() <= static_cast<uint64_t>((extension_traits::integer_limits<IntegerType>::max)());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template is_integer<IntegerType>();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template is_integer<IntegerType>();
+                default:
+                    return false;
+            }
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_unsigned_integer<IntegerType>::value && sizeof(IntegerType) <= sizeof(int64_t),bool>::type
+        is_integer() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::int64:
+                    return as_integer<int64_t>() >= 0 && static_cast<uint64_t>(as_integer<int64_t>()) <= (extension_traits::integer_limits<IntegerType>::max)();
+                case json_storage_kind::uint64:
+                    return as_integer<uint64_t>() <= (extension_traits::integer_limits<IntegerType>::max)();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template is_integer<IntegerType>();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template is_integer<IntegerType>();
+                default:
+                    return false;
+            }
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_unsigned_integer<IntegerType>::value && sizeof(int64_t) < sizeof(IntegerType),bool>::type
+        is_integer() const noexcept
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    IntegerType val;
+                    auto result = jsoncons::detail::to_integer(as_string_view().data(), as_string_view().length(), val);
+                    return result ? true : false;
+                }
+                case json_storage_kind::int64:
+                    return as_integer<int64_t>() >= 0 && static_cast<uint64_t>(as_integer<int64_t>()) <= (extension_traits::integer_limits<IntegerType>::max)();
+                case json_storage_kind::uint64:
+                    return as_integer<uint64_t>() <= (extension_traits::integer_limits<IntegerType>::max)();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template is_integer<IntegerType>();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template is_integer<IntegerType>();
+                default:
+                    return false;
+            }
+        }
+
+        double as_double() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    const jsoncons::detail::chars_to to_double;
+                    // to_double() throws std::invalid_argument if conversion fails
+                    return to_double(as_cstring(), as_string_view().length());
+                }
+                case json_storage_kind::half_float:
+                    return binary::decode_half(cast<half_storage>().value());
+                case json_storage_kind::float64:
+                    return cast<double_storage>().value();
+                case json_storage_kind::int64:
+                    return static_cast<double>(cast<int64_storage>().value());
+                case json_storage_kind::uint64:
+                    return static_cast<double>(cast<uint64_storage>().value());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_double();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_double();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Not a double"));
+            }
+        }
+
+        template <typename SAllocator=std::allocator<char_type>>
+        std::basic_string<char_type,char_traits_type,SAllocator> as_string() const 
+        {
+            return as_string(SAllocator());
+        }
+
+        template <typename SAllocator=std::allocator<char_type>>
+        std::basic_string<char_type,char_traits_type,SAllocator> as_string(const SAllocator& alloc) const 
+        {
+            using string_type2 = std::basic_string<char_type,char_traits_type,SAllocator>;
+
+            std::error_code ec;
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                {
+                    return string_type2(as_string_view().data(),as_string_view().length(),alloc);
+                }
+                case json_storage_kind::byte_str:
+                {
+                    value_converter<byte_string_view,string_type2> converter;
+                    auto s = converter.convert(as_byte_string_view(), tag(), ec);
+                    if (ec)
+                    {
+                        JSONCONS_THROW(ser_error(ec));
+                    }
+                    return s;
+                }
+                case json_storage_kind::array:
+                {
+                    string_type2 s(alloc);
+                    {
+                        basic_compact_json_encoder<char_type,jsoncons::string_sink<string_type2>> encoder(s);
+                        dump(encoder);
+                    }
+                    return s;
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_string(alloc);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_string(alloc);
+                default:
+                {
+                    string_type2 s(alloc);
+                    basic_compact_json_encoder<char_type,jsoncons::string_sink<string_type2>> encoder(s);
+                    dump(encoder);
+                    return s;
+                }
+            }
+        }
+
+        const char_type* as_cstring() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                    return cast<short_string_storage>().c_str();
+                case json_storage_kind::long_str:
+                    return cast<long_string_storage>().c_str();
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().as_cstring();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().as_cstring();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not a cstring"));
+            }
+        }
+
+        basic_json& at(const string_view_type& key)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    JSONCONS_THROW(key_not_found(key.data(),key.length()));
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it == cast<object_storage>().value().end())
+                    {
+                        JSONCONS_THROW(key_not_found(key.data(),key.length()));
+                    }
+                    return (*it).value();
+                }
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().at(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        const basic_json& at(const string_view_type& key) const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    JSONCONS_THROW(key_not_found(key.data(),key.length()));
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it == cast<object_storage>().value().end())
+                    {
+                        JSONCONS_THROW(key_not_found(key.data(),key.length()));
+                    }
+                    return (*it).value();
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().at(key);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().at(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        basic_json& at(std::size_t i)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    if (i >= cast<array_storage>().value().size())
+                    {
+                        JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+                    }
+                    return cast<array_storage>().value().operator[](i);
+                case json_storage_kind::object:
+                    return cast<object_storage>().value().at(i);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().at(i);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Index on non-array value not supported"));
+            }
+        }
+
+        const basic_json& at(std::size_t i) const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    if (i >= cast<array_storage>().value().size())
+                    {
+                        JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+                    }
+                    return cast<array_storage>().value().operator[](i);
+                case json_storage_kind::object:
+                    return cast<object_storage>().value().at(i);
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().at(i);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().at(i);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Index on non-array value not supported"));
+            }
+        }
+
+        object_iterator find(const string_view_type& key)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return object_range().end();
+                case json_storage_kind::object:
+                    return object_iterator(cast<object_storage>().value().find(key));
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().find(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        const_object_iterator find(const string_view_type& key) const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return object_range().end();
+                case json_storage_kind::object:
+                    return const_object_iterator(cast<object_storage>().value().find(key));
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().find(key);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().find(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        const basic_json& at_or_null(const string_view_type& key) const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::null:
+                case json_storage_kind::empty_object:
+                {
+                    return null();
+                }
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it != cast<object_storage>().value().end())
+                    {
+                        return (*it).value();
+                    }
+                    else
+                    {
+                        return null();
+                    }
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().at_or_null(key);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().at_or_null(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        template <typename T,typename U>
+        T get_value_or(const string_view_type& key, U&& default_value) const
+        {
+            static_assert(std::is_copy_constructible<T>::value,
+                          "get_value_or: T must be copy constructible");
+            static_assert(std::is_convertible<U&&, T>::value,
+                          "get_value_or: U must be convertible to T");
+            switch (storage_kind())
+            {
+                case json_storage_kind::null:
+                case json_storage_kind::empty_object:
+                    return static_cast<T>(std::forward<U>(default_value));
+                case json_storage_kind::object:
+                {
+                    auto it = cast<object_storage>().value().find(key);
+                    if (it != cast<object_storage>().value().end())
+                    {
+                        return (*it).value().template as<T>();
+                    }
+                    else
+                    {
+                        return static_cast<T>(std::forward<U>(default_value));
+                    }
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().template get_value_or<T,U>(key,std::forward<U>(default_value));
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().template get_value_or<T,U>(key,std::forward<U>(default_value));
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        // Modifiers
+
+        void shrink_to_fit()
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().shrink_to_fit();
+                    break;
+                case json_storage_kind::object:
+                    cast<object_storage>().value().shrink_to_fit();
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().shrink_to_fit();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        void clear()
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().clear();
+                    break;
+                case json_storage_kind::object:
+                    cast<object_storage>().value().clear();
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().clear();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        object_iterator erase(const_object_iterator pos)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return object_range().end();
+                case json_storage_kind::object:
+                    return object_iterator(cast<object_storage>().value().erase(pos));
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().erase(pos);
+            default:
+                JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an object"));
+            }
+        }
+
+        object_iterator erase(const_object_iterator first, const_object_iterator last)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return object_range().end();
+                case json_storage_kind::object:
+                    return object_iterator(cast<object_storage>().value().erase(first, last));
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().erase(first, last);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an object"));
+            }
+        }
+
+        array_iterator erase(const_array_iterator pos)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().erase(pos);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().erase(pos);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an array"));
+            }
+        }
+
+        array_iterator erase(const_array_iterator first, const_array_iterator last)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().erase(first, last);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().erase(first, last);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an array"));
+            }
+        }
+
+        // Removes all elements from an array value whose index is between from_index, inclusive, and to_index, exclusive.
+
+        void erase(const string_view_type& key)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    cast<object_storage>().value().erase(key);
+                    break;
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().erase(key);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        template <typename T>
+        std::pair<object_iterator,bool> insert_or_assign(const string_view_type& key, T&& val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                {
+                    create_object_implicitly();
+                    auto result = cast<object_storage>().value().insert_or_assign(key, std::forward<T>(val));
+                    return std::make_pair(object_iterator(result.first), result.second);
+                }
+                case json_storage_kind::object:
+                {
+                    auto result = cast<object_storage>().value().insert_or_assign(key, std::forward<T>(val));
+                    return std::make_pair(object_iterator(result.first), result.second);
+                }
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().insert_or_assign(key, std::forward<T>(val));
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        template <typename ... Args>
+        std::pair<object_iterator,bool> try_emplace(const string_view_type& key, Args&&... args)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                {
+                    create_object_implicitly();
+                    auto result = cast<object_storage>().value().try_emplace(key, std::forward<Args>(args)...);
+                    return std::make_pair(object_iterator(result.first),result.second);
+                }
+                case json_storage_kind::object:
+                {
+                    auto result = cast<object_storage>().value().try_emplace(key, std::forward<Args>(args)...);
+                    return std::make_pair(object_iterator(result.first),result.second);
+                }
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().try_emplace(key, std::forward<Args>(args)...);
+                default:
+                    JSONCONS_THROW(not_an_object(key.data(),key.length()));
+            }
+        }
+
+        // merge
+
+        void merge(const basic_json& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge(source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge(source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge(source);
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge(source.cast<json_reference_storage>().value());
+                    break;
+               default:
+                   JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+           }
+        }
+
+        void merge(basic_json&& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge(std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge(std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge(std::move(source));
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge(std::move(source.cast<json_reference_storage>().value()));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+           }
+        }
+
+        void merge(object_iterator hint, const basic_json& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge(hint, source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge(hint, source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge(hint, source);
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+                    }
+                     break;
+                case json_storage_kind::json_reference:
+                    merge(hint, source.cast<json_reference_storage>().value());
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        void merge(object_iterator hint, basic_json&& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge(hint, std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge(hint, std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge(hint, std::move(source));
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge(hint, std::move(source.cast<json_reference_storage>().value()));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        // merge_or_update
+
+        void merge_or_update(const basic_json& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge_or_update(source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge_or_update(source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge_or_update(source);
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge or update a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge_or_update(source.cast<json_reference_storage>().value());
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        void merge_or_update(basic_json&& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge_or_update(std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge_or_update(std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge_or_update(std::move(source));
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge or update a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge_or_update(std::move(source.cast<json_reference_storage>().value()));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        void merge_or_update(object_iterator hint, const basic_json& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge_or_update(hint, source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge_or_update(hint, source.cast<object_storage>().value());
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge_or_update(hint, source);
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge or update a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge_or_update(hint, source.cast<json_reference_storage>().value());
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        void merge_or_update(object_iterator hint, basic_json&& source)
+        {
+            switch (source.storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    break;
+                case json_storage_kind::object:
+                    switch (storage_kind())
+                    {
+                        case json_storage_kind::empty_object:
+                            create_object_implicitly();
+                            cast<object_storage>().value().merge_or_update(hint, std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::object:
+                            cast<object_storage>().value().merge_or_update(hint, std::move(source.cast<object_storage>().value()));
+                            break;
+                        case json_storage_kind::json_reference:
+                            cast<json_reference_storage>().value().merge_or_update(hint, std::move(source));
+                            break;
+                        default:
+                            JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge or update a value that is not an object"));
+                    }
+                    break;
+                case json_storage_kind::json_reference:
+                    merge_or_update(hint, std::move(source.cast<json_reference_storage>().value()));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to merge a value that is not an object"));
+            }
+        }
+
+        template <typename T>
+        object_iterator insert_or_assign(object_iterator hint, const string_view_type& name, T&& val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    create_object_implicitly();
+                    return object_iterator(cast<object_storage>().value().insert_or_assign(hint, name, std::forward<T>(val)));
+                case json_storage_kind::object:
+                    return object_iterator(cast<object_storage>().value().insert_or_assign(hint, name, std::forward<T>(val)));
+                case json_storage_kind::json_reference:
+                    return object_iterator(cast<json_reference_storage>().value().insert_or_assign(hint, name, std::forward<T>(val)));
+                default:
+                    JSONCONS_THROW(not_an_object(name.data(),name.length()));
+            }
+        }
+
+        template <typename ... Args>
+        object_iterator try_emplace(object_iterator hint, const string_view_type& name, Args&&... args)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    create_object_implicitly();
+                    return object_iterator(cast<object_storage>().value().try_emplace(hint, name, std::forward<Args>(args)...));
+                case json_storage_kind::object:
+                    return object_iterator(cast<object_storage>().value().try_emplace(hint, name, std::forward<Args>(args)...));
+                case json_storage_kind::json_reference:
+                    return object_iterator(cast<json_reference_storage>().value().try_emplace(hint, name, std::forward<Args>(args)...));
+                default:
+                    JSONCONS_THROW(not_an_object(name.data(),name.length()));
+            }
+        }
+
+        template <typename T>
+        array_iterator insert(const_array_iterator pos, T&& val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().insert(pos, std::forward<T>(val));
+                    break;
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().insert(pos, std::forward<T>(val));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        template <typename InputIt>
+        array_iterator insert(const_array_iterator pos, InputIt first, InputIt last)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().insert(pos, first, last);
+                    break;
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().insert(pos, first, last);
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        template <typename InputIt>
+        void insert(InputIt first, InputIt last)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    create_object_implicitly();
+                    cast<object_storage>().value().insert(first, last);
+                    break;
+                case json_storage_kind::object:
+                    cast<object_storage>().value().insert(first, last);
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().insert(first, last);
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an object"));
+            }
+        }
+
+        template <typename InputIt>
+        void insert(sorted_unique_range_tag tag, InputIt first, InputIt last)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    create_object_implicitly();
+                    cast<object_storage>().value().insert(tag, first, last);
+                    break;
+                case json_storage_kind::object:
+                    cast<object_storage>().value().insert(tag, first, last);
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().insert(tag, first, last);
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an object"));
+            }
+        }
+
+        template <typename... Args> 
+        array_iterator emplace(const_array_iterator pos, Args&&... args)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().emplace(pos, std::forward<Args>(args)...);
+                    break;
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().emplace(pos, std::forward<Args>(args)...);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        template <typename... Args> 
+        basic_json& emplace_back(Args&&... args)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return cast<array_storage>().value().emplace_back(std::forward<Args>(args)...);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().emplace_back(std::forward<Args>(args)...);
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        friend void swap(basic_json& a, basic_json& b) noexcept
+        {
+            a.swap(b);
+        }
+
+        template <typename T>
+        void push_back(T&& val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().push_back(std::forward<T>(val));
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().push_back(std::forward<T>(val));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        void push_back(basic_json&& val)
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    cast<array_storage>().value().push_back(std::move(val));
+                    break;
+                case json_storage_kind::json_reference:
+                    cast<json_reference_storage>().value().push_back(std::move(val));
+                    break;
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Attempting to insert into a value that is not an array"));
+            }
+        }
+
+        std::basic_string<char_type> to_string() const noexcept
+        {
+            using string_type2 = std::basic_string<char_type>;
+            string_type2 s;
+            basic_compact_json_encoder<char_type, jsoncons::string_sink<string_type2>> encoder(s);
+            dump(encoder);
+            return s;
+        }
+
+        template <typename InputIterator>
+        basic_json(InputIterator first, InputIterator last, const Allocator& alloc = Allocator())
+            : basic_json(json_array_arg,first,last,alloc)
+        {
+        }
+
+        object_range_type object_range()
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return object_range_type(object_iterator(), object_iterator());
+                case json_storage_kind::object:
+                    return object_range_type(object_iterator(cast<object_storage>().value().begin()),
+                                                  object_iterator(cast<object_storage>().value().end()));
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().object_range();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an object"));
+            }
+        }
+
+        const_object_range_type object_range() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::empty_object:
+                    return const_object_range_type(const_object_iterator(), const_object_iterator());
+                case json_storage_kind::object:
+                    return const_object_range_type(const_object_iterator(cast<object_storage>().value().begin()),
+                                                        const_object_iterator(cast<object_storage>().value().end()));
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().object_range();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().object_range();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an object"));
+            }
+        }
+
+        array_range_type array_range()
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return array_range_type(cast<array_storage>().value().begin(),
+                        cast<array_storage>().value().end());
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().array_range();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an array"));
+            }
+        }
+
+        const_array_range_type array_range() const
+        {
+            switch (storage_kind())
+            {
+                case json_storage_kind::array:
+                    return const_array_range_type(cast<array_storage>().value().begin(),
+                        cast<array_storage>().value().end());
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().array_range();
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().array_range();
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::domain_error>("Not an array"));
+            }
+        }
+
+    private:
+
+        void dump_noflush(basic_json_visitor<char_type>& visitor, std::error_code& ec) const
+        {
+            const ser_context context{};
+            switch (storage_kind())
+            {
+                case json_storage_kind::short_str:
+                case json_storage_kind::long_str:
+                    visitor.string_value(as_string_view(), tag(), context, ec);
+                    break;
+                case json_storage_kind::byte_str:
+                    if (tag() == semantic_tag::ext)
+                    {
+                        visitor.byte_string_value(as_byte_string_view(), ext_tag(), context, ec);
+                    }
+                    else
+                    {
+                        visitor.byte_string_value(as_byte_string_view(), tag(), context, ec);
+                    }
+                    break;
+                case json_storage_kind::half_float:
+                    visitor.half_value(cast<half_storage>().value(), tag(), context, ec);
+                    break;
+                case json_storage_kind::float64:
+                    visitor.double_value(cast<double_storage>().value(), 
+                                         tag(), context, ec);
+                    break;
+                case json_storage_kind::int64:
+                    visitor.int64_value(cast<int64_storage>().value(), tag(), context, ec);
+                    break;
+                case json_storage_kind::uint64:
+                    visitor.uint64_value(cast<uint64_storage>().value(), tag(), context, ec);
+                    break;
+                case json_storage_kind::boolean:
+                    visitor.bool_value(cast<bool_storage>().value(), tag(), context, ec);
+                    break;
+                case json_storage_kind::null:
+                    visitor.null_value(tag(), context, ec);
+                    break;
+                case json_storage_kind::empty_object:
+                    visitor.begin_object(0, tag(), context, ec);
+                    visitor.end_object(context, ec);
+                    break;
+                case json_storage_kind::object:
+                {
+                    bool more = visitor.begin_object(size(), tag(), context, ec);
+                    const object& o = cast<object_storage>().value();
+                    for (auto it = o.begin(); more && it != o.end(); ++it)
+                    {
+                        visitor.key(string_view_type(((*it).key()).data(),(*it).key().length()), context, ec);
+                        (*it).value().dump_noflush(visitor, ec);
+                    }
+                    if (more)
+                    {
+                        visitor.end_object(context, ec);
+                    }
+                    break;
+                }
+                case json_storage_kind::array:
+                {
+                    bool more = visitor.begin_array(size(), tag(), context, ec);
+                    const array& o = cast<array_storage>().value();
+                    for (const_array_iterator it = o.begin(); more && it != o.end(); ++it)
+                    {
+                        (*it).dump_noflush(visitor, ec);
+                    }
+                    if (more)
+                    {
+                        visitor.end_array(context, ec);
+                    }
+                    break;
+                }
+                case json_storage_kind::json_const_reference:
+                    return cast<json_const_reference_storage>().value().dump_noflush(visitor, ec);
+                case json_storage_kind::json_reference:
+                    return cast<json_reference_storage>().value().dump_noflush(visitor, ec);
+                default:
+                    break;
+            }
+        }
+
+        friend std::basic_ostream<char_type>& operator<<(std::basic_ostream<char_type>& os, const basic_json& o)
+        {
+            o.dump(os);
+            return os;
+        }
+
+        friend std::basic_istream<char_type>& operator>>(std::basic_istream<char_type>& is, basic_json& o)
+        {
+            json_decoder<basic_json> visitor;
+            basic_json_reader<char_type,stream_source<char_type>> reader(is, visitor);
+            reader.read_next();
+            reader.check_done();
+            if (!visitor.is_valid())
+            {
+                JSONCONS_THROW(json_runtime_error<std::runtime_error>("Failed to parse json stream"));
+            }
+            o = visitor.get_result();
+            return is;
+        }
+
+        friend basic_json deep_copy(const basic_json& other)
+        {
+            switch (other.storage_kind())
+            {
+                case json_storage_kind::array:
+                {
+                    basic_json j(json_array_arg, other.tag(), other.get_allocator());
+                    j.reserve(other.size());
+
+                    for (const auto& item : other.array_range())
+                    {
+                        j.push_back(deep_copy(item));
+                    }
+                    return j;
+                }
+                case json_storage_kind::object:
+                {
+                    basic_json j(json_object_arg, other.tag(), other.get_allocator());
+                    j.reserve(other.size());
+
+                    for (const auto& item : other.object_range())
+                    {
+                        j.try_emplace(item.key(), deep_copy(item.value()));
+                    }
+                    return j;
+                }
+                case json_storage_kind::json_const_reference:
+                    return deep_copy(other.cast<json_const_reference_storage>().value());
+                case json_storage_kind::json_reference:
+                    return deep_copy(other.cast<json_reference_storage>().value());
+                default:
+                    return other;
+            }
+        }
+    };
+
+    // operator==
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator==(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator==(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) == 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator==(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    // operator!=
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator!=(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator!=(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) != 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator!=(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    // operator<
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator<(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator<(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) < 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator<(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    // operator<=
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator<=(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator<=(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator<=(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    // operator>
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator>(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator>(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) > 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator>(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    // operator>=
+
+    template <typename Json>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value,bool>::type
+    operator>=(const Json& lhs, const Json& rhs) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator>=(const Json& lhs, const T& rhs) 
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<extension_traits::is_basic_json<Json>::value && std::is_convertible<T,Json>::value,bool>::type
+    operator>=(const T& lhs, const Json& rhs) 
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+
+    // swap
+
+    template <typename Json>
+    void swap(typename Json::key_value_type& a,typename Json::key_value_type& b) noexcept
+    {
+        a.swap(b);
+    }
+
+    using json = basic_json<char,sorted_policy,std::allocator<char>>;
+    using wjson = basic_json<wchar_t,sorted_policy,std::allocator<char>>;
+    using ojson = basic_json<char, order_preserving_policy, std::allocator<char>>;
+    using wojson = basic_json<wchar_t, order_preserving_policy, std::allocator<char>>;
+
+    inline namespace literals {
+
+    inline 
+    jsoncons::json operator "" _json(const char* s, std::size_t n)
+    {
+        return jsoncons::json::parse(jsoncons::json::string_view_type(s, n));
+    }
+
+    inline 
+    jsoncons::wjson operator "" _json(const wchar_t* s, std::size_t n)
+    {
+        return jsoncons::wjson::parse(jsoncons::wjson::string_view_type(s, n));
+    }
+
+    inline
+    jsoncons::ojson operator "" _ojson(const char* s, std::size_t n)
+    {
+        return jsoncons::ojson::parse(jsoncons::ojson::string_view_type(s, n));
+    }
+
+    inline
+    jsoncons::wojson operator "" _ojson(const wchar_t* s, std::size_t n)
+    {
+        return jsoncons::wojson::parse(jsoncons::wojson::string_view_type(s, n));
+    }
+
+    } // inline namespace literals
+
+    #if defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR)
+    namespace pmr {
+        template< typename CharT,typename Policy>
+        using basic_json = jsoncons::basic_json<CharT, Policy, std::pmr::polymorphic_allocator<char>>;
+        using json = basic_json<char,sorted_policy>;
+        using wjson = basic_json<wchar_t,sorted_policy>;
+        using ojson = basic_json<char, order_preserving_policy>;
+        using wojson = basic_json<wchar_t, order_preserving_policy>;
+    } // namespace pmr
+    #endif
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_BASIC_JSON_HPP

--- a/velox/external/jsoncons/config/compiler_support.hpp
+++ b/velox/external/jsoncons/config/compiler_support.hpp
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_CONFIG_COMPILER_SUPPORT_HPP
+#define JSONCONS_CONFIG_COMPILER_SUPPORT_HPP
+
+#include <cmath>
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <limits> // std::numeric_limits
+
+#if !defined(JSONCONS_NO_EXCEPTIONS)
+    #define JSONCONS_THROW(exception) throw exception
+    #define JSONCONS_RETHROW throw
+    #define JSONCONS_TRY try
+    #define JSONCONS_CATCH(exception) catch(exception)
+#else
+    #define JSONCONS_THROW(exception) std::terminate()
+    #define JSONCONS_RETHROW std::terminate()
+    #define JSONCONS_TRY if (true)
+    #define JSONCONS_CATCH(exception) if (false)
+#endif
+
+#if defined(__GNUC__)
+#   if defined(__GNUC_PATCHLEVEL__)
+#       define JSONCONS_GCC_AVAILABLE(major, minor, patch) \
+            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__) \
+            >= ((major) * 10000 + (minor) * 100 + (patch)))
+#   else
+#       define JSONCONS_GCC_AVAILABLE(major, minor, patch) \
+            ((__GNUC__ * 10000 + __GNUC_MINOR__ * 100) \
+            >= ((major) * 10000 + (minor) * 100 + (patch)))
+#   endif
+#   else
+#       define JSONCONS_GCC_AVAILABLE(major, minor, patch) 0
+#endif
+
+#if defined(__clang__)
+#   define JSONCONS_CLANG_AVAILABLE(major, minor, patch) \
+            ((__clang_major__ * 10000 + __clang_minor__ * 100 + __clang_patchlevel__) \
+            >= ((major) * 10000 + (minor) * 100 + (patch)))
+#   else
+#       define JSONCONS_CLANG_AVAILABLE(major, minor, patch) 0
+#endif
+
+// Uncomment the following line to suppress deprecated names (recommended for new code)
+//#define JSONCONS_NO_DEPRECATED
+
+// The definitions below follow the definitions in compiler_support_p.h, https://github.com/01org/tinycbor
+// MIT license
+
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54577
+
+#if defined(__GNUC__) || defined(__clang__)
+#define JSONCONS_LIKELY(x) __builtin_expect(!!(x), 1)
+#define JSONCONS_UNLIKELY(x) __builtin_expect(!!(x), 0)
+#define JSONCONS_UNREACHABLE() __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define JSONCONS_LIKELY(x) x
+#define JSONCONS_UNLIKELY(x) x
+#define JSONCONS_UNREACHABLE() __assume(0)
+#else
+#define JSONCONS_LIKELY(x) x
+#define JSONCONS_UNLIKELY(x) x
+#define JSONCONS_UNREACHABLE() do {} while (0)
+#endif
+
+// Deprecated symbols markup
+#if (defined(__cplusplus) && __cplusplus >= 201402L)
+#define JSONCONS_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#endif
+
+#if !defined(JSONCONS_DEPRECATED_MSG) && defined(__GNUC__) && defined(__has_extension)
+#if __has_extension(attribute_deprecated_with_message)
+#define JSONCONS_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#endif
+#endif
+
+#if !defined(JSONCONS_DEPRECATED_MSG) && defined(_MSC_VER)
+#if (_MSC_VER) >= 1920
+#define JSONCONS_DEPRECATED_MSG(msg) [[deprecated(msg)]]
+#else
+#define JSONCONS_DEPRECATED_MSG(msg) __declspec(deprecated(msg))
+#endif
+#endif
+
+// Following boost/atomic/detail/config.hpp
+#if !defined(JSONCONS_DEPRECATED_MSG) && (\
+    (defined(__GNUC__) && ((__GNUC__ + 0) * 100 + (__GNUC_MINOR__ + 0)) >= 405) ||\
+    (defined(__SUNPRO_CC) && (__SUNPRO_CC + 0) >= 0x5130))
+    #define JSONCONS_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+#endif
+
+#if !defined(JSONCONS_DEPRECATED_MSG) && defined(__clang__) && defined(__has_extension)
+    #if __has_extension(attribute_deprecated_with_message)
+        #define JSONCONS_DEPRECATED_MSG(msg) __attribute__((deprecated(msg)))
+    #else
+        #define JSONCONS_DEPRECATED_MSG(msg) __attribute__((deprecated))
+    #endif
+#endif
+
+#if !defined(JSONCONS_DEPRECATED_MSG)
+#define JSONCONS_DEPRECATED_MSG(msg)
+#endif
+
+#if defined(ANDROID) || defined(__ANDROID__)
+#if __ANDROID_API__ >= 21
+#define JSONCONS_HAS_STRTOLD_L
+#else
+#define JSONCONS_NO_LOCALECONV
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define JSONCONS_HAS_MSC_STRTOD_L
+#define JSONCONS_HAS_FOPEN_S
+#endif
+
+#ifndef JSONCONS_HAS_CP14
+   #if defined(_MSVC_LANG) 
+       #if _MSVC_LANG >= 201402L
+           #define JSONCONS_HAS_CP14 
+       #endif
+   #elif __cplusplus >= 201402L
+        #define JSONCONS_HAS_CP14 
+   #endif
+#endif
+
+#if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
+#include <charconv>
+#endif
+
+#if !defined(JSONCONS_HAS_2017)
+#  if defined(__clang__)
+#   if (__cplusplus >= 201703)
+#     define JSONCONS_HAS_2017 1
+#   endif // (__cplusplus >= 201703)
+#  endif // defined(__clang__)
+#  if defined(__GNUC__)
+#   if (__GNUC__ >= 7)
+#    if (__cplusplus >= 201703)
+#     define JSONCONS_HAS_2017 1
+#    endif // (__cplusplus >= 201703)
+#   endif // (__GNUC__ >= 7)
+#  endif // defined(__GNUC__)
+#  if defined(_MSC_VER)
+#   if (_MSC_VER >= 1910 && _MSVC_LANG >= 201703)
+#    define JSONCONS_HAS_2017 1
+#   endif // (_MSC_VER >= 1910 && MSVC_LANG >= 201703)
+#  endif // defined(_MSC_VER)
+#endif
+
+#if defined(JSONCONS_HAS_2017)
+    #define JSONCONS_NODISCARD [[nodiscard]]
+    #define JSONCONS_IF_CONSTEXPR if constexpr
+#else
+    #define JSONCONS_NODISCARD
+    #define JSONCONS_IF_CONSTEXPR if 
+#endif
+
+#if !defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR)
+#if defined(JSONCONS_HAS_2017)
+#      if __has_include(<memory_resource>)
+#        define JSONCONS_HAS_POLYMORPHIC_ALLOCATOR 1
+#     endif // __has_include(<string_view>)
+#endif
+#endif
+
+#if !defined(JSONCONS_HAS_STD_STRING_VIEW)
+#  if (defined JSONCONS_HAS_2017)
+#    if defined(__clang__)
+#      if __has_include(<string_view>)
+#        define JSONCONS_HAS_STD_STRING_VIEW 1
+#     endif // __has_include(<string_view>)
+#   else
+#      define JSONCONS_HAS_STD_STRING_VIEW 1
+#   endif
+#  endif // defined(JSONCONS_HAS_2017)
+#endif // !defined(JSONCONS_HAS_STD_STRING_VIEW)
+
+#if !defined(JSONCONS_HAS_STD_BYTE)
+#  if (defined JSONCONS_HAS_2017)
+#    define JSONCONS_HAS_STD_BYTE 1
+#  endif // defined(JSONCONS_HAS_2017)
+#endif // !defined(JSONCONS_HAS_STD_BYTE)
+
+#if !defined(JSONCONS_HAS_STD_OPTIONAL)
+#  if (defined JSONCONS_HAS_2017)
+#    if defined(__clang__)
+#      if __has_include(<optional>)
+#        define JSONCONS_HAS_STD_OPTIONAL 1
+#     endif // __has_include(<string_view>)
+#   else
+#      define JSONCONS_HAS_STD_OPTIONAL 1
+#   endif
+#  endif // defined(JSONCONS_HAS_2017)
+#endif // !defined(JSONCONS_HAS_STD_OPTIONAL)
+
+#if !defined(JSONCONS_HAS_STD_VARIANT)
+#  if (defined JSONCONS_HAS_2017)
+#    if defined(__clang__)
+#      if defined(__APPLE__)
+#        if JSONCONS_CLANG_AVAILABLE(10,0,1)
+#          define JSONCONS_HAS_STD_VARIANT 1
+#        endif
+#      elif __has_include(<variant>)
+#        define JSONCONS_HAS_STD_VARIANT 1
+#     endif // __has_include(<variant>)
+#   else
+#      define JSONCONS_HAS_STD_VARIANT 1
+#   endif
+#  endif // defined(JSONCONS_HAS_2017)
+#endif // !defined(JSONCONS_HAS_STD_VARIANT)
+
+#if !defined(JSONCONS_HAS_FILESYSTEM)
+#  if (defined JSONCONS_HAS_2017)
+#    if defined(__clang__)
+#      if __has_include(<filesystem>)
+#        define JSONCONS_HAS_FILESYSTEM 1
+#     endif // __has_include(<filesystem>)
+#   else
+#      define JSONCONS_HAS_FILESYSTEM 1
+#   endif
+#  endif // defined(JSONCONS_HAS_2017)
+#endif // !defined(JSONCONS_HAS_FILESYSTEM)
+
+#if (!defined(JSONCONS_NO_EXCEPTIONS))
+// Check if exceptions are disabled.
+#  if defined( __cpp_exceptions) && __cpp_exceptions == 0
+#   define JSONCONS_NO_EXCEPTIONS 1
+#  endif
+#endif
+
+#if !defined(JSONCONS_NO_EXCEPTIONS)
+
+#if defined(__GNUC__) && !defined(__EXCEPTIONS)
+# define JSONCONS_NO_EXCEPTIONS 1
+#elif defined(_MSC_VER)
+#if defined(_HAS_EXCEPTIONS) && _HAS_EXCEPTIONS == 0
+# define JSONCONS_NO_EXCEPTIONS 1
+#elif !defined(_CPPUNWIND)
+# define JSONCONS_NO_EXCEPTIONS 1
+#endif
+#endif
+#endif
+
+#if !defined(JSONCONS_HAS_STD_MAKE_UNIQUE)
+   #if defined(__clang__) && defined(__cplusplus)
+      #if defined(__APPLE__)
+         #if __clang_major__ >= 6  && __cplusplus >= 201402L // Xcode 6
+            #define JSONCONS_HAS_STD_MAKE_UNIQUE
+         #endif
+      #elif ((__clang_major__*100 +__clang_minor__) >= 340) && __cplusplus >= 201402L
+         #define JSONCONS_HAS_STD_MAKE_UNIQUE
+      #endif
+   #elif defined(__GNUC__)
+      #if (__GNUC__ * 100 + __GNUC_MINOR__) >= 409 && __cplusplus > 201103L
+         #define JSONCONS_HAS_STD_MAKE_UNIQUE
+      #endif
+   #elif defined(_MSC_VER)
+      #if _MSC_VER >= 1800
+         #define JSONCONS_HAS_STD_MAKE_UNIQUE
+      #endif
+   #endif
+#endif // !defined(JSONCONS_HAS_STD_MAKE_UNIQUE)
+
+#ifndef JSONCONS_HAS_CP14_CONSTEXPR
+    #if defined(_MSC_VER)
+        #if _MSC_VER >= 1910
+            #define JSONCONS_HAS_CP14_CONSTEXPR
+        #endif
+   #elif defined(__GNUC__)
+      #if (__GNUC__ * 100 + __GNUC_MINOR__) >= 600 && __cplusplus >= 201402L
+         #define JSONCONS_HAS_CP14_CONSTEXPR
+      #endif
+   #endif
+#endif
+
+#if defined(JSONCONS_HAS_CP14_CONSTEXPR)
+#  define JSONCONS_CPP14_CONSTEXPR constexpr
+#else
+#  define JSONCONS_CPP14_CONSTEXPR
+#endif
+
+// Follows boost
+
+// gcc and clang
+#if !defined(__CUDA_ARCH__)
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__cplusplus)
+#if defined(__SIZEOF_INT128__) && !defined(_MSC_VER)
+#  define JSONCONS_HAS_INT128
+#endif
+
+#if (defined(linux) || defined(__linux) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)) && !defined(_CRAYC)
+#if (__clang_major__ >= 4) && defined(__has_include)
+#if __has_include(<quadmath.h>)
+#  define JSONCONS_HAS_FLOAT128
+#endif
+#endif
+#endif
+#endif
+
+#if defined(__GNUC__)
+#if defined(_GLIBCXX_USE_FLOAT128)
+# define JSONCONS_HAS_FLOAT128
+#endif
+#endif
+
+#if defined(__clang__)
+#if (defined(linux) || defined(__linux) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)) && !defined(_CRAYC)
+#if (__clang_major__ >= 4) && defined(__has_include)
+#if __has_include(<quadmath.h>)
+#  define JSONCONS_HAS_FLOAT128
+#endif
+#endif
+#endif
+#endif
+#endif // __CUDA_ARCH__
+
+// Follows boost config/detail/suffix.hpp
+#if defined(JSONCONS_HAS_INT128) && defined(__cplusplus)
+namespace facebook::velox::jsoncons{
+#  ifdef __GNUC__
+   __extension__ typedef __int128 int128_type;
+   __extension__ typedef unsigned __int128 uint128_type;
+#  else
+   typedef __int128 int128_type;
+   typedef unsigned __int128 uint128_type;
+#  endif
+}
+#endif
+#if defined(JSONCONS_HAS_FLOAT128) && defined(__cplusplus)
+namespace facebook::velox::jsoncons {
+#  ifdef __GNUC__
+   __extension__ typedef __float128 float128_type;
+#  else
+   typedef __float128 float128_type;
+#  endif
+}
+#endif
+    
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+    #define JSONCONS_COPY(first,last,d_first) std::copy(first, last, stdext::make_checked_array_iterator(d_first, static_cast<std::size_t>(std::distance(first, last))))
+#else 
+    #define JSONCONS_COPY(first,last,d_first) std::copy(first, last, d_first)
+#endif
+
+#if defined(JSONCONS_HAS_CP14)
+#define JSONCONS_CONSTEXPR constexpr
+#else
+#define JSONCONS_CONSTEXPR
+#endif
+
+#if !defined(JSONCONS_HAS_STD_REGEX)
+#if defined(__clang__) 
+#define JSONCONS_HAS_STD_REGEX 1
+#elif (defined(__GNUC__) && (__GNUC__ == 4)) && (defined(__GNUC__) && __GNUC_MINOR__ < 9)
+// GCC 4.8 has broken regex support: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53631
+#else
+#define JSONCONS_HAS_STD_REGEX 1
+#endif
+#endif
+
+#if !defined(JSONCONS_HAS_STATEFUL_ALLOCATOR)
+#if defined(__clang__) && !JSONCONS_CLANG_AVAILABLE(11,0,0)
+#elif defined(__GNUC__) && !JSONCONS_GCC_AVAILABLE(10,0,0)
+#else
+#define JSONCONS_HAS_STATEFUL_ALLOCATOR 1
+#endif
+#endif
+
+// The definitions below follow the definitions in compiler_support_p.h, https://github.com/01org/tinycbor
+// MIT license
+
+#ifdef __F16C__
+#  include <immintrin.h>
+#endif
+
+#ifndef __has_builtin
+#  define __has_builtin(x)  0
+#endif
+
+#if defined(__GNUC__)
+#if (__GNUC__ * 100 + __GNUC_MINOR__ >= 403) || (__has_builtin(__builtin_bswap64) && __has_builtin(__builtin_bswap32))
+#  define JSONCONS_BYTE_SWAP_64 __builtin_bswap64
+#  define JSONCONS_BYTE_SWAP_32 __builtin_bswap32
+#    ifdef __INTEL_COMPILER
+#      define JSONCONS_BYTE_SWAP_16 _bswap16
+#    elif (__GNUC__ * 100 + __GNUC_MINOR__ >= 608) || __has_builtin(__builtin_bswap16)
+#      define JSONCONS_BYTE_SWAP_16    __builtin_bswap16
+#  endif
+#endif
+#elif defined(__sun)
+#  include <sys/byteorder.h>
+#elif defined(_MSC_VER)
+// MSVC, which implies sizeof(long) == 4 
+#  define JSONCONS_BYTE_SWAP_64       _byteswap_uint64
+#  define JSONCONS_BYTE_SWAP_32       _byteswap_ulong
+#  define JSONCONS_BYTE_SWAP_16       _byteswap_ushort
+#endif
+
+namespace facebook::velox::jsoncons { 
+namespace binary { 
+
+    static inline bool add_check_overflow(std::size_t v1, std::size_t v2, std::size_t *r)
+    {
+    #if ((defined(__GNUC__) && (__GNUC__ >= 5)) && !defined(__INTEL_COMPILER)) || __has_builtin(__builtin_add_overflow)
+        return __builtin_add_overflow(v1, v2, r);
+    #else
+        // unsigned additions are well-defined 
+        *r = v1 + v2;
+        return v1 > v1 + v2;
+    #endif
+    }
+
+    #if defined(__apple_build_version__) && ((__clang_major__ < 8) || ((__clang_major__ == 8) && (__clang_minor__ < 1)))
+    #define APPLE_MISSING_INTRINSICS 1
+    #endif
+
+    inline 
+    uint16_t encode_half(double val)
+    {
+    #if defined(__F16C__) && !defined(APPLE_MISSING_INTRINSICS)
+        return _cvtss_sh((float)val, 3);
+    #else
+        uint64_t v;
+        std::memcpy(&v, &val, sizeof(v));
+        int64_t sign = static_cast<int64_t>(v >> 63 << 15);
+        int64_t exp = (v >> 52) & 0x7ff;
+        int64_t mant = v << 12 >> 12 >> (53-11);    /* keep only the 11 most significant bits of the mantissa */
+        exp -= 1023;
+        if (exp == 1024) {
+            /* infinity or NaN */
+            exp = 16;
+            mant >>= 1;
+        } else if (exp >= 16) {
+            /* overflow, as largest number */
+            exp = 15;
+            mant = 1023;
+        } else if (exp >= -14) {
+            /* regular normal */
+        } else if (exp >= -24) {
+            /* subnormal */
+            mant |= 1024;
+            mant >>= -(exp + 14);
+            exp = -15;
+        } else {
+            /* underflow, make zero */
+            return 0;
+        }
+
+        /* safe cast here as bit operations above guarantee not to overflow */
+        return static_cast<uint16_t>(sign | ((exp + 15) << 10) | mant);
+    #endif
+    }
+
+    /* this function was copied & adapted from RFC 7049 Appendix D */
+    inline 
+    double decode_half(uint16_t half)
+    {
+    #if defined(__F16C__) && !defined(APPLE_MISSING_INTRINSICS)
+        return _cvtsh_ss(half);
+    #else
+        int64_t exp = (half >> 10) & 0x1f;
+        int64_t mant = half & 0x3ff;
+        double val;
+        if (exp == 0) 
+        {
+            val = ldexp(static_cast<double>(mant), -24);
+        }
+        else if (exp != 31) 
+        {
+            val = ldexp(static_cast<double>(mant) + 1024.0, static_cast<int>(exp - 25));
+        } 
+        else
+        {
+            val = mant == 0 ? std::numeric_limits<double>::infinity() : std::nan("");
+        }
+        return half & 0x8000 ? -val : val;
+    #endif
+    }
+
+} // namespace binary
+} // namespace facebook::velox::jsoncons
+// allow to disable exceptions
+
+#endif // JSONCONS_CONFIG_COMPILER_SUPPORT_HPP

--- a/velox/external/jsoncons/config/jsoncons_config.hpp
+++ b/velox/external/jsoncons/config/jsoncons_config.hpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_CONFIG_JSONCONS_CONFIG_HPP
+#define JSONCONS_CONFIG_JSONCONS_CONFIG_HPP
+
+#include <cfloat> 
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    class assertion_error : public std::runtime_error
+    {
+    public:
+        assertion_error(const std::string& s) noexcept
+            : std::runtime_error(s)
+        {
+        }
+        const char* what() const noexcept override
+        {
+            return std::runtime_error::what();
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#define JSONCONS_STR2(x)  #x
+#define JSONCONS_STR(x)  JSONCONS_STR2(x)
+
+#ifdef _DEBUG
+#define JSONCONS_ASSERT(x) if (!(x)) { \
+    JSONCONS_THROW(jsoncons::assertion_error("assertion '" #x "' failed at " __FILE__ ":" \
+            JSONCONS_STR(__LINE__))); }
+#else
+#define JSONCONS_ASSERT(x) if (!(x)) { \
+    JSONCONS_THROW(jsoncons::assertion_error("assertion '" #x "' failed at  <> :" \
+            JSONCONS_STR( 0 ))); }
+#endif // _DEBUG
+
+#if defined(JSONCONS_HAS_2017)
+#  define JSONCONS_FALLTHROUGH [[fallthrough]]
+#elif defined(__clang__)
+#  define JSONCONS_FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__GNUC__) && ((__GNUC__ >= 7))
+#  define JSONCONS_FALLTHROUGH __attribute__((fallthrough))
+#elif defined (__GNUC__)
+#  define JSONCONS_FALLTHROUGH // FALLTHRU
+#else
+#  define JSONCONS_FALLTHROUGH
+#endif
+        
+#if !defined(JSONCONS_HAS_STD_STRING_VIEW)
+#include "velox/external/jsoncons/detail/string_view.hpp"
+namespace facebook::velox::jsoncons {
+using jsoncons::detail::basic_string_view;
+using string_view = jsoncons::detail::string_view;
+using wstring_view = jsoncons::detail::wstring_view;
+}
+#else 
+#include <string_view>
+namespace facebook::velox::jsoncons {
+using std::basic_string_view;
+using std::string_view;
+using std::wstring_view;
+}
+#endif
+
+#if !defined(JSONCONS_HAS_STD_SPAN)
+#include "velox/external/jsoncons/detail/span.hpp"
+namespace facebook::velox::jsoncons {
+using jsoncons::detail::span;
+}
+#else 
+#include <span>
+namespace facebook::velox::jsoncons {
+using std::span;
+}
+#endif
+
+#if defined(JSONCONS_HAS_STD_OPTIONAL)
+    #include <optional>
+    namespace facebook::velox::jsoncons {
+    using std::optional;
+    }
+#elif defined(JSONCONS_HAS_BOOST_OPTIONAL)
+    #include <boost/optional.hpp>
+    namespace facebook::velox::jsoncons {
+    using boost::optional;
+    }
+#else 
+    #include "velox/external/jsoncons/detail/optional.hpp"
+    namespace facebook::velox::jsoncons {
+    using jsoncons::detail::optional;
+}
+#endif // !defined(JSONCONS_HAS_STD_OPTIONAL)
+
+#if !defined(JSONCONS_HAS_STD_ENDIAN)
+#include "velox/external/jsoncons/detail/endian.hpp"
+namespace facebook::velox::jsoncons {
+using jsoncons::detail::endian;
+}
+#else
+#include <bit>
+namespace facebook::velox::jsoncons 
+{
+    using std::endian;
+}
+#endif
+
+#if !defined(JSONCONS_HAS_STD_MAKE_UNIQUE)
+
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+namespace facebook::velox::jsoncons {
+
+    template <typename T> 
+    struct unique_if 
+    {
+        using value_is_not_array = std::unique_ptr<T>;
+    };
+
+    template <typename T> 
+    struct unique_if<T[]> 
+    {
+        typedef std::unique_ptr<T[]> value_is_array_of_unknown_bound;
+    };
+
+    template <typename T, std::size_t N> 
+    struct unique_if<T[N]> {
+        using value_is_array_of_known_bound = void;
+    };
+
+    template <typename T,typename... Args>
+    typename unique_if<T>::value_is_not_array
+    make_unique(Args&&... args) 
+    {
+        return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+    }
+
+    template <typename T>
+    typename unique_if<T>::value_is_array_of_unknown_bound
+    make_unique(std::size_t n) 
+    {
+        using U = typename std::remove_extent<T>::type;
+        return std::unique_ptr<T>(new U[n]());
+    }
+
+    template <typename T,typename... Args>
+    typename unique_if<T>::value_is_array_of_known_bound
+    make_unique(Args&&...) = delete;
+} // namespace facebook::velox::jsoncons
+
+#else
+
+#include <memory>
+namespace facebook::velox::jsoncons 
+{
+    using std::make_unique;
+}
+
+#endif // !defined(JSONCONS_HAS_STD_MAKE_UNIQUE)
+
+namespace facebook::velox::jsoncons {
+
+    template <typename CharT>
+    constexpr const CharT* cstring_constant_of_type(const char* c, const wchar_t* w);
+
+    template<> inline
+    constexpr const char* cstring_constant_of_type<char>(const char* c, const wchar_t*)
+    {
+        return c;
+    }
+    template<> inline
+    constexpr const wchar_t* cstring_constant_of_type<wchar_t>(const char*, const wchar_t* w)
+    {
+        return w;
+    }
+
+    template <typename CharT>
+    std::basic_string<CharT> string_constant_of_type(const char* c, const wchar_t* w);
+
+    template<> inline
+    std::string string_constant_of_type<char>(const char* c, const wchar_t*)
+    {
+        return std::string(c);
+    }
+    template<> inline
+    std::wstring string_constant_of_type<wchar_t>(const char*, const wchar_t* w)
+    {
+        return std::wstring(w);
+    }
+
+    template <typename CharT>
+    jsoncons::basic_string_view<CharT> string_view_constant_of_type(const char* c, const wchar_t* w);
+
+    template<> inline
+    jsoncons::string_view string_view_constant_of_type<char>(const char* c, const wchar_t*)
+    {
+        return jsoncons::string_view(c);
+    }
+    template<> inline
+    jsoncons::wstring_view string_view_constant_of_type<wchar_t>(const char*, const wchar_t* w)
+    {
+        return jsoncons::wstring_view(w);
+    }
+
+} // namespace facebook::velox::jsoncons
+
+#define JSONCONS_EXPAND(X) X    
+#define JSONCONS_QUOTE(Prefix, A) JSONCONS_EXPAND(Prefix ## #A)
+#define JSONCONS_WIDEN(A) JSONCONS_EXPAND(L ## A)
+
+#define JSONCONS_CSTRING_CONSTANT(CharT, Str) cstring_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
+#define JSONCONS_STRING_CONSTANT(CharT, Str) string_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
+#define JSONCONS_STRING_VIEW_CONSTANT(CharT, Str) string_view_constant_of_type<CharT>(Str, JSONCONS_WIDEN(Str))
+
+
+#endif // JSONCONS_CONFIG_JSONCONS_CONFIG_HPP

--- a/velox/external/jsoncons/config/version.hpp
+++ b/velox/external/jsoncons/config/version.hpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_CONFIG_VERSION_HPP
+#define JSONCONS_CONFIG_VERSION_HPP
+ 
+#include <iostream>
+    
+#define JSONCONS_VERSION_MAJOR 1
+#define JSONCONS_VERSION_MINOR 1
+#define JSONCONS_VERSION_PATCH 0
+
+namespace facebook::velox::jsoncons {
+
+struct versioning_info
+{
+    unsigned int const major;
+    unsigned int const minor;
+    unsigned int const patch;
+
+    friend std::ostream& operator<<(std::ostream& os, const versioning_info& ver)
+    {
+        os << ver.major << '.'
+           << ver.minor << '.'
+           << ver.patch;
+        return os;
+    }
+}; 
+
+constexpr versioning_info version()
+{
+    return versioning_info{JSONCONS_VERSION_MAJOR, JSONCONS_VERSION_MINOR, JSONCONS_VERSION_PATCH};
+}
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_CONFIG_VERSION_HPP

--- a/velox/external/jsoncons/conv_error.hpp
+++ b/velox/external/jsoncons/conv_error.hpp
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_CONV_ERROR_HPP
+#define JSONCONS_CONV_ERROR_HPP
+
+#include <cstddef>
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    class conv_error : public std::system_error, public virtual json_exception
+    {
+        std::size_t line_number_{0};
+        std::size_t column_number_{0};
+        mutable std::string what_;
+    public:
+        conv_error(std::error_code ec)
+            : std::system_error(ec)
+        {
+        }
+        conv_error(std::error_code ec, const std::string& what_arg)
+            : std::system_error(ec, what_arg)
+        {
+        }
+        conv_error(std::error_code ec, std::size_t position)
+            : std::system_error(ec), line_number_(0), column_number_(position)
+        {
+        }
+        conv_error(std::error_code ec, std::size_t line, std::size_t column)
+            : std::system_error(ec), line_number_(line), column_number_(column)
+        {
+        }
+        conv_error(const conv_error& other) = default;
+
+        conv_error(conv_error&& other) = default;
+
+        const char* what() const noexcept override
+        {
+            if (what_.empty())
+            {
+                JSONCONS_TRY
+                {
+                    what_.append(std::system_error::what());
+                    if (line_number_ != 0 && column_number_ != 0)
+                    {
+                        what_.append(" at line ");
+                        what_.append(std::to_string(line_number_));
+                        what_.append(" and column ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    else if (column_number_ != 0)
+                    {
+                        what_.append(" at position ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    return what_.c_str();
+                }
+                JSONCONS_CATCH(...)
+                {
+                    return std::system_error::what();
+                }
+            }
+            else
+            {
+                return what_.c_str();
+            }
+        }
+
+        std::size_t line() const noexcept
+        {
+            return line_number_;
+        }
+
+        std::size_t column() const noexcept
+        {
+            return column_number_;
+        }
+    };
+
+    enum class conv_errc
+    {
+        success = 0,
+        conversion_failed,
+        not_utf8,
+        not_wide_char,
+        not_vector,
+        not_array,
+        not_map,
+        not_pair,
+        not_string,
+        not_string_view,
+        not_byte_string,
+        not_byte_string_view,
+        not_integer,
+        not_signed_integer,
+        not_unsigned_integer,
+        not_bigint,
+        not_double,
+        not_bool,
+        not_variant,
+        not_nullptr,
+        not_jsoncons_null_type,
+        not_bitset,
+        not_base64,
+        not_base64url,
+        not_base16
+    };
+
+    template <typename InputIt>
+    struct decode_result 
+    {
+        InputIt it;
+        conv_errc ec;
+    };
+
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::conv_errc> : public true_type
+    {
+    };
+
+} // namespace std
+
+namespace facebook::velox::jsoncons {
+
+namespace detail {
+    class conv_error_category_impl
+       : public std::error_category
+    {
+    public:
+        const char* name() const noexcept override
+        {
+            return "jsoncons/convert";
+        }
+        std::string message(int ev) const override
+        {
+            switch (static_cast<conv_errc>(ev))
+            {
+                case conv_errc::conversion_failed:
+                    return "Unable to convert into the provided type";
+                case conv_errc::not_utf8:
+                    return "Cannot convert string to UTF-8";
+                case conv_errc::not_wide_char:
+                    return "Cannot convert string to wide characters";
+                case conv_errc::not_vector:
+                    return "Cannot convert to vector";
+                case conv_errc::not_array:
+                    return "Cannot convert to std::array";
+                case conv_errc::not_map:
+                    return "Cannot convert to map";
+                case conv_errc::not_pair:
+                    return "Cannot convert to std::pair";
+                case conv_errc::not_string:
+                    return "Cannot convert to string";
+                case conv_errc::not_string_view:
+                    return "Cannot convert to string_view";
+                case conv_errc::not_byte_string:
+                    return "Cannot convert to byte_string";
+                case conv_errc::not_byte_string_view:
+                    return "Cannot convert to byte_string_view";
+                case conv_errc::not_integer:
+                    return "Cannot convert to integer";
+                case conv_errc::not_signed_integer:
+                    return "Cannot convert to signed integer";
+                case conv_errc::not_unsigned_integer:
+                    return "Cannot convert to unsigned integer";
+                case conv_errc::not_bigint:
+                    return "Cannot convert to bigint";
+                case conv_errc::not_double:
+                    return "Cannot convert to double";
+                case conv_errc::not_bool:
+                    return "Cannot convert to bool";
+                case conv_errc::not_variant:
+                    return "Cannot convert to std::variant";
+                case conv_errc::not_nullptr:
+                    return "Cannot convert to std::nullptr_t";
+                case conv_errc::not_jsoncons_null_type:
+                    return "Cannot convert to jsoncons::null_type";
+                case conv_errc::not_bitset:
+                    return "Cannot convert to std::bitset";
+                case conv_errc::not_base64:
+                    return "Input is not a base64 encoded string";
+                case conv_errc::not_base64url:
+                    return "Input is not a base64url encoded string";
+                case conv_errc::not_base16:
+                    return "Input is not a base16 encoded string";
+                default:
+                    return "Unknown conversion error";
+            }
+        }
+    };
+    
+} // namespace detail
+
+extern inline
+const std::error_category& conv_error_category()
+{
+  static detail::conv_error_category_impl instance;
+  return instance;
+}
+
+inline 
+std::error_code make_error_code(conv_errc result)
+{
+    return std::error_code(static_cast<int>(result),conv_error_category());
+}
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_CONV_ERROR_HPP

--- a/velox/external/jsoncons/decode_json.hpp
+++ b/velox/external/jsoncons/decode_json.hpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DECODE_JSON_HPP
+#define JSONCONS_DECODE_JSON_HPP
+
+#include <iostream>
+#include <istream> // std::basic_istream
+#include <tuple>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/allocator_set.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/decode_traits.hpp"
+#include "velox/external/jsoncons/json_cursor.hpp"
+#include "velox/external/jsoncons/basic_json.hpp"
+#include "velox/external/jsoncons/source.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // decode_json
+
+    template <typename T,typename Source>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_sequence_of<Source,typename T::char_type>::value,T>::type
+    decode_json(const Source& s,
+                const basic_json_decode_options<typename Source::value_type>& options = basic_json_decode_options<typename Source::value_type>())
+    {
+        using char_type = typename Source::value_type;
+
+        jsoncons::json_decoder<T> decoder;
+        basic_json_reader<char_type, string_source<char_type>> reader(s, decoder, options);
+        reader.read();
+        if (!decoder.is_valid())
+        {
+            JSONCONS_THROW(ser_error(conv_errc::conversion_failed, reader.line(), reader.column()));
+        }
+        return decoder.get_result();
+    }
+
+    template <typename T,typename Source>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_char_sequence<Source>::value,T>::type
+    decode_json(const Source& s,
+                const basic_json_decode_options<typename Source::value_type>& options = basic_json_decode_options<typename Source::value_type>())
+    {
+        using char_type = typename Source::value_type;
+
+        basic_json_cursor<char_type,string_source<char_type>> cursor(s, options, default_json_parsing());
+        jsoncons::json_decoder<basic_json<char_type>> decoder;
+        std::error_code ec;
+        T val = decode_traits<T,char_type>::decode(cursor, decoder, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec, cursor.context().line(), cursor.context().column()));
+        }
+        return val;
+    }
+
+    template <typename T,typename CharT>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(std::basic_istream<CharT>& is,
+                const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>())
+    {
+        jsoncons::json_decoder<T> decoder;
+        basic_json_reader<CharT, stream_source<CharT>> reader(is, decoder, options);
+        reader.read();
+        if (!decoder.is_valid())
+        {
+            JSONCONS_THROW(ser_error(conv_errc::conversion_failed, reader.line(), reader.column()));
+        }
+        return decoder.get_result();
+    }
+
+    template <typename T,typename CharT>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(std::basic_istream<CharT>& is,
+                const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>())
+    {
+        basic_json_cursor<CharT> cursor(is, options, default_json_parsing());
+        json_decoder<basic_json<CharT>> decoder{};
+
+        std::error_code ec;
+        T val = decode_traits<T,CharT>::decode(cursor, decoder, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec, cursor.line(), cursor.column()));
+        }
+        return val;
+    }
+
+    template <typename T,typename InputIt>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(InputIt first, InputIt last,
+                const basic_json_decode_options<typename std::iterator_traits<InputIt>::value_type>& options = 
+                    basic_json_decode_options<typename std::iterator_traits<InputIt>::value_type>())
+    {
+        using char_type = typename std::iterator_traits<InputIt>::value_type;
+
+        jsoncons::json_decoder<T> decoder;
+        basic_json_reader<char_type, iterator_source<InputIt>> reader(iterator_source<InputIt>(first,last), decoder, options);
+        reader.read();
+        if (!decoder.is_valid())
+        {
+            JSONCONS_THROW(ser_error(conv_errc::conversion_failed, reader.line(), reader.column()));
+        }
+        return decoder.get_result();
+    }
+
+    template <typename T,typename InputIt>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(InputIt first, InputIt last,
+                const basic_json_decode_options<typename std::iterator_traits<InputIt>::value_type>& options = 
+                    basic_json_decode_options<typename std::iterator_traits<InputIt>::value_type>())
+    {
+        using char_type = typename std::iterator_traits<InputIt>::value_type;
+
+        basic_json_cursor<char_type,iterator_source<InputIt>> cursor(iterator_source<InputIt>(first, last), options, default_json_parsing());
+        jsoncons::json_decoder<basic_json<char_type>> decoder;
+        std::error_code ec;
+        T val = decode_traits<T,char_type>::decode(cursor, decoder, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec, cursor.line(), cursor.column()));
+        }
+        return val;
+    }
+
+    // With leading allocator_set parameter
+
+    template <typename T,typename Source,typename Allocator,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_sequence_of<Source,typename T::char_type>::value,T>::type
+    decode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const Source& s,
+        const basic_json_decode_options<typename Source::value_type>& options = basic_json_decode_options<typename Source::value_type>())
+    {
+        using char_type = typename Source::value_type;
+
+        json_decoder<T,TempAllocator> decoder(alloc_set.get_allocator(), alloc_set.get_temp_allocator());
+
+        basic_json_reader<char_type, string_source<char_type>,TempAllocator> reader(s, decoder, options, alloc_set.get_temp_allocator());
+        reader.read();
+        if (!decoder.is_valid())
+        {
+            JSONCONS_THROW(ser_error(conv_errc::conversion_failed, reader.line(), reader.column()));
+        }
+        return decoder.get_result();
+    }
+
+    template <typename T,typename Source,typename Allocator,typename TempAllocator >
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_char_sequence<Source>::value,T>::type
+    decode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const Source& s,
+        const basic_json_decode_options<typename Source::value_type>& options = basic_json_decode_options<typename Source::value_type>())
+    {
+        using char_type = typename Source::value_type;
+
+        basic_json_cursor<char_type,string_source<char_type>,TempAllocator> cursor(s, options, default_json_parsing(), alloc_set.get_temp_allocator());
+        json_decoder<basic_json<char_type,sorted_policy,TempAllocator>,TempAllocator> decoder(alloc_set.get_temp_allocator(), alloc_set.get_temp_allocator());
+
+        std::error_code ec;
+        T val = decode_traits<T,char_type>::decode(cursor, decoder, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec, cursor.context().line(), cursor.context().column()));
+        }
+        return val;
+    }
+
+    template <typename T,typename CharT,typename Allocator,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+                std::basic_istream<CharT>& is,
+                const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>())
+    {
+        json_decoder<T,TempAllocator> decoder(alloc_set.get_allocator(), alloc_set.get_temp_allocator());
+
+        basic_json_reader<CharT, stream_source<CharT>,TempAllocator> reader(is, decoder, options, alloc_set.get_temp_allocator());
+        reader.read();
+        if (!decoder.is_valid())
+        {
+            JSONCONS_THROW(ser_error(conv_errc::conversion_failed, reader.line(), reader.column()));
+        }
+        return decoder.get_result();
+    }
+
+    template <typename T,typename CharT,typename Allocator,typename TempAllocator >
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value,T>::type
+    decode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+                std::basic_istream<CharT>& is,
+                const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>())
+    {
+        basic_json_cursor<CharT,stream_source<CharT>,TempAllocator> cursor(is, options, default_json_parsing(), alloc_set.get_temp_allocator());
+        json_decoder<basic_json<CharT,sorted_policy,TempAllocator>,TempAllocator> decoder(alloc_set.get_temp_allocator(),alloc_set.get_temp_allocator());
+
+        std::error_code ec;
+        T val = decode_traits<T,CharT>::decode(cursor, decoder, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec, cursor.context().line(), cursor.context().column()));
+        }
+        return val;
+    }
+
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DECODE_JSON_HPP

--- a/velox/external/jsoncons/decode_traits.hpp
+++ b/velox/external/jsoncons/decode_traits.hpp
@@ -1,0 +1,675 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DECODE_TRAITS_HPP
+#define JSONCONS_DECODE_TRAITS_HPP
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <system_error>
+#include <tuple>
+#include <type_traits> // std::enable_if, std::true_type, std::false_type
+#include <utility>
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/json_decoder.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/staj_event.hpp"
+#include "velox/external/jsoncons/staj_cursor.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // decode_traits
+
+    template <typename T,typename CharT,typename Enable = void>
+    struct decode_traits
+    {
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>& decoder, 
+                        std::error_code& ec)
+        {
+            decoder.reset();
+            cursor.read_to(decoder, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, cursor.context().line(), cursor.context().column()));
+            }
+            else if (!decoder.is_valid())
+            {
+                JSONCONS_THROW(ser_error(conv_errc::conversion_failed, cursor.context().line(), cursor.context().column()));
+            }
+            return decoder.get_result().template as<T>();
+        }
+    };
+
+    // specializations
+
+    // primitive
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_primitive<T>::value
+    >::type>
+    {
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>&, 
+                        std::error_code& ec)
+        {
+            T v = cursor.current().template get<T>(ec);
+            return v;
+        }
+    };
+
+    // string
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_string<T>::value &&
+                                std::is_same<typename T::value_type,CharT>::value
+    >::type>
+    {
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>&, 
+                        std::error_code& ec)
+        {
+            T v = cursor.current().template get<T>(ec);
+            return v;
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_string<T>::value &&
+                                !std::is_same<typename T::value_type,CharT>::value
+    >::type>
+    {
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>&, 
+                        std::error_code& ec)
+        {
+            auto val = cursor.current().template get<std::basic_string<CharT>>(ec);
+            T s;
+            if (!ec)
+            {
+                unicode_traits::convert(val.data(), val.size(), s);
+            }
+            return s;
+        }
+    };
+
+    // std::pair
+
+    template <typename T1,typename T2,typename CharT>
+    struct decode_traits<std::pair<T1, T2>, CharT>
+    {
+        template <typename Json,typename TempAllocator >
+        static std::pair<T1, T2> decode(basic_staj_cursor<CharT>& cursor,
+                                        json_decoder<Json, TempAllocator>& decoder,
+                                        std::error_code& ec)
+        {
+            using value_type = std::pair<T1, T2>;
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                return value_type{};
+            }
+            if (cursor.current().event_type() != staj_event_type::begin_array)
+            {
+                ec = conv_errc::not_pair;
+                return value_type();
+            }
+            cursor.next(ec); // skip past array
+            if (ec)
+            {
+                return value_type();
+            }
+
+            T1 v1 = decode_traits<T1,CharT>::decode(cursor, decoder, ec);
+            if (ec) {return value_type();}
+            cursor.next(ec);
+            if (ec) {return value_type();}
+            T2 v2 = decode_traits<T2, CharT>::decode(cursor, decoder, ec);
+            if (ec) {return value_type();}
+            cursor.next(ec);
+
+            if (cursor.current().event_type() != staj_event_type::end_array)
+            {
+                ec = conv_errc::not_pair;
+                return value_type();
+            }
+            return std::make_pair(v1, v2);
+        }
+    };
+
+    // vector like
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 extension_traits::is_back_insertable<T>::value &&
+                 !extension_traits::is_typed_array<T>::value 
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>& decoder, 
+                        std::error_code& ec)
+        {
+            T v;
+
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                return T{};
+            }
+            if (cursor.current().event_type() != staj_event_type::begin_array)
+            {
+                ec = conv_errc::not_vector;
+                return v;
+            }
+            cursor.next(ec);
+            while (cursor.current().event_type() != staj_event_type::end_array && !ec)
+            {
+                v.push_back(decode_traits<value_type,CharT>::decode(cursor, decoder, ec));
+                if (ec) {return T{};}
+                cursor.next(ec);
+            }
+            return v;
+        }
+    };
+
+    template <typename T>
+    struct typed_array_visitor : public default_json_visitor
+    {
+        T& v_;
+        int level_;
+    public:
+        using value_type = typename T::value_type;
+
+        typed_array_visitor(T& v)
+            : default_json_visitor(false,conv_errc::not_vector), v_(v), level_(0)
+        {
+        }
+    private:
+        bool visit_begin_array(semantic_tag, 
+                               const ser_context&, 
+                               std::error_code& ec) override
+        {      
+            if (++level_ != 1)
+            {
+                ec = conv_errc::not_vector;
+                return false;
+            }
+            return true;
+        }
+
+        bool visit_begin_array(std::size_t size, 
+                            semantic_tag, 
+                            const ser_context&, 
+                            std::error_code& ec) override
+        {
+            if (++level_ != 1)
+            {
+                ec = conv_errc::not_vector;
+                return false;
+            }
+            if (size > 0)
+            {
+                reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), v_, size);
+            }
+            return true;
+        }
+
+        bool visit_end_array(const ser_context&, 
+                          std::error_code& ec) override
+        {
+            if (level_ != 1)
+            {
+                ec = conv_errc::not_vector;
+                return false;
+            }
+            return false;
+        }
+
+        bool visit_uint64(uint64_t value, 
+                             semantic_tag, 
+                             const ser_context&,
+                             std::error_code&) override
+        {
+            v_.push_back(static_cast<value_type>(value));
+            return true;
+        }
+
+        bool visit_int64(int64_t value, 
+                            semantic_tag,
+                            const ser_context&,
+                            std::error_code&) override
+        {
+            v_.push_back(static_cast<value_type>(value));
+            return true;
+        }
+
+        bool visit_half(uint16_t value, 
+                           semantic_tag,
+                           const ser_context&,
+                           std::error_code&) override
+        {
+            return visit_half_(typename std::integral_constant<bool, std::is_integral<value_type>::value>::type(), value);
+        }
+
+        bool visit_half_(std::true_type, uint16_t value)
+        {
+            v_.push_back(static_cast<value_type>(value));
+            return true;
+        }
+
+        bool visit_half_(std::false_type, uint16_t value)
+        {
+            v_.push_back(static_cast<value_type>(binary::decode_half(value)));
+            return true;
+        }
+
+        bool visit_double(double value, 
+                             semantic_tag,
+                             const ser_context&,
+                             std::error_code&) override
+        {
+            v_.push_back(static_cast<value_type>(value));
+            return true;
+        }
+
+        bool visit_typed_array(const jsoncons::span<const value_type>& data,  
+                            semantic_tag,
+                            const ser_context&,
+                            std::error_code&) override
+        {
+            v_ = std::vector<value_type>(data.begin(),data.end());
+            return false;
+        }
+
+        static
+        void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static
+        void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 extension_traits::is_back_insertable_byte_container<T>::value &&
+                 extension_traits::is_typed_array<T>::value
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>&, 
+                        std::error_code& ec)
+        {
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                return T{};
+            }
+            switch (cursor.current().event_type())
+            {
+                case staj_event_type::byte_string_value:
+                {
+                    auto bytes = cursor.current().template get<byte_string_view>(ec);
+                    if (!ec) 
+                    {
+                        T v;
+                        if (cursor.current().size() > 0)
+                        {
+                            reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), v, cursor.current().size());
+                        }
+                        for (auto ch : bytes)
+                        {
+                            v.push_back(static_cast<value_type>(ch));
+                        }
+                        cursor.next(ec);
+                        return v;
+                    }
+                    else
+                    {
+                        return T{};
+                    }
+                }
+                case staj_event_type::begin_array:
+                {
+                    T v;
+                    if (cursor.current().size() > 0)
+                    {
+                        reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), v, cursor.current().size());
+                    }
+                    typed_array_visitor<T> visitor(v);
+                    cursor.read_to(visitor, ec);
+                    return v;
+                }
+                default:
+                {
+                    ec = conv_errc::not_vector;
+                    return T{};
+                }
+            }
+        }
+
+        static void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 extension_traits::is_back_insertable<T>::value &&
+                 !extension_traits::is_back_insertable_byte_container<T>::value &&
+                 extension_traits::is_typed_array<T>::value
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>&, 
+                        std::error_code& ec)
+        {
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                return T{};
+            }
+            switch (cursor.current().event_type())
+            {
+                case staj_event_type::begin_array:
+                {
+                    T v;
+                    if (cursor.current().size() > 0)
+                    {
+                        reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), v, cursor.current().size());
+                    }
+                    typed_array_visitor<T> visitor(v);
+                    cursor.read_to(visitor, ec);
+                    return v;
+                }
+                default:
+                {
+                    ec = conv_errc::not_vector;
+                    return T{};
+                }
+            }
+        }
+
+        static void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    // set like
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 !extension_traits::is_back_insertable<T>::value &&
+                 extension_traits::is_insertable<T>::value 
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>& decoder, 
+                        std::error_code& ec)
+        {
+            T v;
+
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                return T{};
+            }
+            if (cursor.current().event_type() != staj_event_type::begin_array)
+            {
+                ec = conv_errc::not_vector;
+                return v;
+            }
+            if (cursor.current().size() > 0)
+            {
+                reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), v, cursor.current().size());
+            }
+            cursor.next(ec);
+            while (cursor.current().event_type() != staj_event_type::end_array && !ec)
+            {
+                v.insert(decode_traits<value_type,CharT>::decode(cursor, decoder, ec));
+                if (ec) {return T{};}
+                cursor.next(ec);
+                if (ec) {return T{};}
+            }
+            return v;
+        }
+
+        static void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    // std::array
+
+    template <typename T,typename CharT, std::size_t N>
+    struct decode_traits<std::array<T,N>,CharT>
+    {
+        using value_type = typename std::array<T,N>::value_type;
+
+        template <typename Json,typename TempAllocator >
+        static std::array<T, N> decode(basic_staj_cursor<CharT>& cursor, 
+                                       json_decoder<Json,TempAllocator>& decoder, 
+                                       std::error_code& ec)
+        {
+            std::array<T,N> v;
+            cursor.array_expected(ec);
+            if (ec)
+            {
+                v.fill(T());
+                return v;
+            }
+            v.fill(T{});
+            if (cursor.current().event_type() != staj_event_type::begin_array)
+            {
+                ec = conv_errc::not_vector;
+                return v;
+            }
+            cursor.next(ec);
+            for (std::size_t i = 0; i < N && cursor.current().event_type() != staj_event_type::end_array && !ec; ++i)
+            {
+                v[i] = decode_traits<value_type,CharT>::decode(cursor, decoder, ec);
+                if (ec) {return v;}
+                cursor.next(ec);
+                if (ec) {return v;}
+            }
+            return v;
+        }
+    };
+
+    // map like
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                extension_traits::is_map_like<T>::value &&
+                                extension_traits::is_constructible_from_const_pointer_and_size<typename T::key_type>::value
+    >::type>
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>& decoder, 
+                        std::error_code& ec)
+        {
+            T val;
+            if (cursor.current().event_type() != staj_event_type::begin_object)
+            {
+                ec = conv_errc::not_map;
+                return val;
+            }
+            if (cursor.current().size() > 0)
+            {
+                reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), val, cursor.current().size());
+            }
+            cursor.next(ec);
+
+            while (cursor.current().event_type() != staj_event_type::end_object && !ec)
+            {
+                if (cursor.current().event_type() != staj_event_type::key)
+                {
+                    ec = json_errc::expected_key;
+                    return val;
+                }
+                auto key = cursor.current().template get<key_type>(ec);
+                if (ec) {return val;}
+                cursor.next(ec);
+                if (ec) {return val;}
+                val.emplace(std::move(key),decode_traits<mapped_type,CharT>::decode(cursor, decoder, ec));
+                if (ec) {return val;}
+                cursor.next(ec);
+                if (ec) {return val;}
+            }
+            return val;
+        }
+
+        static void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct decode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                extension_traits::is_map_like<T>::value &&
+                                std::is_integral<typename T::key_type>::value
+    >::type>
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+
+        template <typename Json,typename TempAllocator >
+        static T decode(basic_staj_cursor<CharT>& cursor, 
+                        json_decoder<Json,TempAllocator>& decoder, 
+                        std::error_code& ec)
+        {
+            T val;
+            if (cursor.current().event_type() != staj_event_type::begin_object)
+            {
+                ec = conv_errc::not_map;
+                return val;
+            }
+            if (cursor.current().size() > 0)
+            {
+                reserve_storage(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(), val, cursor.current().size());
+            }
+            cursor.next(ec);
+
+            while (cursor.current().event_type() != staj_event_type::end_object && !ec)
+            {
+                if (cursor.current().event_type() != staj_event_type::key)
+                {
+                    ec = json_errc::expected_key;
+                    return val;
+                }
+                auto s = cursor.current().template get<jsoncons::basic_string_view<typename Json::char_type>>(ec);
+                if (ec) {return val;}
+                key_type n{0};
+                auto r = jsoncons::detail::to_integer(s.data(), s.size(), n); 
+                if (r.ec != jsoncons::detail::to_integer_errc())
+                {
+                    ec = json_errc::invalid_number;
+                    return val;
+                }
+                cursor.next(ec);
+                if (ec) {return val;}
+                val.emplace(n, decode_traits<mapped_type,CharT>::decode(cursor, decoder, ec));
+                if (ec) {return val;}
+                cursor.next(ec);
+                if (ec) {return val;}
+            }
+            return val;
+        }
+
+        static void reserve_storage(std::true_type, T& v, std::size_t new_cap)
+        {
+            v.reserve(new_cap);
+        }
+
+        static void reserve_storage(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DECODE_TRAITS_HPP

--- a/velox/external/jsoncons/detail/endian.hpp
+++ b/velox/external/jsoncons/detail/endian.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_ENDIAN_HPP
+#define JSONCONS_DETAIL_ENDIAN_HPP
+
+#if defined(__sun)
+#  include <sys/byteorder.h>
+#endif
+
+namespace facebook::velox::jsoncons { 
+namespace detail {
+
+    enum class endian
+    {
+    #if defined(_MSC_VER) 
+    // MSVC, which implies Windows, which implies little-endian
+         little = 0,
+         big    = 1,
+         native = little
+    #elif defined(__ORDER_LITTLE_ENDIAN__) && defined(__ORDER_BIG_ENDIAN__) && defined(__BYTE_ORDER__) 
+         little = __ORDER_LITTLE_ENDIAN__,
+         big    = __ORDER_BIG_ENDIAN__,
+         native = __BYTE_ORDER__
+    #elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)
+        little = 0,
+        big    = 1,
+        native = big
+    #elif !defined(_BIG_ENDIAN) && defined(_LITTLE_ENDIAN)
+        little = 0,
+        big    = 1,
+        native = little
+    #else
+    #error "Unable to determine byte order!"
+    #endif
+    };
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_ENDIAN_HPP

--- a/velox/external/jsoncons/detail/grisu3.hpp
+++ b/velox/external/jsoncons/detail/grisu3.hpp
@@ -1,0 +1,312 @@
+/*
+Implements the Grisu3 algorithm for printing floating-point numbers. 
+ 
+Follows Florian Loitsch's grisu3_59_56 implementation, available at
+http://florian.loitsch.com/publications, in bench.tar.gz, with 
+minor modifications. 
+*/
+
+/*
+  Copyright (c) 2009 Florian Loitsch
+
+  Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.
+  */
+
+#ifndef JSONCONS_DETAIL_GRISU3_HPP
+#define JSONCONS_DETAIL_GRISU3_HPP 
+
+#pragma once
+#include <cassert>
+#include <cinttypes>
+#include <cmath>
+#include <cstdint>
+#include <cstring> // std::memmove
+#include <stdlib.h>
+
+namespace facebook::velox::jsoncons { namespace detail {
+
+// diy_fp
+
+typedef struct diy_fp_t {
+    uint64_t f;
+    int e;
+} diy_fp_t;
+
+inline 
+diy_fp_t minus(diy_fp_t x, diy_fp_t y)
+{
+    assert(x.e == y.e);
+    assert(x.f >= y.f);
+    diy_fp_t r = { x.f = x.f - y.f, x.e };
+    return r;
+}
+
+inline 
+diy_fp_t multiply(diy_fp_t x, diy_fp_t y)
+{
+    uint64_t a, b, c, d, ac, bc, ad, bd, tmp;
+    diy_fp_t r; uint64_t M32 = 0xFFFFFFFF;
+    a = x.f >> 32; b = x.f & M32;
+    c = y.f >> 32; d = y.f & M32;
+    ac = a * c; bc = b * c; ad = a * d; bd = b * d;
+    tmp = (bd >> 32) + (ad & M32) + (bc & M32);
+    tmp += 1U << 31; /// mult_round
+    r.f = ac + (ad >> 32) + (bc >> 32) + (tmp >> 32);
+    r.e = x.e + y.e + 64;
+    return r;
+}
+
+// k_comp
+
+inline 
+int k_comp(int e, int alpha, int /*gamma*/)
+{
+    constexpr double d_1_log2_10 = 0.30102999566398114; //  1 / lg(10)
+    int x = alpha - e + 63;
+    return static_cast<int>(std::ceil(x * d_1_log2_10));
+}
+
+// powers_ten_round64
+
+constexpr int diy_significand_size = 64;
+
+static constexpr uint64_t powers_ten[] = { 0xbf29dcaba82fdeae, 0xeef453d6923bd65a, 0x9558b4661b6565f8, 0xbaaee17fa23ebf76, 0xe95a99df8ace6f54, 0x91d8a02bb6c10594, 0xb64ec836a47146fa, 0xe3e27a444d8d98b8, 0x8e6d8c6ab0787f73, 0xb208ef855c969f50, 0xde8b2b66b3bc4724, 0x8b16fb203055ac76, 0xaddcb9e83c6b1794, 0xd953e8624b85dd79, 0x87d4713d6f33aa6c, 0xa9c98d8ccb009506, 0xd43bf0effdc0ba48, 0x84a57695fe98746d, 0xa5ced43b7e3e9188, 0xcf42894a5dce35ea, 0x818995ce7aa0e1b2, 0xa1ebfb4219491a1f, 0xca66fa129f9b60a7, 0xfd00b897478238d1, 0x9e20735e8cb16382, 0xc5a890362fddbc63, 0xf712b443bbd52b7c, 0x9a6bb0aa55653b2d, 0xc1069cd4eabe89f9, 0xf148440a256e2c77, 0x96cd2a865764dbca, 0xbc807527ed3e12bd, 0xeba09271e88d976c, 0x93445b8731587ea3, 0xb8157268fdae9e4c, 0xe61acf033d1a45df, 0x8fd0c16206306bac, 0xb3c4f1ba87bc8697, 0xe0b62e2929aba83c, 0x8c71dcd9ba0b4926, 0xaf8e5410288e1b6f, 0xdb71e91432b1a24b, 0x892731ac9faf056f, 0xab70fe17c79ac6ca, 0xd64d3d9db981787d, 0x85f0468293f0eb4e, 0xa76c582338ed2622, 0xd1476e2c07286faa, 0x82cca4db847945ca, 0xa37fce126597973d, 0xcc5fc196fefd7d0c, 0xff77b1fcbebcdc4f, 0x9faacf3df73609b1, 0xc795830d75038c1e, 0xf97ae3d0d2446f25, 0x9becce62836ac577, 0xc2e801fb244576d5, 0xf3a20279ed56d48a, 0x9845418c345644d7, 0xbe5691ef416bd60c, 0xedec366b11c6cb8f, 0x94b3a202eb1c3f39, 0xb9e08a83a5e34f08, 0xe858ad248f5c22ca, 0x91376c36d99995be, 0xb58547448ffffb2e, 0xe2e69915b3fff9f9, 0x8dd01fad907ffc3c, 0xb1442798f49ffb4b, 0xdd95317f31c7fa1d, 0x8a7d3eef7f1cfc52, 0xad1c8eab5ee43b67, 0xd863b256369d4a41, 0x873e4f75e2224e68, 0xa90de3535aaae202, 0xd3515c2831559a83, 0x8412d9991ed58092, 0xa5178fff668ae0b6, 0xce5d73ff402d98e4, 0x80fa687f881c7f8e, 0xa139029f6a239f72, 0xc987434744ac874f, 0xfbe9141915d7a922, 0x9d71ac8fada6c9b5, 0xc4ce17b399107c23, 0xf6019da07f549b2b, 0x99c102844f94e0fb, 0xc0314325637a193a, 0xf03d93eebc589f88, 0x96267c7535b763b5, 0xbbb01b9283253ca3, 0xea9c227723ee8bcb, 0x92a1958a7675175f, 0xb749faed14125d37, 0xe51c79a85916f485, 0x8f31cc0937ae58d3, 0xb2fe3f0b8599ef08, 0xdfbdcece67006ac9, 0x8bd6a141006042be, 0xaecc49914078536d, 0xda7f5bf590966849, 0x888f99797a5e012d, 0xaab37fd7d8f58179, 0xd5605fcdcf32e1d7, 0x855c3be0a17fcd26, 0xa6b34ad8c9dfc070, 0xd0601d8efc57b08c, 0x823c12795db6ce57, 0xa2cb1717b52481ed, 0xcb7ddcdda26da269, 0xfe5d54150b090b03, 0x9efa548d26e5a6e2, 0xc6b8e9b0709f109a, 0xf867241c8cc6d4c1, 0x9b407691d7fc44f8, 0xc21094364dfb5637, 0xf294b943e17a2bc4, 0x979cf3ca6cec5b5b, 0xbd8430bd08277231, 0xece53cec4a314ebe, 0x940f4613ae5ed137, 0xb913179899f68584, 0xe757dd7ec07426e5, 0x9096ea6f3848984f, 0xb4bca50b065abe63, 0xe1ebce4dc7f16dfc, 0x8d3360f09cf6e4bd, 0xb080392cc4349ded, 0xdca04777f541c568, 0x89e42caaf9491b61, 0xac5d37d5b79b6239, 0xd77485cb25823ac7, 0x86a8d39ef77164bd, 0xa8530886b54dbdec, 0xd267caa862a12d67, 0x8380dea93da4bc60, 0xa46116538d0deb78, 0xcd795be870516656, 0x806bd9714632dff6, 0xa086cfcd97bf97f4, 0xc8a883c0fdaf7df0, 0xfad2a4b13d1b5d6c, 0x9cc3a6eec6311a64, 0xc3f490aa77bd60fd, 0xf4f1b4d515acb93c, 0x991711052d8bf3c5, 0xbf5cd54678eef0b7, 0xef340a98172aace5, 0x9580869f0e7aac0f, 0xbae0a846d2195713, 0xe998d258869facd7, 0x91ff83775423cc06, 0xb67f6455292cbf08, 0xe41f3d6a7377eeca, 0x8e938662882af53e, 0xb23867fb2a35b28e, 0xdec681f9f4c31f31, 0x8b3c113c38f9f37f, 0xae0b158b4738705f, 0xd98ddaee19068c76, 0x87f8a8d4cfa417ca, 0xa9f6d30a038d1dbc, 0xd47487cc8470652b, 0x84c8d4dfd2c63f3b, 0xa5fb0a17c777cf0a, 0xcf79cc9db955c2cc, 0x81ac1fe293d599c0, 0xa21727db38cb0030, 0xca9cf1d206fdc03c, 0xfd442e4688bd304b, 0x9e4a9cec15763e2f, 0xc5dd44271ad3cdba, 0xf7549530e188c129, 0x9a94dd3e8cf578ba, 0xc13a148e3032d6e8, 0xf18899b1bc3f8ca2, 0x96f5600f15a7b7e5, 0xbcb2b812db11a5de, 0xebdf661791d60f56, 0x936b9fcebb25c996, 0xb84687c269ef3bfb, 0xe65829b3046b0afa, 0x8ff71a0fe2c2e6dc, 0xb3f4e093db73a093, 0xe0f218b8d25088b8, 0x8c974f7383725573, 0xafbd2350644eead0, 0xdbac6c247d62a584, 0x894bc396ce5da772, 0xab9eb47c81f5114f, 0xd686619ba27255a3, 0x8613fd0145877586, 0xa798fc4196e952e7, 0xd17f3b51fca3a7a1, 0x82ef85133de648c5, 0xa3ab66580d5fdaf6, 0xcc963fee10b7d1b3, 0xffbbcfe994e5c620, 0x9fd561f1fd0f9bd4, 0xc7caba6e7c5382c9, 0xf9bd690a1b68637b, 0x9c1661a651213e2d, 0xc31bfa0fe5698db8, 0xf3e2f893dec3f126, 0x986ddb5c6b3a76b8, 0xbe89523386091466, 0xee2ba6c0678b597f, 0x94db483840b717f0, 0xba121a4650e4ddec, 0xe896a0d7e51e1566, 0x915e2486ef32cd60, 0xb5b5ada8aaff80b8, 0xe3231912d5bf60e6, 0x8df5efabc5979c90, 0xb1736b96b6fd83b4, 0xddd0467c64bce4a1, 0x8aa22c0dbef60ee4, 0xad4ab7112eb3929e, 0xd89d64d57a607745, 0x87625f056c7c4a8b, 0xa93af6c6c79b5d2e, 0xd389b47879823479, 0x843610cb4bf160cc, 0xa54394fe1eedb8ff, 0xce947a3da6a9273e, 0x811ccc668829b887, 0xa163ff802a3426a9, 0xc9bcff6034c13053, 0xfc2c3f3841f17c68, 0x9d9ba7832936edc1, 0xc5029163f384a931, 0xf64335bcf065d37d, 0x99ea0196163fa42e, 0xc06481fb9bcf8d3a, 0xf07da27a82c37088, 0x964e858c91ba2655, 0xbbe226efb628afeb, 0xeadab0aba3b2dbe5, 0x92c8ae6b464fc96f, 0xb77ada0617e3bbcb, 0xe55990879ddcaabe, 0x8f57fa54c2a9eab7, 0xb32df8e9f3546564, 0xdff9772470297ebd, 0x8bfbea76c619ef36, 0xaefae51477a06b04, 0xdab99e59958885c5, 0x88b402f7fd75539b, 0xaae103b5fcd2a882, 0xd59944a37c0752a2, 0x857fcae62d8493a5, 0xa6dfbd9fb8e5b88f, 0xd097ad07a71f26b2, 0x825ecc24c8737830, 0xa2f67f2dfa90563b, 0xcbb41ef979346bca, 0xfea126b7d78186bd, 0x9f24b832e6b0f436, 0xc6ede63fa05d3144, 0xf8a95fcf88747d94, 0x9b69dbe1b548ce7d, 0xc24452da229b021c, 0xf2d56790ab41c2a3, 0x97c560ba6b0919a6, 0xbdb6b8e905cb600f, 0xed246723473e3813, 0x9436c0760c86e30c, 0xb94470938fa89bcf, 0xe7958cb87392c2c3, 0x90bd77f3483bb9ba, 0xb4ecd5f01a4aa828, 0xe2280b6c20dd5232, 0x8d590723948a535f, 0xb0af48ec79ace837, 0xdcdb1b2798182245, 0x8a08f0f8bf0f156b, 0xac8b2d36eed2dac6, 0xd7adf884aa879177, 0x86ccbb52ea94baeb, 0xa87fea27a539e9a5, 0xd29fe4b18e88640f, 0x83a3eeeef9153e89, 0xa48ceaaab75a8e2b, 0xcdb02555653131b6, 0x808e17555f3ebf12, 0xa0b19d2ab70e6ed6, 0xc8de047564d20a8c, 0xfb158592be068d2f, 0x9ced737bb6c4183d, 0xc428d05aa4751e4d, 0xf53304714d9265e0, 0x993fe2c6d07b7fac, 0xbf8fdb78849a5f97, 0xef73d256a5c0f77d, 0x95a8637627989aae, 0xbb127c53b17ec159, 0xe9d71b689dde71b0, 0x9226712162ab070e, 0xb6b00d69bb55c8d1, 0xe45c10c42a2b3b06, 0x8eb98a7a9a5b04e3, 0xb267ed1940f1c61c, 0xdf01e85f912e37a3, 0x8b61313bbabce2c6, 0xae397d8aa96c1b78, 0xd9c7dced53c72256, 0x881cea14545c7575, 0xaa242499697392d3, 0xd4ad2dbfc3d07788, 0x84ec3c97da624ab5, 0xa6274bbdd0fadd62, 0xcfb11ead453994ba, 0x81ceb32c4b43fcf5, 0xa2425ff75e14fc32, 0xcad2f7f5359a3b3e, 0xfd87b5f28300ca0e, 0x9e74d1b791e07e48, 0xc612062576589ddb, 0xf79687aed3eec551, 0x9abe14cd44753b53, 0xc16d9a0095928a27, 0xf1c90080baf72cb1, 0x971da05074da7bef, 0xbce5086492111aeb, 0xec1e4a7db69561a5, 0x9392ee8e921d5d07, 0xb877aa3236a4b449, 0xe69594bec44de15b, 0x901d7cf73ab0acd9, 0xb424dc35095cd80f, 0xe12e13424bb40e13, 0x8cbccc096f5088cc, 0xafebff0bcb24aaff, 0xdbe6fecebdedd5bf, 0x89705f4136b4a597, 0xabcc77118461cefd, 0xd6bf94d5e57a42bc, 0x8637bd05af6c69b6, 0xa7c5ac471b478423, 0xd1b71758e219652c, 0x83126e978d4fdf3b, 0xa3d70a3d70a3d70a, 0xcccccccccccccccd, 0x8000000000000000, 0xa000000000000000, 0xc800000000000000, 0xfa00000000000000, 0x9c40000000000000, 0xc350000000000000, 0xf424000000000000, 0x9896800000000000, 0xbebc200000000000, 0xee6b280000000000, 0x9502f90000000000, 0xba43b74000000000, 0xe8d4a51000000000, 0x9184e72a00000000, 0xb5e620f480000000, 0xe35fa931a0000000, 0x8e1bc9bf04000000, 0xb1a2bc2ec5000000, 0xde0b6b3a76400000, 0x8ac7230489e80000, 0xad78ebc5ac620000, 0xd8d726b7177a8000, 0x878678326eac9000, 0xa968163f0a57b400, 0xd3c21bcecceda100, 0x84595161401484a0, 0xa56fa5b99019a5c8, 0xcecb8f27f4200f3a, 0x813f3978f8940984, 0xa18f07d736b90be5, 0xc9f2c9cd04674edf, 0xfc6f7c4045812296, 0x9dc5ada82b70b59e, 0xc5371912364ce305, 0xf684df56c3e01bc7, 0x9a130b963a6c115c, 0xc097ce7bc90715b3, 0xf0bdc21abb48db20, 0x96769950b50d88f4, 0xbc143fa4e250eb31, 0xeb194f8e1ae525fd, 0x92efd1b8d0cf37be, 0xb7abc627050305ae, 0xe596b7b0c643c719, 0x8f7e32ce7bea5c70, 0xb35dbf821ae4f38c, 0xe0352f62a19e306f, 0x8c213d9da502de45, 0xaf298d050e4395d7, 0xdaf3f04651d47b4c, 0x88d8762bf324cd10, 0xab0e93b6efee0054, 0xd5d238a4abe98068, 0x85a36366eb71f041, 0xa70c3c40a64e6c52, 0xd0cf4b50cfe20766, 0x82818f1281ed44a0, 0xa321f2d7226895c8, 0xcbea6f8ceb02bb3a, 0xfee50b7025c36a08, 0x9f4f2726179a2245, 0xc722f0ef9d80aad6, 0xf8ebad2b84e0d58c, 0x9b934c3b330c8577, 0xc2781f49ffcfa6d5, 0xf316271c7fc3908b, 0x97edd871cfda3a57, 0xbde94e8e43d0c8ec, 0xed63a231d4c4fb27, 0x945e455f24fb1cf9, 0xb975d6b6ee39e437, 0xe7d34c64a9c85d44, 0x90e40fbeea1d3a4b, 0xb51d13aea4a488dd, 0xe264589a4dcdab15, 0x8d7eb76070a08aed, 0xb0de65388cc8ada8, 0xdd15fe86affad912, 0x8a2dbf142dfcc7ab, 0xacb92ed9397bf996, 0xd7e77a8f87daf7fc, 0x86f0ac99b4e8dafd, 0xa8acd7c0222311bd, 0xd2d80db02aabd62c, 0x83c7088e1aab65db, 0xa4b8cab1a1563f52, 0xcde6fd5e09abcf27, 0x80b05e5ac60b6178, 0xa0dc75f1778e39d6, 0xc913936dd571c84c, 0xfb5878494ace3a5f, 0x9d174b2dcec0e47b, 0xc45d1df942711d9a, 0xf5746577930d6501, 0x9968bf6abbe85f20, 0xbfc2ef456ae276e9, 0xefb3ab16c59b14a3, 0x95d04aee3b80ece6, 0xbb445da9ca61281f, 0xea1575143cf97227, 0x924d692ca61be758, 0xb6e0c377cfa2e12e, 0xe498f455c38b997a, 0x8edf98b59a373fec, 0xb2977ee300c50fe7, 0xdf3d5e9bc0f653e1, 0x8b865b215899f46d, 0xae67f1e9aec07188, 0xda01ee641a708dea, 0x884134fe908658b2, 0xaa51823e34a7eedf, 0xd4e5e2cdc1d1ea96, 0x850fadc09923329e, 0xa6539930bf6bff46, 0xcfe87f7cef46ff17, 0x81f14fae158c5f6e, 0xa26da3999aef774a, 0xcb090c8001ab551c, 0xfdcb4fa002162a63, 0x9e9f11c4014dda7e, 0xc646d63501a1511e, 0xf7d88bc24209a565, 0x9ae757596946075f, 0xc1a12d2fc3978937, 0xf209787bb47d6b85, 0x9745eb4d50ce6333, 0xbd176620a501fc00, 0xec5d3fa8ce427b00, 0x93ba47c980e98ce0, 0xb8a8d9bbe123f018, 0xe6d3102ad96cec1e, 0x9043ea1ac7e41393, 0xb454e4a179dd1877, 0xe16a1dc9d8545e95, 0x8ce2529e2734bb1d, 0xb01ae745b101e9e4, 0xdc21a1171d42645d, 0x899504ae72497eba, 0xabfa45da0edbde69, 0xd6f8d7509292d603, 0x865b86925b9bc5c2, 0xa7f26836f282b733, 0xd1ef0244af2364ff, 0x8335616aed761f1f, 0xa402b9c5a8d3a6e7, 0xcd036837130890a1, 0x802221226be55a65, 0xa02aa96b06deb0fe, 0xc83553c5c8965d3d, 0xfa42a8b73abbf48d, 0x9c69a97284b578d8, 0xc38413cf25e2d70e, 0xf46518c2ef5b8cd1, 0x98bf2f79d5993803, 0xbeeefb584aff8604, 0xeeaaba2e5dbf6785, 0x952ab45cfa97a0b3, 0xba756174393d88e0, 0xe912b9d1478ceb17, 0x91abb422ccb812ef, 0xb616a12b7fe617aa, 0xe39c49765fdf9d95, 0x8e41ade9fbebc27d, 0xb1d219647ae6b31c, 0xde469fbd99a05fe3, 0x8aec23d680043bee, 0xada72ccc20054aea, 0xd910f7ff28069da4, 0x87aa9aff79042287, 0xa99541bf57452b28, 0xd3fa922f2d1675f2, 0x847c9b5d7c2e09b7, 0xa59bc234db398c25, 0xcf02b2c21207ef2f, 0x8161afb94b44f57d, 0xa1ba1ba79e1632dc, 0xca28a291859bbf93, 0xfcb2cb35e702af78, 0x9defbf01b061adab, 0xc56baec21c7a1916, 0xf6c69a72a3989f5c, 0x9a3c2087a63f6399, 0xc0cb28a98fcf3c80, 0xf0fdf2d3f3c30b9f, 0x969eb7c47859e744, 0xbc4665b596706115, 0xeb57ff22fc0c795a, 0x9316ff75dd87cbd8, 0xb7dcbf5354e9bece, 0xe5d3ef282a242e82, 0x8fa475791a569d11, 0xb38d92d760ec4455, 0xe070f78d3927556b, 0x8c469ab843b89563, 0xaf58416654a6babb, 0xdb2e51bfe9d0696a, 0x88fcf317f22241e2, 0xab3c2fddeeaad25b, 0xd60b3bd56a5586f2, 0x85c7056562757457, 0xa738c6bebb12d16d, 0xd106f86e69d785c8, 0x82a45b450226b39d, 0xa34d721642b06084, 0xcc20ce9bd35c78a5, 0xff290242c83396ce, 0x9f79a169bd203e41, 0xc75809c42c684dd1, 0xf92e0c3537826146, 0x9bbcc7a142b17ccc, 0xc2abf989935ddbfe, 0xf356f7ebf83552fe, 0x98165af37b2153df, 0xbe1bf1b059e9a8d6, 0xeda2ee1c7064130c, 0x9485d4d1c63e8be8, 0xb9a74a0637ce2ee1, 0xe8111c87c5c1ba9a, 0x910ab1d4db9914a0, 0xb54d5e4a127f59c8, 0xe2a0b5dc971f303a, 0x8da471a9de737e24, 0xb10d8e1456105dad, 0xdd50f1996b947519, 0x8a5296ffe33cc930, 0xace73cbfdc0bfb7b, 0xd8210befd30efa5a, 0x8714a775e3e95c78, 0xa8d9d1535ce3b396, 0xd31045a8341ca07c, 0x83ea2b892091e44e, 0xa4e4b66b68b65d61, 0xce1de40642e3f4b9, 0x80d2ae83e9ce78f4, 0xa1075a24e4421731, 0xc94930ae1d529cfd, 0xfb9b7cd9a4a7443c, 0x9d412e0806e88aa6, 0xc491798a08a2ad4f, 0xf5b5d7ec8acb58a3, 0x9991a6f3d6bf1766, 0xbff610b0cc6edd3f, 0xeff394dcff8a948f, 0x95f83d0a1fb69cd9, 0xbb764c4ca7a44410, 0xea53df5fd18d5514, 0x92746b9be2f8552c, 0xb7118682dbb66a77, 0xe4d5e82392a40515, 0x8f05b1163ba6832d, 0xb2c71d5bca9023f8, 0xdf78e4b2bd342cf7, 0x8bab8eefb6409c1a, 0xae9672aba3d0c321, 0xda3c0f568cc4f3e9, 0x8865899617fb1871, 0xaa7eebfb9df9de8e, 0xd51ea6fa85785631, 0x8533285c936b35df, 0xa67ff273b8460357, 0xd01fef10a657842c, 0x8213f56a67f6b29c, 0xa298f2c501f45f43, 0xcb3f2f7642717713, 0xfe0efb53d30dd4d8, 0x9ec95d1463e8a507, 0xc67bb4597ce2ce49, 0xf81aa16fdc1b81db, 0x9b10a4e5e9913129, 0xc1d4ce1f63f57d73, 0xf24a01a73cf2dcd0, 0x976e41088617ca02, 0xbd49d14aa79dbc82, 0xec9c459d51852ba3, 0x93e1ab8252f33b46, 0xb8da1662e7b00a17, 0xe7109bfba19c0c9d, 0x906a617d450187e2, 0xb484f9dc9641e9db, 0xe1a63853bbd26451, 0x8d07e33455637eb3, 0xb049dc016abc5e60, 0xdc5c5301c56b75f7, 0x89b9b3e11b6329bb, 0xac2820d9623bf429, 0xd732290fbacaf134, 0x867f59a9d4bed6c0, 0xa81f301449ee8c70, 0xd226fc195c6a2f8c, 0x83585d8fd9c25db8, 0xa42e74f3d032f526, 0xcd3a1230c43fb26f, 0x80444b5e7aa7cf85, 0xa0555e361951c367, 0xc86ab5c39fa63441, 0xfa856334878fc151, 0x9c935e00d4b9d8d2, 0xc3b8358109e84f07, 0xf4a642e14c6262c9, 0x98e7e9cccfbd7dbe, 0xbf21e44003acdd2d, 0xeeea5d5004981478, 0x95527a5202df0ccb, 0xbaa718e68396cffe, 0xe950df20247c83fd, 0x91d28b7416cdd27e, 0xb6472e511c81471e, 0xe3d8f9e563a198e5, 0x8e679c2f5e44ff8f, 0xb201833b35d63f73, 0xde81e40a034bcf50, 0x8b112e86420f6192, 0xadd57a27d29339f6, 0xd94ad8b1c7380874, 0x87cec76f1c830549, 0xa9c2794ae3a3c69b, 0xd433179d9c8cb841, 0x849feec281d7f329, 0xa5c7ea73224deff3, 0xcf39e50feae16bf0, 0x81842f29f2cce376, 0xa1e53af46f801c53, 0xca5e89b18b602368, 0xfcf62c1dee382c42, 0x9e19db92b4e31ba9, 0xc5a05277621be294, 0xf70867153aa2db39, 0x9a65406d44a5c903, 0xc0fe908895cf3b44, 0xf13e34aabb430a15, 0x96c6e0eab509e64d, 0xbc789925624c5fe1, 0xeb96bf6ebadf77d9, 0x933e37a534cbaae8, 0xb80dc58e81fe95a1, 0xe61136f2227e3b0a, 0x8fcac257558ee4e6, 0xb3bd72ed2af29e20, 0xe0accfa875af45a8, 0x8c6c01c9498d8b89, 0xaf87023b9bf0ee6b, 0xdb68c2ca82ed2a06, 0x892179be91d43a44, 0xab69d82e364948d4 };
+static constexpr int powers_ten_e[] = { -1203, -1200, -1196, -1193, -1190, -1186, -1183, -1180, -1176, -1173, -1170, -1166, -1163, -1160, -1156, -1153, -1150, -1146, -1143, -1140, -1136, -1133, -1130, -1127, -1123, -1120, -1117, -1113, -1110, -1107, -1103, -1100, -1097, -1093, -1090, -1087, -1083, -1080, -1077, -1073, -1070, -1067, -1063, -1060, -1057, -1053, -1050, -1047, -1043, -1040, -1037, -1034, -1030, -1027, -1024, -1020, -1017, -1014, -1010, -1007, -1004, -1000, -997, -994, -990, -987, -984, -980, -977, -974, -970, -967, -964, -960, -957, -954, -950, -947, -944, -940, -937, -934, -931, -927, -924, -921, -917, -914, -911, -907, -904, -901, -897, -894, -891, -887, -884, -881, -877, -874, -871, -867, -864, -861, -857, -854, -851, -847, -844, -841, -838, -834, -831, -828, -824, -821, -818, -814, -811, -808, -804, -801, -798, -794, -791, -788, -784, -781, -778, -774, -771, -768, -764, -761, -758, -754, -751, -748, -744, -741, -738, -735, -731, -728, -725, -721, -718, -715, -711, -708, -705, -701, -698, -695, -691, -688, -685, -681, -678, -675, -671, -668, -665, -661, -658, -655, -651, -648, -645, -642, -638, -635, -632, -628, -625, -622, -618, -615, -612, -608, -605, -602, -598, -595, -592, -588, -585, -582, -578, -575, -572, -568, -565, -562, -558, -555, -552, -549, -545, -542, -539, -535, -532, -529, -525, -522, -519, -515, -512, -509, -505, -502, -499, -495, -492, -489, -485, -482, -479, -475, -472, -469, -465, -462, -459, -455, -452, -449, -446, -442, -439, -436, -432, -429, -426, -422, -419, -416, -412, -409, -406, -402, -399, -396, -392, -389, -386, -382, -379, -376, -372, -369, -366, -362, -359, -356, -353, -349, -346, -343, -339, -336, -333, -329, -326, -323, -319, -316, -313, -309, -306, -303, -299, -296, -293, -289, -286, -283, -279, -276, -273, -269, -266, -263, -259, -256, -253, -250, -246, -243, -240, -236, -233, -230, -226, -223, -220, -216, -213, -210, -206, -203, -200, -196, -193, -190, -186, -183, -180, -176, -173, -170, -166, -163, -160, -157, -153, -150, -147, -143, -140, -137, -133, -130, -127, -123, -120, -117, -113, -110, -107, -103, -100, -97, -93, -90, -87, -83, -80, -77, -73, -70, -67, -63, -60, -57, -54, -50, -47, -44, -40, -37, -34, -30, -27, -24, -20, -17, -14, -10, -7, -4, 0, 3, 6, 10, 13, 16, 20, 23, 26, 30, 33, 36, 39, 43, 46, 49, 53, 56, 59, 63, 66, 69, 73, 76, 79, 83, 86, 89, 93, 96, 99, 103, 106, 109, 113, 116, 119, 123, 126, 129, 132, 136, 139, 142, 146, 149, 152, 156, 159, 162, 166, 169, 172, 176, 179, 182, 186, 189, 192, 196, 199, 202, 206, 209, 212, 216, 219, 222, 226, 229, 232, 235, 239, 242, 245, 249, 252, 255, 259, 262, 265, 269, 272, 275, 279, 282, 285, 289, 292, 295, 299, 302, 305, 309, 312, 315, 319, 322, 325, 328, 332, 335, 338, 342, 345, 348, 352, 355, 358, 362, 365, 368, 372, 375, 378, 382, 385, 388, 392, 395, 398, 402, 405, 408, 412, 415, 418, 422, 425, 428, 431, 435, 438, 441, 445, 448, 451, 455, 458, 461, 465, 468, 471, 475, 478, 481, 485, 488, 491, 495, 498, 501, 505, 508, 511, 515, 518, 521, 524, 528, 531, 534, 538, 541, 544, 548, 551, 554, 558, 561, 564, 568, 571, 574, 578, 581, 584, 588, 591, 594, 598, 601, 604, 608, 611, 614, 617, 621, 624, 627, 631, 634, 637, 641, 644, 647, 651, 654, 657, 661, 664, 667, 671, 674, 677, 681, 684, 687, 691, 694, 697, 701, 704, 707, 711, 714, 717, 720, 724, 727, 730, 734, 737, 740, 744, 747, 750, 754, 757, 760, 764, 767, 770, 774, 777, 780, 784, 787, 790, 794, 797, 800, 804, 807, 810, 813, 817, 820, 823, 827, 830, 833, 837, 840, 843, 847, 850, 853, 857, 860, 863, 867, 870, 873, 877, 880, 883, 887, 890, 893, 897, 900, 903, 907, 910, 913, 916, 920, 923, 926, 930, 933, 936, 940, 943, 946, 950, 953, 956, 960, 963, 966, 970, 973, 976, 980, 983, 986, 990, 993, 996, 1000, 1003, 1006, 1009, 1013, 1016, 1019, 1023, 1026, 1029, 1033, 1036, 1039, 1043, 1046, 1049, 1053, 1056, 1059, 1063, 1066, 1069, 1073, 1076 };
+
+inline 
+diy_fp_t cached_power(int k)
+{
+    diy_fp_t res;
+    int index = 343 + k;
+    res.f = powers_ten[index];
+    res.e = powers_ten_e[index];
+    return res;
+}
+
+// double
+
+/*
+typedef union {
+    double d;
+    uint64_t n;
+} converter_t;
+
+inline 
+uint64_t double_to_uint64(double d) { converter_t tmp; tmp.d = d; return tmp.n; }
+
+inline 
+double uint64_to_double(uint64_t d64) { converter_t tmp; tmp.n = d64; return tmp.d; }
+*/
+inline 
+uint64_t double_to_uint64(double d) {uint64_t d64; std::memcpy(&d64,&d,sizeof(double)); return d64; }
+
+inline 
+double uint64_to_double(uint64_t d64) {double d; std::memcpy(&d,&d64,sizeof(double)); return d; }
+
+constexpr int dp_significand_size = 52;
+constexpr int dp_exponent_bias = (0x3FF + dp_significand_size);
+constexpr int dp_min_exponent = (-dp_exponent_bias);
+constexpr uint64_t dp_exponent_mask = 0x7FF0000000000000;
+constexpr uint64_t dp_significand_mask = 0x000FFFFFFFFFFFFF;
+constexpr uint64_t dp_hidden_bit = 0x0010000000000000;
+
+inline 
+diy_fp_t normalize_diy_fp(diy_fp_t in)
+{
+    diy_fp_t res = in;
+    /* Normalize now */
+    /* the original number could have been a denormal. */
+    while (!(res.f & dp_hidden_bit))
+    {
+        res.f <<= 1;
+        res.e--;
+    }
+    /* do the final shifts in one go. Don't forget the hidden bit (the '-1') */
+    res.f <<= (diy_significand_size - dp_significand_size - 1);
+    res.e = res.e - (diy_significand_size - dp_significand_size - 1);
+    return res;
+}
+
+inline 
+diy_fp_t double2diy_fp(double d)
+{
+    uint64_t d64 = double_to_uint64(d);
+    int biased_e = (d64 & dp_exponent_mask) >> dp_significand_size;
+    uint64_t significand = (d64 & dp_significand_mask);
+    diy_fp_t res;
+    if (biased_e != 0)
+    {
+        res.f = significand + dp_hidden_bit;
+        res.e = biased_e - dp_exponent_bias;
+    } 
+    else
+    {
+        res.f = significand;
+        res.e = dp_min_exponent + 1;
+    }
+    return res;
+}
+
+inline 
+diy_fp_t normalize_boundary(diy_fp_t in)
+{
+    diy_fp_t res = in;
+    /* Normalize now */
+    /* the original number could have been a denormal. */
+    while (!(res.f & (dp_hidden_bit << 1)))
+    {
+        res.f <<= 1;
+        res.e--;
+    }
+    /* do the final shifts in one go. Don't forget the hidden bit (the '-1') */
+    res.f <<= (diy_significand_size - dp_significand_size - 2);
+    res.e = res.e - (diy_significand_size - dp_significand_size - 2);
+    return res;
+}
+
+inline 
+void normalized_boundaries(double d, diy_fp_t *out_m_minus, diy_fp_t *out_m_plus)
+{
+    diy_fp_t v = double2diy_fp(d);
+    diy_fp_t pl, mi;
+    bool significand_is_zero = v.f == dp_hidden_bit;
+    pl.f  = (v.f << 1) + 1; pl.e  = v.e - 1;
+    pl = normalize_boundary(pl);
+    if (significand_is_zero)
+    {
+        mi.f = (v.f << 2) - 1;
+        mi.e = v.e - 2;
+    } else
+    {
+        mi.f = (v.f << 1) - 1;
+        mi.e = v.e - 1;
+    }
+    int x = mi.e - pl.e;
+    mi.f <<= x;
+    mi.e = pl.e;
+    *out_m_plus = pl;
+    *out_m_minus = mi;
+}
+
+inline 
+double random_double()
+{
+    uint64_t tmp = 0;
+    int i;
+    for (i = 0; i < 8; i++)
+    {
+        tmp <<= 8;
+        tmp += rand() % 256;
+    }
+    return uint64_to_double(tmp);
+}
+
+// grisu3
+
+inline
+bool round_weed(char *buffer, int len,
+                uint64_t wp_W, uint64_t Delta,
+                uint64_t rest, uint64_t ten_kappa,
+                uint64_t ulp)
+{
+    uint64_t wp_Wup = wp_W - ulp;
+    uint64_t wp_Wdown = wp_W + ulp;
+    while (rest < wp_Wup &&  /// round1
+           Delta - rest >= ten_kappa &&
+           (rest + ten_kappa < wp_Wup || /// closer
+            wp_Wup - rest >= rest + ten_kappa - wp_Wup))
+    {
+        buffer[len - 1]--; rest += ten_kappa;
+    }
+    if (rest < wp_Wdown && /// round2
+        Delta - rest >= ten_kappa &&
+        (rest + ten_kappa < wp_Wdown ||
+         wp_Wdown - rest > rest + ten_kappa - wp_Wdown)) return 0;
+    return 2 * ulp <= rest && rest <= Delta - 4 * ulp; /// weed
+}
+
+inline
+bool digit_gen(diy_fp_t Wm, diy_fp_t W, diy_fp_t Wp,
+               char *buffer, int *len, int *K)
+{
+    const uint32_t TEN2 = 100;
+
+    uint32_t div, p1; uint64_t p2, tmp, unit = 1;
+    int d, kappa;
+    diy_fp_t one, wp_W, Delta;
+    Delta = minus(Wp, Wm); Delta.f += 2 * unit;
+    wp_W = minus(Wp, W); wp_W.f += unit;
+    one.f = ((uint64_t)1) << -Wp.e; one.e = Wp.e;
+    p1 = static_cast<uint32_t>((Wp.f + 1) >> -one.e);
+    p2 = (Wp.f + 1) & (one.f - 1);
+    *len = 0; kappa = 3; div = TEN2;
+    while (kappa > 0)
+    {
+        d = p1 / div;
+        if (d || *len) buffer[(*len)++] = (char)('0' + d);
+        p1 %= div; kappa--;
+        tmp = (((uint64_t)p1) << -one.e) + p2;
+        if (tmp < Delta.f)
+        {
+            *K += kappa;
+            return round_weed(buffer, *len, wp_W.f, Delta.f, tmp,
+                              ((uint64_t)div) << -one.e, unit);
+        }
+        div /= 10;
+    }
+    while (1)
+    {
+        p2 *= 10; Delta.f *= 10; unit *= 10;
+        d = static_cast<int>(p2 >> -one.e);
+        if (d || *len) buffer[(*len)++] = (char)('0' + d);
+        p2 &= one.f - 1; kappa--;
+        if (p2 < Delta.f)
+        {
+            *K += kappa;
+            return round_weed(buffer, *len, wp_W.f * unit, Delta.f, p2,
+                              one.f, unit);
+        }
+    }
+}
+
+inline
+bool grisu3(double v, char *buffer, int *length, int *K)
+{
+    diy_fp_t w_m, w_p;
+    int q = 64, alpha = -59, gamma = -56;
+    normalized_boundaries(v, &w_m, &w_p);
+    diy_fp_t w = normalize_diy_fp(double2diy_fp(v));
+    int mk = k_comp(w_p.e + q, alpha, gamma);
+    diy_fp_t c_mk = cached_power(mk);
+    diy_fp_t W  = multiply(w,   c_mk);
+    diy_fp_t Wp = multiply(w_p, c_mk);
+    diy_fp_t Wm = multiply(w_m, c_mk);
+    *K = -mk;
+    bool result = digit_gen(Wm, W, Wp, buffer, length, K);
+    buffer[*length] = 0;
+    return result;
+}
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_GRISU3_HPP

--- a/velox/external/jsoncons/detail/optional.hpp
+++ b/velox/external/jsoncons/detail/optional.hpp
@@ -1,0 +1,503 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_OPTIONAL_HPP
+#define JSONCONS_DETAIL_OPTIONAL_HPP
+
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility> // std::swap
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+
+namespace facebook::velox::jsoncons 
+{ 
+namespace detail 
+{ 
+    template <typename T>
+    class optional;
+
+    template <typename T1,typename T2>
+    struct is_constructible_or_convertible_from_optional
+        : std::integral_constant<
+              bool, std::is_constructible<T1, optional<T2>&>::value ||
+                    std::is_constructible<T1, optional<T2>&&>::value ||
+                    std::is_constructible<T1, const optional<T2>&>::value ||
+                    std::is_constructible<T1, const optional<T2>&&>::value ||
+                    std::is_convertible<optional<T2>&, T1>::value ||
+                    std::is_convertible<optional<T2>&&, T1>::value ||
+                    std::is_convertible<const optional<T2>&, T1>::value ||
+                    std::is_convertible<const optional<T2>&&, T1>::value> {};
+
+    template <typename T1,typename T2>
+    struct is_constructible_convertible_or_assignable_from_optional
+        : std::integral_constant<
+              bool, is_constructible_or_convertible_from_optional<T1, T2>::value ||
+                    std::is_assignable<T1&, optional<T2>&>::value ||
+                    std::is_assignable<T1&, optional<T2>&&>::value ||
+                    std::is_assignable<T1&, const optional<T2>&>::value ||
+                    std::is_assignable<T1&, const optional<T2>&&>::value> {};
+
+    template <typename T>
+    class optional
+    {
+    public:
+        using value_type = T;
+    private:
+        bool has_value_;
+        union {
+            char dummy_;
+            T value_;
+        };
+    public:
+        constexpr optional() noexcept
+            : has_value_(false), dummy_{}
+        {
+        }
+        
+        // copy constructors
+        optional(const optional<T>& other)
+            : has_value_(false), dummy_{}
+        {
+            if (other)
+            {
+                construct(*other);
+            }
+        }
+
+        // converting
+        template <typename U,
+                  typename std::enable_if<!std::is_same<T,U>::value &&
+                                          std::is_constructible<T, const U&>::value &&
+                                          std::is_convertible<const U&,T>::value &&
+                                          !is_constructible_or_convertible_from_optional<T,U>::value &&
+                                          std::is_copy_constructible<typename std::decay<U>::type>::value,int>::type = 0>
+        optional(const optional<U>& other)
+            : has_value_(false), dummy_{}
+        {
+            if (other)
+            {
+                construct(*other);
+            }
+        }
+
+        template <typename U,
+                  typename std::enable_if<!std::is_same<T,U>::value &&
+                                          std::is_constructible<T, const U&>::value &&
+                                          !std::is_convertible<const U&,T>::value &&
+                                          !is_constructible_or_convertible_from_optional<T,U>::value &&
+                                          std::is_copy_constructible<typename std::decay<U>::type>::value,int>::type = 0>
+        explicit optional(const optional<U>& other)
+            : has_value_(false), dummy_{}
+        {
+            if (other)
+            {
+                construct(*other);
+            }
+        }
+
+        // move constructors
+        template <typename T2 = T>
+        optional(optional<T>&& other,
+                 typename std::enable_if<std::is_move_constructible<typename std::decay<T2>::type>::value>::type* = 0)
+            : has_value_(false), dummy_{}
+       {
+            if (other)
+            {
+                construct(std::move(other.value_));
+            }
+       }
+
+        // converting 
+        template <typename U>
+        optional(optional<U>&& value,
+             typename std::enable_if<!std::is_same<T,U>::value &&
+                                     std::is_constructible<T, U&&>::value &&
+                                     !is_constructible_or_convertible_from_optional<T,U>::value &&
+                                     std::is_convertible<U&&,T>::value,int>::type = 0) // (8)
+            : has_value_(true), value_(std::forward<U>(value))
+        {
+        }
+
+        template <typename U>
+        explicit optional(optional<U>&& value,
+                         typename std::enable_if<!std::is_same<T,U>::value &&
+                                                 std::is_constructible<T, U&&>::value &&
+                                                 !is_constructible_or_convertible_from_optional<T,U>::value &&
+                                                 !std::is_convertible<U&&,T>::value,int>::type = 0) // (8)
+            : has_value_(true), value_(std::forward<U>(value))
+        {
+        }
+
+
+        // value constructors
+        template <typename T2>
+        optional(T2&& value,
+             typename std::enable_if<!std::is_same<optional<T>,typename std::decay<T2>::type>::value &&
+                                     std::is_constructible<T, T2>::value &&
+                                     std::is_convertible<T2,T>::value,int>::type = 0) // (8)
+            : has_value_(true), value_(std::forward<T2>(value))
+        {
+        }
+
+        template <typename T2>
+        explicit optional(T2&& value,
+                         typename std::enable_if<!std::is_same<optional<T>,typename std::decay<T2>::type>::value &&
+                                                 std::is_constructible<T, T2>::value &&
+                                                 !std::is_convertible<T2,T>::value,int>::type = 0) // (8)
+            : has_value_(true), value_(std::forward<T2>(value))
+        {
+        }
+
+        ~optional() noexcept
+        {
+            destroy();
+        }
+
+        optional& operator=(const optional& other)
+        {
+            if (other)
+            {
+                assign(*other);
+            }
+            else
+            {
+                reset();
+            }
+            return *this;
+        }
+
+        optional& operator=(optional&& other )
+        {
+            if (other)
+            {
+                assign(std::move(*other));
+            }
+            else
+            {
+                reset();
+            }
+            return *this;
+        }
+
+        template <typename U>
+        typename std::enable_if<!std::is_same<optional<T>, U>::value &&
+                                std::is_constructible<T, const U&>::value &&
+                               !is_constructible_convertible_or_assignable_from_optional<T,U>::value &&
+                                std::is_assignable<T&, const U&>::value,
+            optional&>::type
+        operator=(const optional<U>& other)
+        {
+            if (other) 
+            {
+                assign(*other);
+            } 
+            else 
+            {
+                destroy();
+            }
+            return *this;
+        }
+
+        template <typename U>
+        typename std::enable_if<!std::is_same<optional<T>, U>::value &&
+                                std::is_constructible<T, U>::value &&
+                                !is_constructible_convertible_or_assignable_from_optional<T,U>::value &&
+                                std::is_assignable<T&, U>::value,
+            optional&>::type
+        operator=(optional<U>&& other) noexcept
+        {
+            if (other) 
+            {
+                assign(std::move(*other));
+            } 
+            else 
+            {
+                destroy();
+            }
+            return *this;
+        }
+
+        // value assignment
+        template <typename T2>
+        typename std::enable_if<!std::is_same<optional<T>,typename std::decay<T2>::type>::value &&
+                                std::is_constructible<T, T2>::value &&
+                                std::is_assignable<T&, T2>::value &&
+                                !(std::is_scalar<T>::value && std::is_same<T,typename std::decay<T2>::type>::value),
+            optional&>::type
+        operator=(T2&& v)
+        {
+            assign(std::forward<T2>(v));
+            return *this;
+        }
+
+        constexpr explicit operator bool() const noexcept
+        {
+            return has_value_;
+        }
+        constexpr bool has_value() const noexcept
+        {
+            return has_value_;
+        }
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif // _MSC_VER
+
+        T& value() &
+        {
+            if (has_value_)
+            {
+                return get();
+            }
+            JSONCONS_THROW(std::runtime_error("Bad optional access"));
+        }
+
+        JSONCONS_CONSTEXPR const T& value() const &
+        {
+            if (has_value_)
+            {
+                return get();
+            }
+            JSONCONS_THROW(std::runtime_error("Bad optional access"));
+        }
+
+        template <typename U>
+        constexpr T value_or(U&& default_value) const & 
+        {
+            static_assert(std::is_copy_constructible<T>::value,
+                          "get_value_or: T must be copy constructible");
+            static_assert(std::is_convertible<U&&, T>::value,
+                          "get_value_or: U must be convertible to T");
+            return static_cast<bool>(*this)
+                       ? **this
+                       : static_cast<T>(std::forward<U>(default_value));
+        }
+
+        template <typename U>
+        T value_or(U&& default_value) && 
+        {
+            static_assert(std::is_move_constructible<T>::value,
+                          "get_value_or: T must be move constructible");
+            static_assert(std::is_convertible<U&&, T>::value,
+                          "get_value_or: U must be convertible to T");
+            return static_cast<bool>(*this) ? std::move(**this)
+                                            : static_cast<T>(std::forward<U>(default_value));
+        }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
+
+        const T* operator->() const
+        {
+            return std::addressof(this->value_);
+        }
+
+        T* operator->()
+        {
+            return std::addressof(this->value_);
+        }
+
+        JSONCONS_CONSTEXPR const T& operator*() const&
+        {
+            return value();
+        }
+
+        T& operator*() &
+        {
+            return value();
+        }
+
+        void reset() noexcept
+        {
+            destroy();
+        }
+
+        void swap(optional& other) noexcept(std::is_nothrow_move_constructible<T>::value /*&&
+                                            std::is_nothrow_swappable<T>::value*/)
+        {
+            const bool contains_a_value = has_value();
+            if (contains_a_value == other.has_value())
+            {
+                if (contains_a_value)
+                {
+                    using std::swap;
+                    swap(**this, *other);
+                }
+            }
+            else
+            {
+                optional& source = contains_a_value ? *this : other;
+                optional& target = contains_a_value ? other : *this;
+                target = optional<T>(*source);
+                source.reset();
+            }
+        }
+    private:
+        constexpr const T& get() const { return this->value_; }
+        T& get() { return this->value_; }
+
+        template <typename... Args>
+        void construct(Args&&... args) 
+        {
+            ::new (static_cast<void*>(&this->value_)) T(std::forward<Args>(args)...);
+            has_value_ = true;
+        }
+
+        void destroy() noexcept 
+        {
+            if (has_value_) 
+            {
+                value_.~T();
+                has_value_ = false;
+            }
+        }
+
+        template <typename U>
+        void assign(U&& u) 
+        {
+            if (has_value_) 
+            {
+                value_ = std::forward<U>(u);
+            } 
+            else 
+            {
+                construct(std::forward<U>(u));
+            }
+        }
+    };
+
+    template <typename T>
+    typename std::enable_if<std::is_nothrow_move_constructible<T>::value,void>::type
+    swap(optional<T>& lhs, optional<T>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator==(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return lhs.has_value() == rhs.has_value() && (!lhs.has_value() || *lhs == *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator!=(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return lhs.has_value() != rhs.has_value() || (lhs.has_value() && *lhs != *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator<(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs.has_value() && (!lhs.has_value() || *lhs < *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator>(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return lhs.has_value() && (!rhs.has_value() || *lhs > *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator<=(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return !lhs.has_value() || (rhs.has_value() && *lhs <= *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator>=(const optional<T1>& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return !rhs.has_value() || (lhs.has_value() && *lhs >= *rhs);
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator==(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs == rhs : false;
+    }
+    template <typename T1,typename T2>
+    constexpr bool operator==(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs == *rhs : false;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator!=(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs != rhs : true;
+    }
+    template <typename T1,typename T2>
+    constexpr bool operator!=(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs != *rhs : true;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator<(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs < rhs : true;
+    }
+    template <typename T1,typename T2>
+    constexpr bool operator<(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs < *rhs : false;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator<=(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs <= rhs : true;
+    }
+    template <typename T1,typename T2>
+    constexpr bool operator<=(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs <= *rhs : false;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator>(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs > rhs : false;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator>(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs > *rhs : true;
+    }
+
+    template <typename T1,typename T2>
+    constexpr bool operator>=(const optional<T1>& lhs, const T2& rhs) noexcept 
+    {
+        return lhs ? *lhs >= rhs : false;
+    }
+    template <typename T1,typename T2>
+    constexpr bool operator>=(const T1& lhs, const optional<T2>& rhs) noexcept 
+    {
+        return rhs ? lhs >= *rhs : true;
+    }
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_OPTIONAL_HPP

--- a/velox/external/jsoncons/detail/parse_number.hpp
+++ b/velox/external/jsoncons/detail/parse_number.hpp
@@ -1,0 +1,1065 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_PARSE_NUMBER_HPP
+#define JSONCONS_DETAIL_PARSE_NUMBER_HPP
+
+#include <cctype>
+#include <cstddef>
+#include <cstdint>
+#include <locale>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+#include <type_traits> // std::enable_if
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { namespace detail {
+
+    enum class to_integer_errc : uint8_t {success=0, overflow, invalid_digit, invalid_number};
+
+    class to_integer_error_category_impl
+       : public std::error_category
+    {
+    public:
+        const char* name() const noexcept override
+        {
+            return "jsoncons/to_integer_unchecked";
+        }
+        std::string message(int ev) const override
+        {
+            switch (static_cast<to_integer_errc>(ev))
+            {
+                case to_integer_errc::overflow:
+                    return "Integer overflow";
+                case to_integer_errc::invalid_digit:
+                    return "Invalid digit";
+                case to_integer_errc::invalid_number:
+                    return "Invalid number";
+                default:
+                    return "Unknown to_integer_unchecked error";
+            }
+        }
+    };
+
+    inline
+    const std::error_category& to_integer_error_category()
+    {
+      static to_integer_error_category_impl instance;
+      return instance;
+    }
+
+    inline 
+    std::error_code make_error_code(to_integer_errc e)
+    {
+        return std::error_code(static_cast<int>(e),to_integer_error_category());
+    }
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::detail::to_integer_errc> : public true_type
+    {
+    };
+} // namespace std
+
+namespace facebook::velox::jsoncons { namespace detail {
+
+template <typename T,typename CharT>
+struct to_integer_result
+{
+    const CharT* ptr;
+    to_integer_errc ec;
+    constexpr to_integer_result(const CharT* ptr_)
+        : ptr(ptr_), ec(to_integer_errc())
+    {
+    }
+    constexpr to_integer_result(const CharT* ptr_, to_integer_errc ec_)
+        : ptr(ptr_), ec(ec_)
+    {
+    }
+
+    to_integer_result(const to_integer_result&) = default;
+
+    to_integer_result& operator=(const to_integer_result&) = default;
+
+    constexpr explicit operator bool() const noexcept
+    {
+        return ec == to_integer_errc();
+    }
+    std::error_code error_code() const
+    {
+        return make_error_code(ec);
+    }
+};
+
+enum class integer_chars_format : uint8_t {decimal=1,hex};
+enum class integer_chars_state {initial,minus,integer,binary,octal,decimal,base16};
+
+template <typename CharT>
+bool is_base10(const CharT* s, std::size_t length)
+{
+    integer_chars_state state = integer_chars_state::initial;
+
+    const CharT* end = s + length; 
+    for (;s < end; ++s)
+    {
+        switch(state)
+        {
+            case integer_chars_state::initial:
+            {
+                switch(*s)
+                {
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                        state = integer_chars_state::decimal;
+                        break;
+                    case '-':
+                        state = integer_chars_state::minus;
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            }
+            case integer_chars_state::minus:
+            {
+                switch(*s)
+                {
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                        state = integer_chars_state::decimal;
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            }
+            case integer_chars_state::decimal:
+            {
+                switch(*s)
+                {
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+    return state == integer_chars_state::decimal ? true : false;
+}
+
+template <typename T,typename CharT>
+bool is_base16(const CharT* s, std::size_t length)
+{
+    integer_chars_state state = integer_chars_state::initial;
+
+    const CharT* end = s + length; 
+    for (;s < end; ++s)
+    {
+        switch(state)
+        {
+            case integer_chars_state::initial:
+            {
+                switch(*s)
+                {
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9': // Must be base16
+                    case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                    case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                        state = integer_chars_state::base16;
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            }
+            case integer_chars_state::base16:
+            {
+                switch(*s)
+                {
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9': // Must be base16
+                    case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                    case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                        state = integer_chars_state::base16;
+                        break;
+                    default:
+                        return false;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+    return state == integer_chars_state::base16 ? true : false;
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && !extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+decimal_to_integer(const CharT* s, std::size_t length, T& n)
+{
+    n = 0;
+
+    integer_chars_state state = integer_chars_state::initial;
+
+    const CharT* end = s + length; 
+    while (s < end)
+    {
+        switch(state)
+        {
+            case integer_chars_state::initial:
+            {
+                switch(*s)
+                {
+                    case '0':
+                        if (++s == end)
+                        {
+                            return (++s == end) ? to_integer_result<T,CharT>(s) : to_integer_result<T, CharT>(s, to_integer_errc());
+                        }
+                        else
+                        {
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                        }
+                    case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9': // Must be decimal
+                        state = integer_chars_state::decimal;
+                        break;
+                    default:
+                        return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                }
+                break;
+            }
+            case integer_chars_state::decimal:
+            {
+                static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+                static constexpr T max_value_div_10 = max_value / 10;
+                for (; s < end; ++s)
+                {
+                    T x = 0;
+                    switch(*s)
+                    {
+                        case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                            x = static_cast<T>(*s) - static_cast<T>('0');
+                            break;
+                        default:
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                    }
+                    if (n > max_value_div_10)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n = n * 10;
+                    if (n > max_value - x)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n += x;
+                }
+                break;
+            }
+            default:
+                JSONCONS_UNREACHABLE();
+                break;
+        }
+    }
+    return (state == integer_chars_state::initial) ? to_integer_result<T,CharT>(s, to_integer_errc::invalid_number) : to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+decimal_to_integer(const CharT* s, std::size_t length, T& n)
+{
+    n = 0;
+
+    if (length == 0)
+    {
+        return to_integer_result<T,CharT>(s, to_integer_errc::invalid_number);
+    }
+
+    bool is_negative = *s == '-' ? true : false;
+    if (is_negative)
+    {
+        ++s;
+        --length;
+    }
+
+    using U = typename extension_traits::make_unsigned<T>::type;
+
+    U u;
+    auto ru = decimal_to_integer(s, length, u);
+    if (ru.ec != to_integer_errc())
+    {
+        return to_integer_result<T,CharT>(ru.ptr, ru.ec);
+    }
+    if (is_negative)
+    {
+        if (u > static_cast<U>(-((extension_traits::integer_limits<T>::lowest)()+T(1))) + U(1))
+        {
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc::overflow);
+        }
+        else
+        {
+            n = static_cast<T>(U(0) - u);
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc());
+        }
+    }
+    else
+    {
+        if (u > static_cast<U>((extension_traits::integer_limits<T>::max)()))
+        {
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc::overflow);
+        }
+        else
+        {
+            n = static_cast<T>(u);
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc());
+        }
+    }
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && !extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+to_integer(const CharT* s, std::size_t length, T& n)
+{
+    n = 0;
+
+    integer_chars_state state = integer_chars_state::initial;
+
+    const CharT* end = s + length; 
+    while (s < end)
+    {
+        switch(state)
+        {
+            case integer_chars_state::initial:
+            {
+                switch(*s)
+                {
+                    case '0':
+                        state = integer_chars_state::integer; // Could be binary, octal, hex 
+                        ++s;
+                        break;
+                    case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9': // Must be decimal
+                        state = integer_chars_state::decimal;
+                        break;
+                    default:
+                        return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                }
+                break;
+            }
+            case integer_chars_state::integer:
+            {
+                switch(*s)
+                {
+                    case 'b':case 'B':
+                    {
+                        state = integer_chars_state::binary;
+                        ++s;
+                        break;
+                    }
+                    case 'x':case 'X':
+                    {
+                        state = integer_chars_state::base16;
+                        ++s;
+                        break;
+                    }
+                    case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                    {
+                        state = integer_chars_state::octal;
+                        break;
+                    }
+                    default:
+                        return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                }
+                break;
+            }
+            case integer_chars_state::binary:
+            {
+                static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+                static constexpr T max_value_div_2 = max_value / 2;
+                for (; s < end; ++s)
+                {
+                    T x = 0;
+                    switch(*s)
+                    {
+                        case '0':case '1':
+                            x = static_cast<T>(*s) - static_cast<T>('0');
+                            break;
+                        default:
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                    }
+                    if (n > max_value_div_2)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n = n * 2;
+                    if (n > max_value - x)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n += x;
+                }
+                break;
+            }
+            case integer_chars_state::octal:
+            {
+                static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+                static constexpr T max_value_div_8 = max_value / 8;
+                for (; s < end; ++s)
+                {
+                    T x = 0;
+                    switch(*s)
+                    {
+                        case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':
+                            x = static_cast<T>(*s) - static_cast<T>('0');
+                            break;
+                        default:
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                    }
+                    if (n > max_value_div_8)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n = n * 8;
+                    if (n > max_value - x)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n += x;
+                }
+                break;
+            }
+            case integer_chars_state::decimal:
+            {
+                static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+                static constexpr T max_value_div_10 = max_value / 10;
+                for (; s < end; ++s)
+                {
+                    T x = 0;
+                    switch(*s)
+                    {
+                        case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                            x = static_cast<T>(*s) - static_cast<T>('0');
+                            break;
+                        default:
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                    }
+                    if (n > max_value_div_10)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n = n * 10;
+                    if (n > max_value - x)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n += x;
+                }
+                break;
+            }
+            case integer_chars_state::base16:
+            {
+                static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+                static constexpr T max_value_div_16 = max_value / 16;
+                for (; s < end; ++s)
+                {
+                    CharT c = *s;
+                    T x = 0;
+                    switch (c)
+                    {
+                        case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                            x = c - '0';
+                            break;
+                        case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                            x = c - ('a' - 10);
+                            break;
+                        case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                            x = c - ('A' - 10);
+                            break;
+                        default:
+                            return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+                    }
+                    if (n > max_value_div_16)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+                    n = n * 16;
+                    if (n > max_value - x)
+                    {
+                        return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+                    }
+
+                    n += x;
+                }
+                break;
+            }
+            default:
+                JSONCONS_UNREACHABLE();
+                break;
+        }
+    }
+    return (state == integer_chars_state::initial) ? to_integer_result<T,CharT>(s, to_integer_errc::invalid_number) : to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+to_integer(const CharT* s, std::size_t length, T& n)
+{
+    n = 0;
+
+    if (length == 0)
+    {
+        return to_integer_result<T,CharT>(s, to_integer_errc::invalid_number);
+    }
+
+    bool is_negative = *s == '-' ? true : false;
+    if (is_negative)
+    {
+        ++s;
+        --length;
+    }
+
+    using U = typename extension_traits::make_unsigned<T>::type;
+
+    U u;
+    auto ru = to_integer(s, length, u);
+    if (ru.ec != to_integer_errc())
+    {
+        return to_integer_result<T,CharT>(ru.ptr, ru.ec);
+    }
+    if (is_negative)
+    {
+        if (u > static_cast<U>(-((extension_traits::integer_limits<T>::lowest)()+T(1))) + U(1))
+        {
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc::overflow);
+        }
+        else
+        {
+            n = static_cast<T>(U(0) - u);
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc());
+        }
+    }
+    else
+    {
+        if (u > static_cast<U>((extension_traits::integer_limits<T>::max)()))
+        {
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc::overflow);
+        }
+        else
+        {
+            n = static_cast<T>(u);
+            return to_integer_result<T,CharT>(ru.ptr, to_integer_errc());
+        }
+    }
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized,to_integer_result<T,CharT>>::type
+to_integer(const CharT* s, T& n)
+{
+    return to_integer<T,CharT>(s, std::char_traits<CharT>::length(s), n);
+}
+
+// Precondition: s satisfies
+
+// digit
+// digit1-digits 
+// - digit
+// - digit1-digits
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && !extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+to_integer_unchecked(const CharT* s, std::size_t length, T& n)
+{
+    static_assert(extension_traits::integer_limits<T>::is_specialized, "Integer type not specialized");
+    JSONCONS_ASSERT(length > 0);
+
+    n = 0;
+    const CharT* end = s + length; 
+    if (*s == '-')
+    {
+        static constexpr T min_value = (extension_traits::integer_limits<T>::lowest)();
+        static constexpr T min_value_div_10 = min_value / 10;
+        ++s;
+        for (; s < end; ++s)
+        {
+            T x = (T)*s - (T)('0');
+            if (n < min_value_div_10)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 10;
+            if (n < min_value + x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+
+            n -= x;
+        }
+    }
+    else
+    {
+        static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+        static constexpr T max_value_div_10 = max_value / 10;
+        for (; s < end; ++s)
+        {
+            T x = static_cast<T>(*s) - static_cast<T>('0');
+            if (n > max_value_div_10)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 10;
+            if (n > max_value - x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+
+            n += x;
+        }
+    }
+
+    return to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+// Precondition: s satisfies
+
+// digit
+// digit1-digits 
+// - digit
+// - digit1-digits
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+to_integer_unchecked(const CharT* s, std::size_t length, T& n)
+{
+    static_assert(extension_traits::integer_limits<T>::is_specialized, "Integer type not specialized");
+    JSONCONS_ASSERT(length > 0);
+
+    n = 0;
+
+    const CharT* end = s + length; 
+    if (*s == '-')
+    {
+        static constexpr T min_value = (extension_traits::integer_limits<T>::lowest)();
+        static constexpr T min_value_div_10 = min_value / 10;
+        ++s;
+        for (; s < end; ++s)
+        {
+            T x = (T)*s - (T)('0');
+            if (n < min_value_div_10)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 10;
+            if (n < min_value + x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+
+            n -= x;
+        }
+    }
+    else
+    {
+        static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+        static constexpr T max_value_div_10 = max_value / 10;
+        for (; s < end; ++s)
+        {
+            T x = static_cast<T>(*s) - static_cast<T>('0');
+            if (n > max_value_div_10)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 10;
+            if (n > max_value - x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+
+            n += x;
+        }
+    }
+
+    return to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+// hex_to_integer
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+hex_to_integer(const CharT* s, std::size_t length, T& n)
+{
+    static_assert(extension_traits::integer_limits<T>::is_specialized, "Integer type not specialized");
+    JSONCONS_ASSERT(length > 0);
+
+    n = 0;
+
+    const CharT* end = s + length; 
+    if (*s == '-')
+    {
+        static constexpr T min_value = (extension_traits::integer_limits<T>::lowest)();
+        static constexpr T min_value_div_16 = min_value / 16;
+        ++s;
+        for (; s < end; ++s)
+        {
+            CharT c = *s;
+            T x = 0;
+            switch (c)
+            {
+                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                    x = c - '0';
+                    break;
+                case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                    x = c - ('a' - 10);
+                    break;
+                case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                    x = c - ('A' - 10);
+                    break;
+                default:
+                    return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+            }
+            if (n < min_value_div_16)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 16;
+            if (n < min_value + x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n -= x;
+        }
+    }
+    else
+    {
+        static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+        static constexpr T max_value_div_16 = max_value / 16;
+        for (; s < end; ++s)
+        {
+            CharT c = *s;
+            T x = 0;
+            switch (c)
+            {
+                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                    x = c - '0';
+                    break;
+                case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                    x = c - ('a' - 10);
+                    break;
+                case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                    x = c - ('A' - 10);
+                    break;
+                default:
+                    return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+            }
+            if (n > max_value_div_16)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+            n = n * 16;
+            if (n > max_value - x)
+            {
+                return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+            }
+
+            n += x;
+        }
+    }
+
+    return to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+template <typename T,typename CharT>
+typename std::enable_if<extension_traits::integer_limits<T>::is_specialized && !extension_traits::integer_limits<T>::is_signed,to_integer_result<T,CharT>>::type
+hex_to_integer(const CharT* s, std::size_t length, T& n)
+{
+    static_assert(extension_traits::integer_limits<T>::is_specialized, "Integer type not specialized");
+    JSONCONS_ASSERT(length > 0);
+
+    n = 0;
+    const CharT* end = s + length; 
+
+    static constexpr T max_value = (extension_traits::integer_limits<T>::max)();
+    static constexpr T max_value_div_16 = max_value / 16;
+    for (; s < end; ++s)
+    {
+        CharT c = *s;
+        T x = *s;
+        switch (c)
+        {
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                x = c - '0';
+                break;
+            case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                x = c - ('a' - 10);
+                break;
+            case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                x = c - ('A' - 10);
+                break;
+            default:
+                return to_integer_result<T,CharT>(s, to_integer_errc::invalid_digit);
+        }
+        if (n > max_value_div_16)
+        {
+            return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+        }
+        n = n * 16;
+        if (n > max_value - x)
+        {
+            return to_integer_result<T,CharT>(s, to_integer_errc::overflow);
+        }
+
+        n += x;
+    }
+
+    return to_integer_result<T,CharT>(s, to_integer_errc());
+}
+
+
+#if defined(JSONCONS_HAS_STD_FROM_CHARS) && JSONCONS_HAS_STD_FROM_CHARS
+
+class chars_to
+{
+public:
+
+    char get_decimal_point() const
+    {
+        return '.';
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,char>::value,double>::type
+    operator()(const CharT* s, std::size_t len) const
+    {
+        double val = 0;
+        const auto res = std::from_chars(s, s+len, val);
+        if (res.ec != std::errc())
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert chars to double failed"));
+        }
+        return val;
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,wchar_t>::value,double>::type
+    operator()(const CharT* s, std::size_t len) const
+    {
+        std::string input(len,'0');
+        for (size_t i = 0; i < len; ++i)
+        {
+            input[i] = static_cast<char>(s[i]);
+        }
+
+        double val = 0;
+        const auto res = std::from_chars(input.data(), input.data() + len, val);
+        if (res.ec != std::errc())
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert chars to double failed"));
+        }
+        return val;
+    }
+};
+#elif defined(JSONCONS_HAS_MSC_STRTOD_L)
+
+class chars_to
+{
+private:
+    _locale_t locale_;
+public:
+    chars_to()
+    {
+        locale_ = _create_locale(LC_NUMERIC, "C");
+    }
+    ~chars_to() noexcept
+    {
+        _free_locale(locale_);
+    }
+
+    chars_to(const chars_to&)
+    {
+        locale_ = _create_locale(LC_NUMERIC, "C");
+    }
+
+    chars_to& operator=(const chars_to&) 
+    {
+        // Don't assign locale
+        return *this;
+    }
+
+    char get_decimal_point() const
+    {
+        return '.';
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,char>::value,double>::type
+    operator()(const CharT* s, std::size_t) const
+    {
+        CharT *end = nullptr;
+        double val = _strtod_l(s, &end, locale_);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,wchar_t>::value,double>::type
+    operator()(const CharT* s, std::size_t) const
+    {
+        CharT *end = nullptr;
+        double val = _wcstod_l(s, &end, locale_);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+};
+
+#elif defined(JSONCONS_HAS_STRTOLD_L)
+
+class chars_to
+{
+private:
+    locale_t locale_;
+public:
+    chars_to()
+    {
+        locale_ = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
+    }
+    ~chars_to() noexcept
+    {
+        freelocale(locale_);
+    }
+
+    chars_to(const chars_to&)
+    {
+        locale_ = newlocale(LC_ALL_MASK, "C", (locale_t) 0);
+    }
+
+    chars_to& operator=(const chars_to&) 
+    {
+        return *this;
+    }
+
+    char get_decimal_point() const
+    {
+        return '.';
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,char>::value,double>::type
+    operator()(const CharT* s, std::size_t) const
+    {
+        char *end = nullptr;
+        double val = strtold_l(s, &end, locale_);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,wchar_t>::value,double>::type
+    operator()(const CharT* s, std::size_t) const
+    {
+        CharT *end = nullptr;
+        double val = wcstold_l(s, &end, locale_);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+};
+
+#else
+class chars_to
+{
+private:
+    std::vector<char> buffer_;
+    char decimal_point_;
+public:
+    chars_to()
+        : buffer_()
+    {
+        struct lconv * lc = localeconv();
+        if (lc != nullptr && lc->decimal_point[0] != 0)
+        {
+            decimal_point_ = lc->decimal_point[0];    
+        }
+        else
+        {
+            decimal_point_ = '.'; 
+        }
+        buffer_.reserve(100);
+    }
+
+    chars_to(const chars_to&) = default;
+    chars_to& operator=(const chars_to&) = default;
+
+    char get_decimal_point() const
+    {
+        return decimal_point_;
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,char>::value,double>::type
+    operator()(const CharT* s, std::size_t /*length*/) const
+    {
+        CharT *end = nullptr;
+        double val = strtod(s, &end);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+
+    template <typename CharT>
+    typename std::enable_if<std::is_same<CharT,wchar_t>::value,double>::type
+    operator()(const CharT* s, std::size_t /*length*/) const
+    {
+        CharT *end = nullptr;
+        double val = wcstod(s, &end);
+        if (s == end)
+        {
+            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("Convert string to double failed"));
+        }
+        return val;
+    }
+};
+#endif
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_PARSE_NUMBER_HPP

--- a/velox/external/jsoncons/detail/span.hpp
+++ b/velox/external/jsoncons/detail/span.hpp
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_SPAN_HPP
+#define JSONCONS_DETAIL_SPAN_HPP
+
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <limits>
+#include <memory> // std::addressof
+#include <type_traits> // std::enable_if, std::true_type, std::false_type
+
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+namespace detail {
+
+    constexpr std::size_t dynamic_extent = (std::numeric_limits<std::size_t>::max)();
+
+    template< typename T, std::size_t Extent = dynamic_extent>
+    class span;
+
+    template <typename T>
+    struct is_span : std::false_type{};
+
+    template< typename T>
+    struct is_span<span<T>> : std::true_type{};
+
+    template<
+        typename T,
+        std::size_t Extent
+    > class span
+    {
+    public:
+        using element_type = T;
+        using value_type = typename std::remove_const<T>::type;
+        using size_type = std::size_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using const_pointer = const T*;
+        using reference = T&;
+        using const_reference = const T&;
+        using iterator = pointer;
+        using const_iterator = const_pointer;
+        using reverse_iterator = std::reverse_iterator<iterator>;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    private:
+        pointer data_;
+        size_type size_;
+    public:
+        static constexpr std::size_t extent = Extent;
+
+        constexpr span() noexcept
+            : data_(nullptr), size_(0)
+        {
+        }
+        constexpr span(pointer data, size_type size)
+            : data_(data), size_(size)
+        {
+        }
+
+        template <typename C>
+        constexpr span(C& c,
+                       typename std::enable_if<!is_span<C>::value && !extension_traits::is_std_array<C>::value && extension_traits::is_compatible_element<C,element_type>::value && extension_traits::has_data_and_size<C>::value>::type* = 0)
+            : data_(c.data()), size_(c.size())
+        {
+        }
+
+        template <std::size_t N>
+        span(element_type (&arr)[N]) noexcept
+            : data_(std::addressof(arr[0])), size_(N)
+        {
+        }
+
+        template <std::size_t N>
+        span(std::array<value_type, N>& arr,
+             typename std::enable_if<(extent == dynamic_extent || extent == N)>::type* = 0) noexcept
+            : data_(arr.data()), size_(arr.size())
+        {
+        }
+
+        template <std::size_t N>
+        span(const std::array<value_type, N>& arr,
+             typename std::enable_if<(extent == dynamic_extent || extent == N)>::type* = 0) noexcept
+            : data_(arr.data()), size_(arr.size())
+        {
+        }
+
+        template <typename C>
+        constexpr span(const C& c,
+                       typename std::enable_if<!is_span<C>::value && !extension_traits::is_std_array<C>::value && extension_traits::is_compatible_element<C,element_type>::value && extension_traits::has_data_and_size<C>::value>::type* = 0)
+            : data_(c.data()), size_(c.size())
+        {
+        }
+
+        template <typename U, std::size_t N>
+        constexpr span(const span<U, N>& s,
+                       typename std::enable_if<(N == dynamic_extent || N == extent) && std::is_convertible<U(*)[], element_type(*)[]>::value>::type* = 0) noexcept
+            : data_(s.data()), size_(s.size())
+        {
+        }
+
+        constexpr span(const span& other) = default;
+
+        span& operator=( const span& other ) = default;
+
+        constexpr pointer data() const noexcept
+        {
+            return data_;
+        }
+
+        constexpr size_type size() const noexcept
+        {
+            return size_;
+        }
+
+         constexpr bool empty() const noexcept 
+        { 
+            return size_ == 0; 
+        }
+
+         constexpr reference operator[](size_type index) const
+         {
+             return data_[index];
+         }
+
+        // iterator support 
+        const_iterator begin() const noexcept
+        {
+            return data_;
+        }
+        const_iterator end() const noexcept
+        {
+            return data_ + size_;
+        }
+        const_iterator cbegin() const noexcept 
+        { 
+            return data_; 
+        }
+        const_iterator cend() const noexcept 
+        { 
+            return data_ + size_; 
+        }
+        const_reverse_iterator rbegin() const noexcept 
+        { 
+            return const_reverse_iterator(end()); 
+        }
+        const_reverse_iterator rend() const noexcept 
+        { 
+            return const_reverse_iterator(begin()); 
+        }
+        const_reverse_iterator crbegin() const noexcept 
+        { 
+            return const_reverse_iterator(end()); 
+        }
+        const_reverse_iterator crend() const noexcept 
+        { 
+            return const_reverse_iterator(begin()); 
+        }
+
+        span<element_type, dynamic_extent>
+        first(std::size_t count) const
+        {
+            JSONCONS_ASSERT(count <= size());
+
+            return span< element_type, dynamic_extent >( data(), count );
+        }
+
+        span<element_type, dynamic_extent>
+        last(std::size_t count) const
+        {
+            JSONCONS_ASSERT(count <= size());
+
+            return span<element_type, dynamic_extent>(data() + ( size() - count ), count);
+        }
+
+        span<element_type, dynamic_extent>
+        subspan(std::size_t offset, std::size_t count = dynamic_extent) const
+        {
+            //JSONCONS_ASSERT((offset <= size() && (count == dynamic_extent || (offset + count <= size()))));
+
+            return span<element_type, dynamic_extent>(
+                data() + offset, count == dynamic_extent ? size() - offset : count );
+        }
+    };
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_SPAN_HPP

--- a/velox/external/jsoncons/detail/string_view.hpp
+++ b/velox/external/jsoncons/detail/string_view.hpp
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_STRING_VIEW_HPP
+#define JSONCONS_DETAIL_STRING_VIEW_HPP
+
+#include <algorithm> // std::find, std::min, std::reverse
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <memory>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace detail {
+
+    template <typename CharT,typename Traits = std::char_traits<CharT>>
+    class basic_string_view
+    {
+    private:
+        const CharT* data_;
+        std::size_t length_{0};
+    public:
+        using value_type = CharT;
+        using const_reference = const CharT&;
+        using traits_type = Traits;
+        using size_type = std::size_t;
+        static constexpr size_type npos = size_type(-1);
+        using const_iterator = const CharT*;
+        using iterator = const CharT*;
+        using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+        constexpr basic_string_view() noexcept
+            : data_(nullptr)
+        {
+        }
+        constexpr basic_string_view(const CharT* data, std::size_t length)
+            : data_(data), length_(length)
+        {
+        }
+        
+        basic_string_view(const CharT* data)
+            : data_(data), length_(Traits::length(data))
+        {
+        }
+        constexpr basic_string_view(const basic_string_view& other) = default;
+
+        template <typename Tr,typename Allocator>
+        JSONCONS_CPP14_CONSTEXPR  basic_string_view(const std::basic_string<CharT,Tr,Allocator>& s) noexcept
+            : data_(s.data()), length_(s.length())
+        {
+        }
+        
+        ~basic_string_view() = default;
+
+        JSONCONS_CPP14_CONSTEXPR basic_string_view& operator=( const basic_string_view& view ) noexcept
+        {
+            data_ = view.data();
+            length_ = view.length();
+
+            return *this;
+        }
+
+        template <typename Allocator>
+        explicit operator std::basic_string<CharT,Traits,Allocator>() const
+        { 
+            return std::basic_string<CharT,Traits,Allocator>(data_,length_); 
+        }
+
+        // iterator support 
+        const_iterator begin() const noexcept
+        {
+            return data_;
+        }
+        const_iterator end() const noexcept
+        {
+            return data_ + length_;
+        }
+        const_iterator cbegin() const noexcept 
+        { 
+            return data_; 
+        }
+        const_iterator cend() const noexcept 
+        { 
+            return data_ + length_; 
+        }
+        const_reverse_iterator rbegin() const noexcept 
+        { 
+            return const_reverse_iterator(end()); 
+        }
+        const_reverse_iterator rend() const noexcept 
+        { 
+            return const_reverse_iterator(begin()); 
+        }
+        const_reverse_iterator crbegin() const noexcept 
+        { 
+            return const_reverse_iterator(end()); 
+        }
+        const_reverse_iterator crend() const noexcept 
+        { 
+            return const_reverse_iterator(begin()); 
+        }
+
+        // capacity
+
+        std::size_t size() const
+        {
+            return length_;
+        }
+
+        std::size_t length() const
+        {
+            return length_;
+        }
+        size_type max_size() const noexcept 
+        { 
+            return length_; 
+        }
+        bool empty() const noexcept 
+        { 
+            return length_ == 0; 
+        }
+
+        // element access
+
+        const_reference operator[](size_type pos) const 
+        { 
+            return data_[pos]; 
+        }
+
+        const_reference at(std::size_t pos) const 
+        {
+            if (pos >= length_)
+            {
+                JSONCONS_THROW(std::out_of_range("pos exceeds length"));
+            }
+            return data_[pos];
+        }
+
+        const_reference front() const                
+        { 
+            return data_[0]; 
+        }
+        const_reference back()  const                
+        { 
+            return data_[length_-1]; 
+        }
+
+        const CharT* data() const
+        {
+            return data_;
+        }
+
+        // string operations
+
+        basic_string_view substr(size_type pos, size_type n=npos) const 
+        {
+            if (pos > length_)
+            {
+                JSONCONS_THROW(std::out_of_range("pos exceeds size"));
+            }
+            if (n == npos || pos + n > length_)
+            {
+                n = length_ - pos;
+            }
+            return basic_string_view(data_ + pos, n);
+        }
+
+        int compare(const basic_string_view& s) const noexcept
+        {
+            const int rc = Traits::compare(data_, s.data_, (std::min)(length_, s.length_));
+            return rc != 0 ? rc : (length_ == s.length_ ? 0 : length_ < s.length_ ? -1 : 1);
+        }
+
+        int compare(const CharT* data) const noexcept 
+        {
+            const size_t length = Traits::length(data);
+            const int rc = Traits::compare(data_, data, (std::min)(length_, length));
+            return rc != 0 ? rc : (length_ == length? 0 : length_ < length? -1 : 1);
+        }
+
+        template <typename Allocator>
+        int compare(const std::basic_string<CharT,Traits,Allocator>& s) const noexcept 
+        {
+            const int rc = Traits::compare(data_, s.data(), (std::min)(length_, s.length()));
+            return rc != 0 ? rc : (length_ == s.length() ? 0 : length_ < s.length() ? -1 : 1);
+        }
+
+        size_type find(basic_string_view s, size_type pos = 0) const noexcept 
+        {
+            if (pos > length_)
+            {
+                return npos;
+            }
+            if (s.length_ == 0)
+            {
+                return pos;
+            }
+            const_iterator it = std::search(cbegin() + pos, cend(),
+                                            s.cbegin(), s.cend(), Traits::eq);
+            return it == cend() ? npos : std::distance(cbegin(), it);
+        }
+        size_type find(CharT ch, size_type pos = 0) const noexcept
+        { 
+            return find(basic_string_view(&ch, 1), pos); 
+        }
+        size_type find(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return find(basic_string_view(s, n), pos); 
+        }
+        size_type find(const CharT* s, size_type pos = 0) const noexcept
+        { 
+            return find(basic_string_view(s), pos); 
+        }
+
+        size_type rfind(basic_string_view s, size_type pos = npos) const noexcept 
+        {
+            if (length_ < s.length_)
+            {
+                return npos;
+            }
+            if (pos > length_ - s.length_)
+            {
+                pos = length_ - s.length_;
+            }
+            if (s.length_ == 0) 
+            {
+                return pos;
+            }
+            for (const CharT* p = data_ + pos; true; --p) 
+            {
+                if (Traits::compare(p, s.data_, s.length_) == 0)
+                {
+                    return p - data_;
+                }
+                if (p == data_)
+                {
+                    return npos;
+                }
+             };
+        }
+        size_type rfind(CharT ch, size_type pos = npos) const noexcept
+        { 
+            return rfind(basic_string_view(&ch, 1), pos); 
+        }
+        size_type rfind(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return rfind(basic_string_view(s, n), pos); 
+        }
+        size_type rfind(const CharT* s, size_type pos = npos) const noexcept
+        { 
+            return rfind(basic_string_view(s), pos); 
+        }
+
+        size_type find_first_of(basic_string_view s, size_type pos = 0) const noexcept 
+        {
+            if (pos >= length_ || s.length_ == 0)
+            {
+                return npos;
+            }
+            const_iterator it = std::find_first_of
+                (cbegin() + pos, cend(), s.cbegin(), s.cend(), Traits::eq);
+            return it == cend() ? npos : std::distance (cbegin(), it);
+        }
+        size_type find_first_of(CharT ch, size_type pos = 0) const noexcept
+        {
+             return find_first_of(basic_string_view(&ch, 1), pos); 
+        }
+        size_type find_first_of(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return find_first_of(basic_string_view(s, n), pos); 
+        }
+        size_type find_first_of(const CharT* s, size_type pos = 0) const noexcept
+        { 
+            return find_first_of(basic_string_view(s), pos); 
+        }
+
+        size_type find_last_of(basic_string_view s, size_type pos = npos) const noexcept 
+        {
+            if (s.length_ == 0)
+            {
+                return npos;
+            }
+            if (pos >= length_)
+            {
+                pos = 0;
+            }
+            else
+            {
+                pos = length_ - (pos+1);
+            }
+            const_reverse_iterator it = std::find_first_of
+                (crbegin() + pos, crend(), s.cbegin(), s.cend(), Traits::eq);
+            return it == crend() ? npos : (length_ - 1 - std::distance(crbegin(), it));
+        }
+        size_type find_last_of(CharT ch, size_type pos = npos) const noexcept
+        { 
+            return find_last_of(basic_string_view(&ch, 1), pos); 
+        }
+        size_type find_last_of(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return find_last_of(basic_string_view(s, n), pos); 
+        }
+        size_type find_last_of(const CharT* s, size_type pos = npos) const noexcept
+        { 
+            return find_last_of(basic_string_view(s), pos); 
+        }
+
+        size_type find_first_not_of(basic_string_view s, size_type pos = 0) const noexcept 
+        {
+            if (pos >= length_)
+                return npos;
+            if (s.length_ == 0)
+                return pos;
+
+            const_iterator it = cend();
+            for (auto p = cbegin()+pos; p != cend(); ++p)
+            {
+                if (Traits::find(s.data_, s.length_, *p) == 0)
+                {
+                    it = p;
+                    break;
+                }
+            }
+            return it == cend() ? npos : std::distance (cbegin(), it);
+        }
+        size_type find_first_not_of(CharT ch, size_type pos = 0) const noexcept
+        { 
+            return find_first_not_of(basic_string_view(&ch, 1), pos); 
+        }
+        size_type find_first_not_of(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return find_first_not_of(basic_string_view(s, n), pos); 
+        }
+        size_type find_first_not_of(const CharT* s, size_type pos = 0) const noexcept
+        { 
+            return find_first_not_of(basic_string_view(s), pos); 
+        }
+
+        size_type find_last_not_of(basic_string_view s, size_type pos = npos) const noexcept 
+        {
+            if (pos >= length_)
+            {
+                pos = length_ - 1;
+            }
+            if (s.length_ == 0)
+            {
+                return pos;
+            }
+            pos = length_ - (pos+1);
+
+            const_iterator it = crend();
+            for (auto p = crbegin()+pos; p != crend(); ++p)
+            {
+                if (Traits::find(s.data_, s.length_, *p) == 0)
+                {
+                    it = p;
+                    break;
+                }
+            }
+            return it == crend() ? npos : (length_ - 1 - std::distance(crbegin(), it));
+        }
+        size_type find_last_not_of(CharT ch, size_type pos = npos) const noexcept
+        { 
+            return find_last_not_of(basic_string_view(&ch, 1), pos); 
+        }
+        size_type find_last_not_of(const CharT* s, size_type pos, size_type n) const noexcept
+        { 
+            return find_last_not_of(basic_string_view(s, n), pos); 
+        }
+        size_type find_last_not_of(const CharT* s, size_type pos = npos) const noexcept
+        { 
+            return find_last_not_of(basic_string_view(s), pos); 
+        }
+
+        friend std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, const basic_string_view& sv)
+        {
+            os.write(sv.data_,sv.length_);
+            return os;
+        }
+    };
+
+    // ==
+    template <typename CharT,typename Traits>
+    bool operator==(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator==(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator==(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+    template <typename CharT,typename Traits>
+    bool operator==(const basic_string_view<CharT,Traits>& lhs, 
+                    const CharT* rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+    template <typename CharT,typename Traits>
+    bool operator==(const CharT* lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    // !=
+    template <typename CharT,typename Traits>
+    bool operator!=(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator!=(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator!=(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+    template <typename CharT,typename Traits>
+    bool operator!=(const basic_string_view<CharT,Traits>& lhs, 
+                    const CharT* rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+    template <typename CharT,typename Traits>
+    bool operator!=(const CharT* lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    // <=
+    template <typename CharT,typename Traits>
+    bool operator<=(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator<=(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator<=(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    // <
+    template <typename CharT,typename Traits>
+    bool operator<(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator<(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator<(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    // >=
+    template <typename CharT,typename Traits>
+    bool operator>=(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator>=(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator>=(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+
+    // >
+    template <typename CharT,typename Traits>
+    bool operator>(const basic_string_view<CharT,Traits>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator>(const basic_string_view<CharT,Traits>& lhs, 
+                    const std::basic_string<CharT,Traits,Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+    template <typename CharT,typename Traits,typename Allocator>
+    bool operator>(const std::basic_string<CharT,Traits,Allocator>& lhs, 
+                    const basic_string_view<CharT,Traits>& rhs) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    using string_view = basic_string_view<char>;
+    using wstring_view = basic_string_view<wchar_t>;
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template <typename CharT,typename Traits>
+    struct hash<facebook::velox::jsoncons::detail::basic_string_view<CharT, Traits>>
+    {
+        std::size_t operator()(const facebook::velox::jsoncons::detail::basic_string_view<CharT, Traits>& s) const noexcept
+        {
+            const int p = 53;
+            const int m = 1000000009;
+            std::size_t hash_value = 0;
+            std::size_t p_pow = 1;
+            for (CharT c : s) {
+                hash_value = (hash_value + (c - 'a' + 1) * p_pow) % m;
+                p_pow = (p_pow * p) % m;
+            }
+            return hash_value;
+        }
+    };
+} // namespace std
+
+#endif // JSONCONS_DETAIL_STRING_VIEW_HPP

--- a/velox/external/jsoncons/detail/write_number.hpp
+++ b/velox/external/jsoncons/detail/write_number.hpp
@@ -1,0 +1,587 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_DETAIL_WRITE_NUMBER_HPP
+#define JSONCONS_DETAIL_WRITE_NUMBER_HPP
+
+#include <clocale>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits> // std::numeric_limits
+#include <locale>
+#include <stdexcept>
+#include <stdio.h> // snprintf
+#include <string>
+#include <type_traits>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/detail/grisu3.hpp"
+#include "velox/external/jsoncons/detail/parse_number.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace detail {
+
+    inline
+    char to_hex_character(uint8_t c)
+    {
+        return (char)((c < 10) ? ('0' + c) : ('A' - 10 + c));
+    }
+
+    // from_integer
+
+    template <typename Integer,typename Result>
+    typename std::enable_if<extension_traits::is_integer<Integer>::value,std::size_t>::type
+    from_integer(Integer value, Result& result)
+    {
+        using char_type = typename Result::value_type;
+
+        char_type buf[255];
+        char_type *p = buf;
+        const char_type* last = buf+255;
+
+        bool is_negative = value < 0;
+
+        if (value < 0)
+        {
+            do
+            {
+                *p++ = static_cast<char_type>(48 - (value % 10));
+            }
+            while ((value /= 10) && (p < last));
+        }
+        else
+        {
+
+            do
+            {
+                *p++ = static_cast<char_type>(48 + value % 10);
+            }
+            while ((value /= 10) && (p < last));
+        }
+        JSONCONS_ASSERT(p != last);
+
+        std::size_t count = (p - buf);
+        if (is_negative)
+        {
+            result.push_back('-');
+            ++count;
+        }
+        while (--p >= buf)
+        {
+            result.push_back(*p);
+        }
+
+        return count;
+    }
+
+    // integer_to_hex
+
+    template <typename Integer,typename Result>
+    typename std::enable_if<extension_traits::is_integer<Integer>::value,std::size_t>::type
+    integer_to_hex(Integer value, Result& result)
+    {
+        using char_type = typename Result::value_type;
+
+        char_type buf[255];
+        char_type *p = buf;
+        const char_type* last = buf+255;
+
+        bool is_negative = value < 0;
+
+        if (value < 0)
+        {
+            do
+            {
+                *p++ = to_hex_character(0-(value % 16));
+            }
+            while ((value /= 16) && (p < last));
+        }
+        else
+        {
+
+            do
+            {
+                *p++ = to_hex_character(value % 16);
+            }
+            while ((value /= 16) && (p < last));
+        }
+        JSONCONS_ASSERT(p != last);
+
+        std::size_t count = (p - buf);
+        if (is_negative)
+        {
+            result.push_back('-');
+            ++count;
+        }
+        while (--p >= buf)
+        {
+            result.push_back(*p);
+        }
+
+        return count;
+    }
+
+    // write_double
+
+    // fast exponent
+    template <typename Result>
+    void fill_exponent(int K, Result& result)
+    {
+        if (K < 0)
+        {
+            result.push_back('-');
+            K = -K;
+        }
+        else
+        {
+            result.push_back('+'); // compatibility with sprintf
+        }
+
+        if (K < 10)
+        {
+            result.push_back('0'); // compatibility with sprintf
+            result.push_back((char)('0' + K));
+        }
+        else if (K < 100)
+        {
+            result.push_back((char)('0' + K / 10)); K %= 10;
+            result.push_back((char)('0' + K));
+        }
+        else if (K < 1000)
+        {
+            result.push_back((char)('0' + K / 100)); K %= 100;
+            result.push_back((char)('0' + K / 10)); K %= 10;
+            result.push_back((char)('0' + K));
+        }
+        else
+        {
+            jsoncons::detail::from_integer(K, result);
+        }
+    }
+
+    template <typename Result>
+    void prettify_string(const char *buffer, std::size_t length, int k, int min_exp, int max_exp, Result& result)
+    {
+        int nb_digits = (int)length;
+        int offset;
+        /* v = buffer * 10^k
+           kk is such that 10^(kk-1) <= v < 10^kk
+           this way kk gives the position of the decimal point.
+        */
+        int kk = nb_digits + k;
+
+        if (nb_digits <= kk && kk <= max_exp)
+        {
+            /* the first digits are already in. Add some 0s and call it a day. */
+            /* the max_exp is a personal choice. Only 16 digits could possibly be relevant.
+             * Basically we want to print 12340000000 rather than 1234.0e7 or 1.234e10 */
+            for (int i = 0; i < nb_digits; ++i)
+            {
+                result.push_back(buffer[i]);
+            }
+            for (int i = nb_digits; i < kk; ++i)
+            {
+                result.push_back('0');
+            }
+            result.push_back('.');
+            result.push_back('0');
+        } 
+        else if (0 < kk && kk <= max_exp)
+        {
+            /* comma number. Just insert a '.' at the correct location. */
+            for (int i = 0; i < kk; ++i)
+            {
+                result.push_back(buffer[i]);
+            }
+            result.push_back('.');
+            for (int i = kk; i < nb_digits; ++i)
+            {
+                result.push_back(buffer[i]);
+            }
+        } 
+        else if (min_exp < kk && kk <= 0)
+        {
+            offset = 2 - kk;
+
+            result.push_back('0');
+            result.push_back('.');
+            for (int i = 2; i < offset; ++i) 
+                result.push_back('0');
+            for (int i = 0; i < nb_digits; ++i)
+            {
+                result.push_back(buffer[i]);
+            }
+        } 
+        else if (nb_digits == 1)
+        {
+            result.push_back(buffer[0]);
+            result.push_back('e');
+            fill_exponent(kk - 1, result);
+        } 
+        else
+        {
+            result.push_back(buffer[0]);
+            result.push_back('.');
+            for (int i = 1; i < nb_digits; ++i)
+            {
+                result.push_back(buffer[i]);
+            }
+            result.push_back('e');
+            fill_exponent(kk - 1, result);
+        }
+    }
+
+    template <typename Result>
+    void dump_buffer(const char *buffer, std::size_t length, char decimal_point, Result& result)
+    {
+        const char *sbeg = buffer;
+        const char *send = sbeg + length;
+
+        if (sbeg != send)
+        {
+            bool needs_dot = true;
+            for (const char* q = sbeg; q < send; ++q)
+            {
+                switch (*q)
+                {
+                case '-':
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '+':
+                    result.push_back(*q);
+                    break;
+                case 'e':
+                case 'E':
+                    result.push_back('e');
+                    needs_dot = false;
+                    break;
+                default:
+                    if (*q == decimal_point)
+                    {
+                        needs_dot = false;
+                        result.push_back('.');
+                    }
+                    break;
+                }
+            }
+            if (needs_dot)
+            {
+                result.push_back('.');
+                result.push_back('0');
+            }
+        }
+    }
+
+    template <typename Result>
+    bool dtoa_scientific(double val, char decimal_point, Result& result)
+    {
+        if (val == 0)
+        {
+            result.push_back('0');
+            result.push_back('.');
+            result.push_back('0');
+            return true;
+        }
+
+        const jsoncons::detail::chars_to to_double;
+
+        char buffer[100];
+        int precision = std::numeric_limits<double>::digits10;
+        int length = snprintf(buffer, sizeof(buffer), "%1.*e", precision, val);
+        if (length < 0)
+        {
+            return false;
+        }
+        if (to_double(buffer, sizeof(buffer)) != val)
+        {
+            const int precision2 = std::numeric_limits<double>::max_digits10;
+            length = snprintf(buffer, sizeof(buffer), "%1.*e", precision2, val);
+            if (length < 0)
+            {
+                return false;
+            }
+        }
+        dump_buffer(buffer, static_cast<std::size_t>(length), decimal_point, result);
+        return true;
+    }
+
+    template <typename Result>
+    bool dtoa_general(double val, char decimal_point, Result& result, std::false_type)
+    {
+        if (val == 0)
+        {
+            result.push_back('0');
+            result.push_back('.');
+            result.push_back('0');
+            return true;
+        }
+
+        const jsoncons::detail::chars_to to_double;
+
+        char buffer[100];
+        int precision = std::numeric_limits<double>::digits10;
+        int length = snprintf(buffer, sizeof(buffer), "%1.*g", precision, val);
+        if (length < 0)
+        {
+            return false;
+        }
+        if (to_double(buffer, sizeof(buffer)) != val)
+        {
+            const int precision2 = std::numeric_limits<double>::max_digits10;
+            length = snprintf(buffer, sizeof(buffer), "%1.*g", precision2, val);
+            if (length < 0)
+            {
+                return false;
+            }
+        }
+        dump_buffer(buffer, length, decimal_point, result);
+        return true;
+    }
+
+    template <typename Result>
+    bool dtoa_general(double v, char decimal_point, Result& result, std::true_type)
+    {
+        if (v == 0)
+        {
+            result.push_back('0');
+            result.push_back('.');
+            result.push_back('0');
+            return true;
+        }
+
+        int length = 0;
+        int k;
+
+        char buffer[100];
+
+        double u = std::signbit(v) ? -v : v;
+        if (jsoncons::detail::grisu3(u, buffer, &length, &k))
+        {
+            if (std::signbit(v))
+            {
+                result.push_back('-');
+            }
+            // min exp: -4 is consistent with sprintf
+            // max exp: std::numeric_limits<double>::max_digits10
+            jsoncons::detail::prettify_string(buffer, length, k, -4, std::numeric_limits<double>::max_digits10, result);
+            return true;
+        }
+        else
+        {
+            return dtoa_general(v, decimal_point, result, std::false_type());
+        }
+    }
+
+    template <typename Result>
+    bool dtoa_fixed(double val, char decimal_point, Result& result, std::false_type)
+    {
+        if (val == 0)
+        {
+            result.push_back('0');
+            result.push_back('.');
+            result.push_back('0');
+            return true;
+        }
+
+        const jsoncons::detail::chars_to to_double;
+
+        char buffer[100];
+        int precision = std::numeric_limits<double>::digits10;
+        int length = snprintf(buffer, sizeof(buffer), "%1.*f", precision, val);
+        if (length < 0)
+        {
+            return false;
+        }
+        if (to_double(buffer, sizeof(buffer)) != val)
+        {
+            const int precision2 = std::numeric_limits<double>::max_digits10;
+            length = snprintf(buffer, sizeof(buffer), "%1.*f", precision2, val);
+            if (length < 0)
+            {
+                return false;
+            }
+        }
+        dump_buffer(buffer, length, decimal_point, result);
+        return true;
+    }
+
+    template <typename Result>
+    bool dtoa_fixed(double v, char decimal_point, Result& result, std::true_type)
+    {
+        if (v == 0)
+        {
+            result.push_back('0');
+            result.push_back('.');
+            result.push_back('0');
+            return true;
+        }
+
+        int length = 0;
+        int k;
+
+        char buffer[100];
+
+        double u = std::signbit(v) ? -v : v;
+        if (jsoncons::detail::grisu3(u, buffer, &length, &k))
+        {
+            if (std::signbit(v))
+            {
+                result.push_back('-');
+            }
+            jsoncons::detail::prettify_string(buffer, length, k, std::numeric_limits<int>::lowest(), (std::numeric_limits<int>::max)(), result);
+            return true;
+        }
+        else
+        {
+            return dtoa_fixed(v, decimal_point, result, std::false_type());
+        }
+    }
+
+    template <typename Result>
+    bool dtoa_fixed(double v, char decimal_point, Result& result)
+    {
+        return dtoa_fixed(v, decimal_point, result, std::integral_constant<bool, std::numeric_limits<double>::is_iec559>());
+    }
+
+    template <typename Result>
+    bool dtoa_general(double v, char decimal_point, Result& result)
+    {
+        return dtoa_general(v, decimal_point, result, std::integral_constant<bool, std::numeric_limits<double>::is_iec559>());
+    }
+
+    class write_double
+    {
+    private:
+        chars_to to_double_;
+        float_chars_format float_format_;
+        int precision_;
+        char decimal_point_;
+    public:
+        write_double(float_chars_format float_format, int precision)
+           : float_format_(float_format), precision_(precision), decimal_point_('.')
+        {
+    #if !defined(JSONCONS_NO_LOCALECONV)
+            struct lconv *lc = localeconv();
+            if (lc != nullptr && lc->decimal_point[0] != 0)
+            {
+                decimal_point_ = lc->decimal_point[0];
+            }
+    #endif
+        }
+        write_double(const write_double&) = default;
+
+        write_double& operator=(const write_double&) = default;
+
+        template <typename Result>
+        std::size_t operator()(double val, Result& result)
+        {
+            std::size_t count = 0;
+
+            char number_buffer[200];
+            int length = 0;
+
+            switch (float_format_)
+            {
+            case float_chars_format::fixed:
+                {
+                    if (precision_ > 0)
+                    {
+                        length = snprintf(number_buffer, sizeof(number_buffer), "%1.*f", precision_, val);
+                        if (length < 0)
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                        dump_buffer(number_buffer, length, decimal_point_, result);
+                    }
+                    else
+                    {
+                        if (!dtoa_fixed(val, decimal_point_, result))
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                    }
+                }
+                break;
+            case float_chars_format::scientific:
+                {
+                    if (precision_ > 0)
+                    {
+                        length = snprintf(number_buffer, sizeof(number_buffer), "%1.*e", precision_, val);
+                        if (length < 0)
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                        dump_buffer(number_buffer, length, decimal_point_, result);
+                    }
+                    else
+                    {
+                        if (!dtoa_scientific(val, decimal_point_, result))
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                    }
+                }
+                break;
+            case float_chars_format::general:
+                {
+                    if (precision_ > 0)
+                    {
+                        length = snprintf(number_buffer, sizeof(number_buffer), "%1.*g", precision_, val);
+                        if (length < 0)
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                        dump_buffer(number_buffer, length, decimal_point_, result);
+                    }
+                    else
+                    {
+                        if (!dtoa_general(val, decimal_point_, result))
+                        {
+                            JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                        }
+                    }             
+                    break;
+                }
+                default:
+                    JSONCONS_THROW(json_runtime_error<std::invalid_argument>("write_double failed."));
+                    break;
+            }
+            return count;
+        }
+    };
+
+} // namespace detail
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_DETAIL_WRITE_NUMBER_HPP

--- a/velox/external/jsoncons/encode_json.hpp
+++ b/velox/external/jsoncons/encode_json.hpp
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_ENCODE_JSON_HPP
+#define JSONCONS_ENCODE_JSON_HPP
+
+#include <iostream>
+#include <system_error>
+#include <tuple>
+
+#include "velox/external/jsoncons/encode_traits.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_cursor.hpp"
+#include "velox/external/jsoncons/basic_json.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // to string
+
+    template <typename T,typename CharContainer>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value &&
+        extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json(const T& val, CharContainer& cont, 
+        const basic_json_encode_options<typename CharContainer::value_type>& options = 
+            basic_json_encode_options<typename CharContainer::value_type>(),
+        indenting indent = indenting::no_indent)
+    {
+        using char_type = typename CharContainer::value_type;
+
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<char_type, jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            val.dump(encoder);
+        }
+        else
+        {
+            basic_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            val.dump(encoder);
+        }
+    }
+
+    template <typename T,typename CharContainer>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json(const T& val, CharContainer& cont, 
+        const basic_json_encode_options<typename CharContainer::value_type>& options = 
+            basic_json_encode_options<typename CharContainer::value_type>(),
+        indenting indent = indenting::no_indent)
+    {
+        using char_type = typename CharContainer::value_type;
+
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<char_type, jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            encode_json(val, encoder);
+        }
+        else
+        {
+            basic_json_encoder<char_type, jsoncons::string_sink<CharContainer>> encoder(cont, options);
+            encode_json(val, encoder);
+        }
+    }
+
+    // to stream
+
+    template <typename T,typename CharT>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value>::type
+    encode_json(const T& val, std::basic_ostream<CharT>& os, 
+        const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>(),
+        indenting indent = indenting::no_indent)
+    {
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<CharT> encoder(os, options);
+            val.dump(encoder);
+        }
+        else
+        {
+            basic_json_encoder<CharT> encoder(os, options);
+            val.dump(encoder);
+        }
+    }
+
+    template <typename T,typename CharT>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value>::type
+    encode_json(const T& val, std::basic_ostream<CharT>& os, 
+        const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>(),
+        indenting indent = indenting::no_indent)
+    {
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<CharT> encoder(os, options);
+            encode_json(val, encoder);
+        }
+        else
+        {
+            basic_json_encoder<CharT> encoder(os, options);
+            encode_json(val, encoder);
+        }
+    }
+
+    // to string with allocator_set
+
+    template <typename T,typename CharContainer,typename Allocator,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_basic_json<T>::value &&
+        extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const T& val, CharContainer& cont, 
+        const basic_json_encode_options<typename CharContainer::value_type>& options = 
+            basic_json_encode_options<typename CharContainer::value_type>(),
+        indenting indent = indenting::no_indent)
+    {
+        using char_type = typename CharContainer::value_type;
+
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<char_type, jsoncons::string_sink<CharContainer>,TempAllocator> encoder(cont, options, alloc_set.get_temp_allocator());
+            val.dump(encoder);
+        }
+        else
+        {
+            basic_json_encoder<char_type,jsoncons::string_sink<CharContainer>,TempAllocator> encoder(cont, options, alloc_set.get_temp_allocator());
+            val.dump(encoder);
+        }
+    }
+
+    template <typename T,typename CharContainer,typename Allocator,typename TempAllocator >
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const T& val, CharContainer& cont, 
+        const basic_json_encode_options<typename CharContainer::value_type>& options = 
+            basic_json_encode_options<typename CharContainer::value_type>(),
+        indenting indent = indenting::no_indent)
+    {
+        using char_type = typename CharContainer::value_type;
+
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<char_type, jsoncons::string_sink<CharContainer>,TempAllocator> encoder(cont, options,
+                alloc_set.get_temp_allocator());
+            encode_json(val, encoder);
+        }
+        else
+        {
+            basic_json_encoder<char_type, jsoncons::string_sink<CharContainer>, TempAllocator> encoder(cont, options, 
+                alloc_set.get_temp_allocator());
+            encode_json(val, encoder);
+        }
+    }
+
+    // to stream with allocator_set
+
+    template <typename T,typename CharT,typename Allocator,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_basic_json<T>::value>::type
+    encode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const T& val, std::basic_ostream<CharT>& os, 
+        const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>(),
+        indenting indent = indenting::no_indent)
+    {
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<CharT,TempAllocator> encoder(os, options, alloc_set.get_temp_allocator());
+            val.dump(encoder);
+        }
+        else
+        {
+            basic_json_encoder<CharT,TempAllocator> encoder(os, options, alloc_set.get_temp_allocator());
+            val.dump(encoder);
+        }
+    }
+
+    template <typename T,typename CharT,typename Allocator,typename TempAllocator >
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value>::type
+    encode_json(const allocator_set<Allocator,TempAllocator>& alloc_set,
+        const T& val, std::basic_ostream<CharT>& os, 
+        const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>(),
+        indenting indent = indenting::no_indent)
+    {
+        if (indent == indenting::no_indent)
+        {
+            basic_compact_json_encoder<CharT,TempAllocator> encoder(os, options, alloc_set.get_temp_allocator());
+            encode_json(val, encoder);
+        }
+        else
+        {
+            basic_json_encoder<CharT,TempAllocator> encoder(os, options, alloc_set.get_temp_allocator());
+            encode_json(val, encoder);
+        }
+    }
+
+    // to encoder
+
+    template <typename T,typename CharT>
+    void encode_json(const T& val, basic_json_visitor<CharT>& encoder)
+    {
+        std::error_code ec;
+        encode_traits<T,CharT>::encode(val, encoder, basic_json<CharT>(), ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec));
+        }
+        encoder.flush();
+    }
+
+    // encode_json_pretty
+
+    template <typename T,typename CharContainer>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json_pretty(const T& val,
+                       CharContainer& cont, 
+                       const basic_json_encode_options<typename CharContainer::value_type>& options = basic_json_encode_options<typename CharContainer::value_type>())
+    {
+        using char_type = typename CharContainer::value_type;
+
+        basic_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont, options);
+        val.dump(encoder);
+    }
+
+    template <typename T,typename CharContainer>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value &&
+                            extension_traits::is_back_insertable_char_container<CharContainer>::value>::type
+    encode_json_pretty(const T& val,
+                       CharContainer& cont, 
+                       const basic_json_encode_options<typename CharContainer::value_type>& options = basic_json_encode_options<typename CharContainer::value_type>())
+    {
+        using char_type = typename CharContainer::value_type;
+        basic_json_encoder<char_type,jsoncons::string_sink<CharContainer>> encoder(cont, options);
+        encode_json(val, encoder);
+    }
+
+    template <typename T,typename CharT>
+    typename std::enable_if<extension_traits::is_basic_json<T>::value>::type
+    encode_json_pretty(const T& val,
+                       std::basic_ostream<CharT>& os, 
+                       const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>())
+    {
+        basic_json_encoder<CharT> encoder(os, options);
+        val.dump(encoder);
+    }
+
+    template <typename T,typename CharT>
+    typename std::enable_if<!extension_traits::is_basic_json<T>::value>::type
+    encode_json_pretty(const T& val,
+                       std::basic_ostream<CharT>& os, 
+                       const basic_json_encode_options<CharT>& options = basic_json_encode_options<CharT>())
+    {
+        basic_json_encoder<CharT> encoder(os, options);
+        encode_json(val, encoder);
+    }
+
+// legacy
+
+    template <typename T,typename CharContainer>
+    void encode_json(const T& val, CharContainer& cont, indenting indent)
+    {
+        if (indent == indenting::indent)
+        {
+            encode_json_pretty(val,cont);
+        }
+        else
+        {
+            encode_json(val,cont);
+        }
+    }
+
+    template <typename T,typename CharT>
+    void encode_json(const T& val,
+                     std::basic_ostream<CharT>& os, 
+                     indenting indent)
+    {
+        if (indent == indenting::indent)
+        {
+            encode_json_pretty(val, os);
+        }
+        else
+        {
+            encode_json(val, os);
+        }
+    }
+
+//end legacy
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_ENCODE_JSON_HPP

--- a/velox/external/jsoncons/encode_traits.hpp
+++ b/velox/external/jsoncons/encode_traits.hpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_ENCODE_TRAITS_HPP
+#define JSONCONS_ENCODE_TRAITS_HPP
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <string>
+#include <system_error>
+#include <tuple>
+#include <type_traits> // std::enable_if, std::true_type, std::false_type
+
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/json_decoder.hpp"
+#include "velox/external/jsoncons/json_encoder.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // encode_traits
+
+    template <typename T,typename CharT,typename Enable = void>
+    struct encode_traits
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder,
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encode(std::integral_constant<bool, std::allocator_traits<typename Json::allocator_type>::is_always_equal::value>(),
+                      val, encoder, proto, ec);
+        }
+    private:
+        template <typename Json>
+        static void encode(std::true_type,
+                           const T& val, 
+                           basic_json_visitor<CharT>& encoder,
+                           const Json& /*proto*/, 
+                           std::error_code& ec)
+        {
+            auto j = json_type_traits<Json,T>::to_json(val);
+            j.dump(encoder, ec);
+        }
+        template <typename Json>
+        static void encode(std::false_type, 
+                           const T& val, 
+                           basic_json_visitor<CharT>& encoder,
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            auto j = json_type_traits<Json,T>::to_json(val, proto.get_allocator());
+            j.dump(encoder, ec);
+        }
+    };
+
+    // specializations
+
+    // bool
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_bool<T>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            encoder.bool_value(val,semantic_tag::none,ser_context(),ec);
+        }
+    };
+
+    // uint
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_u8_u16_u32_or_u64<T>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            encoder.uint64_value(val,semantic_tag::none,ser_context(),ec);
+        }
+    };
+
+    // int
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_i8_i16_i32_or_i64<T>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            encoder.int64_value(val,semantic_tag::none,ser_context(),ec);
+        }
+    };
+
+    // float or double
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_float_or_double<T>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            encoder.double_value(val,semantic_tag::none,ser_context(),ec);
+        }
+    };
+
+    // string
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_string<T>::value &&
+                                std::is_same<typename T::value_type,CharT>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            encoder.string_value(val,semantic_tag::none,ser_context(),ec);
+        }
+    };
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<extension_traits::is_string<T>::value &&
+                                !std::is_same<typename T::value_type,CharT>::value 
+    >::type>
+    {
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&, 
+                           std::error_code& ec)
+        {
+            std::basic_string<CharT> s;
+            unicode_traits::convert(val.data(), val.size(), s);
+            encoder.string_value(s,semantic_tag::none,ser_context(),ec);
+        }
+    };
+
+    // std::pair
+
+    template <typename T1,typename T2,typename CharT>
+    struct encode_traits<std::pair<T1, T2>, CharT>
+    {
+        using value_type = std::pair<T1, T2>;
+
+        template <typename Json>
+        static void encode(const value_type& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encoder.begin_array(2,semantic_tag::none,ser_context(),ec);
+            if (ec) {return;}
+            encode_traits<T1,CharT>::encode(val.first, encoder, proto, ec);
+            if (ec) {return;}
+            encode_traits<T2,CharT>::encode(val.second, encoder, proto, ec);
+            if (ec) {return;}
+            encoder.end_array(ser_context(),ec);
+        }
+    };
+
+    // std::tuple
+
+    namespace detail
+    {
+        template<size_t Pos, std::size_t Size,typename Json,typename Tuple>
+        struct json_serialize_tuple_helper
+        {
+            using char_type = typename Json::char_type;
+            using element_type = typename std::tuple_element<Size-Pos, Tuple>::type;
+            using next = json_serialize_tuple_helper<Pos-1, Size, Json, Tuple>;
+
+            static void encode(const Tuple& tuple,
+                               basic_json_visitor<char_type>& encoder, 
+                               const Json& proto, 
+                               std::error_code& ec)
+            {
+                encode_traits<element_type,char_type>::encode(std::get<Size-Pos>(tuple), encoder, proto, ec);
+                if (ec) {return;}
+                next::encode(tuple, encoder, proto, ec);
+            }
+        };
+
+        template<size_t Size,typename Json,typename Tuple>
+        struct json_serialize_tuple_helper<0, Size, Json, Tuple>
+        {
+            using char_type = typename Json::char_type;
+            static void encode(const Tuple&,
+                               basic_json_visitor<char_type>&, 
+                               const Json&, 
+                               std::error_code&)
+            {
+            }
+        };
+    } // namespace detail
+
+
+    template <typename CharT,typename... E>
+    struct encode_traits<std::tuple<E...>, CharT>
+    {
+        using value_type = std::tuple<E...>;
+        static constexpr std::size_t size = sizeof...(E);
+
+        template <typename Json>
+        static void encode(const value_type& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            using helper = jsoncons::detail::json_serialize_tuple_helper<size, size, Json, std::tuple<E...>>;
+            encoder.begin_array(size,semantic_tag::none,ser_context(),ec);
+            if (ec) {return;}
+            helper::encode(val, encoder, proto, ec);
+            if (ec) {return;}
+            encoder.end_array(ser_context(),ec);
+        }
+    };
+
+    // vector like
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 !extension_traits::is_typed_array<T>::value 
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encoder.begin_array(val.size(),semantic_tag::none,ser_context(),ec);
+            if (ec) {return;}
+            for (auto it = std::begin(val); it != std::end(val); ++it)
+            {
+                encode_traits<value_type,CharT>::encode(*it, encoder, proto, ec);
+                if (ec) {return;}
+            }
+            encoder.end_array(ser_context(), ec);
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                 extension_traits::is_array_like<T>::value &&
+                 extension_traits::is_typed_array<T>::value 
+    >::type>
+    {
+        using value_type = typename T::value_type;
+
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json&,
+                           std::error_code& ec)
+        {
+            encoder.typed_array(jsoncons::span<const value_type>(val), semantic_tag::none, ser_context(), ec);
+        }
+    };
+
+    // std::array
+
+    template <typename T,typename CharT, std::size_t N>
+    struct encode_traits<std::array<T,N>,CharT>
+    {
+        using value_type = typename std::array<T,N>::value_type;
+
+        template <typename Json>
+        static void encode(const std::array<T, N>& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encoder.begin_array(val.size(),semantic_tag::none,ser_context(),ec);
+            if (ec) {return;}
+            for (auto it = std::begin(val); it != std::end(val); ++it)
+            {
+                encode_traits<value_type,CharT>::encode(*it, encoder, proto, ec);
+                if (ec) {return;}
+            }
+            encoder.end_array(ser_context(),ec);
+        }
+    };
+
+    // map like
+
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                extension_traits::is_map_like<T>::value &&
+                                extension_traits::is_constructible_from_const_pointer_and_size<typename T::key_type>::value
+    >::type>
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encoder.begin_object(val.size(), semantic_tag::none, ser_context(), ec);
+            if (ec) {return;}
+            for (auto it = std::begin(val); it != std::end(val); ++it)
+            {
+                encoder.key((*it).first);
+                encode_traits<mapped_type,CharT>::encode((*it).second, encoder, proto, ec);
+                if (ec) {return;}
+            }
+            encoder.end_object(ser_context(), ec);
+            if (ec) {return;}
+        }
+    };
+
+    template <typename T,typename CharT>
+    struct encode_traits<T,CharT,
+        typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                extension_traits::is_map_like<T>::value &&
+                                std::is_integral<typename T::key_type>::value
+    >::type>
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+
+        template <typename Json>
+        static void encode(const T& val, 
+                           basic_json_visitor<CharT>& encoder, 
+                           const Json& proto, 
+                           std::error_code& ec)
+        {
+            encoder.begin_object(val.size(), semantic_tag::none, ser_context(), ec);
+            if (ec) {return;}
+            for (auto it = std::begin(val); it != std::end(val); ++it)
+            {
+                std::basic_string<typename Json::char_type> s;
+                jsoncons::detail::from_integer((*it).first,s);
+                encoder.key(s);
+                encode_traits<mapped_type,CharT>::encode((*it).second, encoder, proto, ec);
+                if (ec) {return;}
+            }
+            encoder.end_object(ser_context(), ec);
+            if (ec) {return;}
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_ENCODE_TRAITS_HPP

--- a/velox/external/jsoncons/item_event_visitor.hpp
+++ b/velox/external/jsoncons/item_event_visitor.hpp
@@ -1,0 +1,2113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_ITEM_EVENT_VISITOR_HPP
+#define JSONCONS_ITEM_EVENT_VISITOR_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { 
+
+    template <typename CharT,typename Allocator = std::allocator<char>>
+    class basic_item_event_visitor_to_json_visitor;
+
+    template <typename CharT>
+    class basic_item_event_visitor 
+    {
+        template <typename Ch,typename Allocator>
+        friend class basic_item_event_visitor_to_json_visitor;
+    public:
+        using char_type = CharT;
+        using char_traits_type = std::char_traits<char_type>;
+
+        using string_view_type = jsoncons::basic_string_view<char_type,char_traits_type>;
+
+        basic_item_event_visitor(basic_item_event_visitor&&) = default;
+
+        basic_item_event_visitor& operator=(basic_item_event_visitor&&) = default;
+
+        basic_item_event_visitor() = default;
+
+        virtual ~basic_item_event_visitor() = default;
+
+        void flush()
+        {
+            visit_flush();
+        }
+
+        bool begin_object(semantic_tag tag=semantic_tag::none,
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_object(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_object(std::size_t length, 
+                          semantic_tag tag=semantic_tag::none, 
+                          const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_object(length, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_object(const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_end_object(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_array(semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_array(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_array(std::size_t length, 
+                         semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_array(length, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_array(const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_end_array(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool key(const string_view_type& name, const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_string(name, semantic_tag::none, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool null_value(semantic_tag tag = semantic_tag::none,
+                        const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_null(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool bool_value(bool value, 
+                        semantic_tag tag = semantic_tag::none,
+                        const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_bool(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool string_value(const string_view_type& value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_string(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               semantic_tag tag=semantic_tag::none, 
+                               const ser_context& context=ser_context(),
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            std::error_code ec;
+            bool more = visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               uint64_t ext_tag, 
+                               const ser_context& context=ser_context(),
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            std::error_code ec;
+            bool more = visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), ext_tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool uint64_value(uint64_t value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_uint64(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool int64_value(int64_t value, 
+                         semantic_tag tag = semantic_tag::none, 
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_int64(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool half_value(uint16_t value, 
+                        semantic_tag tag = semantic_tag::none, 
+                        const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_half(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool double_value(double value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_double(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_object(semantic_tag tag,
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_begin_object(tag, context, ec);
+        }
+
+        bool begin_object(std::size_t length, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_begin_object(length, tag, context, ec);
+        }
+
+        bool end_object(const ser_context& context, std::error_code& ec)
+        {
+            return visit_end_object(context, ec);
+        }
+
+        bool begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec)
+        {
+            return visit_begin_array(tag, context, ec);
+        }
+
+        bool begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec)
+        {
+            return visit_begin_array(length, tag, context, ec);
+        }
+
+        bool end_array(const ser_context& context, std::error_code& ec)
+        {
+            return visit_end_array(context, ec);
+        }
+
+        bool key(const string_view_type& name, const ser_context& context, std::error_code& ec)
+        {
+            return visit_string(name, semantic_tag::none, context, ec);
+        }
+
+        bool null_value(semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) 
+        {
+            return visit_null(tag, context, ec);
+        }
+
+        bool bool_value(bool value, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) 
+        {
+            return visit_bool(value, tag, context, ec);
+        }
+
+        bool string_value(const string_view_type& value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec) 
+        {
+            return visit_string(value, tag, context, ec);
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               semantic_tag tag, 
+                               const ser_context& context,
+                               std::error_code& ec,
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            return visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), tag, context, ec);
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               uint64_t ext_tag, 
+                               const ser_context& context,
+                               std::error_code& ec,
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            return visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), ext_tag, context, ec);
+        }
+
+        bool uint64_value(uint64_t value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_uint64(value, tag, context, ec);
+        }
+
+        bool int64_value(int64_t value, 
+                         semantic_tag tag, 
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_int64(value, tag, context, ec);
+        }
+
+        bool half_value(uint16_t value, 
+                        semantic_tag tag, 
+                        const ser_context& context,
+                        std::error_code& ec)
+        {
+            return visit_half(value, tag, context, ec);
+        }
+
+        bool double_value(double value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_double(value, tag, context, ec);
+        }
+
+        template <typename T>
+        bool typed_array(const jsoncons::span<T>& data, 
+                         semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_typed_array(data, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename T>
+        bool typed_array(const jsoncons::span<T>& data, 
+                         semantic_tag tag,
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_typed_array(data, tag, context, ec);
+        }
+
+        bool typed_array(half_arg_t, const jsoncons::span<const uint16_t>& s,
+            semantic_tag tag = semantic_tag::none,
+            const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_typed_array(half_arg, s, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool typed_array(half_arg_t, const jsoncons::span<const uint16_t>& s,
+                         semantic_tag tag,
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_typed_array(half_arg, s, tag, context, ec);
+        }
+
+        bool begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                             semantic_tag tag = semantic_tag::multi_dim_row_major,
+                             const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_begin_multi_dim(shape, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec) 
+        {
+            return visit_begin_multi_dim(shape, tag, context, ec);
+        }
+
+        bool end_multi_dim(const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_end_multi_dim(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_multi_dim(const ser_context& context,
+                           std::error_code& ec) 
+        {
+            return visit_end_multi_dim(context, ec);
+        }
+
+    private:
+
+        virtual void visit_flush() = 0;
+
+        virtual bool visit_begin_object(semantic_tag tag, 
+                                        const ser_context& context, 
+                                        std::error_code& ec) = 0;
+
+        virtual bool visit_begin_object(std::size_t /*length*/, 
+                                        semantic_tag tag, 
+                                        const ser_context& context, 
+                                        std::error_code& ec)
+        {
+            return visit_begin_object(tag, context, ec);
+        }
+
+        virtual bool visit_end_object(const ser_context& context, 
+                                      std::error_code& ec) = 0;
+
+        virtual bool visit_begin_array(semantic_tag tag, 
+                                       const ser_context& context, 
+                                       std::error_code& ec) = 0;
+
+        virtual bool visit_begin_array(std::size_t /*length*/, 
+                                       semantic_tag tag, 
+                                       const ser_context& context, 
+                                       std::error_code& ec)
+        {
+            return visit_begin_array(tag, context, ec);
+        }
+
+        virtual bool visit_end_array(const ser_context& context, 
+                                     std::error_code& ec) = 0;
+
+        virtual bool visit_null(semantic_tag tag, 
+                             const ser_context& context, 
+                             std::error_code& ec) = 0;
+
+        virtual bool visit_bool(bool value, 
+                             semantic_tag tag, 
+                             const ser_context& context, 
+                             std::error_code&) = 0;
+
+        virtual bool visit_string(const string_view_type& value, 
+                               semantic_tag tag, 
+                               const ser_context& context, 
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_byte_string(const byte_string_view& value, 
+                                    semantic_tag tag, 
+                                    const ser_context& context,
+                                    std::error_code& ec) = 0;
+
+        virtual bool visit_byte_string(const byte_string_view& value, 
+                                       uint64_t /*ext_tag*/, 
+                                       const ser_context& context,
+                                       std::error_code& ec) 
+        {
+            return visit_byte_string(value, semantic_tag::none, context, ec);
+        }
+
+        virtual bool visit_uint64(uint64_t value, 
+                               semantic_tag tag, 
+                               const ser_context& context,
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_int64(int64_t value, 
+                              semantic_tag tag,
+                              const ser_context& context,
+                              std::error_code& ec) = 0;
+
+        virtual bool visit_half(uint16_t value, 
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec)
+        {
+            return visit_double(binary::decode_half(value),
+                             tag,
+                             context,
+                             ec);
+        }
+
+        virtual bool visit_double(double value, 
+                               semantic_tag tag,
+                               const ser_context& context,
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint8_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) 
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) 
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int8_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int16_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(half_arg_t, 
+                                    const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = half_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const float>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = double_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const double>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = double_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                                        semantic_tag tag,
+                                        const ser_context& context, 
+                                        std::error_code& ec) 
+        {
+            bool more = visit_begin_array(2, tag, context, ec);
+            if (more)
+            {
+                more = visit_begin_array(shape.size(), tag, context, ec);
+                for (auto it = shape.begin(); more && it != shape.end(); ++it)
+                {
+                    visit_uint64(*it, semantic_tag::none, context, ec);
+                }
+                if (more)
+                {
+                    more = visit_end_array(context, ec);
+                }
+            }
+            return more;
+        }
+
+        virtual bool visit_end_multi_dim(const ser_context& context,
+                                      std::error_code& ec) 
+        {
+            return visit_end_array(context, ec);
+        }
+    };
+
+ template <typename CharT,typename Allocator>
+    class basic_item_event_visitor_to_json_visitor : public basic_item_event_visitor<CharT>
+    {
+    public:
+        using typename basic_item_event_visitor<CharT>::char_type;
+        using typename basic_item_event_visitor<CharT>::string_view_type;
+    private:
+        using char_allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<char_type>;
+
+        using string_type = std::basic_string<char_type,std::char_traits<char_type>,char_allocator_type>;
+
+        enum class container_t {root, array, object};
+        enum class target_t {destination, buffer};
+
+        struct level
+        {
+        private:
+            target_t state_;
+            container_t type_;
+            int even_odd_;
+            std::size_t count_{0};
+        public:
+
+            level(target_t state, container_t type) noexcept
+                : state_(state), type_(type), even_odd_(type == container_t::object ? 0 : 1)
+            {
+            }
+
+            void advance()
+            {
+                if (!is_key())
+                {
+                    ++count_;
+                }
+                if (is_object())
+                {
+                    even_odd_ = !even_odd_;
+                }
+            }
+
+            bool is_key() const
+            {
+                return even_odd_ == 0;
+            }
+
+            bool is_object() const
+            {
+                return type_ == container_t::object;
+            }
+
+            target_t target() const
+            {
+                return state_;
+            }
+
+            std::size_t count() const
+            {
+                return count_;
+            }
+        };
+        using level_allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<level>;
+
+        basic_default_json_visitor<char_type> default_visitor_;
+        basic_json_visitor<char_type>* destination_;
+        string_type key_;
+        string_type key_buffer_;
+        std::vector<level,level_allocator_type> level_stack_;
+
+        const std::basic_string<char> null_constant = {'n','u','l','l'};
+        const std::basic_string<char> true_constant = { 't','r','u','e' };
+        const std::basic_string<char> false_constant = { 'f', 'a', 'l', 's', 'e' };
+
+        // noncopyable and nonmoveable
+        basic_item_event_visitor_to_json_visitor(const basic_item_event_visitor_to_json_visitor&) = delete;
+        basic_item_event_visitor_to_json_visitor& operator=(const basic_item_event_visitor_to_json_visitor&) = delete;
+    public:
+        explicit basic_item_event_visitor_to_json_visitor(const Allocator& alloc = Allocator())
+            : default_visitor_(), destination_(std::addressof(default_visitor_)),
+              key_(alloc), key_buffer_(alloc), level_stack_(alloc)
+        {
+            level_stack_.emplace_back(target_t::destination,container_t::root); // root
+        }
+
+        explicit basic_item_event_visitor_to_json_visitor(basic_json_visitor<char_type>& visitor, 
+                                                     const Allocator& alloc = Allocator())
+            : destination_(std::addressof(visitor)), 
+              key_(alloc), key_buffer_(alloc), level_stack_(alloc)
+        {
+            level_stack_.emplace_back(target_t::destination,container_t::root); // root
+        }
+
+        void reset()
+        {
+            key_.clear();
+            key_buffer_.clear();
+            level_stack_.clear();
+            level_stack_.emplace_back(target_t::destination,container_t::root); // root
+        }
+
+        basic_json_visitor<char_type>& destination()
+        {
+            return *destination_;
+        }
+
+        void destination(basic_json_visitor<char_type>& dest)
+        {
+            destination_ = std::addressof(dest);
+        }
+
+    private:
+        void visit_flush() override
+        {
+            destination_->flush();
+        }
+
+        bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key())
+            {
+                if (level_stack_.back().target() == target_t::buffer && level_stack_.back().count() > 0)
+                {
+                    key_buffer_.push_back(',');
+                }
+                level_stack_.emplace_back(target_t::buffer, container_t::object);
+                key_buffer_.push_back('{');
+                return true;
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        level_stack_.emplace_back(target_t::buffer, container_t::object);
+                        key_buffer_.push_back('{');
+                        return true;
+                    default:
+                        level_stack_.emplace_back(target_t::destination, container_t::object);
+                        return destination_->begin_object(tag, context, ec);
+                }
+            }
+        }
+
+        bool visit_begin_object(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key())
+            {
+                if (level_stack_.back().target() == target_t::buffer && level_stack_.back().count() > 0)
+                {
+                    key_buffer_.push_back(',');
+                }
+                level_stack_.emplace_back(target_t::buffer, container_t::object);
+                key_buffer_.push_back('{');
+                return true;
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        level_stack_.emplace_back(target_t::buffer, container_t::object);
+                        key_buffer_.push_back('{');
+                        return true;
+                    default:
+                        level_stack_.emplace_back(target_t::destination, container_t::object);
+                        return destination_->begin_object(length, tag, context, ec);
+                }
+            }
+        }
+
+        bool visit_end_object(const ser_context& context, std::error_code& ec) override
+        {
+            bool retval = true;
+            switch (level_stack_.back().target())
+            {
+                case target_t::buffer:
+                    key_buffer_.push_back('}');
+                    JSONCONS_ASSERT(level_stack_.size() > 1);
+                    level_stack_.pop_back();
+                    
+                    if (level_stack_.back().target() == target_t::destination)
+                    {
+                        retval = destination_->key(key_buffer_,context, ec);
+                        key_buffer_.clear();
+                    }
+                    else if (level_stack_.back().is_key())
+                    {
+                        key_buffer_.push_back(':');
+                    }
+                    level_stack_.back().advance();
+                    break;
+                default:
+                    JSONCONS_ASSERT(level_stack_.size() > 1);
+                    level_stack_.pop_back();
+                    level_stack_.back().advance();
+                    retval = destination_->end_object(context, ec);
+                    break;
+            }
+            return retval;
+        }
+
+        bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key())
+            {
+                if (level_stack_.back().target() == target_t::buffer && level_stack_.back().count() > 0)
+                {
+                    key_buffer_.push_back(',');
+                }
+                level_stack_.emplace_back(target_t::buffer, container_t::array);
+                key_buffer_.push_back('[');
+                return true;
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        level_stack_.emplace_back(target_t::buffer, container_t::array);
+                        key_buffer_.push_back('[');
+                        return true;
+                    default:
+                        level_stack_.emplace_back(target_t::destination, container_t::array);
+                        return destination_->begin_array(tag, context, ec);
+                }
+            }
+        }
+
+        bool visit_begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key())
+            {
+                if (level_stack_.back().target() == target_t::buffer && level_stack_.back().count() > 0)
+                {
+                    key_buffer_.push_back(',');
+                }
+                level_stack_.emplace_back(target_t::buffer, container_t::array);
+                key_buffer_.push_back('[');
+                return true;
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        level_stack_.emplace_back(target_t::buffer, container_t::array);
+                        key_buffer_.push_back('[');
+                        return true;
+                    default:
+                        level_stack_.emplace_back(target_t::destination, container_t::array);
+                        return destination_->begin_array(length, tag, context, ec);
+                }
+            }
+        }
+
+        bool visit_end_array(const ser_context& context, std::error_code& ec) override
+        {
+            bool retval = true;
+            switch (level_stack_.back().target())
+            {
+                case target_t::buffer:
+                    key_buffer_.push_back(']');
+                    JSONCONS_ASSERT(level_stack_.size() > 1);
+                    level_stack_.pop_back();
+                    if (level_stack_.back().target() == target_t::destination)
+                    {
+                        retval = destination_->key(key_buffer_, context, ec);
+                        key_buffer_.clear();
+                    }
+                    else if (level_stack_.back().is_key())
+                    {
+                        key_buffer_.push_back(':');
+                    }
+                    level_stack_.back().advance();
+                    break;
+                default:
+                    JSONCONS_ASSERT(level_stack_.size() > 1);
+                    level_stack_.pop_back();
+                    level_stack_.back().advance();
+                    retval = destination_->end_array(context, ec);
+                    break;
+            }
+            return retval;
+        }
+
+        bool visit_string(const string_view_type& value,
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec) override
+        {
+            bool retval;
+
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), value.begin(), value.end());
+                        key_buffer_.push_back('\"');
+                        key_buffer_.push_back(':');
+                        retval = true;
+                        break;
+                    default:
+                        retval = destination_->key(value, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), value.begin(), value.end());
+                        key_buffer_.push_back('\"');
+                        retval = true;
+                        break;
+                    default:
+                        retval = destination_->string_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_byte_string(const byte_string_view& value, 
+                                  semantic_tag tag,
+                                  const ser_context& context,
+                                  std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                switch (tag)
+                {
+                    case semantic_tag::base64:
+                        encode_base64(value.begin(), value.end(), key_);
+                        break;
+                    case semantic_tag::base16:
+                        encode_base16(value.begin(), value.end(),key_);
+                        break;
+                    default:
+                        encode_base64url(value.begin(), value.end(),key_);
+                        break;
+                }
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back('\"');
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back('\"');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->byte_string_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_byte_string(const byte_string_view& value, 
+                               uint64_t ext_tag,
+                               const ser_context& context,
+                               std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                encode_base64url(value.begin(), value.end(),key_);
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back('\"');
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.push_back('\"');
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back('\"');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->byte_string_value(value, ext_tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_uint64(uint64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                jsoncons::detail::from_integer(value,key_);
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->uint64_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_int64(int64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                jsoncons::detail::from_integer(value,key_);
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->int64_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_half(uint16_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                jsoncons::string_sink<string_type> sink(key_);
+                jsoncons::detail::write_double f{float_chars_format::general,0};
+                double x = binary::decode_half(value);
+                f(x, sink);
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->half_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_double(double value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear();
+                string_sink<string_type> sink(key_);
+                jsoncons::detail::write_double f{float_chars_format::general,0};
+                f(value, sink);
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->double_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear(); 
+                if (value)
+                {
+                    key_.insert(key_.begin(), true_constant.begin(), true_constant.end());
+                }
+                else
+                {
+                    key_.insert(key_.begin(), false_constant.begin(), false_constant.end());
+                }
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->bool_value(value, tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_null(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            if (level_stack_.back().is_key() || level_stack_.back().target() == target_t::buffer)
+            {
+                key_.clear(); 
+                key_.insert(key_.begin(), null_constant.begin(), null_constant.end());
+            }
+
+            bool retval;
+            if (level_stack_.back().is_key())
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        key_buffer_.push_back(':');
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->key(key_, context, ec);
+                        break;
+                }
+            }
+            else
+            {
+                switch (level_stack_.back().target())
+                {
+                    case target_t::buffer:
+                        if (!level_stack_.back().is_object() && level_stack_.back().count() > 0)
+                        {
+                            key_buffer_.push_back(',');
+                        }
+                        key_buffer_.insert(key_buffer_.end(), key_.begin(), key_.end());
+                        retval = true; 
+                        break;
+                    default:
+                        retval = destination_->null_value(tag, context, ec);
+                        break;
+                }
+            }
+
+            level_stack_.back().advance();
+            return retval;
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint8_t>& s, 
+                               semantic_tag tag,
+                               const ser_context& context, 
+                               std::error_code& ec) override 
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override 
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override 
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int8_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int16_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(half_arg_t, 
+                               const jsoncons::span<const uint16_t>& s, 
+                               semantic_tag tag, 
+                               const ser_context& context, 
+                               std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(half_arg,s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(half_arg, s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const float>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+
+        bool visit_typed_array(const jsoncons::span<const double>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) override  
+        {
+            bool is_key = level_stack_.back().is_key();
+            level_stack_.back().advance();
+
+            if (is_key || level_stack_.back().target() == target_t::buffer)
+            {
+                return basic_item_event_visitor<CharT>::visit_typed_array(s,tag,context,ec);
+            }
+            else
+            {
+                return destination_->typed_array(s, tag, context, ec);
+            }
+        }
+    };
+
+    template <typename CharT>
+    class basic_default_item_event_visitor : public basic_item_event_visitor<CharT>
+    {
+        bool parse_more_;
+        std::error_code ec_;
+    public:
+        using typename basic_item_event_visitor<CharT>::string_view_type;
+
+        basic_default_item_event_visitor(bool accept_more = true,
+                                    std::error_code ec = std::error_code())
+            : parse_more_(accept_more), ec_(ec)
+        {
+        }
+    private:
+        void visit_flush() override
+        {
+        }
+
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_begin_object(std::size_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_begin_array(std::size_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_null(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_string(const string_view_type&, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_byte_string(const byte_string_view&, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_uint64(uint64_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_int64(int64_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_half(uint16_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_double(double, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_bool(bool, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+    };
+
+    // basic_json_visitor_to_item_event_visitor
+
+    template <typename CharT>
+    class basic_json_visitor_to_item_event_visitor : public basic_json_visitor<CharT>
+    {
+    public:
+        using typename basic_json_visitor<CharT>::char_type;
+        using typename basic_json_visitor<CharT>::string_view_type;
+    private:
+        basic_item_event_visitor<char_type>& destination_;
+
+        // noncopyable and nonmoveable
+        basic_json_visitor_to_item_event_visitor(const basic_json_visitor_to_item_event_visitor&) = delete;
+        basic_json_visitor_to_item_event_visitor& operator=(const basic_json_visitor_to_item_event_visitor&) = delete;
+    public:
+        basic_json_visitor_to_item_event_visitor(basic_item_event_visitor<char_type>& visitor)
+            : destination_(visitor)
+        {
+        }
+
+        basic_item_event_visitor<char_type>& destination()
+        {
+            return destination_;
+        }
+
+    private:
+        void visit_flush() override
+        {
+            destination_.flush();
+        }
+
+        bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.begin_object(tag, context, ec);
+        }
+
+        bool visit_begin_object(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.begin_object(length, tag, context, ec);
+        }
+
+        bool visit_end_object(const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.end_object(context, ec);
+        }
+
+        bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.begin_array(tag, context, ec);
+        }
+
+        bool visit_begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.begin_array(length, tag, context, ec);
+        }
+
+        bool visit_end_array(const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.end_array(context, ec);
+        }
+
+        bool visit_key(const string_view_type& name,
+                       const ser_context& context,
+                       std::error_code& ec) override
+        {
+            return destination_.visit_string(name, context, ec);
+        }
+
+        bool visit_string(const string_view_type& value,
+                          semantic_tag tag,
+                          const ser_context& context,
+                          std::error_code& ec) override
+        {
+            return destination_.string_value(value, tag, context, ec);
+        }
+
+        bool visit_byte_string(const byte_string_view& b, 
+                               semantic_tag tag,
+                               const ser_context& context,
+                               std::error_code& ec) override
+        {
+            return destination_.byte_string_value(b, tag, context, ec);
+        }
+
+        bool visit_uint64(uint64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.uint64_value(value, tag, context, ec);
+        }
+
+        bool visit_int64(int64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.int64_value(value, tag, context, ec);
+        }
+
+        bool visit_half(uint16_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.half_value(value, tag, context, ec);
+        }
+
+        bool visit_double(double value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.double_value(value, tag, context, ec);
+        }
+
+        bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.bool_value(value, tag, context, ec);
+        }
+
+        bool visit_null(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return destination_.null_value(tag, context, ec);
+        }
+    };
+
+    class diagnostics_visitor2 : public basic_default_item_event_visitor<char>
+    {
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_begin_object" << '\n'; 
+            return true;
+        }
+
+        bool visit_begin_object(std::size_t length, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_begin_object " << length << '\n'; 
+            return true;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_end_object" << '\n'; 
+            return true;
+        }
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_begin_array" << '\n';
+            return true;
+        }
+
+        bool visit_begin_array(std::size_t length, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_begin_array " << length << '\n'; 
+            return true;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_end_array" << '\n'; 
+            return true;
+        }
+
+        bool visit_string(const string_view_type& s, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_string " << s << '\n'; 
+            return true;
+        }
+        bool visit_int64(int64_t val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_int64 " << val << '\n'; 
+            return true;
+        }
+        bool visit_uint64(uint64_t val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_uint64 " << val << '\n'; 
+            return true;
+        }
+        bool visit_bool(bool val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_bool " << val << '\n'; 
+            return true;
+        }
+        bool visit_null(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            std::cout << "visit_null " << '\n'; 
+            return true;
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context&, 
+                                    std::error_code&) override  
+        {
+            std::cout << "visit_typed_array uint16_t " << tag << '\n'; 
+            for (auto val : s)
+            {
+                std::cout << val << "" << '\n';
+            }
+            std::cout << "" << '\n';
+            return true;
+        }
+
+        bool visit_typed_array(half_arg_t, const jsoncons::span<const uint16_t>& s,
+            semantic_tag tag,
+            const ser_context&,
+            std::error_code&) override
+        {
+            std::cout << "visit_typed_array half_arg_t uint16_t " << tag << "" << '\n';
+            for (auto val : s)
+            {
+                std::cout << val << "" << '\n';
+            }
+            std::cout << "" << '\n';
+            return true;
+        }
+    };
+
+    using item_event_visitor = basic_item_event_visitor<char>;
+    using default_item_event_visitor = basic_default_item_event_visitor<char>;
+    using item_event_visitor_to_visitor_adaptor = basic_item_event_visitor_to_json_visitor<char>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_ITEM_EVENT_VISITOR_HPP

--- a/velox/external/jsoncons/json.hpp
+++ b/velox/external/jsoncons/json.hpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_HPP
+#define JSONCONS_JSON_HPP
+
+#include "velox/external/jsoncons/basic_json.hpp"
+#include "velox/external/jsoncons/decode_json.hpp"
+#include "velox/external/jsoncons/encode_json.hpp"
+#include "velox/external/jsoncons/json_traits_macros.hpp"
+#include "velox/external/jsoncons/staj_iterator.hpp"
+
+#endif // JSONCONS_JSON_HPP

--- a/velox/external/jsoncons/json_array.hpp
+++ b/velox/external/jsoncons/json_array.hpp
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_ARRAY_HPP
+#define JSONCONS_JSON_ARRAY_HPP
+
+#include <algorithm> // std::sort, std::stable_sort, std::lower_bound, std::unique
+#include <cassert> // assert
+#include <cstring>
+#include <initializer_list>
+#include <iterator> // std::iterator_traits
+#include <memory> // std::allocator
+#include <type_traits> // std::enable_if
+#include <utility>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/allocator_holder.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // json_array
+
+    template <typename Json,template <typename,typename> class SequenceContainer = std::vector>
+    class json_array : public allocator_holder<typename Json::allocator_type>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using value_type = Json;
+    private:
+        using value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<value_type>;                   
+        using value_container_type = SequenceContainer<value_type,value_allocator_type>;
+        value_container_type elements_;
+    public:
+        using iterator = typename value_container_type::iterator;
+        using const_iterator = typename value_container_type::const_iterator;
+        using reference = typename std::iterator_traits<iterator>::reference;
+        using const_reference = typename std::iterator_traits<const_iterator>::reference;
+
+        using allocator_holder<allocator_type>::get_allocator;
+
+        json_array()
+        {
+        }
+
+        explicit json_array(const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(value_allocator_type(alloc))
+        {
+        }
+
+        explicit json_array(std::size_t n, 
+                            const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(n,Json(),value_allocator_type(alloc))
+        {
+        }
+
+        explicit json_array(std::size_t n, 
+                            const Json& value, 
+                            const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(n,value,value_allocator_type(alloc))
+        {
+        }
+
+        template <typename InputIterator>
+        json_array(InputIterator begin, InputIterator end, const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(begin,end,value_allocator_type(alloc))
+        {
+        }
+
+        json_array(const json_array& other)
+            : allocator_holder<allocator_type>(other.get_allocator()),
+              elements_(other.elements_)
+        {
+        }
+        json_array(const json_array& other, const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(other.elements_,value_allocator_type(alloc))
+        {
+        }
+
+        json_array(json_array&& other) noexcept
+            : allocator_holder<allocator_type>(other.get_allocator()), 
+              elements_(std::move(other.elements_))
+        {
+        }
+        json_array(json_array&& other, const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(std::move(other.elements_),value_allocator_type(alloc))
+        {
+        }
+
+        json_array(const std::initializer_list<Json>& init, 
+                   const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              elements_(init,value_allocator_type(alloc))
+        {
+        }
+        ~json_array() noexcept
+        {
+            flatten_and_destroy();
+        }
+
+        reference back()
+        {
+            return elements_.back();
+        }
+
+        const_reference back() const
+        {
+            return elements_.back();
+        }
+
+        void pop_back()
+        {
+            elements_.pop_back();
+        }
+
+        bool empty() const
+        {
+            return elements_.empty();
+        }
+
+        void swap(json_array& other) noexcept
+        {
+            elements_.swap(other.elements_);
+        }
+
+        std::size_t size() const {return elements_.size();}
+
+        std::size_t capacity() const {return elements_.capacity();}
+
+        void clear() {elements_.clear();}
+
+        void shrink_to_fit() 
+        {
+            for (std::size_t i = 0; i < elements_.size(); ++i)
+            {
+                elements_[i].shrink_to_fit();
+            }
+            elements_.shrink_to_fit();
+        }
+
+        void reserve(std::size_t n) {elements_.reserve(n);}
+
+        void resize(std::size_t n) {elements_.resize(n);}
+
+        void resize(std::size_t n, const Json& val) {elements_.resize(n,val);}
+
+        iterator erase(const_iterator pos) 
+        {
+            return elements_.erase(pos);
+        }
+
+        iterator erase(const_iterator first, const_iterator last) 
+        {
+            return elements_.erase(first,last);
+        }
+
+        Json& operator[](std::size_t i) {return elements_[i];}
+
+        const Json& operator[](std::size_t i) const {return elements_[i];}
+
+        // push_back
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,void>::type 
+        push_back(T&& value)
+        {
+            elements_.emplace_back(std::forward<T>(value));
+        }
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,void>::type 
+        push_back(T&& value)
+        {
+            elements_.emplace_back(std::forward<T>(value));
+        }
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert(const_iterator pos, T&& value)
+        {
+            return elements_.emplace(pos, std::forward<T>(value));
+        }
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert(const_iterator pos, T&& value)
+        {
+            return elements_.emplace(pos, std::forward<T>(value));
+        }
+
+        template <typename InputIt>
+        iterator insert(const_iterator pos, InputIt first, InputIt last)
+        {
+            return elements_.insert(pos, first, last);
+        }
+
+        template <typename A=allocator_type,typename... Args>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        emplace(const_iterator pos, Args&&... args)
+        {
+            return elements_.emplace(pos, std::forward<Args>(args)...);
+        }
+
+        template <typename... Args>
+        Json& emplace_back(Args&&... args)
+        {
+            elements_.emplace_back(std::forward<Args>(args)...);
+            return elements_.back();
+        }
+
+        iterator begin() {return elements_.begin();}
+
+        iterator end() {return elements_.end();}
+
+        const_iterator begin() const {return elements_.begin();}
+
+        const_iterator end() const {return elements_.end();}
+
+        bool operator==(const json_array& rhs) const noexcept
+        {
+            return elements_ == rhs.elements_;
+        }
+
+        bool operator<(const json_array& rhs) const noexcept
+        {
+            return elements_ < rhs.elements_;
+        }
+
+        json_array& operator=(const json_array& other)
+        {
+            elements_ = other.elements_;
+            return *this;
+        }
+    private:
+
+        void flatten_and_destroy() noexcept
+        {
+            while (!elements_.empty())
+            {
+                value_type current = std::move(elements_.back());
+                elements_.pop_back();
+                switch (current.storage_kind())
+                {
+                    case json_storage_kind::array:
+                    {
+                        for (auto&& item : current.array_range())
+                        {
+                            if ((item.storage_kind() == json_storage_kind::array || item.storage_kind() == json_storage_kind::object)
+                                && !item.empty()) // non-empty object or array
+                            {
+                                elements_.push_back(std::move(item));
+                            }
+                        }
+                        current.clear();                           
+                        break;
+                    }
+                    case json_storage_kind::object:
+                    {
+                        for (auto&& kv : current.object_range())
+                        {
+                            if ((kv.value().storage_kind() == json_storage_kind::array || kv.value().storage_kind() == json_storage_kind::object)
+                                && !kv.value().empty()) // non-empty object or array
+                            {
+                                elements_.push_back(std::move(kv.value()));
+                            }
+                        }
+                        current.clear();                           
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_ARRAY_HPP

--- a/velox/external/jsoncons/json_cursor.hpp
+++ b/velox/external/jsoncons/json_cursor.hpp
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_CURSOR_HPP
+#define JSONCONS_JSON_CURSOR_HPP
+
+#include <cstddef>
+#include <functional>
+#include <ios>
+#include <memory> // std::allocator
+#include <system_error>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/source.hpp"
+#include "velox/external/jsoncons/source_adaptor.hpp"
+#include "velox/external/jsoncons/staj_cursor.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+template <typename CharT,typename Source=jsoncons::stream_source<CharT>,typename Allocator=std::allocator<char>>
+class basic_json_cursor : public basic_staj_cursor<CharT>, private virtual ser_context
+{
+public:
+    using source_type = Source;
+    using char_type = CharT;
+    using allocator_type = Allocator;
+    using string_view_type = jsoncons::basic_string_view<CharT>;
+private:
+    using char_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<CharT>;
+    static constexpr size_t default_max_buffer_size = 16384;
+
+    json_source_adaptor<Source> source_;
+    basic_json_parser<CharT,Allocator> parser_;
+    basic_staj_visitor<CharT> cursor_visitor_;
+    bool done_;
+
+public:
+
+    // Constructors that throw parse exceptions
+
+    template <typename Sourceable>
+    basic_json_cursor(Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>(),
+                      std::function<bool(json_errc,const ser_context&)> err_handler = default_json_parsing(),
+                      const Allocator& alloc = Allocator(),
+                      typename std::enable_if<!std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type* = 0)
+       : source_(std::forward<Sourceable>(source)),
+         parser_(options,err_handler,alloc),
+         cursor_visitor_(accept_all),
+         done_(false)
+    {
+        if (!done())
+        {
+            std::error_code local_ec;
+            read_next(local_ec);
+            if (local_ec)
+            {
+                if (local_ec == json_errc::unexpected_eof)
+                {
+                    done_ = true;
+                }
+                else
+                {
+                    JSONCONS_THROW(ser_error(local_ec, 1, 1));
+                }
+            }
+        }
+    }
+
+    template <typename Sourceable>
+    basic_json_cursor(Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options = basic_json_decode_options<CharT>(),
+                      std::function<bool(json_errc,const ser_context&)> err_handler = default_json_parsing(),
+                      const Allocator& alloc = Allocator(),
+                      typename std::enable_if<std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type* = 0)
+       : source_(),
+         parser_(options, err_handler, alloc),
+         cursor_visitor_(accept_all),
+         done_(false)
+    {
+        initialize_with_string_view(std::forward<Sourceable>(source));
+    }
+
+
+    // Constructors that set parse error codes
+    template <typename Sourceable>
+    basic_json_cursor(Sourceable&& source, 
+                      std::error_code& ec)
+        : basic_json_cursor(std::allocator_arg, Allocator(), 
+                            std::forward<Sourceable>(source),
+                            basic_json_decode_options<CharT>(),
+                            default_json_parsing(),
+                            ec)
+    {
+    }
+
+    template <typename Sourceable>
+    basic_json_cursor(Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options,
+                      std::error_code& ec)
+        : basic_json_cursor(std::allocator_arg, Allocator(), 
+                            std::forward<Sourceable>(source),
+                            options,
+                            default_json_parsing(),
+                            ec)
+    {
+    }
+
+    template <typename Sourceable>
+    basic_json_cursor(Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options,
+                      std::function<bool(json_errc,const ser_context&)> err_handler,
+                      std::error_code& ec)
+        : basic_json_cursor(std::allocator_arg, Allocator(), 
+                            std::forward<Sourceable>(source),
+                            options,
+                            err_handler,
+                            ec)
+    {
+    }
+
+    template <typename Sourceable>
+    basic_json_cursor(std::allocator_arg_t, const Allocator& alloc,
+                      Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options,
+                      std::function<bool(json_errc,const ser_context&)> err_handler,
+                      std::error_code& ec,
+                      typename std::enable_if<!std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type* = 0)
+       : source_(std::forward<Sourceable>(source)),
+         parser_(options,err_handler,alloc),
+         cursor_visitor_(accept_all),
+         done_(false)
+    {
+        if (!done())
+        {
+            std::error_code local_ec;
+            read_next(local_ec);
+            if (local_ec)
+            {
+                if (local_ec == json_errc::unexpected_eof)
+                {
+                    done_ = true;
+                }
+                else
+                {
+                    ec = local_ec;
+                }
+            }
+        }
+    }
+
+    template <typename Sourceable>
+    basic_json_cursor(std::allocator_arg_t, const Allocator& alloc,
+                      Sourceable&& source, 
+                      const basic_json_decode_options<CharT>& options,
+                      std::function<bool(json_errc,const ser_context&)> err_handler,
+                      std::error_code& ec,
+                      typename std::enable_if<std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type* = 0)
+       : source_(),
+         parser_(options, err_handler, alloc),
+         cursor_visitor_(accept_all),
+         done_(false)
+    {
+        initialize_with_string_view(std::forward<Sourceable>(source), ec);
+    }
+    
+    basic_json_cursor(const basic_json_cursor&) = delete;
+    basic_json_cursor(basic_json_cursor&&) = default;
+    
+    ~basic_json_cursor() = default;
+
+    // Noncopyable and nonmoveable
+
+    basic_json_cursor& operator=(const basic_json_cursor&) = delete;
+    basic_json_cursor& operator=(basic_json_cursor&&) = default;
+
+    void reset()
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        done_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    template <typename Sourceable>
+    typename std::enable_if<!std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type
+    reset(Sourceable&& source)
+    {
+        source_ = std::forward<Sourceable>(source);
+        parser_.reinitialize();
+        cursor_visitor_.reset();
+        done_ = false;
+        if (!done())
+        {
+            next();
+        }
+    }
+
+    template <typename Sourceable>
+    typename std::enable_if<std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type
+    reset(Sourceable&& source)
+    {
+        source_ = {};
+        parser_.reinitialize();
+        cursor_visitor_.reset();
+        done_ = false;
+        initialize_with_string_view(std::forward<Sourceable>(source));
+    }
+
+    void reset(std::error_code& ec)
+    {
+        parser_.reset();
+        cursor_visitor_.reset();
+        done_ = false;
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
+    template <typename Sourceable>
+    typename std::enable_if<!std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type
+    reset(Sourceable&& source, std::error_code& ec)
+    {
+        source_ = std::forward<Sourceable>(source);
+        parser_.reinitialize();
+        cursor_visitor_.reset();
+        done_ = false;
+        if (!done())
+        {
+            next(ec);
+        }
+    }
+
+    template <typename Sourceable>
+    typename std::enable_if<std::is_constructible<jsoncons::basic_string_view<CharT>,Sourceable>::value>::type
+    reset(Sourceable&& source, std::error_code& ec)
+    {
+        source_ = {};
+        parser_.reinitialize();
+        done_ = false;
+        initialize_with_string_view(std::forward<Sourceable>(source), ec);
+    }
+
+    bool done() const override
+    {
+        return parser_.done() || done_;
+    }
+
+    const basic_staj_event<CharT>& current() const override
+    {
+        return cursor_visitor_.event();
+    }
+
+    void read_to(basic_json_visitor<CharT>& visitor) override
+    {
+        std::error_code ec;
+        read_to(visitor, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+        }
+    }
+
+    void read_to(basic_json_visitor<CharT>& visitor,
+                 std::error_code& ec) override
+    {
+        if (cursor_visitor_.event().send_json_event(visitor, *this, ec))
+        {
+            read_next(visitor, ec);
+        }
+    }
+
+    void next() override
+    {
+        std::error_code ec;
+        next(ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+        }
+    }
+
+    void next(std::error_code& ec) override
+    {
+        read_next(ec);
+    }
+
+    void check_done()
+    {
+        std::error_code ec;
+        check_done(ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+        }
+    }
+
+    const ser_context& context() const override
+    {
+        return *this;
+    }
+
+    void check_done(std::error_code& ec)
+    {
+        if (source_.is_error())
+        {
+            ec = json_errc::source_error;
+            return;
+        }   
+        if (source_.eof())
+        {
+            parser_.check_done(ec);
+            if (ec) {return;}
+        }
+        else
+        {
+            do
+            {
+                if (parser_.source_exhausted())
+                {
+                    auto s = source_.read_buffer(ec);
+                    if (ec) {return;}
+                    if (s.size() > 0)
+                    {
+                        parser_.update(s.data(),s.size());
+                    }
+                }
+                if (!parser_.source_exhausted())
+                {
+                    parser_.check_done(ec);
+                    if (ec) {return;}
+                }
+            }
+            while (!eof());
+        }
+    }
+
+    bool eof() const
+    {
+        return parser_.source_exhausted() && source_.eof();
+    }
+
+    std::size_t line() const override
+    {
+        return parser_.line();
+    }
+
+    std::size_t column() const override
+    {
+        return parser_.column();
+    }
+
+    friend
+    basic_staj_filter_view<CharT> operator|(basic_json_cursor& cursor, 
+                                      std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+    {
+        return basic_staj_filter_view<CharT>(cursor, pred);
+    }
+
+private:
+
+    static bool accept_all(const basic_staj_event<CharT>&, const ser_context&) 
+    {
+        return true;
+    }
+
+    void initialize_with_string_view(string_view_type sv)
+    {
+        std::error_code local_ec;
+        initialize_with_string_view(sv, local_ec);
+        if (local_ec)
+        {
+            JSONCONS_THROW(ser_error(local_ec, 1, 1));
+        }
+    }
+
+    void initialize_with_string_view(string_view_type sv, std::error_code& ec)
+    {
+        auto r = unicode_traits::detect_json_encoding(sv.data(), sv.size());
+        if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+        {
+            ec = json_errc::illegal_unicode_character;
+            return;
+        }
+        std::size_t offset = (r.ptr - sv.data());
+        parser_.update(sv.data()+offset,sv.size()-offset);
+        bool is_done = parser_.done() || done_;
+        if (!is_done)
+        {
+            std::error_code local_ec;
+            read_next(local_ec);
+            if (local_ec)
+            {
+                if (local_ec == json_errc::unexpected_eof)
+                {
+                    done_ = true;
+                }
+                else
+                {
+                    ec = local_ec;
+                }
+            }
+        }
+    }
+
+    void read_next()
+    {
+        std::error_code ec;
+        read_next(cursor_visitor_, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+        }
+    }
+
+    void read_next(std::error_code& ec)
+    {
+        read_next(cursor_visitor_, ec);
+    }
+
+    void read_next(basic_json_visitor<CharT>& visitor, std::error_code& ec)
+    {
+        parser_.restart();
+        while (!parser_.stopped())
+        {
+            if (parser_.source_exhausted())
+            {
+                auto s = source_.read_buffer(ec);
+                if (ec) {return;}
+                if (s.size() > 0)
+                {
+                    parser_.update(s.data(),s.size());
+                    if (ec) {return;}
+                }
+            }
+            bool eof = parser_.source_exhausted() && source_.eof();
+            parser_.parse_some(visitor, ec);
+            if (ec) {return;}
+            if (eof)
+            {
+                if (parser_.enter())
+                {
+                    done_ = true;
+                    break;
+                }
+                else if (!parser_.accept())
+                {
+                    ec = json_errc::unexpected_eof;
+                    return;
+                }
+            }
+        }
+    }
+};
+
+using json_stream_cursor = basic_json_cursor<char,jsoncons::stream_source<char>>;
+using json_string_cursor = basic_json_cursor<char,jsoncons::string_source<char>>;
+using wjson_stream_cursor = basic_json_cursor<wchar_t,jsoncons::stream_source<wchar_t>>;
+using wjson_string_cursor = basic_json_cursor<wchar_t,jsoncons::string_source<wchar_t>>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_CURSOR_HPP

--- a/velox/external/jsoncons/json_decoder.hpp
+++ b/velox/external/jsoncons/json_decoder.hpp
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_DECODER_HPP
+#define JSONCONS_JSON_DECODER_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory> // std::allocator
+#include <system_error>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/json_object.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+namespace facebook::velox::jsoncons {
+
+template <typename Json,typename TempAllocator =std::allocator<char>>
+class json_decoder final : public basic_json_visitor<typename Json::char_type>
+{
+public:
+    using char_type = typename Json::char_type;
+    using typename basic_json_visitor<char_type>::string_view_type;
+
+    using key_value_type = typename Json::key_value_type;
+    using key_type = typename Json::key_type;
+    using array = typename Json::array;
+    using object = typename Json::object;
+    using allocator_type = typename Json::allocator_type;
+    using json_string_allocator = typename key_type::allocator_type;
+    using json_array_allocator = typename array::allocator_type;
+    using json_object_allocator = typename object::allocator_type;
+    using json_byte_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<uint8_t>;
+private:
+
+    enum class structure_type {root_t, array_t, object_t};
+
+    struct structure_info
+    {
+        structure_type type_;
+        std::size_t container_index_{0};
+
+        structure_info(structure_type type, std::size_t offset) noexcept
+            : type_(type), container_index_(offset)
+        {
+        }
+        ~structure_info() = default;
+    };
+
+    using temp_allocator_type = TempAllocator;
+    using stack_item_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<index_key_value<Json>>;
+    using structure_info_allocator_type = typename std::allocator_traits<temp_allocator_type>:: template rebind_alloc<structure_info>;
+ 
+    allocator_type allocator_;
+
+    Json result_;
+
+    std::size_t index_;
+    key_type name_;
+    std::vector<index_key_value<Json>,stack_item_allocator_type> item_stack_;
+    std::vector<structure_info,structure_info_allocator_type> structure_stack_;
+    bool is_valid_;
+
+public:
+    json_decoder(const allocator_type& alloc = allocator_type(), 
+        const temp_allocator_type& temp_alloc = temp_allocator_type())
+        : allocator_(alloc),
+          result_(),
+          index_(0),
+          name_(alloc),
+          item_stack_(alloc),
+          structure_stack_(temp_alloc),
+          is_valid_(false)
+    {
+        item_stack_.reserve(1000);
+        structure_stack_.reserve(100);
+        structure_stack_.emplace_back(structure_type::root_t, 0);
+    }
+
+    json_decoder(temp_allocator_arg_t, 
+        const temp_allocator_type& temp_alloc = temp_allocator_type())
+        : allocator_(),
+          result_(),
+          index_(0),
+          name_(),
+          item_stack_(),
+          structure_stack_(temp_alloc),
+          is_valid_(false)
+    {
+        item_stack_.reserve(1000);
+        structure_stack_.reserve(100);
+        structure_stack_.emplace_back(structure_type::root_t, 0);
+    }
+
+    void reset()
+    {
+        is_valid_ = false;
+        index_ = 0;
+        item_stack_.clear();
+        structure_stack_.clear();
+        structure_stack_.emplace_back(structure_type::root_t, 0);
+    }
+
+    bool is_valid() const
+    {
+        return is_valid_;
+    }
+
+    Json get_result()
+    {
+        JSONCONS_ASSERT(is_valid_);
+        is_valid_ = false;
+        return std::move(result_);
+    }
+
+private:
+
+    void visit_flush() override
+    {
+    }
+
+    bool visit_begin_object(semantic_tag tag, const ser_context&, std::error_code&) override
+    {
+        if (structure_stack_.back().type_ == structure_type::root_t)
+        {
+            index_ = 0;
+            item_stack_.clear();
+            is_valid_ = false;
+        }
+        item_stack_.emplace_back(std::move(name_), index_++, json_object_arg, tag);
+        structure_stack_.emplace_back(structure_type::object_t, item_stack_.size()-1);
+        return true;
+    }
+
+    bool visit_end_object(const ser_context&, std::error_code&) override
+    {
+        JSONCONS_ASSERT(structure_stack_.size() > 0);
+        JSONCONS_ASSERT(structure_stack_.back().type_ == structure_type::object_t);
+        const size_t structure_index = structure_stack_.back().container_index_;
+        JSONCONS_ASSERT(item_stack_.size() > structure_index);
+        const size_t count = item_stack_.size() - (structure_index + 1);
+        auto first = item_stack_.begin() + (structure_index+1);
+
+        if (count > 0)
+        {
+            item_stack_[structure_index].value.template cast<typename Json::object_storage>().value().uninitialized_init(
+                &item_stack_[structure_index+1], count);
+        }
+
+        item_stack_.erase(first, item_stack_.end());
+        structure_stack_.pop_back();
+        if (structure_stack_.back().type_ == structure_type::root_t)
+        {
+            result_.swap(item_stack_.front().value);
+            item_stack_.pop_back();
+            is_valid_ = true;
+            return false;
+        }
+        return true;
+    }
+
+    bool visit_begin_array(semantic_tag tag, const ser_context&, std::error_code&) override
+    {
+        if (structure_stack_.back().type_ == structure_type::root_t)
+        {
+            index_ = 0;
+            item_stack_.clear();
+            is_valid_ = false;
+        }
+        item_stack_.emplace_back(std::move(name_), index_++, json_array_arg, tag);
+        structure_stack_.emplace_back(structure_type::array_t, item_stack_.size()-1);
+        return true;
+    }
+
+    bool visit_end_array(const ser_context&, std::error_code&) override
+    {
+        JSONCONS_ASSERT(structure_stack_.size() > 1);
+        JSONCONS_ASSERT(structure_stack_.back().type_ == structure_type::array_t);
+        const size_t container_index = structure_stack_.back().container_index_;
+        JSONCONS_ASSERT(item_stack_.size() > container_index);
+
+        auto& container = item_stack_[container_index].value;
+
+        const size_t size = item_stack_.size() - (container_index + 1);
+        //std::cout << "size on item stack: " << size << "\n";
+
+        if (size > 0)
+        {
+            container.reserve(size);
+            auto first = item_stack_.begin() + (container_index+1);
+            auto last = first + size;
+            for (auto it = first; it != last; ++it)
+            {
+                container.push_back(std::move((*it).value));
+            }
+            item_stack_.erase(first, item_stack_.end());
+        }
+
+        structure_stack_.pop_back();
+        if (structure_stack_.back().type_ == structure_type::root_t)
+        {
+            result_.swap(item_stack_.front().value);
+            item_stack_.pop_back();
+            is_valid_ = true;
+            return false;
+        }
+        return true;
+    }
+
+    bool visit_key(const string_view_type& name, const ser_context&, std::error_code&) override
+    {
+        name_ = key_type(name.data(),name.length(),allocator_);
+        return true;
+    }
+
+    bool visit_string(const string_view_type& sv, semantic_tag tag, const ser_context&, std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, sv, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(sv, tag, allocator_);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           semantic_tag tag, 
+                           const ser_context&,
+                           std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, byte_string_arg, b, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(byte_string_arg, b, tag, allocator_);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           uint64_t ext_tag, 
+                           const ser_context&,
+                           std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, byte_string_arg, b, ext_tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(byte_string_arg, b, ext_tag, allocator_);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_int64(int64_t value, 
+                        semantic_tag tag, 
+                        const ser_context&,
+                        std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, value, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(value,tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_uint64(uint64_t value, 
+                         semantic_tag tag, 
+                         const ser_context&,
+                         std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, value, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(value,tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_half(uint16_t value, 
+                       semantic_tag tag,   
+                       const ser_context&,
+                       std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, half_arg, value, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(half_arg, value, tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_double(double value, 
+                         semantic_tag tag,   
+                         const ser_context&,
+                         std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, value, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(value, tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_bool(bool value, semantic_tag tag, const ser_context&, std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, value, tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(value, tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+
+    bool visit_null(semantic_tag tag, const ser_context&, std::error_code&) override
+    {
+        switch (structure_stack_.back().type_)
+        {
+            case structure_type::object_t:
+            case structure_type::array_t:
+                item_stack_.emplace_back(std::move(name_), index_++, null_type(), tag);
+                break;
+            case structure_type::root_t:
+                result_ = Json(null_type(), tag);
+                is_valid_ = true;
+                return false;
+        }
+        return true;
+    }
+};
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_DECODER_HPP

--- a/velox/external/jsoncons/json_encoder.hpp
+++ b/velox/external/jsoncons/json_encoder.hpp
@@ -1,0 +1,1634 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_ENCODER_HPP
+#define JSONCONS_JSON_ENCODER_HPP
+
+#include <array> // std::array
+#include <cstddef>
+#include <cstdint>
+#include <cmath> // std::isfinite, std::isnan
+#include <limits> // std::numeric_limits
+#include <memory>
+#include <string>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_error.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace detail {
+
+    inline
+    bool is_control_character(uint32_t c)
+    {
+        return c <= 0x1F || c == 0x7f;
+    }
+
+    inline
+    bool is_non_ascii_codepoint(uint32_t cp)
+    {
+        return cp >= 0x80;
+    }
+
+    template <typename CharT,typename Sink>
+    std::size_t escape_string(const CharT* s, std::size_t length,
+                         bool escape_all_non_ascii, bool escape_solidus,
+                         Sink& sink)
+    {
+        std::size_t count = 0;
+        const CharT* begin = s;
+        const CharT* end = s + length;
+        for (const CharT* it = begin; it != end; ++it)
+        {
+            CharT c = *it;
+            switch (c)
+            {
+                case '\\':
+                    sink.push_back('\\');
+                    sink.push_back('\\');
+                    count += 2;
+                    break;
+                case '"':
+                    sink.push_back('\\');
+                    sink.push_back('\"');
+                    count += 2;
+                    break;
+                case '\b':
+                    sink.push_back('\\');
+                    sink.push_back('b');
+                    count += 2;
+                    break;
+                case '\f':
+                    sink.push_back('\\');
+                    sink.push_back('f');
+                    count += 2;
+                    break;
+                case '\n':
+                    sink.push_back('\\');
+                    sink.push_back('n');
+                    count += 2;
+                    break;
+                case '\r':
+                    sink.push_back('\\');
+                    sink.push_back('r');
+                    count += 2;
+                    break;
+                case '\t':
+                    sink.push_back('\\');
+                    sink.push_back('t');
+                    count += 2;
+                    break;
+                default:
+                    if (escape_solidus && c == '/')
+                    {
+                        sink.push_back('\\');
+                        sink.push_back('/');
+                        count += 2;
+                    }
+                    else if (is_control_character(c) || escape_all_non_ascii)
+                    {
+                        // convert to codepoint
+                        uint32_t cp;
+                        auto r = unicode_traits::to_codepoint(it, end, cp, unicode_traits::conv_flags::strict);
+                        if (r.ec != unicode_traits::conv_errc())
+                        {
+                            JSONCONS_THROW(ser_error(json_errc::illegal_codepoint));
+                        }
+                        it = r.ptr - 1;
+                        if (is_non_ascii_codepoint(cp) || is_control_character(c))
+                        {
+                            if (cp > 0xFFFF)
+                            {
+                                cp -= 0x10000;
+                                uint32_t first = (cp >> 10) + 0xD800;
+                                uint32_t second = ((cp & 0x03FF) + 0xDC00);
+
+                                sink.push_back('\\');
+                                sink.push_back('u');
+                                sink.push_back(jsoncons::detail::to_hex_character(first >> 12 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(first >> 8 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(first >> 4 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(first & 0x000F));
+                                sink.push_back('\\');
+                                sink.push_back('u');
+                                sink.push_back(jsoncons::detail::to_hex_character(second >> 12 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(second >> 8 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(second >> 4 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(second & 0x000F));
+                                count += 12;
+                            }
+                            else
+                            {
+                                sink.push_back('\\');
+                                sink.push_back('u');
+                                sink.push_back(jsoncons::detail::to_hex_character(cp >> 12 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(cp >> 8 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(cp >> 4 & 0x000F));
+                                sink.push_back(jsoncons::detail::to_hex_character(cp & 0x000F));
+                                count += 6;
+                            }
+                        }
+                        else
+                        {
+                            sink.push_back(c);
+                            ++count;
+                        }
+                    }
+                    else
+                    {
+                        sink.push_back(c);
+                        ++count;
+                    }
+                    break;
+            }
+        }
+        return count;
+    }
+
+    inline
+    byte_string_chars_format resolve_byte_string_chars_format(byte_string_chars_format format1,
+                                                              byte_string_chars_format format2,
+                                                              byte_string_chars_format default_format = byte_string_chars_format::base64url)
+    {
+        byte_string_chars_format sink;
+        switch (format1)
+        {
+            case byte_string_chars_format::base16:
+            case byte_string_chars_format::base64:
+            case byte_string_chars_format::base64url:
+                sink = format1;
+                break;
+            default:
+                switch (format2)
+                {
+                    case byte_string_chars_format::base64url:
+                    case byte_string_chars_format::base64:
+                    case byte_string_chars_format::base16:
+                        sink = format2;
+                        break;
+                    default: // base64url
+                    {
+                        sink = default_format;
+                        break;
+                    }
+                }
+                break;
+        }
+        return sink;
+    }
+
+} // namespace detail
+
+    template <typename CharT,typename Sink=jsoncons::stream_sink<CharT>,typename Allocator=std::allocator<char>>
+    class basic_json_encoder final : public basic_json_visitor<CharT>
+    {
+        static const jsoncons::basic_string_view<CharT> null_constant()
+        {
+            static const jsoncons::basic_string_view<CharT> k = JSONCONS_STRING_VIEW_CONSTANT(CharT, "null");
+            return k;
+        }
+        static const jsoncons::basic_string_view<CharT> true_constant()
+        {
+            static const jsoncons::basic_string_view<CharT> k = JSONCONS_STRING_VIEW_CONSTANT(CharT, "true");
+            return k;
+        }
+        static const jsoncons::basic_string_view<CharT> false_constant()
+        {
+            static const jsoncons::basic_string_view<CharT> k = JSONCONS_STRING_VIEW_CONSTANT(CharT, "false");
+            return k;
+        }
+    public:
+        using allocator_type = Allocator;
+        using char_type = CharT;
+        using typename basic_json_visitor<CharT>::string_view_type;
+        using sink_type = Sink;
+        using string_type = typename basic_json_encode_options<CharT>::string_type;
+
+    private:
+        enum class container_type {object, array};
+
+        class encoding_context
+        {
+            container_type type_;
+            std::size_t count_{0};
+            line_split_kind line_splits_;
+            bool indent_before_;
+            bool new_line_after_;
+            std::size_t begin_pos_{0};
+            std::size_t data_pos_{0};
+        public:
+            encoding_context(container_type type, line_split_kind split_lines, bool indent_once,
+                             std::size_t begin_pos, std::size_t data_pos) noexcept
+               : type_(type), count_(0), line_splits_(split_lines), indent_before_(indent_once), new_line_after_(false),
+                 begin_pos_(begin_pos), data_pos_(data_pos)
+            {
+            }
+
+            encoding_context(const encoding_context&) = default;
+            
+            ~encoding_context() = default;
+            
+            encoding_context& operator=(const encoding_context&) = default;
+
+            void set_position(std::size_t pos)
+            {
+                data_pos_ = pos;
+            }
+
+            std::size_t begin_pos() const
+            {
+                return begin_pos_;
+            }
+
+            std::size_t data_pos() const
+            {
+                return data_pos_;
+            }
+
+            std::size_t count() const
+            {
+                return count_;
+            }
+
+            void increment_count()
+            {
+                ++count_;
+            }
+
+            bool new_line_after() const
+            {
+                return new_line_after_;
+            }
+
+            void new_line_after(bool value) 
+            {
+                new_line_after_ = value;
+            }
+
+            bool is_object() const
+            {
+                return type_ == container_type::object;
+            }
+
+            bool is_array() const
+            {
+                return type_ == container_type::array;
+            }
+
+            bool is_same_line() const
+            {
+                return line_splits_ == line_split_kind::same_line;
+            }
+
+            bool is_new_line() const
+            {
+                return line_splits_ == line_split_kind::new_line;
+            }
+
+            bool is_multi_line() const
+            {
+                return line_splits_ == line_split_kind::multi_line;
+            }
+
+            bool is_indent_once() const
+            {
+                return count_ == 0 ? indent_before_ : false;
+            }
+
+        };
+        using encoding_context_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<encoding_context>;
+
+        Sink sink_;
+        basic_json_encode_options<CharT> options_;
+        jsoncons::detail::write_double fp_;
+
+        std::vector<encoding_context,encoding_context_allocator_type> stack_;
+        int indent_amount_;
+        std::size_t column_;
+        std::basic_string<CharT> colon_str_;
+        std::basic_string<CharT> comma_str_;
+        std::basic_string<CharT> open_object_brace_str_;
+        std::basic_string<CharT> close_object_brace_str_;
+        std::basic_string<CharT> open_array_bracket_str_;
+        std::basic_string<CharT> close_array_bracket_str_;
+        int nesting_depth_;
+    public:
+
+        // Noncopyable and nonmoveable
+        basic_json_encoder(const basic_json_encoder&) = delete;
+        basic_json_encoder(basic_json_encoder&&) = delete;
+
+        basic_json_encoder(Sink&& sink, 
+                           const Allocator& alloc = Allocator())
+            : basic_json_encoder(std::forward<Sink>(sink), basic_json_encode_options<CharT>(), alloc)
+        {
+        }
+
+        basic_json_encoder(Sink&& sink, 
+                           const basic_json_encode_options<CharT>& options, 
+                           const Allocator& alloc = Allocator())
+           : sink_(std::forward<Sink>(sink)), 
+             options_(options),
+             fp_(options.float_format(), options.precision()),
+             stack_(alloc),
+             indent_amount_(0), 
+             column_(0),
+             nesting_depth_(0)
+        {
+            switch (options.spaces_around_colon())
+            {
+                case spaces_option::space_after:
+                    colon_str_ = std::basic_string<CharT>({':',' '});
+                    break;
+                case spaces_option::space_before:
+                    colon_str_ = std::basic_string<CharT>({' ',':'});
+                    break;
+                case spaces_option::space_before_and_after:
+                    colon_str_ = std::basic_string<CharT>({' ',':',' '});
+                    break;
+                default:
+                    colon_str_.push_back(':');
+                    break;
+            }
+            switch (options.spaces_around_comma())
+            {
+                case spaces_option::space_after:
+                    comma_str_ = std::basic_string<CharT>({',',' '});
+                    break;
+                case spaces_option::space_before:
+                    comma_str_ = std::basic_string<CharT>({' ',','});
+                    break;
+                case spaces_option::space_before_and_after:
+                    comma_str_ = std::basic_string<CharT>({' ',',',' '});
+                    break;
+                default:
+                    comma_str_.push_back(',');
+                    break;
+            }
+            if (options.pad_inside_object_braces())
+            {
+                open_object_brace_str_ = std::basic_string<CharT>({'{', ' '});
+                close_object_brace_str_ = std::basic_string<CharT>({' ', '}'});
+            }
+            else
+            {
+                open_object_brace_str_.push_back('{');
+                close_object_brace_str_.push_back('}');
+            }
+            if (options.pad_inside_array_brackets())
+            {
+                open_array_bracket_str_ = std::basic_string<CharT>({'[', ' '});
+                close_array_bracket_str_ = std::basic_string<CharT>({' ', ']'});
+            }
+            else
+            {
+                open_array_bracket_str_.push_back('[');
+                close_array_bracket_str_.push_back(']');
+            }
+        }
+
+        ~basic_json_encoder() noexcept
+        {
+            JSONCONS_TRY
+            {
+                sink_.flush();
+            }
+            JSONCONS_CATCH(...)
+            {
+            }
+        }
+
+        basic_json_encoder& operator=(const basic_json_encoder&) = delete;
+        basic_json_encoder& operator=(basic_json_encoder&&) = delete;
+
+        void reset()
+        {
+            stack_.clear();
+            indent_amount_ = 0;
+            column_ = 0;
+            nesting_depth_ = 0;
+        }
+
+        void reset(Sink&& sink)
+        {
+            sink_ = std::move(sink);
+            reset();
+        }
+
+    private:
+        // Implementing methods
+        void visit_flush() final
+        {
+            sink_.flush();
+        }
+
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code& ec) final
+        {
+            if (JSONCONS_UNLIKELY(++nesting_depth_ > options_.max_nesting_depth()))
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return false;
+            } 
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.append(comma_str_.data(),comma_str_.length());
+                column_ += comma_str_.length();
+            }
+
+            if (!stack_.empty()) // object or array
+            {
+                if (stack_.back().is_object())
+                {
+                    switch (options_.object_object_line_splits())
+                    {
+                        case line_split_kind::same_line:
+                        case line_split_kind::new_line:
+                            if (column_ >= options_.line_length_limit())
+                            {
+                                break_line();
+                            }
+                            break;
+                        default: // multi_line
+                            break;
+                    }
+                    stack_.emplace_back(container_type::object,options_.object_object_line_splits(), false,
+                                        column_, column_+open_object_brace_str_.length());
+                }
+                else // array
+                {
+                    switch (options_.array_object_line_splits())
+                    {
+                        case line_split_kind::same_line:
+                            if (column_ >= options_.line_length_limit())
+                            {
+                                //stack_.back().new_line_after(true);
+                                new_line();
+                            }
+                            break;
+                        case line_split_kind::new_line:
+                            stack_.back().new_line_after(true);
+                            new_line();
+                            break;
+                        default: // multi_line
+                            stack_.back().new_line_after(true);
+                            new_line();
+                            break;
+                    }
+                    stack_.emplace_back(container_type::object,options_.array_object_line_splits(), false,
+                                        column_, column_+open_object_brace_str_.length());
+                }
+            }
+            else 
+            {
+                stack_.emplace_back(container_type::object, options_.line_splits(), false,
+                                    column_, column_+open_object_brace_str_.length());
+            }
+            indent();
+            
+            sink_.append(open_object_brace_str_.data(), open_object_brace_str_.length());
+            column_ += open_object_brace_str_.length();
+            return true;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code&) final
+        {
+            JSONCONS_ASSERT(!stack_.empty());
+            --nesting_depth_;
+
+            unindent();
+            if (stack_.back().new_line_after())
+            {
+                new_line();
+            }
+            stack_.pop_back();
+            sink_.append(close_object_brace_str_.data(), close_object_brace_str_.length());
+            column_ += close_object_brace_str_.length();
+
+            end_value();
+            return true;
+        }
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code& ec) final
+        {
+            if (JSONCONS_UNLIKELY(++nesting_depth_ > options_.max_nesting_depth()))
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return false;
+            } 
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.append(comma_str_.data(),comma_str_.length());
+                column_ += comma_str_.length();
+            }
+            if (!stack_.empty())
+            {
+                if (stack_.back().is_object())
+                {
+                    switch (options_.object_array_line_splits())
+                    {
+                        case line_split_kind::same_line:
+                            stack_.emplace_back(container_type::array,options_.object_array_line_splits(),false,
+                                                column_, column_ + open_array_bracket_str_.length());
+                            break;
+                        case line_split_kind::new_line:
+                        {
+                            stack_.emplace_back(container_type::array,options_.object_array_line_splits(),true,
+                                                column_, column_+open_array_bracket_str_.length());
+                            break;
+                        }
+                        default: // multi_line
+                            stack_.emplace_back(container_type::array,options_.object_array_line_splits(),true,
+                                                column_, column_+open_array_bracket_str_.length());
+                            break;
+                    }
+                }
+                else // array
+                {
+                    switch (options_.array_array_line_splits())
+                    {
+                        case line_split_kind::same_line:
+                            if (stack_.back().is_multi_line())
+                            {
+                                stack_.back().new_line_after(true);
+                                new_line();
+                            }
+                            stack_.emplace_back(container_type::array,options_.array_array_line_splits(), false,
+                                                column_, column_+open_array_bracket_str_.length());
+                            break;
+                        case line_split_kind::new_line:
+                            stack_.back().new_line_after(true);
+                            new_line();
+                            stack_.emplace_back(container_type::array,options_.array_array_line_splits(), false,
+                                                column_, column_+open_array_bracket_str_.length());
+                            break;
+                        default: // multi_line
+                            stack_.back().new_line_after(true);
+                            new_line();
+                            stack_.emplace_back(container_type::array,options_.array_array_line_splits(), false,
+                                                column_, column_+open_array_bracket_str_.length());
+                            //new_line();
+                            break;
+                    }
+                }
+            }
+            else 
+            {
+                stack_.emplace_back(container_type::array, options_.line_splits(), false,
+                                    column_, column_+open_array_bracket_str_.length());
+            }
+            indent();
+            sink_.append(open_array_bracket_str_.data(), open_array_bracket_str_.length());
+            column_ += open_array_bracket_str_.length();
+            return true;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code&) final
+        {
+            JSONCONS_ASSERT(!stack_.empty());
+            --nesting_depth_;
+
+            unindent();
+            if (stack_.back().new_line_after())
+            {
+                new_line();
+            }
+            stack_.pop_back();
+            sink_.append(close_array_bracket_str_.data(), close_array_bracket_str_.length());
+            column_ += close_array_bracket_str_.length();
+            end_value();
+            return true;
+        }
+
+        bool visit_key(const string_view_type& name, const ser_context&, std::error_code&) final
+        {
+            JSONCONS_ASSERT(!stack_.empty());
+            if (stack_.back().count() > 0)
+            {
+                sink_.append(comma_str_.data(),comma_str_.length());
+                column_ += comma_str_.length();
+            }
+
+            if (stack_.back().is_multi_line())
+            {
+                stack_.back().new_line_after(true);
+                new_line();
+            }
+            else if (stack_.back().count() > 0 && column_ >= options_.line_length_limit())
+            {
+                //stack_.back().new_line_after(true);
+                new_line(stack_.back().data_pos());
+            }
+
+            if (stack_.back().count() == 0)
+            {
+                stack_.back().set_position(column_);
+            }
+            sink_.push_back('\"');
+            std::size_t length = jsoncons::detail::escape_string(name.data(), name.length(),options_.escape_all_non_ascii(),options_.escape_solidus(),sink_);
+            sink_.push_back('\"');
+            sink_.append(colon_str_.data(),colon_str_.length());
+            column_ += (length+2+colon_str_.length());
+            return true;
+        }
+
+        bool visit_null(semantic_tag, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+
+            sink_.append(null_constant().data(), null_constant().size());
+            column_ += null_constant().size();
+
+            end_value();
+            return true;
+        }
+
+        bool visit_string(const string_view_type& sv, semantic_tag tag, const ser_context& context, std::error_code& ec) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+            
+            write_string(sv, tag, context, ec);
+
+            end_value();
+            return true;
+        }
+
+        bool write_string(const string_view_type& sv, semantic_tag tag, const ser_context&, std::error_code&) 
+        {
+            switch (tag)
+            {
+                case semantic_tag::bigint:
+                    write_bigint_value(sv);
+                    break;
+                case semantic_tag::bigdec:
+                {
+                    // output lossless number
+                    if (options_.bignum_format() == bignum_format_kind::raw)
+                    {
+                        write_bigint_value(sv);
+                break;
+            }
+            JSONCONS_FALLTHROUGH;
+        }
+                default:
+                {
+                    sink_.push_back('\"');
+                    std::size_t length = jsoncons::detail::escape_string(sv.data(), sv.length(),options_.escape_all_non_ascii(),options_.escape_solidus(),sink_);
+                    sink_.push_back('\"');
+                    column_ += (length+2);
+                    break;
+                }
+            }
+
+            return true;
+        }
+
+        bool visit_byte_string(const byte_string_view& b, 
+                                  semantic_tag tag,
+                                  const ser_context&,
+                                  std::error_code&) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+
+            byte_string_chars_format encoding_hint;
+            switch (tag)
+            {
+                case semantic_tag::base16:
+                    encoding_hint = byte_string_chars_format::base16;
+                    break;
+                case semantic_tag::base64:
+                    encoding_hint = byte_string_chars_format::base64;
+                    break;
+                case semantic_tag::base64url:
+                    encoding_hint = byte_string_chars_format::base64url;
+                    break;
+                default:
+                    encoding_hint = byte_string_chars_format::none;
+                    break;
+            }
+
+            byte_string_chars_format format = jsoncons::detail::resolve_byte_string_chars_format(options_.byte_string_format(), 
+                                                                                                 encoding_hint, 
+                                                                                                 byte_string_chars_format::base64url);
+            switch (format)
+            {
+                case byte_string_chars_format::base16:
+                {
+                    sink_.push_back('\"');
+                    std::size_t length = encode_base16(b.begin(),b.end(),sink_);
+                    sink_.push_back('\"');
+                    column_ += (length + 2);
+                    break;
+                }
+                case byte_string_chars_format::base64:
+                {
+                    sink_.push_back('\"');
+                    std::size_t length = encode_base64(b.begin(), b.end(), sink_);
+                    sink_.push_back('\"');
+                    column_ += (length + 2);
+                    break;
+                }
+                case byte_string_chars_format::base64url:
+                {
+                    sink_.push_back('\"');
+                    std::size_t length = encode_base64url(b.begin(),b.end(),sink_);
+                    sink_.push_back('\"');
+                    column_ += (length + 2);
+                    break;
+                }
+                default:
+                {
+                    JSONCONS_UNREACHABLE();
+                }
+            }
+
+            end_value();
+            return true;
+        }
+
+        bool visit_double(double value, 
+                             semantic_tag,
+                             const ser_context& context,
+                             std::error_code& ec) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+
+            if (!std::isfinite(value))
+            {
+                if ((std::isnan)(value))
+                {
+                    if (options_.enable_nan_to_num())
+                    {
+                        sink_.append(options_.nan_to_num().data(), options_.nan_to_num().length());
+                        column_ += options_.nan_to_num().length();
+                    }
+                    else if (options_.enable_nan_to_str())
+                    {
+                        write_string(options_.nan_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                        column_ += null_constant().size();
+                    }
+                }
+                else if (value == std::numeric_limits<double>::infinity())
+                {
+                    if (options_.enable_inf_to_num())
+                    {
+                        sink_.append(options_.inf_to_num().data(), options_.inf_to_num().length());
+                        column_ += options_.inf_to_num().length();
+                    }
+                    else if (options_.enable_inf_to_str())
+                    {
+                        write_string(options_.inf_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                        column_ += null_constant().size();
+                    }
+                }
+                else
+                {
+                    if (options_.enable_neginf_to_num())
+                    {
+                        sink_.append(options_.neginf_to_num().data(), options_.neginf_to_num().length());
+                        column_ += options_.neginf_to_num().length();
+                    }
+                    else if (options_.enable_neginf_to_str())
+                    {
+                        write_string(options_.neginf_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                        column_ += null_constant().size();
+                    }
+                }
+            }
+            else
+            {
+                std::size_t length = fp_(value, sink_);
+                column_ += length;
+            }
+
+            end_value();
+            return true;
+        }
+
+        bool visit_int64(int64_t value, 
+                            semantic_tag,
+                            const ser_context&,
+                            std::error_code&) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+            std::size_t length = jsoncons::detail::from_integer(value, sink_);
+            column_ += length;
+            end_value();
+            return true;
+        }
+
+        bool visit_uint64(uint64_t value, 
+                             semantic_tag, 
+                             const ser_context&,
+                             std::error_code&) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+            std::size_t length = jsoncons::detail::from_integer(value, sink_);
+            column_ += length;
+            end_value();
+            return true;
+        }
+
+        bool visit_bool(bool value, semantic_tag, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty()) 
+            {
+                if (stack_.back().is_array())
+                {
+                    begin_scalar_value();
+                }
+                if (!stack_.back().is_multi_line() && column_ >= options_.line_length_limit())
+                {
+                    break_line();
+                }
+            }
+
+            if (value)
+            {
+                sink_.append(true_constant().data(), true_constant().size());
+                column_ += true_constant().size();
+            }
+            else
+            {
+                sink_.append(false_constant().data(), false_constant().size());
+                column_ += false_constant().size();
+            }
+
+            end_value();
+            return true;
+        }
+
+        void begin_scalar_value()
+        {
+            if (!stack_.empty())
+            {
+                if (stack_.back().count() > 0)
+                {
+                    sink_.append(comma_str_.data(),comma_str_.length());
+                    column_ += comma_str_.length();
+                }
+                if (stack_.back().is_multi_line() || stack_.back().is_indent_once())
+                {
+                    stack_.back().new_line_after(true);
+                    new_line();
+                }
+            }
+        }
+
+        void write_bigint_value(const string_view_type& sv)
+        {
+            switch (options_.bignum_format())
+            {
+                case bignum_format_kind::raw:
+                {
+                    sink_.append(sv.data(),sv.size());
+                    column_ += sv.size();
+                    break;
+                }
+                case bignum_format_kind::base64:
+                {
+                    bigint n = bigint::from_string(sv.data(), sv.length());
+                    bool is_neg = n < 0;
+                    if (is_neg)
+                    {
+                        n = - n -1;
+                    }
+                    int signum;
+                    std::vector<uint8_t> v;
+                    n.write_bytes_be(signum, v);
+
+                    sink_.push_back('\"');
+                    if (is_neg)
+                    {
+                        sink_.push_back('~');
+                        ++column_;
+                    }
+                    std::size_t length = encode_base64(v.begin(), v.end(), sink_);
+                    sink_.push_back('\"');
+                    column_ += (length+2);
+                    break;
+                }
+                case bignum_format_kind::base64url:
+                {
+                    bigint n = bigint::from_string(sv.data(), sv.length());
+                    bool is_neg = n < 0;
+                    if (is_neg)
+                    {
+                        n = - n -1;
+                    }
+                    int signum;
+                    std::vector<uint8_t> v;
+                    n.write_bytes_be(signum, v);
+
+                    sink_.push_back('\"');
+                    if (is_neg)
+                    {
+                        sink_.push_back('~');
+                        ++column_;
+                    }
+                    std::size_t length = encode_base64url(v.begin(), v.end(), sink_);
+                    sink_.push_back('\"');
+                    column_ += (length+2);
+                    break;
+                }
+                default:
+                {
+                    sink_.push_back('\"');
+                    sink_.append(sv.data(),sv.size());
+                    sink_.push_back('\"');
+                    column_ += (sv.size() + 2);
+                    break;
+                }
+            }
+        }
+
+        void end_value()
+        {
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+        }
+
+        void indent()
+        {
+            indent_amount_ += static_cast<int>(options_.indent_size());
+        }
+
+        void unindent()
+        {
+            indent_amount_ -= static_cast<int>(options_.indent_size());
+        }
+
+        void new_line()
+        {
+            sink_.append(options_.new_line_chars().data(),options_.new_line_chars().length());
+            for (int i = 0; i < indent_amount_; ++i)
+            {
+                sink_.push_back(' ');
+            }
+            column_ = indent_amount_;
+        }
+
+        void new_line(std::size_t len)
+        {
+            sink_.append(options_.new_line_chars().data(),options_.new_line_chars().length());
+            for (std::size_t i = 0; i < len; ++i)
+            {
+                sink_.push_back(' ');
+            }
+            column_ = len;
+        }
+
+        void break_line()
+        {
+            stack_.back().new_line_after(true);
+            new_line();
+        }
+    };
+
+    template <typename CharT,typename Sink=jsoncons::stream_sink<CharT>,typename Allocator=std::allocator<char>>
+    class basic_compact_json_encoder final : public basic_json_visitor<CharT>
+    {
+        static const std::array<CharT, 4>& null_constant()
+        {
+            static constexpr std::array<CharT,4> k{{'n','u','l','l'}};
+            return k;
+        }
+        static const std::array<CharT, 4>& true_constant()
+        {
+            static constexpr std::array<CharT,4> k{{'t','r','u','e'}};
+            return k;
+        }
+        static const std::array<CharT, 5>& false_constant()
+        {
+            static constexpr std::array<CharT,5> k{{'f','a','l','s','e'}};
+            return k;
+        }
+    public:
+        using allocator_type = Allocator;
+        using char_type = CharT;
+        using typename basic_json_visitor<CharT>::string_view_type;
+        using sink_type = Sink;
+        using string_type = typename basic_json_encode_options<CharT>::string_type;
+
+    private:
+        enum class container_type {object, array};
+
+        class encoding_context
+        {
+            container_type type_;
+            std::size_t count_;
+        public:
+            encoding_context(container_type type) noexcept
+               : type_(type), count_(0)
+            {
+            }
+
+            std::size_t count() const
+            {
+                return count_;
+            }
+
+            void increment_count()
+            {
+                ++count_;
+            }
+
+            bool is_array() const
+            {
+                return type_ == container_type::array;
+            }
+        };
+        using encoding_context_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<encoding_context>;
+
+        Sink sink_;
+        basic_json_encode_options<CharT> options_;
+        jsoncons::detail::write_double fp_;
+        std::vector<encoding_context,encoding_context_allocator_type> stack_;
+        int nesting_depth_;
+    public:
+
+        // Noncopyable and nonmoveable
+        basic_compact_json_encoder(const basic_compact_json_encoder&) = delete;
+        basic_compact_json_encoder(basic_compact_json_encoder&&) = delete;
+
+        basic_compact_json_encoder(Sink&& sink, 
+            const Allocator& alloc = Allocator())
+            : basic_compact_json_encoder(std::forward<Sink>(sink), basic_json_encode_options<CharT>(), alloc)
+        {
+        }
+
+        basic_compact_json_encoder(Sink&& sink, 
+            const basic_json_encode_options<CharT>& options, 
+            const Allocator& alloc = Allocator())
+           : sink_(std::forward<Sink>(sink)),
+             options_(options),
+             fp_(options.float_format(), options.precision()),
+             stack_(alloc),
+             nesting_depth_(0)          
+        {
+        }
+
+        ~basic_compact_json_encoder() noexcept
+        {
+            JSONCONS_TRY
+            {
+                sink_.flush();
+            }
+            JSONCONS_CATCH(...)
+            {
+            }
+        }
+
+        basic_compact_json_encoder& operator=(const basic_compact_json_encoder&) = delete;
+        basic_compact_json_encoder& operator=(basic_compact_json_encoder&&) = delete;
+
+        void reset()
+        {
+            stack_.clear();
+            nesting_depth_ = 0;
+        }
+
+        void reset(Sink&& sink)
+        {
+            sink_ = std::move(sink);
+            reset();
+        }
+
+    private:
+        // Implementing methods
+        void visit_flush() final
+        {
+            sink_.flush();
+        }
+
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code& ec) final
+        {
+            if (JSONCONS_UNLIKELY(++nesting_depth_ > options_.max_nesting_depth()))
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return false;
+            } 
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            stack_.emplace_back(container_type::object);
+            sink_.push_back('{');
+            return true;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code&) final
+        {
+            JSONCONS_ASSERT(!stack_.empty());
+            --nesting_depth_;
+
+            stack_.pop_back();
+            sink_.push_back('}');
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code& ec) final
+        {
+            if (JSONCONS_UNLIKELY(++nesting_depth_ > options_.max_nesting_depth()))
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return false;
+            } 
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+            stack_.emplace_back(container_type::array);
+            sink_.push_back('[');
+            return true;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code&) final
+        {
+            JSONCONS_ASSERT(!stack_.empty());
+            --nesting_depth_;
+
+            stack_.pop_back();
+            sink_.push_back(']');
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool visit_key(const string_view_type& name, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            sink_.push_back('\"');
+            jsoncons::detail::escape_string(name.data(), name.length(),options_.escape_all_non_ascii(),options_.escape_solidus(),sink_);
+            sink_.push_back('\"');
+            sink_.push_back(':');
+            return true;
+        }
+
+        bool visit_null(semantic_tag, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            sink_.append(null_constant().data(), null_constant().size());
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        void write_bigint_value(const string_view_type& sv)
+        {
+            switch (options_.bignum_format())
+            {
+                case bignum_format_kind::raw:
+                {
+                    sink_.append(sv.data(),sv.size());
+                    break;
+                }
+                case bignum_format_kind::base64:
+                {
+                    bigint n = bigint::from_string(sv.data(), sv.length());
+                    bool is_neg = n < 0;
+                    if (is_neg)
+                    {
+                        n = - n -1;
+                    }
+                    int signum;
+                    std::vector<uint8_t> v;
+                    n.write_bytes_be(signum, v);
+
+                    sink_.push_back('\"');
+                    if (is_neg)
+                    {
+                        sink_.push_back('~');
+                    }
+                    encode_base64(v.begin(), v.end(), sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+                case bignum_format_kind::base64url:
+                {
+                    bigint n = bigint::from_string(sv.data(), sv.length());
+                    bool is_neg = n < 0;
+                    if (is_neg)
+                    {
+                        n = - n -1;
+                    }
+                    int signum;
+                    std::vector<uint8_t> v;
+                    n.write_bytes_be(signum, v);
+
+                    sink_.push_back('\"');
+                    if (is_neg)
+                    {
+                        sink_.push_back('~');
+                    }
+                    encode_base64url(v.begin(), v.end(), sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+                default:
+                {
+                    sink_.push_back('\"');
+                    sink_.append(sv.data(),sv.size());
+                    sink_.push_back('\"');
+                    break;
+                }
+            }
+        }
+
+        bool visit_string(const string_view_type& sv, semantic_tag tag, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            switch (tag)
+            {
+                case semantic_tag::bigint:
+                    write_bigint_value(sv);
+                    break;
+                case semantic_tag::bigdec:
+                {
+                    // output lossless number
+                    if (options_.bignum_format() == bignum_format_kind::raw)
+                    {
+                        write_bigint_value(sv);
+                        break;
+            }
+            JSONCONS_FALLTHROUGH;
+        }
+                default:
+                {
+                    sink_.push_back('\"');
+                    jsoncons::detail::escape_string(sv.data(), sv.length(),options_.escape_all_non_ascii(),options_.escape_solidus(),sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+            }
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool write_string(const string_view_type& sv, semantic_tag tag, const ser_context&, std::error_code&) 
+        {
+            switch (tag)
+            {
+                case semantic_tag::bigint:
+                    write_bigint_value(sv);
+                    break;
+                case semantic_tag::bigdec:
+                {
+                    // output lossless number
+                    if (options_.bignum_format() == bignum_format_kind::raw)
+                    {
+                        write_bigint_value(sv);
+                        break;
+            }
+            JSONCONS_FALLTHROUGH;
+        }
+                default:
+                {
+                    sink_.push_back('\"');
+                    jsoncons::detail::escape_string(sv.data(), sv.length(),options_.escape_all_non_ascii(),options_.escape_solidus(),sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+            }
+            return true;
+        }
+
+        bool visit_byte_string(const byte_string_view& b, 
+                                  semantic_tag tag,
+                                  const ser_context&,
+                                  std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            byte_string_chars_format encoding_hint;
+            switch (tag)
+            {
+                case semantic_tag::base16:
+                    encoding_hint = byte_string_chars_format::base16;
+                    break;
+                case semantic_tag::base64:
+                    encoding_hint = byte_string_chars_format::base64;
+                    break;
+                case semantic_tag::base64url:
+                    encoding_hint = byte_string_chars_format::base64url;
+                    break;
+                default:
+                    encoding_hint = byte_string_chars_format::none;
+                    break;
+            }
+
+            byte_string_chars_format format = jsoncons::detail::resolve_byte_string_chars_format(options_.byte_string_format(), 
+                                                                                       encoding_hint, 
+                                                                                       byte_string_chars_format::base64url);
+            switch (format)
+            {
+                case byte_string_chars_format::base16:
+                {
+                    sink_.push_back('\"');
+                    encode_base16(b.begin(),b.end(),sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+                case byte_string_chars_format::base64:
+                {
+                    sink_.push_back('\"');
+                    encode_base64(b.begin(), b.end(), sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+                case byte_string_chars_format::base64url:
+                {
+                    sink_.push_back('\"');
+                    encode_base64url(b.begin(),b.end(),sink_);
+                    sink_.push_back('\"');
+                    break;
+                }
+                default:
+                {
+                    JSONCONS_UNREACHABLE();
+                }
+            }
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool visit_double(double value, 
+                             semantic_tag,
+                             const ser_context& context,
+                             std::error_code& ec) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            if (JSONCONS_UNLIKELY(!std::isfinite(value)))
+            {
+                if ((std::isnan)(value))
+                {
+                    if (options_.enable_nan_to_num())
+                    {
+                        sink_.append(options_.nan_to_num().data(), options_.nan_to_num().length());
+                    }
+                    else if (options_.enable_nan_to_str())
+                    {
+                        write_string(options_.nan_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                    }
+                }
+                else if (value == std::numeric_limits<double>::infinity())
+                {
+                    if (options_.enable_inf_to_num())
+                    {
+                        sink_.append(options_.inf_to_num().data(), options_.inf_to_num().length());
+                    }
+                    else if (options_.enable_inf_to_str())
+                    {
+                        write_string(options_.inf_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                    }
+                }
+                else 
+                {
+                    if (options_.enable_neginf_to_num())
+                    {
+                        sink_.append(options_.neginf_to_num().data(), options_.neginf_to_num().length());
+                    }
+                    else if (options_.enable_neginf_to_str())
+                    {
+                        write_string(options_.neginf_to_str(), semantic_tag::none, context, ec);
+                    }
+                    else
+                    {
+                        sink_.append(null_constant().data(), null_constant().size());
+                    }
+                }
+            }
+            else
+            {
+                fp_(value, sink_);
+            }
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool visit_int64(int64_t value, 
+                            semantic_tag,
+                            const ser_context&,
+                            std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+            jsoncons::detail::from_integer(value, sink_);
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool visit_uint64(uint64_t value, 
+                             semantic_tag, 
+                             const ser_context&,
+                             std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+            jsoncons::detail::from_integer(value, sink_);
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+
+        bool visit_bool(bool value, semantic_tag, const ser_context&, std::error_code&) final
+        {
+            if (!stack_.empty() && stack_.back().is_array() && stack_.back().count() > 0)
+            {
+                sink_.push_back(',');
+            }
+
+            if (value)
+            {
+                sink_.append(true_constant().data(), true_constant().size());
+            }
+            else
+            {
+                sink_.append(false_constant().data(), false_constant().size());
+            }
+
+            if (!stack_.empty())
+            {
+                stack_.back().increment_count();
+            }
+            return true;
+        }
+    };
+
+    using json_stream_encoder = basic_json_encoder<char,jsoncons::stream_sink<char>>;
+    using wjson_stream_encoder = basic_json_encoder<wchar_t,jsoncons::stream_sink<wchar_t>>;
+    using compact_json_stream_encoder = basic_compact_json_encoder<char,jsoncons::stream_sink<char>>;
+    using compact_wjson_stream_encoder = basic_compact_json_encoder<wchar_t,jsoncons::stream_sink<wchar_t>>;
+
+    using json_string_encoder = basic_json_encoder<char,jsoncons::string_sink<std::string>>;
+    using wjson_string_encoder = basic_json_encoder<wchar_t,jsoncons::string_sink<std::wstring>>;
+    using compact_json_string_encoder = basic_compact_json_encoder<char,jsoncons::string_sink<std::string>>;
+    using compact_wjson_string_encoder = basic_compact_json_encoder<wchar_t,jsoncons::string_sink<std::wstring>>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_ENCODER_HPP

--- a/velox/external/jsoncons/json_error.hpp
+++ b/velox/external/jsoncons/json_error.hpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_ERROR_HPP
+#define JSONCONS_JSON_ERROR_HPP
+
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    enum class json_errc
+    {
+        success = 0,
+        unexpected_eof = 1,
+        source_error,
+        syntax_error,
+        extra_character,
+        max_nesting_depth_exceeded,
+        single_quote,
+        illegal_character_in_string,
+        extra_comma,
+        expected_key,
+        expected_value,
+        invalid_value,
+        expected_colon,
+        illegal_control_character,
+        illegal_escaped_character,
+        expected_codepoint_surrogate_pair,
+        invalid_hex_escape_sequence,
+        invalid_unicode_escape_sequence,
+        leading_zero,
+        invalid_number,
+        expected_comma_or_rbrace,
+        expected_comma_or_rbracket,
+        unexpected_rbracket,
+        unexpected_rbrace,
+        illegal_comment,
+        expected_continuation_byte,
+        over_long_utf8_sequence,
+        illegal_codepoint,
+        illegal_surrogate_value,
+        unpaired_high_surrogate,
+        illegal_unicode_character
+    };
+
+    class json_error_category_impl
+       : public std::error_category
+    {
+    public:
+        const char* name() const noexcept final
+        {
+            return "jsoncons/json";
+        }
+        std::string message(int ev) const final
+        {
+            switch (static_cast<json_errc>(ev))
+            {
+                case json_errc::unexpected_eof:
+                    return "Unexpected end of file";
+                case json_errc::source_error:
+                    return "Source error";
+                case json_errc::syntax_error:
+                    return "JSON syntax_error";
+                case json_errc::extra_character:
+                    return "Unexpected non-whitespace character after JSON text";
+                case json_errc::max_nesting_depth_exceeded:
+                    return "Data item nesting exceeds limit in options";
+                case json_errc::single_quote:
+                    return "JSON strings cannot be quoted with single quotes";
+                case json_errc::illegal_character_in_string:
+                    return "Illegal character in string";
+                case json_errc::extra_comma:
+                    return "Extra comma";
+                case json_errc::expected_key:
+                    return "Expected object member key";
+                case json_errc::expected_value:
+                    return "Expected value";
+                case json_errc::invalid_value:
+                    return "Invalid value";
+                case json_errc::expected_colon:
+                    return "Expected name separator ':'";
+                case json_errc::illegal_control_character:
+                    return "Illegal control character in string";
+                case json_errc::illegal_escaped_character:
+                    return "Illegal escaped character in string";
+                case json_errc::expected_codepoint_surrogate_pair:
+                    return "Invalid codepoint, expected another \\u token to begin the second half of a codepoint surrogate pair.";
+                case json_errc::invalid_hex_escape_sequence:
+                    return "Invalid codepoint, expected hexadecimal digit.";
+                case json_errc::invalid_unicode_escape_sequence:
+                    return "Invalid codepoint, expected four hexadecimal digits.";
+                case json_errc::leading_zero:
+                    return "A number cannot have a leading zero";
+                case json_errc::invalid_number:
+                    return "Invalid number";
+                case json_errc::expected_comma_or_rbrace:
+                    return "Expected comma or right brace '}'";
+                case json_errc::expected_comma_or_rbracket:
+                    return "Expected comma or right bracket ']'";
+                case json_errc::unexpected_rbrace:
+                    return "Unexpected right brace '}'";
+                case json_errc::unexpected_rbracket:
+                    return "Unexpected right bracket ']'";
+                case json_errc::illegal_comment:
+                    return "Illegal comment";
+                case json_errc::expected_continuation_byte:
+                    return "Expected continuation byte";
+                case json_errc::over_long_utf8_sequence:
+                    return "Over long UTF-8 sequence";
+                case json_errc::illegal_codepoint:
+                    return "Illegal codepoint (>= 0xd800 && <= 0xdfff)";
+                case json_errc::illegal_surrogate_value:
+                    return "UTF-16 surrogate values are illegal in UTF-32";
+                case json_errc::unpaired_high_surrogate:
+                    return "Expected low surrogate following the high surrogate";
+                case json_errc::illegal_unicode_character:
+                    return "Illegal unicode character";
+                default:
+                    return "Unknown JSON parser error";
+                }
+        }
+    };
+
+    inline
+    const std::error_category& json_error_category()
+    {
+      static json_error_category_impl instance;
+      return instance;
+    }
+
+    inline 
+    std::error_code make_error_code(json_errc result)
+    {
+        return std::error_code(static_cast<int>(result),json_error_category());
+    }
+
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::json_errc> : public true_type
+    {
+    };
+
+} // namespace std
+
+#endif // JSONCONS_JSON_ERROR_HPP

--- a/velox/external/jsoncons/json_exception.hpp
+++ b/velox/external/jsoncons/json_exception.hpp
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_EXCEPTION_HPP
+#define JSONCONS_JSON_EXCEPTION_HPP
+
+#include <cstddef>
+#include <exception>
+#include <stdexcept>
+#include <string> // std::string
+#include <system_error> // std::error_code
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp" // unicode_traits::convert
+
+namespace facebook::velox::jsoncons {
+
+    // json_exception
+
+    class json_exception
+    {
+    public:
+        virtual ~json_exception() = default;
+        virtual const char* what() const noexcept = 0;
+    };
+
+    // json_runtime_error
+
+    template <typename Base,typename Enable = void>
+    class json_runtime_error
+    {
+    };
+
+    template <typename Base>
+    class json_runtime_error<Base,
+                             typename std::enable_if<std::is_convertible<Base*,std::exception*>::value &&
+                                                     extension_traits::is_constructible_from_string<Base>::value>::type> 
+        : public Base, public virtual json_exception
+    {
+    public:
+        json_runtime_error(const std::string& s) noexcept
+            : Base(s)
+        {
+        }
+        ~json_runtime_error() noexcept
+        {
+        }
+        const char* what() const noexcept override
+        {
+            return Base::what();
+        }
+    };
+
+    class key_not_found : public std::out_of_range, public virtual json_exception
+    {
+        std::string name_;
+        mutable std::string what_;
+    public:
+        template <typename CharT>
+        explicit key_not_found(const CharT* key, std::size_t length) noexcept
+            : std::out_of_range("Key not found")
+        {
+            JSONCONS_TRY
+            {
+                unicode_traits::convert(key, length, name_,
+                                 unicode_traits::conv_flags::strict);
+            }
+            JSONCONS_CATCH(...)
+            {
+            }
+        }
+
+        virtual ~key_not_found() noexcept
+        {
+        }
+
+        const char* what() const noexcept override
+        {
+            if (what_.empty())
+            {
+                JSONCONS_TRY
+                {
+                    what_.append(std::out_of_range::what());
+                    what_.append(": '");
+                    what_.append(name_);
+                    what_.append("'");
+                    return what_.c_str();
+                }
+                JSONCONS_CATCH(...)
+                {
+                    return std::out_of_range::what();
+                }
+            }
+            else
+            {
+                return what_.c_str();
+            }
+        }
+    };
+
+    class not_an_object : public std::runtime_error, public virtual json_exception
+    {
+        std::string name_;
+        mutable std::string what_;
+    public:
+        template <typename CharT>
+        explicit not_an_object(const CharT* key, std::size_t length) noexcept
+            : std::runtime_error("Attempting to access a member of a value that is not an object")
+        {
+            JSONCONS_TRY
+            {
+                unicode_traits::convert(key, length, name_,
+                                 unicode_traits::conv_flags::strict);
+            }
+            JSONCONS_CATCH(...)
+            {
+            }
+        }
+
+        virtual ~not_an_object() noexcept
+        {
+        }
+        const char* what() const noexcept override
+        {
+            if (what_.empty())
+            {
+                JSONCONS_TRY
+                {
+                    what_.append(std::runtime_error::what());
+                    what_.append(": '");
+                    what_.append(name_);
+                    what_.append("'");
+                    return what_.c_str();
+                }
+                JSONCONS_CATCH(...)
+                {
+                    return std::runtime_error::what();
+                }
+            }
+            else
+            {
+                return what_.c_str();
+            }
+        }
+    };
+
+    class ser_error : public std::system_error, public virtual json_exception
+    {
+        std::size_t line_number_;
+        std::size_t column_number_;
+        mutable std::string what_;
+    public:
+        ser_error(std::error_code ec)
+            : std::system_error(ec), line_number_(0), column_number_(0)
+        {
+        }
+        ser_error(std::error_code ec, const std::string& what_arg)
+            : std::system_error(ec, what_arg), line_number_(0), column_number_(0)
+        {
+        }
+        ser_error(std::error_code ec, std::size_t position)
+            : std::system_error(ec), line_number_(0), column_number_(position)
+        {
+        }
+        ser_error(std::error_code ec, std::size_t line, std::size_t column)
+            : std::system_error(ec), line_number_(line), column_number_(column)
+        {
+        }
+        ser_error(const ser_error& other) = default;
+
+        ser_error(ser_error&& other) = default;
+
+        const char* what() const noexcept override
+        {
+            if (what_.empty())
+            {
+                JSONCONS_TRY
+                {
+                    what_.append(std::system_error::what());
+                    if (line_number_ != 0 && column_number_ != 0)
+                    {
+                        what_.append(" at line ");
+                        what_.append(std::to_string(line_number_));
+                        what_.append(" and column ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    else if (column_number_ != 0)
+                    {
+                        what_.append(" at position ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    return what_.c_str();
+                }
+                JSONCONS_CATCH(...)
+                {
+                    return std::system_error::what();
+                }
+            }
+            else
+            {
+                return what_.c_str();
+            }
+        }
+
+        std::size_t line() const noexcept
+        {
+            return line_number_;
+        }
+
+        std::size_t column() const noexcept
+        {
+            return column_number_;
+        }
+
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_EXCEPTION_HPP

--- a/velox/external/jsoncons/json_filter.hpp
+++ b/velox/external/jsoncons/json_filter.hpp
@@ -1,0 +1,635 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_FILTER_HPP
+#define JSONCONS_JSON_FILTER_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+template <typename CharT>
+class basic_json_filter : public basic_json_visitor<CharT>
+{
+public:
+    using typename basic_json_visitor<CharT>::char_type;
+    using typename basic_json_visitor<CharT>::string_view_type;
+private:
+    basic_json_visitor<char_type>* destination_;
+
+public:
+    basic_json_filter(basic_json_visitor<char_type>& visitor)
+        : destination_(std::addressof(visitor))
+    {
+    }
+
+    basic_json_visitor<char_type>& destination()
+    {
+        return *destination_;
+    }
+
+private:
+    void visit_flush() override
+    {
+        destination_->flush();
+    }
+
+    bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->begin_object(tag, context, ec);
+    }
+
+    bool visit_begin_object(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->begin_object(length, tag, context, ec);
+    }
+
+    bool visit_end_object(const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->end_object(context, ec);
+    }
+
+    bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->begin_array(tag, context, ec);
+    }
+
+    bool visit_begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->begin_array(length, tag, context, ec);
+    }
+
+    bool visit_end_array(const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->end_array(context, ec);
+    }
+
+    bool visit_key(const string_view_type& name,
+                 const ser_context& context,
+                 std::error_code& ec) override
+    {
+        return destination_->key(name, context, ec);
+    }
+
+    bool visit_string(const string_view_type& value,
+                      semantic_tag tag,
+                      const ser_context& context,
+                      std::error_code& ec) override
+    {
+        return destination_->string_value(value, tag, context, ec);
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           semantic_tag tag,
+                           const ser_context& context,
+                           std::error_code& ec) override
+    {
+        return destination_->byte_string_value(b, tag, context, ec);
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           uint64_t ext_tag,
+                           const ser_context& context,
+                           std::error_code& ec) override
+    {
+        return destination_->byte_string_value(b, ext_tag, context, ec);
+    }
+
+    bool visit_uint64(uint64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->uint64_value(value, tag, context, ec);
+    }
+
+    bool visit_int64(int64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->int64_value(value, tag, context, ec);
+    }
+
+    bool visit_half(uint16_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->half_value(value, tag, context, ec);
+    }
+
+    bool visit_double(double value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->double_value(value, tag, context, ec);
+    }
+
+    bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->bool_value(value, tag, context, ec);
+    }
+
+    bool visit_null(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->null_value(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint8_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint32_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint64_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int8_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int32_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int64_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(half_arg_t, 
+                        const jsoncons::span<const uint16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(half_arg, s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const float>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const double>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                            semantic_tag tag,
+                            const ser_context& context, 
+                            std::error_code& ec) override
+    {
+        return destination_->begin_multi_dim(shape, tag, context, ec);
+    }
+
+    bool visit_end_multi_dim(const ser_context& context,
+                          std::error_code& ec) override
+    {
+        return destination_->end_multi_dim(context, ec);
+    }
+};
+
+template <typename CharT>
+class basic_rename_object_key_filter : public basic_json_filter<CharT>
+{
+public:
+    using typename basic_json_filter<CharT>::string_view_type;
+
+private:
+    std::basic_string<CharT> name_;
+    std::basic_string<CharT> new_name_;
+public:
+    basic_rename_object_key_filter(const std::basic_string<CharT>& name,
+                             const std::basic_string<CharT>& new_name,
+                             basic_json_visitor<CharT>& visitor)
+        : basic_json_filter<CharT>(visitor), 
+          name_(name), new_name_(new_name)
+    {
+    }
+
+private:
+    bool visit_key(const string_view_type& name,
+                 const ser_context& context,
+                 std::error_code& ec) override
+    {
+        if (name == name_)
+        {
+            return this->destination().key(new_name_,context, ec);
+        }
+        else
+        {
+            return this->destination().key(name,context,ec);
+        }
+    }
+};
+
+template <typename From,typename To>
+class json_visitor_adaptor_base : public From
+{
+public:
+    using typename From::string_view_type;
+private:
+    To* destination_;
+public:
+
+    // noncopyable
+    json_visitor_adaptor_base(const json_visitor_adaptor_base&) = delete;
+
+    json_visitor_adaptor_base(To& visitor)
+        : destination_(std::addressof(visitor))
+    {
+    }
+
+    // moveable
+    json_visitor_adaptor_base(json_visitor_adaptor_base&&) = default;
+
+    json_visitor_adaptor_base& operator=(const json_visitor_adaptor_base&) = delete;
+    json_visitor_adaptor_base& operator=(json_visitor_adaptor_base&&) = default;
+
+    To& destination()
+    {
+        return *destination_;
+    }
+
+private:
+    void visit_flush() override
+    {
+        destination_->flush();
+    }
+
+    bool visit_begin_object(semantic_tag tag, 
+                         const ser_context& context,
+                         std::error_code& ec) override
+    {
+        return destination_->begin_object(tag, context, ec);
+    }
+
+    bool visit_begin_object(std::size_t length, 
+                         semantic_tag tag, 
+                         const ser_context& context,
+                         std::error_code& ec) override
+    {
+        return destination_->begin_object(length, tag, context, ec);
+    }
+
+    bool visit_end_object(const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->end_object(context, ec);
+    }
+
+    bool visit_begin_array(semantic_tag tag, 
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        return destination_->begin_array(tag, context, ec);
+    }
+
+    bool visit_begin_array(std::size_t length, 
+                        semantic_tag tag, 
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        return destination_->begin_array(length, tag, context, ec);
+    }
+
+    bool visit_end_array(const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->end_array(context, ec);
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           semantic_tag tag,
+                           const ser_context& context,
+                           std::error_code& ec) override
+    {
+        return destination_->byte_string_value(b, tag, context, ec);
+    }
+
+    bool visit_byte_string(const byte_string_view& b, 
+                           uint64_t ext_tag,
+                           const ser_context& context,
+                           std::error_code& ec) override
+    {
+        return destination_->byte_string_value(b, ext_tag, context, ec);
+    }
+
+    bool visit_half(uint16_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->half_value(value, tag, context, ec);
+    }
+
+    bool visit_double(double value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->double_value(value, tag, context, ec);
+    }
+
+    bool visit_int64(int64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->int64_value(value, tag, context, ec);
+    }
+
+    bool visit_uint64(uint64_t value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->uint64_value(value, tag, context, ec);
+    }
+
+    bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->bool_value(value, tag, context, ec);
+    }
+
+    bool visit_null(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+    {
+        return destination_->null_value(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint8_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint32_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint64_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int8_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int32_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int64_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(half_arg_t, 
+                        const jsoncons::span<const uint16_t>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(half_arg, s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const float>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const double>& s, 
+                        semantic_tag tag,
+                        const ser_context& context, 
+                        std::error_code& ec) override
+    {
+        return destination_->typed_array(s, tag, context, ec);
+    }
+
+    bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                            semantic_tag tag,
+                            const ser_context& context, 
+                            std::error_code& ec) override
+    {
+        return destination_->begin_multi_dim(shape, tag, context, ec);
+    }
+
+    bool visit_end_multi_dim(const ser_context& context,
+                          std::error_code& ec) override
+    {
+        return destination_->end_multi_dim(context, ec);
+    }
+
+};
+
+template <typename From,typename To,typename Enable=void>
+class json_visitor_adaptor 
+{
+};
+
+template <typename From,typename To>
+class json_visitor_adaptor<From,To,typename std::enable_if<extension_traits::is_narrow_character<typename From::char_type>::value &&
+                                                           extension_traits::is_narrow_character<typename To::char_type>::value>::type> : public json_visitor_adaptor_base<From,To>
+{
+    using supertype = json_visitor_adaptor_base<From,To>;
+    using to_char_type = typename To::char_type;
+    using from_char_type = typename From::char_type;
+public:
+    using typename From::string_view_type;
+    using supertype::destination;
+public:
+
+    // noncopyable
+    json_visitor_adaptor(const json_visitor_adaptor&) = delete;
+    // moveable
+    json_visitor_adaptor(json_visitor_adaptor&&) = default;
+
+    json_visitor_adaptor(To& visitor)
+        : supertype(visitor)
+    {
+    }
+
+    json_visitor_adaptor& operator=(const json_visitor_adaptor&) = delete;
+    json_visitor_adaptor& operator=(json_visitor_adaptor&&) = default;
+
+private:
+
+    bool visit_key(const string_view_type& key,
+                 const ser_context& context,
+                 std::error_code& ec) override
+    {
+        return destination().key(string_view_type(reinterpret_cast<const to_char_type*>(key.data()),key.size()), context, ec);
+    }
+
+    bool visit_string(const string_view_type& value,
+                      semantic_tag tag,
+                      const ser_context& context,
+                      std::error_code& ec) override
+    {
+        return destination().string_value(string_view_type(reinterpret_cast<const to_char_type*>(value.data()),value.size()), tag, context, ec);
+    }
+};
+
+template <typename From,typename To>
+class json_visitor_adaptor<From,To,typename std::enable_if<!(extension_traits::is_narrow_character<typename From::char_type>::value &&
+                                                             extension_traits::is_narrow_character<typename To::char_type>::value)>::type> : public json_visitor_adaptor_base<From,To>
+{
+    using supertype = json_visitor_adaptor_base<From,To>;
+public:
+    using typename From::string_view_type;
+    using supertype::destination;
+public:
+
+    // noncopyable
+    json_visitor_adaptor(const json_visitor_adaptor&) = delete;
+    // moveable
+    json_visitor_adaptor(json_visitor_adaptor&&) = default;
+
+    json_visitor_adaptor(To& visitor)
+        : supertype(visitor)
+    {
+    }
+
+    json_visitor_adaptor& operator=(const json_visitor_adaptor&) = delete;
+    json_visitor_adaptor& operator=(json_visitor_adaptor&&) = default;
+
+private:
+
+    bool visit_key(const string_view_type& name,
+                 const ser_context& context,
+                 std::error_code& ec) override
+    {
+        std::basic_string<typename To::char_type> target;
+        auto result = unicode_traits::convert(name.data(), name.size(), target, unicode_traits::conv_flags::strict);
+        if (result.ec != unicode_traits::conv_errc())
+        {
+            ec = result.ec;
+        }
+        return destination().key(target, context, ec);
+    }
+
+    bool visit_string(const string_view_type& value,
+                      semantic_tag tag,
+                      const ser_context& context,
+                      std::error_code& ec) override
+    {
+        std::basic_string<typename To::char_type> target;
+        auto result = unicode_traits::convert(value.data(), value.size(),
+                                              target,unicode_traits::conv_flags::strict);
+        if (result.ec != unicode_traits::conv_errc())
+        {
+            JSONCONS_THROW(ser_error(result.ec));
+        }
+        return destination().string_value(target, tag, context, ec);
+    }
+};
+
+template <typename From,typename To>
+json_visitor_adaptor<From,To> make_json_visitor_adaptor(To& to)
+{
+    return json_visitor_adaptor<From, To>(to);
+}
+
+using json_filter = basic_json_filter<char>;
+using wjson_filter = basic_json_filter<wchar_t>;
+using rename_object_key_filter = basic_rename_object_key_filter<char>;
+using wrename_object_key_filter = basic_rename_object_key_filter<wchar_t>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_FILTER_HPP

--- a/velox/external/jsoncons/json_fwd.hpp
+++ b/velox/external/jsoncons/json_fwd.hpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_FWD_HPP
+#define JSONCONS_JSON_FWD_HPP
+
+#include <memory> // std::allocator
+
+namespace facebook::velox::jsoncons {
+
+struct sorted_policy;
+                        
+template <typename CharT, 
+          typename Policy = sorted_policy, 
+          typename Allocator = std::allocator<CharT>>
+class basic_json;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_FWD_HPP

--- a/velox/external/jsoncons/json_object.hpp
+++ b/velox/external/jsoncons/json_object.hpp
@@ -1,0 +1,1731 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_OBJECT_HPP
+#define JSONCONS_JSON_OBJECT_HPP
+
+#include <algorithm> // std::sort, std::stable_sort, std::lower_bound, std::unique
+#include <cassert> // assert
+#include <cstring>
+#include <initializer_list>
+#include <iterator> // std::iterator_traits
+#include <memory> // std::allocator
+#include <string>
+#include <tuple>
+#include <type_traits> // std::enable_if
+#include <unordered_set>
+#include <utility>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/allocator_holder.hpp"
+#include "velox/external/jsoncons/json_array.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    template <typename Json>
+    struct index_key_value
+    {
+        using key_type = typename Json::key_type;
+        using allocator_type = typename Json::allocator_type;
+
+        key_type name;
+        int64_t index;
+        Json value;
+
+        template <typename... Args>
+        index_key_value(key_type&& Name, int64_t Index, Args&& ... args) 
+            : name(std::move(Name)), index(Index), value(std::forward<Args>(args)...)
+        {
+        }
+
+        index_key_value() = default;
+        index_key_value(const index_key_value&) = default;
+        index_key_value(index_key_value&&) = default;
+        index_key_value(const index_key_value& other, const allocator_type& alloc) 
+            : name(other.name, alloc), index(0), value(other.value, alloc) 
+        {
+        }
+        index_key_value(index_key_value&& other, const allocator_type& alloc)
+            : name(std::move(other.name), alloc), index(0), value(std::move(other.value), alloc) 
+        {
+
+        }
+        index_key_value& operator=(const index_key_value&) = default;
+        index_key_value& operator=(index_key_value&&) = default;
+    };
+
+    struct sorted_unique_range_tag
+    {
+        explicit sorted_unique_range_tag() = default; 
+    };
+
+    // key_value
+
+    template <typename KeyT,typename ValueT>
+    class key_value
+    {
+    public:
+        using key_type = KeyT;
+        using value_type = ValueT;
+        using string_view_type = typename value_type::string_view_type;
+        using allocator_type = typename ValueT::allocator_type;
+    private:
+
+        key_type key_;
+        value_type value_;
+    public:
+
+        key_value() noexcept
+        {
+        }
+
+        template <typename... Args>
+        key_value(key_type&& name,  Args&& ... args) noexcept
+            : key_(std::move(name)), value_(std::forward<Args>(args)...)
+        {
+        }
+        key_value(const key_value& member)
+            : key_(member.key_), value_(member.value_)
+        {
+        }
+
+        key_value(const key_value& member, const allocator_type& alloc)
+            : key_(member.key_, alloc), value_(member.value_, alloc)
+        {
+        }
+
+        key_value(key_value&& member) noexcept
+            : key_(std::move(member.key_)), value_(std::move(member.value_))
+        {
+        }
+
+        key_value(key_value&& member, const allocator_type& alloc) noexcept
+            : key_(std::move(member.key_), alloc), value_(std::move(member.value_), alloc)
+        {
+        }
+
+        const key_type& key() const
+        {
+            return key_;
+        }
+
+        value_type& value()
+        {
+            return value_;
+        }
+
+        const value_type& value() const
+        {
+            return value_;
+        }
+
+        template <typename T>
+        void value(T&& newValue)
+        {
+            value_ = std::forward<T>(newValue);
+        }
+
+        void swap(key_value& member) noexcept
+        {
+            key_.swap(member.key_);
+            value_.swap(member.value_);
+        }
+
+        key_value& operator=(const key_value& member)
+        {
+            if (this != & member)
+            {
+                key_ = member.key_;
+                value_ = member.value_;
+            }
+            return *this;
+        }
+
+        key_value& operator=(key_value&& member) noexcept
+        {
+            if (this != &member)
+            {
+                key_.swap(member.key_);
+                value_.swap(member.value_);
+            }
+            return *this;
+        }
+
+        void shrink_to_fit() 
+        {
+            key_.shrink_to_fit();
+            value_.shrink_to_fit();
+        }
+
+        friend bool operator==(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            return lhs.key_ == rhs.key_ && lhs.value_ == rhs.value_;
+        }
+
+        friend bool operator!=(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator<(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            if (lhs.key_ < rhs.key_)
+            {
+                return true;
+            }
+            if (lhs.key_ == rhs.key_ && lhs.value_ < rhs.value_)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        friend bool operator<=(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            return !(rhs < lhs);
+        }
+
+        friend bool operator>(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            return !(lhs <= rhs);
+        }
+
+        friend bool operator>=(const key_value& lhs, const key_value& rhs) noexcept
+        {
+            return !(lhs < rhs);
+        }
+
+        friend void swap(key_value& a, key_value& b) noexcept(
+            noexcept(std::declval<key_value&>().swap(std::declval<key_value&>()))) 
+        {
+            a.swap(b);
+        }
+    };
+
+    // Structured Bindings Support
+    // See https://blog.tartanllama.xyz/structured-bindings/
+    template<std::size_t N,typename Key,typename Value,typename std::enable_if<N == 0, int>::type = 0>
+    auto get(const key_value<Key,Value>& i) -> decltype(i.key())
+    {
+        return i.key();
+    }
+    // Structured Bindings Support
+    // See https://blog.tartanllama.xyz/structured-bindings/
+    template<std::size_t N,typename Key,typename Value,typename std::enable_if<N == 1, int>::type = 0>
+    auto get(const key_value<Key,Value>& i) -> decltype(i.value())
+    {
+        return i.value();
+    }
+
+} // namespace facebook::velox::jsoncons
+
+namespace std
+{
+#if defined(__clang__)
+    // Fix: https://github.com/nlohmann/json/issues/1401
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wmismatched-tags"
+#endif
+
+    template <typename Key,typename Value>
+    struct tuple_size<facebook::velox::jsoncons::key_value<Key,Value>>
+        : public std::integral_constant<std::size_t, 2> {};
+
+    template <typename Key,typename Value> struct tuple_element<0, facebook::velox::jsoncons::key_value<Key,Value>> { using type = Key; };
+    template <typename Key,typename Value> struct tuple_element<1, facebook::velox::jsoncons::key_value<Key,Value>> { using type = Value; };
+
+#if defined(__clang__)
+    #pragma clang diagnostic pop
+#endif
+
+}  // namespace std
+
+namespace facebook::velox::jsoncons {
+
+    template <typename KeyT,typename ValueT>
+    struct get_key_value
+    {
+        using key_value_type = key_value<KeyT,ValueT>;
+
+        template <typename T1,typename T2>
+        key_value_type operator()(const std::pair<T1,T2>& p) // Remove
+        {
+            return key_value_type(p.first,p.second);
+        }
+        template <typename T1,typename T2>
+        key_value_type operator()(std::pair<T1,T2>&& p)
+        {
+            return key_value_type(std::forward<T1>(p.first),std::forward<T2>(p.second));
+        }
+        template <typename T1,typename T2>
+        const key_value_type& operator()(const key_value<T1,T2>& p)
+        {
+            return p;
+        }
+        template <typename T1,typename T2>
+        key_value_type operator()(key_value<T1,T2>&& p)
+        {
+            return std::move(p);
+        }
+    };
+
+    struct sort_key_order
+    {
+        explicit sort_key_order() = default; 
+    };
+
+    struct preserve_key_order
+    {
+        explicit preserve_key_order() = default; 
+    };
+
+
+    // Sort keys
+    template <typename KeyT,typename Json,template <typename,typename> class SequenceContainer = std::vector>
+    class sorted_json_object : public allocator_holder<typename Json::allocator_type>    
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using key_type = KeyT;
+        using key_value_type = key_value<KeyT,Json>;
+        using char_type = typename Json::char_type;
+        using string_view_type = typename Json::string_view_type;
+    private:
+        struct Comp
+        {
+            bool operator() (const key_value_type& kv, string_view_type k) const { return kv.key() < k; }
+            bool operator() (string_view_type k, const key_value_type& kv) const { return k < kv.key(); }
+        };
+
+        using key_value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<key_value_type>;
+        using key_value_container_type = SequenceContainer<key_value_type,key_value_allocator_type>;
+
+        key_value_container_type members_;
+    public:
+        using iterator = typename key_value_container_type::iterator;
+        using const_iterator = typename key_value_container_type::const_iterator;
+
+        using allocator_holder<allocator_type>::get_allocator;
+
+        sorted_json_object()
+        {
+        }
+
+        explicit sorted_json_object(const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+        }
+
+        sorted_json_object(const sorted_json_object& other)
+            : allocator_holder<allocator_type>(other.get_allocator()),
+              members_(other.members_)
+        {
+        }
+
+        sorted_json_object(const sorted_json_object& other, const allocator_type& alloc) 
+            : allocator_holder<allocator_type>(alloc), 
+              members_(other.members_,key_value_allocator_type(alloc))
+        {
+        }
+
+        sorted_json_object(sorted_json_object&& other) noexcept
+            : allocator_holder<allocator_type>(other.get_allocator()), 
+              members_(std::move(other.members_))
+        {
+        }
+
+        sorted_json_object(sorted_json_object&& other,const allocator_type& alloc) 
+            : allocator_holder<allocator_type>(alloc), members_(std::move(other.members_),key_value_allocator_type(alloc))
+        {
+        }
+
+        sorted_json_object& operator=(const sorted_json_object& other)
+        {
+            members_ = other.members_;
+            return *this;
+        }
+
+        sorted_json_object& operator=(sorted_json_object&& other) noexcept
+        {
+            other.swap(*this);
+            return *this;
+        }
+
+        template <typename InputIt>
+        sorted_json_object(InputIt first, InputIt last)
+        {
+            std::size_t count = std::distance(first,last);
+            members_.reserve(count);
+            for (auto it = first; it != last; ++it)
+            {
+                members_.emplace_back(key_type((*it).first,get_allocator()), (*it).second);
+            }
+            std::stable_sort(members_.begin(),members_.end(),
+                             [](const key_value_type& a, const key_value_type& b) -> bool {return a.key().compare(b.key()) < 0;});
+            auto last2 = std::unique(members_.begin(), members_.end(),
+                                  [](const key_value_type& a, const key_value_type& b) -> bool { return !(a.key().compare(b.key()));});
+            members_.erase(last2, members_.end());
+        }
+
+        template <typename InputIt>
+        sorted_json_object(InputIt first, InputIt last, 
+                    const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+            std::size_t count = std::distance(first,last);
+            members_.reserve(count);
+            for (auto it = first; it != last; ++it)
+            {
+                members_.emplace_back(key_type((*it).first.c_str(), (*it).first.size(), get_allocator()), (*it).second);
+            }
+            std::stable_sort(members_.begin(), members_.end(),
+                             [](const key_value_type& a, const key_value_type& b) -> bool {return a.key().compare(b.key()) < 0;});
+            auto last2 = std::unique(members_.begin(), members_.end(),
+                                  [](const key_value_type& a, const key_value_type& b) -> bool { return !(a.key().compare(b.key()));});
+            members_.erase(last2, members_.end());
+        }
+
+        sorted_json_object(const std::initializer_list<std::pair<std::basic_string<char_type>,Json>>& init, 
+                    const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+            members_.reserve(init.size());
+            for (auto& item : init)
+            {
+                insert_or_assign(item.first, item.second);
+            }
+        }
+
+        ~sorted_json_object() noexcept
+        {
+            flatten_and_destroy();
+        }
+
+        bool empty() const
+        {
+            return members_.empty();
+        }
+
+        void swap(sorted_json_object& other) noexcept
+        {
+            members_.swap(other.members_);
+        }
+
+        iterator begin()
+        {
+            return members_.begin();
+        }
+
+        iterator end()
+        {
+            return members_.end();
+        }
+
+        const_iterator begin() const
+        {
+            return members_.begin();
+        }
+
+        const_iterator end() const
+        {
+            return members_.end();
+        }
+
+        std::size_t size() const {return members_.size();}
+
+        std::size_t capacity() const {return members_.capacity();}
+
+        void clear() {members_.clear();}
+
+        void shrink_to_fit() 
+        {
+            for (std::size_t i = 0; i < members_.size(); ++i)
+            {
+                members_[i].shrink_to_fit();
+            }
+            members_.shrink_to_fit();
+        }
+
+        void reserve(std::size_t n) {members_.reserve(n);}
+
+        Json& at(std::size_t i) 
+        {
+            if (i >= members_.size())
+            {
+                JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+            }
+            return members_[i].value();
+        }
+
+        const Json& at(std::size_t i) const 
+        {
+            if (i >= members_.size())
+            {
+                JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+            }
+            return members_[i].value();
+        }
+
+        iterator find(const string_view_type& name) noexcept
+        {
+            auto p = std::equal_range(members_.begin(),members_.end(), name, 
+                                       Comp());        
+            return p.first == p.second ? members_.end() : p.first;
+        }
+
+        const_iterator find(const string_view_type& name) const noexcept
+        {
+            auto p = std::equal_range(members_.begin(),members_.end(), name, 
+                                       Comp());        
+            return p.first == p.second ? members_.end() : p.first;
+        }
+
+        iterator erase(const_iterator pos) 
+        {
+            return members_.erase(pos);
+        }
+
+        iterator erase(const_iterator first, const_iterator last) 
+        {
+            return members_.erase(first,last);
+        }
+
+        void erase(const string_view_type& name) 
+        {
+            auto it = find(name);
+            if (it != members_.end())
+            {
+                members_.erase(it);
+            }
+        }
+
+        static bool compare(const index_key_value<Json>& item1, const index_key_value<Json>& item2)
+        {
+            int comp = item1.name.compare(item2.name); 
+            if (comp < 0) return true;
+            if (comp == 0) return item1.index < item2.index;
+
+            return false;
+        }
+
+        void uninitialized_init(index_key_value<Json>* items, std::size_t count)
+        {
+            if (count > 0)
+            {
+                members_.reserve(count);
+
+                std::sort(items, items+count, compare);
+                members_.emplace_back(key_type(items[0].name.data(), items[0].name.size(), get_allocator()), std::move(items[0].value));
+                
+                for (std::size_t i = 1; i < count; ++i)
+                {
+                    auto& item = items[i];
+                    if (item.name != items[i-1].name)
+                    {
+                        members_.emplace_back(key_type(item.name.data(), item.name.size(), get_allocator()), std::move(item.value));
+                    }
+                }
+            }
+        }
+
+        template <typename InputIt>
+        void insert(InputIt first, InputIt last)
+        {
+            for (auto it = first; it != last; ++it)
+            {
+                members_.emplace_back(key_type((*it).first.c_str(), (*it).first.size(), get_allocator()), (*it).second);
+            }
+            std::stable_sort(members_.begin(),members_.end(),
+                             [](const key_value_type& a, const key_value_type& b) -> bool {return a.key().compare(b.key()) < 0;});
+            auto last2 = std::unique(members_.begin(), members_.end(),
+                                  [](const key_value_type& a, const key_value_type& b) -> bool { return !(a.key().compare(b.key()));});
+            members_.erase(last2, members_.end());
+        }
+
+        template <typename InputIt>
+        void insert(sorted_unique_range_tag, InputIt first, InputIt last)
+        {
+            if (first != last)
+            {
+                auto it = find(convert(*first).key());
+                if (it != members_.end())
+                {
+                    for (auto s = first; s != last; ++s)
+                    {
+                        it = members_.emplace(it, key_type(s->first, get_allocator()), s->second);
+                    }
+                }
+                else
+                {
+                    for (auto s = first; s != last; ++s)
+                    {
+                        members_.emplace_back(convert(*s));
+                    }
+                }
+            }
+        }
+
+        // insert_or_assign
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        insert_or_assign(const string_view_type& name, T&& value)
+        {
+            bool inserted;
+            auto it = std::lower_bound(members_.begin(),members_.end(), name, Comp());        
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end()), std::forward<T>(value));
+                inserted = true;
+                it = members_.begin() + members_.size() - 1;
+            }
+            else if ((*it).key() == name)
+            {
+                (*it).value(Json(std::forward<T>(value)));
+                inserted = false; // assigned
+            }
+            else
+            {
+                it = members_.emplace(it, key_type(name.begin(),name.end()), std::forward<T>(value));
+                inserted = true;
+            }
+            return std::make_pair(it,inserted);
+        }
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        insert_or_assign(const string_view_type& name, T&& value)
+        {
+            bool inserted;
+            auto it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                       Comp());        
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end(), get_allocator()), std::forward<T>(value));
+                inserted = true;
+                it = members_.begin() + members_.size() - 1;
+            }
+            else if ((*it).key() == name)
+            {
+                (*it).value(Json(std::forward<T>(value), get_allocator()));
+                inserted = false; // assigned
+            }
+            else
+            {
+                it = members_.emplace(it, key_type(name.begin(),name.end(), get_allocator()),
+                    std::forward<T>(value));
+                inserted = true;
+            }
+            return std::make_pair(it,inserted);
+        }
+
+        // try_emplace
+
+        template <typename A=allocator_type,typename... Args>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        try_emplace(const string_view_type& name, Args&&... args)
+        {
+            bool inserted;
+            auto it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                       Comp());        
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end()), std::forward<Args>(args)...);
+                it = members_.begin() + members_.size() - 1;
+                inserted = true;
+            }
+            else if ((*it).key() == name)
+            {
+                inserted = false;
+            }
+            else
+            {
+                it = members_.emplace(it, key_type(name.begin(),name.end()),
+                                            std::forward<Args>(args)...);
+                inserted = true;
+            }
+            return std::make_pair(it,inserted);
+        }
+
+        template <typename A=allocator_type,typename... Args>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        try_emplace(const string_view_type& name, Args&&... args)
+        {
+            bool inserted;
+            auto it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                       Comp());        
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end(), get_allocator()), std::forward<Args>(args)...);
+                it = members_.begin() + members_.size() - 1;
+                inserted = true;
+            }
+            else if ((*it).key() == name)
+            {
+                inserted = false;
+            }
+            else
+            {
+                it = members_.emplace(it,
+                                            key_type(name.begin(),name.end(), get_allocator()),
+                                            std::forward<Args>(args)...);
+                inserted = true;
+            }
+            return std::make_pair(it,inserted);
+        }
+
+        template <typename A=allocator_type,typename ... Args>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        try_emplace(iterator hint, const string_view_type& name, Args&&... args)
+        {
+            iterator it = hint;
+
+            if (hint != members_.end() && hint->key() <= name)
+            {
+                it = std::lower_bound(hint,members_.end(), name, 
+                                      Comp());        
+            }
+            else
+            {
+                it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                      Comp());        
+            }
+
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end()), 
+                    std::forward<Args>(args)...);
+                it = members_.begin() + (members_.size() - 1);
+            }
+            else if ((*it).key() == name)
+            {
+            }
+            else
+            {
+                it = members_.emplace(it,
+                                            key_type(name.begin(),name.end()),
+                                            std::forward<Args>(args)...);
+            }
+
+            return it;
+        }
+
+        template <typename A=allocator_type,typename ... Args>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        try_emplace(iterator hint, const string_view_type& name, Args&&... args)
+        {
+            iterator it = hint;
+            if (hint != members_.end() && hint->key() <= name)
+            {
+                it = std::lower_bound(hint,members_.end(), name, 
+                                      Comp());        
+            }
+            else
+            {
+                it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                      Comp());        
+            }
+
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end(), get_allocator()), 
+                    std::forward<Args>(args)...);
+                it = members_.begin() + (members_.size() - 1);
+            }
+            else if ((*it).key() == name)
+            {
+            }
+            else
+            {
+                it = members_.emplace(it,
+                                            key_type(name.begin(),name.end(), get_allocator()),
+                                            std::forward<Args>(args)...);
+            }
+            return it;
+        }
+
+        // insert_or_assign
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert_or_assign(iterator hint, const string_view_type& name, T&& value)
+        {
+            iterator it;
+            if (hint != members_.end() && hint->key() <= name)
+            {
+                it = std::lower_bound(hint,members_.end(), name, 
+                                      [](const key_value_type& a, const string_view_type& k) -> bool {return string_view_type(a.key()).compare(k) < 0;});        
+            }
+            else
+            {
+                it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                      [](const key_value_type& a, const string_view_type& k) -> bool {return string_view_type(a.key()).compare(k) < 0;});        
+            }
+
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end()), std::forward<T>(value));
+                it = members_.begin() + (members_.size() - 1);
+            }
+            else if ((*it).key() == name)
+            {
+                (*it).value(Json(std::forward<T>(value)));
+            }
+            else
+            {
+                it = members_.emplace(it, key_type(name.begin(),name.end()), std::forward<T>(value));
+            }
+            return it;
+        }
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert_or_assign(iterator hint, const string_view_type& name, T&& value)
+        {
+            iterator it;
+            if (hint != members_.end() && hint->key() <= name)
+            {
+                it = std::lower_bound(hint,members_.end(), name, 
+                                      Comp());        
+            }
+            else
+            {
+                it = std::lower_bound(members_.begin(),members_.end(), name, 
+                                      Comp());        
+            }
+
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end(), get_allocator()), std::forward<T>(value));
+                it = members_.begin() + (members_.size() - 1);
+            }
+            else if ((*it).key() == name)
+            {
+                (*it).value(Json(std::forward<T>(value),get_allocator()));
+            }
+            else
+            {
+                it = members_.emplace(it, key_type(name.begin(),name.end(), get_allocator()),
+                    std::forward<T>(value));
+            }
+            return it;
+        }
+
+        // merge
+
+        void merge(const sorted_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                try_emplace((*it).key(),(*it).value());
+            }
+        }
+
+        void merge(sorted_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                auto pos = std::lower_bound(members_.begin(),members_.end(), (*it).key(), 
+                                            Comp());   
+                if (pos == members_.end() )
+                {
+                    members_.emplace_back(*it);
+                }
+                else if ((*it).key() != pos->key())
+                {
+                    members_.emplace(pos,*it);
+                }
+            }
+        }
+
+        void merge(iterator hint, const sorted_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                hint = try_emplace(hint, (*it).key(),(*it).value());
+            }
+        }
+
+        void merge(iterator hint, sorted_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                iterator pos;
+                if (hint != members_.end() && hint->key() <= (*it).key())
+                {
+                    pos = std::lower_bound(hint,members_.end(), (*it).key(), 
+                                          Comp());        
+                }
+                else
+                {
+                    pos = std::lower_bound(members_.begin(),members_.end(), (*it).key(), 
+                                          Comp());        
+                }
+                if (pos == members_.end() )
+                {
+                    members_.emplace_back(*it);
+                    hint = members_.begin() + (members_.size() - 1);
+                }
+                else if ((*it).key() != pos->key())
+                {
+                    hint = members_.emplace(pos,*it);
+                }
+            }
+        }
+
+        // merge_or_update
+
+        void merge_or_update(const sorted_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                insert_or_assign((*it).key(),(*it).value());
+            }
+        }
+
+        void merge_or_update(sorted_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                auto pos = std::lower_bound(members_.begin(),members_.end(), (*it).key(), 
+                                            Comp());   
+                if (pos == members_.end() )
+                {
+                    members_.emplace_back(*it);
+                }
+                else 
+                {
+                    pos->value((*it).value());
+                }
+            }
+        }
+
+        void merge_or_update(iterator hint, const sorted_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                hint = insert_or_assign(hint, (*it).key(),(*it).value());
+            }
+        }
+
+        void merge_or_update(iterator hint, sorted_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                iterator pos;
+                if (hint != members_.end() && hint->key() <= (*it).key())
+                {
+                    pos = std::lower_bound(hint,members_.end(), (*it).key(), 
+                                          Comp());        
+                }
+                else
+                {
+                    pos = std::lower_bound(members_.begin(),members_.end(), (*it).key(), 
+                                          Comp());        
+                }
+                if (pos == members_.end() )
+                {
+                    members_.emplace_back(*it);
+                    hint = members_.begin() + (members_.size() - 1);
+                }
+                else 
+                {
+                    pos->value((*it).value());
+                    hint = pos;
+                }
+            }
+        }
+
+        bool operator==(const sorted_json_object& rhs) const
+        {
+            return members_ == rhs.members_;
+        }
+
+        bool operator<(const sorted_json_object& rhs) const
+        {
+            return members_ < rhs.members_;
+        }
+    private:
+
+        void flatten_and_destroy() noexcept
+        {
+            if (!members_.empty())
+            {
+                json_array<Json> temp(get_allocator());
+
+                for (auto& kv : members_)
+                {
+                    switch (kv.value().storage_kind())
+                    {
+                        case json_storage_kind::array:
+                        case json_storage_kind::object:
+                            if (!kv.value().empty())
+                            {
+                                temp.emplace_back(std::move(kv.value()));
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+    };
+
+    // Preserve order
+    template <typename KeyT,typename Json,template <typename,typename> class SequenceContainer = std::vector>
+    class order_preserving_json_object : public allocator_holder<typename Json::allocator_type>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using key_type = KeyT;
+        using string_view_type = typename Json::string_view_type;
+        using key_value_type = key_value<KeyT,Json>;
+    private:
+        struct MyHash
+        {
+            std::uintmax_t operator()(const key_type& s) const noexcept
+            {
+                const int p = 31;
+                const int m = static_cast<int>(1e9) + 9;
+                std::uintmax_t hash_value = 0;
+                std::uintmax_t p_pow = 1;
+                for (char_type c : s) {
+                    hash_value = (hash_value + (c - 'a' + 1) * p_pow) % m;
+                    p_pow = (p_pow * p) % m;
+                }
+                return hash_value;   
+            }
+        };
+
+        using key_value_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<key_value_type>;
+        using key_value_container_type = SequenceContainer<key_value_type,key_value_allocator_type>;
+
+        key_value_container_type members_;
+
+        struct Comp
+        {
+            const key_value_container_type& members_;
+
+            Comp(const key_value_container_type& members_)
+                : members_(members_)
+            {
+            }
+
+            bool operator() (std::size_t i, string_view_type k) const { return members_.at(i).key() < k; }
+            bool operator() (string_view_type k, std::size_t i) const { return k < members_.at(i).key(); }
+        };
+    public:
+        using iterator = typename key_value_container_type::iterator;
+        using const_iterator = typename key_value_container_type::const_iterator;
+
+        using allocator_holder<allocator_type>::get_allocator;
+
+        order_preserving_json_object()
+        {
+        }
+        order_preserving_json_object(const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+        }
+
+        order_preserving_json_object(const order_preserving_json_object& val)
+            : allocator_holder<allocator_type>(val.get_allocator()), 
+              members_(val.members_)
+        {
+        }
+
+        order_preserving_json_object(order_preserving_json_object&& val,const allocator_type& alloc) 
+            : allocator_holder<allocator_type>(alloc), 
+              members_(std::move(val.members_),key_value_allocator_type(alloc))
+        {
+        }
+
+        order_preserving_json_object(order_preserving_json_object&& val) noexcept
+            : allocator_holder<allocator_type>(val.get_allocator()), 
+              members_(std::move(val.members_))
+        {
+        }
+
+        order_preserving_json_object(const order_preserving_json_object& val, const allocator_type& alloc) 
+            : allocator_holder<allocator_type>(alloc), 
+              members_(val.members_,key_value_allocator_type(alloc))
+        {
+        }
+
+        template <typename InputIt>
+        order_preserving_json_object(InputIt first, InputIt last)
+        {
+            std::unordered_set<key_type,MyHash> keys;
+            for (auto it = first; it != last; ++it)
+            {
+                auto kv = get_key_value<KeyT,Json>()(*it);
+                if (keys.find(kv.key()) == keys.end())
+                {
+                    keys.emplace(kv.key());
+                    members_.emplace_back(std::move(kv));
+                }
+            }
+        }
+
+        template <typename InputIt>
+        order_preserving_json_object(InputIt first, InputIt last, 
+                    const allocator_type& alloc)
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+            std::unordered_set<key_type,MyHash> keys;
+            for (auto it = first; it != last; ++it)
+            {
+                auto kv = get_key_value<KeyT,Json>()(*it);
+                if (keys.find(kv.key()) == keys.end())
+                {
+                    keys.emplace(kv.key());
+                    members_.emplace_back(std::move(kv));
+                }
+            }
+        }
+
+        order_preserving_json_object(std::initializer_list<std::pair<std::basic_string<char_type>,Json>> init, 
+                    const allocator_type& alloc = allocator_type())
+            : allocator_holder<allocator_type>(alloc), 
+              members_(key_value_allocator_type(alloc))
+        {
+            members_.reserve(init.size());
+            for (auto& item : init)
+            {
+                insert_or_assign(item.first, item.second);
+            }
+        }
+
+        ~order_preserving_json_object() noexcept
+        {
+            flatten_and_destroy();
+        }
+
+        order_preserving_json_object& operator=(order_preserving_json_object&& val)
+        {
+            val.swap(*this);
+            return *this;
+        }
+
+        order_preserving_json_object& operator=(const order_preserving_json_object& val)
+        {
+            members_ = val.members_;
+            return *this;
+        }
+
+        void swap(order_preserving_json_object& other) noexcept
+        {
+            members_.swap(other.members_);
+        }
+
+        bool empty() const
+        {
+            return members_.empty();
+        }
+
+        iterator begin()
+        {
+            return members_.begin();
+        }
+
+        iterator end()
+        {
+            return members_.end();
+        }
+
+        const_iterator begin() const
+        {
+            return members_.begin();
+        }
+
+        const_iterator end() const
+        {
+            return members_.end();
+        }
+
+        std::size_t size() const {return members_.size();}
+
+        std::size_t capacity() const {return members_.capacity();}
+
+        void clear() 
+        {
+            members_.clear();
+        }
+
+        void shrink_to_fit() 
+        {
+            for (std::size_t i = 0; i < members_.size(); ++i)
+            {
+                members_[i].shrink_to_fit();
+            }
+            members_.shrink_to_fit();
+        }
+
+        void reserve(std::size_t n) {members_.reserve(n);}
+
+        Json& at(std::size_t i) 
+        {
+            if (i >= members_.size())
+            {
+                JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+            }
+            return members_[i].value();
+        }
+
+        const Json& at(std::size_t i) const 
+        {
+            if (i >= members_.size())
+            {
+                JSONCONS_THROW(json_runtime_error<std::out_of_range>("Invalid array subscript"));
+            }
+            return members_[i].value();
+        }
+
+        iterator find(const string_view_type& name) noexcept
+        {
+            bool found = false;
+            auto it = members_.begin();
+            while (!found && it != members_.end())
+            {
+                if ((*it).key() == name)
+                {
+                    found = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+            return it;
+        }
+
+        const_iterator find(const string_view_type& name) const noexcept
+        {
+            bool found = false;
+            auto it = members_.begin();
+            while (!found && it != members_.end())
+            {
+                if ((*it).key() == name)
+                {
+                    found = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+            return it;
+        }
+
+        iterator erase(const_iterator pos) 
+        {
+            if (pos != members_.end())
+            {
+                return members_.erase(pos);
+            }
+            else
+            {
+                return members_.end();
+            }
+        }
+
+        iterator erase(const_iterator first, const_iterator last) 
+        {
+            std::size_t pos1 = first == members_.end() ? members_.size() : first - members_.begin();
+            std::size_t pos2 = last == members_.end() ? members_.size() : last - members_.begin();
+
+            if (pos1 < members_.size() && pos2 <= members_.size())
+            {
+
+                return members_.erase(first,last);
+            }
+            else
+            {
+                return members_.end();
+            }
+        }
+
+        void erase(const string_view_type& name) 
+        {
+            auto pos = find(name);
+            if (pos != members_.end())
+            {
+                members_.erase(pos);
+            }
+        }
+
+        static bool compare1(const index_key_value<Json>& item1, const index_key_value<Json>& item2)
+        {
+            int comp = item1.name.compare(item2.name); 
+            if (comp < 0) return true;
+            if (comp == 0) return item1.index < item2.index;
+
+            return false;
+        }
+
+        static bool compare2(const index_key_value<Json>& item1, const index_key_value<Json>& item2)
+        {
+            return item1.index < item2.index;
+        }
+
+        void uninitialized_init(index_key_value<Json>* items, std::size_t length)
+        {
+            if (length > 0)
+            {
+                std::sort(items, items+length, compare1);
+
+                std::size_t count = 1;
+                for (std::size_t i = 1; i < length; ++i)
+                {
+                    while (i < length && items[i-1].name == items[i].name)
+                    {
+                        ++i;
+                    }
+                    if (i < length)
+                    {
+                        if (i != count)
+                        {
+                            items[count] = std::move(items[i]);
+                        }
+                        ++count;
+                    }
+                }
+
+                std::sort(items, items+count, compare2);
+
+                members_.reserve(count);
+
+                for (std::size_t i = 0; i < count; ++i)
+                {
+                    members_.emplace_back(std::move(items[i].name), std::move(items[i].value));
+                }
+            }
+        }
+
+        template <typename InputIt>
+        void insert(InputIt first, InputIt last)
+        {
+            std::unordered_set<key_type,MyHash> keys;
+            for (auto it = first; it != last; ++it)
+            {
+                key_type key{(*it).first.c_str(), (*it).first.size(), get_allocator()};
+                if (keys.find(key) == keys.end())
+                {
+                    keys.emplace(key.c_str(), key.size(), get_allocator());
+                    members_.emplace_back(std::move(key), (*it).second);
+                }
+            }
+        }
+
+        template <typename InputIt>
+        void insert(sorted_unique_range_tag, InputIt first, InputIt last)
+        {
+            for (auto it = first; it != last; ++it)
+            {
+                members_.emplace_back(get_key_value<KeyT,Json>()(*it));
+            }
+        }
+   
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        insert_or_assign(const string_view_type& name, T&& value)
+        {
+            auto it = find(name);
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(), name.end()), std::forward<T>(value));
+                auto pos = members_.begin() + (members_.size() - 1);
+                return std::make_pair(pos, true);
+            }
+            else
+            {
+                (*it).value(Json(std::forward<T>(value)));
+                return std::make_pair(it,false);
+            }
+        }
+
+        template <typename T,typename A=allocator_type>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        insert_or_assign(const string_view_type& name, T&& value)
+        {
+            auto it = find(name);
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(),name.end(),get_allocator()), std::forward<T>(value));
+                auto pos = members_.begin() + (members_.size()-1);
+                return std::make_pair(pos,true);
+            }
+            else
+            {
+                (*it).value(Json(std::forward<T>(value),get_allocator()));
+                return std::make_pair(it,false);
+            }
+        }
+
+        template <typename A=allocator_type,typename T>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert_or_assign(iterator hint, const string_view_type& key, T&& value)
+        {
+            if (hint == members_.end())
+            {
+                auto result = insert_or_assign(key, std::forward<T>(value));
+                return result.first;
+            }
+            else
+            {
+                auto it = find(hint, key);
+                if (it == members_.end())
+                {
+                    members_.emplace_back(key_type(key.begin(), key.end()), std::forward<T>(value));
+                    auto pos = members_.begin() + (members_.size() - 1);
+                    return pos;
+                }
+                else
+                {
+                    (*it).value(Json(std::forward<T>(value)));
+                    return it;
+                }
+            }
+        }
+
+        template <typename A=allocator_type,typename T>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,iterator>::type 
+        insert_or_assign(iterator hint, const string_view_type& key, T&& value)
+        {
+            if (hint == members_.end())
+            {
+                auto result = insert_or_assign(key, std::forward<T>(value));
+                return result.first;
+            }
+            else
+            {
+                auto it = find(hint, key);
+                if (it == members_.end())
+                {
+                    members_.emplace_back(key_type(key.begin(),key.end(),get_allocator()), std::forward<T>(value));
+                    auto pos = members_.begin() + (members_.size()-1);
+                    return pos;
+                }
+                else
+                {
+                    (*it).value(Json(std::forward<T>(value),get_allocator()));
+                    return it;
+                }
+            }
+        }
+
+        // merge
+
+        void merge(const order_preserving_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                try_emplace((*it).key(),(*it).value());
+            }
+        }
+
+        void merge(order_preserving_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                auto pos = find((*it).key());
+                if (pos == members_.end() )
+                {
+                    try_emplace((*it).key(),std::move((*it).value()));
+                }
+            }
+        }
+
+        void merge(iterator hint, const order_preserving_json_object& source)
+        {
+            std::size_t pos = hint - members_.begin();
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                hint = try_emplace(hint, (*it).key(),(*it).value());
+                std::size_t newpos = hint - members_.begin();
+                if (newpos == pos)
+                {
+                    ++hint;
+                    pos = hint - members_.begin();
+                }
+                else
+                {
+                    hint = members_.begin() + pos;
+                }
+            }
+        }
+
+        void merge(iterator hint, order_preserving_json_object&& source)
+        {
+            std::size_t pos = hint - members_.begin();
+
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                hint = try_emplace(hint, (*it).key(), std::move((*it).value()));
+                std::size_t newpos = hint - members_.begin();
+                if (newpos == pos)
+                {
+                    ++hint;
+                    pos = hint - members_.begin();
+                }
+                else
+                {
+                    hint = members_.begin() + pos;
+                }
+            }
+        }
+
+        // merge_or_update
+
+        void merge_or_update(const order_preserving_json_object& source)
+        {
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                insert_or_assign((*it).key(),(*it).value());
+            }
+        }
+
+        void merge_or_update(order_preserving_json_object&& source)
+        {
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                auto pos = find((*it).key());
+                if (pos == members_.end() )
+                {
+                    insert_or_assign((*it).key(),std::move((*it).value()));
+                }
+                else
+                {
+                    pos->value(std::move((*it).value()));
+                }
+            }
+        }
+
+        void merge_or_update(iterator hint, const order_preserving_json_object& source)
+        {
+            std::size_t pos = hint - members_.begin();
+            for (auto it = source.begin(); it != source.end(); ++it)
+            {
+                hint = insert_or_assign(hint, (*it).key(),(*it).value());
+                std::size_t newpos = hint - members_.begin();
+                if (newpos == pos)
+                {
+                    ++hint;
+                    pos = hint - members_.begin();
+                }
+                else
+                {
+                    hint = members_.begin() + pos;
+                }
+            }
+        }
+
+        void merge_or_update(iterator hint, order_preserving_json_object&& source)
+        {
+            std::size_t pos = hint - members_.begin();
+            auto it = std::make_move_iterator(source.begin());
+            auto end = std::make_move_iterator(source.end());
+            for (; it != end; ++it)
+            {
+                hint = insert_or_assign(hint, (*it).key(), std::move((*it).value()));
+                std::size_t newpos = hint - members_.begin();
+                if (newpos == pos)
+                {
+                    ++hint;
+                    pos = hint - members_.begin();
+                }
+                else
+                {
+                    hint = members_.begin() + pos;
+                }
+            }
+        }
+
+        // try_emplace
+
+        template <typename A=allocator_type,typename... Args>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        try_emplace(const string_view_type& name, Args&&... args)
+        {
+            auto it = find(name);
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(name.begin(), name.end()), std::forward<Args>(args)...);
+                auto pos = members_.begin() + (members_.size()-1);
+                return std::make_pair(pos,true);
+            }
+            else
+            {
+                return std::make_pair(it,false);
+            }
+        }
+
+        template <typename A=allocator_type,typename... Args>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,std::pair<iterator,bool>>::type
+        try_emplace(const string_view_type& key, Args&&... args)
+        {
+            auto it = find(key);
+            if (it == members_.end())
+            {
+                members_.emplace_back(key_type(key.begin(),key.end(), get_allocator()), 
+                    std::forward<Args>(args)...);
+                auto pos = members_.begin() + members_.size();
+                return std::make_pair(pos,true);
+            }
+            else
+            {
+                return std::make_pair(it,false);
+            }
+        }
+     
+        template <typename A=allocator_type,typename ... Args>
+        typename std::enable_if<std::allocator_traits<A>::is_always_equal::value,iterator>::type
+        try_emplace(iterator hint, const string_view_type& key, Args&&... args)
+        {
+            if (hint == members_.end())
+            {
+                auto result = try_emplace(key, std::forward<Args>(args)...);
+                return result.first;
+            }
+            else
+            {
+                auto it = find(hint, key);
+                if (it == members_.end())
+                {
+                    members_.emplace_back(key_type(key.begin(),key.end(), get_allocator()), 
+                        std::forward<Args>(args)...);
+                    auto pos = members_.begin() + members_.size();
+                    return pos;
+                }
+                else
+                {
+                    return it;
+                }
+            }
+        }
+
+        template <typename A=allocator_type,typename ... Args>
+        typename std::enable_if<!std::allocator_traits<A>::is_always_equal::value,iterator>::type
+        try_emplace(iterator hint, const string_view_type& key, Args&&... args)
+        {
+            if (hint == members_.end())
+            {
+                auto result = try_emplace(key, std::forward<Args>(args)...);
+                return result.first;
+            }
+            else
+            {
+                auto it = find(hint, key);
+                if (it == members_.end())
+                {
+                    members_.emplace_back(key_type(key.begin(),key.end(), get_allocator()), 
+                        std::forward<Args>(args)...);
+                    auto pos = members_.begin() + members_.size();
+                    return pos;
+                }
+                else
+                {
+                    return it;
+                }
+            }
+        }
+
+        bool operator==(const order_preserving_json_object& rhs) const
+        {
+            return members_ == rhs.members_;
+        }
+     
+        bool operator<(const order_preserving_json_object& rhs) const
+        {
+            return members_ < rhs.members_;
+        }
+    private:
+
+        iterator find(iterator hint, const string_view_type& name) noexcept
+        {
+            bool found = false;
+            auto it = hint;
+            while (!found && it != members_.end())
+            {
+                if ((*it).key() == name)
+                {
+                    found = true;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+            return found ? it : find(name);
+        }
+
+        void flatten_and_destroy() noexcept
+        {
+            if (!members_.empty())
+            {
+                json_array<Json> temp(get_allocator());
+
+                for (auto& kv : members_)
+                {
+                    switch (kv.value().storage_kind())
+                    {
+                        case json_storage_kind::array:
+                        case json_storage_kind::object:
+                            if (!kv.value().empty())
+                            {
+                                temp.emplace_back(std::move(kv.value()));
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_OBJECT_HPP

--- a/velox/external/jsoncons/json_options.hpp
+++ b/velox/external/jsoncons/json_options.hpp
@@ -1,0 +1,726 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_OPTIONS_HPP
+#define JSONCONS_JSON_OPTIONS_HPP
+
+#include <cstdint>
+#include <cwchar>
+#include <functional>
+#include <string>
+#include <system_error>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/json_error.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+
+namespace facebook::velox::jsoncons {
+
+enum class float_chars_format : uint8_t {general,fixed,scientific,hex};
+
+enum class indenting : uint8_t {no_indent = 0, indent = 1};
+
+enum class line_split_kind  : uint8_t {same_line=1, new_line, multi_line};
+
+enum class bignum_format_kind : uint8_t {raw, 
+#if !defined(JSONCONS_NO_DEPRECATED)
+    number=raw, // deprecated, use raw instead 
+#endif    
+    base10, 
+    base64, 
+    base64url};
+
+#if !defined(JSONCONS_NO_DEPRECATED)
+JSONCONS_DEPRECATED_MSG("Instead, use bignum_format_kind") typedef bignum_format_kind bigint_chars_format;
+#endif
+
+enum class byte_string_chars_format : uint8_t {none=0,base16,base64,base64url};
+
+enum class spaces_option : uint8_t {no_spaces=0,space_after,space_before,space_before_and_after};
+
+
+struct default_json_parsing
+{
+    bool operator()(json_errc ec, const ser_context&) noexcept 
+    {
+        return ec == json_errc::illegal_comment;
+    }
+};
+
+struct strict_json_parsing
+{
+    bool operator()(json_errc, const ser_context&) noexcept
+    {
+        return false;
+    }
+};
+
+struct allow_trailing_commas
+{
+    bool operator()(const std::error_code& ec, const ser_context&) noexcept 
+    {
+        return ec == json_errc::illegal_comment || ec == jsoncons::json_errc::extra_comma;
+    }
+};
+
+template <typename CharT>
+class basic_json_options;
+
+template <typename CharT>
+class basic_json_options_common
+{
+    friend class basic_json_options<CharT>;
+public:
+    using char_type = CharT;
+    using string_type = std::basic_string<CharT>;
+private:
+
+    bool enable_nan_to_num_:1;
+    bool enable_inf_to_num_:1;
+    bool enable_neginf_to_num_:1;
+    bool enable_nan_to_str_:1;
+    bool enable_inf_to_str_:1;
+    bool enable_neginf_to_str_:1;
+    bool enable_str_to_nan_:1;
+    bool enable_str_to_inf_:1;
+    bool enable_str_to_neginf_:1;
+
+    string_type nan_to_num_;
+    string_type inf_to_num_;
+    string_type neginf_to_num_;
+    string_type nan_to_str_;
+    string_type inf_to_str_;
+    string_type neginf_to_str_;
+    int max_nesting_depth_;
+
+protected:
+    basic_json_options_common()
+       :
+        enable_nan_to_num_(false),
+        enable_inf_to_num_(false),
+        enable_neginf_to_num_(false),
+        enable_nan_to_str_(false),
+        enable_inf_to_str_(false),
+        enable_neginf_to_str_(false),
+        enable_str_to_nan_(false),
+        enable_str_to_inf_(false),
+        enable_str_to_neginf_(false),
+        max_nesting_depth_(1024)
+    {}
+
+    virtual ~basic_json_options_common() = default;
+
+    basic_json_options_common(const basic_json_options_common&) = default;
+    basic_json_options_common& operator=(const basic_json_options_common&) = default;
+    basic_json_options_common(basic_json_options_common&&) = default;
+    //basic_json_options_common& operator=(basic_json_options_common&&) = default;
+
+public:
+
+    bool enable_nan_to_num() const
+    {
+        return enable_nan_to_num_;
+    }
+
+    bool enable_inf_to_num() const
+    {
+        return enable_inf_to_num_;
+    }
+
+    bool enable_neginf_to_num() const
+    {
+        return enable_neginf_to_num_ || enable_inf_to_num_;
+    }
+
+    bool enable_nan_to_str() const
+    {
+        return enable_nan_to_str_;
+    }
+
+    bool enable_str_to_nan() const
+    {
+        return enable_str_to_nan_;
+    }
+
+    bool enable_inf_to_str() const
+    {
+        return enable_inf_to_str_;
+    }
+
+    bool enable_str_to_inf() const
+    {
+        return enable_str_to_inf_;
+    }
+
+    bool enable_neginf_to_str() const
+    {
+        return enable_neginf_to_str_ || enable_inf_to_str_;
+    }
+
+    bool enable_str_to_neginf() const
+    {
+        return enable_str_to_neginf_ || enable_str_to_inf_;
+    }
+
+    string_type nan_to_num() const
+    {
+        if (enable_nan_to_num_)
+        {
+            return nan_to_num_;
+        }
+        else
+        {
+            return nan_to_num_; // empty string
+        }
+    }
+
+    string_type inf_to_num() const
+    {
+        if (enable_inf_to_num_)
+        {
+            return inf_to_num_;
+        }
+        else
+        {
+            return inf_to_num_; // empty string
+        }
+    }
+
+    string_type neginf_to_num() const
+    {
+        if (enable_neginf_to_num_)
+        {
+            return neginf_to_num_;
+        }
+        else if (enable_inf_to_num_)
+        {
+            string_type s;
+            s.push_back('-');
+            s.append(inf_to_num_);
+            return s;
+        }
+        else
+        {
+            return neginf_to_num_; // empty string
+        }
+    }
+
+    string_type nan_to_str() const
+    {
+        if (enable_nan_to_str_)
+        {
+            return nan_to_str_;
+        }
+        else
+        {
+            return nan_to_str_; // empty string
+        }
+    }
+
+    string_type inf_to_str() const
+    {
+        if (enable_inf_to_str_)
+        {
+            return inf_to_str_;
+        }
+        else
+        {
+            return inf_to_str_; // empty string
+        }
+    }
+
+    string_type neginf_to_str() const
+    {
+        if (enable_neginf_to_str_)
+        {
+            return neginf_to_str_;
+        }
+        else if (enable_inf_to_str_)
+        {
+            string_type s;
+            s.push_back('-');
+            s.append(inf_to_str_);
+            return s;
+        }
+        else
+        {
+            return neginf_to_str_; // empty string
+        }
+    }
+
+    int max_nesting_depth() const 
+    {
+        return max_nesting_depth_;
+    }
+};
+
+template <typename CharT>
+class basic_json_decode_options : public virtual basic_json_options_common<CharT>
+{
+    friend class basic_json_options<CharT>;
+    using super_type = basic_json_options_common<CharT>;
+public:
+    using typename super_type::char_type;
+    using typename super_type::string_type;
+private:
+    bool lossless_number_;
+    std::function<bool(json_errc,const ser_context&)> err_handler_;
+public:
+    basic_json_decode_options()
+        : lossless_number_(false), err_handler_(default_json_parsing())
+    {
+    }
+
+    basic_json_decode_options(const basic_json_decode_options&) = default;
+
+    basic_json_decode_options(basic_json_decode_options&& other) noexcept
+        : super_type(std::move(other)), lossless_number_(other.lossless_number_), err_handler_(std::move(other.err_handler_))
+    {
+    }
+protected:
+    basic_json_decode_options& operator=(const basic_json_decode_options&) = default;
+    basic_json_decode_options& operator=(basic_json_decode_options&&) = default;
+public:
+    bool lossless_number() const 
+    {
+        return lossless_number_;
+    }
+
+    const std::function<bool(json_errc,const ser_context&)>& err_handler() const 
+    {
+        return err_handler_;
+    }
+
+};
+
+template <typename CharT>
+class basic_json_encode_options : public virtual basic_json_options_common<CharT>
+{
+    friend class basic_json_options<CharT>;
+    using super_type = basic_json_options_common<CharT>;
+public:
+    using typename super_type::char_type;
+    using typename super_type::string_type;
+
+    static constexpr uint8_t indent_size_default = 4;
+    static constexpr size_t line_length_limit_default = 120;
+private:
+    bool escape_all_non_ascii_:1;
+    bool escape_solidus_:1;
+    bool pad_inside_object_braces_:1;
+    bool pad_inside_array_brackets_:1;
+    float_chars_format float_format_;
+    byte_string_chars_format byte_string_format_;
+    bignum_format_kind bignum_format_;
+    line_split_kind line_splits_;
+    line_split_kind object_object_line_splits_;
+    line_split_kind object_array_line_splits_;
+    line_split_kind array_array_line_splits_;
+    line_split_kind array_object_line_splits_;
+    spaces_option spaces_around_colon_;
+    spaces_option spaces_around_comma_;
+    int8_t precision_{0};
+    uint8_t indent_size_{indent_size_default};
+    std::size_t line_length_limit_{line_length_limit_default};
+    string_type new_line_chars_;
+public:
+    basic_json_encode_options()
+        : escape_all_non_ascii_(false),
+          escape_solidus_(false),
+          pad_inside_object_braces_(false),
+          pad_inside_array_brackets_(false),
+          float_format_(float_chars_format::general),
+          byte_string_format_(byte_string_chars_format::none),
+          bignum_format_(bignum_format_kind::raw),
+          line_splits_(line_split_kind::multi_line),
+          object_object_line_splits_(line_split_kind{}),
+          object_array_line_splits_(line_split_kind{}),
+          array_array_line_splits_(line_split_kind{}),
+          array_object_line_splits_(line_split_kind{}),
+          spaces_around_colon_(spaces_option::space_after),
+          spaces_around_comma_(spaces_option::space_after)
+    {
+        new_line_chars_.push_back('\n');
+    }
+
+    basic_json_encode_options(const basic_json_encode_options&) = default;
+
+    basic_json_encode_options(basic_json_encode_options&& other) noexcept
+        : super_type(std::move(other)),
+          escape_all_non_ascii_(other.escape_all_non_ascii_),
+          escape_solidus_(other.escape_solidus_),
+          pad_inside_object_braces_(other.pad_inside_object_braces_),
+          pad_inside_array_brackets_(other.pad_inside_array_brackets_),
+          float_format_(other.float_format_),
+          byte_string_format_(other.byte_string_format_),
+          bignum_format_(other.bignum_format_),
+          line_splits_(other.line_splits_),
+          object_object_line_splits_(other.object_object_line_splits_),
+          object_array_line_splits_(other.object_array_line_splits_),
+          array_array_line_splits_(other.array_array_line_splits_),
+          array_object_line_splits_(other.array_object_line_splits_),
+          spaces_around_colon_(other.spaces_around_colon_),
+          spaces_around_comma_(other.spaces_around_comma_),
+          precision_(other.precision_),
+          indent_size_(other.indent_size_),
+          line_length_limit_(other.line_length_limit_),
+          new_line_chars_(std::move(other.new_line_chars_))
+    {
+    }
+    
+    ~basic_json_encode_options() = default;
+protected:
+    basic_json_encode_options& operator=(const basic_json_encode_options&) = default;
+    basic_json_encode_options& operator=(basic_json_encode_options&&) = default;
+public:
+    byte_string_chars_format byte_string_format() const  {return byte_string_format_;}
+
+
+#if !defined(JSONCONS_NO_DEPRECATED)
+    JSONCONS_DEPRECATED_MSG("Instead, use bignum_format")
+    bignum_format_kind bigint_format() const  {return bignum_format_;}
+#endif    
+
+    bignum_format_kind bignum_format() const  {return bignum_format_;}
+
+    line_split_kind line_splits() const  {return line_splits_;}
+
+    line_split_kind object_object_line_splits() const  {return object_object_line_splits_ == line_split_kind{} ? line_splits_ : object_object_line_splits_;}
+
+    line_split_kind array_object_line_splits() const  {return array_object_line_splits_ == line_split_kind{} ? line_splits_ : array_object_line_splits_;}
+
+    line_split_kind object_array_line_splits() const  {return object_array_line_splits_ == line_split_kind{} ? line_splits_ : object_array_line_splits_;}
+
+    line_split_kind array_array_line_splits() const  {return array_array_line_splits_ == line_split_kind{} ? line_splits_ : array_array_line_splits_;}
+
+    uint8_t indent_size() const 
+    {
+        return indent_size_;
+    }
+
+    spaces_option spaces_around_colon() const 
+    {
+        return spaces_around_colon_;
+    }
+
+    spaces_option spaces_around_comma() const 
+    {
+        return spaces_around_comma_;
+    }
+
+    bool pad_inside_object_braces() const 
+    {
+        return pad_inside_object_braces_;
+    }
+
+    bool pad_inside_array_brackets() const 
+    {
+        return pad_inside_array_brackets_;
+    }
+
+    string_type new_line_chars() const 
+    {
+        return new_line_chars_;
+    }
+
+    std::size_t line_length_limit() const 
+    {
+        return line_length_limit_;
+    }
+
+    float_chars_format float_format() const 
+    {
+        return float_format_;
+    }
+
+    int8_t precision() const 
+    {
+        return precision_;
+    }
+
+    bool escape_all_non_ascii() const 
+    {
+        return escape_all_non_ascii_;
+    }
+
+    bool escape_solidus() const 
+    {
+        return escape_solidus_;
+    }
+
+};
+
+template <typename CharT>
+class basic_json_options final: public basic_json_decode_options<CharT>, 
+                                public basic_json_encode_options<CharT>
+{
+public:
+    using char_type = CharT;
+    using string_type = std::basic_string<CharT>;
+
+    using basic_json_options_common<CharT>::max_nesting_depth;
+
+    using basic_json_decode_options<CharT>::enable_str_to_nan;
+    using basic_json_decode_options<CharT>::enable_str_to_inf;
+    using basic_json_decode_options<CharT>::enable_str_to_neginf;
+    using basic_json_decode_options<CharT>::nan_to_str;
+    using basic_json_decode_options<CharT>::inf_to_str;
+    using basic_json_decode_options<CharT>::neginf_to_str;
+    using basic_json_decode_options<CharT>::nan_to_num;
+    using basic_json_decode_options<CharT>::inf_to_num;
+    using basic_json_decode_options<CharT>::neginf_to_num;
+
+    using basic_json_decode_options<CharT>::lossless_number;
+    using basic_json_decode_options<CharT>::err_handler;
+
+    using basic_json_encode_options<CharT>::byte_string_format;
+    using basic_json_encode_options<CharT>::bignum_format;
+    using basic_json_encode_options<CharT>::line_splits;
+    using basic_json_encode_options<CharT>::object_object_line_splits;
+    using basic_json_encode_options<CharT>::array_object_line_splits;
+    using basic_json_encode_options<CharT>::object_array_line_splits;
+    using basic_json_encode_options<CharT>::array_array_line_splits;
+    using basic_json_encode_options<CharT>::indent_size;
+    using basic_json_encode_options<CharT>::spaces_around_colon;
+    using basic_json_encode_options<CharT>::spaces_around_comma;
+    using basic_json_encode_options<CharT>::pad_inside_object_braces;
+    using basic_json_encode_options<CharT>::pad_inside_array_brackets;
+    using basic_json_encode_options<CharT>::new_line_chars;
+    using basic_json_encode_options<CharT>::line_length_limit;
+    using basic_json_encode_options<CharT>::float_format;
+    using basic_json_encode_options<CharT>::precision;
+    using basic_json_encode_options<CharT>::escape_all_non_ascii;
+    using basic_json_encode_options<CharT>::escape_solidus;
+public:
+
+//  Constructors
+
+    basic_json_options() = default;
+    basic_json_options(const basic_json_options&) = default;
+    basic_json_options(basic_json_options&&) = default;
+    basic_json_options& operator=(const basic_json_options&) = default;
+    basic_json_options& operator=(basic_json_options&&) = default;
+
+    basic_json_options& nan_to_num(const string_type& value)
+    {
+        this->enable_nan_to_num_ = true;
+        this->nan_to_str_.clear();
+        this->nan_to_num_ = value;
+        return *this;
+    }
+
+    basic_json_options& inf_to_num(const string_type& value)
+    {
+        this->enable_inf_to_num_ = true;
+        this->inf_to_str_.clear();
+        this->inf_to_num_ = value;
+        return *this;
+    }
+
+    basic_json_options& neginf_to_num(const string_type& value)
+    {
+        this->enable_neginf_to_num_ = true;
+        this->neginf_to_str_.clear();
+        this->neginf_to_num_ = value;
+        return *this;
+    }
+
+    basic_json_options& nan_to_str(const string_type& value, bool enable_inverse = true)
+    {
+        this->enable_nan_to_str_ = true;
+        this->enable_str_to_nan_ = enable_inverse;
+        this->nan_to_num_.clear();
+        this->nan_to_str_ = value;
+        return *this;
+    }
+
+    basic_json_options& inf_to_str(const string_type& value, bool enable_inverse = true)
+    {
+        this->enable_inf_to_str_ = true;
+        this->enable_str_to_inf_ = enable_inverse;
+        this->inf_to_num_.clear();
+        this->inf_to_str_ = value;
+        return *this;
+    }
+
+    basic_json_options& neginf_to_str(const string_type& value, bool enable_inverse = true)
+    {
+        this->enable_neginf_to_str_ = true;
+        this->enable_str_to_neginf_ = enable_inverse;
+        this->neginf_to_num_.clear();
+        this->neginf_to_str_ = value;
+        return *this;
+    }
+
+    basic_json_options&  byte_string_format(byte_string_chars_format value) {this->byte_string_format_ = value; return *this;}
+
+
+#if !defined(JSONCONS_NO_DEPRECATED)
+    JSONCONS_DEPRECATED_MSG("Instead, use bignum_format")
+    basic_json_options&  bigint_format(bignum_format_kind value) {this->bignum_format_ = value; return *this;}
+#endif    
+
+    basic_json_options&  bignum_format(bignum_format_kind value) {this->bignum_format_ = value; return *this;}
+
+    basic_json_options& line_splits(line_split_kind value) {this->line_splits_ = value; return *this;}
+
+    basic_json_options& object_object_line_splits(line_split_kind value) {this->object_object_line_splits_ = value; return *this;}
+
+    basic_json_options& array_object_line_splits(line_split_kind value) {this->array_object_line_splits_ = value; return *this;}
+
+    basic_json_options& object_array_line_splits(line_split_kind value) {this->object_array_line_splits_ = value; return *this;}
+
+    basic_json_options& array_array_line_splits(line_split_kind value) {this->array_array_line_splits_ = value; return *this;}
+
+    basic_json_options& indent_size(uint8_t value)
+    {
+        this->indent_size_ = value;
+        return *this;
+    }
+
+    basic_json_options& spaces_around_colon(spaces_option value)
+    {
+        this->spaces_around_colon_ = value;
+        return *this;
+    }
+
+    basic_json_options& spaces_around_comma(spaces_option value)
+    {
+        this->spaces_around_comma_ = value;
+        return *this;
+    }
+
+    basic_json_options& pad_inside_object_braces(bool value)
+    {
+        this->pad_inside_object_braces_ = value;
+        return *this;
+    }
+
+    basic_json_options& pad_inside_array_brackets(bool value)
+    {
+        this->pad_inside_array_brackets_ = value;
+        return *this;
+    }
+
+    basic_json_options& new_line_chars(const string_type& value)
+    {
+        this->new_line_chars_ = value;
+        return *this;
+    }
+
+    basic_json_options& lossless_number(bool value) 
+    {
+        this->lossless_number_ = value;
+        return *this;
+    }
+
+    basic_json_options& err_handler(const std::function<bool(json_errc,const ser_context&)>& value) 
+    {
+        this->err_handler_ = value;
+        return *this;
+    }
+
+    basic_json_options& line_length_limit(std::size_t value)
+    {
+        this->line_length_limit_ = value;
+        return *this;
+    }
+
+    basic_json_options& float_format(float_chars_format value)
+    {
+        this->float_format_ = value;
+        return *this;
+    }
+
+    basic_json_options& precision(int8_t value)
+    {
+        this->precision_ = value;
+        return *this;
+    }
+
+    basic_json_options& escape_all_non_ascii(bool value)
+    {
+        this->escape_all_non_ascii_ = value;
+        return *this;
+    }
+
+    basic_json_options& escape_solidus(bool value)
+    {
+        this->escape_solidus_ = value;
+        return *this;
+    }
+
+    basic_json_options& max_nesting_depth(int value)
+    {
+        this->max_nesting_depth_ = value;
+        return *this;
+    }
+
+private:
+    enum class input_state {initial,begin_quote,character,end_quote,escape,error};
+    bool is_string(const string_type& s) const
+    {
+        input_state state = input_state::initial;
+        for (char_type c : s)
+        {
+            switch (c)
+            {
+            case '\t': case ' ': case '\n': case'\r':
+                break;
+            case '\\':
+                state = input_state::escape;
+                break;
+            case '\"':
+                switch (state)
+                {
+                case input_state::initial:
+                    state = input_state::begin_quote;
+                    break;
+                case input_state::begin_quote:
+                case input_state::character:
+                    state = input_state::end_quote;
+                    break;
+                case input_state::end_quote:
+                    state = input_state::error;
+                    break;
+                case input_state::escape:
+                    state = input_state::character;
+                    break;
+                default:
+                    state = input_state::character;
+                    break;
+                }
+                break;
+            default:
+                break;
+            }
+
+        }
+        return state == input_state::end_quote;
+    }
+};
+
+using json_options = basic_json_options<char>;
+using wjson_options = basic_json_options<wchar_t>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_OPTIONS_HPP

--- a/velox/external/jsoncons/json_parser.hpp
+++ b/velox/external/jsoncons/json_parser.hpp
@@ -1,0 +1,2833 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_PARSER_HPP
+#define JSONCONS_JSON_PARSER_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <functional> // std::function
+#include <limits> // std::numeric_limits
+#include <memory> // std::allocator
+#include <string>
+#include <system_error>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/detail/parse_number.hpp"
+#include "velox/external/jsoncons/json_error.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_filter.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+#define JSONCONS_ILLEGAL_CONTROL_CHARACTER \
+        case 0x00:case 0x01:case 0x02:case 0x03:case 0x04:case 0x05:case 0x06:case 0x07:case 0x08:case 0x0b: \
+        case 0x0c:case 0x0e:case 0x0f:case 0x10:case 0x11:case 0x12:case 0x13:case 0x14:case 0x15:case 0x16: \
+        case 0x17:case 0x18:case 0x19:case 0x1a:case 0x1b:case 0x1c:case 0x1d:case 0x1e:case 0x1f 
+
+namespace facebook::velox::jsoncons {
+
+namespace detail {
+
+}
+
+enum class parse_state : uint8_t 
+{
+    root,
+    start, 
+    accept, 
+    slash,  
+    slash_slash, 
+    slash_star, 
+    slash_star_star,
+    expect_comma_or_end,  
+    object,
+    expect_member_name_or_end, 
+    expect_member_name, 
+    expect_colon,
+    expect_value_or_end,
+    expect_value,
+    array, 
+    string,
+    member_name,
+    number,
+    n,
+    nu,
+    nul,
+    t,  
+    tr,  
+    tru,  
+    f,  
+    fa,  
+    fal,  
+    fals,  
+    cr,
+    done
+};
+
+enum class parse_string_state : uint8_t 
+{
+    text = 0,
+    escape, 
+    escape_u1, 
+    escape_u2, 
+    escape_u3, 
+    escape_u4, 
+    escape_expect_surrogate_pair1, 
+    escape_expect_surrogate_pair2, 
+    escape_u5, 
+    escape_u6, 
+    escape_u7, 
+    escape_u8
+};
+
+enum class parse_number_state : uint8_t 
+{
+    minus, 
+    zero,  
+    integer,
+    fraction1,
+    fraction2,
+    exp1,
+    exp2,
+    exp3
+};
+
+template <typename CharT,typename TempAllocator  = std::allocator<char>>
+class basic_json_parser : public ser_context
+{
+public:
+    using char_type = CharT;
+    using string_view_type = typename basic_json_visitor<CharT>::string_view_type;
+private:
+    struct string_maps_to_double
+    {
+        string_view_type s;
+
+        bool operator()(const std::pair<string_view_type,double>& val) const
+        {
+            return val.first == s;
+        }
+    };
+
+    using temp_allocator_type = TempAllocator;
+    using char_allocator_type = typename std::allocator_traits<temp_allocator_type>:: template rebind_alloc<CharT>;
+    using parse_state_allocator_type = typename std::allocator_traits<temp_allocator_type>:: template rebind_alloc<parse_state>;
+
+    static constexpr std::size_t initial_string_buffer_capacity = 256;
+    static constexpr int default_initial_stack_capacity = 66;
+
+    basic_json_decode_options<char_type> options_;
+
+    std::function<bool(json_errc,const ser_context&)> err_handler_;
+    int nesting_depth_;
+    uint32_t cp_;
+    uint32_t cp2_;
+    std::size_t line_;
+    std::size_t position_;
+    std::size_t mark_position_;
+    std::size_t saved_position_;
+    const char_type* begin_input_;
+    const char_type* end_input_;
+    const char_type* input_ptr_;
+    parse_state state_;
+    parse_string_state string_state_ = parse_string_state{};
+    parse_number_state number_state_ = parse_number_state{};
+    bool more_;
+    bool done_;
+
+    std::basic_string<char_type,std::char_traits<char_type>,char_allocator_type> string_buffer_;
+    jsoncons::detail::chars_to to_double_;
+
+    std::vector<parse_state,parse_state_allocator_type> state_stack_;
+    std::vector<std::pair<std::basic_string<char_type>,double>> string_double_map_;
+
+    // Noncopyable and nonmoveable
+    basic_json_parser(const basic_json_parser&) = delete;
+    basic_json_parser& operator=(const basic_json_parser&) = delete;
+
+public:
+    basic_json_parser(const TempAllocator& temp_alloc = TempAllocator())
+        : basic_json_parser(basic_json_decode_options<char_type>(), default_json_parsing(), temp_alloc)
+    {
+    }
+
+    basic_json_parser(std::function<bool(json_errc,const ser_context&)> err_handler, 
+                      const TempAllocator& temp_alloc = TempAllocator())
+        : basic_json_parser(basic_json_decode_options<char_type>(), err_handler, temp_alloc)
+    {
+    }
+
+    basic_json_parser(const basic_json_decode_options<char_type>& options, 
+                      const TempAllocator& temp_alloc = TempAllocator())
+        : basic_json_parser(options, options.err_handler(), temp_alloc)
+    {
+    }
+
+    basic_json_parser(const basic_json_decode_options<char_type>& options,
+                      std::function<bool(json_errc,const ser_context&)> err_handler, 
+                      const TempAllocator& temp_alloc = TempAllocator())
+       : options_(options),
+         err_handler_(err_handler),
+         nesting_depth_(0), 
+         cp_(0),
+         cp2_(0),
+         line_(1),
+         position_(0),
+         mark_position_(0),
+         saved_position_(0),
+         begin_input_(nullptr),
+         end_input_(nullptr),
+         input_ptr_(nullptr),
+         state_(parse_state::start),
+         more_(true),
+         done_(false),
+         string_buffer_(temp_alloc),
+         state_stack_(temp_alloc)
+    {
+        string_buffer_.reserve(initial_string_buffer_capacity);
+
+        std::size_t initial_stack_capacity = options.max_nesting_depth() <= (default_initial_stack_capacity-2) ? (options.max_nesting_depth()+2) : default_initial_stack_capacity;
+        state_stack_.reserve(initial_stack_capacity );
+        push_state(parse_state::root);
+
+        if (options_.enable_str_to_nan())
+        {
+            string_double_map_.emplace_back(options_.nan_to_str(),std::nan(""));
+        }
+        if (options_.enable_str_to_inf())
+        {
+            string_double_map_.emplace_back(options_.inf_to_str(),std::numeric_limits<double>::infinity());
+        }
+        if (options_.enable_str_to_neginf())
+        {
+            string_double_map_.emplace_back(options_.neginf_to_str(),-std::numeric_limits<double>::infinity());
+        }
+    }
+
+    bool source_exhausted() const
+    {
+        return input_ptr_ == end_input_;
+    }
+
+    ~basic_json_parser() noexcept
+    {
+    }
+
+    parse_state parent() const
+    {
+        JSONCONS_ASSERT(state_stack_.size() >= 1);
+        return state_stack_.back();
+    }
+
+    bool done() const
+    {
+        return done_;
+    }
+
+    bool enter() const
+    {
+        return state_ == parse_state::start;
+    }
+
+    bool accept() const
+    {
+        return state_ == parse_state::accept || done_;
+    }
+
+    bool stopped() const
+    {
+        return !more_;
+    }
+
+    parse_state state() const
+    {
+        return state_;
+    }
+
+    bool finished() const
+    {
+        return !more_ && state_ != parse_state::accept;
+    }
+
+    const char_type* first() const
+    {
+        return begin_input_;
+    }
+
+    const char_type* current() const
+    {
+        return input_ptr_;
+    }
+
+    const char_type* last() const
+    {
+        return end_input_;
+    }
+
+    void skip_space()
+    {
+        const char_type* local_input_end = end_input_;
+        while (input_ptr_ != local_input_end) 
+        {
+            switch (*input_ptr_)
+            {
+                case ' ':
+                case '\t':
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                case '\r': 
+                    push_state(state_);
+                    ++input_ptr_;
+                    ++position_;
+                    state_ = parse_state::cr;
+                    return; 
+                case '\n': 
+                    ++input_ptr_;
+                    ++line_;
+                    ++position_;
+                    mark_position_ = position_;
+                    return;   
+                default:
+                    return;
+            }
+        }
+    }
+
+    void skip_whitespace()
+    {
+        const char_type* local_input_end = end_input_;
+
+        while (input_ptr_ != local_input_end) 
+        {
+            switch (state_)
+            {
+                case parse_state::cr:
+                    ++line_;
+                    ++position_;
+                    mark_position_ = position_;
+                    switch (*input_ptr_)
+                    {
+                        case '\n':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = pop_state();
+                            break;
+                        default:
+                            state_ = pop_state();
+                            break;
+                    }
+                    break;
+
+                default:
+                    switch (*input_ptr_)
+                    {
+                        case ' ':
+                        case '\t':
+                        case '\n':
+                        case '\r':
+                            skip_space();
+                            break;
+                        default:
+                            return;
+                    }
+                    break;
+            }
+        }
+    }
+
+    void begin_object(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (JSONCONS_UNLIKELY(++nesting_depth_ > options_.max_nesting_depth()))
+        {
+            more_ = err_handler_(json_errc::max_nesting_depth_exceeded, *this);
+            if (!more_)
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return;
+            }
+        } 
+
+        push_state(parse_state::object);
+        state_ = parse_state::expect_member_name_or_end;
+        more_ = visitor.begin_object(semantic_tag::none, *this, ec);
+    }
+
+    void end_object(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (JSONCONS_UNLIKELY(nesting_depth_ < 1))
+        {
+            err_handler_(json_errc::unexpected_rbrace, *this);
+            ec = json_errc::unexpected_rbrace;
+            more_ = false;
+            return;
+        }
+        --nesting_depth_;
+        state_ = pop_state();
+        if (state_ == parse_state::object)
+        {
+            more_ = visitor.end_object(*this, ec);
+        }
+        else if (state_ == parse_state::array)
+        {
+            err_handler_(json_errc::expected_comma_or_rbracket, *this);
+            ec = json_errc::expected_comma_or_rbracket;
+            more_ = false;
+            return;
+        }
+        else
+        {
+            err_handler_(json_errc::unexpected_rbrace, *this);
+            ec = json_errc::unexpected_rbrace;
+            more_ = false;
+            return;
+        }
+
+        if (parent() == parse_state::root)
+        {
+            state_ = parse_state::accept;
+        }
+        else
+        {
+            state_ = parse_state::expect_comma_or_end;
+        }
+    }
+
+    void begin_array(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (++nesting_depth_ > options_.max_nesting_depth())
+        {
+            more_ = err_handler_(json_errc::max_nesting_depth_exceeded, *this);
+            if (!more_)
+            {
+                ec = json_errc::max_nesting_depth_exceeded;
+                return;
+            }
+        }
+
+        push_state(parse_state::array);
+        state_ = parse_state::expect_value_or_end;
+        more_ = visitor.begin_array(semantic_tag::none, *this, ec);
+    }
+
+    void end_array(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (nesting_depth_ < 1)
+        {
+            err_handler_(json_errc::unexpected_rbracket, *this);
+            ec = json_errc::unexpected_rbracket;
+            more_ = false;
+            return;
+        }
+        --nesting_depth_;
+        state_ = pop_state();
+        if (state_ == parse_state::array)
+        {
+            more_ = visitor.end_array(*this, ec);
+        }
+        else if (state_ == parse_state::object)
+        {
+            err_handler_(json_errc::expected_comma_or_rbrace, *this);
+            ec = json_errc::expected_comma_or_rbrace;
+            more_ = false;
+            return;
+        }
+        else
+        {
+            err_handler_(json_errc::unexpected_rbracket, *this);
+            ec = json_errc::unexpected_rbracket;
+            more_ = false;
+            return;
+        }
+        if (parent() == parse_state::root)
+        {
+            state_ = parse_state::accept;
+        }
+        else
+        {
+            state_ = parse_state::expect_comma_or_end;
+        }
+    }
+
+    void reinitialize()
+    {
+        reset();
+        cp_ = 0;
+        cp2_ = 0;
+        saved_position_ = 0;
+        begin_input_ = nullptr;
+        end_input_ = nullptr;
+        input_ptr_ = nullptr;
+        string_buffer_.clear();
+    }
+
+    void reset()
+    {
+        state_stack_.clear();
+        push_state(parse_state::root);
+        state_ = parse_state::start;
+        more_ = true;
+        done_ = false;
+        line_ = 1;
+        position_ = 0;
+        mark_position_ = 0;
+        nesting_depth_ = 0;
+    }
+
+    void restart()
+    {
+        more_ = true;
+    }
+
+    void check_done()
+    {
+        std::error_code ec;
+        check_done(ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,line_,column()));
+        }
+    }
+
+    void check_done(std::error_code& ec)
+    {
+        for (; input_ptr_ != end_input_; ++input_ptr_)
+        {
+            char_type curr_char_ = *input_ptr_;
+            switch (curr_char_)
+            {
+                case '\n':
+                case '\r':
+                case '\t':
+                case ' ':
+                    break;
+                default:
+                    more_ = err_handler_(json_errc::extra_character, *this);
+                    if (!more_)
+                    {
+                        ec = json_errc::extra_character;
+                        return;
+                    }
+                    break;
+            }
+        }
+    }
+
+    void update(const string_view_type sv)
+    {
+        update(sv.data(),sv.length());
+    }
+
+    void update(const char_type* data, std::size_t length)
+    {
+        begin_input_ = data;
+        end_input_ = data + length;
+        input_ptr_ = begin_input_;
+    }
+
+    void parse_some(basic_json_visitor<char_type>& visitor)
+    {
+        std::error_code ec;
+        parse_some(visitor, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,line_,column()));
+        }
+    }
+
+    void parse_some(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        parse_some_(visitor, ec);
+    }
+
+    void finish_parse(basic_json_visitor<char_type>& visitor)
+    {
+        std::error_code ec;
+        finish_parse(visitor, ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec,line_,column()));
+        }
+    }
+
+    void finish_parse(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        while (!finished())
+        {
+            parse_some(visitor, ec);
+        }
+    }
+
+    void parse_some_(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (state_ == parse_state::accept)
+        {
+            visitor.flush();
+            done_ = true;
+            state_ = parse_state::done;
+            more_ = false;
+            return;
+        }
+        const char_type* local_input_end = end_input_;
+
+        if (input_ptr_ == local_input_end && more_)
+        {
+            switch (state_)
+            {
+                case parse_state::number:  
+                    if (number_state_ == parse_number_state::zero || number_state_ == parse_number_state::integer)
+                    {
+                        end_integer_value(visitor, ec);
+                        if (ec) return;
+                    }
+                    else if (number_state_ == parse_number_state::fraction2 || number_state_ == parse_number_state::exp3)
+                    {
+                        end_fraction_value(visitor, ec);
+                        if (ec) return;
+                    }
+                    else
+                    {
+                        err_handler_(json_errc::unexpected_eof, *this);
+                        ec = json_errc::unexpected_eof;
+                        more_ = false;
+                    }
+                    break;
+                case parse_state::accept:
+                    visitor.flush();
+                    done_ = true;
+                    state_ = parse_state::done;
+                    more_ = false;
+                    break;
+                case parse_state::start:
+                    more_ = false;
+                    ec = json_errc::unexpected_eof;
+                    break;                
+                case parse_state::done:
+                    more_ = false;
+                    break;
+                case parse_state::cr:
+                    state_ = pop_state();
+                    break;
+                default:
+                    err_handler_(json_errc::unexpected_eof, *this);
+                    ec = json_errc::unexpected_eof;
+                    more_ = false;
+                    return;
+            }
+        }
+
+        while ((input_ptr_ < local_input_end) && more_)
+        {
+            switch (state_)
+            {
+                case parse_state::accept:
+                    visitor.flush();
+                    done_ = true;
+                    state_ = parse_state::done;
+                    more_ = false;
+                    break;
+                case parse_state::cr:
+                    ++line_;
+                    mark_position_ = position_;
+                    switch (*input_ptr_)
+                    {
+                        case '\n':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = pop_state();
+                            break;
+                        default:
+                            state_ = pop_state();
+                            break;
+                    }
+                    break;
+                case parse_state::start: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                break;
+                            case '\r': 
+                                push_state(state_);
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::slash;
+                                break;
+                            case '{':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_object(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '[':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_array(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '\"':
+                                state_ = parse_state::string;
+                                string_state_ = parse_string_state{};
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                string_buffer_.clear();
+                                parse_string(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '-':
+                                string_buffer_.clear();
+                                string_buffer_.push_back('-');
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::minus;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '0': 
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::zero;
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::integer;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'n':
+                                parse_null(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 't':
+                                parse_true(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'f':
+                                parse_false(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '}':
+                                err_handler_(json_errc::unexpected_rbrace, *this);
+                                ec = json_errc::unexpected_rbrace;
+                                more_ = false;
+                                return;
+                            case ']':
+                                err_handler_(json_errc::unexpected_rbracket, *this);
+                                ec = json_errc::unexpected_rbracket;
+                                more_ = false;
+                                return;
+                            default:
+                                err_handler_(json_errc::syntax_error, *this);
+                                ec = json_errc::syntax_error;
+                                more_ = false;
+                                return;
+                        }
+                    }
+                    break;
+
+                case parse_state::expect_comma_or_end: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/':
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_); 
+                                state_ = parse_state::slash;
+                                break;
+                            case '}':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                end_object(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case ']':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                end_array(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case ',':
+                                begin_member_or_element(ec);
+                                if (ec) return;
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                if (parent() == parse_state::array)
+                                {
+                                    more_ = err_handler_(json_errc::expected_comma_or_rbracket, *this);
+                                    if (!more_)
+                                    {
+                                        ec = json_errc::expected_comma_or_rbracket;
+                                        return;
+                                    }
+                                }
+                                else if (parent() == parse_state::object)
+                                {
+                                    more_ = err_handler_(json_errc::expected_comma_or_rbrace, *this);
+                                    if (!more_)
+                                    {
+                                        ec = json_errc::expected_comma_or_rbrace;
+                                        return;
+                                    }
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                        }
+                    }
+                    break;
+                case parse_state::expect_member_name_or_end: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/':
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_); 
+                                state_ = parse_state::slash;
+                                break;
+                            case '}':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                end_object(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '\"':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(parse_state::member_name);
+                                state_ = parse_state::string;
+                                string_state_ = parse_string_state{};
+                                string_buffer_.clear();
+                                parse_string(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '\'':
+                                more_ = err_handler_(json_errc::single_quote, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::single_quote;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                more_ = err_handler_(json_errc::expected_key, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::expected_key;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                        }
+                    }
+                    break;
+                case parse_state::expect_member_name: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::slash;
+                                break;
+                            case '\"':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(parse_state::member_name);
+                                state_ = parse_state::string;
+                                string_state_ = parse_string_state{};
+                                string_buffer_.clear();
+                                parse_string(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '}':
+                                more_ = err_handler_(json_errc::extra_comma, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::extra_comma;
+                                    return;
+                                }
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                end_object(visitor, ec);  // Recover
+                                if (ec) return;
+                                break;
+                            case '\'':
+                                more_ = err_handler_(json_errc::single_quote, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::single_quote;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                more_ = err_handler_(json_errc::expected_key, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::expected_key;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                        }
+                    }
+                    break;
+                case parse_state::expect_colon: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                push_state(state_);
+                                state_ = parse_state::cr;
+                                ++input_ptr_;
+                                ++position_;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/': 
+                                push_state(state_);
+                                state_ = parse_state::slash;
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case ':':
+                                state_ = parse_state::expect_value;
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                more_ = err_handler_(json_errc::expected_colon, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::expected_colon;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                        }
+                    }
+                    break;
+
+                    case parse_state::expect_value: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                push_state(state_);
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/': 
+                                push_state(state_);
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::slash;
+                                break;
+                            case '{':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_object(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '[':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_array(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '\"':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::string;
+                                string_state_ = parse_string_state{};
+                                string_buffer_.clear();
+                                parse_string(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '-':
+                                string_buffer_.clear();
+                                string_buffer_.push_back('-');
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::minus;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '0': 
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::zero;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::integer;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'n':
+                                parse_null(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 't':
+                                parse_true(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'f':
+                                parse_false(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case ']':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                if (parent() == parse_state::array)
+                                {
+                                    more_ = err_handler_(json_errc::extra_comma, *this);
+                                    if (!more_)
+                                    {
+                                        ec = json_errc::extra_comma;
+                                        return;
+                                    }
+                                    end_array(visitor, ec);  // Recover
+                                    if (ec) return;
+                                }
+                                else
+                                {
+                                    more_ = err_handler_(json_errc::expected_value, *this);
+                                    if (!more_)
+                                    {
+                                        ec = json_errc::expected_value;
+                                        return;
+                                    }
+                                }
+                                break;
+                            case '\'':
+                                more_ = err_handler_(json_errc::single_quote, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::single_quote;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                more_ = err_handler_(json_errc::expected_value, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::expected_value;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                        }
+                    }
+                    break;
+                    case parse_state::expect_value_or_end: 
+                    {
+                        switch (*input_ptr_)
+                        {
+                            JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                                more_ = err_handler_(json_errc::illegal_control_character, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::illegal_control_character;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            case '\r': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::cr;
+                                break; 
+                            case '\n': 
+                                ++input_ptr_;
+                                ++line_;
+                                ++position_;
+                                mark_position_ = position_;
+                                break;   
+                            case ' ':case '\t':
+                                skip_space();
+                                break;
+                            case '/': 
+                                ++input_ptr_;
+                                ++position_;
+                                push_state(state_);
+                                state_ = parse_state::slash;
+                                break;
+                            case '{':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_object(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '[':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                begin_array(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case ']':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                end_array(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '\"':
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::string;
+                                string_state_ = parse_string_state{};
+                                string_buffer_.clear();
+                                parse_string(visitor, ec);
+                                if (ec) return;
+                                break;
+                            case '-':
+                                string_buffer_.clear();
+                                string_buffer_.push_back('-');
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::minus;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '0': 
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::zero;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                                string_buffer_.clear();
+                                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                                saved_position_ = position_;
+                                ++input_ptr_;
+                                ++position_;
+                                state_ = parse_state::number;
+                                number_state_ = parse_number_state::integer;
+                                parse_number(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'n':
+                                parse_null(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 't':
+                                parse_true(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case 'f':
+                                parse_false(visitor, ec);
+                                if (ec) {return;}
+                                break;
+                            case '\'':
+                                more_ = err_handler_(json_errc::single_quote, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::single_quote;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            default:
+                                more_ = err_handler_(json_errc::expected_value, *this);
+                                if (!more_)
+                                {
+                                    ec = json_errc::expected_value;
+                                    return;
+                                }
+                                ++input_ptr_;
+                                ++position_;
+                                break;
+                            }
+                        }
+                    break;
+                case parse_state::string: 
+                    parse_string(visitor, ec);
+                    if (ec) return;
+                    break;
+                case parse_state::number:
+                    parse_number(visitor, ec);  
+                    if (ec) return;
+                    break;
+                case parse_state::t: 
+                    switch (*input_ptr_)
+                    {
+                        case 'r':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = parse_state::tr;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    break;
+                case parse_state::tr: 
+                    switch (*input_ptr_)
+                    {
+                        case 'u':
+                            state_ = parse_state::tru;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                case parse_state::tru: 
+                    switch (*input_ptr_)
+                    {
+                        case 'e':
+                            ++input_ptr_;
+                            ++position_;
+                            more_ = visitor.bool_value(true,  semantic_tag::none, *this, ec);
+                            if (parent() == parse_state::root)
+                            {
+                                state_ = parse_state::accept;
+                            }
+                            else
+                            {
+                                state_ = parse_state::expect_comma_or_end;
+                            }
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    break;
+                case parse_state::f: 
+                    switch (*input_ptr_)
+                    {
+                        case 'a':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = parse_state::fa;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    break;
+                case parse_state::fa: 
+                    switch (*input_ptr_)
+                    {
+                        case 'l':
+                            state_ = parse_state::fal;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                case parse_state::fal: 
+                    switch (*input_ptr_)
+                    {
+                        case 's':
+                            state_ = parse_state::fals;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                case parse_state::fals: 
+                    switch (*input_ptr_)
+                    {
+                        case 'e':
+                            ++input_ptr_;
+                            ++position_;
+                            more_ = visitor.bool_value(false, semantic_tag::none, *this, ec);
+                            if (parent() == parse_state::root)
+                            {
+                                state_ = parse_state::accept;
+                            }
+                            else
+                            {
+                                state_ = parse_state::expect_comma_or_end;
+                            }
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    break;
+                case parse_state::n: 
+                    switch (*input_ptr_)
+                    {
+                        case 'u':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = parse_state::nu;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    break;
+                case parse_state::nu: 
+                    switch (*input_ptr_)
+                    {
+                        case 'l':
+                            state_ = parse_state::nul;
+                            break;
+                        default:
+                            err_handler_(json_errc::invalid_value, *this);
+                            ec = json_errc::invalid_value;
+                            more_ = false;
+                            return;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                case parse_state::nul: 
+                    ++position_;
+                    switch (*input_ptr_)
+                    {
+                    case 'l':
+                        more_ = visitor.null_value(semantic_tag::none, *this, ec);
+                        if (parent() == parse_state::root)
+                        {
+                            state_ = parse_state::accept;
+                        }
+                        else
+                        {
+                            state_ = parse_state::expect_comma_or_end;
+                        }
+                        break;
+                    default:
+                        err_handler_(json_errc::invalid_value, *this);
+                        ec = json_errc::invalid_value;
+                        more_ = false;
+                        return;
+                    }
+                    ++input_ptr_;
+                    break;
+                case parse_state::slash: 
+                {
+                    switch (*input_ptr_)
+                    {
+                    case '*':
+                        state_ = parse_state::slash_star;
+                        more_ = err_handler_(json_errc::illegal_comment, *this);
+                        if (!more_)
+                        {
+                            ec = json_errc::illegal_comment;
+                            return;
+                        }
+                        break;
+                    case '/':
+                        state_ = parse_state::slash_slash;
+                        more_ = err_handler_(json_errc::illegal_comment, *this);
+                        if (!more_)
+                        {
+                            ec = json_errc::illegal_comment;
+                            return;
+                        }
+                        break;
+                    default:    
+                        more_ = err_handler_(json_errc::syntax_error, *this);
+                        if (!more_)
+                        {
+                            ec = json_errc::syntax_error;
+                            return;
+                        }
+                        break;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                }
+                case parse_state::slash_star:  
+                {
+                    switch (*input_ptr_)
+                    {
+                        case '\r':
+                            push_state(state_);
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = parse_state::cr;
+                            break;
+                        case '\n':
+                            ++input_ptr_;
+                            ++line_;
+                            ++position_;
+                            mark_position_ = position_;
+                            break;
+                        case '*':
+                            ++input_ptr_;
+                            ++position_;
+                            state_ = parse_state::slash_star_star;
+                            break;
+                        default:
+                            ++input_ptr_;
+                            ++position_;
+                            break;
+                    }
+                    break;
+                }
+                case parse_state::slash_slash: 
+                {
+                    switch (*input_ptr_)
+                    {
+                    case '\r':
+                    case '\n':
+                        state_ = pop_state();
+                        break;
+                    default:
+                        ++input_ptr_;
+                        ++position_;
+                    }
+                    break;
+                }
+                case parse_state::slash_star_star: 
+                {
+                    switch (*input_ptr_)
+                    {
+                    case '/':
+                        state_ = pop_state();
+                        break;
+                    default:    
+                        state_ = parse_state::slash_star;
+                        break;
+                    }
+                    ++input_ptr_;
+                    ++position_;
+                    break;
+                }
+                default:
+                    JSONCONS_ASSERT(false);
+                    break;
+            }
+        }
+    }
+
+    void parse_true(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        saved_position_ = position_;
+        if (JSONCONS_LIKELY(end_input_ - input_ptr_ >= 4))
+        {
+            if (*(input_ptr_+1) == 'r' && *(input_ptr_+2) == 'u' && *(input_ptr_+3) == 'e')
+            {
+                input_ptr_ += 4;
+                position_ += 4;
+                more_ = visitor.bool_value(true, semantic_tag::none, *this, ec);
+                if (parent() == parse_state::root)
+                {
+                    state_ = parse_state::accept;
+                }
+                else
+                {
+                    state_ = parse_state::expect_comma_or_end;
+                }
+            }
+            else
+            {
+                err_handler_(json_errc::invalid_value, *this);
+                ec = json_errc::invalid_value;
+                more_ = false;
+                return;
+            }
+        }
+        else
+        {
+            ++input_ptr_;
+            ++position_;
+            state_ = parse_state::t;
+        }
+    }
+
+    void parse_null(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        saved_position_ = position_;
+        if (JSONCONS_LIKELY(end_input_ - input_ptr_ >= 4))
+        {
+            if (*(input_ptr_+1) == 'u' && *(input_ptr_+2) == 'l' && *(input_ptr_+3) == 'l')
+            {
+                input_ptr_ += 4;
+                position_ += 4;
+                more_ = visitor.null_value(semantic_tag::none, *this, ec);
+                if (parent() == parse_state::root)
+                {
+                    state_ = parse_state::accept;
+                }
+                else
+                {
+                    state_ = parse_state::expect_comma_or_end;
+                }
+            }
+            else
+            {
+                err_handler_(json_errc::invalid_value, *this);
+                ec = json_errc::invalid_value;
+                more_ = false;
+                return;
+            }
+        }
+        else
+        {
+            ++input_ptr_;
+            ++position_;
+            state_ = parse_state::n;
+        }
+    }
+
+    void parse_false(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        saved_position_ = position_;
+        if (JSONCONS_LIKELY(end_input_ - input_ptr_ >= 5))
+        {
+            if (*(input_ptr_+1) == 'a' && *(input_ptr_+2) == 'l' && *(input_ptr_+3) == 's' && *(input_ptr_+4) == 'e')
+            {
+                input_ptr_ += 5;
+                position_ += 5;
+                more_ = visitor.bool_value(false, semantic_tag::none, *this, ec);
+                if (parent() == parse_state::root)
+                {
+                    state_ = parse_state::accept;
+                }
+                else
+                {
+                    state_ = parse_state::expect_comma_or_end;
+                }
+            }
+            else
+            {
+                err_handler_(json_errc::invalid_value, *this);
+                ec = json_errc::invalid_value;
+                more_ = false;
+                return;
+            }
+        }
+        else
+        {
+            ++input_ptr_;
+            ++position_;
+            state_ = parse_state::f;
+        }
+    }
+
+    void parse_number(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        const char_type* local_input_end = end_input_;
+
+        switch (number_state_)
+        {
+            case parse_number_state::minus:
+                goto minus_sign;
+            case parse_number_state::zero:
+                goto zero;
+            case parse_number_state::integer:
+                goto integer;
+            case parse_number_state::fraction1:
+                goto fraction1;
+            case parse_number_state::fraction2:
+                goto fraction2;
+            case parse_number_state::exp1:
+                goto exp1;
+            case parse_number_state::exp2:
+                goto exp2;
+            case parse_number_state::exp3:
+                goto exp3;
+            default:
+                JSONCONS_UNREACHABLE();               
+        }
+minus_sign:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::minus;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '0': 
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto zero;
+            case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto integer;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::expected_value;
+                more_ = false;
+                return;
+        }
+zero:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::zero;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '\r': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                push_state(state_);
+                state_ = parse_state::cr;
+                return; 
+            case '\n': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++line_;
+                ++position_;
+                mark_position_ = position_;
+                return;   
+            case ' ':case '\t':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                skip_space();
+                return;
+            case '/': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                push_state(state_);
+                state_ = parse_state::slash;
+                return;
+            case '}':
+            case ']':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case '.':
+                string_buffer_.push_back(to_double_.get_decimal_point());
+                ++input_ptr_;
+                ++position_;
+                goto fraction1;
+            case 'e':case 'E':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp1;
+            case ',':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                begin_member_or_element(ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                return;
+            case '0': case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                err_handler_(json_errc::leading_zero, *this);
+                ec = json_errc::leading_zero;
+                more_ = false;
+                number_state_ = parse_number_state::zero;
+                return;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::invalid_number;
+                more_ = false;
+                number_state_ = parse_number_state::zero;
+                return;
+        }
+integer:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::integer;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '\r': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                push_state(state_);
+                ++input_ptr_;
+                ++position_;
+                state_ = parse_state::cr;
+                return; 
+            case '\n': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++line_;
+                ++position_;
+                mark_position_ = position_;
+                return;   
+            case ' ':case '\t':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                skip_space();
+                return;
+            case '/': 
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                push_state(state_);
+                ++input_ptr_;
+                ++position_;
+                state_ = parse_state::slash;
+                return;
+            case '}':
+            case ']':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case '0': case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto integer;
+            case '.':
+                string_buffer_.push_back(to_double_.get_decimal_point());
+                ++input_ptr_;
+                ++position_;
+                goto fraction1;
+            case 'e':case 'E':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp1;
+            case ',':
+                end_integer_value(visitor, ec);
+                if (ec) return;
+                begin_member_or_element(ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                return;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::invalid_number;
+                more_ = false;
+                number_state_ = parse_number_state::integer;
+                return;
+        }
+fraction1:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::fraction1;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto fraction2;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::invalid_number;
+                more_ = false;
+                number_state_ = parse_number_state::fraction1;
+                return;
+        }
+fraction2:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::fraction2;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '\r': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                push_state(state_);
+                ++input_ptr_;
+                ++position_;
+                state_ = parse_state::cr;
+                return; 
+            case '\n': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++line_;
+                ++position_;
+                mark_position_ = position_;
+                return;   
+            case ' ':case '\t':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                skip_space();
+                return;
+            case '/': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                push_state(state_);
+                ++input_ptr_;
+                ++position_;
+                state_ = parse_state::slash;
+                return;
+            case '}':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case ']':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case ',':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                begin_member_or_element(ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                return;
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto fraction2;
+            case 'e':case 'E':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp1;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::invalid_number;
+                more_ = false;
+                number_state_ = parse_number_state::fraction2;
+                return;
+        }
+exp1:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::exp1;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '+':
+                ++input_ptr_;
+                ++position_;
+                goto exp2;
+            case '-':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp2;
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp3;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::expected_value;
+                more_ = false;
+                number_state_ = parse_number_state::exp1;
+                return;
+        }
+exp2:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::exp2;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp3;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::expected_value;
+                more_ = false;
+                number_state_ = parse_number_state::exp2;
+                return;
+        }
+        
+exp3:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            number_state_ = parse_number_state::exp3;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+            case '\r': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                push_state(state_);
+                state_ = parse_state::cr;
+                return; 
+            case '\n': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++line_;
+                ++position_;
+                mark_position_ = position_;
+                return;   
+            case ' ':case '\t':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                skip_space();
+                return;
+            case '/': 
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                push_state(state_);
+                ++input_ptr_;
+                ++position_;
+                state_ = parse_state::slash;
+                return;
+            case '}':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case ']':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                state_ = parse_state::expect_comma_or_end;
+                return;
+            case ',':
+                end_fraction_value(visitor, ec);
+                if (ec) return;
+                begin_member_or_element(ec);
+                if (ec) return;
+                ++input_ptr_;
+                ++position_;
+                return;
+            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                string_buffer_.push_back(static_cast<char>(*input_ptr_));
+                ++input_ptr_;
+                ++position_;
+                goto exp3;
+            default:
+                err_handler_(json_errc::invalid_number, *this);
+                ec = json_errc::invalid_number;
+                more_ = false;
+                number_state_ = parse_number_state::exp3;
+                return;
+        }
+
+        JSONCONS_UNREACHABLE();               
+    }
+
+    void parse_string(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        const char_type* local_input_end = end_input_;
+        const char_type* sb = input_ptr_;
+
+        switch (string_state_)
+        {
+            case parse_string_state::text:
+                goto text;
+            case parse_string_state::escape:
+                goto escape;
+            case parse_string_state::escape_u1:
+                goto escape_u1;
+            case parse_string_state::escape_u2:
+                goto escape_u2;
+            case parse_string_state::escape_u3:
+                goto escape_u3;
+            case parse_string_state::escape_u4:
+                goto escape_u4;
+            case parse_string_state::escape_expect_surrogate_pair1:
+                goto escape_expect_surrogate_pair1;
+            case parse_string_state::escape_expect_surrogate_pair2:
+                goto escape_expect_surrogate_pair2;
+            case parse_string_state::escape_u5:
+                goto escape_u5;
+            case parse_string_state::escape_u6:
+                goto escape_u6;
+            case parse_string_state::escape_u7:
+                goto escape_u7;
+            case parse_string_state::escape_u8:
+                goto escape_u8;
+            default:
+                JSONCONS_UNREACHABLE();               
+        }
+
+text:
+        while (input_ptr_ < local_input_end)
+        {
+            switch (*input_ptr_)
+            {
+                JSONCONS_ILLEGAL_CONTROL_CHARACTER:
+                {
+                    position_ += (input_ptr_ - sb + 1);
+                    more_ = err_handler_(json_errc::illegal_control_character, *this);
+                    if (!more_)
+                    {
+                        ec = json_errc::illegal_control_character;
+                        string_state_ = parse_string_state{};
+                        return;
+                    }
+                    // recovery - skip
+                    string_buffer_.append(sb,input_ptr_-sb);
+                    ++input_ptr_;
+                    string_state_ = parse_string_state{};
+                    return;
+                }
+                case '\n':
+                case '\r':
+                case '\t':
+                {
+                    position_ += (input_ptr_ - sb + 1);
+                    if (!err_handler_(json_errc::illegal_character_in_string, *this))
+                    {
+                        more_ = false;
+                        ec = json_errc::illegal_character_in_string;
+                        return;
+                    }
+                    // recovery - skip
+                    string_buffer_.append(sb,input_ptr_-sb);
+                    sb = input_ptr_ + 1;
+                    break;
+                }
+                case '\\': 
+                {
+                    string_buffer_.append(sb,input_ptr_-sb);
+                    position_ += (input_ptr_ - sb + 1);
+                    ++input_ptr_;
+                    goto escape;
+                }
+                case '\"':
+                {
+                    position_ += (input_ptr_ - sb + 1);
+                    if (string_buffer_.length() == 0)
+                    {
+                        end_string_value(sb,input_ptr_-sb, visitor, ec);
+                        if (ec) {return;}
+                    }
+                    else
+                    {
+                        string_buffer_.append(sb,input_ptr_-sb);
+                        end_string_value(string_buffer_.data(),string_buffer_.length(), visitor, ec);
+                        if (ec) {return;}
+                    }
+                    ++input_ptr_;
+                    return;
+                }
+            default:
+                break;
+            }
+            ++input_ptr_;
+        }
+
+        // Buffer exhausted               
+        {
+            string_buffer_.append(sb,input_ptr_-sb);
+            position_ += (input_ptr_ - sb);
+            string_state_ = parse_string_state{};
+            return;
+        }
+
+escape:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape;
+            return;
+        }
+        switch (*input_ptr_)
+        {
+        case '\"':
+            string_buffer_.push_back('\"');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case '\\': 
+            string_buffer_.push_back('\\');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case '/':
+            string_buffer_.push_back('/');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 'b':
+            string_buffer_.push_back('\b');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 'f':
+            string_buffer_.push_back('\f');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 'n':
+            string_buffer_.push_back('\n');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 'r':
+            string_buffer_.push_back('\r');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 't':
+            string_buffer_.push_back('\t');
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        case 'u':
+             cp_ = 0;
+             ++input_ptr_;
+             ++position_;
+             goto escape_u1;
+        default:    
+            err_handler_(json_errc::illegal_escaped_character, *this);
+            ec = json_errc::illegal_escaped_character;
+            more_ = false;
+            string_state_ = parse_string_state::escape;
+            return;
+        }
+
+escape_u1:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u1;
+            return;
+        }
+        {
+            cp_ = append_to_codepoint(0, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u1;
+                return;
+            }
+            ++input_ptr_;
+            ++position_;
+            goto escape_u2;
+        }
+
+escape_u2:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u2;
+            return;
+        }
+        {
+            cp_ = append_to_codepoint(cp_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u2;
+                return;
+            }
+            ++input_ptr_;
+            ++position_;
+            goto escape_u3;
+        }
+
+escape_u3:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u3;
+            return;
+        }
+        {
+            cp_ = append_to_codepoint(cp_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u3;
+                return;
+            }
+            ++input_ptr_;
+            ++position_;
+            goto escape_u4;
+        }
+
+escape_u4:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u4;
+            return;
+        }
+        {
+            cp_ = append_to_codepoint(cp_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u4;
+                return;
+            }
+            if (unicode_traits::is_high_surrogate(cp_))
+            {
+                ++input_ptr_;
+                ++position_;
+                goto escape_expect_surrogate_pair1;
+            }
+            else
+            {
+                unicode_traits::convert(&cp_, 1, string_buffer_);
+                sb = ++input_ptr_;
+                ++position_;
+                string_state_ = parse_string_state{};
+                return;
+            }
+        }
+
+escape_expect_surrogate_pair1:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_expect_surrogate_pair1;
+            return;
+        }
+        {
+            switch (*input_ptr_)
+            {
+            case '\\': 
+                cp2_ = 0;
+                ++input_ptr_;
+                ++position_;
+                goto escape_expect_surrogate_pair2;
+            default:
+                err_handler_(json_errc::expected_codepoint_surrogate_pair, *this);
+                ec = json_errc::expected_codepoint_surrogate_pair;
+                more_ = false;
+                string_state_ = parse_string_state::escape_expect_surrogate_pair1;
+                return;
+            }
+        }
+
+escape_expect_surrogate_pair2:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_expect_surrogate_pair2;
+            return;
+        }
+        {
+            switch (*input_ptr_)
+            {
+            case 'u':
+                ++input_ptr_;
+                ++position_;
+                goto escape_u5;
+            default:
+                err_handler_(json_errc::expected_codepoint_surrogate_pair, *this);
+                ec = json_errc::expected_codepoint_surrogate_pair;
+                more_ = false;
+                string_state_ = parse_string_state::escape_expect_surrogate_pair2;
+                return;
+            }
+        }
+
+escape_u5:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u5;
+            return;
+        }
+        {
+            cp2_ = append_to_codepoint(0, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u5;
+                return;
+            }
+        }
+        ++input_ptr_;
+        ++position_;
+        goto escape_u6;
+
+escape_u6:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u6;
+            return;
+        }
+        {
+            cp2_ = append_to_codepoint(cp2_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u6;
+                return;
+            }
+            ++input_ptr_;
+            ++position_;
+            goto escape_u7;
+        }
+
+escape_u7:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u7;
+            return;
+        }
+        {
+            cp2_ = append_to_codepoint(cp2_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u7;
+                return;
+            }
+            ++input_ptr_;
+            ++position_;
+            goto escape_u8;
+        }
+
+escape_u8:
+        if (JSONCONS_UNLIKELY(input_ptr_ >= local_input_end)) // Buffer exhausted               
+        {
+            string_state_ = parse_string_state::escape_u8;
+            return;
+        }
+        {
+            cp2_ = append_to_codepoint(cp2_, *input_ptr_, ec);
+            if (ec)
+            {
+                string_state_ = parse_string_state::escape_u8;
+                return;
+            }
+            uint32_t cp = 0x10000 + ((cp_ & 0x3FF) << 10) + (cp2_ & 0x3FF);
+            unicode_traits::convert(&cp, 1, string_buffer_);
+            sb = ++input_ptr_;
+            ++position_;
+            goto text;
+        }
+
+        JSONCONS_UNREACHABLE();               
+    }
+
+    void translate_conv_errc(unicode_traits::conv_errc result, std::error_code& ec)
+    {
+        switch (result)
+        {
+        case unicode_traits::conv_errc():
+            break;
+        case unicode_traits::conv_errc::over_long_utf8_sequence:
+            more_ = err_handler_(json_errc::over_long_utf8_sequence, *this);
+            if (!more_)
+            {
+                ec = json_errc::over_long_utf8_sequence;
+                return;
+            }
+            break;
+        case unicode_traits::conv_errc::unpaired_high_surrogate:
+            more_ = err_handler_(json_errc::unpaired_high_surrogate, *this);
+            if (!more_)
+            {
+                ec = json_errc::unpaired_high_surrogate;
+                return;
+            }
+            break;
+        case unicode_traits::conv_errc::expected_continuation_byte:
+            more_ = err_handler_(json_errc::expected_continuation_byte, *this);
+            if (!more_)
+            {
+                ec = json_errc::expected_continuation_byte;
+                return;
+            }
+            break;
+        case unicode_traits::conv_errc::illegal_surrogate_value:
+            more_ = err_handler_(json_errc::illegal_surrogate_value, *this);
+            if (!more_)
+            {
+                ec = json_errc::illegal_surrogate_value;
+                return;
+            }
+            break;
+        default:
+            more_ = err_handler_(json_errc::illegal_codepoint, *this);
+            if (!more_)
+            {
+                ec = json_errc::illegal_codepoint;
+                return;
+            }
+            break;
+        }
+    }
+
+    std::size_t line() const override
+    {
+        return line_;
+    }
+
+    std::size_t column() const override
+    {
+        return (position_ - mark_position_) + 1;
+    }
+
+    std::size_t position() const override
+    {
+        return saved_position_;
+    }
+
+    std::size_t end_position() const override
+    {
+        return position_;
+    }
+
+    std::size_t offset() const 
+    {
+        return input_ptr_ - begin_input_;
+    }
+private:
+
+    void end_integer_value(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        if (string_buffer_[0] == '-')
+        {
+            end_negative_value(visitor, ec);
+        }
+        else
+        {
+            end_positive_value(visitor, ec);
+        }
+    }
+
+    void end_negative_value(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        int64_t val;
+        auto result = jsoncons::detail::to_integer_unchecked(string_buffer_.data(), string_buffer_.length(), val);
+        if (result)
+        {
+            more_ = visitor.int64_value(val, semantic_tag::none, *this, ec);
+        }
+        else // Must be overflow
+        {
+            more_ = visitor.string_value(string_buffer_, semantic_tag::bigint, *this, ec);
+        }
+        after_value(ec);
+    }
+
+    void end_positive_value(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        uint64_t val;
+        auto result = jsoncons::detail::to_integer_unchecked(string_buffer_.data(), string_buffer_.length(), val);
+        if (result)
+        {
+            more_ = visitor.uint64_value(val, semantic_tag::none, *this, ec);
+        }
+        else // Must be overflow
+        {
+            more_ = visitor.string_value(string_buffer_, semantic_tag::bigint, *this, ec);
+        }
+        after_value(ec);
+    }
+
+    void end_fraction_value(basic_json_visitor<char_type>& visitor, std::error_code& ec)
+    {
+        JSONCONS_TRY
+        {
+            if (options_.lossless_number())
+            {
+                more_ = visitor.string_value(string_buffer_, semantic_tag::bigdec, *this, ec);
+            }
+            else
+            {
+                double d = to_double_(string_buffer_.c_str(), string_buffer_.length());
+                more_ = visitor.double_value(d, semantic_tag::none, *this, ec);
+            }
+        }
+        JSONCONS_CATCH(...)
+        {
+            more_ = err_handler_(json_errc::invalid_number, *this);
+            if (!more_)
+            {
+                ec = json_errc::invalid_number;
+                return;
+            }
+            more_ = visitor.null_value(semantic_tag::none, *this, ec); // recovery
+        }
+
+        after_value(ec);
+    }
+
+    void end_string_value(const char_type* s, std::size_t length, basic_json_visitor<char_type>& visitor, std::error_code& ec) 
+    {
+        string_view_type sv(s, length);
+        auto result = unicode_traits::validate(s, length);
+        if (result.ec != unicode_traits::conv_errc())
+        {
+            translate_conv_errc(result.ec,ec);
+            position_ += (result.ptr - s);
+            return;
+        }
+        switch (parent())
+        {
+        case parse_state::member_name:
+            more_ = visitor.key(sv, *this, ec);
+            pop_state();
+            state_ = parse_state::expect_colon;
+            break;
+        case parse_state::object:
+        case parse_state::array:
+        {
+            auto it = std::find_if(string_double_map_.begin(), string_double_map_.end(), string_maps_to_double{ sv });
+            if (it != string_double_map_.end())
+            {
+                more_ = visitor.double_value((*it).second, semantic_tag::none, *this, ec);
+            }
+            else
+            {
+                more_ = visitor.string_value(sv, semantic_tag::none, *this, ec);
+            }
+            state_ = parse_state::expect_comma_or_end;
+            break;
+        }
+        case parse_state::root:
+        {
+            auto it = std::find_if(string_double_map_.begin(),string_double_map_.end(),string_maps_to_double{sv});
+            if (it != string_double_map_.end())
+            {
+                more_ = visitor.double_value((*it).second, semantic_tag::none, *this, ec);
+            }
+            else
+            {
+                more_ = visitor.string_value(sv, semantic_tag::none, *this, ec);
+            }
+            state_ = parse_state::accept;
+            break;
+        }
+        default:
+            more_ = err_handler_(json_errc::syntax_error, *this);
+            if (!more_)
+            {
+                ec = json_errc::syntax_error;
+                return;
+            }
+            break;
+        }
+    }
+
+    void begin_member_or_element(std::error_code& ec) 
+    {
+        switch (parent())
+        {
+        case parse_state::object:
+            state_ = parse_state::expect_member_name;
+            break;
+        case parse_state::array:
+            state_ = parse_state::expect_value;
+            break;
+        case parse_state::root:
+            break;
+        default:
+            more_ = err_handler_(json_errc::syntax_error, *this);
+            if (!more_)
+            {
+                ec = json_errc::syntax_error;
+                return;
+            }
+            break;
+        }
+    }
+
+    void after_value(std::error_code& ec) 
+    {
+        switch (parent())
+        {
+        case parse_state::array:
+        case parse_state::object:
+            state_ = parse_state::expect_comma_or_end;
+            break;
+        case parse_state::root:
+            state_ = parse_state::accept;
+            break;
+        default:
+            more_ = err_handler_(json_errc::syntax_error, *this);
+            if (!more_)
+            {
+                ec = json_errc::syntax_error;
+                return;
+            }
+            break;
+        }
+    }
+
+    void push_state(parse_state state)
+    {
+        state_stack_.push_back(state);
+        //std::cout << "max_nesting_depth: " << options_.max_nesting_depth() << ", capacity: " << state_stack_.capacity() << ", nesting_depth: " << nesting_depth_ << ", stack size: " << state_stack_.size() << "\n";
+    }
+
+    parse_state pop_state()
+    {
+        JSONCONS_ASSERT(!state_stack_.empty())
+        parse_state state = state_stack_.back();
+        state_stack_.pop_back();
+        return state;
+    }
+ 
+    uint32_t append_to_codepoint(uint32_t cp, int c, std::error_code& ec)
+    {
+        cp *= 16;
+        if (c >= '0'  &&  c <= '9')
+        {
+            cp += c - '0';
+        }
+        else if (c >= 'a'  &&  c <= 'f')
+        {
+            cp += c - 'a' + 10;
+        }
+        else if (c >= 'A'  &&  c <= 'F')
+        {
+            cp += c - 'A' + 10;
+        }
+        else
+        {
+            more_ = err_handler_(json_errc::invalid_unicode_escape_sequence, *this);
+            if (!more_)
+            {
+                ec = json_errc::invalid_unicode_escape_sequence;
+                return cp;
+            }
+        }
+        return cp;
+    }
+};
+
+using json_parser = basic_json_parser<char>;
+using wjson_parser = basic_json_parser<wchar_t>;
+
+}
+
+#endif

--- a/velox/external/jsoncons/json_reader.hpp
+++ b/velox/external/jsoncons/json_reader.hpp
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_READER_HPP
+#define JSONCONS_JSON_READER_HPP
+
+#include <cstddef>
+#include <functional>
+#include <ios>
+#include <memory> // std::allocator
+#include <string>
+#include <system_error>
+#include <utility> // std::move
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/source.hpp"
+#include "velox/external/jsoncons/source_adaptor.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // utf8_other_json_input_adapter
+
+    template <typename CharT>
+    class json_utf8_to_other_visitor_adaptor : public json_visitor
+    {
+    public:
+        using json_visitor::string_view_type;
+    private:
+        basic_default_json_visitor<CharT> default_visitor_;
+        basic_json_visitor<CharT>& other_visitor_;
+        //std::function<bool(json_errc,const ser_context&)> err_handler_;
+
+        // noncopyable and nonmoveable
+        json_utf8_to_other_visitor_adaptor(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
+        json_utf8_to_other_visitor_adaptor<CharT>& operator=(const json_utf8_to_other_visitor_adaptor<CharT>&) = delete;
+
+    public:
+        json_utf8_to_other_visitor_adaptor()
+            : other_visitor_(default_visitor_)
+        {
+        }
+
+        json_utf8_to_other_visitor_adaptor(basic_json_visitor<CharT>& other_visitor/*,
+                                              std::function<bool(json_errc,const ser_context&)> err_handler*/)
+            : other_visitor_(other_visitor)/*,
+              err_handler_(err_handler)*/
+        {
+        }
+
+    private:
+
+        void visit_flush() override
+        {
+            other_visitor_.flush();
+        }
+
+        bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.begin_object(tag, context, ec);
+        }
+
+        bool visit_end_object(const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.end_object(context, ec);
+        }
+
+        bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.begin_array(tag, context, ec);
+        }
+
+        bool visit_end_array(const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.end_array(context, ec);
+        }
+
+        bool visit_key(const string_view_type& name, const ser_context& context, std::error_code& ec) override
+        {
+            std::basic_string<CharT> target;
+            auto result = unicode_traits::convert(
+                name.data(), name.size(), target, 
+                unicode_traits::conv_flags::strict);
+            if (result.ec != unicode_traits::conv_errc())
+            {
+                JSONCONS_THROW(ser_error(result.ec,context.line(),context.column()));
+            }
+            return other_visitor_.key(target, context, ec);
+        }
+
+        bool visit_string(const string_view_type& value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            std::basic_string<CharT> target;
+            auto result = unicode_traits::convert(
+                value.data(), value.size(), target, 
+                unicode_traits::conv_flags::strict);
+            if (result.ec != unicode_traits::conv_errc())
+            {
+                ec = result.ec;
+                return false;
+            }
+            return other_visitor_.string_value(target, tag, context, ec);
+        }
+
+        bool visit_int64(int64_t value, 
+                            semantic_tag tag, 
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            return other_visitor_.int64_value(value, tag, context, ec);
+        }
+
+        bool visit_uint64(uint64_t value, 
+                             semantic_tag tag, 
+                             const ser_context& context,
+                             std::error_code& ec) override
+        {
+            return other_visitor_.uint64_value(value, tag, context, ec);
+        }
+
+        bool visit_half(uint16_t value, 
+                           semantic_tag tag,
+                           const ser_context& context,
+                           std::error_code& ec) override
+        {
+            return other_visitor_.half_value(value, tag, context, ec);
+        }
+
+        bool visit_double(double value, 
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec) override
+        {
+            return other_visitor_.double_value(value, tag, context, ec);
+        }
+
+        bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.bool_value(value, tag, context, ec);
+        }
+
+        bool visit_null(semantic_tag tag, const ser_context& context, std::error_code& ec) override
+        {
+            return other_visitor_.null_value(tag, context, ec);
+        }
+    };
+
+    template <typename CharT,typename Source=jsoncons::stream_source<CharT>,typename TempAllocator =std::allocator<char>>
+    class basic_json_reader 
+    {
+    public:
+        using char_type = CharT;
+        using source_type = Source;
+        using string_view_type = jsoncons::basic_string_view<CharT>;
+    private:
+        using char_allocator_type = typename std::allocator_traits<TempAllocator>:: template rebind_alloc<CharT>;
+
+        static constexpr size_t default_max_buffer_size = 16384;
+
+        json_source_adaptor<Source> source_;
+        basic_default_json_visitor<CharT> default_visitor_;
+        basic_json_visitor<CharT>& visitor_;
+        basic_json_parser<CharT,TempAllocator> parser_;
+
+        // Noncopyable and nonmoveable
+        basic_json_reader(const basic_json_reader&) = delete;
+        basic_json_reader& operator=(const basic_json_reader&) = delete;
+
+    public:
+        template <typename Sourceable>
+        explicit basic_json_reader(Sourceable&& source, const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                default_visitor_,
+                                basic_json_decode_options<CharT>(),
+                                default_json_parsing(),
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source, 
+                          const basic_json_decode_options<CharT>& options, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                default_visitor_,
+                                options,
+                                options.err_handler(),
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source,
+                          std::function<bool(json_errc,const ser_context&)> err_handler, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                default_visitor_,
+                                basic_json_decode_options<CharT>(),
+                                err_handler,
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source, 
+                          const basic_json_decode_options<CharT>& options,
+                          std::function<bool(json_errc,const ser_context&)> err_handler, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                default_visitor_,
+                                options,
+                                err_handler,
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source, 
+                          basic_json_visitor<CharT>& visitor, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                visitor,
+                                basic_json_decode_options<CharT>(),
+                                default_json_parsing(),
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source, 
+                          basic_json_visitor<CharT>& visitor,
+                          const basic_json_decode_options<CharT>& options, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                visitor,
+                                options,
+                                options.err_handler(),
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source,
+                          basic_json_visitor<CharT>& visitor,
+                          std::function<bool(json_errc,const ser_context&)> err_handler, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+            : basic_json_reader(std::forward<Sourceable>(source),
+                                visitor,
+                                basic_json_decode_options<CharT>(),
+                                err_handler,
+                                temp_alloc)
+        {
+        }
+
+        template <typename Sourceable>
+        basic_json_reader(Sourceable&& source,
+                          basic_json_visitor<CharT>& visitor, 
+                          const basic_json_decode_options<CharT>& options,
+                          std::function<bool(json_errc,const ser_context&)> err_handler, 
+                          const TempAllocator& temp_alloc = TempAllocator())
+           : source_(std::forward<Sourceable>(source)),
+             visitor_(visitor),
+             parser_(options,err_handler,temp_alloc)
+        {
+        }
+
+        void read_next()
+        {
+            std::error_code ec;
+            read_next(ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+            }
+        }
+
+        void read_next(std::error_code& ec)
+        {
+            if (source_.is_error())
+            {
+                ec = json_errc::source_error;
+                return;
+            }        
+            parser_.reset();
+            while (!parser_.stopped())
+            {
+                if (parser_.source_exhausted())
+                {
+                    auto s = source_.read_buffer(ec);
+                    if (ec) return;
+                    if (s.size() > 0)
+                    {
+                        parser_.update(s.data(),s.size());
+                    }
+                }
+                bool eof = parser_.source_exhausted();
+                parser_.parse_some(visitor_, ec);
+                if (ec) return;
+                if (eof)
+                {
+                    if (parser_.enter())
+                    {
+                        break;
+                    }
+                    else if (!parser_.accept())
+                    {
+                        ec = json_errc::unexpected_eof;
+                        return;
+                    }
+                }
+            }
+            
+            parser_.skip_whitespace();
+            while (!source_.eof())
+            {
+                parser_.skip_whitespace();
+                if (parser_.source_exhausted())
+                {
+                    auto s = source_.read_buffer(ec);
+                    if (ec) return;
+                    if (s.size() > 0)
+                    {
+                        parser_.update(s.data(),s.size());
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+
+        void check_done()
+        {
+            std::error_code ec;
+            check_done(ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec,parser_.line(),parser_.column()));
+            }
+        }
+
+        std::size_t line() const
+        {
+            return parser_.line();
+        }
+
+        std::size_t column() const
+        {
+            return parser_.column();
+        }
+
+        void check_done(std::error_code& ec)
+        {
+            if (source_.is_error())
+            {
+                ec = json_errc::source_error;
+                return;
+            }   
+            if (source_.eof())
+            {
+                parser_.check_done(ec);
+                if (ec) return;
+            }
+            else
+            {
+                do
+                {
+                    if (parser_.source_exhausted())
+                    {
+                        auto s = source_.read_buffer(ec);
+                        if (ec) return;
+                        if (s.size() > 0)
+                        {
+                            parser_.update(s.data(),s.size());
+                        }
+                    }
+                    if (!parser_.source_exhausted())
+                    {
+                        parser_.check_done(ec);
+                        if (ec) return;
+                    }
+                }
+                while (!eof());
+            }
+        }
+
+        bool eof() const
+        {
+            return parser_.source_exhausted() && source_.eof();
+        }
+
+        void read()
+        {
+            read_next();
+            check_done();
+        }
+
+        void read(std::error_code& ec)
+        {
+            read_next(ec);
+            if (!ec)
+            {
+                check_done(ec);
+            }
+        }
+    };
+
+    using json_string_reader = basic_json_reader<char,string_source<char>>;
+    using wjson_string_reader = basic_json_reader<wchar_t,string_source<wchar_t>>;
+    using json_stream_reader = basic_json_reader<char,stream_source<char>>;
+    using wjson_stream_reader = basic_json_reader<wchar_t,stream_source<wchar_t>>;
+
+}
+
+#endif

--- a/velox/external/jsoncons/json_traits_macros.hpp
+++ b/velox/external/jsoncons/json_traits_macros.hpp
@@ -1,0 +1,962 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_TRAITS_MACROS_HPP
+#define JSONCONS_JSON_TRAITS_MACROS_HPP
+
+#include <utility>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp" // JSONCONS_EXPAND, JSONCONS_QUOTE
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+
+namespace facebook::velox::jsoncons
+{
+    #define JSONCONS_RDONLY(X)
+
+    #define JSONCONS_RDWR(X) X
+
+    struct always_true
+    {
+        template< typename T>
+        constexpr bool operator()(const T&) const noexcept
+        {
+            return true;
+        }
+    };
+
+    struct identity
+    {
+        template< typename T>
+        constexpr T&& operator()(T&& val) const noexcept
+        {
+            return std::forward<T>(val);
+        }
+    };
+
+    template <typename ChT,typename T>
+    struct json_traits_macro_names
+    {};
+
+    template <typename Json>
+    struct json_traits_helper
+    {
+        using string_view_type = typename Json::string_view_type; 
+
+        template <typename OutputType> 
+        static void set_udt_member(const Json&, const string_view_type&, const OutputType&) 
+        { 
+        } 
+        template <typename OutputType> 
+        static void set_udt_member(const Json& j, const string_view_type& key, OutputType& val) 
+        { 
+            val = j.at(key).template as<OutputType>(); 
+        } 
+
+        template <typename T,typename From,typename OutputType> 
+        static void set_udt_member(const Json&, const string_view_type&, From, const OutputType&) 
+        { 
+        } 
+        template <typename T,typename From,typename OutputType> 
+        static void set_udt_member(const Json& j, const string_view_type& key, From from, OutputType& val) 
+        { 
+            val = from(j.at(key).template as<T>()); 
+        } 
+        template <typename U> 
+        static void set_optional_json_member(const string_view_type& key, const std::shared_ptr<U>& val, Json& j) 
+        { 
+            if (val) j.try_emplace(key, val); 
+        } 
+        template <typename U> 
+        static void set_optional_json_member(const string_view_type& key, const std::unique_ptr<U>& val, Json& j) 
+        { 
+            if (val) j.try_emplace(key, val); 
+        } 
+        template <typename U> 
+        static void set_optional_json_member(const string_view_type& key, const jsoncons::optional<U>& val, Json& j) 
+        { 
+            if (val) j.try_emplace(key, val); 
+        } 
+        template <typename U> 
+        static void set_optional_json_member(const string_view_type& key, const U& val, Json& j) 
+        { 
+            j.try_emplace(key, val); 
+        } 
+    };
+}
+
+#if defined(_MSC_VER)
+#pragma warning( disable : 4127)
+#endif
+
+#define JSONCONS_CONCAT_IMPL(a, b) a ## b
+#define JSONCONS_CONCAT(a, b) JSONCONS_CONCAT_IMPL(a, b)
+
+// Inspired by https://github.com/Loki-Astari/ThorsSerializer/blob/master/src/Serialize/Traits.h
+
+#define JSONCONS_NARGS(...) JSONCONS_NARG_(__VA_ARGS__, 70,69,68,67,66,65,64,63,62,61,60,59,58,57,56,55,54,53,52,51,50,49,48,47,46,45,44,43,42,41,40,39,38,37,36,35,34,33,32,31,30,29,28,27,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0)
+#define JSONCONS_NARG_(...) JSONCONS_EXPAND( JSONCONS_ARG_N(__VA_ARGS__) )
+#define JSONCONS_ARG_N(e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35,e36,e37,e38,e39,e40,e41,e42,e43,e44,e45,e46,e47,e48,e49,e50,e51,e52,e53,e54,e55,e56,e57,e58,e59,e60,e61,e62,e63,e64,e65,e66,e67,e68,e69,e70,N,...)N
+
+#define JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, Count) Call(P1, P2, P3, P4, Count) 
+ 
+#define JSONKONS_VARIADIC_FOR_EACH(Call, P1, P2, P3, ...)            JSONCONS_VARIADIC_REP_OF_N(Call, P1,P2, P3, JSONCONS_NARGS(__VA_ARGS__), __VA_ARGS__)
+#define JSONCONS_VARIADIC_REP_OF_N(Call, P1, P2, P3, Count, ...)  JSONCONS_VARIADIC_REP_OF_N_(Call, P1, P2, P3, Count, __VA_ARGS__)
+#define JSONCONS_VARIADIC_REP_OF_N_(Call, P1, P2, P3, Count, ...) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_ ## Count(Call, P1, P2, P3, __VA_ARGS__))
+
+#define JSONCONS_VARIADIC_REP_OF_70(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 70) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_69(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_69(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 69) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_68(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_68(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 68) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_67(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_67(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 67) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_66(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_66(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 66) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_65(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_65(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 65) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_64(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_64(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 64) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_63(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_63(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 63) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_62(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_62(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 62) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_61(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_61(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 61) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_60(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_60(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 60) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_59(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_59(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 59) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_58(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_58(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 58) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_57(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_57(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 57) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_56(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_56(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 56) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_55(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_55(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 55) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_54(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_54(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 54) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_53(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_53(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 53) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_52(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_52(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 52) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_51(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_51(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 51) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_50(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_50(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 50) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_49(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_49(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 49) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_48(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_48(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 48) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_47(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_47(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 47) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_46(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_46(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 46) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_45(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_45(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 45) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_44(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_44(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 44) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_43(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_43(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 43) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_42(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_42(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 42) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_41(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_41(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 41) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_40(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_40(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 40) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_39(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_39(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 39) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_38(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_38(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 38) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_37(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_37(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 37) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_36(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_36(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 36) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_35(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_35(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 35) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_34(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_34(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 34) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_33(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_33(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 33) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_32(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_32(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 32) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_31(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_31(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 31) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_30(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_30(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 30) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_29(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_29(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 29) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_28(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_28(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 28) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_27(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_27(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 27) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_26(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_26(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 26) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_25(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_25(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 25) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_24(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_24(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 24) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_23(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_23(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 23) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_22(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_22(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 22) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_21(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_21(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 21) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_20(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_20(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 20) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_19(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_19(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 19) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_18(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_18(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 18) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_17(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_17(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 17) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_16(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_16(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 16) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_15(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_15(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 15) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_14(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_14(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 14) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_13(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_13(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 13) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_12(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_12(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 12) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_11(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_11(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 11) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_10(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_10(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 10) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_9(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_9(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 9) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_8(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_8(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 8) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_7(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_7(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 7) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_6(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_6(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 6) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_5(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_5(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 5) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_4(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_4(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 4) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_3(Call, P1, P2, P3, __VA_ARGS__))
+#define JSONCONS_VARIADIC_REP_OF_3(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 3) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_2(Call, P1, P2, P3, __VA_ARGS__)) 
+#define JSONCONS_VARIADIC_REP_OF_2(Call, P1, P2, P3, P4, ...)    JSONCONS_EXPAND_CALL5(Call, P1, P2, P3, P4, 2) JSONCONS_EXPAND(JSONCONS_VARIADIC_REP_OF_1(Call, P1, P2, P3, __VA_ARGS__)) 
+#define JSONCONS_VARIADIC_REP_OF_1(Call, P1, P2, P3, P4)         JSONCONS_EXPAND(Call ## _LAST(P1, P2, P3, P4, 1))
+
+#define JSONCONS_TYPE_TRAITS_FRIEND \
+    template <typename JSON,typename T,typename Enable> \
+    friend struct jsoncons::json_type_traits;
+
+#define JSONCONS_EXPAND_CALL2(Call, Expr, Id) JSONCONS_EXPAND(Call(Expr, Id))
+
+#define JSONCONS_REP_OF_N(Call, Expr, Pre, App, Count)  JSONCONS_REP_OF_ ## Count(Call, Expr, Pre, App)
+
+#define JSONCONS_REP_OF_50(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 50) JSONCONS_REP_OF_49(Call, Expr, , App)
+#define JSONCONS_REP_OF_49(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 49) JSONCONS_REP_OF_48(Call, Expr, , App)
+#define JSONCONS_REP_OF_48(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 48) JSONCONS_REP_OF_47(Call, Expr, , App)
+#define JSONCONS_REP_OF_47(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 47) JSONCONS_REP_OF_46(Call, Expr, , App)
+#define JSONCONS_REP_OF_46(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 46) JSONCONS_REP_OF_45(Call, Expr, , App)
+#define JSONCONS_REP_OF_45(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 45) JSONCONS_REP_OF_44(Call, Expr, , App)
+#define JSONCONS_REP_OF_44(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 44) JSONCONS_REP_OF_43(Call, Expr, , App)
+#define JSONCONS_REP_OF_43(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 43) JSONCONS_REP_OF_42(Call, Expr, , App)
+#define JSONCONS_REP_OF_42(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 42) JSONCONS_REP_OF_41(Call, Expr, , App)
+#define JSONCONS_REP_OF_41(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 41) JSONCONS_REP_OF_40(Call, Expr, , App)
+#define JSONCONS_REP_OF_40(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 40) JSONCONS_REP_OF_39(Call, Expr, , App)
+#define JSONCONS_REP_OF_39(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 39) JSONCONS_REP_OF_38(Call, Expr, , App)
+#define JSONCONS_REP_OF_38(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 38) JSONCONS_REP_OF_37(Call, Expr, , App)
+#define JSONCONS_REP_OF_37(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 37) JSONCONS_REP_OF_36(Call, Expr, , App)
+#define JSONCONS_REP_OF_36(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 36) JSONCONS_REP_OF_35(Call, Expr, , App)
+#define JSONCONS_REP_OF_35(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 35) JSONCONS_REP_OF_34(Call, Expr, , App)
+#define JSONCONS_REP_OF_34(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 34) JSONCONS_REP_OF_33(Call, Expr, , App)
+#define JSONCONS_REP_OF_33(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 33) JSONCONS_REP_OF_32(Call, Expr, , App)
+#define JSONCONS_REP_OF_32(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 32) JSONCONS_REP_OF_31(Call, Expr, , App)
+#define JSONCONS_REP_OF_31(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 31) JSONCONS_REP_OF_30(Call, Expr, , App)
+#define JSONCONS_REP_OF_30(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 30) JSONCONS_REP_OF_29(Call, Expr, , App)
+#define JSONCONS_REP_OF_29(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 29) JSONCONS_REP_OF_28(Call, Expr, , App)
+#define JSONCONS_REP_OF_28(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 28) JSONCONS_REP_OF_27(Call, Expr, , App)
+#define JSONCONS_REP_OF_27(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 27) JSONCONS_REP_OF_26(Call, Expr, , App)
+#define JSONCONS_REP_OF_26(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 26) JSONCONS_REP_OF_25(Call, Expr, , App)
+#define JSONCONS_REP_OF_25(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 25) JSONCONS_REP_OF_24(Call, Expr, , App)
+#define JSONCONS_REP_OF_24(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 24) JSONCONS_REP_OF_23(Call, Expr, , App)
+#define JSONCONS_REP_OF_23(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 23) JSONCONS_REP_OF_22(Call, Expr, , App)
+#define JSONCONS_REP_OF_22(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 22) JSONCONS_REP_OF_21(Call, Expr, , App)
+#define JSONCONS_REP_OF_21(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 21) JSONCONS_REP_OF_20(Call, Expr, , App)
+#define JSONCONS_REP_OF_20(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 20) JSONCONS_REP_OF_19(Call, Expr, , App)
+#define JSONCONS_REP_OF_19(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 19) JSONCONS_REP_OF_18(Call, Expr, , App)
+#define JSONCONS_REP_OF_18(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 18) JSONCONS_REP_OF_17(Call, Expr, , App)
+#define JSONCONS_REP_OF_17(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 17) JSONCONS_REP_OF_16(Call, Expr, , App)
+#define JSONCONS_REP_OF_16(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 16) JSONCONS_REP_OF_15(Call, Expr, , App)
+#define JSONCONS_REP_OF_15(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 15) JSONCONS_REP_OF_14(Call, Expr, , App)
+#define JSONCONS_REP_OF_14(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 14) JSONCONS_REP_OF_13(Call, Expr, , App)
+#define JSONCONS_REP_OF_13(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 13) JSONCONS_REP_OF_12(Call, Expr, , App)
+#define JSONCONS_REP_OF_12(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 12) JSONCONS_REP_OF_11(Call, Expr, , App)
+#define JSONCONS_REP_OF_11(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 11) JSONCONS_REP_OF_10(Call, Expr, , App)
+#define JSONCONS_REP_OF_10(Call, Expr, Pre, App)     Pre JSONCONS_EXPAND_CALL2(Call, Expr, 10) JSONCONS_REP_OF_9(Call, Expr, , App)
+#define JSONCONS_REP_OF_9(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 9) JSONCONS_REP_OF_8(Call, Expr, , App)
+#define JSONCONS_REP_OF_8(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 8) JSONCONS_REP_OF_7(Call, Expr, , App)
+#define JSONCONS_REP_OF_7(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 7) JSONCONS_REP_OF_6(Call, Expr, , App)
+#define JSONCONS_REP_OF_6(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 6) JSONCONS_REP_OF_5(Call, Expr, , App)
+#define JSONCONS_REP_OF_5(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 5) JSONCONS_REP_OF_4(Call, Expr, , App)
+#define JSONCONS_REP_OF_4(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 4) JSONCONS_REP_OF_3(Call, Expr, , App)
+#define JSONCONS_REP_OF_3(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 3) JSONCONS_REP_OF_2(Call, Expr, , App)
+#define JSONCONS_REP_OF_2(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call, Expr, 2) JSONCONS_REP_OF_1(Call, Expr, , App)
+#define JSONCONS_REP_OF_1(Call, Expr, Pre, App)      Pre JSONCONS_EXPAND_CALL2(Call ## _LAST, Expr, 1) App
+#define JSONCONS_REP_OF_0(Call, Expr, Pre, App)
+
+#define JSONCONS_GENERATE_TPL_PARAMS(Call, Count) JSONCONS_REP_OF_N(Call, , , ,Count)
+#define JSONCONS_GENERATE_TPL_ARGS(Call, Count) JSONCONS_REP_OF_N(Call, ,<,>,Count)
+#define JSONCONS_GENERATE_TPL_PARAM(Expr, Id) typename T ## Id,
+#define JSONCONS_GENERATE_TPL_PARAM_LAST(Expr, Id) typename T ## Id
+#define JSONCONS_GENERATE_MORE_TPL_PARAM(Expr, Id) ,typename T ## Id
+#define JSONCONS_GENERATE_MORE_TPL_PARAM_LAST(Expr, Id) ,typename T ## Id
+#define JSONCONS_GENERATE_TPL_ARG(Expr, Id) T ## Id,
+#define JSONCONS_GENERATE_TPL_ARG_LAST(Ex, Id) T ## Id 
+
+#define JSONCONS_GENERATE_NAME_STR(Prefix, P2, P3, Member, Count) JSONCONS_GENERATE_NAME_STR_LAST(Prefix, P2, P3, Member, Count) 
+#define JSONCONS_GENERATE_NAME_STR_LAST(Prefix, P2, P3, Member, Count) \
+    static inline const char* Member ## _str(char) {return JSONCONS_QUOTE(,Member);} \
+    static inline const wchar_t* Member ## _str(wchar_t) {return JSONCONS_QUOTE(L,Member);} \
+    /**/
+
+#define JSONCONS_N_MEMBER_IS(Prefix, P2, P3, Member, Count) JSONCONS_N_MEMBER_IS_LAST(Prefix, P2, P3, Member, Count)
+#define JSONCONS_N_MEMBER_IS_LAST(Prefix, P2, P3, Member, Count) if ((num_params-Count) < num_mandatory_params1 && !ajson.contains(json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}))) return false;
+
+#define JSONCONS_N_MEMBER_AS(Prefix,P2,P3, Member, Count) JSONCONS_N_MEMBER_AS_LAST(Prefix,P2,P3, Member, Count)
+#define JSONCONS_N_MEMBER_AS_LAST(Prefix,P2,P3, Member, Count) \
+    if ((num_params-Count) < num_mandatory_params2 || ajson.contains(json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}))) \
+        {json_traits_helper<Json>::set_udt_member(ajson,json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}),class_instance.Member);}
+
+#define JSONCONS_ALL_MEMBER_AS(Prefix, P2,P3,Member, Count) JSONCONS_ALL_MEMBER_AS_LAST(Prefix,P2,P3, Member, Count)
+#define JSONCONS_ALL_MEMBER_AS_LAST(Prefix,P2,P3, Member, Count) \
+    json_traits_helper<Json>::set_udt_member(ajson,json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}),class_instance.Member);
+
+#define JSONCONS_TO_JSON(Prefix, P2, P3, Member, Count) JSONCONS_TO_JSON_LAST(Prefix, P2, P3, Member, Count)
+#define JSONCONS_TO_JSON_LAST(Prefix, P2, P3, Member, Count) if ((num_params-Count) < num_mandatory_params2) \
+    {ajson.try_emplace(json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}),class_instance.Member);} \
+    else {json_traits_helper<Json>::set_optional_json_member(json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}),class_instance.Member, ajson);}
+
+#define JSONCONS_ALL_TO_JSON(Prefix, P2, P3, Member, Count) JSONCONS_ALL_TO_JSON_LAST(Prefix, P2, P3, Member, Count)
+#define JSONCONS_ALL_TO_JSON_LAST(Prefix, P2, P3, Member, Count) \
+    ajson.try_emplace(json_traits_macro_names<char_type,class_type>::Member##_str(char_type{}),class_instance.Member);
+
+#define JSONCONS_MEMBER_TRAITS_BASE(AsT,ToJ,NumTemplateParams,ClassType,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename ChT JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_traits_macro_names<ChT,ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        JSONKONS_VARIADIC_FOR_EACH(JSONCONS_GENERATE_NAME_STR, ,,, __VA_ARGS__)\
+    }; \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_N_MEMBER_IS, ,,, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            class_type class_instance{}; \
+            JSONKONS_VARIADIC_FOR_EACH(AsT, ,,, __VA_ARGS__) \
+            return class_instance; \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(ToJ, ,,, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+
+#define JSONCONS_MEMBER_NAME_IS(P1, P2, P3, Seq, Count) JSONCONS_MEMBER_NAME_IS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_MEMBER_NAME_IS_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params1 && JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_MEMBER_NAME_IS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_MEMBER_NAME_IS_2(Member, Name) !ajson.contains(Name)) return false;
+#define JSONCONS_MEMBER_NAME_IS_3(Member, Name, Mode) JSONCONS_MEMBER_NAME_IS_2(Member, Name)
+#define JSONCONS_MEMBER_NAME_IS_4(Member, Name, Mode, Match) JSONCONS_MEMBER_NAME_IS_6(Member, Name, Mode, Match, , )
+#define JSONCONS_MEMBER_NAME_IS_5(Member, Name, Mode, Match, Into) JSONCONS_MEMBER_NAME_IS_6(Member, Name, Mode, Match, Into, )
+#define JSONCONS_MEMBER_NAME_IS_6(Member, Name, Mode, Match, Into, From) !ajson.contains(Name)) return false; \
+    JSONCONS_TRY{if (!Match(ajson.at(Name).template as<typename std::decay<decltype(Into((std::declval<class_type*>())->Member))>::type>())) return false;} \
+    JSONCONS_CATCH(...) {return false;}
+
+#define JSONCONS_N_MEMBER_NAME_AS(P1, P2, P3, Seq, Count) JSONCONS_N_MEMBER_NAME_AS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_N_MEMBER_NAME_AS_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_N_MEMBER_NAME_AS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_N_MEMBER_NAME_AS_2(Member, Name) \
+    if (ajson.contains(Name)) {json_traits_helper<Json>::set_udt_member(ajson,Name,class_instance.Member);}
+#define JSONCONS_N_MEMBER_NAME_AS_3(Member, Name, Mode) Mode(JSONCONS_N_MEMBER_NAME_AS_2(Member, Name))
+#define JSONCONS_N_MEMBER_NAME_AS_4(Member, Name, Mode, Match) \
+    Mode(if (ajson.contains(Name)) {json_traits_helper<Json>::set_udt_member(ajson,Name,class_instance.Member);})
+#define JSONCONS_N_MEMBER_NAME_AS_5(Member, Name, Mode, Match, Into) \
+    Mode(if (ajson.contains(Name)) {json_traits_helper<Json>::template set_udt_member<typename std::decay<decltype(Into((std::declval<class_type*>())->Member))>::type>(ajson,Name,class_instance.Member);})
+#define JSONCONS_N_MEMBER_NAME_AS_6(Member, Name, Mode, Match, Into, From) \
+    Mode(if (ajson.contains(Name)) {json_traits_helper<Json>::template set_udt_member<typename std::decay<decltype(Into((std::declval<class_type*>())->Member))>::type>(ajson,Name,From,class_instance.Member);})
+
+#define JSONCONS_ALL_MEMBER_NAME_AS(P1, P2, P3, Seq, Count) JSONCONS_ALL_MEMBER_NAME_AS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_ALL_MEMBER_NAME_AS_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_ALL_MEMBER_NAME_AS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_ALL_MEMBER_NAME_AS_2(Member, Name) \
+    json_traits_helper<Json>::set_udt_member(ajson,Name,class_instance.Member);
+#define JSONCONS_ALL_MEMBER_NAME_AS_3(Member, Name, Mode) Mode(JSONCONS_ALL_MEMBER_NAME_AS_2(Member, Name))
+#define JSONCONS_ALL_MEMBER_NAME_AS_4(Member, Name, Mode, Match) \
+    Mode(json_traits_helper<Json>::set_udt_member(ajson,Name,class_instance.Member);)
+#define JSONCONS_ALL_MEMBER_NAME_AS_5(Member, Name, Mode, Match, Into) \
+    Mode(json_traits_helper<Json>::template set_udt_member<typename std::decay<decltype(Into((std::declval<class_type*>())->Member))>::type>(ajson,Name,class_instance.Member);)
+#define JSONCONS_ALL_MEMBER_NAME_AS_6(Member, Name, Mode, Match, Into, From) \
+    Mode(json_traits_helper<Json>::template set_udt_member<typename std::decay<decltype(Into((std::declval<class_type*>())->Member))>::type>(ajson,Name,From,class_instance.Member);)
+
+#define JSONCONS_N_MEMBER_NAME_TO_JSON(P1, P2, P3, Seq, Count) JSONCONS_N_MEMBER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params2) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_N_MEMBER_NAME_TO_JSON_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_2(Member, Name) \
+  {ajson.try_emplace(Name,class_instance.Member);} \
+else \
+  {json_traits_helper<Json>::set_optional_json_member(Name,class_instance.Member, ajson);}
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_3(Member, Name, Mode) JSONCONS_N_MEMBER_NAME_TO_JSON_2(Member, Name)
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_4(Member, Name, Mode, Match) JSONCONS_N_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match,,)
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_5(Member, Name, Mode, Match, Into) JSONCONS_N_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match, Into, )
+#define JSONCONS_N_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match, Into, From) \
+  {ajson.try_emplace(Name, Into(class_instance.Member));} \
+else \
+  {json_traits_helper<Json>::set_optional_json_member(Name, Into(class_instance.Member), ajson);}
+
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON(P1, P2, P3, Seq, Count) JSONCONS_ALL_MEMBER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_ALL_MEMBER_NAME_TO_JSON_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_2(Member, Name) ajson.try_emplace(Name,class_instance.Member);
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_3(Member, Name, Mode) JSONCONS_ALL_MEMBER_NAME_TO_JSON_2(Member, Name)
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_4(Member, Name, Mode, Match) JSONCONS_ALL_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match,,)
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_5(Member, Name, Mode, Match, Into) JSONCONS_ALL_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match, Into, )
+#define JSONCONS_ALL_MEMBER_NAME_TO_JSON_6(Member, Name, Mode, Match, Into, From) ajson.try_emplace(Name, Into(class_instance.Member));
+
+#define JSONCONS_MEMBER_NAME_TRAITS_BASE(AsT,ToJ, NumTemplateParams, ClassType,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_MEMBER_NAME_IS,,,, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            class_type class_instance{}; \
+            JSONKONS_VARIADIC_FOR_EACH(AsT,,,, __VA_ARGS__) \
+            return class_instance; \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(ToJ,,,, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+
+#define JSONCONS_CTOR_GETTER_IS(Prefix, P2, P3, Getter, Count) JSONCONS_CTOR_GETTER_IS_LAST(Prefix, P2, P3, Getter, Count)
+#define JSONCONS_CTOR_GETTER_IS_LAST(Prefix, P2, P3, Getter, Count) if ((num_params-Count) < num_mandatory_params1 && !ajson.contains(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{}))) return false;
+
+#define JSONCONS_CTOR_GETTER_AS(Prefix, P2, P3, Getter, Count) JSONCONS_CTOR_GETTER_AS_LAST(Prefix, P2, P3, Getter, Count),
+#define JSONCONS_CTOR_GETTER_AS_LAST(Prefix, P2, P3, Getter, Count) ((num_params-Count) < num_mandatory_params2) ? (ajson.at(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{}))).template as<typename std::decay<decltype((std::declval<class_type*>())->Getter())>::type>() : (ajson.contains(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{})) ? (ajson.at(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{}))).template as<typename std::decay<decltype((std::declval<class_type*>())->Getter())>::type>() : typename std::decay<decltype((std::declval<class_type*>())->Getter())>::type())
+
+#define JSONCONS_CTOR_GETTER_TO_JSON(Prefix, P2, P3, Getter, Count) JSONCONS_CTOR_GETTER_TO_JSON_LAST(Prefix, P2, P3, Getter, Count)
+
+#define JSONCONS_CTOR_GETTER_TO_JSON_LAST(Prefix, P2, P3, Getter, Count) \
+if ((num_params-Count) < num_mandatory_params2) { \
+       ajson.try_emplace(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{}),class_instance.Getter() ); \
+  } \
+else { \
+  json_traits_helper<Json>::set_optional_json_member(json_traits_macro_names<char_type,class_type>::Getter##_str(char_type{}),class_instance.Getter(), ajson); \
+}
+
+#define JSONCONS_CTOR_GETTER_TRAITS_BASE(NumTemplateParams, ClassType,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename ChT JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_traits_macro_names<ChT,ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        JSONKONS_VARIADIC_FOR_EACH(JSONCONS_GENERATE_NAME_STR, ,,, __VA_ARGS__)\
+    }; \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_IS, ,,, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            return class_type ( JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_AS, ,,, __VA_ARGS__) ); \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_TO_JSON, ,,, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+ 
+#define JSONCONS_CTOR_GETTER_NAME_IS(P1, P2, P3, Seq, Count) JSONCONS_CTOR_GETTER_NAME_IS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_CTOR_GETTER_NAME_IS_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params1 && JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_CTOR_GETTER_NAME_IS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_CTOR_GETTER_NAME_IS_2(Getter, Name) !ajson.contains(Name)) return false;
+#define JSONCONS_CTOR_GETTER_NAME_IS_3(Getter, Name, Mode) JSONCONS_CTOR_GETTER_NAME_IS_2(Getter, Name)
+#define JSONCONS_CTOR_GETTER_NAME_IS_4(Getter, Name, Mode, Match) JSONCONS_CTOR_GETTER_NAME_IS_6(Getter, Name, Mode, Match, , )
+#define JSONCONS_CTOR_GETTER_NAME_IS_5(Getter, Name, Mode, Match, Into) JSONCONS_CTOR_GETTER_NAME_IS_6(Getter, Name, Mode, Match, Into, )
+#define JSONCONS_CTOR_GETTER_NAME_IS_6(Getter, Name, Mode, Match, Into, From) !ajson.contains(Name)) return false; \
+    JSONCONS_TRY{if (!Match(ajson.at(Name).template as<typename std::decay<decltype(Into((std::declval<class_type*>())->Getter()))>::type>())) return false;} \
+    JSONCONS_CATCH(...) {return false;}
+
+#define JSONCONS_CTOR_GETTER_NAME_AS(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_CTOR_GETTER_NAME_AS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_CTOR_GETTER_NAME_AS_2(Getter, Name) JSONCONS_CTOR_GETTER_NAME_AS_LAST_2(Getter, Name) JSONCONS_COMMA
+#define JSONCONS_CTOR_GETTER_NAME_AS_3(Getter, Name, Mode) Mode(JSONCONS_CTOR_GETTER_NAME_AS_LAST_2(Getter, Name)) Mode(JSONCONS_COMMA)
+#define JSONCONS_CTOR_GETTER_NAME_AS_4(Getter, Name, Mode, Match) JSONCONS_CTOR_GETTER_NAME_AS_6(Getter, Name, Mode, Match,,) 
+#define JSONCONS_CTOR_GETTER_NAME_AS_5(Getter, Name, Mode, Match, Into) JSONCONS_CTOR_GETTER_NAME_AS_6(Getter, Name, Mode, Match, Into, ) 
+#define JSONCONS_CTOR_GETTER_NAME_AS_6(Getter, Name, Mode, Match, Into, From) JSONCONS_CTOR_GETTER_NAME_AS_LAST_6(Getter,Name,Mode,Match,Into,From) Mode(JSONCONS_COMMA)
+#define JSONCONS_COMMA ,
+
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_CTOR_GETTER_NAME_AS_LAST_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST_2(Getter, Name) (ajson.contains(Name)) ? (ajson.at(Name)).template as<typename std::decay<decltype((std::declval<class_type*>())->Getter())>::type>() : typename std::decay<decltype((std::declval<class_type*>())->Getter())>::type()
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST_3(Getter, Name, Mode) Mode(JSONCONS_CTOR_GETTER_NAME_AS_LAST_2(Getter, Name))
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST_4(Getter, Name, Mode, Match) JSONCONS_CTOR_GETTER_NAME_AS_LAST_6(Getter, Name, Mode, Match,,)
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST_5(Getter, Name, Mode, Match, Into) JSONCONS_CTOR_GETTER_NAME_AS_LAST_6(Getter, Name, Mode, Match, Into, )
+#define JSONCONS_CTOR_GETTER_NAME_AS_LAST_6(Getter, Name, Mode, Match, Into, From) Mode(ajson.contains(Name) ? From(ajson.at(Name).template as<typename std::decay<decltype(Into((std::declval<class_type*>())->Getter()))>::type>()) : From(typename std::decay<decltype(Into((std::declval<class_type*>())->Getter()))>::type()))
+
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON(P1, P2, P3, Seq, Count) JSONCONS_CTOR_GETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params2) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_CTOR_GETTER_NAME_TO_JSON_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_2(Getter, Name) \
+{ \
+  ajson.try_emplace(Name,class_instance.Getter() ); \
+} \
+else { \
+  json_traits_helper<Json>::set_optional_json_member(Name,class_instance.Getter(), ajson); \
+}
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_3(Getter, Name, Mode) JSONCONS_CTOR_GETTER_NAME_TO_JSON_2(Getter, Name)
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_4(Getter, Name, Mode, Match) JSONCONS_CTOR_GETTER_NAME_TO_JSON_2(Getter, Name)
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_5(Getter, Name, Mode, Match, Into) JSONCONS_CTOR_GETTER_NAME_TO_JSON_6(Getter, Name, Mode, Match, Into, )
+#define JSONCONS_CTOR_GETTER_NAME_TO_JSON_6(Getter, Name, Mode, Match, Into, From) \
+{ \
+  ajson.try_emplace(Name, Into(class_instance.Getter()) ); \
+} \
+else { \
+  json_traits_helper<Json>::set_optional_json_member(Name, Into(class_instance.Getter()), ajson); \
+}
+
+#define JSONCONS_CTOR_GETTER_NAME_TRAITS_BASE(NumTemplateParams, ClassType,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+                JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_NAME_IS,,,, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            return class_type ( JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_NAME_AS,,,, __VA_ARGS__) ); \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_CTOR_GETTER_NAME_TO_JSON,,,, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+
+#define JSONCONS_ENUM_PAIR(Prefix, P2, P3, Member, Count) JSONCONS_ENUM_PAIR_LAST(Prefix, P2, P3, Member, Count),
+#define JSONCONS_ENUM_PAIR_LAST(Prefix, P2, P3, Member, Count) {enum_type::Member, json_traits_macro_names<char_type,enum_type>::Member##_str(char_type{})}
+
+#define JSONCONS_ENUM_TRAITS_BASE(EnumType, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename ChT> \
+    struct json_traits_macro_names<ChT,EnumType> \
+    { \
+        JSONKONS_VARIADIC_FOR_EACH(JSONCONS_GENERATE_NAME_STR, ,,, __VA_ARGS__)\
+    }; \
+    template <typename Json> \
+    struct json_type_traits<Json, EnumType> \
+    { \
+        static_assert(std::is_enum<EnumType>::value, # EnumType " must be an enum"); \
+        using enum_type = EnumType; \
+        using char_type = typename Json::char_type; \
+        using string_type = std::basic_string<char_type>; \
+        using string_view_type = jsoncons::basic_string_view<char_type>; \
+        using allocator_type = typename Json::allocator_type; \
+        using mapped_type = std::pair<EnumType,string_type>; \
+        \
+        static std::pair<const mapped_type*,const mapped_type*> get_values() \
+        { \
+            static const mapped_type v[] = { \
+                JSONKONS_VARIADIC_FOR_EACH(JSONCONS_ENUM_PAIR, ,,, __VA_ARGS__)\
+            };\
+            return std::make_pair(v,v+JSONCONS_NARGS(__VA_ARGS__)); \
+        } \
+        \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_string()) return false; \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            const string_view_type s = ajson.template as<string_view_type>(); \
+            if (s.empty() && std::find_if(first, last, \
+                                          [](const mapped_type& item) -> bool \
+                                          { return item.first == enum_type(); }) == last) \
+            { \
+                return true; \
+            } \
+            auto it = std::find_if(first, last, \
+                                   [&](const mapped_type& item) -> bool \
+                                   { return item.second == s; }); \
+            return it != last; \
+        } \
+        static enum_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # EnumType)); \
+            const string_view_type s = ajson.template as<string_view_type>(); \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            if (s.empty() && std::find_if(first, last, \
+                                          [](const mapped_type& item) -> bool \
+                                          { return item.first == enum_type(); }) == last) \
+            { \
+                return enum_type(); \
+            } \
+            auto it = std::find_if(first, last, \
+                                   [&](const mapped_type& item) -> bool \
+                                   { return item.second == s; }); \
+            if (it == last) \
+            { \
+                if (s.empty()) \
+                { \
+                    return enum_type(); \
+                } \
+                else \
+                { \
+                    JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not an enum")); \
+                } \
+            } \
+            return (*it).first; \
+        } \
+        static Json to_json(enum_type class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            static constexpr char_type empty_string[] = {0}; \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            auto it = std::find_if(first, last, \
+                                   [class_instance](const mapped_type& item) -> bool \
+                                   { return item.first == class_instance; }); \
+            if (it == last) \
+            { \
+                if (class_instance == enum_type()) \
+                { \
+                    return Json(empty_string); \
+                } \
+                else \
+                { \
+                    JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not an enum")); \
+                } \
+            } \
+            return Json((*it).second,alloc); \
+        } \
+    }; \
+} \
+    /**/
+
+#define JSONCONS_ENUM_TRAITS(EnumType, ...)  \
+    JSONCONS_ENUM_TRAITS_BASE(EnumType,__VA_ARGS__) \
+    namespace facebook::velox::jsoncons { template <> struct is_json_type_traits_declared<EnumType> : public std::true_type {}; } \
+  /**/
+
+#define JSONCONS_NAME_ENUM_PAIR(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_NAME_ENUM_PAIR_ Seq),
+#define JSONCONS_NAME_ENUM_PAIR_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_NAME_ENUM_PAIR_ Seq)
+#define JSONCONS_NAME_ENUM_PAIR_(Member, Name) {enum_type::Member, Name}
+
+#define JSONCONS_ENUM_NAME_TRAITS(EnumType, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename Json> \
+    struct json_type_traits<Json, EnumType> \
+    { \
+        static_assert(std::is_enum<EnumType>::value, # EnumType " must be an enum"); \
+        using enum_type = EnumType; \
+        using char_type = typename Json::char_type; \
+        using string_type = std::basic_string<char_type>; \
+        using string_view_type = jsoncons::basic_string_view<char_type>; \
+        using allocator_type = typename Json::allocator_type; \
+        using mapped_type = std::pair<EnumType,string_type>; \
+        \
+        static std::pair<const mapped_type*,const mapped_type*> get_values() \
+        { \
+            static const mapped_type v[] = { \
+                JSONKONS_VARIADIC_FOR_EACH(JSONCONS_NAME_ENUM_PAIR,,,, __VA_ARGS__)\
+            };\
+            return std::make_pair(v,v+JSONCONS_NARGS(__VA_ARGS__)); \
+        } \
+        \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_string()) return false; \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            const string_view_type s = ajson.template as<string_view_type>(); \
+            if (s.empty() && std::find_if(first, last, \
+                                          [](const mapped_type& item) -> bool \
+                                          { return item.first == enum_type(); }) == last) \
+            { \
+                return true; \
+            } \
+            auto it = std::find_if(first, last, \
+                                   [&](const mapped_type& item) -> bool \
+                                   { return item.second == s; }); \
+            return it != last; \
+        } \
+        static enum_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # EnumType)); \
+            const string_view_type s = ajson.template as<string_view_type>(); \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            if (s.empty() && std::find_if(first, last, \
+                                          [](const mapped_type& item) -> bool \
+                                          { return item.first == enum_type(); }) == last) \
+            { \
+                return enum_type(); \
+            } \
+            auto it = std::find_if(first, last, \
+                                   [&](const mapped_type& item) -> bool \
+                                   { return item.second == s; }); \
+            if (it == last) \
+            { \
+                if (s.empty()) \
+                { \
+                    return enum_type(); \
+                } \
+                else \
+                { \
+                    JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not an enum")); \
+                } \
+            } \
+            return (*it).first; \
+        } \
+        static Json to_json(enum_type class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            static constexpr char_type empty_string[] = {0}; \
+            auto first = get_values().first; \
+            auto last = get_values().second; \
+            auto it = std::find_if(first, last, \
+                                   [class_instance](const mapped_type& item) -> bool \
+                                   { return item.first == class_instance; }); \
+            if (it == last) \
+            { \
+                if (class_instance == enum_type()) \
+                { \
+                    return Json(empty_string); \
+                } \
+                else \
+                { \
+                    JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not an enum")); \
+                } \
+            } \
+            return Json((*it).second,alloc); \
+        } \
+    }; \
+    template <> struct is_json_type_traits_declared<EnumType> : public std::true_type {}; \
+} \
+    /**/
+
+#define JSONCONS_GETTER_SETTER_AS(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_GETTER_SETTER_AS_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_GETTER_SETTER_AS_LAST(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_GETTER_SETTER_AS_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count)  
+#define JSONCONS_GETTER_SETTER_AS_(Prefix, Getter, Setter, Property, Count) if ((num_params-Count) < num_mandatory_params2 || ajson.contains(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{}))) {class_instance.Setter(ajson.at(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{})).template as<typename std::decay<decltype(class_instance.Getter())>::type>());}
+
+#define JSONCONS_ALL_GETTER_SETTER_AS(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_ALL_GETTER_SETTER_AS_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_ALL_GETTER_SETTER_AS_LAST(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_ALL_GETTER_SETTER_AS_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_ALL_GETTER_SETTER_AS_(Prefix, Getter, Setter, Property, Count) class_instance.Setter(ajson.at(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{})).template as<typename std::decay<decltype(class_instance.Getter())>::type>());
+
+#define JSONCONS_GETTER_SETTER_TO_JSON(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_GETTER_SETTER_TO_JSON_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_GETTER_SETTER_TO_JSON_LAST(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_GETTER_SETTER_TO_JSON_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_GETTER_SETTER_TO_JSON_(Prefix, Getter, Setter, Property, Count) \
+if ((num_params-Count) < num_mandatory_params2) \
+  {ajson.try_emplace(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{}),class_instance.Getter());} \
+else \
+  {json_traits_helper<Json>::set_optional_json_member(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{}),class_instance.Getter(), ajson);}
+
+#define JSONCONS_ALL_GETTER_SETTER_TO_JSON(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_ALL_GETTER_SETTER_TO_JSON_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_ALL_GETTER_SETTER_TO_JSON_LAST(Prefix, GetPrefix, SetPrefix, Property, Count) JSONCONS_ALL_GETTER_SETTER_TO_JSON_(Prefix, GetPrefix ## Property, SetPrefix ## Property, Property, Count) 
+#define JSONCONS_ALL_GETTER_SETTER_TO_JSON_(Prefix, Getter, Setter, Property, Count) ajson.try_emplace(json_traits_macro_names<char_type,class_type>::Property##_str(char_type{}),class_instance.Getter() );
+
+#define JSONCONS_GETTER_SETTER_TRAITS_BASE(AsT,ToJ,NumTemplateParams, ClassType,GetPrefix,SetPrefix,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename ChT JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_traits_macro_names<ChT,ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        JSONKONS_VARIADIC_FOR_EACH(JSONCONS_GENERATE_NAME_STR, ,,, __VA_ARGS__)\
+    }; \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_N_MEMBER_IS, ,GetPrefix,SetPrefix, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            class_type class_instance{}; \
+            JSONKONS_VARIADIC_FOR_EACH(AsT, ,GetPrefix,SetPrefix, __VA_ARGS__) \
+            return class_instance; \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(ToJ, ,GetPrefix,SetPrefix, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+
+#define JSONCONS_GETTER_SETTER_NAME_IS(P1, P2, P3, Seq, Count) JSONCONS_GETTER_SETTER_NAME_IS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_GETTER_SETTER_NAME_IS_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params1 && JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_GETTER_SETTER_NAME_IS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_GETTER_SETTER_NAME_IS_3(Getter, Setter, Name) !ajson.contains(Name)) return false;
+#define JSONCONS_GETTER_SETTER_NAME_IS_5(Getter, Setter, Name, Mode, Match) JSONCONS_GETTER_SETTER_NAME_IS_7(Getter, Setter, Name, Mode, Match,, )
+#define JSONCONS_GETTER_SETTER_NAME_IS_6(Getter, Setter, Name, Mode, Match, Into) JSONCONS_GETTER_SETTER_NAME_IS_7(Getter, Setter, Name, Mode, Match, Into, )
+#define JSONCONS_GETTER_SETTER_NAME_IS_7(Getter, Setter, Name, Mode, Match, Into, From) !ajson.contains(Name)) return false; \
+    JSONCONS_TRY{if (!Match(ajson.at(Name).template as<typename std::decay<decltype(Into((std::declval<class_type*>())->Getter()))>::type>())) return false;} \
+    JSONCONS_CATCH(...) {return false;}
+
+#define JSONCONS_N_GETTER_SETTER_NAME_AS(P1, P2, P3, Seq, Count) JSONCONS_N_GETTER_SETTER_NAME_AS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_N_GETTER_SETTER_NAME_AS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_3(Getter, Setter, Name) if (ajson.contains(Name)) class_instance.Setter(ajson.at(Name).template as<typename std::decay<decltype(class_instance.Getter())>::type>());
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_4(Getter, Setter, Name, Mode) Mode(JSONCONS_N_GETTER_SETTER_NAME_AS_3(Getter, Setter, Name))
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_5(Getter, Setter, Name, Mode, Match) JSONCONS_N_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, , )
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_6(Getter, Setter, Name, Mode, Match, Into) JSONCONS_N_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, Into, )
+#define JSONCONS_N_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, Into, From) Mode(if (ajson.contains(Name)) class_instance.Setter(From(ajson.at(Name).template as<typename std::decay<decltype(Into(class_instance.Getter()))>::type>()));)
+
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON(P1, P2, P3, Seq, Count) JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_3(Getter, Setter, Name) ajson.try_emplace(Name,class_instance.Getter() );
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_5(Getter, Setter, Name, Mode, Match) JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, , )
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_6(Getter, Setter, Name, Mode, Match, Into) JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, Into, )
+#define JSONCONS_N_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, Into, From) ajson.try_emplace(Name, Into(class_instance.Getter()) );
+
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS(P1, P2, P3, Seq, Count) JSONCONS_ALL_GETTER_SETTER_NAME_AS_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_LAST(P1, P2, P3, Seq, Count) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_ALL_GETTER_SETTER_NAME_AS_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_3(Getter, Setter, Name) class_instance.Setter(ajson.at(Name).template as<typename std::decay<decltype(class_instance.Getter())>::type>());
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_4(Getter, Setter, Name, Mode) Mode(JSONCONS_ALL_GETTER_SETTER_NAME_AS_3(Getter, Setter, Name))
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_5(Getter, Setter, Name, Mode, Match) JSONCONS_ALL_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, , )
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_6(Getter, Setter, Name, Mode, Match, Into) JSONCONS_ALL_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, Into, )
+#define JSONCONS_ALL_GETTER_SETTER_NAME_AS_7(Getter, Setter, Name, Mode, Match, Into, From) Mode(class_instance.Setter(From(ajson.at(Name).template as<typename std::decay<decltype(Into(class_instance.Getter()))>::type>()));)
+
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON(P1, P2, P3, Seq, Count) JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count)
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_LAST(P1, P2, P3, Seq, Count) if ((num_params-Count) < num_mandatory_params2) JSONCONS_EXPAND(JSONCONS_CONCAT(JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_,JSONCONS_NARGS Seq) Seq)
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_3(Getter, Setter, Name) \
+  ajson.try_emplace(Name,class_instance.Getter()); \
+else \
+  {json_traits_helper<Json>::set_optional_json_member(Name,class_instance.Getter(), ajson);}
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_5(Getter, Setter, Name, Mode, Match) JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, , )
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_6(Getter, Setter, Name, Mode, Match, Into) JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, Into, )
+#define JSONCONS_ALL_GETTER_SETTER_NAME_TO_JSON_7(Getter, Setter, Name, Mode, Match, Into, From) \
+  ajson.try_emplace(Name, Into(class_instance.Getter())); \
+else \
+  {json_traits_helper<Json>::set_optional_json_member(Name, Into(class_instance.Getter()), ajson);}
+ 
+#define JSONCONS_GETTER_SETTER_NAME_TRAITS_BASE(AsT,ToJ, NumTemplateParams, ClassType,NumMandatoryParams1,NumMandatoryParams2, ...)  \
+namespace facebook::velox::jsoncons \
+{ \
+    template <typename Json JSONCONS_GENERATE_TPL_PARAMS(JSONCONS_GENERATE_MORE_TPL_PARAM, NumTemplateParams)> \
+    struct json_type_traits<Json, ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams)> \
+    { \
+        using class_type = ClassType JSONCONS_GENERATE_TPL_ARGS(JSONCONS_GENERATE_TPL_ARG, NumTemplateParams); \
+        using allocator_type = typename Json::allocator_type; \
+        using char_type = typename Json::char_type; \
+        using string_view_type = typename Json::string_view_type; \
+        constexpr static size_t num_params = JSONCONS_NARGS(__VA_ARGS__); \
+        constexpr static size_t num_mandatory_params1 = NumMandatoryParams1; \
+        constexpr static size_t num_mandatory_params2 = NumMandatoryParams2; \
+        static bool is(const Json& ajson) noexcept \
+        { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_GETTER_SETTER_NAME_IS,,,, __VA_ARGS__)\
+            return true; \
+        } \
+        static class_type as(const Json& ajson) \
+        { \
+            if (!is(ajson)) JSONCONS_THROW(conv_error(conv_errc::conversion_failed, "Not a " # ClassType)); \
+            class_type class_instance{}; \
+            JSONKONS_VARIADIC_FOR_EACH(AsT,,,, __VA_ARGS__) \
+            return class_instance; \
+        } \
+        static Json to_json(const class_type& class_instance, allocator_type alloc=allocator_type()) \
+        { \
+            Json ajson(json_object_arg, semantic_tag::none, alloc); \
+            JSONKONS_VARIADIC_FOR_EACH(ToJ,,,, __VA_ARGS__) \
+            return ajson; \
+        } \
+    }; \
+} \
+  /**/
+ 
+#define JSONCONS_POLYMORPHIC_IS(BaseClass, P2, P3, DerivedClass, Count) if (ajson.template is<DerivedClass>()) return true;
+#define JSONCONS_POLYMORPHIC_IS_LAST(BaseClass, P2, P3, DerivedClass, Count)  if (ajson.template is<DerivedClass>()) return true;
+
+#define JSONCONS_POLYMORPHIC_AS(BaseClass, P2, P3, DerivedClass, Count) if (ajson.template is<DerivedClass>()) return std::make_shared<DerivedClass>(ajson.template as<DerivedClass>());
+#define JSONCONS_POLYMORPHIC_AS_LAST(BaseClass, P2, P3, DerivedClass, Count)  if (ajson.template is<DerivedClass>()) return std::make_shared<DerivedClass>(ajson.template as<DerivedClass>());
+
+#define JSONCONS_POLYMORPHIC_AS_UNIQUE_PTR(BaseClass, P2, P3, DerivedClass, Count) if (ajson.template is<DerivedClass>()) return jsoncons::make_unique<DerivedClass>(ajson.template as<DerivedClass>());
+#define JSONCONS_POLYMORPHIC_AS_UNIQUE_PTR_LAST(BaseClass, P2, P3, DerivedClass, Count)  if (ajson.template is<DerivedClass>()) return jsoncons::make_unique<DerivedClass>(ajson.template as<DerivedClass>());
+
+#define JSONCONS_POLYMORPHIC_AS_SHARED_PTR(BaseClass, P2, P3, DerivedClass, Count) if (ajson.template is<DerivedClass>()) return std::make_shared<DerivedClass>(ajson.template as<DerivedClass>());
+#define JSONCONS_POLYMORPHIC_AS_SHARED_PTR_LAST(BaseClass, P2, P3, DerivedClass, Count)  if (ajson.template is<DerivedClass>()) return std::make_shared<DerivedClass>(ajson.template as<DerivedClass>());
+ 
+#define JSONCONS_POLYMORPHIC_TO_JSON(BaseClass, P2, P3, DerivedClass, Count) if (DerivedClass* p = dynamic_cast<DerivedClass*>(ptr.get())) {return Json(*p);}
+#define JSONCONS_POLYMORPHIC_TO_JSON_LAST(BaseClass, P2, P3, DerivedClass, Count) if (DerivedClass* p = dynamic_cast<DerivedClass*>(ptr.get())) {return Json(*p);}
+
+#define JSONCONS_POLYMORPHIC_TRAITS(BaseClass, ...)  \
+namespace facebook::velox::jsoncons { \
+    template <typename Json> \
+    struct json_type_traits<Json, std::shared_ptr<BaseClass>> { \
+        static bool is(const Json& ajson) noexcept { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_IS, BaseClass,,, __VA_ARGS__)\
+            return false; \
+        } \
+\
+        static std::shared_ptr<BaseClass> as(const Json& ajson) { \
+            if (!ajson.is_object()) return std::shared_ptr<BaseClass>(); \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_AS_SHARED_PTR, BaseClass,,, __VA_ARGS__)\
+            return std::shared_ptr<BaseClass>(); \
+        } \
+\
+        static Json to_json(const std::shared_ptr<BaseClass>& ptr) { \
+            if (ptr.get() == nullptr) {return Json::null();} \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_TO_JSON, BaseClass,,, __VA_ARGS__)\
+            return Json::null(); \
+        } \
+    }; \
+    template <typename Json> \
+    struct json_type_traits<Json, std::unique_ptr<BaseClass>> { \
+        static bool is(const Json& ajson) noexcept { \
+            if (!ajson.is_object()) return false; \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_IS, BaseClass,,, __VA_ARGS__)\
+            return false; \
+        } \
+        static std::unique_ptr<BaseClass> as(const Json& ajson) { \
+            if (!ajson.is_object()) return std::unique_ptr<BaseClass>(); \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_AS_UNIQUE_PTR, BaseClass,,, __VA_ARGS__)\
+            return std::unique_ptr<BaseClass>(); \
+        } \
+        static Json to_json(const std::unique_ptr<BaseClass>& ptr) { \
+            if (ptr.get() == nullptr) {return Json::null();} \
+            JSONKONS_VARIADIC_FOR_EACH(JSONCONS_POLYMORPHIC_TO_JSON, BaseClass,,, __VA_ARGS__)\
+            return Json::null(); \
+        } \
+    }; \
+}  \
+  /**/
+
+#endif // JSONCONS_JSON_TRAITS_MACROS_HPP

--- a/velox/external/jsoncons/json_type.hpp
+++ b/velox/external/jsoncons/json_type.hpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_TYPE_HPP
+#define JSONCONS_JSON_TYPE_HPP
+
+#include <cstdint>
+#include <ostream>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    enum class json_type : uint8_t 
+    {
+        null_value,
+        bool_value,
+        int64_value,
+        uint64_value,
+        half_value,
+        double_value,
+        string_value,
+        byte_string_value,
+        array_value,
+        object_value
+    };
+
+    template <typename CharT>
+    std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, json_type type)
+    {
+        static constexpr const CharT* null_value = JSONCONS_CSTRING_CONSTANT(CharT, "null");
+        static constexpr const CharT* bool_value = JSONCONS_CSTRING_CONSTANT(CharT, "bool");
+        static constexpr const CharT* int64_value = JSONCONS_CSTRING_CONSTANT(CharT, "int64");
+        static constexpr const CharT* uint64_value = JSONCONS_CSTRING_CONSTANT(CharT, "uint64");
+        static constexpr const CharT* half_value = JSONCONS_CSTRING_CONSTANT(CharT, "half");
+        static constexpr const CharT* double_value = JSONCONS_CSTRING_CONSTANT(CharT, "double");
+        static constexpr const CharT* string_value = JSONCONS_CSTRING_CONSTANT(CharT, "string");
+        static constexpr const CharT* byte_string_value = JSONCONS_CSTRING_CONSTANT(CharT, "byte_string");
+        static constexpr const CharT* array_value = JSONCONS_CSTRING_CONSTANT(CharT, "array");
+        static constexpr const CharT* object_value = JSONCONS_CSTRING_CONSTANT(CharT, "object");
+
+        switch (type)
+        {
+            case json_type::null_value:
+            {
+                os << null_value;
+                break;
+            }
+            case json_type::bool_value:
+            {
+                os << bool_value;
+                break;
+            }
+            case json_type::int64_value:
+            {
+                os << int64_value;
+                break;
+            }
+            case json_type::uint64_value:
+            {
+                os << uint64_value;
+                break;
+            }
+            case json_type::half_value:
+            {
+                os << half_value;
+                break;
+            }
+            case json_type::double_value:
+            {
+                os << double_value;
+                break;
+            }
+            case json_type::string_value:
+            {
+                os << string_value;
+                break;
+            }
+            case json_type::byte_string_value:
+            {
+                os << byte_string_value;
+                break;
+            }
+            case json_type::array_value:
+            {
+                os << array_value;
+                break;
+            }
+            case json_type::object_value:
+            {
+                os << object_value;
+                break;
+            }
+        }
+        return os;
+    }
+
+    enum class json_storage_kind : uint8_t 
+    {
+        null = 0,                 // 0000
+        boolean = 1,              // 0001
+        int64 = 2,                // 0010
+        uint64 = 3,               // 0011
+        empty_object = 4,         // 0100
+        float64 = 5,              // 0101
+        half_float = 6,           // 0110
+        short_str = 7,            // 0111
+        json_const_reference = 8, // 1000    
+        json_reference = 9,       // 1001    
+        byte_str = 12,            // 1100  
+        object = 13,              // 1101
+        array = 14,               // 1110
+        long_str = 15             // 1111
+    };
+
+    inline bool is_string_storage(json_storage_kind storage_kind) noexcept
+    {
+        static const uint8_t mask{ uint8_t(json_storage_kind::short_str) & uint8_t(json_storage_kind::long_str) };
+        return (uint8_t(storage_kind) & mask) == mask;
+    }
+
+    inline bool is_trivial_storage(json_storage_kind storage_kind) noexcept
+    {
+        static const uint8_t mask{ uint8_t(json_storage_kind::long_str) & uint8_t(json_storage_kind::byte_str) 
+            & uint8_t(json_storage_kind::array) & uint8_t(json_storage_kind::object) };
+        return (uint8_t(storage_kind) & mask) != mask;
+    }
+
+    template <typename CharT>
+    std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, json_storage_kind storage)
+    {
+        static constexpr const CharT* null_value = JSONCONS_CSTRING_CONSTANT(CharT, "null");
+        static constexpr const CharT* bool_value = JSONCONS_CSTRING_CONSTANT(CharT, "bool");
+        static constexpr const CharT* int64_value = JSONCONS_CSTRING_CONSTANT(CharT, "int64");
+        static constexpr const CharT* uint64_value = JSONCONS_CSTRING_CONSTANT(CharT, "uint64");
+        static constexpr const CharT* half_value = JSONCONS_CSTRING_CONSTANT(CharT, "half");
+        static constexpr const CharT* double_value = JSONCONS_CSTRING_CONSTANT(CharT, "double");
+        static constexpr const CharT* short_string_value = JSONCONS_CSTRING_CONSTANT(CharT, "short_string");
+        static constexpr const CharT* long_string_value = JSONCONS_CSTRING_CONSTANT(CharT, "string");
+        static constexpr const CharT* byte_string_value = JSONCONS_CSTRING_CONSTANT(CharT, "byte_string");
+        static constexpr const CharT* array_value = JSONCONS_CSTRING_CONSTANT(CharT, "array");
+        static constexpr const CharT* empty_object_value = JSONCONS_CSTRING_CONSTANT(CharT, "empty_object");
+        static constexpr const CharT* object_value = JSONCONS_CSTRING_CONSTANT(CharT, "object");
+        static constexpr const CharT* json_const_reference = JSONCONS_CSTRING_CONSTANT(CharT, "json_const_reference");
+        static constexpr const CharT* json_reference = JSONCONS_CSTRING_CONSTANT(CharT, "json_reference");
+
+        switch (storage)
+        {
+            case json_storage_kind::null:
+            {
+                os << null_value;
+                break;
+            }
+            case json_storage_kind::boolean:
+            {
+                os << bool_value;
+                break;
+            }
+            case json_storage_kind::int64:
+            {
+                os << int64_value;
+                break;
+            }
+            case json_storage_kind::uint64:
+            {
+                os << uint64_value;
+                break;
+            }
+            case json_storage_kind::half_float:
+            {
+                os << half_value;
+                break;
+            }
+            case json_storage_kind::float64:
+            {
+                os << double_value;
+                break;
+            }
+            case json_storage_kind::short_str:
+            {
+                os << short_string_value;
+                break;
+            }
+            case json_storage_kind::long_str:
+            {
+                os << long_string_value;
+                break;
+            }
+            case json_storage_kind::byte_str:
+            {
+                os << byte_string_value;
+                break;
+            }
+            case json_storage_kind::array:
+            {
+                os << array_value;
+                break;
+            }
+            case json_storage_kind::empty_object:
+            {
+                os << empty_object_value;
+                break;
+            }
+            case json_storage_kind::object:
+            {
+                os << object_value;
+                break;
+            }
+            case json_storage_kind::json_const_reference:
+            {
+                os << json_const_reference;
+                break;
+            }
+            case json_storage_kind::json_reference:
+            {
+                os << json_reference;
+                break;
+            }
+        }
+        return os;
+    }
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_TYPE_HPP

--- a/velox/external/jsoncons/json_type_traits.hpp
+++ b/velox/external/jsoncons/json_type_traits.hpp
@@ -1,0 +1,1921 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_TYPE_TRAITS_HPP
+#define JSONCONS_JSON_TYPE_TRAITS_HPP
+
+#include <algorithm> // std::swap
+#include <array>
+#include <bitset> // std::bitset
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <iterator> // std::iterator_traits, std::input_iterator_tag
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <type_traits> // std::enable_if
+#include <utility>
+#include <valarray>
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/value_converter.hpp"
+
+#if defined(JSONCONS_HAS_STD_VARIANT)
+  #include <variant>
+#endif
+
+namespace facebook::velox::jsoncons {
+
+    template <typename T>
+    struct is_json_type_traits_declared : public std::false_type
+    {};
+
+    // json_type_traits
+
+    template <typename T>
+    struct unimplemented : std::false_type
+    {};
+
+    template <typename Json,typename T,typename Enable=void>
+    struct json_type_traits
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static constexpr bool is_compatible = false;
+
+        static constexpr bool is(const Json&) noexcept
+        {
+            return false;
+        }
+
+        static T as(const Json&)
+        {
+            static_assert(unimplemented<T>::value, "as not implemented");
+        }
+
+        static Json to_json(const T&)
+        {
+            static_assert(unimplemented<T>::value, "to_json not implemented");
+        }
+
+        static Json to_json(const T&, const allocator_type&)
+        {
+            static_assert(unimplemented<T>::value, "to_json not implemented");
+        }
+    };
+
+namespace detail {
+
+template <typename Json,typename T>
+using
+traits_can_convert_t = decltype(json_type_traits<Json,T>::can_convert(Json()));
+
+template <typename Json,typename T>
+using
+has_can_convert = extension_traits::is_detected<traits_can_convert_t, Json, T>;
+
+    template <typename T>
+    struct invoke_can_convert
+    {
+        template <typename Json>
+        static 
+        typename std::enable_if<has_can_convert<Json,T>::value,bool>::type
+        can_convert(const Json& j) noexcept
+        {
+            return json_type_traits<Json,T>::can_convert(j);
+        }
+        template <typename Json>
+        static 
+        typename std::enable_if<!has_can_convert<Json,T>::value,bool>::type
+        can_convert(const Json& j) noexcept
+        {
+            return json_type_traits<Json,T>::is(j);
+        }
+    };
+
+    // is_json_type_traits_unspecialized
+    template <typename Json,typename T,typename Enable = void>
+    struct is_json_type_traits_unspecialized : std::false_type {};
+
+    // is_json_type_traits_unspecialized
+    template <typename Json,typename T>
+    struct is_json_type_traits_unspecialized<Json,T,
+        typename std::enable_if<!std::integral_constant<bool, json_type_traits<Json, T>::is_compatible>::value>::type
+    > : std::true_type {};
+
+    // is_compatible_array_type
+    template <typename Json,typename T,typename Enable=void>
+    struct is_compatible_array_type : std::false_type {};
+
+    template <typename Json,typename T>
+    struct is_compatible_array_type<Json,T, 
+        typename std::enable_if<!std::is_same<T,typename Json::array>::value &&
+        extension_traits::is_array_like<T>::value && 
+        !is_json_type_traits_unspecialized<Json,typename std::iterator_traits<typename T::iterator>::value_type>::value
+    >::type> : std::true_type {};
+
+} // namespace detail
+
+    // is_json_type_traits_specialized
+    template <typename Json,typename T,typename Enable=void>
+    struct is_json_type_traits_specialized : std::false_type {};
+
+    template <typename Json,typename T>
+    struct is_json_type_traits_specialized<Json,T, 
+        typename std::enable_if<!jsoncons::detail::is_json_type_traits_unspecialized<Json,T>::value
+    >::type> : std::true_type {};
+
+    template <typename Json>
+    struct json_type_traits<Json, const typename std::decay<typename Json::char_type>::type*>
+    {
+        using char_type = typename Json::char_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_string();
+        }
+        static const char_type* as(const Json& j)
+        {
+            return j.as_cstring();
+        }
+        template <typename ... Args>
+        static Json to_json(const char_type* s, Args&&... args)
+        {
+            return Json(s, semantic_tag::none, std::forward<Args>(args)...);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json,typename std::decay<typename Json::char_type>::type*>
+    {
+        using char_type = typename Json::char_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_string();
+        }
+        template <typename ... Args>
+        static Json to_json(const char_type* s, Args&&... args)
+        {
+            return Json(s, semantic_tag::none, std::forward<Args>(args)...);
+        }
+    };
+
+    // integer
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T,
+        typename std::enable_if<(extension_traits::is_signed_integer<T>::value && sizeof(T) <= sizeof(int64_t)) || (extension_traits::is_unsigned_integer<T>::value && sizeof(T) <= sizeof(uint64_t)) 
+    >::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.template is_integer<T>();
+        }
+        static T as(const Json& j)
+        {
+            return j.template as_integer<T>();
+        }
+
+        static Json to_json(T val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+
+        static Json to_json(T val, const allocator_type&)
+        {
+            return Json(val, semantic_tag::none);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T,
+        typename std::enable_if<(extension_traits::is_signed_integer<T>::value && sizeof(T) > sizeof(int64_t)) || (extension_traits::is_unsigned_integer<T>::value && sizeof(T) > sizeof(uint64_t)) 
+    >::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.template is_integer<T>();
+        }
+        static T as(const Json& j)
+        {
+            return j.template as_integer<T>();
+        }
+
+        static Json to_json(T val, const allocator_type& alloc = allocator_type())
+        {
+            return Json(val, semantic_tag::none, alloc);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T,
+                            typename std::enable_if<std::is_floating_point<T>::value
+    >::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_double();
+        }
+        static T as(const Json& j)
+        {
+            return static_cast<T>(j.as_double());
+        }
+        static Json to_json(T val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+        static Json to_json(T val, const allocator_type&)
+        {
+            return Json(val, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json,typename Json::object>
+    {
+        using json_object = typename Json::object;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_object();
+        }
+        static Json to_json(const json_object& o)
+        {
+            return Json(o,semantic_tag::none);
+        }
+        static Json to_json(const json_object& o, const allocator_type&)
+        {
+            return Json(o,semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json,typename Json::array>
+    {
+        using json_array = typename Json::array;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_array();
+        }
+        static Json to_json(const json_array& a)
+        {
+            return Json(a, semantic_tag::none);
+        }
+        static Json to_json(const json_array& a, const allocator_type&)
+        {
+            return Json(a, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json, Json>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json&) noexcept
+        {
+            return true;
+        }
+        static Json as(Json j)
+        {
+            return j;
+        }
+        static Json to_json(const Json& val)
+        {
+            return val;
+        }
+        static Json to_json(const Json& val, const allocator_type&)
+        {
+            return val;
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json, jsoncons::null_type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_null();
+        }
+        static typename jsoncons::null_type as(const Json& j)
+        {
+            if (!j.is_null())
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_jsoncons_null_type));
+            }
+            return jsoncons::null_type();
+        }
+        static Json to_json(jsoncons::null_type)
+        {
+            return Json(jsoncons::null_type{}, semantic_tag::none);
+        }
+        static Json to_json(jsoncons::null_type, const allocator_type&)
+        {
+            return Json(jsoncons::null_type{}, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json, bool>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_bool();
+        }
+        static bool as(const Json& j)
+        {
+            return j.as_bool();
+        }
+        static Json to_json(bool val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+        static Json to_json(bool val, const allocator_type&)
+        {
+            return Json(val, semantic_tag::none);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T,typename std::enable_if<std::is_same<T, 
+        std::conditional<!std::is_same<bool,std::vector<bool>::const_reference>::value,
+                         std::vector<bool>::const_reference,
+                         void>::type>::value>::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_bool();
+        }
+        static bool as(const Json& j)
+        {
+            return j.as_bool();
+        }
+        static Json to_json(bool val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+        static Json to_json(bool val, const allocator_type&)
+        {
+            return Json(val, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json, std::vector<bool>::reference>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_bool();
+        }
+        static bool as(const Json& j)
+        {
+            return j.as_bool();
+        }
+        static Json to_json(bool val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+        static Json to_json(bool val, const allocator_type&)
+        {
+            return Json(val, semantic_tag::none);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    extension_traits::is_string<T>::value &&
+                                                    std::is_same<typename Json::char_type,typename T::value_type>::value>::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_string();
+        }
+
+        static T as(const Json& j)
+        {
+            return T(j.as_string());
+        }
+
+        static Json to_json(const T& val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            return Json(val, semantic_tag::none, alloc);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    extension_traits::is_string<T>::value &&
+                                                    !std::is_same<typename Json::char_type,typename T::value_type>::value>::type>
+    {
+        using char_type = typename Json::char_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_string();
+        }
+
+        static T as(const Json& j)
+        {
+            auto s = j.as_string();
+            T val;
+            unicode_traits::convert(s.data(), s.size(), val);
+            return val;
+        }
+
+        static Json to_json(const T& val)
+        {
+            std::basic_string<char_type> s;
+            unicode_traits::convert(val.data(), val.size(), s);
+
+            return Json(s, semantic_tag::none);
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            std::basic_string<char_type> s;
+            unicode_traits::convert(val.data(), val.size(), s);
+            return Json(s, semantic_tag::none, alloc);
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    extension_traits::is_string_view<T>::value &&
+                                                    std::is_same<typename Json::char_type,typename T::value_type>::value>::type>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_string_view();
+        }
+
+        static T as(const Json& j)
+        {
+            return T(j.as_string_view().data(),j.as_string_view().size());
+        }
+
+        static Json to_json(const T& val)
+        {
+            return Json(val, semantic_tag::none);
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            return Json(val, semantic_tag::none, alloc);
+        }
+    };
+
+    // array back insertable
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    jsoncons::detail::is_compatible_array_type<Json,T>::value &&
+                                                    extension_traits::is_back_insertable<T>::value 
+                                                    >::type>
+    {
+        typedef typename std::iterator_traits<typename T::iterator>::value_type value_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_array();
+            if (result)
+            {
+                for (auto e : j.array_range())
+                {
+                    if (!e.template is<value_type>())
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        // array back insertable non-byte container
+
+        template <typename Container = T>
+        static typename std::enable_if<!extension_traits::is_byte<typename Container::value_type>::value,Container>::type
+        as(const Json& j)
+        {
+            if (j.is_array())
+            {
+                T result;
+                visit_reserve_(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(),result,j.size());
+                for (const auto& item : j.array_range())
+                {
+                    result.push_back(item.template as<value_type>());
+                }
+
+                return result;
+            }
+            else 
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_vector));
+            }
+        }
+
+        // array back insertable byte container
+
+        template <typename Container = T>
+        static typename std::enable_if<extension_traits::is_byte<typename Container::value_type>::value,Container>::type
+        as(const Json& j)
+        {
+            std::error_code ec;
+            if (j.is_array())
+            {
+                T result;
+                visit_reserve_(typename std::integral_constant<bool, extension_traits::has_reserve<T>::value>::type(),result,j.size());
+                for (const auto& item : j.array_range())
+                {
+                    result.push_back(item.template as<value_type>());
+                }
+
+                return result;
+            }
+            else if (j.is_byte_string_view())
+            {
+                value_converter<byte_string_view,T> converter;
+                auto v = converter.convert(j.as_byte_string_view(),j.tag(), ec);
+                if (ec)
+                {
+                    JSONCONS_THROW(conv_error(ec));
+                }
+                return v;
+            }
+            else if (j.is_string())
+            {
+                value_converter<basic_string_view<char>,T> converter;
+                auto v = converter.convert(j.as_string_view(),j.tag(), ec);
+                if (ec)
+                {
+                    JSONCONS_THROW(conv_error(ec));
+                }
+                return v;
+            }
+            else
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_vector));
+            }
+        }
+
+        template <typename Container = T>
+        static typename std::enable_if<!extension_traits::is_std_byte<typename Container::value_type>::value,Json>::type
+        to_json(const T& val)
+        {
+            Json j(json_array_arg);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first,last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+
+        template <typename Container = T>
+        static typename std::enable_if<!extension_traits::is_std_byte<typename Container::value_type>::value,Json>::type
+        to_json(const T& val, const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first, last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+
+        template <typename Container = T>
+        static typename std::enable_if<extension_traits::is_std_byte<typename Container::value_type>::value,Json>::type
+        to_json(const T& val)
+        {
+            Json j(byte_string_arg, val);
+            return j;
+        }
+
+        template <typename Container = T>
+        static typename std::enable_if<extension_traits::is_std_byte<typename Container::value_type>::value,Json>::type
+        to_json(const T& val, const allocator_type& alloc)
+        {
+            Json j(byte_string_arg, val, semantic_tag::none, alloc);
+            return j;
+        }
+
+        static void visit_reserve_(std::true_type, T& v, std::size_t size)
+        {
+            v.reserve(size);
+        }
+
+        static void visit_reserve_(std::false_type, T&, std::size_t)
+        {
+        }
+    };
+
+    // array, not back insertable but insertable
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    jsoncons::detail::is_compatible_array_type<Json,T>::value &&
+                                                    !extension_traits::is_back_insertable<T>::value &&
+                                                    extension_traits::is_insertable<T>::value>::type>
+    {
+        typedef typename std::iterator_traits<typename T::iterator>::value_type value_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_array();
+            if (result)
+            {
+                for (auto e : j.array_range())
+                {
+                    if (!e.template is<value_type>())
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        static T as(const Json& j)
+        {
+            if (j.is_array())
+            {
+                T result;
+                for (const auto& item : j.array_range())
+                {
+                    result.insert(item.template as<value_type>());
+                }
+
+                return result;
+            }
+            else 
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_vector));
+            }
+        }
+
+        static Json to_json(const T& val)
+        {
+            Json j(json_array_arg);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first,last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first, last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+    };
+
+    // array not back insertable or insertable, but front insertable
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    jsoncons::detail::is_compatible_array_type<Json,T>::value &&
+                                                    !extension_traits::is_back_insertable<T>::value &&
+                                                    !extension_traits::is_insertable<T>::value &&
+                                                    extension_traits::is_front_insertable<T>::value>::type>
+    {
+        typedef typename std::iterator_traits<typename T::iterator>::value_type value_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_array();
+            if (result)
+            {
+                for (auto e : j.array_range())
+                {
+                    if (!e.template is<value_type>())
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        static T as(const Json& j)
+        {
+            if (j.is_array())
+            {
+                T result;
+
+                auto it = j.array_range().rbegin();
+                auto end = j.array_range().rend();
+                for (; it != end; ++it)
+                {
+                    result.push_front((*it).template as<value_type>());
+                }
+
+                return result;
+            }
+            else 
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_vector));
+            }
+        }
+
+        static Json to_json(const T& val)
+        {
+            Json j(json_array_arg);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first,last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first, last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+    };
+
+    // std::array
+
+    template <typename Json,typename E, std::size_t N>
+    struct json_type_traits<Json, std::array<E, N>>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        using value_type = E;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_array() && j.size() == N;
+            if (result)
+            {
+                for (auto e : j.array_range())
+                {
+                    if (!e.template is<value_type>())
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+
+        static std::array<E, N> as(const Json& j)
+        {
+            std::array<E, N> buff;
+            if (j.size() != N)
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_array));
+            }
+            for (std::size_t i = 0; i < N; i++)
+            {
+                buff[i] = j[i].template as<E>();
+            }
+            return buff;
+        }
+
+        static Json to_json(const std::array<E, N>& val)
+        {
+            Json j(json_array_arg);
+            j.reserve(N);
+            for (auto it = val.begin(); it != val.end(); ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+
+        static Json to_json(const std::array<E, N>& val, 
+                            const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            j.reserve(N);
+            for (auto it = val.begin(); it != val.end(); ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+    };
+
+    // map like
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    extension_traits::is_map_like<T>::value &&
+                                                    extension_traits::is_constructible_from_const_pointer_and_size<typename T::key_type>::value &&
+                                                    is_json_type_traits_specialized<Json,typename T::mapped_type>::value>::type
+    >
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_object();
+            for (auto member : j.object_range())
+            {
+                if (!member.value().template is<mapped_type>())
+                {
+                    result = false;
+                }
+            }
+            return result;
+        }
+
+        static T as(const Json& j)
+        {
+            if (!j.is_object())
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_map));
+            }
+            T result;
+            for (const auto& item : j.object_range())
+            {
+                result.emplace(key_type(item.key().data(),item.key().size()), item.value().template as<mapped_type>());
+            }
+
+            return result;
+        }
+
+        static Json to_json(const T& val)
+        {
+            Json j(json_object_arg, val.begin(), val.end());
+            return j;
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc)
+        {
+            Json j(json_object_arg, val.begin(), val.end(), alloc);
+            return j;
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T, 
+                            typename std::enable_if<!is_json_type_traits_declared<T>::value && 
+                                                    extension_traits::is_map_like<T>::value &&
+                                                    !extension_traits::is_constructible_from_const_pointer_and_size<typename T::key_type>::value &&
+                                                    is_json_type_traits_specialized<Json,typename T::key_type>::value &&
+                                                    is_json_type_traits_specialized<Json,typename T::mapped_type>::value>::type
+    >
+    {
+        using mapped_type = typename T::mapped_type;
+        using value_type = typename T::value_type;
+        using key_type = typename T::key_type;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& val) noexcept 
+        {
+            if (!val.is_object())
+                return false;
+            for (const auto& item : val.object_range())
+            {
+                Json j(item.key());
+                if (!j.template is<key_type>())
+                {
+                    return false;
+                }
+                if (!item.value().template is<mapped_type>())
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static T as(const Json& val) 
+        {
+            T result;
+            for (const auto& item : val.object_range())
+            {
+                Json j(item.key());
+                auto key = json_type_traits<Json,key_type>::as(j);
+                result.emplace(std::move(key), item.value().template as<mapped_type>());
+            }
+
+            return result;
+        }
+
+        static Json to_json(const T& val) 
+        {
+            Json j(json_object_arg);
+            j.reserve(val.size());
+            for (const auto& item : val)
+            {
+                auto temp = json_type_traits<Json,key_type>::to_json(item.first);
+                if (temp.is_string_view())
+                {
+                    j.try_emplace(typename Json::key_type(temp.as_string_view()), item.second);
+                }
+                else
+                {
+                    typename Json::key_type key;
+                    temp.dump(key);
+                    j.try_emplace(std::move(key), item.second);
+                }
+            }
+            return j;
+        }
+
+        static Json to_json(const T& val, const allocator_type& alloc) 
+        {
+            Json j(json_object_arg, semantic_tag::none, alloc);
+            j.reserve(val.size());
+            for (const auto& item : val)
+            {
+                auto temp = json_type_traits<Json, key_type>::to_json(item.first, alloc);
+                if (temp.is_string_view())
+                {
+                    j.try_emplace(typename Json::key_type(temp.as_string_view(), alloc), item.second);
+                }
+                else
+                {
+                    typename Json::key_type key(alloc);
+                    temp.dump(key);
+                    j.try_emplace(std::move(key), item.second, alloc);
+                }
+            }
+            return j;
+        }
+    };
+
+    namespace tuple_detail
+    {
+        template<size_t Pos, std::size_t Size,typename Json,typename Tuple>
+        struct json_tuple_helper
+        {
+            using element_type = typename std::tuple_element<Size-Pos, Tuple>::type;
+            using next = json_tuple_helper<Pos-1, Size, Json, Tuple>;
+            
+            static bool is(const Json& j) noexcept
+            {
+                if (j[Size-Pos].template is<element_type>())
+                {
+                    return next::is(j);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            static void as(Tuple& tuple, const Json& j)
+            {
+                std::get<Size-Pos>(tuple) = j[Size-Pos].template as<element_type>();
+                next::as(tuple, j);
+            }
+
+            static void to_json(const Tuple& tuple, Json& j)
+            {
+                j.push_back(json_type_traits<Json, element_type>::to_json(std::get<Size-Pos>(tuple)));
+                next::to_json(tuple, j);
+            }
+        };
+
+        template<size_t Size,typename Json,typename Tuple>
+        struct json_tuple_helper<0, Size, Json, Tuple>
+        {
+            static bool is(const Json&) noexcept
+            {
+                return true;
+            }
+
+            static void as(Tuple&, const Json&)
+            {
+            }
+
+            static void to_json(const Tuple&, Json&)
+            {
+            }
+        };
+    } // namespace tuple_detail
+
+    template <typename Json,typename... E>
+    struct json_type_traits<Json, std::tuple<E...>>
+    {
+    private:
+        using helper = tuple_detail::json_tuple_helper<sizeof...(E), sizeof...(E), Json, std::tuple<E...>>;
+
+    public:
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return helper::is(j);
+        }
+        
+        static std::tuple<E...> as(const Json& j)
+        {
+            std::tuple<E...> buff;
+            helper::as(buff, j);
+            return buff;
+        }
+         
+        static Json to_json(const std::tuple<E...>& val)
+        {
+            Json j(json_array_arg);
+            j.reserve(sizeof...(E));
+            helper::to_json(val, j);
+            return j;
+        }
+
+        static Json to_json(const std::tuple<E...>& val,
+                            const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            j.reserve(sizeof...(E));
+            helper::to_json(val, j);
+            return j;
+        }
+    };
+
+    template <typename Json,typename T1,typename T2>
+    struct json_type_traits<Json, std::pair<T1,T2>>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_array() && j.size() == 2;
+        }
+        
+        static std::pair<T1,T2> as(const Json& j)
+        {
+            return std::make_pair<T1,T2>(j[0].template as<T1>(),j[1].template as<T2>());
+        }
+        
+        static Json to_json(const std::pair<T1,T2>& val)
+        {
+            Json j(json_array_arg);
+            j.reserve(2);
+            j.push_back(val.first);
+            j.push_back(val.second);
+            return j;
+        }
+
+        static Json to_json(const std::pair<T1, T2>& val, const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            j.reserve(2);
+            j.push_back(val.first);
+            j.push_back(val.second);
+            return j;
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, T,
+                            typename std::enable_if<extension_traits::is_basic_byte_string<T>::value>::type>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_byte_string();
+        }
+        
+        static T as(const Json& j)
+        { 
+            return j.template as_byte_string<typename T::allocator_type>();
+        }
+        
+        static Json to_json(const T& val, 
+                            const allocator_type& alloc = allocator_type())
+        {
+            return Json(byte_string_arg, val, semantic_tag::none, alloc);
+        }
+    };
+
+    template <typename Json,typename ValueType>
+    struct json_type_traits<Json, std::shared_ptr<ValueType>,
+                            typename std::enable_if<!is_json_type_traits_declared<std::shared_ptr<ValueType>>::value &&
+                                                    !std::is_polymorphic<ValueType>::value
+    >::type>
+    {
+        static bool is(const Json& j) noexcept 
+        {
+            return j.is_null() || j.template is<ValueType>();
+        }
+
+        static std::shared_ptr<ValueType> as(const Json& j) 
+        {
+            return j.is_null() ? std::shared_ptr<ValueType>(nullptr) : std::make_shared<ValueType>(j.template as<ValueType>());
+        }
+
+        static Json to_json(const std::shared_ptr<ValueType>& ptr) 
+        {
+            if (ptr.get() != nullptr) 
+            {
+                Json j(*ptr);
+                return j;
+            }
+            else 
+            {
+                return Json::null();
+            }
+        }
+    };
+
+    template <typename Json,typename ValueType>
+    struct json_type_traits<Json, std::unique_ptr<ValueType>,
+                            typename std::enable_if<!is_json_type_traits_declared<std::unique_ptr<ValueType>>::value &&
+                                                    !std::is_polymorphic<ValueType>::value
+    >::type>
+    {
+        static bool is(const Json& j) noexcept 
+        {
+            return j.is_null() || j.template is<ValueType>();
+        }
+
+        static std::unique_ptr<ValueType> as(const Json& j) 
+        {
+            return j.is_null() ? std::unique_ptr<ValueType>(nullptr) : jsoncons::make_unique<ValueType>(j.template as<ValueType>());
+        }
+
+        static Json to_json(const std::unique_ptr<ValueType>& ptr) 
+        {
+            if (ptr.get() != nullptr) 
+            {
+                Json j(*ptr);
+                return j;
+            }
+            else 
+            {
+                return Json::null();
+            }
+        }
+    };
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, jsoncons::optional<T>,
+                            typename std::enable_if<!is_json_type_traits_declared<jsoncons::optional<T>>::value>::type>
+    {
+    public:
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_null() || j.template is<T>();
+        }
+        
+        static jsoncons::optional<T> as(const Json& j)
+        { 
+            return j.is_null() ? jsoncons::optional<T>() : jsoncons::optional<T>(j.template as<T>());
+        }
+        
+        static Json to_json(const jsoncons::optional<T>& val)
+        {
+            return val.has_value() ? Json(*val) : Json::null();
+        }
+    };
+
+    template <typename Json>
+    struct json_type_traits<Json, byte_string_view>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+    public:
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_byte_string_view();
+        }
+        
+        static byte_string_view as(const Json& j)
+        {
+            return j.as_byte_string_view();
+        }
+        
+        static Json to_json(const byte_string_view& val, const allocator_type& alloc = allocator_type())
+        {
+            return Json(byte_string_arg, val, semantic_tag::none, alloc);
+        }
+    };
+
+    // basic_bigint
+
+    template <typename Json,typename Allocator>
+    struct json_type_traits<Json, basic_bigint<Allocator>>
+    {
+    public:
+        using char_type = typename Json::char_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            switch (j.type())
+            {
+                case json_type::string_value:
+                    return jsoncons::detail::is_base10(j.as_string_view().data(), j.as_string_view().length());
+                case json_type::int64_value:
+                case json_type::uint64_value:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        
+        static basic_bigint<Allocator> as(const Json& j)
+        {
+            switch (j.type())
+            {
+                case json_type::string_value:
+                    if (!jsoncons::detail::is_base10(j.as_string_view().data(), j.as_string_view().length()))
+                    {
+                        JSONCONS_THROW(conv_error(conv_errc::not_bigint));
+                    }
+                    return basic_bigint<Allocator>::from_string(j.as_string_view().data(), j.as_string_view().length());
+                case json_type::half_value:
+                case json_type::double_value:
+                    return basic_bigint<Allocator>(j.template as<int64_t>());
+                case json_type::int64_value:
+                    return basic_bigint<Allocator>(j.template as<int64_t>());
+                case json_type::uint64_value:
+                    return basic_bigint<Allocator>(j.template as<uint64_t>());
+                default:
+                    JSONCONS_THROW(conv_error(conv_errc::not_bigint));
+            }
+        }
+        
+        static Json to_json(const basic_bigint<Allocator>& val)
+        {
+            std::basic_string<char_type> s;
+            val.write_string(s);
+            return Json(s,semantic_tag::bigint);
+        }
+    };
+
+    // std::valarray
+
+    template <typename Json,typename T>
+    struct json_type_traits<Json, std::valarray<T>>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            bool result = j.is_array();
+            if (result)
+            {
+                for (auto e : j.array_range())
+                {
+                    if (!e.template is<T>())
+                    {
+                        result = false;
+                        break;
+                    }
+                }
+            }
+            return result;
+        }
+        
+        static std::valarray<T> as(const Json& j)
+        {
+            if (j.is_array())
+            {
+                std::valarray<T> v(j.size());
+                for (std::size_t i = 0; i < j.size(); ++i)
+                {
+                    v[i] = j[i].template as<T>();
+                }
+                return v;
+            }
+            else
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_array));
+            }
+        }
+        
+        static Json to_json(const std::valarray<T>& val)
+        {
+            Json j(json_array_arg);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first,last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        } 
+
+        static Json to_json(const std::valarray<T>& val, const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            auto first = std::begin(val);
+            auto last = std::end(val);
+            std::size_t size = std::distance(first,last);
+            j.reserve(size);
+            for (auto it = first; it != last; ++it)
+            {
+                j.push_back(*it);
+            }
+            return j;
+        }
+    };
+
+#if defined(JSONCONS_HAS_STD_VARIANT)
+
+namespace variant_detail
+{
+    template<int N,typename Json,typename Variant,typename ... Args>
+    typename std::enable_if<N == std::variant_size_v<Variant>, bool>::type
+    is_variant(const Json& /*j*/)
+    {
+        return false;
+    }
+
+    template<std::size_t N,typename Json,typename Variant,typename T,typename ... U>
+    typename std::enable_if<N < std::variant_size_v<Variant>, bool>::type
+    is_variant(const Json& j)
+    {
+      if (j.template is<T>())
+      {
+          return true;
+      }
+      else
+      {
+          return is_variant<N+1, Json, Variant, U...>(j);
+      }
+    }
+
+    template<int N,typename Json,typename Variant,typename ... Args>
+    typename std::enable_if<N == std::variant_size_v<Variant>, Variant>::type
+    as_variant(const Json& /*j*/)
+    {
+        JSONCONS_THROW(conv_error(conv_errc::not_variant));
+    }
+
+    template<std::size_t N,typename Json,typename Variant,typename T,typename ... U>
+    typename std::enable_if<N < std::variant_size_v<Variant>, Variant>::type
+    as_variant(const Json& j)
+    {
+      if (j.template is<T>())
+      {
+        Variant var(j.template as<T>());
+        return var;
+      }
+      else
+      {
+          return as_variant<N+1, Json, Variant, U...>(j);
+      }
+    }
+
+    template <typename Json>
+    struct variant_to_json_visitor
+    {
+        Json& j_;
+
+        variant_to_json_visitor(Json& j) : j_(j) {}
+
+        template <typename T>
+        void operator()(const T& value) const
+        {
+            j_ = value;
+        }
+    };
+
+} // namespace variant_detail
+
+    template <typename Json,typename... VariantTypes>
+    struct json_type_traits<Json, std::variant<VariantTypes...>>
+    {
+    public:
+        using variant_type = typename std::variant<VariantTypes...>;
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return variant_detail::is_variant<0,Json,variant_type, VariantTypes...>(j); 
+        }
+
+        static std::variant<VariantTypes...> as(const Json& j)
+        {
+            return variant_detail::as_variant<0,Json,variant_type, VariantTypes...>(j); 
+        }
+
+        static Json to_json(const std::variant<VariantTypes...>& var)
+        {
+            Json j(json_array_arg);
+            variant_detail::variant_to_json_visitor<Json> visitor(j);
+            std::visit(visitor, var);
+            return j;
+        }
+
+        static Json to_json(const std::variant<VariantTypes...>& var,
+                            const allocator_type& alloc)
+        {
+            Json j(json_array_arg, alloc);
+            variant_detail::variant_to_json_visitor<Json> visitor(j);
+            std::visit(visitor, var);
+            return j;
+        }
+    };
+#endif
+
+    // std::chrono::duration
+    template <typename Json,typename Rep,typename Period>
+    struct json_type_traits<Json,std::chrono::duration<Rep,Period>>
+    {
+        using duration_type = std::chrono::duration<Rep,Period>;
+
+        using allocator_type = typename Json::allocator_type;
+
+        static constexpr int64_t nanos_in_milli = 1000000;
+        static constexpr int64_t nanos_in_second = 1000000000;
+        static constexpr int64_t millis_in_second = 1000;
+
+        static bool is(const Json& j) noexcept
+        {
+            return (j.tag() == semantic_tag::epoch_second || j.tag() == semantic_tag::epoch_milli || j.tag() == semantic_tag::epoch_nano);
+        }
+
+        static duration_type as(const Json& j)
+        {
+            return from_json_(j);
+        }
+
+        static Json to_json(const duration_type& val, const allocator_type& = allocator_type())
+        {
+            return to_json_(val);
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::ratio<1>>::value, duration_type>::type
+        from_json_(const Json& j)
+        {
+            if (j.is_int64() || j.is_uint64() || j.is_double())
+            {
+                auto count = j.template as<Rep>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(count);
+                    case semantic_tag::epoch_milli:
+                        return duration_type(count == 0 ? 0 : count/millis_in_second);
+                    case semantic_tag::epoch_nano:
+                        return duration_type(count == 0 ? 0 : count/nanos_in_second);
+                    default:
+                        return duration_type(count);
+                }
+            }
+            else if (j.is_string())
+            {
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                    {
+                        auto count = j.template as<Rep>();
+                        return duration_type(count);
+                    }
+                    case semantic_tag::epoch_milli:
+                    {
+                        auto sv = j.as_string_view();
+                        bigint n = bigint::from_string(sv.data(), sv.length());
+                        if (n != 0)
+                        {
+                            n = n / millis_in_second;
+                        }
+                        return duration_type(static_cast<Rep>(n));
+                    }
+                    case semantic_tag::epoch_nano:
+                    {
+                        auto sv = j.as_string_view();
+                        bigint n = bigint::from_string(sv.data(), sv.length());
+                        if (n != 0)
+                        {
+                            n = n / nanos_in_second;
+                        }
+                        return duration_type(static_cast<Rep>(n));
+                    }
+                    default:
+                    {
+                        auto count = j.template as<Rep>();
+                        return duration_type(count);
+                    }
+                }
+            }
+            else
+            {
+                return duration_type();
+            }
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::milli>::value, duration_type>::type
+        from_json_(const Json& j)
+        {
+            if (j.is_int64() || j.is_uint64())
+            {
+                auto count = j.template as<Rep>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(count*millis_in_second);
+                    case semantic_tag::epoch_milli:
+                        return duration_type(count);
+                    case semantic_tag::epoch_nano:
+                        return duration_type(count == 0 ? 0 : count/nanos_in_milli);
+                    default:
+                        return duration_type(count);
+                }
+            }
+            else if (j.is_double())
+            {
+                auto count = j.template as<double>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(static_cast<Rep>(count * millis_in_second));
+                    case semantic_tag::epoch_milli:
+                        return duration_type(static_cast<Rep>(count));
+                    case semantic_tag::epoch_nano:
+                        return duration_type(count == 0 ? 0 : static_cast<Rep>(count / nanos_in_milli));
+                    default:
+                        return duration_type(static_cast<Rep>(count));
+                }
+            }
+            else if (j.is_string())
+            {
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                    {
+                        auto count = j.template as<Rep>();
+                        return duration_type(count*millis_in_second);
+                    }
+                    case semantic_tag::epoch_milli:
+                    {
+                        auto sv = j.as_string_view();
+                        Rep n{0};
+                        auto result = jsoncons::detail::decimal_to_integer(sv.data(), sv.size(), n);
+                        if (!result)
+                        {
+                            return duration_type();
+                        }
+                        return duration_type(n);
+                    }
+                    case semantic_tag::epoch_nano:
+                    {
+                        auto sv = j.as_string_view();
+                        bigint n = bigint::from_string(sv.data(), sv.length());
+                        if (n != 0)
+                        {
+                            n = n / nanos_in_milli;
+                        }
+                        return duration_type(static_cast<Rep>(n));
+                    }
+                    default:
+                    {
+                        auto count = j.template as<Rep>();
+                        return duration_type(count);
+                    }
+                }
+            }
+            else
+            {
+                return duration_type();
+            }
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::nano>::value, duration_type>::type
+        from_json_(const Json& j)
+        {
+            if (j.is_int64() || j.is_uint64() || j.is_double())
+            {
+                auto count = j.template as<Rep>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(count*nanos_in_second);
+                    case semantic_tag::epoch_milli:
+                        return duration_type(count*nanos_in_milli);
+                    case semantic_tag::epoch_nano:
+                        return duration_type(count);
+                    default:
+                        return duration_type(count);
+                }
+            }
+            else if (j.is_double())
+            {
+                auto count = j.template as<double>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(static_cast<Rep>(count * nanos_in_second));
+                    case semantic_tag::epoch_milli:
+                        return duration_type(static_cast<Rep>(count * nanos_in_milli));
+                    case semantic_tag::epoch_nano:
+                        return duration_type(static_cast<Rep>(count));
+                    default:
+                        return duration_type(static_cast<Rep>(count));
+                }
+            }
+            else if (j.is_string())
+            {
+                auto count = j.template as<Rep>();
+                switch (j.tag())
+                {
+                    case semantic_tag::epoch_second:
+                        return duration_type(count*nanos_in_second);
+                    case semantic_tag::epoch_milli:
+                        return duration_type(count*nanos_in_milli);
+                    case semantic_tag::epoch_nano:
+                        return duration_type(count);
+                    default:
+                        return duration_type(count);
+                }
+            }
+            else
+            {
+                return duration_type();
+            }
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::ratio<1>>::value,Json>::type
+        to_json_(const duration_type& val)
+        {
+            return Json(val.count(), semantic_tag::epoch_second);
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::milli>::value,Json>::type
+        to_json_(const duration_type& val)
+        {
+            return Json(val.count(), semantic_tag::epoch_milli);
+        }
+
+        template <typename PeriodT=Period>
+        static 
+        typename std::enable_if<std::is_same<PeriodT,std::nano>::value,Json>::type
+        to_json_(const duration_type& val)
+        {
+            return Json(val.count(), semantic_tag::epoch_nano);
+        }
+    };
+
+    // std::nullptr_t
+    template <typename Json>
+    struct json_type_traits<Json,std::nullptr_t>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            return j.is_null();
+        }
+
+        static std::nullptr_t as(const Json& j)
+        {
+            if (!j.is_null())
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_nullptr));
+            }
+            return nullptr;
+        }
+
+        static Json to_json(const std::nullptr_t&, const allocator_type& = allocator_type())
+        {
+            return Json::null();
+        }
+    };
+
+    // std::bitset
+
+    struct null_back_insertable_byte_container
+    {
+        using value_type = uint8_t;
+
+        void push_back(value_type)
+        {
+        }
+    };
+
+    template <typename Json, std::size_t N>
+    struct json_type_traits<Json, std::bitset<N>>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        static bool is(const Json& j) noexcept
+        {
+            if (j.is_byte_string())
+            {
+                return true;
+            }
+            else if (j.is_string())
+            {
+                jsoncons::string_view sv = j.as_string_view();
+                null_back_insertable_byte_container cont;
+                auto result = decode_base16(sv.begin(), sv.end(), cont);
+                return result.ec == conv_errc::success ? true : false;
+            }
+            return false;
+        }
+
+        static std::bitset<N> as(const Json& j)
+        {
+            if (j.template is<uint64_t>())
+            {
+                auto bits = j.template as<uint64_t>();
+                std::bitset<N> bs = static_cast<unsigned long long>(bits);
+                return bs;
+            }
+            else if (j.is_byte_string() || j.is_string())
+            {
+                std::bitset<N> bs;
+                std::vector<uint8_t> bits;
+                if (j.is_byte_string())
+                {
+                    bits = j.template as<std::vector<uint8_t>>();
+                }
+                else
+                {
+                    jsoncons::string_view sv = j.as_string_view();
+                    auto result = decode_base16(sv.begin(), sv.end(), bits);
+                    if (result.ec != conv_errc::success)
+                    {
+                        JSONCONS_THROW(conv_error(conv_errc::not_bitset));
+                    }
+                }
+                std::uint8_t byte = 0;
+                std::uint8_t mask  = 0;
+
+                std::size_t pos = 0;
+                for (std::size_t i = 0; i < N; ++i)
+                {
+                    if (mask == 0)
+                    {
+                        if (pos >= bits.size())
+                        {
+                            JSONCONS_THROW(conv_error(conv_errc::not_bitset));
+                        }
+                        byte = bits.at(pos++);
+                        mask = 0x80;
+                    }
+
+                    if (byte & mask)
+                    {
+                        bs[i] = 1;
+                    }
+
+                    mask = static_cast<std::uint8_t>(mask >> 1);
+                }
+                return bs;
+            }
+            else
+            {
+                JSONCONS_THROW(conv_error(conv_errc::not_bitset));
+            }
+        }
+
+        static Json to_json(const std::bitset<N>& val, 
+                            const allocator_type& alloc = allocator_type())
+        {
+            std::vector<uint8_t> bits;
+
+            uint8_t byte = 0;
+            uint8_t mask = 0x80;
+
+            for (std::size_t i = 0; i < N; ++i)
+            {
+                if (val[i])
+                {
+                    byte |= mask;
+                }
+
+                mask = static_cast<uint8_t>(mask >> 1);
+
+                if (mask == 0)
+                {
+                    bits.push_back(byte);
+                    byte = 0;
+                    mask = 0x80;
+                }
+            }
+
+            // Encode remainder
+            if (mask != 0x80)
+            {
+                bits.push_back(byte);
+            }
+
+            Json j(byte_string_arg, bits, semantic_tag::base16, alloc);
+            return j;
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_TYPE_TRAITS_HPP

--- a/velox/external/jsoncons/json_visitor.hpp
+++ b/velox/external/jsoncons/json_visitor.hpp
@@ -1,0 +1,1088 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_JSON_VISITOR_HPP
+#define JSONCONS_JSON_VISITOR_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <system_error>
+#include <utility>
+
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    template <typename CharT>
+    class basic_json_visitor
+    {
+    public:
+        using char_type = CharT;
+        using char_traits_type = std::char_traits<char_type>;
+
+        using string_view_type = jsoncons::basic_string_view<char_type,char_traits_type>;
+
+        basic_json_visitor() = default;
+
+        virtual ~basic_json_visitor() = default;
+
+        void flush()
+        {
+            visit_flush();
+        }
+
+        bool begin_object(semantic_tag tag=semantic_tag::none,
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_object(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_object(std::size_t length, 
+                          semantic_tag tag=semantic_tag::none, 
+                          const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_object(length, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_object(const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_end_object(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_array(semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_array(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_array(std::size_t length, 
+                         semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_begin_array(length, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_array(const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_end_array(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool key(const string_view_type& name, const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_key(name, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool null_value(semantic_tag tag = semantic_tag::none,
+                        const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_null(tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool bool_value(bool value, 
+                        semantic_tag tag = semantic_tag::none,
+                        const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_bool(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool string_value(const string_view_type& value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_string(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               semantic_tag tag=semantic_tag::none, 
+                               const ser_context& context=ser_context(),
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            std::error_code ec;
+            bool more = visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               uint64_t ext_tag, 
+                               const ser_context& context=ser_context(),
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            std::error_code ec;
+            bool more = visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), ext_tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool uint64_value(uint64_t value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_uint64(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool int64_value(int64_t value, 
+                         semantic_tag tag = semantic_tag::none, 
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_int64(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool half_value(uint16_t value, 
+                        semantic_tag tag = semantic_tag::none, 
+                        const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_half(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool double_value(double value, 
+                          semantic_tag tag = semantic_tag::none, 
+                          const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_double(value, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_object(semantic_tag tag,
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_begin_object(tag, context, ec);
+        }
+
+        bool begin_object(std::size_t length, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_begin_object(length, tag, context, ec);
+        }
+
+        bool end_object(const ser_context& context, std::error_code& ec)
+        {
+            return visit_end_object(context, ec);
+        }
+
+        bool begin_array(semantic_tag tag, const ser_context& context, std::error_code& ec)
+        {
+            return visit_begin_array(tag, context, ec);
+        }
+
+        bool begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code& ec)
+        {
+            return visit_begin_array(length, tag, context, ec);
+        }
+
+        bool end_array(const ser_context& context, std::error_code& ec)
+        {
+            return visit_end_array(context, ec);
+        }
+
+        bool key(const string_view_type& name, const ser_context& context, std::error_code& ec)
+        {
+            return visit_key(name, context, ec);
+        }
+
+        bool null_value(semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) 
+        {
+            return visit_null(tag, context, ec);
+        }
+
+        bool bool_value(bool value, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) 
+        {
+            return visit_bool(value, tag, context, ec);
+        }
+
+        bool string_value(const string_view_type& value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec) 
+        {
+            return visit_string(value, tag, context, ec);
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               semantic_tag tag, 
+                               const ser_context& context,
+                               std::error_code& ec,
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            return visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), tag, context, ec);
+        }
+
+        template <typename Source>
+        bool byte_string_value(const Source& b, 
+                               uint64_t ext_tag, 
+                               const ser_context& context,
+                               std::error_code& ec,
+                               typename std::enable_if<extension_traits::is_byte_sequence<Source>::value,int>::type = 0)
+        {
+            return visit_byte_string(byte_string_view(reinterpret_cast<const uint8_t*>(b.data()),b.size()), ext_tag, context, ec);
+        }
+
+        bool uint64_value(uint64_t value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_uint64(value, tag, context, ec);
+        }
+
+        bool int64_value(int64_t value, 
+                         semantic_tag tag, 
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_int64(value, tag, context, ec);
+        }
+
+        bool half_value(uint16_t value, 
+                        semantic_tag tag, 
+                        const ser_context& context,
+                        std::error_code& ec)
+        {
+            return visit_half(value, tag, context, ec);
+        }
+
+        bool double_value(double value, 
+                          semantic_tag tag, 
+                          const ser_context& context,
+                          std::error_code& ec)
+        {
+            return visit_double(value, tag, context, ec);
+        }
+
+        template <typename T>
+        bool typed_array(const jsoncons::span<T>& data, 
+                         semantic_tag tag=semantic_tag::none,
+                         const ser_context& context=ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_typed_array(data, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        template <typename T>
+        bool typed_array(const jsoncons::span<T>& data, 
+                         semantic_tag tag,
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_typed_array(data, tag, context, ec);
+        }
+
+        bool typed_array(half_arg_t, const jsoncons::span<const uint16_t>& s,
+            semantic_tag tag = semantic_tag::none,
+            const ser_context& context = ser_context())
+        {
+            std::error_code ec;
+            bool more = visit_typed_array(half_arg, s, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool typed_array(half_arg_t, const jsoncons::span<const uint16_t>& s,
+                         semantic_tag tag,
+                         const ser_context& context,
+                         std::error_code& ec)
+        {
+            return visit_typed_array(half_arg, s, tag, context, ec);
+        }
+
+        bool begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                             semantic_tag tag = semantic_tag::multi_dim_row_major,
+                             const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_begin_multi_dim(shape, tag, context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec) 
+        {
+            return visit_begin_multi_dim(shape, tag, context, ec);
+        }
+
+        bool end_multi_dim(const ser_context& context=ser_context()) 
+        {
+            std::error_code ec;
+            bool more = visit_end_multi_dim(context, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, context.line(), context.column()));
+            }
+            return more;
+        }
+
+        bool end_multi_dim(const ser_context& context,
+                           std::error_code& ec) 
+        {
+            return visit_end_multi_dim(context, ec);
+        }
+
+    private:
+
+        virtual void visit_flush() = 0;
+
+        virtual bool visit_begin_object(semantic_tag tag, 
+                                     const ser_context& context, 
+                                     std::error_code& ec) = 0;
+
+        virtual bool visit_begin_object(std::size_t /*length*/, 
+                                     semantic_tag tag, 
+                                     const ser_context& context, 
+                                     std::error_code& ec)
+        {
+            return visit_begin_object(tag, context, ec);
+        }
+
+        virtual bool visit_end_object(const ser_context& context, 
+                                   std::error_code& ec) = 0;
+
+        virtual bool visit_begin_array(semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec) = 0;
+
+        virtual bool visit_begin_array(std::size_t /*length*/, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec)
+        {
+            return visit_begin_array(tag, context, ec);
+        }
+
+        virtual bool visit_end_array(const ser_context& context, 
+                                  std::error_code& ec) = 0;
+
+        virtual bool visit_key(const string_view_type& name, 
+                             const ser_context& context, 
+                             std::error_code&) = 0;
+
+        virtual bool visit_null(semantic_tag tag, 
+                             const ser_context& context, 
+                             std::error_code& ec) = 0;
+
+        virtual bool visit_bool(bool value, 
+                             semantic_tag tag, 
+                             const ser_context& context, 
+                             std::error_code&) = 0;
+
+        virtual bool visit_string(const string_view_type& value, 
+                               semantic_tag tag, 
+                               const ser_context& context, 
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_byte_string(const byte_string_view& value, 
+                                       semantic_tag tag, 
+                                       const ser_context& context,
+                                       std::error_code& ec) = 0;
+
+        virtual bool visit_byte_string(const byte_string_view& value, 
+                                       uint64_t /* ext_tag */, 
+                                       const ser_context& context,
+                                       std::error_code& ec) 
+        {
+            return visit_byte_string(value, semantic_tag::none, context, ec);
+        }
+
+        virtual bool visit_uint64(uint64_t value, 
+                               semantic_tag tag, 
+                               const ser_context& context,
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_int64(int64_t value, 
+                              semantic_tag tag,
+                              const ser_context& context,
+                              std::error_code& ec) = 0;
+
+        virtual bool visit_half(uint16_t value, 
+                             semantic_tag tag,
+                             const ser_context& context,
+                             std::error_code& ec)
+        {
+            return visit_double(binary::decode_half(value),
+                             tag,
+                             context,
+                             ec);
+        }
+
+        virtual bool visit_double(double value, 
+                               semantic_tag tag,
+                               const ser_context& context,
+                               std::error_code& ec) = 0;
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint8_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) 
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const uint64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec) 
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = uint64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int8_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int16_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int32_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const int64_t>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = int64_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(half_arg_t, 
+                                    const jsoncons::span<const uint16_t>& s, 
+                                    semantic_tag tag, 
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag, context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = half_value(*p, semantic_tag::none, context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const float>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = double_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_typed_array(const jsoncons::span<const double>& s, 
+                                    semantic_tag tag,
+                                    const ser_context& context, 
+                                    std::error_code& ec)  
+        {
+            bool more = begin_array(s.size(), tag,context, ec);
+            for (auto p = s.begin(); more && p != s.end(); ++p)
+            {
+                more = double_value(*p,semantic_tag::none,context, ec);
+            }
+            if (more)
+            {
+                more = end_array(context, ec);
+            }
+            return more;
+        }
+
+        virtual bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                                        semantic_tag tag,
+                                        const ser_context& context, 
+                                        std::error_code& ec) 
+        {
+            bool more = visit_begin_array(2, tag, context, ec);
+            if (more)
+            {
+                more = visit_begin_array(shape.size(), tag, context, ec);
+                for (auto it = shape.begin(); more && it != shape.end(); ++it)
+                {
+                    visit_uint64(*it, semantic_tag::none, context, ec);
+                }
+                if (more)
+                {
+                    more = visit_end_array(context, ec);
+                }
+            }
+            return more;
+        }
+
+        virtual bool visit_end_multi_dim(const ser_context& context,
+                                      std::error_code& ec) 
+        {
+            return visit_end_array(context, ec);
+        }
+    };
+
+    template <typename CharT>
+    class basic_default_json_visitor : public basic_json_visitor<CharT>
+    {
+        bool parse_more_;
+        std::error_code ec_;
+    public:
+        using typename basic_json_visitor<CharT>::string_view_type;
+
+        basic_default_json_visitor(bool accept_more = true,
+                                           std::error_code ec = std::error_code())
+            : parse_more_(accept_more), ec_(ec)
+        {
+        }
+    private:
+        void visit_flush() override
+        {
+        }
+
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_key(const string_view_type&, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_null(semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_string(const string_view_type&, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_byte_string(const byte_string_view&, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_uint64(uint64_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_int64(int64_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_half(uint16_t, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_double(double, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+
+        bool visit_bool(bool, semantic_tag, const ser_context&, std::error_code& ec) override
+        {
+            if (ec_)
+            {
+                ec = ec_;
+            }
+            return parse_more_;
+        }
+    };
+
+    template <typename CharT>
+    class basic_json_diagnostics_visitor : public basic_default_json_visitor<CharT>
+    {
+    public:
+        using stream_type = std::basic_ostream<CharT>;
+        using string_type = std::basic_string<CharT>;
+
+    private:
+        using supertype = basic_default_json_visitor<CharT>;
+        using string_view_type = typename supertype::string_view_type;
+
+        struct enabler {};
+
+        static constexpr CharT visit_begin_array_name[] = {'v','i','s','i','t','_','b','e','g','i','n','_','a','r','r','a','y', 0};
+        static constexpr CharT visit_end_array_name[] =  {'v','i','s','i','t','_','e','n','d','_','a','r','r','a','y', 0};
+        static constexpr CharT visit_begin_object_name[] =  {'v','i','s','i','t','_','b','e','g','i','n','_','o','b','j','e','c','t', 0};
+        static constexpr CharT visit_end_object_name[] =  {'v','i','s','i','t','_','e','n','d','_','o','b','j','e','c','t', 0};
+        static constexpr CharT visit_key_name[] =  {'v','i','s','i','t','_','k','e','y', 0};
+        static constexpr CharT visit_string_name[] =  {'v','i','s','i','t','_','s','t','r','i','n','g', 0};
+        static constexpr CharT visit_byte_string_name[] =  {'v','i','s','i','t','_','b','y','t','e','_','s','t','r','i','n','g', 0};
+        static constexpr CharT visit_null_name[] =  {'v','i','s','i','t','_','n','u','l','l', 0};
+        static constexpr CharT visit_bool_name[] =  {'v','i','s','i','t','_','b','o','o','l', 0};
+        static constexpr CharT visit_uint64_name[] =  {'v','i','s','i','t','_','u','i','n','t','6','4', 0};
+        static constexpr CharT visit_int64_name[] =  {'v','i','s','i','t','_','i','n','t','6','4', 0};
+        static constexpr CharT visit_half_name[] =  {'v','i','s','i','t','_','h','a','l','f', 0};
+        static constexpr CharT visit_double_name[] =  {'v','i','s','i','t','_','d','o','u','b','l','e', 0};
+
+        static constexpr CharT separator_ = ':';
+
+        stream_type& output_;
+        string_type indentation_;
+        long level_;
+
+    public:
+        // If CharT is char, then enable the default constructor which binds to
+        // std::cout.
+        template <typename U = enabler>
+        basic_json_diagnostics_visitor(
+            typename std::enable_if<std::is_same<CharT, char>::value, U>::type = enabler{})
+            : basic_json_diagnostics_visitor(std::cout)
+        {
+        }
+
+        // If CharT is wchar_t, then enable the default constructor which binds
+        // to std::wcout.
+        template <typename U = enabler>
+        basic_json_diagnostics_visitor(
+            typename std::enable_if<std::is_same<CharT, wchar_t>::value, U>::type = enabler{})
+            : basic_json_diagnostics_visitor(std::wcout)
+        {
+        }
+
+        explicit basic_json_diagnostics_visitor(
+            stream_type& output,
+            string_type indentation = string_type())
+            : output_(output),
+              indentation_(std::move(indentation)),
+              level_(0)
+        {
+        }
+
+    private:
+        void indent()
+        {
+            for (long i=0; i<level_; ++i)
+                output_ << indentation_;
+        }
+
+        bool visit_begin_object(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_begin_object_name << '\n';
+            ++level_;
+            return true;
+        }
+
+        bool visit_begin_object(std::size_t length, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_begin_object_name << separator_ << length << '\n';
+            ++level_;
+            return true;
+        }
+
+        bool visit_end_object(const ser_context&, std::error_code&) override
+        {
+            --level_;
+            indent();
+            output_ << visit_end_object_name << '\n';
+            return true;
+        }
+
+        bool visit_begin_array(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_begin_array_name << '\n';
+            ++level_;
+            return true;
+        }
+
+        bool visit_begin_array(std::size_t length, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_begin_array_name << separator_  << length << '\n';
+            ++level_;
+            return true;
+        }
+
+        bool visit_end_array(const ser_context&, std::error_code&) override
+        {
+            --level_;
+            indent();
+            output_ << visit_end_array_name << '\n';
+            return true;
+        }
+
+        bool visit_key(const string_view_type& s, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_key_name << separator_  << s << '\n';
+            return true;
+        }
+        bool visit_string(const string_view_type& s, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_string_name << separator_  << s << '\n';
+            return true;
+        }
+        bool visit_int64(int64_t val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_int64_name << separator_  << val << '\n';
+            return true;
+        }
+        bool visit_uint64(uint64_t val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_uint64_name << separator_ << val << '\n';
+            return true;
+        }
+        bool visit_bool(bool val, semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_bool_name << separator_ << val << '\n';
+            return true;
+        }
+        bool visit_null(semantic_tag, const ser_context&, std::error_code&) override
+        {
+            indent();
+            output_ << visit_null_name << '\n';
+            return true;
+        }
+    };
+
+#if __cplusplus >= 201703L
+// not needed for C++17
+#else
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_begin_array_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_end_array_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_begin_object_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_end_object_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_key_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_string_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_byte_string_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_null_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_bool_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_uint64_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_int64_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_half_name[];
+    template <typename C> constexpr C basic_json_diagnostics_visitor<C>::visit_double_name[];
+#endif // C++17 check
+
+    using json_visitor = basic_json_visitor<char>;
+    using wjson_visitor = basic_json_visitor<wchar_t>;
+
+    using default_json_visitor = basic_default_json_visitor<char>;
+    using wdefault_json_visitor = basic_default_json_visitor<wchar_t>;
+
+    using json_diagnostics_visitor = basic_json_diagnostics_visitor<char>;
+    using wjson_diagnostics_visitor = basic_json_diagnostics_visitor<wchar_t>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_JSON_VISITOR_HPP

--- a/velox/external/jsoncons/jsonpath/expression.hpp
+++ b/velox/external/jsoncons/jsonpath/expression.hpp
@@ -1,0 +1,3486 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_EXPRESSION_HPP
+#define JSONCONS_EXT_JSONPATH_EXPRESSION_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <string> // std::basic_string
+#include <system_error>
+#include <type_traits>
+#include <unordered_map> // std::unordered_map
+#include <utility> // std::move
+#include <vector> // std::vector
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/detail/parse_number.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+#include "velox/external/jsoncons/jsonpath/jsonpath_error.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+
+#if defined(JSONCONS_HAS_STD_REGEX)
+#include <regex>
+#endif
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+
+    template <typename Json>
+    struct jsonpath_traits
+    {
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using value_type = typename std::remove_const<Json>::type;
+        using pointer = value_type*;
+        using const_pointer = const value_type*;
+        using reference = value_type&;
+        using const_reference = const value_type&;
+    };
+
+    struct reference_arg_t
+    {
+        explicit reference_arg_t() = default;
+    };
+    constexpr reference_arg_t reference_arg{};
+
+    struct const_reference_arg_t
+    {
+        explicit const_reference_arg_t() = default;
+    };
+    constexpr const_reference_arg_t const_reference_arg{};
+
+    struct literal_arg_t
+    {
+        explicit literal_arg_t() = default;
+    };
+    constexpr literal_arg_t literal_arg{};
+
+    struct end_of_expression_arg_t
+    {
+        explicit end_of_expression_arg_t() = default;
+    };
+    constexpr end_of_expression_arg_t end_of_expression_arg{};
+
+    struct separator_arg_t
+    {
+        explicit separator_arg_t() = default;
+    };
+    constexpr separator_arg_t separator_arg{};
+
+    struct lparen_arg_t
+    {
+        explicit lparen_arg_t() = default;
+    };
+    constexpr lparen_arg_t lparen_arg{};
+
+    struct rparen_arg_t
+    {
+        explicit rparen_arg_t() = default;
+    };
+    constexpr rparen_arg_t rparen_arg{};
+
+    struct begin_union_arg_t
+    {
+        explicit begin_union_arg_t() = default;
+    };
+    constexpr begin_union_arg_t begin_union_arg{};
+
+    struct end_union_arg_t
+    {
+        explicit end_union_arg_t() = default;
+    };
+    constexpr end_union_arg_t end_union_arg{};
+
+    struct begin_filter_arg_t
+    {
+        explicit begin_filter_arg_t() = default;
+    };
+    constexpr begin_filter_arg_t begin_filter_arg{};
+
+    struct end_filter_arg_t
+    {
+        explicit end_filter_arg_t() = default;
+    };
+    constexpr end_filter_arg_t end_filter_arg{};
+
+    struct begin_expression_arg_t
+    {
+        explicit begin_expression_arg_t() = default;
+    };
+    constexpr begin_expression_arg_t begin_expression_arg{};
+
+    struct end_index_expression_arg_t
+    {
+        explicit end_index_expression_arg_t() = default;
+    };
+    constexpr end_index_expression_arg_t end_index_expression_arg{};
+
+    struct end_argument_expression_arg_t
+    {
+        explicit end_argument_expression_arg_t() = default;
+    };
+    constexpr end_argument_expression_arg_t end_argument_expression_arg{};
+
+    struct current_node_arg_t
+    {
+        explicit current_node_arg_t() = default;
+    };
+    constexpr current_node_arg_t current_node_arg{};
+
+    struct root_node_arg_t
+    {
+        explicit root_node_arg_t() = default;
+    };
+    constexpr root_node_arg_t root_node_arg{};
+
+    struct end_function_arg_t
+    {
+        explicit end_function_arg_t() = default;
+    };
+    constexpr end_function_arg_t end_function_arg{};
+
+    struct argument_arg_t
+    {
+        explicit argument_arg_t() = default;
+    };
+    constexpr argument_arg_t argument_arg{};
+
+    enum class result_options {value=0, nodups=1, sort=2, sort_descending=4, path=8};
+
+    inline result_options operator~(result_options a)
+    {
+        return static_cast<result_options>(~static_cast<unsigned int>(a));
+    }
+
+    inline result_options operator&(result_options a, result_options b)
+    {
+        return static_cast<result_options>(static_cast<unsigned int>(a) & static_cast<unsigned int>(b));
+    }
+
+    inline result_options operator^(result_options a, result_options b)
+    {
+        return static_cast<result_options>(static_cast<unsigned int>(a) ^ static_cast<unsigned int>(b));
+    }
+
+    inline result_options operator|(result_options a, result_options b)
+    {
+        return static_cast<result_options>(static_cast<unsigned int>(a) | static_cast<unsigned int>(b));
+    }
+
+    inline result_options operator&=(result_options& a, result_options b)
+    {
+        a = a & b;
+        return a;
+    }
+
+    inline result_options operator^=(result_options& a, result_options b)
+    {
+        a = a ^ b;
+        return a;
+    }
+
+    inline result_options operator|=(result_options& a, result_options b)
+    {
+        a = a | b;
+        return a;
+    }
+
+    template <typename Json>
+    class parameter;
+
+    template <typename Json,typename JsonReference>
+    class value_or_pointer
+    {
+    public:
+        friend class parameter<Json>;
+        using value_type = Json;
+        using reference = JsonReference;
+        using pointer = typename std::conditional<std::is_const<typename std::remove_reference<reference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+    private:
+        bool is_value_;
+        union
+        {
+            value_type val_;
+            pointer ptr_;
+        };
+    public:
+        value_or_pointer(value_type&& val)
+            : is_value_(true), val_(std::move(val))
+        {
+        }
+
+        value_or_pointer(pointer ptr)
+            : is_value_(false), ptr_(std::move(ptr))
+        {
+        }
+
+        value_or_pointer(const value_or_pointer& other) = delete;
+
+        value_or_pointer(value_or_pointer&& other) noexcept
+            : is_value_(other.is_value_)
+        {
+            if (is_value_)
+            {
+                new(&val_)value_type(std::move(other.val_));
+            }
+            else
+            {
+                ptr_ = other.ptr_;
+            }
+        }
+
+        ~value_or_pointer() noexcept
+        {
+            if (is_value_)
+            {
+                val_.~value_type();
+            }
+        }
+
+        value_or_pointer& operator=(const value_or_pointer& other) noexcept = delete;
+
+        value_or_pointer& operator=(value_or_pointer&& other) noexcept
+        {
+            if (is_value_)
+            {
+                val_.~value_type();
+            }
+            is_value_ = other.is_value_;
+
+            if (is_value_)
+            {
+                new(&val_)value_type(std::move(other.val_));
+            }
+            else
+            {
+                ptr_ = other.ptr_;
+            }
+            return *this;
+        }
+
+        reference value() 
+        {
+            return is_value_ ? val_ : *ptr_;
+        }
+
+        pointer ptr() 
+        {
+            return is_value_ ? &val_ : ptr_;
+        }
+    };
+
+    template <typename Json>
+    class parameter
+    {
+        using value_type = Json;
+        using reference = const Json&;
+        using pointer = const Json*;
+    private:
+        value_or_pointer<Json,reference> data_;
+    public:
+        template <typename JsonReference>
+        parameter(value_or_pointer<Json,JsonReference>&& data) noexcept
+            : data_(nullptr)
+        {
+            data_.is_value_ = data.is_value_;
+            if (data.is_value_)
+            {
+                data_.val_ = std::move(data.val_);
+            }
+            else
+            {
+                data_.ptr_ = data.ptr_;
+            }
+        }
+
+        parameter(const parameter& other) = default;
+
+        parameter(parameter&& other) = default;
+        
+        ~parameter() = default; 
+
+        parameter& operator=(const parameter& other) = default;
+
+        parameter& operator=(parameter&& other) = default;
+
+        const Json& value() const
+        {
+            return data_.is_value_ ? data_.val_ : *data_.ptr_;
+        }
+    };
+
+    template <typename Json>
+    class custom_function
+    {
+    public:
+        using value_type = Json;
+        using char_type = typename Json::char_type;
+        using parameter_type = parameter<Json>;
+        using function_type = std::function<value_type(jsoncons::span<const parameter_type>, std::error_code& ec)>;
+        using string_type = typename Json::string_type;
+
+        string_type function_name_;
+        optional<std::size_t> arity_;
+        function_type f_;
+
+        custom_function(const custom_function&) = default;
+        custom_function(custom_function&&) = default;
+
+        custom_function(const string_type& function_name,
+                        const optional<std::size_t>& arity,
+                        const function_type& f)
+            : function_name_(function_name),
+              arity_(arity),
+              f_(f)
+        {
+        }
+
+        custom_function(string_type&& function_name,
+                        optional<std::size_t>&& arity,
+                        function_type&& f)
+            : function_name_(std::move(function_name)),
+              arity_(arity),
+              f_(std::move(f))
+        {
+        }
+        
+        ~custom_function() = default; 
+
+        custom_function& operator=(const custom_function&) = default;
+        custom_function& operator=(custom_function&&) = default;
+
+        const string_type& name() const 
+        {
+            return function_name_;
+        }
+
+        optional<std::size_t> arity() const 
+        {
+            return arity_;
+        }
+
+        const function_type& function() const 
+        {
+            return f_;
+        }
+    };
+
+    template <typename Json>
+    class custom_functions
+    {
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using function_type = std::function<value_type(jsoncons::span<const parameter_type>, std::error_code& ec)>;
+        using const_iterator = typename std::vector<custom_function<Json>>::const_iterator;
+
+        std::vector<custom_function<Json>> functions_;
+    public:
+        void register_function(const string_type& name,
+                               jsoncons::optional<std::size_t> arity,
+                               const function_type& f)
+        {
+            functions_.emplace_back(name, arity, f);
+        }
+
+        const_iterator begin() const
+        {
+            return functions_.begin();
+        }
+
+        const_iterator end() const
+        {
+            return functions_.end();
+        }
+    };
+
+namespace detail {
+
+    template <typename Json>
+    struct unary_operator
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        
+        std::size_t precedence_level_;
+        bool is_right_associative_;
+
+        unary_operator(std::size_t precedence_level,
+                       bool is_right_associative)
+            : precedence_level_(precedence_level),
+              is_right_associative_(is_right_associative)
+        {
+        }
+        
+        unary_operator(const unary_operator& other) = default;
+        unary_operator(unary_operator&& other) = default;
+
+        virtual ~unary_operator() = default;
+
+        unary_operator& operator=(const unary_operator& other) = default;
+        unary_operator& operator=(unary_operator&& other) = default;
+
+        std::size_t precedence_level() const 
+        {
+            return precedence_level_;
+        }
+        bool is_right_associative() const
+        {
+            return is_right_associative_;
+        }
+
+        virtual Json evaluate(const_reference, std::error_code&) const = 0;
+    };
+
+    template <typename Json>
+    bool is_false(const Json& val)
+    {
+        return ((val.is_array() && val.empty()) ||
+                 (val.is_object() && val.empty()) ||
+                 (val.is_string() && val.as_string_view().empty()) ||
+                 (val.is_bool() && !val.as_bool()) ||
+                 val.is_null());
+    }
+
+    template <typename Json>
+    bool is_true(const Json& val)
+    {
+        return !is_false(val);
+    }
+
+    template <typename Json>
+    class unary_not_operator final : public unary_operator<Json>
+    {
+    public:
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+        unary_not_operator()
+            : unary_operator<Json>(1, true)
+        {}
+
+        Json evaluate(const_reference val, std::error_code&) const override
+        {
+            return is_false(val) ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    class unary_minus_operator final : public unary_operator<Json>
+    {
+    public:
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+        unary_minus_operator()
+            : unary_operator<Json>(1, true)
+        {}
+
+        Json evaluate(const_reference val, 
+                      std::error_code&) const override
+        {
+            if (val.is_int64())
+            {
+                return Json(-val.template as<int64_t>(), semantic_tag::none);
+            }
+            if (val.is_double())
+            {
+                return Json(-val.as_double(), semantic_tag::none);
+            }
+            return Json::null();
+        }
+    };
+
+    template <typename Json>
+    class regex_operator final : public unary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        std::basic_regex<char_type> pattern_;
+    public:
+        regex_operator(std::basic_regex<char_type>&& pattern)
+            : unary_operator<Json>(2, true),
+              pattern_(std::move(pattern))
+        {
+        }
+
+        Json evaluate(const_reference val, std::error_code&) const override
+        {
+            if (!val.is_string())
+            {
+                return Json::null();
+            }
+            return std::regex_search(val.as_string(), pattern_) ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+        }
+    };
+
+    template <typename Json>
+    struct binary_operator
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        std::size_t precedence_level_;
+        bool is_right_associative_;
+
+        binary_operator(std::size_t precedence_level,
+                        bool is_right_associative = false)
+            : precedence_level_(precedence_level),
+              is_right_associative_(is_right_associative)
+        {
+        }
+        
+        virtual ~binary_operator() = default;
+
+        std::size_t precedence_level() const 
+        {
+            return precedence_level_;
+        }
+        bool is_right_associative() const
+        {
+            return is_right_associative_;
+        }
+
+        virtual Json evaluate(const_reference lhs, const_reference rhs, 
+            std::error_code&) const = 0;
+
+        virtual std::string to_string(int) const
+        {
+            return "binary operator";
+        }
+    };
+
+    // Implementations
+
+    template <typename Json>
+    class or_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        or_operator()
+            : binary_operator<Json>(9)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (lhs.is_null() && rhs.is_null())
+            {
+                return Json::null();
+            }
+            if (!is_false(lhs))
+            {
+                return lhs;
+            }
+            return rhs;
+        }
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                //s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("or operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class and_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        and_operator()
+            : binary_operator<Json>(8)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (is_true(lhs))
+            {
+                return rhs;
+            }
+            return lhs;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("and operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class eq_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        eq_operator()
+            : binary_operator<Json>(6)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override 
+        {
+            return lhs == rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("equal operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class ne_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        ne_operator()
+            : binary_operator<Json>(6)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override 
+        {
+            return lhs != rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("not equal operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class lt_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        lt_operator()
+            : binary_operator<Json>(5)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override 
+        {
+            if (lhs.is_number() && rhs.is_number())
+            {
+                return lhs < rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            if (lhs.is_string() && rhs.is_string())
+            {
+                return lhs < rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            return Json::null();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("less than operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class lte_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        lte_operator()
+            : binary_operator<Json>(5)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override 
+        {
+            if (lhs.is_number() && rhs.is_number())
+            {
+                return lhs <= rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            if (lhs.is_string() && rhs.is_string())
+            {
+                return lhs <= rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            return Json::null();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("less than or equal operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class gt_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        gt_operator()
+            : binary_operator<Json>(5)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            //std::cout << "operator> lhs: " << lhs << ", rhs: " << rhs << "\n";
+
+            if (lhs.is_number() && rhs.is_number())
+            {
+                return lhs > rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            if (lhs.is_string() && rhs.is_string())
+            {
+                return lhs > rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            return Json::null();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("greater than operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class gte_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        gte_operator()
+            : binary_operator<Json>(5)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (lhs.is_number() && rhs.is_number())
+            {
+                return lhs >= rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            if (lhs.is_string() && rhs.is_string())
+            {
+                return lhs >= rhs ? Json(true, semantic_tag::none) : Json(false, semantic_tag::none);
+            }
+            return Json::null();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("greater than or equal operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class plus_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        plus_operator()
+            : binary_operator<Json>(4)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (!(lhs.is_number() && rhs.is_number()))
+            {
+                return Json::null();
+            }
+            if (lhs.is_int64() && rhs.is_int64())
+            {
+                return Json(((lhs.template as<int64_t>() + rhs.template as<int64_t>())), semantic_tag::none);
+            }
+            if (lhs.is_uint64() && rhs.is_uint64())
+            {
+                return Json((lhs.template as<uint64_t>() + rhs.template as<uint64_t>()), semantic_tag::none);
+            }
+            return Json((lhs.as_double() + rhs.as_double()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("plus operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class minus_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        minus_operator()
+            : binary_operator<Json>(4)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (!(lhs.is_number() && rhs.is_number()))
+            {
+                return Json::null();
+            }
+            if (lhs.is_int64() && rhs.is_int64())
+            {
+                return Json(((lhs.template as<int64_t>() - rhs.template as<int64_t>())), semantic_tag::none);
+            }
+            if (lhs.is_uint64() && rhs.is_uint64())
+            {
+                return Json((lhs.template as<uint64_t>() - rhs.template as<uint64_t>()), semantic_tag::none);
+            }
+            return Json((lhs.as_double() - rhs.as_double()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("minus operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class mult_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        mult_operator()
+            : binary_operator<Json>(3)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            if (!(lhs.is_number() && rhs.is_number()))
+            {
+                return Json::null();
+            }
+            if (lhs.is_int64() && rhs.is_int64())
+            {
+                return Json(((lhs.template as<int64_t>() * rhs.template as<int64_t>())), semantic_tag::none);
+            }
+            if (lhs.is_uint64() && rhs.is_uint64())
+            {
+                return Json((lhs.template as<uint64_t>() * rhs.template as<uint64_t>()), semantic_tag::none);
+            }
+            return Json((lhs.as_double() * rhs.as_double()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("multiply operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class div_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        div_operator()
+            : binary_operator<Json>(3)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            //std::cout << "operator/ lhs: " << lhs << ", rhs: " << rhs << "\n";
+
+            if (!(lhs.is_number() && rhs.is_number()))
+            {
+                return Json::null();
+            }
+            if (lhs.is_int64() && rhs.is_int64())
+            {
+                return Json(((lhs.template as<int64_t>() / rhs.template as<int64_t>())), semantic_tag::none);
+            }
+            if (lhs.is_uint64() && rhs.is_uint64())
+            {
+                return Json((lhs.template as<uint64_t>() / rhs.template as<uint64_t>()), semantic_tag::none);
+            }
+            return Json((lhs.as_double() / rhs.as_double()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("divide operator");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class modulus_operator final : public binary_operator<Json>
+    {
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+
+    public:
+        modulus_operator()
+            : binary_operator<Json>(3)
+        {
+        }
+
+        Json evaluate(const_reference lhs, const_reference rhs, std::error_code&) const override
+        {
+            //std::cout << "operator/ lhs: " << lhs << ", rhs: " << rhs << "\n";
+
+            if (!(lhs.is_number() && rhs.is_number()))
+            {
+                return Json::null();
+            }
+            if (lhs.is_int64() && rhs.is_int64())
+            {
+                return Json(((lhs.template as<int64_t>() % rhs.template as<int64_t>())), semantic_tag::none);
+            }
+            if (lhs.is_uint64() && rhs.is_uint64())
+            {
+                return Json((lhs.template as<uint64_t>() % rhs.template as<uint64_t>()), semantic_tag::none);
+            }
+            return Json(fmod(lhs.as_double(), rhs.as_double()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("modulus operator");
+            return s;
+        }
+    };
+
+    // function_base
+    template <typename Json>
+    class function_base
+    {
+        jsoncons::optional<std::size_t> arg_count_;
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        function_base(jsoncons::optional<std::size_t> arg_count)
+            : arg_count_(arg_count)
+        {
+        }
+
+        function_base(const function_base&) = default;
+        function_base(function_base&&) = default;
+        
+        virtual ~function_base() = default;
+
+        function_base& operator=(const function_base&) = default;
+        function_base& operator=(function_base&&) = default;
+
+        jsoncons::optional<std::size_t> arity() const
+        {
+            return arg_count_;
+        }
+
+        virtual value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const = 0;
+
+        virtual std::string to_string(int level) const
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("function");
+            return s;
+        }
+    };  
+
+    template <typename Json>
+    class decorator_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using string_view_type = typename Json::string_view_type;
+        using function_type = std::function<value_type(jsoncons::span<const parameter_type>, std::error_code& ec)>;
+    private:
+        function_type f_;
+    public:
+        decorator_function(jsoncons::optional<std::size_t> arity,
+            const function_type& f)
+            : function_base<Json>(arity), f_(f)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args,
+            std::error_code& ec) const override
+        {
+            return f_(args, ec);
+        }
+    };
+
+    template <typename Json>
+    class contains_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using string_view_type = typename Json::string_view_type;
+
+        contains_function()
+            : function_base<Json>(2)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            auto arg1= args[1].value();
+
+            switch (arg0.type())
+            {
+                case json_type::array_value:
+                    for (auto& j : arg0.array_range())
+                    {
+                        if (j == arg1)
+                        {
+                            return value_type(true, semantic_tag::none);
+                        }
+                    }
+                    return value_type(false, semantic_tag::none);
+                case json_type::string_value:
+                {
+                    if (!arg1.is_string())
+                    {
+                        ec = jsonpath_errc::invalid_type;
+                        return value_type::null();
+                    }
+                    auto sv0 = arg0.template as<string_view_type>();
+                    auto sv1 = arg1.template as<string_view_type>();
+                    return sv0.find(sv1) != string_view_type::npos ? value_type(true, semantic_tag::none) : value_type(false, semantic_tag::none);
+                }
+                default:
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("contains function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class ends_with_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using string_view_type = typename Json::string_view_type;
+
+        ends_with_function()
+            : function_base<Json>(2)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_string())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            auto arg1= args[1].value();
+            if (!arg1.is_string())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            auto sv0 = arg0.template as<string_view_type>();
+            auto sv1 = arg1.template as<string_view_type>();
+
+            if (sv1.length() <= sv0.length() && sv1 == sv0.substr(sv0.length() - sv1.length()))
+            {
+                return value_type(true, semantic_tag::none);
+            }
+            return value_type(false, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("ends_with function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class starts_with_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using string_view_type = typename Json::string_view_type;
+
+        starts_with_function()
+            : function_base<Json>(2)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_string())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            auto arg1= args[1].value();
+            if (!arg1.is_string())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            auto sv0 = arg0.template as<string_view_type>();
+            auto sv1 = arg1.template as<string_view_type>();
+
+            if (sv1.length() <= sv0.length() && sv1 == sv0.substr(0, sv1.length()))
+            {
+                return value_type(true, semantic_tag::none);
+            }
+            return value_type(false, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("starts_with function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class sum_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        sum_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_array())
+            {
+                //std::cout << "arg: " << arg0 << "\n";
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            //std::cout << "sum function arg: " << arg0 << "\n";
+
+            double sum = 0;
+            for (auto& j : arg0.array_range())
+            {
+                if (!j.is_number())
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+                sum += j.template as<double>();
+            }
+
+            return value_type(sum, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("sum function");
+            return s;
+        }
+    };
+
+#if defined(JSONCONS_HAS_STD_REGEX)
+
+    template <typename Json>
+    class tokenize_function : public function_base<Json>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        allocator_type alloc_;
+
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+
+        tokenize_function(const allocator_type& alloc)
+            : function_base<Json>(2), alloc_(alloc)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            if (!args[0].value().is_string() || !args[1].value().is_string())
+            {
+                //std::cout << "arg: " << arg0 << "\n";
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            auto arg0 = args[0].value().template as<string_view_type>();
+            auto arg1 = args[1].value().template as<string_view_type>();
+
+            auto s0 = string_type(arg0.begin(), arg0.end(), alloc_);
+            auto s1 = string_type(arg1.begin(), arg1.end(), alloc_);
+
+            std::regex::flag_type options = std::regex_constants::ECMAScript; 
+            std::basic_regex<char_type> pieces_regex(s1, options);
+
+            std::regex_token_iterator<typename string_type::const_iterator> rit ( s0.begin(), s0.end(), pieces_regex, -1);
+            std::regex_token_iterator<typename string_type::const_iterator> rend;
+
+            value_type j(json_array_arg, semantic_tag::none, alloc_);
+            while (rit != rend) 
+            {
+                auto s = (*rit).str();
+                j.emplace_back(s.c_str(), semantic_tag::none);
+                ++rit;
+            }
+            return j;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("tokenize function");
+            return s;
+        }
+    };
+
+#endif // defined(JSONCONS_HAS_STD_REGEX)
+
+    template <typename Json>
+    class ceil_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        ceil_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            switch (arg0.type())
+            {
+                case json_type::uint64_value:
+                case json_type::int64_value:
+                {
+                    return value_type(arg0.template as<double>(), semantic_tag::none);
+                }
+                case json_type::double_value:
+                {
+                    return value_type(std::ceil(arg0.template as<double>()), semantic_tag::none);
+                }
+                default:
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("ceil function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class floor_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        floor_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            switch (arg0.type())
+            {
+                case json_type::uint64_value:
+                case json_type::int64_value:
+                {
+                    return value_type(arg0.template as<double>(), semantic_tag::none);
+                }
+                case json_type::double_value:
+                {
+                    return value_type(std::floor(arg0.template as<double>()), semantic_tag::none);
+                }
+                default:
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("floor function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class to_number_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        to_number_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            switch (arg0.type())
+            {
+                case json_type::int64_value:
+                case json_type::uint64_value:
+                case json_type::double_value:
+                    return arg0;
+                case json_type::string_value:
+                {
+                    auto sv = arg0.as_string_view();
+                    uint64_t un{0};
+                    auto result1 = jsoncons::detail::to_integer(sv.data(), sv.length(), un);
+                    if (result1)
+                    {
+                        return value_type(un, semantic_tag::none);
+                    }
+                    int64_t sn{0};
+                    auto result2 = jsoncons::detail::to_integer(sv.data(), sv.length(), sn);
+                    if (result2)
+                    {
+                        return value_type(sn, semantic_tag::none);
+                    }
+                    const jsoncons::detail::chars_to to_double;
+                    try
+                    {
+                        auto s = arg0.as_string();
+                        double d = to_double(s.c_str(), s.length());
+                        return value_type(d, semantic_tag::none);
+                    }
+                    catch (const std::exception&)
+                    {
+                        return value_type::null();
+                    }
+                }
+                default:
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("to_number function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class prod_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        prod_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_array() || arg0.empty())
+            {
+                //std::cout << "arg: " << arg0 << "\n";
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            double prod = 1;
+            for (auto& j : arg0.array_range())
+            {
+                if (!j.is_number())
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+                prod *= j.template as<double>();
+            }
+
+            return value_type(prod, semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("prod function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class avg_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        avg_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_array())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            if (arg0.empty())
+            {
+                return value_type::null();
+            }
+            double sum = 0;
+            for (auto& j : arg0.array_range())
+            {
+                if (!j.is_number())
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+                sum += j.template as<double>();
+            }
+
+            return value_type(sum / static_cast<double>(arg0.size()), semantic_tag::none);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("to_string function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class min_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        min_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_array())
+            {
+                //std::cout << "arg: " << arg0 << "\n";
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            if (arg0.empty())
+            {
+                return value_type::null();
+            }
+            bool is_number = arg0.at(0).is_number();
+            bool is_string = arg0.at(0).is_string();
+            if (!is_number && !is_string)
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            std::size_t index = 0;
+            for (std::size_t i = 1; i < arg0.size(); ++i)
+            {
+                if (!(arg0.at(i).is_number() == is_number && arg0.at(i).is_string() == is_string))
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+                if (arg0.at(i) < arg0.at(index))
+                {
+                    index = i;
+                }
+            }
+
+            return arg0.at(index);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("min function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class max_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        max_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            if (!arg0.is_array())
+            {
+                //std::cout << "arg: " << arg0 << "\n";
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+            if (arg0.empty())
+            {
+                return value_type::null();
+            }
+
+            bool is_number = arg0.at(0).is_number();
+            bool is_string = arg0.at(0).is_string();
+            if (!is_number && !is_string)
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            std::size_t index = 0;
+            for (std::size_t i = 1; i < arg0.size(); ++i)
+            {
+                if (!(arg0.at(i).is_number() == is_number && arg0.at(i).is_string() == is_string))
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+                if (arg0.at(i) > arg0.at(index))
+                {
+                    index = i;
+                }
+            }
+
+            return arg0.at(index);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("max function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class abs_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+
+        abs_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+                 std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            switch (arg0.type())
+            {
+                case json_type::uint64_value:
+                    return arg0;
+                case json_type::int64_value:
+                {
+                    return arg0.template as<int64_t>() >= 0 ? arg0 : value_type(std::abs(arg0.template as<int64_t>()), semantic_tag::none);
+                }
+                case json_type::double_value:
+                {
+                    return arg0.template as<double>() >= 0 ? arg0 : value_type(std::abs(arg0.template as<double>()), semantic_tag::none);
+                }
+                default:
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("abs function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class length_function : public function_base<Json>
+    {
+    public:
+        using value_type = Json;
+        using string_view_type = typename Json::string_view_type;
+        using parameter_type = parameter<Json>;
+
+        length_function()
+            : function_base<Json>(1)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0= args[0].value();
+            //std::cout << "length function arg: " << arg0 << "\n";
+
+            switch (arg0.type())
+            {
+                case json_type::object_value:
+                case json_type::array_value:
+                    return value_type(arg0.size(), semantic_tag::none);
+                case json_type::string_value:
+                {
+                    auto sv0 = arg0.template as<string_view_type>();
+                    auto length = unicode_traits::count_codepoints(sv0.data(), sv0.size());
+                    return value_type(length, semantic_tag::none);
+                }
+                default:
+                {
+                    ec = jsonpath_errc::invalid_type;
+                    return value_type::null();
+                }
+            }
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("length function");
+            return s;
+        }
+    };
+
+    template <typename Json>
+    class keys_function : public function_base<Json>
+    {
+        using allocator_type = typename Json::allocator_type;
+
+        allocator_type alloc_;
+    public:
+        using value_type = Json;
+        using parameter_type = parameter<Json>;
+        using string_view_type = typename Json::string_view_type;
+
+        keys_function(const allocator_type& alloc)
+            : function_base<Json>(1), alloc_(alloc)
+        {
+        }
+
+        value_type evaluate(const std::vector<parameter_type>& args, 
+            std::error_code& ec) const override
+        {
+            if (args.size() != *this->arity())
+            {
+                ec = jsonpath_errc::invalid_arity;
+                return value_type::null();
+            }
+
+            auto arg0 = args[0].value();
+            if (!arg0.is_object())
+            {
+                ec = jsonpath_errc::invalid_type;
+                return value_type::null();
+            }
+
+            value_type result(json_array_arg, semantic_tag::none, alloc_);
+            result.reserve(args.size());
+
+            for (auto& item : arg0.object_range())
+            {
+                auto s = item.key();
+                result.emplace_back(s.c_str(), semantic_tag::none);
+            }
+            return result;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("keys function");
+            return s;
+        }
+    };
+
+    enum class jsonpath_token_kind
+    {
+        root_node,
+        current_node,
+        expression,
+        lparen,
+        rparen,
+        begin_union,
+        end_union,
+        begin_filter,
+        end_filter,
+        begin_expression,
+        end_index_expression,
+        end_argument_expression,
+        separator,
+        literal,
+        selector,
+        function,
+        end_function,
+        argument,
+        unary_operator,
+        binary_operator
+    };
+
+    inline
+    std::string to_string(jsonpath_token_kind kind)
+    {
+        switch (kind)
+        {
+            case jsonpath_token_kind::root_node:
+                return "root_node";
+            case jsonpath_token_kind::current_node:
+                return "current_node";
+            case jsonpath_token_kind::lparen:
+                return "lparen";
+            case jsonpath_token_kind::rparen:
+                return "rparen";
+            case jsonpath_token_kind::begin_union:
+                return "begin_union";
+            case jsonpath_token_kind::end_union:
+                return "end_union";
+            case jsonpath_token_kind::begin_filter:
+                return "begin_filter";
+            case jsonpath_token_kind::end_filter:
+                return "end_filter";
+            case jsonpath_token_kind::begin_expression:
+                return "begin_expression";
+            case jsonpath_token_kind::end_index_expression:
+                return "end_index_expression";
+            case jsonpath_token_kind::end_argument_expression:
+                return "end_argument_expression";
+            case jsonpath_token_kind::separator:
+                return "separator";
+            case jsonpath_token_kind::literal:
+                return "literal";
+            case jsonpath_token_kind::selector:
+                return "selector";
+            case jsonpath_token_kind::function:
+                return "function";
+            case jsonpath_token_kind::end_function:
+                return "end_function";
+            case jsonpath_token_kind::argument:
+                return "argument";
+            case jsonpath_token_kind::unary_operator:
+                return "unary_operator";
+            case jsonpath_token_kind::binary_operator:
+                return "binary_operator";
+            default:
+                return "";
+        }
+    }
+
+    template <typename Json,typename JsonReference>
+    struct path_value_pair
+    {
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using value_type = Json;
+        using reference = JsonReference;
+        using value_pointer = typename std::conditional<std::is_const<typename std::remove_reference<JsonReference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using path_pointer = const path_node_type*;
+
+        path_pointer path_ptr_;
+        value_pointer value_ptr_;
+
+        path_value_pair(const path_node_type& path, reference value) noexcept
+            : path_ptr_(std::addressof(path)), value_ptr_(std::addressof(value))
+        {
+        }
+
+        path_value_pair(const path_value_pair&) = default;
+        path_value_pair(path_value_pair&& other) = default;
+        path_value_pair& operator=(const path_value_pair&) = default;
+        path_value_pair& operator=(path_value_pair&& other) = default;
+        
+        ~path_value_pair() = default;
+
+        path_node_type path() const
+        {
+            return *path_ptr_;
+        }
+
+        reference value() 
+        {
+            return *value_ptr_;
+        }
+    };
+ 
+    template <typename Json,typename JsonReference>
+    struct path_value_pair_less
+    {
+        bool operator()(const path_value_pair<Json,JsonReference>& lhs,
+                        const path_value_pair<Json,JsonReference>& rhs) const noexcept
+        {
+            return lhs.path() < rhs.path();
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    struct path_value_pair_greater
+    {
+        bool operator()(const path_value_pair<Json,JsonReference>& lhs,
+                        const path_value_pair<Json,JsonReference>& rhs) const noexcept
+        {
+            return rhs.path() < lhs.path();
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    struct path_value_pair_equal
+    {
+        bool operator()(const path_value_pair<Json,JsonReference>& lhs,
+                        const path_value_pair<Json,JsonReference>& rhs) const noexcept
+        {
+            return lhs.path() == rhs.path();
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    struct path_component_value_pair
+    {
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using value_type = Json;
+        using reference = JsonReference;
+        using value_pointer = typename std::conditional<std::is_const<typename std::remove_reference<JsonReference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using path_pointer = const path_node_type*;
+    private:
+        const path_node_type* last_ptr_;
+        value_pointer value_ptr_;
+    public:
+        path_component_value_pair(const path_node_type& last, reference value) noexcept
+            : last_ptr_(std::addressof(last)), value_ptr_(std::addressof(value))
+        {
+        }
+
+        const path_node_type& last() const
+        {
+            return *last_ptr_;
+        }
+
+        reference value() const
+        {
+            return *value_ptr_;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class node_receiver
+    {
+    public:
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using reference = JsonReference;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        node_receiver() = default;
+        node_receiver(const node_receiver&) = default;
+        node_receiver(node_receiver&&) = default;
+
+        virtual ~node_receiver() = default;
+
+        node_receiver& operator=(const node_receiver&) = default;
+        node_receiver& operator=(node_receiver&&) = default;
+
+        virtual void add(const path_node_type& base_path, reference value) = 0;
+    };
+
+    template <typename Json,typename JsonReference>
+    class path_value_receiver : public node_receiver<Json,JsonReference>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using reference = JsonReference;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+
+        allocator_type alloc_;
+        std::vector<path_value_pair_type> nodes;
+
+        path_value_receiver(const allocator_type& alloc)
+            : alloc_(alloc)
+        {
+        }
+
+        void add(const path_node_type& base_path, reference value) override
+        {
+            nodes.emplace_back(base_path, value);
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class path_component_value_receiver : public node_receiver<Json,JsonReference>
+    {
+    public:
+        using reference = JsonReference;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using path_component_value_pair_type = path_component_value_pair<Json,JsonReference>;
+
+        std::vector<path_component_value_pair_type> nodes;
+
+        void add(const path_node_type& base_path, reference value) override
+        {
+            nodes.emplace_back(base_path, value);
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class eval_context
+    {
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using reference = JsonReference;
+        using pointer = typename std::conditional<std::is_const<typename std::remove_reference<reference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        allocator_type alloc_;
+        std::vector<std::unique_ptr<Json>> temp_json_values_;
+        std::vector<std::unique_ptr<path_node_type>> temp_node_values_;
+        std::unordered_map<std::size_t,pointer> cache_;
+        string_type length_label_;
+    public:
+        eval_context(const allocator_type& alloc = allocator_type())
+            : alloc_(alloc), length_label_{JSONCONS_CSTRING_CONSTANT(char_type, "length"), alloc}
+        {
+        }
+
+        allocator_type get_allocator() const
+        {
+            return alloc_;
+        }
+
+        bool is_cached(std::size_t id) const
+        {
+            return cache_.find(id) != cache_.end();
+        }
+        void add_to_cache(std::size_t id, reference val) 
+        {
+            cache_.emplace(id, std::addressof(val));
+        }
+        reference get_from_cache(std::size_t id) 
+        {
+            return *cache_[id];
+        }
+
+        reference null_value()
+        {
+            static Json a_null = Json(null_type(), semantic_tag::none);
+            return a_null;
+        }
+
+        template <typename... Args>
+        Json* create_json(Args&& ... args)
+        {
+            auto temp = jsoncons::make_unique<Json>(std::forward<Args>(args)...);
+            Json* ptr = temp.get();
+            temp_json_values_.emplace_back(std::move(temp));
+            return ptr;
+        }
+
+        const string_type& length_label() const
+        {
+            return length_label_;
+        }
+
+        template <typename... Args>
+        const path_node_type* create_path_node(Args&& ... args)
+        {
+            auto temp = jsoncons::make_unique<path_node_type>(std::forward<Args>(args)...);
+            path_node_type* ptr = temp.get();
+            temp_node_values_.emplace_back(std::move(temp));
+            return ptr;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    struct node_less
+    {
+        bool operator()(const path_value_pair<Json,JsonReference>& a, const path_value_pair<Json,JsonReference>& b) const
+        {
+            return *(a.ptr) < *(b.ptr);
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class jsonpath_selector
+    {
+        bool is_path_;
+        std::size_t precedence_level_;
+
+    public:
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = jsoncons::basic_string_view<char_type, std::char_traits<char_type>>;
+        using value_type = Json;
+        using reference = JsonReference;
+        using pointer = typename std::conditional<std::is_const<typename std::remove_reference<JsonReference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using node_receiver_type = node_receiver<Json,JsonReference>;
+        using selector_type = jsonpath_selector<Json,JsonReference>;
+
+        jsonpath_selector(bool is_path,
+                          std::size_t precedence_level = 0)
+            : is_path_(is_path), 
+              precedence_level_(precedence_level)
+        {
+        }
+
+        virtual ~jsonpath_selector() = default;
+
+        bool is_path() const 
+        {
+            return is_path_;
+        }
+
+        std::size_t precedence_level() const
+        {
+            return precedence_level_;
+        }
+
+        bool is_right_associative() const
+        {
+            return true;
+        }
+
+        virtual void select(eval_context<Json,JsonReference>& context,
+            reference root,
+            const path_node_type& base_path, 
+            reference val, 
+            node_receiver_type& receiver,
+            result_options options) const = 0;
+
+        virtual reference evaluate(eval_context<Json,JsonReference>& context,
+            reference root,
+            const path_node_type& base_path, 
+            reference current, 
+            result_options options,
+            std::error_code& ec) const = 0;
+
+        virtual void append_selector(jsonpath_selector*) 
+        {
+        }
+
+        virtual std::string to_string(int) const
+        {
+            return std::string();
+        }
+    };
+
+    template <typename Json>
+    struct static_resources
+    {
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using value_type = Json;
+        using reference = typename jsonpath_traits<Json>::reference;
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        using function_base_type = function_base<Json>;
+        using selector_type = jsonpath_selector<Json,reference>;
+        using const_selector_type = jsonpath_selector<Json,const_reference>;
+
+        struct MyHash
+        {
+            std::uintmax_t operator()(string_type const& s) const noexcept
+            {
+                const int p = 31;
+                const int m = static_cast<int>(1e9) + 9;
+                std::uintmax_t hash_value = 0;
+                std::uintmax_t p_pow = 1;
+                for (char_type c : s) {
+                    hash_value = (hash_value + (c - 'a' + 1) * p_pow) % m;
+                    p_pow = (p_pow * p) % m;
+                }
+                return hash_value;   
+            }
+        };
+
+        allocator_type alloc_;
+        std::vector<std::unique_ptr<selector_type>> selectors_;
+        std::vector<std::unique_ptr<const_selector_type>> const_selectors_;
+        std::vector<std::unique_ptr<Json>> temp_json_values_;
+        std::vector<std::unique_ptr<unary_operator<Json>>> unary_operators_;
+
+        std::unordered_map<string_type,std::unique_ptr<function_base_type>,MyHash> functions_;
+        std::unordered_map<string_type,std::unique_ptr<function_base_type>,MyHash> custom_functions_;
+
+        static_resources(const static_resources&) = delete;
+        static_resources(static_resources&&) = default;
+
+        static_resources(const allocator_type& alloc = allocator_type())
+            : alloc_(alloc)
+        {
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "abs"), alloc_}, 
+                    jsoncons::make_unique<abs_function<Json>>());
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "contains"), alloc_ },
+                    jsoncons::make_unique<contains_function<Json>>());
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "starts_with"), alloc_ },
+                    jsoncons::make_unique<starts_with_function<Json>>());
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "ends_with"), alloc_ },
+                    jsoncons::make_unique<ends_with_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "ceil"), alloc_}, 
+                    jsoncons::make_unique<ceil_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "floor"), alloc_}, 
+                    jsoncons::make_unique<floor_function<Json>>());
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "to_number"), alloc_ },
+                    jsoncons::make_unique<to_number_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "sum"), alloc_}, 
+                    jsoncons::make_unique<sum_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "prod"), alloc_}, 
+                    jsoncons::make_unique<prod_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "avg"), alloc_}, 
+                    jsoncons::make_unique<avg_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "min"), alloc_}, 
+                    jsoncons::make_unique<min_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "max"), alloc_}, 
+                    jsoncons::make_unique<max_function<Json>>());
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "length"), alloc_}, 
+                    jsoncons::make_unique<length_function<Json>>());
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "keys"), alloc_ },
+                    jsoncons::make_unique<keys_function<Json>>(alloc_));
+#if defined(JSONCONS_HAS_STD_REGEX)
+                functions_.emplace(string_type{ JSONCONS_CSTRING_CONSTANT(char_type, "tokenize"), alloc_ },
+                    jsoncons::make_unique<tokenize_function<Json>>(alloc_));
+#endif
+                functions_.emplace(string_type{JSONCONS_CSTRING_CONSTANT(char_type, "count"), alloc_}, 
+                    jsoncons::make_unique<length_function<Json>>());
+        }
+
+        static_resources(const custom_functions<Json>& functions, 
+            const allocator_type& alloc = allocator_type())
+            : static_resources(alloc)
+        {
+            for (const auto& item : functions)
+            {
+                custom_functions_.emplace(item.name(),
+                                          jsoncons::make_unique<decorator_function<Json>>(item.arity(),item.function()));
+            }
+        }
+        
+        ~static_resources() = default;
+
+        static_resources operator=(const static_resources&) = delete;
+        static_resources operator=(static_resources&&) = delete;
+
+        const function_base_type* get_function(const string_type& name, std::error_code& ec) const
+        {
+            auto it = functions_.find(name);
+            if (it == functions_.end())
+            {
+                auto it2 = custom_functions_.find(name);
+                if (it2 == custom_functions_.end())
+                {
+                    ec = jsonpath_errc::unknown_function;
+                    return nullptr;
+                }
+                return it2->second.get();
+            }
+            return (*it).second.get();
+        }
+
+        const unary_operator<Json>* get_unary_not() const
+        {
+            static unary_not_operator<Json> oper;
+            return &oper;
+        }
+
+        const unary_operator<Json>* get_unary_minus() const
+        {
+            static unary_minus_operator<Json> oper;
+            return &oper;
+        }
+
+        const unary_operator<Json>* get_regex_operator(std::basic_regex<char_type>&& pattern) 
+        {
+            unary_operators_.push_back(jsoncons::make_unique<regex_operator<Json>>(std::move(pattern)));
+            return unary_operators_.back().get();
+        }
+
+        const binary_operator<Json>* get_or_operator() const
+        {
+            static or_operator<Json> oper;
+
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_and_operator() const
+        {
+            static and_operator<Json> oper;
+
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_eq_operator() const
+        {
+            static eq_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_ne_operator() const
+        {
+            static ne_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_lt_operator() const
+        {
+            static lt_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_lte_operator() const
+        {
+            static lte_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_gt_operator() const
+        {
+            static gt_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_gte_operator() const
+        {
+            static gte_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_plus_operator() const
+        {
+            static plus_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_minus_operator() const
+        {
+            static minus_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_mult_operator() const
+        {
+            static mult_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_div_operator() const
+        {
+            static div_operator<Json> oper;
+            return &oper;
+        }
+
+        const binary_operator<Json>* get_modulus_operator() const
+        {
+            static modulus_operator<Json> oper;
+            return &oper;
+        }
+
+        template <typename T>
+        typename std::enable_if<std::is_const<typename std::remove_reference<typename T::reference>::type>::value,const_selector_type*>::type    
+        new_selector(T&& val)
+        {
+            const_selectors_.emplace_back(jsoncons::make_unique<T>(std::forward<T>(val)));
+            return const_selectors_.back().get();
+        }
+
+        template <typename T>
+        typename std::enable_if<!std::is_const<typename std::remove_reference<typename T::reference>::type>::value,selector_type*>::type    
+        new_selector(T&& val)
+        {
+            selectors_.emplace_back(jsoncons::make_unique<T>(std::forward<T>(val)));
+            return selectors_.back().get();
+        }
+
+        template <typename... Args>
+        Json* create_json(Args&& ... args)
+        {
+            auto temp = jsoncons::make_unique<Json>(std::forward<Args>(args)...);
+            Json* ptr = temp.get();
+            temp_json_values_.emplace_back(std::move(temp));
+            return ptr;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class expression_base
+    {
+    public:
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = jsoncons::basic_string_view<char_type, std::char_traits<char_type>>;
+        using value_type = Json;
+        using reference = JsonReference;
+        using pointer = typename std::conditional<std::is_const<typename std::remove_reference<JsonReference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        expression_base() = default;
+        
+        expression_base(const expression_base&) = default;
+        expression_base(expression_base&&) = default;
+
+        virtual ~expression_base() = default;
+
+        expression_base& operator=(const expression_base&) = default;
+        expression_base& operator=(expression_base&&) = default;
+
+        virtual value_type evaluate(eval_context<Json,JsonReference>& context,
+            reference root,
+            reference val, 
+            result_options options,
+            std::error_code& ec) const = 0;
+
+        virtual std::string to_string(int level) const = 0;
+    };
+
+    template <typename Json,typename JsonReference>
+    class token
+    {
+    public:
+        using selector_type = jsonpath_selector<Json,JsonReference>;
+        using expression_base_type = expression_base<Json,JsonReference>;
+
+        jsonpath_token_kind token_kind_;
+
+        union
+        {
+            char dummy_;
+            selector_type* selector_;
+            std::unique_ptr<expression_base_type> expression_;
+            const unary_operator<Json>* unary_operator_;
+            const binary_operator<Json>* binary_operator_;
+            const function_base<Json>* function_;
+            Json value_;
+        };
+    public:
+
+        token(const token& other) = delete;
+
+        token(token&& other) noexcept
+        {
+            construct(std::move(other));
+        }
+
+        token(const unary_operator<Json>* expr) noexcept
+            : token_kind_(jsonpath_token_kind::unary_operator),
+              unary_operator_(expr)
+        {
+        }
+
+        token(const binary_operator<Json>* expr) noexcept
+            : token_kind_(jsonpath_token_kind::binary_operator),
+              binary_operator_(expr)
+        {
+        }
+
+        token(current_node_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::current_node), dummy_{}
+        {
+        }
+
+        token(root_node_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::root_node), dummy_{}
+        {
+        }
+
+        token(end_function_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::end_function), dummy_{}
+        {
+        }
+
+        token(separator_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::separator), dummy_{}
+        {
+        }
+
+        token(lparen_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::lparen), dummy_{}
+        {
+        }
+
+        token(rparen_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::rparen), dummy_{}
+        {
+        }
+
+        token(begin_union_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::begin_union), dummy_{}
+        {
+        }
+
+        token(end_union_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::end_union), dummy_{}
+        {
+        }
+
+        token(begin_filter_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::begin_filter), dummy_{}
+        {
+        }
+
+        token(end_filter_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::end_filter), dummy_{}
+        {
+        }
+
+        token(begin_expression_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::begin_expression), dummy_{}
+        {
+        }
+
+        token(end_index_expression_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::end_index_expression), dummy_{}
+        {
+        }
+
+        token(end_argument_expression_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::end_argument_expression), dummy_{}
+        {
+        }
+
+        token(selector_type* selector)
+            : token_kind_(jsonpath_token_kind::selector), selector_(selector)
+        {
+        }
+
+        token(std::unique_ptr<expression_base_type>&& expr)
+            : token_kind_(jsonpath_token_kind::expression)
+        {
+            new (&expression_) std::unique_ptr<expression_base_type>(std::move(expr));
+        }
+
+        token(const function_base<Json>* function) noexcept
+            : token_kind_(jsonpath_token_kind::function),
+              function_(function)
+        {
+        }
+
+        token(argument_arg_t) noexcept
+            : token_kind_(jsonpath_token_kind::argument), dummy_{}
+        {
+        }
+
+        token(literal_arg_t, Json&& value) noexcept
+            : token_kind_(jsonpath_token_kind::literal), value_(std::move(value))
+        {
+        }
+
+        const Json& get_value(const_reference_arg_t, eval_context<Json,JsonReference>&) const
+        {
+            return value_;
+        }
+
+        Json& get_value(reference_arg_t, eval_context<Json,JsonReference>& context) const
+        {
+            return *context.create_json(value_);
+        }
+
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        token& operator=(const token& other) = delete;
+
+        token& operator=(token&& other) noexcept
+        {
+
+            if (&other != this)
+            {
+                if (token_kind_ == other.token_kind_)
+                {
+                    switch (token_kind_)
+                    {
+                        case jsonpath_token_kind::selector:
+                            selector_ = other.selector_;
+                            break;
+                        case jsonpath_token_kind::expression:
+                            expression_ = std::move(other.expression_);
+                            break;
+                        case jsonpath_token_kind::unary_operator:
+                            unary_operator_ = other.unary_operator_;
+                            break;
+                        case jsonpath_token_kind::binary_operator:
+                            binary_operator_ = other.binary_operator_;
+                            break;
+                        case jsonpath_token_kind::function:
+                            function_ = other.function_;
+                            break;
+                        case jsonpath_token_kind::literal:
+                            value_ = std::move(other.value_);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                else
+                {
+                    destroy();
+                    construct(std::move(other));
+                }
+            }
+            return *this;
+        }
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic pop
+#endif
+
+        ~token() noexcept
+        {
+            destroy();
+        }
+
+        jsonpath_token_kind token_kind() const
+        {
+            return token_kind_;
+        }
+
+        bool is_lparen() const
+        {
+            return token_kind_ == jsonpath_token_kind::lparen; 
+        }
+
+        bool is_rparen() const
+        {
+            return token_kind_ == jsonpath_token_kind::rparen; 
+        }
+
+        bool is_current_node() const
+        {
+            return token_kind_ == jsonpath_token_kind::current_node; 
+        }
+
+        bool is_path() const
+        {
+            return token_kind_ == jsonpath_token_kind::selector && selector_->is_path(); 
+        }
+
+        bool is_operator() const
+        {
+            return token_kind_ == jsonpath_token_kind::unary_operator || 
+                   token_kind_ == jsonpath_token_kind::binary_operator; 
+        }
+
+        std::size_t precedence_level() const
+        {
+            switch(token_kind_)
+            {
+                case jsonpath_token_kind::selector:
+                    return selector_->precedence_level();
+                case jsonpath_token_kind::unary_operator:
+                    return unary_operator_->precedence_level();
+                case jsonpath_token_kind::binary_operator:
+                    return binary_operator_->precedence_level();
+                default:
+                    return 0;
+            }
+        }
+
+        jsoncons::optional<std::size_t> arity() const
+        {
+            return token_kind_ == jsonpath_token_kind::function ? function_->arity() : jsoncons::optional<std::size_t>();
+        }
+
+        bool is_right_associative() const
+        {
+            switch(token_kind_)
+            {
+                case jsonpath_token_kind::selector:
+                    return selector_->is_right_associative();
+                case jsonpath_token_kind::unary_operator:
+                    return unary_operator_->is_right_associative();
+                case jsonpath_token_kind::binary_operator:
+                    return binary_operator_->is_right_associative();
+                default:
+                    return false;
+            }
+        }
+
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+        void construct(token&& other) noexcept
+        {
+            token_kind_ = other.token_kind_;
+            switch (token_kind_)
+            {
+                case jsonpath_token_kind::selector:
+                    selector_ = other.selector_;
+                    break;
+                case jsonpath_token_kind::expression:
+                    new (&expression_) std::unique_ptr<expression_base_type>(std::move(other.expression_));
+                    break;
+                case jsonpath_token_kind::unary_operator:
+                    unary_operator_ = other.unary_operator_;
+                    break;
+                case jsonpath_token_kind::binary_operator:
+                    binary_operator_ = other.binary_operator_;
+                    break;
+                case jsonpath_token_kind::function:
+                    function_ = other.function_;
+                    break;
+                case jsonpath_token_kind::literal:
+                    new (&value_) Json(std::move(other.value_));
+                    break;
+                default:
+                    break;
+            }
+        }
+#if defined(__GNUC__) && JSONCONS_GCC_AVAILABLE(12,0,0)
+# pragma GCC diagnostic pop
+#endif
+
+        void destroy() noexcept 
+        {
+            switch(token_kind_)
+            {
+                case jsonpath_token_kind::expression:
+                    expression_.~unique_ptr();
+                    break;
+                case jsonpath_token_kind::literal:
+                    value_.~Json();
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        std::string to_string(int level) const
+        {
+            std::string s;
+            switch (token_kind_)
+            {
+                case jsonpath_token_kind::root_node:
+                    if (level > 0)
+                    {
+                        s.append("\n");
+                        s.append(std::size_t(level)*2, ' ');
+                    }
+                    s.append("root node");
+                    break;
+                case jsonpath_token_kind::current_node:
+                    if (level > 0)
+                    {
+                        s.append("\n");
+                        s.append(std::size_t(level)*2, ' ');
+                    }
+                    s.append("current node");
+                    break;
+                case jsonpath_token_kind::argument:
+                    if (level > 0)
+                    {
+                        s.append("\n");
+                        s.append(std::size_t(level)*2, ' ');
+                    }
+                    s.append("argument");
+                    break;
+                case jsonpath_token_kind::selector:
+                    s.append(selector_->to_string(level));
+                    break;
+                case jsonpath_token_kind::expression:
+                    s.append(expression_->to_string(level));
+                    break;
+                case jsonpath_token_kind::literal:
+                {
+                    if (level > 0)
+                    {
+                        s.append("\n");
+                        s.append(std::size_t(level)*2, ' ');
+                    }
+                    auto sbuf = value_.to_string();
+                    unicode_traits::convert(sbuf.data(), sbuf.size(), s);
+                    break;
+                }
+                case jsonpath_token_kind::binary_operator:
+                    s.append(binary_operator_->to_string(level));
+                    break;
+                case jsonpath_token_kind::function:
+                    s.append(function_->to_string(level));
+                    break;
+                default:
+                    if (level > 0)
+                    {
+                        s.append("\n");
+                        s.append(std::size_t(level)*2, ' ');
+                    }
+                    s.append("token kind: ");
+                    s.append(jsoncons::jsonpath::detail::to_string(token_kind_));
+                    break;
+            }
+            //s.append("\n");
+            return s;
+        }
+    };
+
+    template <typename Callback,typename Json,typename JsonReference>
+    class callback_receiver : public node_receiver<Json,JsonReference>
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using reference = JsonReference;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+    private:
+        allocator_type alloc_;
+        Callback& callback_;
+    public:
+
+        callback_receiver(Callback& callback, const allocator_type& alloc)
+            : alloc_(alloc), callback_(callback)
+        {
+        }
+
+        void add(const path_node_type& base_path, 
+                 reference value) override
+        {
+            callback_(base_path, value);
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class path_expression
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+        using path_value_pair_less_type = path_value_pair_less<Json,JsonReference>;
+        using path_value_pair_greater_type = path_value_pair_greater<Json,JsonReference>;
+        using path_value_pair_equal_type = path_value_pair_equal<Json,JsonReference>;
+        using value_type = Json;
+        using reference = typename path_value_pair_type::reference;
+        using pointer = typename path_value_pair_type::value_pointer;
+        using token_type = token<Json,JsonReference>;
+        using reference_arg_type = typename std::conditional<std::is_const<typename std::remove_reference<JsonReference>::type>::value,
+            const_reference_arg_t,reference_arg_t>::type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using selector_type = jsonpath_selector<Json,JsonReference>;
+    private:
+        allocator_type alloc_;
+        selector_type* selector_;
+        result_options required_options_;
+    public:
+
+        path_expression(selector_type* selector, bool paths_required, const allocator_type& alloc)
+            : alloc_(alloc), selector_(selector), required_options_()
+        {
+            if (paths_required)
+            {
+                required_options_ |= result_options::path;
+            }
+        }
+
+        path_expression(const allocator_type& alloc)
+            : alloc_(alloc), selector_(nullptr), required_options_()
+        {
+        }
+
+        path_expression(const path_expression& expr) = delete;
+        path_expression(path_expression&& expr) = default;
+
+        ~path_expression() = default;
+        
+        path_expression& operator=(const path_expression& expr) = delete;
+        path_expression& operator=(path_expression&& expr) = default;
+
+        Json evaluate(eval_context<Json,JsonReference>& context, 
+            reference root,
+            const path_node_type& path, 
+            reference instance,
+            result_options options) const
+        {
+            Json result(json_array_arg, semantic_tag::none, alloc_);
+
+            if ((options & result_options::path) == result_options::path)
+            {
+                auto callback = [&result](const path_node_type& pathp, reference)
+                {
+                    result.emplace_back(to_basic_string(pathp)); 
+                };
+                evaluate(context, root, path, instance, callback, options);
+            }
+            else
+            {
+                auto callback = [&result](const path_node_type&, reference val)
+                {
+                    result.push_back(val);
+                };
+                evaluate(context, root, path, instance, callback, options);
+            }
+
+            return result;
+        }
+
+        template <typename Callback>
+        typename std::enable_if<extension_traits::is_binary_function_object<Callback,const path_node_type&,reference>::value,void>::type
+        evaluate(eval_context<Json,JsonReference>& context, 
+            reference root,
+            const path_node_type& path, 
+            reference current, 
+            Callback callback,
+            result_options options) const
+        {
+            std::error_code ec;
+
+            options |= required_options_;
+
+            const result_options require_more = result_options::nodups | result_options::sort | result_options::sort_descending;
+
+            if (selector_ != nullptr && (options & require_more) != result_options())
+            {
+                path_value_receiver<Json,JsonReference> receiver{alloc_};
+                selector_->select(context, root, path, current, receiver, options);
+
+                if (receiver.nodes.size() > 1) 
+                {
+                    if ((options & result_options::sort_descending) == result_options::sort_descending)
+                    {
+                        std::sort(receiver.nodes.begin(), receiver.nodes.end(), path_value_pair_greater_type());
+                    } 
+                    else if ((options & result_options::sort) == result_options::sort)
+                    {
+                        std::sort(receiver.nodes.begin(), receiver.nodes.end(), path_value_pair_less_type());
+                    }
+                }
+
+                if (receiver.nodes.size() > 1 && (options & result_options::nodups) == result_options::nodups)
+                {
+                    if ((options & result_options::sort_descending) == result_options::sort_descending)
+                    {
+                        auto last = std::unique(receiver.nodes.rbegin(),receiver.nodes.rend(),path_value_pair_equal_type());
+                        receiver.nodes.erase(receiver.nodes.begin(), last.base());
+                        for (auto& node : receiver.nodes)
+                        {
+                            callback(node.path(), node.value());
+                        }
+                    }
+                    else if ((options & result_options::sort) == result_options::sort)
+                    {
+                        auto last = std::unique(receiver.nodes.begin(),receiver.nodes.end(),path_value_pair_equal_type());
+                        receiver.nodes.erase(last,receiver.nodes.end());
+                        for (auto& node : receiver.nodes)
+                        {
+                            callback(node.path(), node.value());
+                        }
+                    }
+                    else
+                    {
+                        std::vector<path_value_pair_type> index(receiver.nodes);
+                        std::sort(index.begin(), index.end(), path_value_pair_less_type());
+                        auto last = std::unique(index.begin(),index.end(),path_value_pair_equal_type());
+                        index.erase(last,index.end());
+
+                        std::vector<path_value_pair_type> temp2;
+                        temp2.reserve(index.size());
+                        for (auto&& node : receiver.nodes)
+                        {
+                            auto it = std::lower_bound(index.begin(),index.end(),node, path_value_pair_less_type());
+                            if (it != index.end() && (*it).path() == node.path()) 
+                            {
+                                temp2.emplace_back(std::move(node));
+                                index.erase(it);
+                            }
+                        }
+                        for (auto& node : temp2)
+                        {
+                            callback(node.path(), node.value());
+                        }
+                    }
+                }
+                else
+                {
+                    for (auto& node : receiver.nodes)
+                    {
+                        callback(node.path(), node.value());
+                    }
+                }
+            }
+            else
+            {
+                callback_receiver<Callback,Json,JsonReference> receiver(callback, alloc_);
+                selector_->select(context, root, path, current, receiver, options);
+            }
+        }
+
+        std::string to_string(int level) const
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("expression ");
+            if (selector_ != nullptr)
+            {
+                s.append(selector_->to_string(level+1));
+            }
+
+            return s;
+
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class expression : public expression_base<Json,JsonReference>
+    {
+    public:
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+        using value_type = Json;
+        using reference = typename path_value_pair_type::reference;
+        using pointer = typename path_value_pair_type::value_pointer;
+        using const_pointer = const value_type*;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using path_value_pair_less_type = path_value_pair_less<Json,reference>;
+        using path_value_pair_greater_type = path_value_pair_greater<Json,reference>;
+        using path_value_pair_equal_type = path_value_pair_equal<Json,reference>;
+        using parameter_type = parameter<Json>;
+        using token_type = token<Json,reference>;
+        using reference_arg_type = typename std::conditional<std::is_const<typename std::remove_reference<reference>::type>::value,
+            const_reference_arg_t,reference_arg_t>::type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using stack_item_type = value_or_pointer<Json,JsonReference>;
+    private:
+        std::vector<token_type> token_list_;
+    public:
+
+        expression()
+        {
+        }
+
+        expression(const expression& expr) = delete;
+        expression(expression&& expr) = default;
+
+        expression(std::vector<token_type>&& token_stack)
+            : token_list_(std::move(token_stack))
+        {
+        }
+
+        expression& operator=(const expression& expr) = delete;
+        expression& operator=(expression&& expr) = default;
+        
+        ~expression() = default;
+
+        value_type evaluate(eval_context<Json,reference>& context, 
+            reference root,
+            reference current,
+            result_options options,
+            std::error_code& ec) const override
+        {
+            std::vector<stack_item_type> stack;
+            std::vector<parameter_type> arg_stack;
+
+            //std::cout << "EVALUATE TOKENS\n";
+            //for (auto& tok : token_list_)
+            //{
+            //    std::cout << tok.to_string() << "\n";
+            //}
+            //std::cout << "\n";
+
+            if (!token_list_.empty())
+            {
+                for (auto& tok : token_list_)
+                {
+                    //std::cout << "Token: " << tok.to_string() << "\n";
+                    switch (tok.token_kind())
+                    { 
+                        case jsonpath_token_kind::literal:
+                        {
+                            stack.emplace_back(std::addressof(tok.get_value(reference_arg_type(), context)));
+                            break;
+                        }
+                        case jsonpath_token_kind::unary_operator:
+                        {
+                            JSONCONS_ASSERT(!stack.empty());
+                            auto item = std::move(stack.back());
+                            stack.pop_back();
+
+                            auto val = tok.unary_operator_->evaluate(item.value(), ec);
+                            stack.emplace_back(std::move(val));
+                            break;
+                        }
+                        case jsonpath_token_kind::binary_operator:
+                        {
+                            //std::cout << "binary operator: " << stack.size() << "\n";
+                            JSONCONS_ASSERT(stack.size() >= 2);
+                            auto rhs = std::move(stack.back());
+                            //std::cout << "rhs: " << *rhs << "\n";
+                            stack.pop_back();
+                            auto lhs = std::move(stack.back());
+                            //std::cout << "lhs: " << *lhs << "\n";
+                            stack.pop_back();
+
+                            auto val = tok.binary_operator_->evaluate(lhs.value(), rhs.value(), ec);
+                            //std::cout << "Evaluate binary expression: " << r << "\n";
+                            stack.emplace_back(std::move(val));
+                            break;
+                        }
+                        case jsonpath_token_kind::root_node:
+                            //std::cout << "root: " << root << "\n";
+                            stack.emplace_back(std::addressof(root));
+                            break;
+                        case jsonpath_token_kind::current_node:
+                            //std::cout << "current: " << current << "\n";
+                            stack.emplace_back(std::addressof(current));
+                            break;
+                        case jsonpath_token_kind::argument:
+                            JSONCONS_ASSERT(!stack.empty());
+                            arg_stack.emplace_back(std::move(stack.back()));
+                            stack.pop_back();
+                            break;
+                        case jsonpath_token_kind::function:
+                        {
+                            if (tok.function_->arity() && *(tok.function_->arity()) != arg_stack.size())
+                            {
+                                ec = jsonpath_errc::invalid_arity;
+                                return Json::null();
+                            }
+
+                            value_type val = tok.function_->evaluate(arg_stack, ec);
+                            if (ec)
+                            {
+                                return Json::null();
+                            }
+                            //std::cout << "function result: " << val << "\n";
+                            arg_stack.clear();
+                            stack.emplace_back(std::move(val));
+                            break;
+                        }
+                        case jsonpath_token_kind::expression:
+                        {
+                            value_type val = tok.expression_->evaluate(context, root, current, options, ec);
+                            stack.emplace_back(std::move(val));
+                            break;
+                        }
+                        case jsonpath_token_kind::selector:
+                        {
+                            JSONCONS_ASSERT(!stack.empty());
+                            auto item = std::move(stack.back());
+                            //for (auto& item : stack)
+                            //{
+                                //std::cout << "selector stack input:\n";
+                                //switch (item.tag)
+                                //{
+                                //    case node_set_tag::single:
+                                //        std::cout << "single: " << *(item.node.ptr) << "\n";
+                                //        break;
+                                //    case node_set_tag::multi:
+                                //        for (auto& node : stack.back().ptr().nodes)
+                                //        {
+                                //            std::cout << "multi: " << *node.ptr << "\n";
+                                //        }
+                                //        break;
+                                //    default:
+                                //        break;
+                            //}
+                            //std::cout << "\n";
+                            //}
+                            //std::cout << "selector item: " << *ptr << "\n";
+
+                            reference val = tok.selector_->evaluate(context, root, path_node_type{}, item.value(), options, ec);
+
+                            stack.pop_back();
+                            stack.emplace_back(stack_item_type(std::addressof(val)));
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            //if (stack.size() != 1)
+            //{
+            //    std::cout << "Stack size: " << stack.size() << "\n";
+            //}
+            return stack.empty() ? Json::null() : stack.back().value();
+        }
+ 
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("expression ");
+            for (const auto& item : token_list_)
+            {
+                s.append(item.to_string(level+1));
+            }
+
+            return s;
+
+        }
+    private:
+    };
+
+} // namespace detail
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_EXPRESSION_HPP

--- a/velox/external/jsoncons/jsonpath/flatten.hpp
+++ b/velox/external/jsoncons/jsonpath/flatten.hpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_FLATTEN_HPP
+#define JSONCONS_EXT_JSONPATH_FLATTEN_HPP
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/detail/parse_number.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+#include "velox/external/jsoncons/jsonpath/jsonpath_error.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_utilities.hpp"
+
+namespace facebook::velox::jsoncons { namespace jsonpath {
+
+    template <typename Json>
+    void flatten_(const typename Json::string_type& parent_key,
+                  const Json& parent_value,
+                  Json& result)
+    {
+        using char_type = typename Json::char_type;
+        using string_type = std::basic_string<char_type>;
+
+        switch (parent_value.type())
+        {
+            case json_type::array_value:
+            {
+                if (parent_value.empty())
+                {
+                    result.try_emplace(parent_key, parent_value);
+                }
+                else
+                {
+                    for (std::size_t i = 0; i < parent_value.size(); ++i)
+                    {
+                        string_type key(parent_key);
+                        key.push_back('[');
+                        jsoncons::detail::from_integer(i,key);
+                        key.push_back(']');
+                        flatten_(key, parent_value.at(i), result);
+                    }
+                }
+                break;
+            }
+
+            case json_type::object_value:
+            {
+                if (parent_value.empty())
+                {
+                    result.try_emplace(parent_key, Json());
+                }
+                else
+                {
+                    for (const auto& item : parent_value.object_range())
+                    {
+                        string_type key(parent_key);
+                        key.push_back('[');
+                        key.push_back('\'');
+                        escape_string(item.key().data(), item.key().length(), key);
+                        key.push_back('\'');
+                        key.push_back(']');
+                        flatten_(key, item.value(), result);
+                    }
+                }
+                break;
+            }
+
+            default:
+            {
+                result[parent_key] = parent_value;
+                break;
+            }
+        }
+    }
+
+    template <typename Json>
+    Json flatten(const Json& value)
+    {
+        Json result;
+        typename Json::string_type parent_key = {'$'};
+        flatten_(parent_key, value, result);
+        return result;
+    }
+
+    enum class unflatten_state 
+    {
+        start,
+        expect_lbracket,
+        lbracket,
+        single_quoted_name_state,
+        double_quoted_name_state,
+        index_state,
+        expect_rbracket,
+        double_quoted_string_escape_char,
+        single_quoted_string_escape_char
+    };
+
+    template <typename Json>
+    Json unflatten(const Json& value)
+    {
+        using char_type = typename Json::char_type;
+        using string_type = std::basic_string<char_type>;
+
+        if (JSONCONS_UNLIKELY(!value.is_object()))
+        {
+            JSONCONS_THROW(jsonpath_error(jsonpath_errc::argument_to_unflatten_invalid));
+        }
+
+        Json result;
+
+        for (const auto& item : value.object_range())
+        {
+            Json* part = &result;
+            string_type buffer;
+            unflatten_state state = unflatten_state::start;
+
+            auto it = item.key().begin();
+            auto last = item.key().end();
+
+            for (; it != last; ++it)
+            {
+                switch (state)
+                {
+                    case unflatten_state::start:
+                    {
+                        switch (*it)
+                        {
+                            case '$':
+                                state = unflatten_state::expect_lbracket;
+                                break;
+                            default:
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::expect_lbracket:
+                    {
+                        switch (*it)
+                        {
+                            case '[':
+                                state = unflatten_state::lbracket;
+                                break;
+                            default:
+                                JSONCONS_THROW(jsonpath_error(jsonpath_errc::invalid_flattened_key));
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::lbracket:
+                    {
+                        switch (*it)
+                        {
+                            case '\'':
+                                state = unflatten_state::single_quoted_name_state;
+                                break;
+                            case '\"':
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                                buffer.push_back(*it);
+                                state = unflatten_state::index_state;
+                                break;
+                            default:
+                                JSONCONS_THROW(jsonpath_error(jsonpath_errc::invalid_flattened_key));
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::single_quoted_name_state:
+                    {
+                        switch (*it)
+                        {
+                            case '\'':
+                                if (it != last-2)
+                                {
+                                    auto res = part->try_emplace(buffer,Json());
+                                    part = &(res.first->value());
+                                }
+                                else
+                                {
+                                    auto res = part->try_emplace(buffer,item.value());
+                                    part = &(res.first->value());
+                                }
+                                buffer.clear();
+                                state = unflatten_state::expect_rbracket;
+                                break;
+                            case '\\':
+                                state = unflatten_state::single_quoted_string_escape_char;
+                                break;
+                            default:
+                                buffer.push_back(*it);
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::double_quoted_name_state:
+                    {
+                        switch (*it)
+                        {
+                            case '\"':
+                                if (it != last-2)
+                                {
+                                    auto res = part->try_emplace(buffer,Json());
+                                    part = &(res.first->value());
+                                }
+                                else
+                                {
+                                    auto res = part->try_emplace(buffer,item.value());
+                                    part = &(res.first->value());
+                                }
+                                buffer.clear();
+                                state = unflatten_state::expect_rbracket;
+                                break;
+                            case '\\':
+                                state = unflatten_state::double_quoted_string_escape_char;
+                                break;
+                            default:
+                                buffer.push_back(*it);
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::double_quoted_string_escape_char:
+                        switch (*it)
+                        {
+                            case '\"':
+                                buffer.push_back('\"');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case '\\': 
+                                buffer.push_back('\\');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case '/':
+                                buffer.push_back('/');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'b':
+                                buffer.push_back('\b');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'f':
+                                buffer.push_back('\f');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'n':
+                                buffer.push_back('\n');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'r':
+                                buffer.push_back('\r');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 't':
+                                buffer.push_back('\t');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            default:
+                                break;
+                        }
+                        break;
+                    case unflatten_state::single_quoted_string_escape_char:
+                        switch (*it)
+                        {
+                            case '\'':
+                                buffer.push_back('\'');
+                                state = unflatten_state::single_quoted_name_state;
+                                break;
+                            case '\\': 
+                                buffer.push_back('\\');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case '/':
+                                buffer.push_back('/');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'b':
+                                buffer.push_back('\b');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'f':
+                                buffer.push_back('\f');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'n':
+                                buffer.push_back('\n');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 'r':
+                                buffer.push_back('\r');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            case 't':
+                                buffer.push_back('\t');
+                                state = unflatten_state::double_quoted_name_state;
+                                break;
+                            default:
+                                break;
+                        }
+                        break;
+                    case unflatten_state::index_state:
+                    {
+                        switch (*it)
+                        {
+                            case ']':
+                            {
+                                std::size_t n{0};
+                                auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                                if (r)
+                                {
+                                    if (!part->is_array())
+                                    {
+                                        *part = Json(json_array_arg, semantic_tag::none, value.get_allocator());
+                                    }
+                                    if (it != last-1)
+                                    {
+                                        if (n+1 > part->size())
+                                        {
+                                            Json& ref = part->emplace_back();
+                                            part = std::addressof(ref);
+                                        }
+                                        else
+                                        {
+                                            part = &part->at(n);
+                                        }
+                                    }
+                                    else
+                                    {
+                                        Json& ref = part->emplace_back(item.value());
+                                        part = std::addressof(ref);
+                                    }
+                                }
+                                buffer.clear();
+                                state = unflatten_state::expect_lbracket;
+                                break;
+                            }
+                            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                                buffer.push_back(*it);
+                                break;
+                            default:
+                                JSONCONS_THROW(jsonpath_error(jsonpath_errc::invalid_flattened_key));
+                                break;
+                        }
+                        break;
+                    }
+                    case unflatten_state::expect_rbracket:
+                    {
+                        switch (*it)
+                        {
+                            case ']':
+                                state = unflatten_state::expect_lbracket;
+                                break;
+                            default:
+                                JSONCONS_THROW(jsonpath_error(jsonpath_errc::invalid_flattened_key));
+                                break;
+                        }
+                        break;
+                    }
+                    default:
+                        JSONCONS_UNREACHABLE();
+                        break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_FLATTEN_HPP

--- a/velox/external/jsoncons/jsonpath/json_location.hpp
+++ b/velox/external/jsoncons/jsonpath/json_location.hpp
@@ -1,0 +1,998 @@
+﻿/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSON_LOCATION_HPP
+#define JSONCONS_EXT_JSONPATH_JSON_LOCATION_HPP
+
+#include <algorithm> // std::reverse
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <type_traits> // std::is_const
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+#include "velox/external/jsoncons/jsonpath/jsonpath_error.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_utilities.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath { 
+
+    template <typename CharT,typename Allocator>
+    class basic_path_element 
+    {
+    public:
+        using char_type = CharT;
+        using allocator_type = Allocator;
+        using char_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<CharT>;
+        using string_type = std::basic_string<char_type,std::char_traits<char_type>,char_allocator_type>;
+    private:
+        bool has_name_;
+        string_type name_;
+        std::size_t index_{0};
+
+    public:
+        basic_path_element(const char_type* name, std::size_t length, 
+            const Allocator& alloc = Allocator())
+            : has_name_(true), name_(name, length, alloc)
+        {
+        }
+
+        explicit basic_path_element(const string_type& name)
+            : has_name_(true), name_(name)
+        {
+        }
+
+        explicit basic_path_element(string_type&& name)
+            : has_name_(true), name_(std::move(name))
+        {
+        }
+
+        basic_path_element(std::size_t index, 
+            const Allocator& alloc = Allocator())
+            : has_name_(false), name_(alloc), index_(index)
+        {
+        }
+
+        basic_path_element(const basic_path_element& other) = default;
+
+        basic_path_element(basic_path_element&& other) = default;
+        
+        ~basic_path_element() = default;
+
+        basic_path_element& operator=(const basic_path_element& other) = default;
+
+        basic_path_element& operator=(basic_path_element&& other) = default;
+
+        bool has_name() const
+        {
+            return has_name_;
+        }
+
+        bool has_index() const
+        {
+            return !has_name_;
+        }
+
+        const string_type& name() const
+        {
+            return name_;
+        }
+
+        std::size_t index() const 
+        {
+            return index_;
+        }
+
+        int compare(const basic_path_element& other) const
+        {
+            int diff = 0;
+            if (has_name_ != other.has_name_)
+            {
+                diff = static_cast<int>(has_name_) - static_cast<int>(other.has_name_);
+            }
+            else
+            {
+                if (has_name_)
+                {
+                    diff = name_.compare(other.name_);
+                }
+                else if (index_ < other.index_)
+                {
+                    diff = -1;
+                }
+                else if (index_ > other.index_)
+                {
+                    diff = 1;
+                }
+                else
+                {
+                    diff = 0;
+                }
+            }
+            return diff;
+        }
+    };
+
+    // parser
+    namespace detail {
+     
+        enum class json_location_state 
+        {
+            start,
+            relative_location,
+            single_quoted_string,
+            double_quoted_string,
+            unquoted_string,
+            selector,
+            digit,
+            expect_rbracket,
+            quoted_string_escape_char
+        };
+
+        enum class selector_separator_kind{bracket,dot};
+
+        template <typename CharT,typename Allocator>
+        class json_location_parser
+        {
+        public:
+            using allocator_type = Allocator;
+            using char_type = CharT;
+            using string_type = std::basic_string<CharT>;
+            using string_view_type = jsoncons::basic_string_view<CharT>;
+            using path_element_type = basic_path_element<CharT,Allocator>;
+            using path_element_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<path_element_type>;
+            using path_type = std::vector<path_element_type>;
+
+        private:
+
+            allocator_type alloc_;
+            std::size_t line_;
+            std::size_t column_;
+            const char_type* end_input_;
+            const char_type* p_;
+
+        public:
+            json_location_parser(const allocator_type& alloc = allocator_type())
+                : alloc_(alloc), line_(1), column_(1),
+                  end_input_(nullptr),
+                  p_(nullptr)
+            {
+            }
+
+            json_location_parser(std::size_t line, std::size_t column, 
+                const allocator_type& alloc = allocator_type())
+                : alloc_(alloc), line_(line), column_(column),
+                  end_input_(nullptr),
+                  p_(nullptr)
+            {
+            }
+
+            std::size_t line() const
+            {
+                return line_;
+            }
+
+            std::size_t column() const
+            {
+                return column_;
+            }
+
+            path_type parse(const string_view_type& path)
+            {
+                std::error_code ec;
+                auto result = parse(path, ec);
+                if (ec)
+                {
+                    JSONCONS_THROW(jsonpath_error(ec, line_, column_));
+                }
+                return result;
+            }
+
+            path_type parse(const string_view_type& path, std::error_code& ec)
+            {
+                std::vector<path_element_type> elements;
+
+                string_type buffer(alloc_);
+
+                end_input_ = path.data() + path.length();
+                p_ = path.data();
+
+
+                selector_separator_kind separator_kind = selector_separator_kind::bracket;
+
+                json_location_state state = json_location_state::start;
+
+                while (p_ < end_input_)
+                {
+                    switch (state)
+                    {
+                        case json_location_state::start: 
+                        {
+                            switch (*p_)
+                            {
+                                case ' ':case '\t':case '\r':case '\n':
+                                    advance_past_space_character();
+                                    break;
+                                case '$':
+                                case '@':
+                                {
+                                    state = json_location_state::relative_location;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                }
+                                default:
+                                {
+                                    ec = jsonpath_errc::expected_root_or_current_node;
+                                    return path_type{};
+                                }
+                            }
+                            break;
+                        }
+                        case json_location_state::relative_location: 
+                            switch (*p_)
+                            {
+                                case ' ':case '\t':case '\r':case '\n':
+                                    advance_past_space_character();
+                                    break;
+                                case '[':
+                                    separator_kind = selector_separator_kind::bracket;
+                                    state = json_location_state::selector;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '.':
+                                    separator_kind = selector_separator_kind::dot;
+                                    state = json_location_state::selector;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    ec = jsonpath_errc::expected_lbracket_or_dot;
+                                    return path_type();
+                            };
+                            break;
+                        case json_location_state::selector:
+                            switch (*p_)
+                            {
+                                case ' ':case '\t':case '\r':case '\n':
+                                    advance_past_space_character();
+                                    break;
+                                case '\'':
+                                    state = json_location_state::single_quoted_string;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '\"':
+                                    state = json_location_state::double_quoted_string;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                                    state = json_location_state::digit;
+                                    break;
+                                case '-':
+                                    ec = jsonpath_errc::expected_single_quote_or_digit;
+                                    return path_type();
+                                default:
+                                    if (separator_kind == selector_separator_kind::dot)
+                                    {
+                                        state = json_location_state::unquoted_string;
+                                    }
+                                    else
+                                    {
+                                        ec = jsonpath_errc::expected_single_quote_or_digit;
+                                        return path_type();
+                                    }
+                                    break;
+                            }
+                            break;
+                        case json_location_state::single_quoted_string:
+                            switch (*p_)
+                            {
+                                case '\'':
+                                    elements.emplace_back(buffer);
+                                    buffer.clear();
+                                    if (separator_kind == selector_separator_kind::bracket)
+                                    {
+                                        state = json_location_state::expect_rbracket;
+                                    }
+                                    else
+                                    {
+                                        state = json_location_state::relative_location;
+                                    }
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '\\':
+                                    state = json_location_state::quoted_string_escape_char;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    buffer.push_back(*p_);
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                            };
+                            break;
+                        case json_location_state::double_quoted_string:
+                            switch (*p_)
+                            {
+                                case '\"':
+                                    elements.emplace_back(buffer);
+                                    buffer.clear();
+                                    if (separator_kind == selector_separator_kind::bracket)
+                                    {
+                                        state = json_location_state::expect_rbracket;
+                                    }
+                                    else
+                                    {
+                                        state = json_location_state::relative_location;
+                                    }
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '\\':
+                                    state = json_location_state::quoted_string_escape_char;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    buffer.push_back(*p_);
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                            };
+                            break;
+                        case json_location_state::unquoted_string:
+                            switch (*p_)
+                            {
+                                case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
+                                case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
+                                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                                case '_':
+                                    buffer.push_back(*p_);
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                case '\\':
+                                    state = json_location_state::quoted_string_escape_char;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    if (typename std::make_unsigned<char_type>::type(*p_) > 127)
+                                    {
+                                        buffer.push_back(*p_);
+                                        ++p_;
+                                        ++column_;
+                                    }
+                                    else
+                                    {
+                                        elements.emplace_back(buffer);
+                                        buffer.clear();
+                                        advance_past_space_character();
+                                        state = json_location_state::relative_location;
+                                    }
+                                    break;
+                            };
+                            break;
+                        case json_location_state::expect_rbracket:
+                            switch (*p_)
+                            {
+                                case ' ':case '\t':case '\r':case '\n':
+                                    advance_past_space_character();
+                                    break;
+                                case ']':
+                                    state = json_location_state::relative_location;
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    ec = jsonpath_errc::expected_rbracket;
+                                    return path_type(alloc_);
+                            }
+                            break;
+
+                        case json_location_state::digit:
+                            switch(*p_)
+                            {
+                                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                                    buffer.push_back(*p_);
+                                    ++p_;
+                                    ++column_;
+                                    break;
+                                default:
+                                    std::size_t n{0};
+                                    auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                                    if (!r)
+                                    {
+                                        ec = jsonpath_errc::invalid_number;
+                                        return path_type(alloc_);
+                                    }
+                                    elements.emplace_back(n);
+                                    buffer.clear();
+                                    if (separator_kind == selector_separator_kind::bracket)
+                                    {
+                                        state = json_location_state::expect_rbracket;
+                                    }
+                                    else
+                                    {
+                                        state = json_location_state::relative_location;
+                                    }
+                                    break;
+                            }
+                            break;
+                        case json_location_state::quoted_string_escape_char:
+                            switch (*p_)
+                            {
+                                case '\"':
+                                    buffer.push_back('\"');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case '\'':
+                                    buffer.push_back('\'');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case '\\': 
+                                    buffer.push_back('\\');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case '/':
+                                    buffer.push_back('/');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 'b':
+                                    buffer.push_back('\b');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 'f':
+                                    buffer.push_back('\f');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 'n':
+                                    buffer.push_back('\n');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 'r':
+                                    buffer.push_back('\r');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 't':
+                                    buffer.push_back('\t');
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                case 'u':
+                                    ++p_;
+                                    ++column_;
+                                    state = json_location_state::single_quoted_string;
+                                    break;
+                                default:
+                                    ec = jsonpath_errc::illegal_escaped_character;
+                                    return path_type(alloc_);
+                            }
+                            break;
+                        default:
+                            ++p_;
+                            ++column_;
+                            break;
+                    }
+                }
+                if (state == json_location_state::unquoted_string)
+                {
+                    elements.emplace_back(buffer);
+                }
+                else if (state == json_location_state::digit)
+                {
+                    std::size_t n{ 0 };
+                    auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                    if (!r)
+                    {
+                        ec = jsonpath_errc::invalid_number;
+                        return path_type(alloc_);
+                    }
+                    elements.emplace_back(n);
+                }
+                else if (state != json_location_state::relative_location)
+                {
+                    ec = jsonpath_errc::unexpected_eof;
+                    return path_type();
+                }
+                return path_type(std::move(elements));
+            }
+
+            void advance_past_space_character()
+            {
+                switch (*p_)
+                {
+                    case ' ':case '\t':
+                        ++p_;
+                        ++column_;
+                        break;
+                    case '\r':
+                        if ((p_+1 < end_input_) && (*(p_+1) == '\n'))
+                        {
+                            ++p_;
+                        }
+                        ++line_;
+                        column_ = 1;
+                        ++p_;
+                        break;
+                    case '\n':
+                        ++line_;
+                        column_ = 1;
+                        ++p_;
+                        break;
+                    default:
+                        break;
+                }
+            }
+        };
+
+    } // namespace detail
+
+    template <typename CharT,typename Allocator = std::allocator<CharT>>
+    class basic_json_location
+    {
+    public:
+        using char_type = CharT;
+        using allocator_type = Allocator;
+        using string_view_type = jsoncons::basic_string_view<char_type, std::char_traits<char_type>>;
+        using value_type = basic_path_element<CharT,Allocator>;
+        using const_iterator = typename std::vector<value_type>::const_iterator;
+        using iterator = const_iterator;
+    private:
+        using path_element_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<value_type>;
+        std::vector<value_type,path_element_allocator_type> elements_;
+    public:
+
+        basic_json_location(const allocator_type& alloc=Allocator())
+            : elements_(alloc)
+        {
+        }
+
+        explicit basic_json_location(const basic_path_node<char_type>& path, const allocator_type& alloc=Allocator())
+            : elements_(alloc)
+        {
+            auto p_node = std::addressof(path);
+            while (p_node != nullptr)
+            {
+                switch (p_node->node_kind())
+                {
+                    case path_node_kind::root:
+                        break;
+                    case path_node_kind::name:
+                        elements_.emplace_back(p_node->name().data(), p_node->name().size());
+                        break;
+                    case path_node_kind::index:
+                        elements_.emplace_back(p_node->index());
+                        break;
+                }
+                p_node = p_node->parent();
+            }
+            std::reverse(elements_.begin(), elements_.end());
+        }
+
+        basic_json_location(const basic_json_location&) = default;
+
+        basic_json_location(basic_json_location&&) = default;
+
+        explicit basic_json_location(std::vector<value_type,path_element_allocator_type>&& elements)
+            : elements_(std::move(elements))
+        {
+        }
+        
+        ~basic_json_location() = default;
+
+        basic_json_location& operator=(const basic_json_location&) = default;
+
+        basic_json_location& operator=(basic_json_location&&) = default;
+
+        // Iterators
+
+        const_iterator begin() const
+        {
+            return elements_.begin();
+        }
+
+        const_iterator end() const
+        {
+            return elements_.end();
+        }
+
+        // Accessors
+
+        bool empty() const
+        {
+            return elements_.empty();
+        }
+
+        std::size_t size() const
+        {
+            return elements_.size();
+        }
+
+        const value_type& operator[](std::size_t index) const
+        {
+            return elements_[index];
+        }
+
+        int compare(const basic_json_location& other) const
+        {
+            if (this == &other)
+            {
+               return 0;
+            }
+
+            auto it1 = elements_.begin();
+            auto it2 = other.elements_.begin();
+            while (it1 != elements_.end() && it2 != other.elements_.end())
+            {
+                int diff = it1->compare(*it2);
+                if (diff != 0)
+                {
+                    return diff;
+                }
+                ++it1;
+                ++it2;
+            }
+            if (elements_.size() < other.elements_.size())
+            {
+                return -1;
+            }
+            if (elements_.size() > other.elements_.size())
+            {
+                return 1;
+            }
+            return 0;
+        }
+
+        // Modifiers
+
+        void clear()
+        {
+            elements_.clear();
+        }
+
+        basic_json_location& append(const string_view_type& s)
+        {
+            elements_.emplace_back(s.data(), s.size());
+            return *this;
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_integer<IntegerType>::value, basic_json_location&>::type
+            append(IntegerType val)
+        {
+            elements_.emplace_back(static_cast<std::size_t>(val));
+
+            return *this;
+        }
+
+        basic_json_location& operator/=(const string_view_type& s)
+        {
+            elements_.emplace_back(s.data(), s.size());
+            return *this;
+        }
+
+        template <typename IntegerType>
+        typename std::enable_if<extension_traits::is_integer<IntegerType>::value, basic_json_location&>::type
+            operator/=(IntegerType val)
+        {
+            elements_.emplace_back(static_cast<std::size_t>(val));
+
+            return *this;
+        }
+
+        friend bool operator==(const basic_json_location& lhs, const basic_json_location& rhs) 
+        {
+            return lhs.compare(rhs) == 0;
+        }
+
+        friend bool operator!=(const basic_json_location& lhs, const basic_json_location& rhs)
+        {
+            return !(lhs == rhs);
+        }
+
+        friend bool operator<(const basic_json_location& lhs, const basic_json_location& rhs) 
+        {
+            return lhs.compare(rhs) < 0;
+        }
+
+        static basic_json_location parse(const jsoncons::basic_string_view<char_type>& normalized_path)
+        {
+            jsonpath::detail::json_location_parser<char,std::allocator<char>> parser;
+
+            std::vector<value_type> location = parser.parse(normalized_path);
+            return basic_json_location(std::move(location));
+        }
+
+        static basic_json_location parse(const jsoncons::basic_string_view<char_type>& normalized_path, 
+            std::error_code ec)
+        {
+            jsonpath::detail::json_location_parser<char,std::allocator<char>> parser;
+
+            std::vector<value_type> location = parser.parse(normalized_path, ec);
+            if (ec)
+            {
+                return basic_json_location();
+            }
+            return basic_json_location(std::move(location));
+        }
+    };
+
+    template <typename Json>
+    std::size_t remove(Json& root, const basic_json_location<typename Json::char_type>& location)
+    {
+        std::size_t count = 0;
+
+        Json* p_current = std::addressof(root);
+
+        std::size_t last = location.size() == 0 ? 0 : location.size() - 1;
+        for (std::size_t i = 0; i < location.size(); ++i)
+        {
+            const auto& element = location[i];
+            if (element.has_name())
+            {
+                if (p_current->is_object())
+                {
+                    auto it = p_current->find(element.name());
+                    if (it != p_current->object_range().end())
+                    {
+                        if (i < last)
+                        {
+                            p_current = std::addressof((*it).value());
+                        }
+                        else
+                        {
+                            p_current->erase(it);
+                            count = 1;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else // if (element.has_index())
+            {
+                if (p_current->is_array() && element.index() < p_current->size())
+                {
+                    if (i < last)
+                    {
+                        p_current = std::addressof(p_current->at(element.index()));
+                    }
+                    else
+                    {
+                        p_current->erase(p_current->array_range().begin()+element.index());
+                        count = 1;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        return count;
+    }
+
+    template <typename Json>
+    std::pair<Json*,bool> get(Json& root, const basic_json_location<typename Json::char_type>& location)
+    {
+        Json* p_current = std::addressof(root);
+        bool found = false;
+
+        std::size_t last = location.size() == 0 ? 0 : location.size() - 1;
+        for (std::size_t i = 0; i < location.size(); ++i)
+        {
+            const auto& element = location[i];
+            if (element.has_name())
+            {
+                if (p_current->is_object())
+                {
+                    auto it = p_current->find(element.name());
+                    if (it != p_current->object_range().end())
+                    {
+                        p_current = std::addressof((*it).value());
+                        if (i == last)
+                        {
+                            found = true;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else // if (element.has_index())
+            {
+                if (p_current->is_array() && element.index() < p_current->size())
+                {
+                    p_current = std::addressof(p_current->at(element.index()));
+                    if (i == last)
+                    {
+                        found = true;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+        }
+        return std::make_pair(p_current,found);
+    }
+
+    template <typename CharT,typename Allocator = std::allocator<CharT>>
+    std::basic_string<CharT, std::char_traits<CharT>, Allocator> to_basic_string(const basic_json_location<CharT,Allocator>& location, 
+        const Allocator& alloc = Allocator())
+    {
+        std::basic_string<CharT, std::char_traits<CharT>, Allocator> buffer(alloc);
+
+        buffer.push_back('$');
+        for (const auto& element : location)
+        {
+            if (element.has_name())
+            {
+                buffer.push_back('[');
+                buffer.push_back('\'');
+                jsoncons::jsonpath::escape_string(element.name().data(), element.name().size(), buffer);
+                buffer.push_back('\'');
+                buffer.push_back(']');
+            }
+            else
+            {
+                buffer.push_back('[');
+                jsoncons::detail::from_integer(element.index(), buffer);
+                buffer.push_back(']');
+            }
+        }
+
+        return buffer;
+    }
+
+    template <typename Json>
+    std::pair<Json*,bool> replace(Json& root, const basic_json_location<typename Json::char_type>& location, const Json& value,
+        bool create_if_missing=false)
+    {
+        Json* p_current = std::addressof(root);
+        bool found = false;
+
+        std::size_t last = location.size() == 0 ? 0 : location.size() - 1;
+        for (std::size_t i = 0; i < location.size(); ++i)
+        {
+            const auto& element = location[i];
+            if (element.has_name() && p_current->is_object())
+            {
+                auto it = p_current->find(element.name());
+                if (it != p_current->object_range().end())
+                {
+                    p_current = std::addressof((*it).value());
+                    if (i == last)
+                    {
+                        *p_current = std::move(value);
+                        found = true;
+                    }
+                }
+                else
+                {
+                    if (create_if_missing)
+                    {
+                        if (i == last)
+                        {
+                            auto result = p_current->try_emplace(element.name(), value);
+                            p_current = std::addressof(result.first->value());
+                            found = true;
+                        }
+                        else
+                        {
+                            auto result = p_current->try_emplace(element.name(), Json{});
+                            p_current = std::addressof(result.first->value());
+                        }
+                    }
+                }
+            }
+            else if (element.has_index() && p_current->is_array())
+            {
+                if (element.index() < p_current->size())
+                {
+                    p_current = std::addressof(p_current->at(element.index()));
+                    if (i == last)
+                    {
+                        *p_current = value;
+                        found = true;
+                    }
+                }
+                else
+                {
+                    break;
+                }
+            }
+            else
+            {
+                break;
+            }
+        }
+        if (found)
+        {
+            return std::make_pair(p_current,true);
+        }
+        return std::make_pair(p_current, false);
+    }
+
+    using json_location = basic_json_location<char>;
+    using wjson_location = basic_json_location<wchar_t>;
+    using path_element = basic_path_element<char,std::allocator<char>>;
+    using wpath_element = basic_path_element<wchar_t,std::allocator<char>>;
+
+    inline
+    std::string to_string(const json_location& location)
+    {
+        return to_basic_string(location);
+    }
+
+    inline
+    std::wstring to_wstring(const wjson_location& location)
+    {
+        return to_basic_string(location);
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSON_LOCATION_HPP

--- a/velox/external/jsoncons/jsonpath/json_query.hpp
+++ b/velox/external/jsoncons/jsonpath/json_query.hpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSON_QUERY_HPP
+#define JSONCONS_EXT_JSONPATH_JSON_QUERY_HPP
+
+#include <type_traits>
+
+#include "velox/external/jsoncons/allocator_set.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+#include "velox/external/jsoncons/jsonpath/expression.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_expression.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_parser.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+
+    template <typename Json,typename JsonReference = const Json&>
+    struct legacy_jsonpath_traits
+    {
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using element_type = Json;
+        using value_type = typename std::remove_cv<Json>::type;
+        using reference = JsonReference;
+        using const_reference = const value_type&;
+        using pointer = typename std::conditional<std::is_const<typename std::remove_reference<reference>::type>::value,typename Json::const_pointer,typename Json::pointer>::type;
+        using allocator_type = typename value_type::allocator_type;
+        using evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, reference>;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using path_expression_type = jsoncons::jsonpath::detail::path_expression<value_type,reference>;
+        using path_pointer = const path_node_type*;
+    };
+     
+    template <typename Json>
+    Json json_query(const Json& root,
+                    const typename Json::string_view_type& path, 
+                    result_options options = result_options(),
+                    const custom_functions<Json>& functions = custom_functions<Json>())
+    {
+        auto expr = make_expression<Json>(path, functions);
+        return expr.evaluate(root, options);
+    }
+
+    template <typename Json,typename Callback>
+    typename std::enable_if<extension_traits::is_binary_function_object<Callback,const typename Json::string_type&,const Json&>::value,void>::type
+    json_query(const Json& root, 
+               const typename Json::string_view_type& path, 
+               Callback callback,
+               result_options options = result_options(),
+               const custom_functions<Json>& functions = custom_functions<Json>())
+    {
+        auto expr = make_expression<Json>(path, functions);
+        expr.evaluate(root, callback, options);
+    }
+
+    template <typename Json,typename TempAllocator >
+    Json json_query(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+        const Json& root, const typename Json::string_view_type& path, 
+        result_options options = result_options(),
+        const custom_functions<Json>& functions = custom_functions<Json>())
+    {
+        auto expr = make_expression<Json>(alloc_set, path, functions);
+        return expr.evaluate(root, options);
+    }
+
+    template <typename Json,typename Callback,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_binary_function_object<Callback,const typename Json::string_type&,const Json&>::value,void>::type
+    json_query(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+        const Json& root, const typename Json::string_view_type& path, 
+        Callback callback,
+        result_options options = result_options(),
+        const custom_functions<Json>& functions = custom_functions<Json>())
+    {
+        auto expr = make_expression<Json>(alloc_set, path, functions);
+        expr.evaluate(root, callback, options);
+    }
+
+    template <typename Json,typename T>
+    typename std::enable_if<is_json_type_traits_specialized<Json,T>::value,void>::type
+        json_replace(Json& root, const typename Json::string_view_type& path, T&& new_value,
+                     const custom_functions<Json>& funcs = custom_functions<Json>())
+    {
+        using jsonpath_traits_type = jsoncons::jsonpath::legacy_jsonpath_traits<Json, Json&>;
+
+        using value_type = typename jsonpath_traits_type::value_type;
+        using reference = typename jsonpath_traits_type::reference;
+        using evaluator_type = typename jsonpath_traits_type::evaluator_type;
+        using path_expression_type = typename jsonpath_traits_type::path_expression_type;
+        using path_node_type = typename jsonpath_traits_type::path_node_type;
+
+        auto resources = jsoncons::make_unique<jsoncons::jsonpath::detail::static_resources<value_type>>(funcs);
+        evaluator_type evaluator;
+        path_expression_type expr = evaluator.compile(*resources, path);
+
+        jsoncons::jsonpath::detail::eval_context<Json,reference> context;
+        auto callback = [&new_value](const path_node_type&, reference v)
+        {
+            v = std::forward<T>(new_value);
+        };
+
+        result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+        expr.evaluate(context, root, path_node_type{}, root, callback, options);
+    }
+
+    template <typename Json,typename T,typename TempAllocator >
+    typename std::enable_if<is_json_type_traits_specialized<Json,T>::value,void>::type
+        json_replace(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+            Json& root, const typename Json::string_view_type& path, T&& new_value,
+            const custom_functions<Json>& funcs = custom_functions<Json>())
+    {
+        using jsonpath_traits_type = jsoncons::jsonpath::legacy_jsonpath_traits<Json, Json&>;
+
+        using value_type = typename jsonpath_traits_type::value_type;
+        using reference = typename jsonpath_traits_type::reference;
+        using evaluator_type = typename jsonpath_traits_type::evaluator_type;
+        using path_expression_type = typename jsonpath_traits_type::path_expression_type;
+        using path_node_type = typename jsonpath_traits_type::path_node_type;
+
+        auto resources = jsoncons::make_unique<jsoncons::jsonpath::detail::static_resources<value_type>>(funcs, alloc_set.get_allocator());
+        evaluator_type evaluator{alloc_set.get_allocator()};
+        path_expression_type expr = evaluator.compile(*resources, path);
+
+        jsoncons::jsonpath::detail::eval_context<Json,reference> context{alloc_set.get_allocator()};
+        auto callback = [&new_value](const path_node_type&, reference v)
+        {
+            v = Json(std::forward<T>(new_value), semantic_tag::none);
+        };
+        result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+        expr.evaluate(context, root, path_node_type{}, root, callback, options);
+    }
+
+    template <typename Json,typename BinaryCallback>
+    typename std::enable_if<extension_traits::is_binary_function_object<BinaryCallback,const typename Json::string_type&,Json&>::value,void>::type
+    json_replace(Json& root, const typename Json::string_view_type& path , BinaryCallback callback, 
+                 const custom_functions<Json>& funcs = custom_functions<Json>())
+    {
+        using jsonpath_traits_type = jsoncons::jsonpath::legacy_jsonpath_traits<Json, Json&>;
+
+        using value_type = typename jsonpath_traits_type::value_type;
+        using reference = typename jsonpath_traits_type::reference;
+        using evaluator_type = typename jsonpath_traits_type::evaluator_type;
+        using path_expression_type = typename jsonpath_traits_type::path_expression_type;
+        using path_node_type = typename jsonpath_traits_type::path_node_type;
+
+        auto resources = jsoncons::make_unique<jsoncons::jsonpath::detail::static_resources<value_type>>(funcs);
+        evaluator_type evaluator;
+        path_expression_type expr = evaluator.compile(*resources, path);
+
+        jsoncons::jsonpath::detail::eval_context<Json,reference> context;
+
+        auto f = [&callback](const path_node_type& path, reference val)
+        {
+            callback(to_basic_string(path), val);
+        };
+        result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+        expr.evaluate(context, root, path_node_type{}, root, f, options);
+    }
+
+    template <typename Json,typename BinaryCallback,typename TempAllocator >
+    typename std::enable_if<extension_traits::is_binary_function_object<BinaryCallback,const typename Json::string_type&,Json&>::value,void>::type
+    json_replace(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+        Json& root, const typename Json::string_view_type& path , BinaryCallback callback, 
+        const custom_functions<Json>& funcs = custom_functions<Json>())
+    {
+        using jsonpath_traits_type = jsoncons::jsonpath::legacy_jsonpath_traits<Json, Json&>;
+
+        using value_type = typename jsonpath_traits_type::value_type;
+        using reference = typename jsonpath_traits_type::reference;
+        using evaluator_type = typename jsonpath_traits_type::evaluator_type;
+        using path_expression_type = typename jsonpath_traits_type::path_expression_type;
+        using path_node_type = typename jsonpath_traits_type::path_node_type;
+
+        auto resources = jsoncons::make_unique<jsoncons::jsonpath::detail::static_resources<value_type>>(funcs, alloc_set.get_allocator());
+        evaluator_type evaluator{alloc_set.get_allocator()};
+        path_expression_type expr = evaluator.compile(*resources, path);
+
+        jsoncons::jsonpath::detail::eval_context<Json,reference> context{alloc_set.get_allocator()};
+
+        auto f = [&callback](const path_node_type& path, reference val)
+        {
+            callback(to_basic_string(path), val);
+        };
+        result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+        expr.evaluate(context, root, path_node_type{}, root, f, options);
+    }
+
+    // Legacy replace function
+    template <typename Json,typename UnaryCallback>
+    typename std::enable_if<extension_traits::is_unary_function_object<UnaryCallback,Json>::value,void>::type
+    json_replace(Json& root, const typename Json::string_view_type& path , UnaryCallback callback)
+    {
+        using jsonpath_traits_type = jsoncons::jsonpath::legacy_jsonpath_traits<Json, Json&>;
+
+        using value_type = typename jsonpath_traits_type::value_type;
+        using reference = typename jsonpath_traits_type::reference;
+        using evaluator_type = typename jsonpath_traits_type::evaluator_type;
+        using path_expression_type = typename jsonpath_traits_type::path_expression_type;
+        using path_node_type = typename jsonpath_traits_type::path_node_type;
+
+        auto resources = jsoncons::make_unique<jsoncons::jsonpath::detail::static_resources<value_type>>();
+        evaluator_type evaluator;
+        path_expression_type expr = evaluator.compile(*resources, path);
+
+        jsoncons::jsonpath::detail::eval_context<Json,reference> context;
+        auto f = [callback](const path_node_type&, reference v)
+        {
+            v = callback(v);
+        };
+        result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+        expr.evaluate(context, root, path_node_type{}, root, f, options);
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSON_QUERY_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath.hpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_HPP
+
+#include "velox/external/jsoncons/jsonpath/flatten.hpp"
+#include "velox/external/jsoncons/jsonpath/json_location.hpp"
+#include "velox/external/jsoncons/jsonpath/json_query.hpp"
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath_error.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath_error.hpp
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_ERROR_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_ERROR_HPP
+
+#include <cstddef>
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+
+namespace facebook::velox::jsoncons { namespace jsonpath {
+
+    enum class jsonpath_errc 
+    {
+        success = 0,
+        expected_root_or_current_node,
+        expected_lbracket_or_dot,
+        expected_single_quote_or_digit,
+        expected_root_or_function,
+        expected_current_node,
+        expected_rparen,
+        expected_rbracket,
+        expected_separator,
+        expected_forward_slash,
+        expected_slice_start,
+        expected_slice_end,
+        expected_slice_step,
+        expected_bracket_specifier_or_union,
+        unexpected_operator,
+        invalid_function_name,
+        invalid_argument,
+        invalid_arity,
+        function_name_not_found,
+        parse_error_in_filter,
+        argument_parse_error,
+        unidentified_error,
+        unexpected_eof,
+        expected_colon_dot_left_bracket_comma_or_rbracket,
+        argument_to_unflatten_invalid,
+        invalid_flattened_key,
+        step_cannot_be_zero,
+        invalid_number,
+        illegal_escaped_character,
+        invalid_codepoint,
+        unknown_function,
+        invalid_type,
+        unbalanced_parentheses,
+        syntax_error,
+        expected_comparator,
+        expected_or,
+        expected_and,
+        expected_comma_or_rparen,
+        expected_comma_or_rbracket,
+        expected_relative_path,
+        unsupported_path
+    };
+
+    class jsonpath_error_category_impl
+       : public std::error_category
+    {
+    public:
+        const char* name() const noexcept override
+        {
+            return "jsoncons/jsonpath";
+        }
+        std::string message(int ev) const override
+        {
+            switch (static_cast<jsonpath_errc>(ev))
+            {
+                case jsonpath_errc::expected_root_or_current_node:
+                    return "Expected '$' or '@'";
+                case jsonpath_errc::expected_lbracket_or_dot:
+                    return "Expected '[' or '.'";
+                case jsonpath_errc::expected_single_quote_or_digit:
+                    return "Expected '\'' or digit";
+                case jsonpath_errc::expected_root_or_function:
+                    return "Expected '$' or function expression";
+                case jsonpath_errc::expected_current_node:
+                    return "Expected @";
+                case jsonpath_errc::expected_rbracket:
+                    return "Expected ]";
+                case jsonpath_errc::expected_rparen:
+                    return "Expected )";
+                case jsonpath_errc::expected_slice_start:
+                    return "Expected slice start";
+                case jsonpath_errc::expected_slice_end:
+                    return "Expected slice end";
+                case jsonpath_errc::expected_slice_step:
+                    return "Expected slice step";
+                case jsonpath_errc::expected_separator:
+                    return "Expected dot or left bracket separator";
+                case jsonpath_errc::expected_forward_slash:
+                    return "Invalid path filter, expected '/'";
+                case jsonpath_errc::expected_bracket_specifier_or_union:
+                    return "Expected index, single or double quoted name, expression, filter, absolute ('$') path or relative ('@') path";
+                case jsonpath_errc::invalid_function_name:
+                    return "Invalid function name";
+                case jsonpath_errc::invalid_argument:
+                    return "Invalid argument type";
+                case jsonpath_errc::invalid_arity:
+                    return "Incorrect number of arguments";
+                case jsonpath_errc::function_name_not_found:
+                    return "Function name not found";
+                case jsonpath_errc::parse_error_in_filter:
+                    return "Could not parse JSON expression in a JSONPath filter";
+                case jsonpath_errc::argument_parse_error:
+                    return "Could not parse JSON expression passed to JSONPath function";
+                case jsonpath_errc::unidentified_error:
+                    return "Unidentified error";
+                case jsonpath_errc::unexpected_eof:
+                    return "Unexpected EOF while parsing jsonpath expression";
+                case jsonpath_errc::expected_colon_dot_left_bracket_comma_or_rbracket:
+                    return "Expected ':', '.', '[', ',', or ']'";
+                case jsonpath_errc::argument_to_unflatten_invalid:
+                    return "Argument to unflatten must be an object";
+                case jsonpath_errc::invalid_flattened_key:
+                    return "Flattened key is invalid";
+                case jsonpath_errc::step_cannot_be_zero:
+                    return "Slice step cannot be zero";
+                case jsonpath_errc::invalid_number:
+                    return "Invalid number";
+                case jsonpath_errc::illegal_escaped_character:
+                    return "Illegal escaped character";
+                case jsonpath_errc::invalid_codepoint:
+                    return "Invalid codepoint";
+                case jsonpath_errc::unknown_function:
+                    return "Unknown function";
+                case jsonpath_errc::invalid_type:
+                    return "Invalid type";
+                case jsonpath_errc::unbalanced_parentheses:
+                    return "Unbalanced parentheses";
+                case jsonpath_errc::syntax_error:
+                    return "Syntax error";
+                case jsonpath_errc::expected_comparator:
+                    return "Expected comparator";
+                case jsonpath_errc::expected_or:
+                    return "Expected operator '||'";
+                case jsonpath_errc::expected_and:
+                    return "Expected operator '&&'";
+                case jsonpath_errc::expected_comma_or_rparen:
+                    return "Expected comma or right parenthesis";
+                case jsonpath_errc::expected_comma_or_rbracket:
+                    return "Expected comma or right bracket";
+                case jsonpath_errc::expected_relative_path:
+                    return "Expected unquoted string, or single or double quoted string, or index or '*'";
+                case jsonpath_errc::unsupported_path:
+                  return "Unsupported Json Path";
+                default:
+                    return "Unknown jsonpath parser error";
+            }
+        }
+    };
+
+    inline
+    const std::error_category& jsonpath_error_category()
+    {
+      static jsonpath_error_category_impl instance;
+      return instance;
+    }
+
+    inline 
+    std::error_code make_error_code(jsonpath_errc result)
+    {
+        return std::error_code(static_cast<int>(result),jsonpath_error_category());
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::jsonpath::jsonpath_errc> : public true_type
+    {
+    };
+} // namespace std
+
+namespace facebook::velox::jsoncons { namespace jsonpath {
+
+    class jsonpath_error : public std::system_error, public virtual json_exception
+    {
+        std::size_t line_number_{0};
+        std::size_t column_number_{0};
+        mutable std::string what_;
+    public:
+        jsonpath_error(std::error_code ec)
+            : std::system_error(ec)
+        {
+        }
+        jsonpath_error(std::error_code ec, const std::string& what_arg)
+            : std::system_error(ec, what_arg)
+        {
+        }
+        jsonpath_error(std::error_code ec, std::size_t position)
+            : std::system_error(ec), column_number_(position)
+        {
+        }
+        jsonpath_error(std::error_code ec, std::size_t line, std::size_t column)
+            : std::system_error(ec), line_number_(line), column_number_(column)
+        {
+        }
+        jsonpath_error(const jsonpath_error& other) = default;
+
+        jsonpath_error(jsonpath_error&& other) = default;
+        
+        ~jsonpath_error() override = default;
+
+        const char* what() const noexcept override
+        {
+            if (what_.empty())
+            {
+                JSONCONS_TRY
+                {
+                    what_.append(std::system_error::what());
+                    if (line_number_ != 0 && column_number_ != 0)
+                    {
+                        what_.append(" at line ");
+                        what_.append(std::to_string(line_number_));
+                        what_.append(" and column ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    else if (column_number_ != 0)
+                    {
+                        what_.append(" at position ");
+                        what_.append(std::to_string(column_number_));
+                    }
+                    return what_.c_str();
+                }
+                JSONCONS_CATCH(...)
+                {
+                    return std::system_error::what();
+                }
+            }
+            else
+            {
+                return what_.c_str();
+            }
+        }
+
+        std::size_t line() const noexcept
+        {
+            return line_number_;
+        }
+
+        std::size_t column() const noexcept
+        {
+            return column_number_;
+        }
+    };
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_ERROR_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath_expression.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath_expression.hpp
@@ -1,0 +1,275 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_EXPRESSION_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_EXPRESSION_HPP
+
+#include <algorithm> // std::reverse
+#include <cstddef>
+#include <memory>
+#include <system_error>
+#include <type_traits> // std::is_const
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/allocator_set.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+#include "velox/external/jsoncons/jsonpath/expression.hpp"
+#include "velox/external/jsoncons/jsonpath/json_location.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_parser.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+
+    template <typename Json,typename TempAllocator =std::allocator<char>>
+    class jsonpath_expression
+    {
+    public:
+        using allocator_type = typename jsonpath_traits<Json>::allocator_type;
+        using char_type = typename jsonpath_traits<Json>::char_type;
+        using string_type = typename jsonpath_traits<Json>::string_type;
+        using string_view_type = typename jsonpath_traits<Json>::string_view_type;
+        
+        using value_type = typename jsonpath_traits<Json>::value_type;
+        using reference = typename jsonpath_traits<Json>::reference;
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        
+        using static_resources_type = jsoncons::jsonpath::detail::static_resources<value_type>;
+        using path_expression_type = jsoncons::jsonpath::detail::path_expression<value_type,reference>;
+        using const_path_expression_type = jsoncons::jsonpath::detail::path_expression<value_type,const_reference>;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+    private:
+        allocator_type alloc_;
+        std::unique_ptr<static_resources_type> static_resources_;
+        const_path_expression_type const_expr_;
+        path_expression_type expr_;
+    public:
+        jsonpath_expression(const allocator_set<allocator_type,TempAllocator>& alloc_set,
+            std::unique_ptr<static_resources_type>&& resources,
+            const_path_expression_type&& const_expr, 
+            path_expression_type&& expr)
+            : alloc_(alloc_set.get_allocator()),
+              static_resources_(std::move(resources)), 
+              const_expr_(std::move(const_expr)),
+              expr_(std::move(expr))
+        {
+        }
+
+        jsonpath_expression(const jsonpath_expression&) = delete;
+        jsonpath_expression(jsonpath_expression&&) = default;
+
+        ~jsonpath_expression() = default;
+
+        jsonpath_expression& operator=(const jsonpath_expression&) = delete;
+        jsonpath_expression& operator=(jsonpath_expression&&) = default;
+
+        template <typename BinaryCallback>
+        typename std::enable_if<extension_traits::is_binary_function_object<BinaryCallback,const string_type&,const_reference>::value,void>::type
+        evaluate(const_reference root, BinaryCallback callback, result_options options = result_options()) const
+        {
+            jsoncons::jsonpath::detail::eval_context<Json,const_reference> context{alloc_};
+            auto f = [&callback](const path_node_type& path, const_reference val)
+            {
+                callback(to_basic_string(path), val);
+            };
+            const_expr_.evaluate(context, root, path_node_type{}, root, f, options | result_options::path);
+        }
+
+        value_type evaluate(const_reference root, result_options options = result_options()) const
+        {
+            if ((options & result_options::path) == result_options::path)
+            {
+                jsoncons::jsonpath::detail::eval_context<value_type, const_reference> context{ alloc_ };
+
+                value_type result(json_array_arg, semantic_tag::none, alloc_);
+                auto callback = [&result](const path_node_type& p, const_reference)
+                {
+                    result.emplace_back(to_basic_string(p));
+                };
+                const_expr_.evaluate(context, root, path_node_type{}, root, callback, options);
+                return result;
+            }
+            jsoncons::jsonpath::detail::eval_context<value_type, const_reference> context{ alloc_ };
+            return const_expr_.evaluate(context, root, path_node_type{}, root, options);
+        }
+
+        value_type select(const_reference root, result_options options = result_options()) const
+        {
+            if ((options & result_options::path) == result_options::path)
+            {
+                jsoncons::jsonpath::detail::eval_context<value_type, const_reference> context{ alloc_ };
+
+                value_type result(json_array_arg, semantic_tag::none, alloc_);
+                auto callback = [&result](const path_node_type& p, const_reference)
+                {
+                    result.emplace_back(to_basic_string(p));
+                };
+                const_expr_.evaluate(context, root, path_node_type{}, root, callback, options);
+                return result;
+            }
+            jsoncons::jsonpath::detail::eval_context<value_type, const_reference> context{ alloc_ };
+            return const_expr_.evaluate(context, root, path_node_type{}, root, options);
+        }
+
+        template <typename BinaryCallback>
+        typename std::enable_if<extension_traits::is_binary_function_object<BinaryCallback,const path_node_type&,const_reference>::value,void>::type
+        select(const_reference root, BinaryCallback callback, result_options options = result_options()) const
+        {
+            jsoncons::jsonpath::detail::eval_context<value_type,const_reference> context{alloc_};
+            const_expr_.evaluate(context, root, path_node_type{}, root, callback, options | result_options::path);
+        }
+
+        template <typename BinaryCallback>
+        typename std::enable_if<extension_traits::is_binary_function_object<BinaryCallback,const path_node_type&,value_type&>::value,void>::type
+        update(reference root, BinaryCallback callback) const
+        {
+            jsoncons::jsonpath::detail::eval_context<value_type,reference> context{alloc_};
+
+            result_options options = result_options::nodups | result_options::path | result_options::sort_descending;
+            expr_.evaluate(context, root, path_node_type{}, root, callback, options);
+        }
+
+        std::vector<basic_json_location<char_type>> select_paths(const_reference root, 
+            result_options options = result_options::nodups | result_options::sort) const
+        {
+            std::vector<basic_json_location<char_type>> result;
+
+            options = options | result_options::path;
+
+            auto callback = [&result](const path_node_type& path, const_reference)
+            {
+                result.emplace_back(path);
+            };
+
+            jsoncons::jsonpath::detail::eval_context<value_type,const_reference> context{alloc_};
+            const_expr_.evaluate(context, root, path_node_type{}, root, callback, options);
+
+            return result;
+        }
+    };
+
+    template <typename Json>
+    jsonpath_expression<Json> make_expression(const typename Json::string_view_type& path,
+        const jsoncons::jsonpath::custom_functions<typename jsonpath_traits<Json>::value_type>& funcs = jsoncons::jsonpath::custom_functions<typename jsonpath_traits<Json>::value_type>())
+    {
+        using value_type = typename jsonpath_traits<Json>::value_type;
+        using reference = typename jsonpath_traits<Json>::reference;
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        using static_resources_type = jsoncons::jsonpath::detail::static_resources<value_type>;
+        using evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, reference>;
+        using const_evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, const_reference>;
+
+        auto resources = jsoncons::make_unique<static_resources_type>(funcs);
+        const_evaluator_type const_evaluator;
+        auto const_expr = const_evaluator.compile(*resources, path);
+
+        evaluator_type evaluator;
+        auto expr = evaluator.compile(*resources, path);
+
+        return jsonpath_expression<Json>(jsoncons::combine_allocators(), 
+            std::move(resources), std::move(const_expr), std::move(expr));
+    }
+
+    template <typename Json>
+    jsonpath_expression<Json> make_expression(const typename Json::string_view_type& expr, std::error_code& ec)
+    {
+        return make_expression<Json>(jsoncons::combine_allocators(), expr, custom_functions<Json>(), ec);
+    }
+
+    template <typename Json,typename TempAllocator >
+    jsonpath_expression<Json> make_expression(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+        const typename Json::string_view_type& expr, std::error_code& ec)
+    {
+        return make_expression<Json>(alloc_set, expr, custom_functions<Json>(), ec);
+    }
+
+    template <typename Json,typename TempAllocator >
+    jsonpath_expression<Json> make_expression(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set, 
+        const typename Json::string_view_type& path, 
+        const custom_functions<Json>& funcs = custom_functions<Json>())
+    {
+        using value_type = typename jsonpath_traits<Json>::value_type;
+        using reference = typename jsonpath_traits<Json>::reference;
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        using static_resources_type = jsoncons::jsonpath::detail::static_resources<value_type>;
+        using evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, reference>;
+        using const_evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, const_reference>;
+
+        auto resources = jsoncons::make_unique<static_resources_type>(funcs,
+            alloc_set.get_allocator());
+        const_evaluator_type const_evaluator{alloc_set.get_allocator()};
+        auto const_expr = const_evaluator.compile(*resources, path);
+
+        evaluator_type evaluator{alloc_set.get_allocator()};
+        auto expr = evaluator.compile(*resources, path);
+
+        return jsonpath_expression<Json>(alloc_set, 
+            std::move(resources), std::move(const_expr), std::move(expr));
+    }
+
+    template <typename Json,typename TempAllocator >
+    jsonpath_expression<Json> make_expression(const allocator_set<typename Json::allocator_type,TempAllocator>& alloc_set,
+        const typename Json::string_view_type& path,
+        const jsoncons::jsonpath::custom_functions<typename jsonpath_traits<Json>::value_type>& funcs, std::error_code& ec)
+    {
+        using value_type = typename jsonpath_traits<Json>::value_type;
+        using reference = typename jsonpath_traits<Json>::reference;
+        using const_reference = typename jsonpath_traits<Json>::const_reference;
+        using static_resources_type = jsoncons::jsonpath::detail::static_resources<value_type>;
+        using evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, reference>;
+        using const_evaluator_type = typename jsoncons::jsonpath::detail::jsonpath_evaluator<value_type, const_reference>;
+
+        auto resources = jsoncons::make_unique<static_resources_type>(funcs);
+        const_evaluator_type const_evaluator{alloc_set.get_allocator()};
+        auto const_expr = const_evaluator.compile(*resources, path, ec);
+
+        evaluator_type evaluator{alloc_set.get_allocator()};
+        auto expr = evaluator.compile(*resources, path, ec);
+
+        return jsonpath_expression<Json>(alloc_set, 
+            std::move(resources), std::move(const_expr), std::move(expr));
+    }
+
+    template <typename Json>
+    std::size_t remove(Json& root, const jsoncons::basic_string_view<typename Json::char_type>& path_string)
+    {
+        std::size_t count = 0;
+
+        auto expr = jsonpath::make_expression<Json>(path_string);
+        std::vector<jsonpath::json_location> locations = expr.select_paths(root,
+            jsonpath::result_options::nodups | jsonpath::result_options::sort_descending);
+
+        for (const auto& location : locations)
+        {
+            std::size_t n = jsonpath::remove(root, location);
+            count += n;
+        }
+        return count;
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_EXPRESSION_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath_parser.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath_parser.hpp
@@ -1,0 +1,2618 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_PARSER_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_PARSER_HPP
+
+#include <algorithm> // std::reverse
+#include <cstddef>
+#include <cstdint>
+#include <regex>
+#include <system_error>
+#include <type_traits> // std::is_const
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/json_decoder.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+#include "velox/external/jsoncons/jsonpath/expression.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_error.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_selector.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+namespace detail {
+     
+    enum class path_state 
+    {
+        start,
+        root_or_current_node,
+        expect_function_expr,
+        relative_path,
+        relative_location,
+        parent_operator,
+        ancestor_depth,
+        filter_expression,
+        expression_rhs,
+        recursive_descent_or_expression_lhs,
+        path_or_literal_or_function,
+        json_text_or_function,
+        json_text_or_function_name,
+        json_text_string,
+        json_value,
+        json_text,
+        identifier_or_function_expr,
+        name_or_lbracket,
+        unquoted_string,
+        index_or_identifier,
+        anything,
+        number,
+        function_expression,
+        argument,
+        zero_or_one_arguments,
+        one_or_more_arguments,
+        identifier,
+        single_quoted_string,
+        double_quoted_string,
+        bracketed_unquoted_name_or_union,
+        union_expression,
+        identifier_or_union,
+        bracket_specifier_or_union,
+        bracketed_wildcard,
+        index_or_slice,
+        wildcard_or_union,
+        union_element,
+        index_or_slice_or_union_or_identifier,
+        integer,
+        digit,
+        slice_expression_stop,
+        slice_expression_step,
+        comma_or_rbracket,
+        expect_rparen,
+        expect_rbracket,
+        quoted_string_escape_char,
+        escape_u1, 
+        escape_u2, 
+        escape_u3, 
+        escape_u4, 
+        escape_expect_surrogate_pair1, 
+        escape_expect_surrogate_pair2, 
+        escape_u5, 
+        escape_u6, 
+        escape_u7, 
+        escape_u8,
+        expression,
+        comparator_expression,
+        eq_or_regex,
+        expect_regex,
+        regex,
+        regex_options,
+        regex_pattern,
+        cmp_lt_or_lte,
+        cmp_gt_or_gte,
+        cmp_ne,
+        expect_or,
+        expect_and
+    };
+
+    template <typename Json,
+             class JsonReference>
+    class jsonpath_evaluator : public ser_context
+    {
+    public:
+        using allocator_type = typename Json::allocator_type;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using path_value_pair_type = path_value_pair<Json,JsonReference>;
+        using value_type = Json;
+        using reference = JsonReference;
+        using pointer = typename path_value_pair_type::value_pointer;
+        using token_type = token<Json,JsonReference>;
+        using path_expression_type = path_expression<Json,JsonReference>;
+        using expression_type = expression<Json,JsonReference>;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+        using selector_type = jsonpath_selector<Json,JsonReference>;
+
+    private:
+
+        allocator_type alloc_;
+        std::size_t line_{1};
+        std::size_t column_{1};
+        const char_type* begin_input_;
+        const char_type* end_input_;
+        const char_type* p_;
+
+        using argument_type = std::vector<pointer>;
+        std::vector<argument_type> function_stack_;
+        std::vector<path_state> state_stack_;
+        std::vector<token_type> output_stack_;
+        std::vector<token_type> operator_stack_;
+
+    public:
+        jsonpath_evaluator(const allocator_type& alloc = allocator_type())
+            : alloc_(alloc), 
+              begin_input_(nullptr), end_input_(nullptr),
+              p_(nullptr)
+        {
+        }
+
+        jsonpath_evaluator(std::size_t line, std::size_t column, 
+            const allocator_type& alloc = allocator_type())
+            : alloc_(alloc), line_(line), column_(column),
+              begin_input_(nullptr), end_input_(nullptr),
+              p_(nullptr)
+        {
+        }
+
+        std::size_t line() const final
+        {
+            return line_;
+        }
+
+        std::size_t column() const final
+        {
+            return column_;
+        }
+
+        path_expression_type compile(static_resources<value_type>& resources, const string_view_type& path)
+        {
+            std::error_code ec;
+            auto result = compile(resources, path, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(jsonpath_error(ec, line_, column_));
+            }
+            return result;
+        }
+
+        path_expression_type compile(static_resources<value_type>& resources,
+                                     const string_view_type& path,
+                                     std::error_code& ec, bool throwOnUnSupportedPaths = true)
+        {
+          std::size_t selector_id = 0;
+
+          string_type buffer(alloc_);
+          string_type buffer2(alloc_);
+          uint32_t cp = 0;
+          uint32_t cp2 = 0;
+
+          begin_input_ = path.data();
+          end_input_ = path.data() + path.length();
+          p_ = begin_input_;
+
+          slice slic;
+          bool paths_required = false;
+          int ancestor_depth = 0;
+          bool absolute_start = true;
+          state_stack_.emplace_back(path_state::start);
+          while (p_ < end_input_ && !state_stack_.empty())
+          {
+            switch (state_stack_.back())
+            {
+              case path_state::start:
+              {
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '$':
+                  case '@':
+                  {
+                    if (throwOnUnSupportedPaths && *p_ == '@') {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.emplace_back(path_state::relative_location);
+                    ++p_;
+                    ++column_;
+                    absolute_start = false;
+                    break;
+                  }
+                  default:
+                  {
+                    state_stack_.emplace_back(path_state::relative_location);
+                    if(absolute_start){
+                      // Support special case to conform with jayway where it
+                      // prepends $. if not specified at the start to support
+                      // paths like '[0]' or 'key'
+                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                      state_stack_.emplace_back(path_state::recursive_descent_or_expression_lhs);
+                    } else {
+                      state_stack_.emplace_back(path_state::expect_function_expr);
+                      state_stack_.emplace_back(path_state::unquoted_string);
+                    }
+                    absolute_start = false;
+                    break;
+                  }
+                }
+                break;
+              }
+              case path_state::root_or_current_node:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '$':
+                    push_token(resources, token_type(root_node_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(root_selector<Json,JsonReference>(selector_id++))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '@':
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::syntax_error;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::recursive_descent_or_expression_lhs:
+                switch (*p_)
+                {
+                  case '.':
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(resources.new_selector(recursive_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::name_or_lbracket;
+                    break;
+                  case '[':
+                    // Add support for bracket after dot $.[<id>]
+                    state_stack_.back() =  path_state::bracket_specifier_or_union;
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    state_stack_.back() = path_state::relative_path;
+                    break;
+                }
+                break;
+              case path_state::name_or_lbracket:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '[': // [ can follow ..
+                    state_stack_.back() = path_state::bracket_specifier_or_union;
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    buffer.clear();
+                    state_stack_.back() = path_state::relative_path;
+                    break;
+                }
+                break;
+              case path_state::json_text:
+              {
+                //std::cout << "literal: " << buffer << "\n";
+                push_token(resources, token_type(literal_arg, Json(buffer,semantic_tag::none,alloc_)), ec);
+                if (ec) {return path_expression_type(alloc_);}
+                buffer.clear();
+                state_stack_.pop_back(); // json_value
+                break;
+              }
+              case path_state::path_or_literal_or_function:
+              {
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '$':
+                  case '@':
+                    if (throwOnUnSupportedPaths && *p_ == '@') {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    state_stack_.back() = path_state::relative_location;
+                    state_stack_.push_back(path_state::root_or_current_node);
+                    break;
+                  case '(':
+                  {
+                    ++p_;
+                    ++column_;
+                    push_token(resources, lparen_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::expect_rparen;
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    break;
+                  }
+                  case '\'':
+                    state_stack_.back() = path_state::json_text;
+                    state_stack_.emplace_back(path_state::single_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    state_stack_.back() = path_state::json_text;
+                    state_stack_.emplace_back(path_state::double_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '!':
+                  {
+                    ++p_;
+                    ++column_;
+                    push_token(resources, token_type(resources.get_unary_not()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    break;
+                  }
+                  case '-':
+                  {
+                    ++p_;
+                    ++column_;
+                    push_token(resources, token_type(resources.get_unary_minus()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    break;
+                  }
+                  case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                  {
+                    state_stack_.back() = path_state::json_value;
+                    state_stack_.emplace_back(path_state::number);
+                    break;
+                  }
+                  default:
+                  {
+                    state_stack_.back() = path_state::json_text_or_function_name;
+                    break;
+                  }
+                }
+                break;
+              }
+              case path_state::json_text_or_function:
+              {
+                switch(*p_)
+                {
+                  case '(':
+                  {
+                    auto f = resources.get_function(buffer, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    buffer.clear();
+                    push_token(resources, current_node_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    push_token(resources, token_type(f), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::function_expression;
+                    state_stack_.emplace_back(path_state::zero_or_one_arguments);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                  {
+                    json_decoder<Json> decoder(alloc_);
+                    basic_json_parser<char_type> parser;
+                    parser.update(buffer.data(),buffer.size());
+                    parser.parse_some(decoder, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    parser.finish_parse(decoder, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(literal_arg, decoder.get_result()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    break;
+                  }
+                }
+                break;
+              }
+              case path_state::json_value:
+              {
+                json_decoder<Json> decoder(alloc_);
+                basic_json_parser<char_type> parser;
+                parser.update(buffer.data(),buffer.size());
+                parser.parse_some(decoder, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                parser.finish_parse(decoder, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                push_token(resources, token_type(literal_arg, decoder.get_result()), ec);
+                if (ec) {return path_expression_type(alloc_);}
+                buffer.clear();
+                state_stack_.pop_back();
+                break;
+              }
+              case path_state::json_text_or_function_name:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '{':
+                  case '[':
+                  {
+                    json_decoder<Json> decoder(alloc_);
+                    basic_json_parser<char_type> parser;
+                    parser.update(p_,end_input_ - p_);
+                    parser.parse_some(decoder, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    parser.finish_parse(decoder, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(literal_arg, decoder.get_result()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    p_ = parser.current();
+                    column_ = column_ + parser.column() - 1;
+                    break;
+                  }
+                  case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                    state_stack_.back() = path_state::json_text_or_function;
+                    state_stack_.emplace_back(path_state::number);
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    state_stack_.back() = path_state::json_text_or_function;
+                    state_stack_.emplace_back(path_state::json_text_string);
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    state_stack_.back() = path_state::json_text_or_function;
+                    state_stack_.emplace_back(path_state::unquoted_string);
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                };
+                break;
+              case path_state::number:
+                switch (*p_)
+                {
+                  case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                  case 'e':case 'E':case '.':
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    state_stack_.pop_back(); // number
+                    break;
+                };
+                break;
+              case path_state::json_text_string:
+                switch (*p_)
+                {
+                  case '\\':
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    if (p_ == end_input_)
+                    {
+                      ec = jsonpath_errc::unexpected_eof;
+                      return path_expression_type(alloc_);
+                    }
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    buffer.push_back(*p_);
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                };
+                break;
+              case path_state::relative_path:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '*':
+                    push_token(resources, token_type(resources.new_selector(wildcard_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\'':
+                    state_stack_.back() = path_state::identifier;
+                    state_stack_.emplace_back(path_state::single_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    state_stack_.back() = path_state::identifier;
+                    state_stack_.emplace_back(path_state::double_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '[':
+                  case '.':
+                    ec = jsonpath_errc::expected_relative_path;
+                    return path_expression_type(alloc_);
+                  default:
+                    buffer.clear();
+                    state_stack_.back() = path_state::identifier_or_function_expr;
+                    state_stack_.emplace_back(path_state::unquoted_string);
+                    break;
+                }
+                break;
+              case path_state::identifier_or_function_expr:
+              {
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '(':
+                  {
+                    auto f = resources.get_function(buffer, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    buffer.clear();
+                    push_token(resources, current_node_arg, ec);
+                    push_token(resources, token_type(f), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::function_expression;
+                    state_stack_.emplace_back(path_state::zero_or_one_arguments);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                  {
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    break;
+                  }
+                }
+                break;
+              }
+              case path_state::expect_function_expr:
+              {
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '(':
+                  {
+                    auto f = resources.get_function(buffer, ec);
+                    if (ec)
+                    {
+                      return path_expression_type(alloc_);
+                    }
+                    buffer.clear();
+                    push_token(resources, current_node_arg, ec);
+                    push_token(resources, token_type(f), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::function_expression;
+                    state_stack_.emplace_back(path_state::zero_or_one_arguments);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                  {
+                    ec = jsonpath_errc::expected_root_or_function;
+                    return path_expression_type(alloc_);
+                  }
+                }
+                break;
+              }
+              case path_state::function_expression:
+              {
+
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                    push_token(resources, token_type(current_node_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    push_token(resources, token_type(begin_expression_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.emplace_back(path_state::argument);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ')':
+                  {
+                    push_token(resources, token_type(end_function_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::syntax_error;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::zero_or_one_arguments:
+              {
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ')':
+                    state_stack_.pop_back();
+                    break;
+                  default:
+                    push_token(resources, token_type(begin_expression_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::one_or_more_arguments;
+                    state_stack_.emplace_back(path_state::argument);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    break;
+                }
+                break;
+              }
+              case path_state::one_or_more_arguments:
+              {
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ')':
+                    state_stack_.pop_back();
+                    break;
+                  case ',':
+                    push_token(resources, token_type(begin_expression_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.emplace_back(path_state::argument);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                }
+                break;
+              }
+              case path_state::argument:
+              {
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                  case ')':
+                  {
+                    push_token(resources, token_type(end_argument_expression_arg), ec);
+                    push_token(resources, argument_arg, ec);
+                    //push_token(resources, argument_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::expected_comma_or_rparen;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::index_or_identifier:
+                // Does not support (:) or (,) as its only used after a bracket start ([)
+                switch (*p_)
+                {
+                  case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
+                  case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
+                  case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                  case '_':case '-':
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    if (typename std::make_unsigned<char_type>::type(*p_) > 127)
+                    {
+                      buffer.push_back(*p_);
+                      ++p_;
+                      ++column_;
+                    }
+                    else
+                    {
+                      state_stack_.pop_back(); // unquoted_string
+                    }
+                    break;
+                };
+                break;
+              case path_state::unquoted_string:
+                switch (*p_)
+                {
+                  case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
+                  case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
+                  case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                  case '_':case '-':case ':':case ',':
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    if (typename std::make_unsigned<char_type>::type(*p_) > 127)
+                    {
+                      buffer.push_back(*p_);
+                      ++p_;
+                      ++column_;
+                    }
+                    else
+                    {
+                      state_stack_.pop_back(); // unquoted_string
+                    }
+                    break;
+                };
+                break;
+              case path_state::relative_location:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '.':
+                    state_stack_.emplace_back(path_state::recursive_descent_or_expression_lhs);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '[':
+                    state_stack_.emplace_back(path_state::bracket_specifier_or_union);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '^':
+                    ancestor_depth = 0;
+                    state_stack_.emplace_back(path_state::parent_operator);
+                    state_stack_.emplace_back(path_state::ancestor_depth);
+                    break;
+                  default:
+                    state_stack_.pop_back();
+                    break;
+                };
+                break;
+              case path_state::parent_operator:
+              {
+                push_token(resources, token_type(resources.new_selector(parent_node_selector<Json,JsonReference>(ancestor_depth))), ec);
+                paths_required = true;
+                ancestor_depth = 0;
+                ++p_;
+                ++column_;
+                state_stack_.pop_back();
+                break;
+              }
+              case path_state::ancestor_depth:
+              {
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '^':
+                  {
+                    ++ancestor_depth;
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                  {
+                    state_stack_.pop_back();
+                    break;
+                  }
+                }
+                break;
+              }
+              case path_state::expression_rhs:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '.':
+                    state_stack_.emplace_back(path_state::recursive_descent_or_expression_lhs);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '[':
+                    state_stack_.emplace_back(path_state::bracket_specifier_or_union);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ')':
+                  {
+                    state_stack_.pop_back();
+                    break;
+                  }
+                  case '|':
+                    ++p_;
+                    ++column_;
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    state_stack_.emplace_back(path_state::expect_or);
+                    break;
+                  case '&':
+                    ++p_;
+                    ++column_;
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    state_stack_.emplace_back(path_state::expect_and);
+                    break;
+                  case '<':
+                  case '>':
+                  {
+                    state_stack_.emplace_back(path_state::comparator_expression);
+                    break;
+                  }
+                  case '=':
+                  {
+                    state_stack_.emplace_back(path_state::eq_or_regex);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '!':
+                  {
+                    ++p_;
+                    ++column_;
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    state_stack_.emplace_back(path_state::cmp_ne);
+                    break;
+                  }
+                  case '+':
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    push_token(resources, token_type(resources.get_plus_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '-':
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    push_token(resources, token_type(resources.get_minus_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '*':
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    push_token(resources, token_type(resources.get_mult_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '/':
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    push_token(resources, token_type(resources.get_div_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '%':
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    push_token(resources, token_type(resources.get_modulus_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ']':
+                  case ',':
+                    state_stack_.pop_back();
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_separator;
+                    return path_expression_type(alloc_);
+                };
+                break;
+              case path_state::expect_or:
+              {
+                switch (*p_)
+                {
+                  case '|':
+                    push_token(resources, token_type(resources.get_or_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_or;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::expect_and:
+              {
+                switch(*p_)
+                {
+                  case '&':
+                    push_token(resources, token_type(resources.get_and_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back(); // expect_and
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_and;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::comparator_expression:
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '<':
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::path_or_literal_or_function;
+                    state_stack_.emplace_back(path_state::cmp_lt_or_lte);
+                    break;
+                  case '>':
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::path_or_literal_or_function;
+                    state_stack_.emplace_back(path_state::cmp_gt_or_gte);
+                    break;
+                  default:
+                    if (state_stack_.size() > 1)
+                    {
+                      state_stack_.pop_back();
+                    }
+                    else
+                    {
+                      ec = jsonpath_errc::syntax_error;
+                      return path_expression_type(alloc_);
+                    }
+                    break;
+                }
+                break;
+              case path_state::eq_or_regex:
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '=':
+                  {
+                    push_token(resources, token_type(resources.get_eq_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::path_or_literal_or_function;
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '~':
+                  {
+                    ++p_;
+                    ++column_;
+                    state_stack_.emplace_back(path_state::expect_regex);
+                    break;
+                  }
+                  default:
+                    if (state_stack_.size() > 1)
+                    {
+                      state_stack_.pop_back();
+                    }
+                    else
+                    {
+                      ec = jsonpath_errc::syntax_error;
+                      return path_expression_type(alloc_);
+                    }
+                    break;
+                }
+                break;
+              case path_state::expect_regex:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '/':
+                    state_stack_.back() = path_state::regex;
+                    state_stack_.emplace_back(path_state::regex_options);
+                    state_stack_.emplace_back(path_state::regex_pattern);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_forward_slash;
+                    return path_expression_type(alloc_);
+                };
+                break;
+              case path_state::regex:
+              {
+                std::regex::flag_type options = std::regex_constants::ECMAScript;
+                if (buffer2.find('i') != string_type::npos)
+                {
+                  options |= std::regex_constants::icase;
+                }
+                std::basic_regex<char_type> pattern(buffer, options);
+                push_token(resources, resources.get_regex_operator(std::move(pattern)), ec);
+                if (ec) {return path_expression_type(alloc_);}
+                buffer.clear();
+                buffer2.clear();
+                state_stack_.pop_back();
+                break;
+              }
+              case path_state::regex_pattern:
+              {
+                switch (*p_)
+                {
+                  case '/':
+                  {
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                  }
+                  break;
+
+                  default:
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                }
+                break;
+              }
+              case path_state::regex_options:
+              {
+                if (*p_ == 'i')
+                {
+                  buffer2.push_back(*p_);
+                  ++p_;
+                  ++column_;
+                }
+                else
+                {
+                  state_stack_.pop_back();
+                }
+                break;
+              }
+              case path_state::cmp_lt_or_lte:
+              {
+                switch(*p_)
+                {
+                  case '=':
+                    push_token(resources, token_type(resources.get_lte_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    push_token(resources, token_type(resources.get_lt_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    break;
+                }
+                break;
+              }
+              case path_state::cmp_gt_or_gte:
+              {
+                switch(*p_)
+                {
+                  case '=':
+                    push_token(resources, token_type(resources.get_gte_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    //std::cout << "Parse: gt_operator\n";
+                    push_token(resources, token_type(resources.get_gt_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    break;
+                }
+                break;
+              }
+              case path_state::cmp_ne:
+              {
+                switch(*p_)
+                {
+                  case '=':
+                    push_token(resources, token_type(resources.get_ne_operator()), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_comparator;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::identifier:
+                push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                if (ec) {return path_expression_type(alloc_);}
+                buffer.clear();
+                state_stack_.pop_back();
+                break;
+              case path_state::single_quoted_string:
+                switch (*p_)
+                {
+                  case '\'':
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\\':
+                    state_stack_.emplace_back(path_state::quoted_string_escape_char);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                };
+                break;
+              case path_state::double_quoted_string:
+                switch (*p_)
+                {
+                  case '\"':
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\\':
+                    state_stack_.emplace_back(path_state::quoted_string_escape_char);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                };
+                break;
+              case path_state::comma_or_rbracket:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                    state_stack_.back() = path_state::bracket_specifier_or_union;
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ']':
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_comma_or_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::expect_rbracket:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::expect_rparen:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ')':
+                    ++p_;
+                    ++column_;
+                    push_token(resources, rparen_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::expression_rhs;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rparen;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::bracket_specifier_or_union:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '(':
+                  {
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(begin_expression_arg), ec);
+                    push_token(resources, lparen_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::expression);
+                    state_stack_.emplace_back(path_state::expect_rparen);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '?':
+                  {
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(begin_filter_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::filter_expression);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '*':
+                    state_stack_.back() = path_state::wildcard_or_union;
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\'':
+                    state_stack_.back() = path_state::identifier_or_union;
+                    state_stack_.push_back(path_state::single_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    state_stack_.back() = path_state::identifier_or_union;
+                    state_stack_.push_back(path_state::double_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ':': // slice_expression
+                    state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
+                    break;
+                  case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
+                  case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
+                  case '_':case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                    // Add support for unquoted identifier after bracket $[<identifier>] that can also start with a number.
+                    state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
+                    state_stack_.emplace_back(path_state::index_or_identifier);
+                    break;
+                  case '$':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, root_node_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::relative_location);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '@':
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::relative_location);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    if (typename std::make_unsigned<char_type>::type(*p_) > 127)
+                    {
+                      // Add support for unquoted identifier after bracket $[<identifier>]
+                      state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
+                      state_stack_.push_back(path_state::index_or_identifier);
+                    } else {
+                      ec = jsonpath_errc::expected_bracket_specifier_or_union;
+                      return path_expression_type(alloc_);
+                    }
+                }
+                break;
+              case path_state::union_element:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ':': // slice_expression
+                    state_stack_.back() = path_state::index_or_slice;
+                    break;
+                  case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                    state_stack_.back() = path_state::index_or_slice;
+                    state_stack_.emplace_back(path_state::integer);
+                    break;
+                  case '(':
+                  {
+                    push_token(resources, token_type(begin_expression_arg), ec);
+                    push_token(resources, lparen_arg, ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::expression;
+                    state_stack_.emplace_back(path_state::expect_rparen);
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '?':
+                  {
+                    push_token(resources, token_type(begin_filter_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::filter_expression;
+                    state_stack_.emplace_back(path_state::expression_rhs);
+                    state_stack_.emplace_back(path_state::path_or_literal_or_function);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case '*':
+                    push_token(resources, token_type(resources.new_selector(wildcard_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::relative_location;
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '$':
+                    push_token(resources, token_type(root_node_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(root_selector<Json,JsonReference>(selector_id++))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::relative_location;
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '@':
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::relative_location;
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\'':
+                    state_stack_.back() = path_state::identifier;
+                    state_stack_.push_back(path_state::single_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '\"':
+                    state_stack_.back() = path_state::identifier;
+                    state_stack_.push_back(path_state::double_quoted_string);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_bracket_specifier_or_union;
+                    return path_expression_type(alloc_);
+                }
+                break;
+
+              case path_state::integer:
+                switch(*p_)
+                {
+                  case '-':
+                    buffer.push_back(*p_);
+                    state_stack_.back() = path_state::digit;
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    state_stack_.back() = path_state::digit;
+                    break;
+                }
+                break;
+              case path_state::digit:
+                switch(*p_)
+                {
+                  case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    state_stack_.pop_back(); // digit
+                    break;
+                }
+                break;
+              case path_state::index_or_slice_or_union_or_identifier:
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                  {
+                    if (buffer.empty())
+                    {
+                      ec = jsonpath_errc::invalid_number;
+                      return path_expression_type(alloc_);
+                    }
+                    int64_t n{0};
+                    auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                    if (!r)
+                    {
+                        push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    }
+                    else
+                    {
+                        push_token(resources, token_type(resources.new_selector(index_selector<Json,JsonReference>(n))), ec);
+                    }
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back(); // index_or_slice_or_union_or_identifier
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case ',':
+                  {
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    if (buffer.empty())
+                    {
+                      ec = jsonpath_errc::invalid_number;
+                      return path_expression_type(alloc_);
+                    }
+
+                    int64_t n{0};
+                    auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                    if (!r)
+                    {
+                      ec = jsonpath_errc::invalid_number;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(resources.new_selector(index_selector<Json,JsonReference>(n))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+
+                    buffer.clear();
+
+                    push_token(resources, token_type(separator_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::union_element);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  case ':':
+                  {
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    if (!buffer.empty())
+                    {
+                      int64_t n{0};
+                      auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                      if (!r)
+                      {
+                        ec = jsonpath_errc::invalid_number;
+                        return path_expression_type(alloc_);
+                      }
+                      slic.start_ = n;
+                      buffer.clear();
+                    }
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::slice_expression_stop);
+                    state_stack_.emplace_back(path_state::integer);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::slice_expression_stop:
+              {
+                if (throwOnUnSupportedPaths) {
+                  ec = jsonpath_errc::unsupported_path;
+                  return path_expression_type(alloc_);
+                }
+                if (!buffer.empty())
+                {
+                  int64_t n{0};
+                  auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                  if (!r)
+                  {
+                    ec = jsonpath_errc::invalid_number;
+                    return path_expression_type(alloc_);
+                  }
+                  slic.stop_ = jsoncons::optional<int64_t>(n);
+                  buffer.clear();
+                }
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                  case ',':
+                    push_token(resources, token_type(resources.new_selector(slice_selector<Json,JsonReference>(slic))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    slic = slice{};
+                    state_stack_.pop_back(); // bracket_specifier2
+                    break;
+                  case ':':
+                    state_stack_.back() = path_state::slice_expression_step;
+                    state_stack_.emplace_back(path_state::integer);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::slice_expression_step:
+              {
+                if (throwOnUnSupportedPaths) {
+                  ec = jsonpath_errc::unsupported_path;
+                  return path_expression_type(alloc_);
+                }
+                if (!buffer.empty())
+                {
+                  int64_t n{0};
+                  auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                  if (!r)
+                  {
+                    ec = jsonpath_errc::invalid_number;
+                    return path_expression_type(alloc_);
+                  }
+                  if (n == 0)
+                  {
+                    ec = jsonpath_errc::step_cannot_be_zero;
+                    return path_expression_type(alloc_);
+                  }
+                  slic.step_ = n;
+                  buffer.clear();
+                }
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                  case ',':
+                    push_token(resources, token_type(resources.new_selector(slice_selector<Json,JsonReference>(slic))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    slic = slice{};
+                    state_stack_.pop_back(); // slice_expression_step
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+
+              case path_state::bracketed_unquoted_name_or_union:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '.':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::relative_path);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '[':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::relative_path);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ',':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    push_token(resources, token_type(separator_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::relative_path);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    buffer.push_back(*p_);
+                    ++p_;
+                    ++column_;
+                    break;
+                }
+                break;
+              case path_state::union_expression:
+              {
+                if (throwOnUnSupportedPaths) {
+                  ec = jsonpath_errc::unsupported_path;
+                  return path_expression_type(alloc_);
+                }
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '.':
+                    state_stack_.emplace_back(path_state::relative_path);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case '[':
+                    state_stack_.emplace_back(path_state::bracket_specifier_or_union);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ',':
+                    push_token(resources, token_type(separator_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.emplace_back(path_state::union_element);
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ']':
+                    push_token(resources, token_type(end_union_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::identifier_or_union:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ',':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                    push_token(resources, token_type(separator_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::union_element);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::bracketed_wildcard:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case '[':
+                  case ']':
+                  case ',':
+                  case '.':
+                    push_token(resources, token_type(resources.new_selector(wildcard_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::index_or_slice:
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                  case ']':
+                  {
+                    if (buffer.empty())
+                    {
+                      ec = jsonpath_errc::invalid_number;
+                      return path_expression_type(alloc_);
+                    }
+
+                    int64_t n{0};
+                    auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                    if (!r)
+                    {
+                      ec = jsonpath_errc::invalid_number;
+                      return path_expression_type(alloc_);
+                    }
+                    push_token(resources, token_type(resources.new_selector(index_selector<Json,JsonReference>(n))), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+
+                    buffer.clear();
+
+                    state_stack_.pop_back(); // bracket_specifier
+                    break;
+                  }
+                  case ':': {
+                    if (throwOnUnSupportedPaths) {
+                      ec = jsonpath_errc::unsupported_path;
+                      return path_expression_type(alloc_);
+                    }
+                    if (!buffer.empty()) {
+                      int64_t n{0};
+                      auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                      if (!r) {
+                        ec = jsonpath_errc::invalid_number;
+                        return path_expression_type(alloc_);
+                      }
+                      slic.start_ = n;
+                      buffer.clear();
+                    }
+                    state_stack_.back() = path_state::slice_expression_stop;
+                    state_stack_.emplace_back(path_state::integer);
+                    ++p_;
+                    ++column_;
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::wildcard_or_union:
+                switch (*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ']':
+                    push_token(resources, token_type(resources.new_selector(wildcard_selector<Json,JsonReference>())), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.pop_back();
+                    ++p_;
+                    ++column_;
+                    break;
+                  case ',':
+                    push_token(resources, token_type(begin_union_arg), ec);
+                    push_token(resources, token_type(resources.new_selector(wildcard_selector<Json,JsonReference>())), ec);
+                    push_token(resources, token_type(separator_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    buffer.clear();
+                    state_stack_.back() = path_state::union_expression; // union
+                    state_stack_.emplace_back(path_state::union_element);
+                    ++p_;
+                    ++column_;
+                    break;
+                  default:
+                    ec = jsonpath_errc::expected_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::quoted_string_escape_char:
+                switch (*p_)
+                {
+                  case '\"':
+                    buffer.push_back('\"');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case '\'':
+                    buffer.push_back('\'');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case '\\':
+                    buffer.push_back('\\');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case '/':
+                    buffer.push_back('/');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 'b':
+                    buffer.push_back('\b');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 'f':
+                    buffer.push_back('\f');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 'n':
+                    buffer.push_back('\n');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 'r':
+                    buffer.push_back('\r');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 't':
+                    buffer.push_back('\t');
+                    ++p_;
+                    ++column_;
+                    state_stack_.pop_back();
+                    break;
+                  case 'u':
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::escape_u1;
+                    break;
+                  default:
+                    ec = jsonpath_errc::illegal_escaped_character;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::escape_u1:
+                cp = append_to_codepoint(0, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u2;
+                break;
+              case path_state::escape_u2:
+                cp = append_to_codepoint(cp, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u3;
+                break;
+              case path_state::escape_u3:
+                cp = append_to_codepoint(cp, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u4;
+                break;
+              case path_state::escape_u4:
+                cp = append_to_codepoint(cp, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                if (unicode_traits::is_high_surrogate(cp))
+                {
+                  ++p_;
+                  ++column_;
+                  state_stack_.back() = path_state::escape_expect_surrogate_pair1;
+                }
+                else
+                {
+                  unicode_traits::convert(&cp, 1, buffer);
+                  ++p_;
+                  ++column_;
+                  state_stack_.pop_back();
+                }
+                break;
+              case path_state::escape_expect_surrogate_pair1:
+                switch (*p_)
+                {
+                  case '\\':
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::escape_expect_surrogate_pair2;
+                    break;
+                  default:
+                    ec = jsonpath_errc::invalid_codepoint;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::escape_expect_surrogate_pair2:
+                switch (*p_)
+                {
+                  case 'u':
+                    ++p_;
+                    ++column_;
+                    state_stack_.back() = path_state::escape_u5;
+                    break;
+                  default:
+                    ec = jsonpath_errc::invalid_codepoint;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              case path_state::escape_u5:
+                cp2 = append_to_codepoint(0, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u6;
+                break;
+              case path_state::escape_u6:
+                cp2 = append_to_codepoint(cp2, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u7;
+                break;
+              case path_state::escape_u7:
+                cp2 = append_to_codepoint(cp2, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                ++p_;
+                ++column_;
+                state_stack_.back() = path_state::escape_u8;
+                break;
+              case path_state::escape_u8:
+              {
+                cp2 = append_to_codepoint(cp2, *p_, ec);
+                if (ec)
+                {
+                  return path_expression_type(alloc_);
+                }
+                uint32_t codepoint = 0x10000 + ((cp & 0x3FF) << 10) + (cp2 & 0x3FF);
+                unicode_traits::convert(&codepoint, 1, buffer);
+                state_stack_.pop_back();
+                ++p_;
+                ++column_;
+                break;
+              }
+              case path_state::filter_expression:
+              {
+                if (throwOnUnSupportedPaths) {
+                  ec = jsonpath_errc::unsupported_path;
+                  return path_expression_type(alloc_);
+                }
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                  case ']':
+                  {
+                    push_token(resources, token_type(end_filter_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::expected_comma_or_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              case path_state::expression:
+              {
+                if (throwOnUnSupportedPaths) {
+                  ec = jsonpath_errc::unsupported_path;
+                  return path_expression_type(alloc_);
+                }
+                switch(*p_)
+                {
+                  case ' ':case '\t':case '\r':case '\n':
+                    advance_past_space_character();
+                    break;
+                  case ',':
+                  case ']':
+                  {
+                    push_token(resources, token_type(end_index_expression_arg), ec);
+                    if (ec) {return path_expression_type(alloc_);}
+                    state_stack_.pop_back();
+                    break;
+                  }
+                  default:
+                    ec = jsonpath_errc::expected_comma_or_rbracket;
+                    return path_expression_type(alloc_);
+                }
+                break;
+              }
+              default:
+                ++p_;
+                ++column_;
+                break;
+            }
+          }
+
+          if (state_stack_.empty())
+          {
+            ec = jsonpath_errc::syntax_error;
+            return path_expression_type(alloc_);
+          }
+
+          while (state_stack_.size() > 1)
+          {
+            switch (state_stack_.back())
+            {
+              case path_state::name_or_lbracket:
+                state_stack_.back() = path_state::relative_path;
+                break;
+              case path_state::relative_path:
+                state_stack_.back() = path_state::identifier_or_function_expr;
+                state_stack_.emplace_back(path_state::unquoted_string);
+                break;
+              case path_state::identifier_or_function_expr:
+                if (!buffer.empty()) // Can't be quoted string
+                {
+                  push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                  if (ec) {return path_expression_type(alloc_);}
+                }
+                state_stack_.pop_back();
+                break;
+              case path_state::unquoted_string:
+                state_stack_.pop_back(); // unquoted_string
+                break;
+              case path_state::relative_location:
+                state_stack_.pop_back();
+                break;
+              case path_state::identifier:
+                if (!buffer.empty()) // Can't be quoted string
+                {
+                  push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                  if (ec) {return path_expression_type(alloc_);}
+                }
+                state_stack_.pop_back();
+                break;
+              case path_state::parent_operator:
+              {
+                push_token(resources, token_type(resources.new_selector(parent_node_selector<Json,JsonReference>(ancestor_depth))), ec);
+                if (ec) { return path_expression_type(alloc_); }
+                paths_required = true;
+                state_stack_.pop_back();
+                break;
+              }
+              case path_state::ancestor_depth:
+                state_stack_.pop_back();
+                break;
+              default:
+                ec = jsonpath_errc::syntax_error;
+                return path_expression_type(alloc_);
+            }
+          }
+
+          if (state_stack_.size() > 2)
+          {
+            ec = jsonpath_errc::unexpected_eof;
+            return path_expression_type(alloc_);
+          }
+
+          //std::cout << "\nTokens\n\n";
+          //for (const auto& tok : output_stack_)
+          //{
+          //    std::cout << tok.to_string(0) << "\n";
+          //}
+          //std::cout << "\n";
+
+          if (output_stack_.empty() || !operator_stack_.empty())
+          {
+            ec = jsonpath_errc::unexpected_eof;
+            return path_expression_type(alloc_);
+          }
+
+          return path_expression_type(output_stack_.back().selector_, paths_required, alloc_);
+        }
+
+        void advance_past_space_character()
+        {
+            switch (*p_)
+            {
+                case ' ':case '\t':
+                    ++p_;
+                    ++column_;
+                    break;
+                case '\r':
+                    if (p_+1 < end_input_ && *(p_+1) == '\n')
+                    {
+                        ++p_;
+                    }
+                    ++line_;
+                    column_ = 1;
+                    ++p_;
+                    break;
+                case '\n':
+                    ++line_;
+                    column_ = 1;
+                    ++p_;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        void unwind_rparen(std::error_code& ec)
+        {
+            auto it = operator_stack_.rbegin();
+            while (it != operator_stack_.rend() && !(*it).is_lparen())
+            {
+                output_stack_.emplace_back(std::move(*it));
+                ++it;
+            }
+            if (it == operator_stack_.rend())
+            {
+                ec = jsonpath_errc::unbalanced_parentheses;
+                return;
+            }
+            ++it;
+            operator_stack_.erase(it.base(),operator_stack_.end());
+        }
+
+        void push_token(jsoncons::jsonpath::detail::static_resources<value_type>& resources, token_type&& tok, std::error_code& ec)
+        {
+            //std::cout << tok.to_string(0) << "\n";
+            switch (tok.token_kind())
+            {
+                case jsonpath_token_kind::begin_filter:
+                    output_stack_.emplace_back(std::move(tok));
+                    operator_stack_.emplace_back(token_type(lparen_arg));
+                    break;
+                case jsonpath_token_kind::end_filter:
+                {
+                    //std::cout << "push_token end_filter 1\n";
+                    //for (const auto& tok2 : output_stack_)
+                    //{
+                    //    std::cout << tok2.to_string(0) << "\n";
+                    //}
+                    //std::cout << "\n\n";
+                    unwind_rparen(ec);
+                    if (ec)
+                    {
+                        return;
+                    }
+                    std::vector<token_type> toks;
+                    auto it = output_stack_.rbegin();
+                    while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::begin_filter)
+                    {
+                        toks.emplace_back(std::move(*it));
+                        ++it;
+                    }
+                    if (it == output_stack_.rend())
+                    {
+                        ec = jsonpath_errc::unbalanced_parentheses;
+                        return;
+                    }
+                    std::reverse(toks.begin(), toks.end());
+                    ++it;
+                    output_stack_.erase(it.base(),output_stack_.end());
+
+                    if (!output_stack_.empty() && output_stack_.back().is_path())
+                    {
+                        output_stack_.back().selector_->append_selector(resources.new_selector(filter_selector<Json,JsonReference>(expression_type(std::move(toks)))));
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(token_type(resources.new_selector(filter_selector<Json,JsonReference>(expression_type(std::move(toks))))));
+                    }
+                    //std::cout << "push_token end_filter 2\n";
+                    //for (const auto& tok2 : output_stack_)
+                    //{
+                    //    std::cout << tok2.to_string(0) << "\n";
+                    //}
+                    //std::cout << "\n\n";
+                    break;
+                }
+                case jsonpath_token_kind::begin_expression:
+                    //std::cout << "begin_expression\n";
+                    output_stack_.emplace_back(std::move(tok));
+                    operator_stack_.emplace_back(token_type(lparen_arg));
+                    break;
+                case jsonpath_token_kind::end_index_expression:
+                {
+                    //std::cout << "jsonpath_token_kind::end_index_expression\n";
+                    //for (const auto& t : output_stack_)
+                    //{
+                    //    std::cout << t.to_string(0) << "\n";
+                    //}
+                    //std::cout << "/jsonpath_token_kind::end_index_expression\n";
+                    unwind_rparen(ec);
+                    if (ec)
+                    {
+                        return;
+                    }
+                    std::vector<token_type> toks;
+                    auto it = output_stack_.rbegin();
+                    while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::begin_expression)
+                    {
+                        toks.emplace_back(std::move(*it));
+                        ++it;
+                    }
+                    if (it == output_stack_.rend())
+                    {
+                        ec = jsonpath_errc::unbalanced_parentheses;
+                        return;
+                    }
+                    std::reverse(toks.begin(), toks.end());
+                    ++it;
+                    output_stack_.erase(it.base(),output_stack_.end());
+
+                    if (!output_stack_.empty() && output_stack_.back().is_path())
+                    {
+                        output_stack_.back().selector_->append_selector(resources.new_selector(index_expression_selector<Json,JsonReference>(expression_type(std::move(toks)))));
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(token_type(resources.new_selector(index_expression_selector<Json,JsonReference>(expression_type(std::move(toks))))));
+                    }
+                    break;
+                }
+                case jsonpath_token_kind::end_argument_expression:
+                {
+                    //std::cout << "jsonpath_token_kind::end_index_expression\n";
+                    //for (const auto& t : output_stack_)
+                    //{
+                    //    std::cout << t.to_string(0) << "\n";
+                    //}
+                    //std::cout << "/jsonpath_token_kind::end_index_expression\n";
+                    unwind_rparen(ec);
+                    if (ec)
+                    {
+                        return;
+                    }
+                    std::vector<token_type> toks;
+                    auto it = output_stack_.rbegin();
+                    while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::begin_expression)
+                    {
+                        toks.emplace_back(std::move(*it));
+                        ++it;
+                    }
+                    if (it == output_stack_.rend())
+                    {
+                        ec = jsonpath_errc::unbalanced_parentheses;
+                        return;
+                    }
+                    std::reverse(toks.begin(), toks.end());
+                    ++it;
+                    output_stack_.erase(it.base(),output_stack_.end());
+                    output_stack_.emplace_back(token_type(jsoncons::make_unique<expression_type>(std::move(toks))));
+                    break;
+                }
+                case jsonpath_token_kind::selector:
+                {
+                    if (!output_stack_.empty() && output_stack_.back().is_path())
+                    {
+                        output_stack_.back().selector_->append_selector(std::move(tok.selector_));
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(std::move(tok));
+                    }
+                    break;
+                }
+                case jsonpath_token_kind::separator:
+                    output_stack_.emplace_back(std::move(tok));
+                    break;
+                case jsonpath_token_kind::begin_union:
+                    output_stack_.emplace_back(std::move(tok));
+                    break;
+                case jsonpath_token_kind::end_union:
+                {
+                    std::vector<selector_type*> expressions;
+                    auto it = output_stack_.rbegin();
+                    while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::begin_union)
+                    {
+                        if ((*it).token_kind() == jsonpath_token_kind::selector)
+                        {
+                            expressions.emplace_back(std::move((*it).selector_));
+                        }
+                        do
+                        {
+                            ++it;
+                        } 
+                        while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::begin_union && (*it).token_kind() != jsonpath_token_kind::separator);
+                        if ((*it).token_kind() == jsonpath_token_kind::separator)
+                        {
+                            ++it;
+                        }
+                    }
+                    if (it == output_stack_.rend())
+                    {
+                        ec = jsonpath_errc::unbalanced_parentheses;
+                        return;
+                    }
+                    std::reverse(expressions.begin(), expressions.end());
+                    ++it;
+                    output_stack_.erase(it.base(),output_stack_.end());
+
+                    if (!output_stack_.empty() && output_stack_.back().is_path())
+                    {
+                        output_stack_.back().selector_->append_selector(resources.new_selector(union_selector<Json,JsonReference>(std::move(expressions))));
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(token_type(resources.new_selector(union_selector<Json,JsonReference>(std::move(expressions)))));
+                    }
+                    break;
+                }
+                case jsonpath_token_kind::lparen:
+                    operator_stack_.emplace_back(std::move(tok));
+                    break;
+                case jsonpath_token_kind::rparen:
+                {
+                    unwind_rparen(ec);
+                    break;
+                }
+                case jsonpath_token_kind::end_function:
+                {
+                    //std::cout << "jsonpath_token_kind::end_function\n";
+                    unwind_rparen(ec);
+                    if (ec)
+                    {
+                        return;
+                    }
+                    std::vector<token_type> toks;
+                    auto it = output_stack_.rbegin();
+                    std::size_t arg_count = 0;
+                    while (it != output_stack_.rend() && (*it).token_kind() != jsonpath_token_kind::function)
+                    {
+                        if ((*it).token_kind() == jsonpath_token_kind::argument)
+                        {
+                            ++arg_count;
+                        }
+                        toks.emplace_back(std::move(*it));
+                        ++it;
+                    }
+                    if (it == output_stack_.rend())
+                    {
+                        ec = jsonpath_errc::unbalanced_parentheses;
+                        return;
+                    }
+                    std::reverse(toks.begin(), toks.end());
+                    if ((*it).arity() && arg_count != *((*it).arity()))
+                    {
+                        ec = jsonpath_errc::invalid_arity;
+                        return;
+                    }
+                    toks.push_back(std::move(*it));
+                    ++it;
+                    output_stack_.erase(it.base(),output_stack_.end());
+
+                    if (!output_stack_.empty() && output_stack_.back().is_path())
+                    {
+                        output_stack_.back().selector_->append_selector(resources.new_selector(function_selector<Json,JsonReference>(expression_type(std::move(toks)))));
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(token_type(resources.new_selector(function_selector<Json,JsonReference>(std::move(toks)))));
+                    }
+                    break;
+                }
+                case jsonpath_token_kind::literal:
+                    if (!output_stack_.empty() && (output_stack_.back().token_kind() == jsonpath_token_kind::current_node || output_stack_.back().token_kind() == jsonpath_token_kind::root_node))
+                    {
+                        output_stack_.back() = std::move(tok);
+                    }
+                    else
+                    {
+                        output_stack_.emplace_back(std::move(tok));
+                    }
+                    break;
+                case jsonpath_token_kind::function:
+                    output_stack_.emplace_back(std::move(tok));
+                    operator_stack_.emplace_back(token_type(lparen_arg));
+                    break;
+                case jsonpath_token_kind::argument:
+                    output_stack_.emplace_back(std::move(tok));
+                    break;
+                case jsonpath_token_kind::root_node:
+                case jsonpath_token_kind::current_node:
+                    output_stack_.emplace_back(std::move(tok));
+                    break;
+                case jsonpath_token_kind::unary_operator:
+                case jsonpath_token_kind::binary_operator:
+                {
+                    if (operator_stack_.empty() || operator_stack_.back().is_lparen())
+                    {
+                        operator_stack_.emplace_back(std::move(tok));
+                    }
+                    else if (tok.precedence_level() < operator_stack_.back().precedence_level()
+                             || (tok.precedence_level() == operator_stack_.back().precedence_level() && tok.is_right_associative()))
+                    {
+                        operator_stack_.emplace_back(std::move(tok));
+                    }
+                    else
+                    {
+                        auto it = operator_stack_.rbegin();
+                        while (it != operator_stack_.rend() && (*it).is_operator()
+                               && (tok.precedence_level() > (*it).precedence_level()
+                             || (tok.precedence_level() == (*it).precedence_level() && tok.is_right_associative())))
+                        {
+                            output_stack_.emplace_back(std::move(*it));
+                            ++it;
+                        }
+
+                        operator_stack_.erase(it.base(),operator_stack_.end());
+                        operator_stack_.emplace_back(std::move(tok));
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+            //std::cout << "  " << "Output Stack\n";
+            //for (auto&& t : output_stack_)
+            //{
+            //    std::cout << t.to_string(2) << "\n";
+            //}
+            //if (!operator_stack_.empty())
+            //{
+            //    std::cout << "  " << "Operator Stack\n";
+            //    for (auto&& t : operator_stack_)
+            //    {
+            //        std::cout << t.to_string(2) << "\n";
+            //    }
+            //}
+        }
+
+        uint32_t append_to_codepoint(uint32_t cp, int c, std::error_code& ec)
+        {
+            cp *= 16;
+            if (c >= '0'  &&  c <= '9')
+            {
+                cp += c - '0';
+            }
+            else if (c >= 'a'  &&  c <= 'f')
+            {
+                cp += c - 'a' + 10;
+            }
+            else if (c >= 'A'  &&  c <= 'F')
+            {
+                cp += c - 'A' + 10;
+            }
+            else
+            {
+                ec = jsonpath_errc::invalid_codepoint;
+            }
+            return cp;
+        }
+    };
+
+    } // namespace detail
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_PARSER_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath_selector.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath_selector.hpp
@@ -1,0 +1,1278 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_SELECTOR_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_SELECTOR_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <system_error>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+#include "velox/external/jsoncons/jsonpath/expression.hpp"
+#include "velox/external/jsoncons/jsonpath/path_node.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+namespace detail {
+
+    struct slice
+    {
+        jsoncons::optional<int64_t> start_;
+        jsoncons::optional<int64_t> stop_;
+        int64_t step_;
+
+        slice()
+            : step_(1)
+        {
+        }
+
+        slice(const jsoncons::optional<int64_t>& start, const jsoncons::optional<int64_t>& end, int64_t step) 
+            : start_(start), stop_(end), step_(step)
+        {
+        }
+
+        slice(const slice& other) = default;
+
+        slice(slice&& other) = default;
+
+        slice& operator=(const slice& other) = default;
+
+        slice& operator=(slice&& other) = default;
+        
+        ~slice() = default;
+
+        int64_t get_start(std::size_t size) const
+        {
+            if (start_)
+            {
+                auto len = *start_ >= 0 ? *start_ : (static_cast<int64_t>(size) + *start_);
+                return len <= static_cast<int64_t>(size) ? len : static_cast<int64_t>(size);
+            }
+            if (step_ >= 0)
+            {
+                return 0;
+            }
+            return static_cast<int64_t>(size);
+        }
+
+        int64_t get_stop(std::size_t size) const
+        {
+            if (stop_)
+            {
+                auto len = *stop_ >= 0 ? *stop_ : (static_cast<int64_t>(size) + *stop_);
+                return len <= static_cast<int64_t>(size) ? len : static_cast<int64_t>(size);
+            }
+            return step_ >= 0 ? static_cast<int64_t>(size) : -1;
+        }
+
+        int64_t step() const
+        {
+            return step_; // Allow negative
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class json_array_receiver : public node_receiver<Json,JsonReference>
+    {
+    public:
+        using reference = JsonReference;
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        Json* val;
+
+        json_array_receiver(Json* ptr)
+            : val(ptr)
+        {
+        }
+
+        void add(const path_node_type&, reference value) override
+        {
+            val->emplace_back(value);
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    struct path_generator
+    {
+        using char_type = typename Json::char_type;
+        using string_view_type = typename Json::string_view_type;
+        using string_type = typename Json::string_type;
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        static const path_node_type& generate(eval_context<Json,JsonReference>& context,
+            const path_node_type& last, 
+            std::size_t index, 
+            result_options options) 
+        {
+            const result_options require_path = result_options::path | result_options::nodups | result_options::sort;
+            if ((options & require_path) != result_options())
+            {
+                return *context.create_path_node(&last, index);
+            }
+            return last;
+        }
+
+        static const path_node_type& generate(eval_context<Json,JsonReference>& context,
+            const path_node_type& last, 
+            const string_view_type& identifier, 
+            result_options options) 
+        {
+            const result_options require_path = result_options::path | result_options::nodups | result_options::sort;
+            if ((options & require_path) != result_options())
+            {
+                return *context.create_path_node(&last, identifier);
+            }
+            return last;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class base_selector : public jsonpath_selector<Json,JsonReference>
+    {
+        using supertype = jsonpath_selector<Json,JsonReference>;
+
+        supertype* tail_;
+    public:
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using node_receiver_type = typename supertype::node_receiver_type;
+        using selector_type = typename supertype::selector_type;
+
+        base_selector()
+            : supertype(true, 11), tail_(nullptr)
+        {
+        }
+
+        base_selector(bool is_path, std::size_t precedence_level)
+            : supertype(is_path, precedence_level), tail_(nullptr)
+        {
+        }
+
+        void append_selector(selector_type* expr) override
+        {
+            if (!tail_)
+            {
+                tail_ = expr;
+            }
+            else
+            {
+                tail_->append_selector(expr);
+            }
+        }
+
+        void tail_select(eval_context<Json,JsonReference>& context,
+            reference root,
+            const path_node_type& last, 
+            reference current,
+            node_receiver_type& receiver,
+            result_options options) const
+        {
+            if (!tail_)
+            {
+                receiver.add(last, current);
+            }
+            else
+            {
+                tail_->select(context, root, last, current, receiver, options);
+            }
+        }
+
+        reference evaluate_tail(eval_context<Json,JsonReference>& context,
+            reference root,
+            const path_node_type& last, 
+            reference current, 
+            result_options options,
+            std::error_code& ec) const
+        {
+            if (!tail_)
+            {
+                return current;
+            }
+            return tail_->evaluate(context, root, last, current, options, ec);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            if (tail_)
+            {
+                s.append(tail_->to_string(level));
+            }
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class identifier_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+        using path_generator_type = path_generator<Json,JsonReference>;
+    public:
+        using char_type = typename Json::char_type;
+        using string_type = typename Json::string_type;
+        using string_view_type = typename Json::string_view_type;
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using node_receiver_type = typename supertype::node_receiver_type;
+    private:
+        string_type identifier_;
+    public:
+
+        identifier_selector(const string_type& identifier)
+            : base_selector<Json,JsonReference>(), identifier_(identifier)
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+            reference root,
+            const path_node_type& last, 
+            reference current,
+            node_receiver_type& receiver,
+            result_options options) const override
+        {
+            if (current.is_object())
+            {
+                auto it = current.find(identifier_);
+                if (it != current.object_range().end())
+                {
+                    this->tail_select(context, root, 
+                                        path_generator_type::generate(context, last, identifier_, options),
+                                        (*it).value(), receiver, options);
+                }
+            }
+            else if (current.is_array())
+            {
+                int64_t n{0};
+                auto r = jsoncons::detail::decimal_to_integer(identifier_.data(), identifier_.size(), n);
+                if (r)
+                {
+                    auto index = (n >= 0) ? static_cast<std::size_t>(n) : static_cast<std::size_t>(static_cast<int64_t>(current.size()) + n);
+                    if (index < current.size())
+                    {
+                        this->tail_select(context, root, 
+                                            path_generator_type::generate(context, last, index, options),
+                                            current[index], receiver, options);
+                    }
+                }
+                else if (identifier_ == context.length_label() && current.size() >= 0)
+                {
+                    pointer ptr = context.create_json(current.size(), semantic_tag::none, context.get_allocator());
+                    this->tail_select(context, root, 
+                                        path_generator_type::generate(context, last, identifier_, options), 
+                                        *ptr, 
+                                        receiver, options);
+                }
+            }
+            else if (current.is_string() && identifier_ == context.length_label())
+            {
+                string_view_type sv = current.as_string_view();
+                std::size_t count = unicode_traits::count_codepoints(sv.data(), sv.size());
+                pointer ptr = context.create_json(count, semantic_tag::none, context.get_allocator());
+                this->tail_select(context, root, 
+                                    path_generator_type::generate(context, last, identifier_, options), 
+                                    *ptr, receiver, options);
+            }
+            //std::cout << "end identifier_selector\n";
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            if (current.is_object())
+            {
+                auto it = current.find(identifier_);
+                if (it != current.object_range().end())
+                {
+                    return this->evaluate_tail(context, root, 
+                                               path_generator_type::generate(context, last, identifier_, options),
+                                              (*it).value(), options, ec);
+                }
+                return context.null_value();
+            }
+            if (current.is_array())
+            {
+                int64_t n{0};
+                auto r = jsoncons::detail::decimal_to_integer(identifier_.data(), identifier_.size(), n);
+                if (r)
+                {
+                    auto index = (n >= 0) ? static_cast<std::size_t>(n) : static_cast<std::size_t>(static_cast<int64_t>(current.size()) + n);
+                    if (index < current.size())
+                    {
+                        return this->evaluate_tail(context, root, 
+                                                   path_generator_type::generate(context, last, index, options),
+                                                   current[index], options, ec);
+                    }
+                    return context.null_value();
+                }
+                if (identifier_ == context.length_label() && current.size() > 0)
+                {
+                    pointer ptr = context.create_json(current.size(), semantic_tag::none, context.get_allocator());
+                    return this->evaluate_tail(context, root, 
+                                               path_generator_type::generate(context, last, identifier_, options), 
+                                               *ptr, 
+                                               options, ec);
+                }
+                return context.null_value();
+            }
+            if (current.is_string() && identifier_ == context.length_label())
+            {
+                string_view_type sv = current.as_string_view();
+                std::size_t count = unicode_traits::count_codepoints(sv.data(), sv.size());
+                pointer ptr = context.create_json(count, semantic_tag::none, context.get_allocator());
+                return this->evaluate_tail(context, root, 
+                                           path_generator_type::generate(context, last, identifier_, options), 
+                                           *ptr, options, ec);
+            }
+            return context.null_value();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("identifier selector ");
+            unicode_traits::convert(identifier_.data(),identifier_.size(),s);
+            s.append(base_selector<Json,JsonReference>::to_string(level+1));
+            //s.append("\n");
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class root_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+        using path_generator_type = path_generator<Json,JsonReference>;
+
+        std::size_t id_;
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        root_selector(std::size_t id)
+            : base_selector<Json,JsonReference>(), id_(id)
+        {
+        }
+        
+        root_selector(const root_selector&) = default;
+        root_selector(root_selector&&) = default;
+        root_selector& operator=(const root_selector&) = default;
+        root_selector& operator=(root_selector&&) = default;
+        
+        ~root_selector() = default;
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+                this->tail_select(context, root, last, root, receiver, options);
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            if (context.is_cached(id_))
+            {
+                return context.get_from_cache(id_);
+            }
+            auto& ref = this->evaluate_tail(context, root, last, root, options, ec);
+            if (!ec)
+            {
+                context.add_to_cache(id_, ref);
+            }
+
+            return ref;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("root_selector ");
+            s.append(base_selector<Json,JsonReference>::to_string(level+1));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class current_node_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        current_node_selector() = default;
+        current_node_selector(const current_node_selector&) = default;
+        current_node_selector(current_node_selector&&) = default;       
+        ~current_node_selector() = default;
+
+        current_node_selector& operator=(const current_node_selector&) = default;
+        current_node_selector& operator=(current_node_selector&&) = default;              
+        
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            this->tail_select(context,  
+                                root, last, current, receiver, options);
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            //std::cout << "current_node_selector: " << current << "\n";
+            return this->evaluate_tail(context,  
+                                root, last, current, options, ec);
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("current_node_selector");
+            s.append(base_selector<Json,JsonReference>::to_string(level+1));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class parent_node_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+        using allocator_type = typename Json::allocator_type;
+
+        int ancestor_depth_;
+
+    public:
+        using char_type = typename Json::char_type;
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        parent_node_selector(int ancestor_depth)
+            : ancestor_depth_(ancestor_depth)
+        {
+        }
+        parent_node_selector(const parent_node_selector&) = default;
+        parent_node_selector(parent_node_selector&&) = default;
+        
+        ~parent_node_selector() = default;
+
+        parent_node_selector& operator=(const parent_node_selector&) = default;
+        parent_node_selector& operator=(parent_node_selector&&) = default;
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            const path_node_type* ancestor = std::addressof(last);
+            int index = 0;
+            while (ancestor != nullptr && index < ancestor_depth_)
+            {
+                ancestor = ancestor->parent();
+                ++index;
+            }
+
+            if (ancestor != nullptr)
+            {
+                pointer ptr = jsoncons::jsonpath::select(root,*ancestor);
+                if (ptr != nullptr)
+                {
+                    this->tail_select(context, root, *ancestor, *ptr, receiver, options);
+                }
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            const path_node_type* ancestor = std::addressof(last);
+            int index = 0;
+            while (ancestor != nullptr && index < ancestor_depth_)
+            {
+                ancestor = ancestor->parent();
+                ++index;
+            }
+
+            if (ancestor != nullptr)
+            {
+                pointer ptr = jsoncons::jsonpath::select(root, *ancestor);
+                if (ptr != nullptr)
+                {
+                    return this->evaluate_tail(context, root, *ancestor, *ptr, options, ec);
+                }
+                return context.null_value();
+            }
+            return context.null_value();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("parent_node_selector");
+            s.append(base_selector<Json,JsonReference>::to_string(level+1));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class index_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+        int64_t index_;
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        index_selector(int64_t index)
+            : base_selector<Json,JsonReference>(), index_(index)
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            if (current.is_array())
+            {
+                auto slen = static_cast<int64_t>(current.size());
+                if (index_ >= 0 && index_ < slen)
+                {
+                    auto i = static_cast<std::size_t>(index_);
+                    this->tail_select(context, root, 
+                                        path_generator_type::generate(context, last, i, options), 
+                                        current.at(i), receiver, options);
+                }
+                else 
+                {
+                    int64_t index = slen + index_;
+                    if (index >= 0 && index < slen)
+                    {
+                        auto i = static_cast<std::size_t>(index);
+                        this->tail_select(context, root, 
+                                            path_generator_type::generate(context, last, i, options), 
+                                            current.at(i), receiver, options);
+                    }
+                }
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            if (current.is_array())
+            {
+                auto slen = static_cast<int64_t>(current.size());
+                if (index_ >= 0 && index_ < slen)
+                {
+                    auto i = static_cast<std::size_t>(index_);
+                    return this->evaluate_tail(context, root, 
+                                        path_generator_type::generate(context, last, i, options), 
+                                        current.at(i), options, ec);
+                }
+                int64_t index = slen + index_;
+                if (index >= 0 && index < slen)
+                {
+                    auto i = static_cast<std::size_t>(index);
+                    return this->evaluate_tail(context, root, 
+                                        path_generator_type::generate(context, last, i, options), 
+                                        current.at(i), options, ec);
+                }
+                return context.null_value();
+            }
+            return context.null_value();
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class wildcard_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        wildcard_selector()
+            : base_selector<Json,JsonReference>()
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            if (current.is_array())
+            {
+                for (std::size_t i = 0; i < current.size(); ++i)
+                {
+                    this->tail_select(context, root, 
+                                        path_generator_type::generate(context, last, i, options), current[i], 
+                                        receiver, options);
+                }
+            }
+            else if (current.is_object())
+            {
+                for (auto& member : current.object_range())
+                {
+                    this->tail_select(context, root, 
+                                        path_generator_type::generate(context, last, member.key(), options), 
+                                        member.value(), receiver, options);
+                }
+            }
+            //std::cout << "end wildcard_selector\n";
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code&) const override
+        {
+            auto jptr = context.create_json(json_array_arg, semantic_tag::none, context.get_allocator());
+            json_array_receiver<Json,JsonReference> receiver(jptr);
+            select(context, root, last, current, receiver, options);
+            return *jptr;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("wildcard selector");
+            s.append(base_selector<Json,JsonReference>::to_string(level));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class recursive_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        recursive_selector()
+            : base_selector<Json,JsonReference>()
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            if (current.is_array())
+            {
+                this->tail_select(context, root, last, current, receiver, options);
+                for (std::size_t i = 0; i < current.size(); ++i)
+                {
+                    select(context, root, 
+                           path_generator_type::generate(context, last, i, options), current[i], receiver, options);
+                }
+            }
+            else if (current.is_object())
+            {
+                this->tail_select(context, root, last, current, receiver, options);
+                for (auto& item : current.object_range())
+                {
+                    select(context, root, 
+                           path_generator_type::generate(context, last, item.key(), options), item.value(), receiver, options);
+                }
+            }
+            //std::cout << "end wildcard_selector\n";
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code&) const override
+        {
+            auto jptr = context.create_json(json_array_arg, semantic_tag::none, context.get_allocator());
+            json_array_receiver<Json,JsonReference> receiver(jptr);
+            select(context, root, last, current, receiver, options);
+            return *jptr;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("wildcard selector");
+            s.append(base_selector<Json,JsonReference>::to_string(level));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class union_selector final : public jsonpath_selector<Json,JsonReference>
+    {
+        using supertype = jsonpath_selector<Json,JsonReference>;
+    public:
+        using char_type = typename Json::char_type;
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_expression_type = path_expression<Json, JsonReference>;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+        using selector_type = typename supertype::selector_type;
+    private:
+        std::vector<selector_type*> selectors_;
+        selector_type* tail_;
+    public:
+        union_selector(std::vector<selector_type*>&& selectors)
+            : supertype(true, 11), selectors_(std::move(selectors)), tail_(nullptr)
+        {
+        }
+
+        void append_selector(selector_type* tail) override
+        {
+            if (tail_ == nullptr)
+            {
+                tail_ = tail;
+                for (auto& selector : selectors_)
+                {
+                    selector->append_selector(tail);
+                }
+            }
+            else
+            {
+                tail_->append_selector(tail);
+            }
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current, 
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            for (auto& selector : selectors_)
+            {
+                selector->select(context, root, last, current, receiver, options);
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code&) const override
+        {
+            auto jptr = context.create_json(json_array_arg, semantic_tag::none, context.get_allocator());
+            json_array_receiver<Json,JsonReference> receiver(jptr);
+            select(context,root,last,current,receiver,options);
+            return *jptr;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("union selector ");
+            for (auto& selector : selectors_)
+            {
+                s.append(selector->to_string(level+1));
+                //s.push_back('\n');
+            }
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class filter_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+        expression<Json,JsonReference> expr_;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        filter_selector(expression<Json,JsonReference>&& expr)
+            : base_selector<Json,JsonReference>(), expr_(std::move(expr))
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current, 
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            if (current.is_array())
+            {
+                for (std::size_t i = 0; i < current.size(); ++i)
+                {
+                    std::error_code ec;
+                    value_type r = expr_.evaluate(context, root, current[i], options, ec);
+                    bool t = ec ? false : detail::is_true(r);
+                    if (t)
+                    {
+                        this->tail_select(context, root, 
+                                            path_generator_type::generate(context, last, i, options), 
+                                            current[i], receiver, options);
+                    }
+                }
+            }
+            else if (current.is_object())
+            {
+                for (auto& member : current.object_range())
+                {
+                    std::error_code ec;
+                    value_type r = expr_.evaluate(context, root, member.value(), options, ec);
+                    bool t = ec ? false : detail::is_true(r);
+                    if (t)
+                    {
+                        this->tail_select(context, root, 
+                                            path_generator_type::generate(context, last, member.key(), options), 
+                                            member.value(), receiver, options);
+                    }
+                }
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code&) const override
+        {
+            auto jptr = context.create_json(json_array_arg, semantic_tag::none, context.get_allocator());
+            json_array_receiver<Json,JsonReference> receiver(jptr);
+            select(context, root, last, current, receiver, options);
+            return *jptr;
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("filter selector ");
+            s.append(expr_.to_string(level+1));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class index_expression_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+        using allocator_type = typename Json::allocator_type;
+        using string_type = typename Json::string_type;
+
+        expression<Json,JsonReference> expr_;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        index_expression_selector(expression<Json,JsonReference>&& expr)
+            : base_selector<Json,JsonReference>(), expr_(std::move(expr))
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current, 
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            std::error_code ec;
+            value_type j = expr_.evaluate(context, root, current, options, ec);
+
+            if (!ec)
+            {
+                if (j.template is<std::size_t>() && current.is_array())
+                {
+                    std::size_t start = j.template as<std::size_t>();
+                    this->tail_select(context, root, 
+                                      path_generator_type::generate(context, last, start, options),
+                                      current.at(start), receiver, options);
+                }
+                else if (j.is_string() && current.is_object())
+                {
+                    auto sv = j.as_string_view();
+                    this->tail_select(context, root, 
+                                      path_generator_type::generate(context, last, sv, options),
+                                      current.at(j.as_string_view()), receiver, options);
+                }
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            //std::cout << "index_expression_selector current: " << current << "\n";
+
+            value_type j = expr_.evaluate(context, root, current, options, ec);
+
+            if (!ec)
+            {
+                if (j.template is<std::size_t>() && current.is_array())
+                {
+                    std::size_t start = j.template as<std::size_t>();
+                    return this->evaluate_tail(context, root, last, current.at(start), options, ec);
+                }
+                if (j.is_string() && current.is_object())
+                {
+                    return this->evaluate_tail(context, root, last, current.at(j.as_string_view()), options, ec);
+                }
+                return context.null_value();
+            }
+            return context.null_value();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("bracket expression selector ");
+            s.append(expr_.to_string(level+1));
+            s.append(base_selector<Json,JsonReference>::to_string(level+1));
+
+            return s;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class slice_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+        using path_generator_type = path_generator<Json, JsonReference>;
+
+        slice slice_;
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        slice_selector(const slice& slic)
+            : base_selector<Json,JsonReference>(), slice_(slic) 
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current,
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            if (current.is_array())
+            {
+                auto start = slice_.get_start(current.size());
+                auto end = slice_.get_stop(current.size());
+                auto step = slice_.step();
+
+                if (step > 0)
+                {
+                    if (start < 0)
+                    {
+                        start = 0;
+                    }
+                    if (end > static_cast<int64_t>(current.size()))
+                    {
+                        end = current.size();
+                    }
+                    for (int64_t i = start; i < end; i += step)
+                    {
+                        auto j = static_cast<std::size_t>(i);
+                        this->tail_select(context, root, 
+                                            path_generator_type::generate(context, last, j, options), 
+                                            current[j], receiver, options);
+                    }
+                }
+                else if (step < 0)
+                {
+                    if (start >= static_cast<int64_t>(current.size()))
+                    {
+                        start = static_cast<int64_t>(current.size()) - 1;
+                    }
+                    if (end < -1)
+                    {
+                        end = -1;
+                    }
+                    for (int64_t i = start; i > end; i += step)
+                    {
+                        auto j = static_cast<std::size_t>(i);
+                        if (j < current.size())
+                        {
+                            this->tail_select(context, root, 
+                                                path_generator_type::generate(context, last,j,options), current[j], receiver, options);
+                        }
+                    }
+                }
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code&) const override
+        {
+            auto jptr = context.create_json(json_array_arg, semantic_tag::none, context.get_allocator());
+            json_array_receiver<Json,JsonReference> accum(jptr);
+            select(context, root, last, current, accum, options);
+            return *jptr;
+        }
+    };
+
+    template <typename Json,typename JsonReference>
+    class function_selector final : public base_selector<Json,JsonReference>
+    {
+        using supertype = base_selector<Json,JsonReference>;
+
+        expression<Json,JsonReference> expr_;
+
+    public:
+        using value_type = typename supertype::value_type;
+        using reference = typename supertype::reference;
+        using pointer = typename supertype::pointer;
+        using path_value_pair_type = typename supertype::path_value_pair_type;
+        using path_node_type = typename supertype::path_node_type;
+        using path_generator_type = path_generator<Json,JsonReference>;
+        using node_receiver_type = typename supertype::node_receiver_type;
+
+        function_selector(expression<Json,JsonReference>&& expr)
+            : base_selector<Json,JsonReference>(), expr_(std::move(expr))
+        {
+        }
+
+        void select(eval_context<Json,JsonReference>& context,
+                    reference root,
+                    const path_node_type& last, 
+                    reference current, 
+                    node_receiver_type& receiver,
+                    result_options options) const override
+        {
+            std::error_code ec;
+            value_type ref = expr_.evaluate(context, root, current, options, ec);
+            if (!ec)
+            {
+                this->tail_select(context, root, last, *context.create_json(std::move(ref)), receiver, options);
+            }
+        }
+
+        reference evaluate(eval_context<Json,JsonReference>& context,
+                           reference root,
+                           const path_node_type& last, 
+                           reference current, 
+                           result_options options,
+                           std::error_code& ec) const override
+        {
+            value_type ref = expr_.evaluate(context, root, current, options, ec);
+            if (!ec)
+            {
+                return this->evaluate_tail(context, root, last, *context.create_json(std::move(ref)), 
+                    options, ec);
+            }
+            return context.null_value();
+        }
+
+        std::string to_string(int level) const override
+        {
+            std::string s;
+            if (level > 0)
+            {
+                s.append("\n");
+                s.append(std::size_t(level)*2, ' ');
+            }
+            s.append("function_selector ");
+            s.append(expr_.to_string(level+1));
+
+            return s;
+        }
+    };
+
+} // namespace detail
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_SELECTOR_HPP

--- a/velox/external/jsoncons/jsonpath/jsonpath_utilities.hpp
+++ b/velox/external/jsoncons/jsonpath/jsonpath_utilities.hpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_JSONPATH_UTILITIES_HPP
+#define JSONCONS_EXT_JSONPATH_JSONPATH_UTILITIES_HPP
+
+#include <cstddef>
+
+namespace facebook::velox::jsoncons { namespace jsonpath {
+
+    template <typename CharT,typename Sink>
+    std::size_t escape_string(const CharT* s, std::size_t length, Sink& sink)
+    {
+        std::size_t count = 0;
+        const CharT* begin = s;
+        const CharT* end = s + length;
+        for (const CharT* it = begin; it != end; ++it)
+        {
+            CharT c = *it;
+            switch (c)
+            {
+                case '\\':
+                    sink.push_back('\\');
+                    sink.push_back('\\');
+                    count += 2;
+                    break;
+                case '\'':
+                    sink.push_back('\\');
+                    sink.push_back('\'');
+                    count += 2;
+                    break;
+                case '\b':
+                    sink.push_back('\\');
+                    sink.push_back('b');
+                    count += 2;
+                    break;
+                case '\f':
+                    sink.push_back('\\');
+                    sink.push_back('f');
+                    count += 2;
+                    break;
+                case '\n':
+                    sink.push_back('\\');
+                    sink.push_back('n');
+                    count += 2;
+                    break;
+                case '\r':
+                    sink.push_back('\\');
+                    sink.push_back('r');
+                    count += 2;
+                    break;
+                case '\t':
+                    sink.push_back('\\');
+                    sink.push_back('t');
+                    count += 2;
+                    break;
+                default:
+                    sink.push_back(c);
+                    ++count;
+                    break;
+            }
+        }
+        return count;
+    }
+    
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_JSONPATH_UTILITIES_HPP

--- a/velox/external/jsoncons/jsonpath/patches/README
+++ b/velox/external/jsoncons/jsonpath/patches/README
@@ -1,0 +1,16 @@
+Contains patches applied to the vendored library, for convenience when upgrading it.
+I will also keep these changes updated to a fork of the jsoncons library
+(https://github.com/bikramSingh91/jsoncons/tree/jayway)
+
+Changes in conform_parser_with_jayway_velox.patch:
+- Added support for unquoted identifier after bracket `$[<identifier>]` that can also start with a number like `$[Key]` or `$[30day]`
+- Added support for bracket (`[`) after dot `$.['key']` (redundant use of dot operator)
+- Added support for dash (`-`) in the middle of an unquoted string
+- Added support for prepending by default `$.` in not included at the beginning of the path. This is to support cases like `[0]` or `key` which will now be equivalent to `$.[0]` or `$.key`
+- Added a new error type for unsupported json path
+
+Apart from this there are general refactoring changes required to build and run the library which include:
+- Only files relevant to json and json parsing have been included
+- The #include directives have been updated to point to local paths
+- Prepend Apache license while preserving the existing boost license
+- The namespaces have been prepended with facebook::velox to avoid namespace conflict if velox is included in projects that already use jsoncons

--- a/velox/external/jsoncons/jsonpath/patches/conform_parser_with_jayway_velox.patch
+++ b/velox/external/jsoncons/jsonpath/patches/conform_parser_with_jayway_velox.patch
@@ -1,0 +1,460 @@
+diff --git a/include/jsoncons_ext/jsonpath/jsonpath_error.hpp b/include/jsoncons_ext/jsonpath/jsonpath_error.hpp
+index 9ec751e7a..d91662a62 100644
+--- a/include/jsoncons_ext/jsonpath/jsonpath_error.hpp
++++ b/include/jsoncons_ext/jsonpath/jsonpath_error.hpp
+@@ -58,7 +58,8 @@ namespace jsoncons { namespace jsonpath {
+         expected_and,
+         expected_comma_or_rparen,
+         expected_comma_or_rbracket,
+-        expected_relative_path
++        expected_relative_path,
++        unsupported_path
+     };
+
+     class jsonpath_error_category_impl
+@@ -149,6 +150,8 @@ namespace jsoncons { namespace jsonpath {
+                     return "Expected comma or right bracket";
+                 case jsonpath_errc::expected_relative_path:
+                     return "Expected unquoted string, or single or double quoted string, or index or '*'";
++                case jsonpath_errc::unsupported_path:
++                    return "Unsupported Json Path";
+                 default:
+                     return "Unknown jsonpath parser error";
+             }
+diff --git a/include/jsoncons_ext/jsonpath/jsonpath_parser.hpp b/include/jsoncons_ext/jsonpath/jsonpath_parser.hpp
+index 7eb932899..a4223534f 100644
+--- a/include/jsoncons_ext/jsonpath/jsonpath_parser.hpp
++++ b/include/jsoncons_ext/jsonpath/jsonpath_parser.hpp
+@@ -53,6 +53,7 @@ namespace detail {
+         identifier_or_function_expr,
+         name_or_lbracket,
+         unquoted_string,
++        index_or_identifier,
+         anything,
+         number,
+         function_expression,
+@@ -70,7 +71,7 @@ namespace detail {
+         index_or_slice,
+         wildcard_or_union,
+         union_element,
+-        index_or_slice_or_union,
++        index_or_slice_or_union_or_identifier,
+         integer,
+         digit,
+         slice_expression_stop,
+@@ -145,11 +146,11 @@ namespace detail {
+         {
+         }
+
+-        jsonpath_evaluator(std::size_t line, std::size_t column,
+-            const allocator_type& alloc = allocator_type())
+-            : alloc_(alloc), line_(line), column_(column),
+-              begin_input_(nullptr), end_input_(nullptr),
+-              p_(nullptr)
++        jsonpath_evaluator(std::size_t line, std::size_t column,
++                           const allocator_type& alloc = allocator_type())
++                : alloc_(alloc), line_(line), column_(column),
++                  begin_input_(nullptr), end_input_(nullptr),
++                  p_(nullptr)
+         {
+         }
+
+@@ -176,7 +177,7 @@ namespace detail {
+
+         path_expression_type compile(static_resources<value_type>& resources,
+                                      const string_view_type& path,
+-                                     std::error_code& ec)
++                                     std::error_code& ec, bool throwOnUnSupportedPaths = true)
+         {
+             std::size_t selector_id = 0;
+
+@@ -192,7 +193,7 @@ namespace detail {
+             slice slic;
+             bool paths_required = false;
+             int ancestor_depth = 0;
+-
++            bool absolute_start = true;
+             state_stack_.emplace_back(path_state::start);
+             while (p_ < end_input_ && !state_stack_.empty())
+             {
+@@ -208,24 +209,39 @@ namespace detail {
+                             case '$':
+                             case '@':
+                             {
++                                if (throwOnUnSupportedPaths && *p_ == '@') {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+                                 state_stack_.emplace_back(path_state::relative_location);
+                                 ++p_;
+                                 ++column_;
++                                absolute_start = false;
+                                 break;
+                             }
+                             default:
+                             {
+                                 state_stack_.emplace_back(path_state::relative_location);
+-                                state_stack_.emplace_back(path_state::expect_function_expr);
+-                                state_stack_.emplace_back(path_state::unquoted_string);
++                                if(absolute_start){
++                                    // Support special case to conform with jayway where it
++                                    // prepends $. if not specified at the start to support
++                                    // paths like '[0]' or 'key'
++                                    push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
++                                    if (ec) {return path_expression_type(alloc_);}
++                                    state_stack_.emplace_back(path_state::recursive_descent_or_expression_lhs);
++                                } else {
++                                    state_stack_.emplace_back(path_state::expect_function_expr);
++                                    state_stack_.emplace_back(path_state::unquoted_string);
++                                }
++                                absolute_start = false;
+                                 break;
+                             }
+                         }
+                         break;
+                     }
+-                    case path_state::root_or_current_node:
++                    case path_state::root_or_current_node:
+                         switch (*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -240,6 +256,10 @@ namespace detail {
+                                 ++column_;
+                                 break;
+                             case '@':
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                                 push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+@@ -256,18 +276,28 @@ namespace detail {
+                         switch (*p_)
+                         {
+                             case '.':
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 push_token(resources, token_type(resources.new_selector(recursive_selector<Json,JsonReference>())), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+                                 ++p_;
+                                 ++column_;
+                                 state_stack_.back() = path_state::name_or_lbracket;
+                                 break;
++                            case '[':
++                                // Add support for bracket after dot $.[<id>]
++                                state_stack_.back() =  path_state::bracket_specifier_or_union;
++                                ++p_;
++                                ++column_;
++                                break;
+                             default:
+                                 state_stack_.back() = path_state::relative_path;
+                                 break;
+                         }
+                         break;
+-                    case path_state::name_or_lbracket:
++                    case path_state::name_or_lbracket:
+                         switch (*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -293,7 +323,7 @@ namespace detail {
+                         state_stack_.pop_back(); // json_value
+                         break;
+                     }
+-                    case path_state::path_or_literal_or_function:
++                    case path_state::path_or_literal_or_function:
+                     {
+                         switch (*p_)
+                         {
+@@ -302,6 +332,10 @@ namespace detail {
+                                 break;
+                             case '$':
+                             case '@':
++                                if (throwOnUnSupportedPaths && *p_ == '@') {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 state_stack_.back() = path_state::relative_location;
+                                 state_stack_.push_back(path_state::root_or_current_node);
+                                 break;
+@@ -478,7 +512,7 @@ namespace detail {
+                                 break;
+                         };
+                         break;
+-                    case path_state::number:
++                    case path_state::number:
+                         switch (*p_)
+                         {
+                             case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+@@ -492,7 +526,7 @@ namespace detail {
+                                 break;
+                         };
+                         break;
+-                    case path_state::json_text_string:
++                    case path_state::json_text_string:
+                         switch (*p_)
+                         {
+                             case '\\':
+@@ -510,7 +544,7 @@ namespace detail {
+                                 break;
+                             case '\"':
+                                 buffer.push_back(*p_);
+-                                state_stack_.pop_back();
++                                state_stack_.pop_back();
+                                 ++p_;
+                                 ++column_;
+                                 break;
+@@ -521,7 +555,7 @@ namespace detail {
+                                 break;
+                         };
+                         break;
+-                    case path_state::relative_path:
++                    case path_state::relative_path:
+                         switch (*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -586,7 +620,7 @@ namespace detail {
+                                 push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+                                 buffer.clear();
+-                                state_stack_.pop_back();
++                                state_stack_.pop_back();
+                                 break;
+                             }
+                         }
+@@ -724,13 +758,39 @@ namespace detail {
+                         }
+                         break;
+                     }
+-                    case path_state::unquoted_string:
++                    case path_state::index_or_identifier:
++                        // Does not support (:) or (,) as its only used after a bracket start ([)
++                        switch (*p_)
++                        {
++                            case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
++                            case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
++                            case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
++                            case '_':case '-':
++                                buffer.push_back(*p_);
++                                ++p_;
++                                ++column_;
++                                break;
++                            default:
++                                if (typename std::make_unsigned<char_type>::type(*p_) > 127)
++                                {
++                                    buffer.push_back(*p_);
++                                    ++p_;
++                                    ++column_;
++                                }
++                                else
++                                {
++                                    state_stack_.pop_back(); // unquoted_string
++                                }
++                                break;
++                        };
++                        break;
++                    case path_state::unquoted_string:
+                         switch (*p_)
+                         {
+                             case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
+                             case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
+                             case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+-                            case '_':
++                            case '_':case '-':case ':':case ',':
+                                 buffer.push_back(*p_);
+                                 ++p_;
+                                 ++column_;
+@@ -1281,22 +1341,29 @@ namespace detail {
+                                 ++column_;
+                                 break;
+                             case ':': // slice_expression
+-                                state_stack_.back() = path_state::index_or_slice_or_union;
++                                state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
+                                 break;
+-                            case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
+-                                state_stack_.back() = path_state::index_or_slice_or_union;
+-                                state_stack_.emplace_back(path_state::integer);
++                            case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':case 'g':case 'h':case 'i':case 'j':case 'k':case 'l':case 'm':case 'n':case 'o':case 'p':case 'q':case 'r':case 's':case 't':case 'u':case 'v':case 'w':case 'x':case 'y':case 'z':
++                            case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':case 'G':case 'H':case 'I':case 'J':case 'K':case 'L':case 'M':case 'N':case 'O':case 'P':case 'Q':case 'R':case 'S':case 'T':case 'U':case 'V':case 'W':case 'X':case 'Y':case 'Z':
++                            case '_':case '-':case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':
++                                // Add support for unquoted identifier after bracket $[<identifier>] that can also start with a number.
++                                state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
++                                state_stack_.emplace_back(path_state::index_or_identifier);
+                                 break;
+                             case '$':
+                                 push_token(resources, token_type(begin_union_arg), ec);
+                                 push_token(resources, root_node_arg, ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+                                 state_stack_.back() = path_state::union_expression; // union
+-                                state_stack_.emplace_back(path_state::relative_location);
++                                state_stack_.emplace_back(path_state::relative_location);
+                                 ++p_;
+                                 ++column_;
+                                 break;
+                             case '@':
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 push_token(resources, token_type(begin_union_arg), ec);
+                                 push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                                 push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+@@ -1307,8 +1374,15 @@ namespace detail {
+                                 ++column_;
+                                 break;
+                             default:
+-                                ec = jsonpath_errc::expected_bracket_specifier_or_union;
+-                                return path_expression_type(alloc_);
++                                if (typename std::make_unsigned<char_type>::type(*p_) > 127)
++                                {
++                                    // Add support for unquoted identifier after bracket $[<identifier>]
++                                    state_stack_.back() = path_state::index_or_slice_or_union_or_identifier;
++                                    state_stack_.push_back(path_state::index_or_identifier);
++                                } else {
++                                    ec = jsonpath_errc::expected_bracket_specifier_or_union;
++                                    return path_expression_type(alloc_);
++                                }
+                         }
+                         break;
+                     case path_state::union_element:
+@@ -1364,6 +1438,10 @@ namespace detail {
+                                 ++column_;
+                                 break;
+                             case '@':
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 push_token(resources, token_type(current_node_arg), ec); // ISSUE
+                                 push_token(resources, token_type(resources.new_selector(current_node_selector<Json,JsonReference>())), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+@@ -1416,7 +1494,7 @@ namespace detail {
+                                 break;
+                         }
+                         break;
+-                    case path_state::index_or_slice_or_union:
++                    case path_state::index_or_slice_or_union_or_identifier:
+                         switch(*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -1433,13 +1511,15 @@ namespace detail {
+                                 auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+                                 if (!r)
+                                 {
+-                                    ec = jsonpath_errc::invalid_number;
+-                                    return path_expression_type(alloc_);
++                                    push_token(resources, token_type(resources.new_selector(identifier_selector<Json,JsonReference>(buffer))), ec);
++                                }
++                                else
++                                {
++                                    push_token(resources, token_type(resources.new_selector(index_selector<Json,JsonReference>(n))), ec);
+                                 }
+-                                push_token(resources, token_type(resources.new_selector(index_selector<Json,JsonReference>(n))), ec);
+                                 if (ec) {return path_expression_type(alloc_);}
+                                 buffer.clear();
+-                                state_stack_.pop_back(); // index_or_slice_or_union
++                                state_stack_.pop_back(); // index_or_slice_or_union_or_identifier
+                                 ++p_;
+                                 ++column_;
+                                 break;
+@@ -1477,6 +1557,10 @@ namespace detail {
+                             }
+                             case ':':
+                             {
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
+                                 if (!buffer.empty())
+                                 {
+                                     int64_t n{0};
+@@ -1505,6 +1589,10 @@ namespace detail {
+                         break;
+                     case path_state::slice_expression_stop:
+                     {
++                        if (throwOnUnSupportedPaths) {
++                            ec = jsonpath_errc::unsupported_path;
++                            return path_expression_type(alloc_);
++                        }
+                         if (!buffer.empty())
+                         {
+                             int64_t n{0};
+@@ -1543,6 +1631,10 @@ namespace detail {
+                     }
+                     case path_state::slice_expression_step:
+                     {
++                        if (throwOnUnSupportedPaths) {
++                            ec = jsonpath_errc::unsupported_path;
++                            return path_expression_type(alloc_);
++                        }
+                         if (!buffer.empty())
+                         {
+                             int64_t n{0};
+@@ -1632,6 +1724,11 @@ namespace detail {
+                         }
+                         break;
+                     case path_state::union_expression:
++                    {
++                        if (throwOnUnSupportedPaths) {
++                            ec = jsonpath_errc::unsupported_path;
++                            return path_expression_type(alloc_);
++                        }
+                         switch (*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -1666,6 +1763,7 @@ namespace detail {
+                                 return path_expression_type(alloc_);
+                         }
+                         break;
++                    }
+                     case path_state::identifier_or_union:
+                         switch (*p_)
+                         {
+@@ -1746,14 +1844,15 @@ namespace detail {
+                                 state_stack_.pop_back(); // bracket_specifier
+                                 break;
+                             }
+-                            case ':':
+-                            {
+-                                if (!buffer.empty())
+-                                {
++                            case ':': {
++                                if (throwOnUnSupportedPaths) {
++                                    ec = jsonpath_errc::unsupported_path;
++                                    return path_expression_type(alloc_);
++                                }
++                                if (!buffer.empty()) {
+                                     int64_t n{0};
+                                     auto r = jsoncons::detail::to_integer(buffer.data(), buffer.size(), n);
+-                                    if (!r)
+-                                    {
++                                    if (!r) {
+                                         ec = jsonpath_errc::invalid_number;
+                                         return path_expression_type(alloc_);
+                                     }
+@@ -1990,6 +2089,10 @@ namespace detail {
+                     }
+                     case path_state::filter_expression:
+                     {
++                        if (throwOnUnSupportedPaths) {
++                            ec = jsonpath_errc::unsupported_path;
++                            return path_expression_type(alloc_);
++                        }
+                         switch(*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':
+@@ -2011,6 +2114,10 @@ namespace detail {
+                     }
+                     case path_state::expression:
+                     {
++                        if (throwOnUnSupportedPaths) {
++                            ec = jsonpath_errc::unsupported_path;
++                            return path_expression_type(alloc_);
++                        }
+                         switch(*p_)
+                         {
+                             case ' ':case '\t':case '\r':case '\n':

--- a/velox/external/jsoncons/jsonpath/path_node.hpp
+++ b/velox/external/jsoncons/jsonpath/path_node.hpp
@@ -1,0 +1,343 @@
+﻿/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_EXT_JSONPATH_PATH_NODE_HPP
+#define JSONCONS_EXT_JSONPATH_PATH_NODE_HPP
+
+#include <algorithm> // std::reverse
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/jsonpath/jsonpath_utilities.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace jsonpath {
+
+    enum class path_node_kind { root, name, index };
+
+    template <typename CharT>
+    class basic_path_node 
+    {
+    public:
+        using string_view_type = jsoncons::basic_string_view<CharT>;
+        using char_type = CharT;
+    private:
+
+        const basic_path_node* parent_;
+        std::size_t size_;
+        path_node_kind node_kind_;
+        string_view_type name_;
+        std::size_t index_{0};
+
+    public:
+        basic_path_node()
+            : parent_(nullptr), size_(1),
+              node_kind_(path_node_kind::root)
+        {
+        }
+
+        basic_path_node(const basic_path_node* parent, string_view_type name)
+            : parent_(parent), size_(parent == nullptr ? 1 : parent->size()+1), 
+              node_kind_(path_node_kind::name), name_(name)
+        {
+        }
+
+        basic_path_node(const basic_path_node* parent, std::size_t index)
+            : parent_(parent), size_(parent == nullptr ? 1 : parent->size()+1), 
+              node_kind_(path_node_kind::index), index_(index)
+        {
+        }
+
+        basic_path_node(const basic_path_node& other) = default;
+        basic_path_node(basic_path_node&& other) = default;
+        
+        ~basic_path_node() = default;
+
+        basic_path_node& operator=(const basic_path_node& other) = default;
+        basic_path_node& operator=(basic_path_node&& other) = default;
+
+        const basic_path_node* parent() const { return parent_;}
+
+        path_node_kind node_kind() const
+        {
+            return node_kind_;
+        }
+
+        string_view_type name() const
+        {
+            return name_;
+        }
+
+        std::size_t size() const
+        {
+            return size_;
+        }
+
+        std::size_t index() const 
+        {
+            return index_;
+        }
+
+        void swap(basic_path_node& node) noexcept
+        {
+            std::swap(parent_, node.parent_);
+            std::swap(node_kind_, node.node_kind_);
+            std::swap(name_, node.name_);
+            std::swap(index_, node.index_);
+        }
+
+    private:
+
+        std::size_t node_hash() const
+        {
+            std::size_t h = node_kind_ == path_node_kind::index ? std::hash<std::size_t>{}(index_) : std::hash<string_view_type>{}(name_);
+
+            return h;
+        }
+        int compare_node(const basic_path_node& other) const
+        {
+            int diff = 0;
+            if (node_kind_ != other.node_kind_)
+            {
+                diff = static_cast<int>(node_kind_) - static_cast<int>(other.node_kind_);
+            }
+            else
+            {
+                switch (node_kind_)
+                {
+                    case path_node_kind::root:
+                    case path_node_kind::name:
+                        diff = name_.compare(other.name_);
+                        break;
+                    case path_node_kind::index:
+                        diff = index_ < other.index_ ? -1 : index_ > other.index_ ? 1 : 0;
+                        break;
+                    default:
+                        break;
+                }
+            }
+            return diff;
+        }
+
+        friend bool operator<(const basic_path_node& lhs, const basic_path_node& rhs)
+        {
+            std::size_t len = (std::min)(lhs.size(),rhs.size());
+
+            const basic_path_node* p_lhs = std::addressof(lhs);
+            const basic_path_node* p_rhs = std::addressof(rhs);
+
+            bool is_less = false;
+            while (p_lhs->size() > len)
+            {
+                p_lhs = p_lhs->parent_;
+                is_less = false;
+            }
+            while (p_rhs->size() > len)
+            {
+                p_rhs = p_rhs->parent_;
+                is_less = true;
+            }
+            while (p_lhs != nullptr)
+            {
+                int diff = 0;
+                if (p_lhs->node_kind_ != p_rhs->node_kind_)
+                {
+                    diff = static_cast<int>(p_lhs->node_kind_) - static_cast<int>(p_rhs->node_kind_);
+                }
+                else
+                {
+                    switch (p_lhs->node_kind_)
+                    {
+                        case path_node_kind::root:
+                        case path_node_kind::name:
+                            diff = p_lhs->name_.compare(p_rhs->name_);
+                            break;
+                        case path_node_kind::index:
+                            diff = static_cast<int>(p_lhs->index_) - static_cast<int>(p_rhs->index_);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                if (diff < 0)
+                {
+                    is_less = true;
+                }
+                else if (diff > 0)
+                {
+                    is_less = false;
+                }
+
+                p_lhs = p_lhs->parent_;
+                p_rhs = p_rhs->parent_;
+            }
+
+            return is_less;
+        }
+
+        friend bool operator==(const basic_path_node& lhs, const basic_path_node& rhs)
+        {
+            if (lhs.size() != rhs.size())
+            {
+                return false;
+            }
+
+            const basic_path_node* p_lhs = std::addressof(lhs);
+            const basic_path_node* p_rhs = std::addressof(rhs);
+
+            bool is_equal = true;
+            while (p_lhs != nullptr && is_equal)
+            {
+                if (p_lhs->node_kind_ != p_rhs->node_kind_)
+                {
+                    is_equal = false;
+                }
+                else
+                {
+                    switch (p_lhs->node_kind_)
+                    {
+                        case path_node_kind::root:
+                        case path_node_kind::name:
+                            is_equal = p_lhs->name_ == p_rhs->name_;
+                            break;
+                        case path_node_kind::index:
+                            is_equal = p_lhs->index_ == p_rhs->index_;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                p_lhs = p_lhs->parent_;
+                p_rhs = p_rhs->parent_;
+            }
+
+            return is_equal;
+        }
+    };
+
+    template <typename Json>
+    Json* select(Json& root, const basic_path_node<typename Json::char_type>& path)
+    {
+        using path_node_type = basic_path_node<typename Json::char_type>;
+
+        std::vector<const path_node_type*> nodes(path.size(), nullptr);
+        std::size_t len = nodes.size();
+        const path_node_type* p = std::addressof(path);
+        while (p != nullptr)
+        {
+            nodes[--len] = p;
+            p = p->parent();
+        }
+
+        Json* current = std::addressof(root);
+        for (auto node : nodes)
+        {
+            if (node->node_kind() == path_node_kind::index)
+            {
+                if (current->type() != json_type::array_value || node->index() >= current->size())
+                {
+                    return nullptr; 
+                }
+                current = std::addressof(current->at(node->index()));
+            }
+            else if (node->node_kind() == path_node_kind::name)
+            {
+                if (current->type() != json_type::object_value)
+                {
+                    return nullptr;
+                }
+                auto it = current->find(node->name());
+                if (it == current->object_range().end())
+                {
+                    return nullptr;
+                }
+                current = std::addressof((*it).value());
+            }
+        }
+        return current;
+    }
+
+    template <typename CharT,typename Allocator=std::allocator<CharT>>
+    std::basic_string<CharT,std::char_traits<CharT>,Allocator> to_basic_string(const basic_path_node<CharT>& path, const Allocator& alloc=Allocator())
+    {
+        std::basic_string<CharT,std::char_traits<CharT>,Allocator> buffer(alloc);
+
+        using path_node_type = basic_path_node<CharT>;
+
+        std::vector<const path_node_type*> nodes(path.size(), nullptr);
+        std::size_t len = nodes.size();
+        const path_node_type* p = std::addressof(path);
+        while (p != nullptr)
+        {
+            nodes[--len] = p;
+            p = p->parent();
+        }
+
+        for (auto node : nodes)
+        {
+            switch (node->node_kind())
+            {
+                case path_node_kind::root:
+                    buffer.push_back('$');
+                    break;
+                case path_node_kind::name:
+                    buffer.push_back('[');
+                    buffer.push_back('\'');
+                    jsoncons::jsonpath::escape_string(node->name().data(), node->name().size(), buffer);
+                    buffer.push_back('\'');
+                    buffer.push_back(']');
+                    break;
+                case path_node_kind::index:
+                    buffer.push_back('[');
+                    jsoncons::detail::from_integer(node->index(), buffer);
+                    buffer.push_back(']');
+                    break;
+            }
+        }
+
+        return buffer;
+    }
+
+    using path_node = basic_path_node<char>;
+    using wpath_node = basic_path_node<wchar_t>;
+
+    inline
+    std::string to_string(const path_node& path)
+    {
+        return to_basic_string(path);
+    }
+
+    inline
+    std::wstring to_wstring(const wpath_node& path)
+    {
+        return to_basic_string(path);
+    }
+
+} // namespace jsonpath
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_EXT_JSONPATH_PATH_NODE_HPP

--- a/velox/external/jsoncons/pretty_print.hpp
+++ b/velox/external/jsoncons/pretty_print.hpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_PRETTY_PRINT_HPP
+#define JSONCONS_PRETTY_PRINT_HPP
+
+#include <cstring>
+#include <ostream>
+#include <typeinfo>
+
+#include "velox/external/jsoncons/json_encoder.hpp"
+#include "velox/external/jsoncons/json_error.hpp"
+#include "velox/external/jsoncons/json_options.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+template <typename Json>
+class json_printable
+{
+public:
+    using char_type = typename Json::char_type;
+
+    json_printable(const Json& j, indenting indent)
+       : j_(&j), indenting_(indent)
+    {
+    }
+
+    json_printable(const Json& j,
+                   const basic_json_encode_options<char_type>& options,
+                   indenting indent)
+       : j_(&j), options_(options), indenting_(indent)
+    {
+    }
+
+    void dump(std::basic_ostream<char_type>& os) const
+    {
+        j_->dump(os, options_, indenting_);
+    }
+
+    friend std::basic_ostream<char_type>& operator<<(std::basic_ostream<char_type>& os, const json_printable<Json>& pr)
+    {
+        pr.dump(os);
+        return os;
+    }
+
+    const Json *j_;
+    basic_json_encode_options<char_type> options_;
+    indenting indenting_;
+private:
+    json_printable();
+};
+
+template <typename Json>
+json_printable<Json> print(const Json& j)
+{
+    return json_printable<Json>(j, indenting::no_indent);
+}
+
+template <typename Json>
+json_printable<Json> print(const Json& j,
+                           const basic_json_encode_options<typename Json::char_type>& options)
+{
+    return json_printable<Json>(j, options, indenting::no_indent);
+}
+
+template <typename Json>
+json_printable<Json> pretty_print(const Json& j)
+{
+    return json_printable<Json>(j, indenting::indent);
+}
+
+template <typename Json>
+json_printable<Json> pretty_print(const Json& j,
+                                  const basic_json_encode_options<typename Json::char_type>& options)
+{
+    return json_printable<Json>(j, options, indenting::indent);
+}
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_PRETTY_PRINT_HPP

--- a/velox/external/jsoncons/ser_context.hpp
+++ b/velox/external/jsoncons/ser_context.hpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_SER_CONTEXT_HPP
+#define JSONCONS_SER_CONTEXT_HPP
+
+#include <cstddef>
+
+namespace facebook::velox::jsoncons {
+
+class ser_context
+{
+public:
+    virtual ~ser_context() = default;
+
+    virtual size_t line() const
+    {
+        return 0;
+    }
+
+    virtual size_t column() const
+    {
+        return 0;
+    }
+
+    virtual size_t position() const
+    {
+        return 0;
+    }
+
+    virtual size_t end_position() const
+    {
+        return 0;
+    }
+};
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_SER_CONTEXT_HPP

--- a/velox/external/jsoncons/sink.hpp
+++ b/velox/external/jsoncons/sink.hpp
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_SINK_HPP
+#define JSONCONS_SINK_HPP
+
+#include <cmath>
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <memory> // std::addressof
+#include <ostream>
+#include <vector>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { 
+
+    // stream_sink
+
+    template <typename CharT>
+    class stream_sink
+    {
+    public:
+        using value_type = CharT;
+        using container_type = std::basic_ostream<CharT>;
+
+    private:
+        static constexpr size_t default_buffer_length = 16384;
+
+        std::basic_ostream<CharT>* stream_ptr_;
+        std::vector<CharT> buffer_;
+        CharT * begin_buffer_;
+        const CharT* end_buffer_;
+        CharT* p_;
+
+    public:
+
+        // Noncopyable
+        stream_sink(const stream_sink&) = delete;
+        stream_sink(stream_sink&&) = default;
+
+        stream_sink(std::basic_ostream<CharT>& os)
+            : stream_ptr_(std::addressof(os)), buffer_(default_buffer_length), begin_buffer_(buffer_.data()), end_buffer_(begin_buffer_+buffer_.size()), p_(begin_buffer_)
+        {
+        }
+        stream_sink(std::basic_ostream<CharT>& os, std::size_t buflen)
+        : stream_ptr_(std::addressof(os)), buffer_(buflen), begin_buffer_(buffer_.data()), end_buffer_(begin_buffer_+buffer_.size()), p_(begin_buffer_)
+        {
+        }
+        ~stream_sink() noexcept
+        {
+            stream_ptr_->write(begin_buffer_, buffer_length());
+            stream_ptr_->flush();
+        }
+
+        // Movable
+        stream_sink& operator=(const stream_sink&) = delete;
+        stream_sink& operator=(stream_sink&&) = default;
+
+        void flush()
+        {
+            stream_ptr_->write(begin_buffer_, buffer_length());
+            stream_ptr_->flush();
+            p_ = buffer_.data();
+        }
+
+        void append(const CharT* s, std::size_t length)
+        {
+            std::size_t diff = end_buffer_ - p_;
+            if (diff >= length)
+            {
+                std::memcpy(p_, s, length*sizeof(CharT));
+                p_ += length;
+            }
+            else
+            {
+                stream_ptr_->write(begin_buffer_, buffer_length());
+                stream_ptr_->write(s,length);
+                p_ = begin_buffer_;
+            }
+        }
+
+        void push_back(CharT ch)
+        {
+            if (p_ < end_buffer_)
+            {
+                *p_++ = ch;
+            }
+            else
+            {
+                stream_ptr_->write(begin_buffer_, buffer_length());
+                p_ = begin_buffer_;
+                push_back(ch);
+            }
+        }
+    private:
+
+        std::size_t buffer_length() const
+        {
+            return p_ - begin_buffer_;
+        }
+    };
+
+    // binary_stream_sink
+
+    class binary_stream_sink
+    {
+    public:
+        typedef uint8_t value_type;
+        using container_type = std::basic_ostream<char>;
+    private:
+        static constexpr size_t default_buffer_length = 16384;
+
+        std::basic_ostream<char>* stream_ptr_;
+        std::vector<uint8_t> buffer_;
+        uint8_t * begin_buffer_;
+        const uint8_t* end_buffer_;
+        uint8_t* p_;
+
+    public:
+
+        // Noncopyable
+        binary_stream_sink(const binary_stream_sink&) = delete;
+
+        binary_stream_sink(binary_stream_sink&&) = default;
+
+        binary_stream_sink(std::basic_ostream<char>& os)
+            : stream_ptr_(std::addressof(os)), 
+              buffer_(default_buffer_length), 
+              begin_buffer_(buffer_.data()), 
+              end_buffer_(begin_buffer_+buffer_.size()), 
+              p_(begin_buffer_)
+        {
+        }
+        binary_stream_sink(std::basic_ostream<char>& os, std::size_t buflen)
+            : stream_ptr_(std::addressof(os)), 
+              buffer_(buflen), 
+              begin_buffer_(buffer_.data()), 
+              end_buffer_(begin_buffer_+buffer_.size()), 
+              p_(begin_buffer_)
+        {
+        }
+        ~binary_stream_sink() noexcept
+        {
+            stream_ptr_->write((char*)begin_buffer_, buffer_length());
+            stream_ptr_->flush();
+        }
+
+        binary_stream_sink& operator=(const binary_stream_sink&) = delete;
+        binary_stream_sink& operator=(binary_stream_sink&&) = default;
+
+        void flush()
+        {
+            stream_ptr_->write((char*)begin_buffer_, buffer_length());
+            p_ = buffer_.data();
+        }
+
+        void append(const uint8_t* s, std::size_t length)
+        {
+            std::size_t diff = end_buffer_ - p_;
+            if (diff >= length)
+            {
+                std::memcpy(p_, s, length*sizeof(uint8_t));
+                p_ += length;
+            }
+            else
+            {
+                stream_ptr_->write((char*)begin_buffer_, buffer_length());
+                stream_ptr_->write((const char*)s,length);
+                p_ = begin_buffer_;
+            }
+        }
+
+        void push_back(uint8_t ch)
+        {
+            if (p_ < end_buffer_)
+            {
+                *p_++ = ch;
+            }
+            else
+            {
+                stream_ptr_->write((char*)begin_buffer_, buffer_length());
+                p_ = begin_buffer_;
+                push_back(ch);
+            }
+        }
+    private:
+
+        std::size_t buffer_length() const
+        {
+            return p_ - begin_buffer_;
+        }
+    };
+
+    // string_sink
+
+    template <typename StringT>
+    class string_sink 
+    {
+    public:
+        using value_type = typename StringT::value_type;
+        using container_type = StringT;
+    private:
+        container_type* buf_ptr;
+    public:
+
+        // Noncopyable
+        string_sink(const string_sink&) = delete;
+
+        string_sink(string_sink&& other) noexcept
+            : buf_ptr(nullptr)
+        {
+            std::swap(buf_ptr,other.buf_ptr);
+        }
+
+        string_sink(container_type& buf)
+            : buf_ptr(std::addressof(buf))
+        {
+        }
+        
+        ~string_sink() = default;
+
+        string_sink& operator=(const string_sink&) = delete;
+
+        string_sink& operator=(string_sink&& other) noexcept
+        {
+            // TODO: Shouldn't other.buf_ptr be nullified?
+            //       Also see move constructor above.
+            std::swap(buf_ptr,other.buf_ptr);
+            return *this;
+        }
+
+        void flush()
+        {
+        }
+
+        void append(const value_type* s, std::size_t length)
+        {
+            buf_ptr->insert(buf_ptr->end(), s, s+length);
+        }
+
+        void push_back(value_type ch)
+        {
+            buf_ptr->push_back(ch);
+        }
+    };
+
+    // bytes_sink
+
+    template <typename Container,typename = void>
+    class bytes_sink
+    {
+    };
+
+    template <typename Container>
+    class bytes_sink<Container,typename std::enable_if<extension_traits::is_back_insertable_byte_container<Container>::value>::type> 
+    {
+    public:
+        using container_type = Container;
+        using value_type = typename Container::value_type;
+    private:
+        container_type* buf_ptr;
+    public:
+
+        // Noncopyable
+        bytes_sink(const bytes_sink&) = delete;
+
+        bytes_sink(bytes_sink&&) = default;
+
+        bytes_sink(container_type& buf)
+            : buf_ptr(std::addressof(buf))
+        {
+        }
+        
+        ~bytes_sink() = default; 
+
+        bytes_sink& operator=(const bytes_sink&) = delete;
+        bytes_sink& operator=(bytes_sink&&) = default;
+
+        void flush()
+        {
+        }
+
+        void push_back(uint8_t ch)
+        {
+            buf_ptr->push_back(static_cast<value_type>(ch));
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_SINK_HPP

--- a/velox/external/jsoncons/source.hpp
+++ b/velox/external/jsoncons/source.hpp
@@ -1,0 +1,815 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_SOURCE_HPP
+#define JSONCONS_SOURCE_HPP
+
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <exception>
+#include <functional>
+#include <istream>
+#include <iterator>
+#include <memory> // std::addressof
+#include <string>
+#include <type_traits> // std::enable_if
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/utility/byte_string.hpp" // jsoncons::byte_traits
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { 
+
+    template <typename CharT>
+    class basic_null_istream : public std::basic_istream<CharT>
+    {
+        class null_buffer : public std::basic_streambuf<CharT>
+        {
+        public:
+            using typename std::basic_streambuf<CharT>::int_type;
+            using typename std::basic_streambuf<CharT>::traits_type;
+
+            null_buffer() = default;
+            null_buffer(const null_buffer&) = delete;
+            null_buffer(null_buffer&&) = default;
+
+            null_buffer& operator=(const null_buffer&) = delete;
+            null_buffer& operator=(null_buffer&&) = default;
+
+            int_type overflow( int_type ch = typename std::basic_streambuf<CharT>::traits_type::eof() ) override
+            {
+                return ch;
+            }
+        } nb_;
+    public:
+        basic_null_istream()
+          : std::basic_istream<CharT>(&nb_)
+        {
+        }
+
+        basic_null_istream(const null_buffer&) = delete;
+        basic_null_istream& operator=(const null_buffer&) = delete;
+        basic_null_istream(basic_null_istream&&) noexcept
+            : std::basic_istream<CharT>(&nb_)
+        {
+        }
+        basic_null_istream& operator=(basic_null_istream&&) noexcept
+        {
+            return *this;
+        }
+    };
+
+    template <typename CharT>
+    struct char_result
+    {
+        CharT value;
+        bool eof;
+    };
+
+    // text sources
+
+    template <typename CharT>
+    class stream_source 
+    {
+    public:
+        using value_type = CharT;
+        static constexpr std::size_t default_max_buffer_size = 16384;
+    private:
+        using char_type = typename std::conditional<sizeof(CharT) == sizeof(char),char,CharT>::type;
+        basic_null_istream<char_type> null_is_;
+        std::basic_istream<char_type>* stream_ptr_;
+        std::basic_streambuf<char_type>* sbuf_;
+        std::size_t position_{0};
+        std::vector<value_type> buffer_;
+        const value_type* buffer_data_;
+        std::size_t buffer_length_{0};
+    public:
+
+        stream_source()
+            : stream_ptr_(&null_is_), sbuf_(null_is_.rdbuf()),
+              buffer_(1), buffer_data_(buffer_.data())
+        {
+        }
+
+        // Noncopyable 
+        stream_source(const stream_source&) = delete;
+
+        stream_source(stream_source&& other) noexcept
+            : stream_ptr_(&null_is_), sbuf_(null_is_.rdbuf()),
+              buffer_(), buffer_data_(buffer_.data())
+        {
+            if (other.stream_ptr_ != &other.null_is_)
+            {
+                stream_ptr_ = other.stream_ptr_;
+                sbuf_ = other.sbuf_;
+                position_ = other.position_;
+                buffer_ = std::move(other.buffer_);
+                buffer_data_ = buffer_.data() + (other.buffer_data_ - other.buffer_.data());
+                buffer_length_ =  other.buffer_length_;
+                other = stream_source();
+            }
+        }
+
+        stream_source(std::basic_istream<char_type>& is, std::size_t buf_size = default_max_buffer_size)
+            : stream_ptr_(std::addressof(is)), sbuf_(is.rdbuf()),
+              buffer_(buf_size), buffer_data_(buffer_.data())
+        {
+        }
+
+        ~stream_source() = default;
+
+        stream_source& operator=(const stream_source&) = delete;
+
+        stream_source& operator=(stream_source&& other) noexcept
+        {
+            if (other.stream_ptr_ != &other.null_is_)
+            {
+                stream_ptr_ = other.stream_ptr_;
+                sbuf_ = other.sbuf_;
+                position_ = other.position_;
+                buffer_ = std::move(other.buffer_);
+                buffer_data_ = buffer_.data() + (other.buffer_data_ - other.buffer_.data());
+                buffer_length_ =  other.buffer_length_;
+                other = stream_source();
+            }
+            else
+            {
+                stream_ptr_ = &null_is_;
+                sbuf_ = null_is_.rdbuf();
+                position_ = 0;
+                buffer_data_ = buffer_.data();
+                buffer_length_ =  0;
+            }
+            return *this;
+        }
+
+        bool eof() const
+        {
+            return buffer_length_ == 0 && stream_ptr_->eof();
+        }
+
+        bool is_error() const
+        {
+            return stream_ptr_->bad();  
+        }
+
+        std::size_t position() const
+        {
+            return position_;
+        }
+
+        void ignore(std::size_t length)
+        {
+            std::size_t len = 0;
+            if (buffer_length_ > 0)
+            {
+                len = (std::min)(buffer_length_, length);
+                position_ += len;
+                buffer_data_ += len;
+                buffer_length_ -= len;
+            }
+            while (len < length)
+            {
+                fill_buffer();
+                if (buffer_length_ == 0)
+                {
+                    break;
+                }
+                std::size_t len2 = (std::min)(buffer_length_, length-len);
+                position_ += len2;
+                buffer_data_ += len2;
+                buffer_length_ -= len2;
+                len += len2;
+            }
+        }
+
+        char_result<value_type> peek() 
+        {
+            if (buffer_length_ == 0)
+            {
+                fill_buffer();
+            }
+            if (buffer_length_ > 0)
+            {
+                value_type c = *buffer_data_;
+                return char_result<value_type>{c, false};
+            }
+            else
+            {
+                return char_result<value_type>{0, true};
+            }
+        }
+
+        span<const value_type> read_buffer() 
+        {
+            if (buffer_length_ == 0)
+            {
+                fill_buffer();
+            }
+            const value_type* data = buffer_data_;
+            std::size_t length = buffer_length_;
+            buffer_data_ += buffer_length_;
+            position_ += buffer_length_;
+            buffer_length_ = 0;
+
+            return span<const value_type>(data, length);
+        }
+
+        std::size_t read(value_type* p, std::size_t length)
+        {
+            std::size_t len = 0;
+            if (buffer_length_ > 0)
+            {
+                len = (std::min)(buffer_length_, length);
+                std::memcpy(p, buffer_data_, len*sizeof(value_type));
+                buffer_data_ += len;
+                buffer_length_ -= len;
+                position_ += len;
+            }
+            if (length - len == 0)
+            {
+                return len;
+            }
+            else if (length - len < buffer_.size())
+            {
+                fill_buffer();
+                if (buffer_length_ > 0)
+                {
+                    std::size_t len2 = (std::min)(buffer_length_, length-len);
+                    std::memcpy(p+len, buffer_data_, len2*sizeof(value_type));
+                    buffer_data_ += len2;
+                    buffer_length_ -= len2;
+                    position_ += len2;
+                    len += len2;
+                }
+                return len;
+            }
+            else
+            {
+                if (stream_ptr_->eof())
+                {
+                    buffer_length_ = 0;
+                    return 0;
+                }
+                JSONCONS_TRY
+                {
+                    std::streamsize count = sbuf_->sgetn(reinterpret_cast<char_type*>(p+len), length-len);
+                    std::size_t len2 = static_cast<std::size_t>(count);
+                    if (len2 < length-len)
+                    {
+                        stream_ptr_->clear(stream_ptr_->rdstate() | std::ios::eofbit);
+                    }
+                    len += len2;
+                    position_ += len2;
+                    return len;
+                }
+                JSONCONS_CATCH(const std::exception&)     
+                {
+                    stream_ptr_->clear(stream_ptr_->rdstate() | std::ios::badbit | std::ios::eofbit);
+                    return 0;
+                }
+            }
+        }
+    private:
+        void fill_buffer()
+        {
+            if (stream_ptr_->eof())
+            {
+                buffer_length_ = 0;
+                return;
+            }
+
+            buffer_data_ = buffer_.data();
+            JSONCONS_TRY
+            {
+                std::streamsize count = sbuf_->sgetn(reinterpret_cast<char_type*>(buffer_.data()), buffer_.size());
+                buffer_length_ = static_cast<std::size_t>(count);
+
+                if (buffer_length_ < buffer_.size())
+                {
+                    stream_ptr_->clear(stream_ptr_->rdstate() | std::ios::eofbit);
+                }
+            }
+            JSONCONS_CATCH(const std::exception&)     
+            {
+                stream_ptr_->clear(stream_ptr_->rdstate() | std::ios::badbit | std::ios::eofbit);
+                buffer_length_ = 0;
+            }
+        }
+    };
+
+    // string_source
+
+    template <typename CharT>
+    class string_source 
+    {
+    public:
+        using value_type = CharT;
+        using string_view_type = jsoncons::basic_string_view<value_type>;
+    private:
+        const value_type* data_;
+        const value_type* current_;
+        const value_type* end_;
+    public:
+        string_source()
+            : data_(nullptr), current_(nullptr), end_(nullptr)
+        {
+        }
+
+        // Noncopyable 
+        string_source(const string_source&) = delete;
+
+        string_source(string_source&& other) = default;
+
+        template <typename Sourceable>
+        string_source(const Sourceable& s,
+                      typename std::enable_if<extension_traits::is_sequence_of<Sourceable,value_type>::value>::type* = 0)
+            : data_(s.data()), current_(s.data()), end_(s.data()+s.size())
+        {
+        }
+
+        string_source(const value_type* data)
+            : data_(data), current_(data), end_(data+std::char_traits<value_type>::length(data))
+        {
+        }
+
+        string_source& operator=(const string_source&) = delete;
+        string_source& operator=(string_source&& other) = default;
+
+        bool eof() const
+        {
+            return current_ == end_;  
+        }
+
+        bool is_error() const
+        {
+            return false;  
+        }
+
+        std::size_t position() const
+        {
+            return (current_ - data_)/sizeof(value_type);
+        }
+
+        void ignore(std::size_t count)
+        {
+            std::size_t len;
+            if (std::size_t(end_ - current_) < count)
+            {
+                len = end_ - current_;
+            }
+            else
+            {
+                len = count;
+            }
+            current_ += len;
+        }
+
+        char_result<value_type> peek() 
+        {
+            return current_ < end_ ? char_result<value_type>{*current_, false} : char_result<value_type>{0, true};
+        }
+
+        span<const value_type> read_buffer() 
+        {
+            const value_type* data = current_;
+            std::size_t length = end_ - current_;
+            current_ = end_;
+
+            return span<const value_type>(data, length);
+        }
+
+        std::size_t read(value_type* p, std::size_t length)
+        {
+            std::size_t len;
+            if (std::size_t(end_ - current_) < length)
+            {
+                len = end_ - current_;
+            }
+            else
+            {
+                len = length;
+            }
+            std::memcpy(p, current_, len*sizeof(value_type));
+            current_  += len;
+            return len;
+        }
+    };
+
+    // iterator source
+
+    template <typename IteratorT>
+    class iterator_source
+    {
+    public:
+        using value_type = typename std::iterator_traits<IteratorT>::value_type;
+    private:
+        static constexpr std::size_t default_max_buffer_size = 16384;
+
+        IteratorT current_;
+        IteratorT end_;
+        std::size_t position_{0};
+        std::vector<value_type> buffer_;
+        std::size_t buffer_length_{0};
+
+        using difference_type = typename std::iterator_traits<IteratorT>::difference_type;
+        using iterator_category = typename std::iterator_traits<IteratorT>::iterator_category;
+    public:
+
+        // Noncopyable 
+        iterator_source(const iterator_source&) = delete;
+
+        iterator_source(iterator_source&& other) = default;
+
+        iterator_source(const IteratorT& first, const IteratorT& last, std::size_t buf_size = default_max_buffer_size)
+            : current_(first), end_(last), buffer_(buf_size)
+        {
+        }
+        
+        ~iterator_source() = default;
+
+        iterator_source& operator=(const iterator_source&) = delete;
+        iterator_source& operator=(iterator_source&& other) = default;
+
+        bool eof() const
+        {
+            return !(current_ != end_);  
+        }
+
+        bool is_error() const
+        {
+            return false;  
+        }
+
+        std::size_t position() const
+        {
+            return position_;
+        }
+
+        void ignore(std::size_t count)
+        {
+            while (count-- > 0 && current_ != end_)
+            {
+                ++position_;
+                ++current_;
+            }
+        }
+
+        char_result<value_type> peek() 
+        {
+            return current_ != end_ ? char_result<value_type>{*current_, false} : char_result<value_type>{0, true};
+        }
+
+        span<const value_type> read_buffer() 
+        {
+            if (buffer_length_ == 0)
+            {
+                buffer_length_ = read(buffer_.data(), buffer_.size());
+            }
+            std::size_t length = buffer_length_;
+            buffer_length_ = 0;
+
+            return span<const value_type>(buffer_.data(), length);
+        }
+
+        template <typename Category = iterator_category>
+        typename std::enable_if<std::is_same<Category,std::random_access_iterator_tag>::value, std::size_t>::type
+        read(value_type* data, std::size_t length)
+        {
+            std::size_t count = (std::min)(length, static_cast<std::size_t>(std::distance(current_, end_)));
+
+            //JSONCONS_COPY(current_, current_ + count, data);
+
+            auto end = current_ + count;
+            value_type* p = data;
+            while (current_ != end)
+            {
+                *p++ = *current_++;
+            }
+
+            //current_ += count;
+            position_ += count;
+
+            return count;
+        }
+
+        template <typename Category = iterator_category>
+        typename std::enable_if<!std::is_same<Category,std::random_access_iterator_tag>::value, std::size_t>::type
+        read(value_type* data, std::size_t length)
+        {
+            value_type* p = data;
+            value_type* pend = data + length;
+
+            while (p < pend && current_ != end_)
+            {
+                *p = static_cast<value_type>(*current_);
+                ++p;
+                ++current_;
+            }
+
+            position_ += (p - data);
+
+            return p - data;
+        }
+    };
+
+    // binary sources
+
+    using binary_stream_source = stream_source<uint8_t>;
+
+    class bytes_source 
+    {
+    public:
+        typedef uint8_t value_type;
+    private:
+        const value_type* data_;
+        const value_type* current_;
+        const value_type* end_;
+    public:
+        bytes_source()
+            : data_(nullptr), current_(nullptr), end_(nullptr)
+        {
+        }
+
+        // Noncopyable 
+        bytes_source(const bytes_source&) = delete;
+
+        bytes_source(bytes_source&&) = default;
+
+        template <typename Sourceable>
+        bytes_source(const Sourceable& source,
+                     typename std::enable_if<extension_traits::is_byte_sequence<Sourceable>::value,int>::type = 0)
+            : data_(reinterpret_cast<const value_type*>(source.data())), 
+              current_(data_), 
+              end_(data_+source.size())
+        {
+        }
+
+        bytes_source& operator=(const bytes_source&) = delete;
+        bytes_source& operator=(bytes_source&&) = default;
+
+        bool eof() const
+        {
+            return current_ == end_;  
+        }
+
+        bool is_error() const
+        {
+            return false;  
+        }
+
+        std::size_t position() const
+        {
+            return current_ - data_;
+        }
+
+        void ignore(std::size_t count)
+        {
+            std::size_t len;
+            if (std::size_t(end_ - current_) < count)
+            {
+                len = end_ - current_;
+            }
+            else
+            {
+                len = count;
+            }
+            current_ += len;
+        }
+
+        char_result<value_type> peek() 
+        {
+            return current_ < end_ ? char_result<value_type>{*current_, false} : char_result<value_type>{0, true};
+        }
+
+        span<const value_type> read_buffer() 
+        {
+            const value_type* data = current_;
+            std::size_t length = end_ - current_;
+            current_ = end_;
+
+            return span<const value_type>(data, length);
+        }
+
+        std::size_t read(value_type* p, std::size_t length)
+        {
+            std::size_t len;
+            if (std::size_t(end_ - current_) < length)
+            {
+                len = end_ - current_;
+            }
+            else
+            {
+                len = length;
+            }
+            std::memcpy(p, current_, len*sizeof(value_type));
+            current_  += len;
+            return len;
+        }
+    };
+
+    // binary_iterator source
+
+    template <typename IteratorT>
+    class binary_iterator_source
+    {
+    public:
+        using value_type = uint8_t;
+    private:
+        static constexpr std::size_t default_max_buffer_size = 16384;
+
+        IteratorT current_;
+        IteratorT end_;
+        std::size_t position_;
+        std::vector<value_type> buffer_;
+        std::size_t buffer_length_;
+
+        using difference_type = typename std::iterator_traits<IteratorT>::difference_type;
+        using iterator_category = typename std::iterator_traits<IteratorT>::iterator_category;
+    public:
+
+        // Noncopyable 
+        binary_iterator_source(const binary_iterator_source&) = delete;
+
+        binary_iterator_source(binary_iterator_source&& other) = default;
+
+        binary_iterator_source(const IteratorT& first, const IteratorT& last, std::size_t buf_size = default_max_buffer_size)
+            : current_(first), end_(last), position_(0), buffer_(buf_size), buffer_length_(0)
+        {
+        }
+
+        binary_iterator_source& operator=(const binary_iterator_source&) = delete;
+        binary_iterator_source& operator=(binary_iterator_source&& other) = default;
+
+        bool eof() const
+        {
+            return !(current_ != end_);  
+        }
+
+        bool is_error() const
+        {
+            return false;  
+        }
+
+        std::size_t position() const
+        {
+            return position_;
+        }
+
+        void ignore(std::size_t count)
+        {
+            while (count-- > 0 && current_ != end_)
+            {
+                ++position_;
+                ++current_;
+            }
+        }
+
+        char_result<value_type> peek() 
+        {
+            return current_ != end_ ? char_result<value_type>{static_cast<value_type>(*current_), false} : char_result<value_type>{0, true};
+        }
+
+        span<const value_type> read_buffer() 
+        {
+            if (buffer_length_ == 0)
+            {
+                buffer_length_ = read(buffer_.data(), buffer_.size());
+            }
+            std::size_t length = buffer_length_;
+            buffer_length_ = 0;
+
+            return span<const value_type>(buffer_.data(), length);
+        }
+
+        template <typename Category = iterator_category>
+        typename std::enable_if<std::is_same<Category,std::random_access_iterator_tag>::value, std::size_t>::type
+        read(value_type* data, std::size_t length)
+        {
+            std::size_t count = (std::min)(length, static_cast<std::size_t>(std::distance(current_, end_)));
+            //JSONCONS_COPY(current_, current_ + count, data);
+
+            auto end = current_ + count;
+            value_type* p = data;
+            while (current_ != end)
+            {
+                *p++ = *current_++;
+            }
+
+            //current_ += count;
+            position_ += count;
+
+            return count;
+        }
+
+        template <typename Category = iterator_category>
+        typename std::enable_if<!std::is_same<Category,std::random_access_iterator_tag>::value, std::size_t>::type
+        read(value_type* data, std::size_t length)
+        {
+            value_type* p = data;
+            value_type* pend = data + length;
+
+            while (p < pend && current_ != end_)
+            {
+                *p = static_cast<value_type>(*current_);
+                ++p;
+                ++current_;
+            }
+
+            position_ += (p - data);
+
+            return p - data;
+        }
+    };
+
+    template <typename Source>
+    struct source_reader
+    {
+        using value_type = typename Source::value_type;
+        static constexpr std::size_t max_buffer_length = 16384;
+
+        template <typename Container>
+        static
+        typename std::enable_if<std::is_convertible<value_type,typename Container::value_type>::value &&
+                                extension_traits::has_reserve<Container>::value &&
+                                extension_traits::has_data_exact<value_type*,Container>::value 
+     , std::size_t>::type
+        read(Source& source, Container& v, std::size_t length)
+        {
+            std::size_t unread = length;
+
+            std::size_t n = (std::min)(max_buffer_length, unread);
+            while (n > 0 && !source.eof())
+            {
+                std::size_t offset = v.size();
+                v.resize(v.size()+n);
+                std::size_t actual = source.read(v.data()+offset, n);
+                unread -= actual;
+                n = (std::min)(max_buffer_length, unread);
+            }
+
+            return length - unread;
+        }
+
+        template <typename Container>
+        static
+        typename std::enable_if<std::is_convertible<value_type,typename Container::value_type>::value &&
+                                extension_traits::has_reserve<Container>::value &&
+                                !extension_traits::has_data_exact<value_type*, Container>::value 
+     , std::size_t>::type
+        read(Source& source, Container& v, std::size_t length)
+        {
+            std::size_t unread = length;
+
+            std::size_t n = (std::min)(max_buffer_length, unread);
+            while (n > 0 && !source.eof())
+            {
+                v.reserve(v.size()+n);
+                std::size_t actual = 0;
+                while (actual < n)
+                {
+                    typename Source::value_type c;
+                    if (source.read(&c,1) != 1)
+                    {
+                        break;
+                    }
+                    v.push_back(c);
+                    ++actual;
+                }
+                unread -= actual;
+                n = (std::min)(max_buffer_length, unread);
+            }
+
+            return length - unread;
+        }
+    };
+#if __cplusplus >= 201703L
+// not needed for C++17
+#else
+    template <typename Source>
+    constexpr std::size_t source_reader<Source>::max_buffer_length;
+#endif
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_SOURCE_HPP

--- a/velox/external/jsoncons/source_adaptor.hpp
+++ b/velox/external/jsoncons/source_adaptor.hpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_SOURCE_ADAPTOR_HPP
+#define JSONCONS_SOURCE_ADAPTOR_HPP
+
+#include <cstddef>
+#include <system_error>
+
+#include "velox/external/jsoncons/json_error.hpp" // json_errc
+#include "velox/external/jsoncons/source.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // text_source_adaptor
+
+    template <typename Source>
+    class text_source_adaptor 
+    {
+    public:
+        using value_type = typename Source::value_type;
+    private:
+        Source source_;
+        bool bof_;
+
+    public:
+        text_source_adaptor()
+            : bof_(true)
+        {
+        }
+
+        template <typename Sourceable>
+        text_source_adaptor(Sourceable&& source)
+            : source_(std::forward<Sourceable>(source)), bof_(true)
+        {
+        }
+
+        bool eof() const
+        {
+            return source_.eof();
+        }
+
+        bool is_error() const
+        {
+            return source_.is_error();  
+        }
+
+        span<const value_type> read_buffer(std::error_code& ec)
+        {
+            if (source_.eof())
+            {
+                return span<const value_type>();
+            }
+
+            auto s = source_.read_buffer();
+            const value_type* data = s.data();
+            std::size_t length = s.size();
+
+            if (bof_ && length > 0)
+            {
+                auto r = unicode_traits::detect_encoding_from_bom(data, length);
+                if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+                {
+                    ec = json_errc::illegal_unicode_character;
+                    return span<const value_type>();
+                }
+                length -= (r.ptr - data);
+                data = r.ptr;
+                bof_ = false;
+            }
+            return span<const value_type>(data, length);           
+        }
+    };
+
+    // json_source_adaptor
+
+    template <typename Source>
+    class json_source_adaptor 
+    {
+    public:
+        using value_type = typename Source::value_type;
+    private:
+        Source source_;
+        bool bof_;
+
+    public:
+        json_source_adaptor()
+            : bof_(true)
+        {
+        }
+
+        template <typename Sourceable>
+        json_source_adaptor(Sourceable&& source)
+            : source_(std::forward<Sourceable>(source)), bof_(true)
+        {
+        }
+
+        bool eof() const
+        {
+            return source_.eof();
+        }
+
+        bool is_error() const
+        {
+            return source_.is_error();  
+        }
+
+        span<const value_type> read_buffer(std::error_code& ec)
+        {
+            if (source_.eof())
+            {
+                return span<const value_type>();
+            }
+
+            auto s = source_.read_buffer();
+            const value_type* data = s.data();
+            std::size_t length = s.size();
+
+            if (bof_ && length > 0)
+            {
+                auto r = unicode_traits::detect_json_encoding(data, length);
+                if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+                {
+                    ec = json_errc::illegal_unicode_character;
+                    return span<const value_type>();
+                }
+                length -= (r.ptr - data);
+                data = r.ptr;
+                bof_ = false;
+            }
+            
+            return span<const value_type>(data, length);           
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_SOURCE_ADAPTOR_HPP

--- a/velox/external/jsoncons/staj_cursor.hpp
+++ b/velox/external/jsoncons/staj_cursor.hpp
@@ -1,0 +1,762 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_STAJ_CURSOR_HPP
+#define JSONCONS_STAJ_CURSOR_HPP
+
+#include <array> // std::array
+#include <cstddef>
+#include <cstdint>
+#include <functional> // std::function
+#include <ios>
+#include <memory> // std::allocator
+#include <system_error>
+
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/staj_event.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/typed_array_view.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/value_converter.hpp"
+
+namespace facebook::velox::jsoncons {
+
+// basic_staj_visitor
+
+enum class staj_cursor_state
+{
+    typed_array = 1,
+    multi_dim,
+    shape
+};
+
+template <typename CharT>
+class basic_staj_visitor : public basic_json_visitor<CharT>
+{
+    using super_type = basic_json_visitor<CharT>;
+public:
+    using char_type = CharT;
+    using typename super_type::string_view_type;
+private:
+    std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred_;
+    basic_staj_event<CharT> event_;
+
+    staj_cursor_state state_;
+    typed_array_view data_;
+    jsoncons::span<const size_t> shape_;
+    std::size_t index_{0};
+public:
+    basic_staj_visitor()
+        : pred_(accept), event_(staj_event_type::null_value),
+          state_(), data_(), shape_()
+    {
+    }
+
+    basic_staj_visitor(std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+        : pred_(pred), event_(staj_event_type::null_value),
+          state_(), data_(), shape_()
+    {
+    }
+    
+    ~basic_staj_visitor() = default;
+
+    void reset()
+    {
+        event_ = staj_event_type::null_value;
+        state_ = {};
+        data_ = {};
+        shape_ = {};
+        index_ = 0;
+    }
+
+    const basic_staj_event<CharT>& event() const
+    {
+        return event_;
+    }
+
+    bool in_available() const
+    {
+        return state_ != staj_cursor_state();
+    }
+
+    void send_available(std::error_code& ec)
+    {
+        switch (state_)
+        {
+            case staj_cursor_state::typed_array:
+                advance_typed_array(ec);
+                break;
+            case staj_cursor_state::multi_dim:
+            case staj_cursor_state::shape:
+                advance_multi_dim(ec);
+                break;
+            default:
+                break;
+        }
+    }
+
+    bool is_typed_array() const
+    {
+        return data_.type() != typed_array_type();
+    }
+
+    staj_cursor_state state() const
+    {
+        return state_;
+    }
+
+    void advance_typed_array(std::error_code& ec)
+    {
+        if (is_typed_array())
+        {
+            if (index_ < data_.size())
+            {
+                switch (data_.type())
+                {
+                    case typed_array_type::uint8_value:
+                    {
+                        this->uint64_value(data_.data(uint8_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::uint16_value:
+                    {
+                        this->uint64_value(data_.data(uint16_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::uint32_value:
+                    {
+                        this->uint64_value(data_.data(uint32_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::uint64_value:
+                    {
+                        this->uint64_value(data_.data(uint64_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::int8_value:
+                    {
+                        this->int64_value(data_.data(int8_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::int16_value:
+                    {
+                        this->int64_value(data_.data(int16_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::int32_value:
+                    {
+                        this->int64_value(data_.data(int32_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::int64_value:
+                    {
+                        this->int64_value(data_.data(int64_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::half_value:
+                    {
+                        this->half_value(data_.data(half_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::float_value:
+                    {
+                        this->double_value(data_.data(float_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    case typed_array_type::double_value:
+                    {
+                        this->double_value(data_.data(double_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                        break;
+                    }
+                    default:
+                        break;
+                }
+                ++index_;
+            }
+            else
+            {
+                this->end_array();
+                state_ = staj_cursor_state();
+                data_ = typed_array_view();
+                index_ = 0;
+            }
+        }
+    }
+
+    void advance_multi_dim(std::error_code& ec)
+    {
+        if (shape_.size() != 0)
+        {
+            if (state_ == staj_cursor_state::multi_dim)
+            {
+                this->begin_array(shape_.size(), semantic_tag::none, ser_context(), ec);
+                state_ = staj_cursor_state::shape;
+            }
+            else if (index_ < shape_.size())
+            {
+                this->uint64_value(shape_[index_], semantic_tag::none, ser_context(), ec);
+                ++index_;
+            }
+            else
+            {
+                state_ = staj_cursor_state();
+                this->end_array(ser_context(), ec);
+                shape_ = jsoncons::span<const size_t>();
+                index_ = 0;
+            }
+        }
+    }
+
+    bool dump(basic_json_visitor<CharT>& visitor, const ser_context& context, std::error_code& ec)
+    {
+        bool more = true;
+        if (is_typed_array())
+        {
+            if (index_ != 0)
+            {
+                more = event().send_json_event(visitor, context, ec);
+                while (more && is_typed_array())
+                {
+                    if (index_ < data_.size())
+                    {
+                        switch (data_.type())
+                        {
+                            case typed_array_type::uint8_value:
+                            {
+                                more = visitor.uint64_value(data_.data(uint8_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::uint16_value:
+                            {
+                                more = visitor.uint64_value(data_.data(uint16_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::uint32_value:
+                            {
+                                more = visitor.uint64_value(data_.data(uint32_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::uint64_value:
+                            {
+                                more = visitor.uint64_value(data_.data(uint64_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::int8_value:
+                            {
+                                more = visitor.int64_value(data_.data(int8_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::int16_value:
+                            {
+                                more = visitor.int64_value(data_.data(int16_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::int32_value:
+                            {
+                                more = visitor.int64_value(data_.data(int32_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::int64_value:
+                            {
+                                more = visitor.int64_value(data_.data(int64_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::float_value:
+                            {
+                                more = visitor.double_value(data_.data(float_array_arg)[index_]);
+                                break;
+                            }
+                            case typed_array_type::double_value:
+                            {
+                                more = visitor.double_value(data_.data(double_array_arg)[index_]);
+                                break;
+                            }
+                            default:
+                                break;
+                        }
+                        ++index_;
+                    }
+                    else
+                    {
+                        more = visitor.end_array();
+                        state_ = staj_cursor_state();
+                        data_ = typed_array_view();
+                        index_ = 0;
+                    }
+                }
+            }
+            else
+            {
+                switch (data_.type())
+                {
+                    case typed_array_type::uint8_value:
+                    {
+                        more = visitor.typed_array(data_.data(uint8_array_arg));
+                        break;
+                    }
+                    case typed_array_type::uint16_value:
+                    {
+                        more = visitor.typed_array(data_.data(uint16_array_arg));
+                        break;
+                    }
+                    case typed_array_type::uint32_value:
+                    {
+                        more = visitor.typed_array(data_.data(uint32_array_arg));
+                        break;
+                    }
+                    case typed_array_type::uint64_value:
+                    {
+                        more = visitor.typed_array(data_.data(uint64_array_arg));
+                        break;
+                    }
+                    case typed_array_type::int8_value:
+                    {
+                        more = visitor.typed_array(data_.data(int8_array_arg));
+                        break;
+                    }
+                    case typed_array_type::int16_value:
+                    {
+                        more = visitor.typed_array(data_.data(int16_array_arg));
+                        break;
+                    }
+                    case typed_array_type::int32_value:
+                    {
+                        more = visitor.typed_array(data_.data(int32_array_arg));
+                        break;
+                    }
+                    case typed_array_type::int64_value:
+                    {
+                        more = visitor.typed_array(data_.data(int64_array_arg));
+                        break;
+                    }
+                    case typed_array_type::float_value:
+                    {
+                        more = visitor.typed_array(data_.data(float_array_arg));
+                        break;
+                    }
+                    case typed_array_type::double_value:
+                    {
+                        more = visitor.typed_array(data_.data(double_array_arg));
+                        break;
+                    }
+                    default:
+                        break;
+                }
+
+                state_ = staj_cursor_state();
+                data_ = typed_array_view();
+            }
+        }
+        else
+        {
+            more = event().send_json_event(visitor, context, ec);
+        }
+        return more;
+    }
+
+private:
+    static constexpr bool accept(const basic_staj_event<CharT>&, const ser_context&) 
+    {
+        return true;
+    }
+
+    bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::begin_object, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_begin_object(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::begin_object, length, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_end_object(const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::end_object);
+        return !pred_(event_, context);
+    }
+
+    bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::begin_array, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::begin_array, length, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_end_array(const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::end_array);
+        return !pred_(event_, context);
+    }
+
+    bool visit_key(const string_view_type& name, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(name, staj_event_type::key);
+        return !pred_(event_, context);
+    }
+
+    bool visit_null(semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(staj_event_type::null_value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_string(const string_view_type& s, semantic_tag tag, const ser_context& context, std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(s, staj_event_type::string_value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_byte_string(const byte_string_view& s, 
+                           semantic_tag tag,
+                           const ser_context& context,
+                           std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(s, staj_event_type::byte_string_value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_byte_string(const byte_string_view& s, 
+                           uint64_t ext_tag,
+                           const ser_context& context,
+                           std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(s, staj_event_type::byte_string_value, ext_tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_uint64(uint64_t value, 
+                         semantic_tag tag, 
+                         const ser_context& context,
+                         std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_int64(int64_t value, 
+                  semantic_tag tag,
+                  const ser_context& context,
+                  std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_half(uint16_t value, 
+                 semantic_tag tag,
+                 const ser_context& context,
+                 std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(half_arg, value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_double(double value, 
+                   semantic_tag tag, 
+                   const ser_context& context,
+                   std::error_code&) override
+    {
+        event_ = basic_staj_event<CharT>(value, tag);
+        return !pred_(event_, context);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint8_t>& v, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(v.data(), v.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint16_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint32_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const uint64_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int8_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int16_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int32_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const int64_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(half_arg_t, const jsoncons::span<const uint16_t>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const float>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+
+    bool visit_typed_array(const jsoncons::span<const double>& data, 
+                        semantic_tag tag,
+                        const ser_context& context,
+                        std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::typed_array;
+        data_ = typed_array_view(data.data(), data.size());
+        index_ = 0;
+        return this->begin_array(tag, context, ec);
+    }
+/*
+    bool visit_typed_array(const jsoncons::span<const float128_type>&, 
+                        semantic_tag,
+                        const ser_context&,
+                        std::error_code&) override
+    {
+        return true;
+    }
+*/
+    bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                            semantic_tag tag,
+                            const ser_context& context, 
+                            std::error_code& ec) override
+    {
+        state_ = staj_cursor_state::multi_dim;
+        shape_ = shape;
+        return this->begin_array(2, tag, context, ec);
+    }
+
+    bool visit_end_multi_dim(const ser_context& context,
+                          std::error_code& ec) override
+    {
+        return this->end_array(context, ec);
+    }
+
+    void visit_flush() override
+    {
+    }
+};
+
+
+// basic_staj_cursor
+
+template <typename CharT>
+class basic_staj_cursor
+{
+public:
+    virtual ~basic_staj_cursor() = default;
+
+    virtual void array_expected(std::error_code& ec)
+    {
+        if (!(current().event_type() == staj_event_type::begin_array || current().event_type() == staj_event_type::byte_string_value))
+        {
+            ec = conv_errc::not_vector;
+        }
+    }
+
+    virtual bool done() const = 0;
+
+    virtual const basic_staj_event<CharT>& current() const = 0;
+
+    virtual void read_to(basic_json_visitor<CharT>& visitor) = 0;
+
+    virtual void read_to(basic_json_visitor<CharT>& visitor,
+                         std::error_code& ec) = 0;
+
+    virtual void next() = 0;
+
+    virtual void next(std::error_code& ec) = 0;
+
+    virtual const ser_context& context() const = 0;
+};
+
+template <typename CharT>
+class basic_staj_filter_view : basic_staj_cursor<CharT>
+{
+    basic_staj_cursor<CharT>* cursor_;
+    std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred_;
+public:
+    basic_staj_filter_view(basic_staj_cursor<CharT>& cursor, 
+                     std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+        : cursor_(std::addressof(cursor)), pred_(pred)
+    {
+        while (!done() && !pred_(current(),context()))
+        {
+            cursor_->next();
+        }
+    }
+
+    bool done() const override
+    {
+        return cursor_->done();
+    }
+
+    const basic_staj_event<CharT>& current() const override
+    {
+        return cursor_->current();
+    }
+
+    void read_to(basic_json_visitor<CharT>& visitor) override
+    {
+        cursor_->read_to(visitor);
+    }
+
+    void read_to(basic_json_visitor<CharT>& visitor,
+                 std::error_code& ec) override
+    {
+        cursor_->read_to(visitor, ec);
+    }
+
+    void next() override
+    {
+        cursor_->next();
+        while (!done() && !pred_(current(),context()))
+        {
+            cursor_->next();
+        }
+    }
+
+    void next(std::error_code& ec) override
+    {
+        cursor_->next(ec);
+        while (!done() && !pred_(current(),context()) && !ec)
+        {
+            cursor_->next(ec);
+        }
+    }
+
+    const ser_context& context() const override
+    {
+        return cursor_->context();
+    }
+
+    friend
+    basic_staj_filter_view<CharT> operator|(basic_staj_filter_view& cursor, 
+                                      std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+    {
+        return basic_staj_filter_view<CharT>(cursor, pred);
+    }
+};
+
+using staj_event = basic_staj_event<char>;
+using wstaj_event = basic_staj_event<wchar_t>;
+
+using staj_cursor = basic_staj_cursor<char>;
+using wstaj_cursor = basic_staj_cursor<wchar_t>;
+
+using staj_filter_view = basic_staj_filter_view<char>;
+using wstaj_filter_view = basic_staj_filter_view<wchar_t>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_STAJ_CURSOR_HPP

--- a/velox/external/jsoncons/staj_event.hpp
+++ b/velox/external/jsoncons/staj_event.hpp
@@ -1,0 +1,563 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_STAJ_EVENT_HPP
+#define JSONCONS_STAJ_EVENT_HPP
+
+#include <array> // std::array
+#include <cstddef>
+#include <cstdint>
+#include <functional> // std::function
+#include <ios>
+#include <memory> // std::allocator
+#include <system_error>
+#include <type_traits> // std::enable_if
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/item_event_visitor.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/typed_array_view.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+#include "velox/external/jsoncons/value_converter.hpp"
+
+namespace facebook::velox::jsoncons {
+
+enum class staj_event_type
+{
+    begin_array,
+    end_array,
+    begin_object,
+    end_object,
+    key,
+    string_value,
+    byte_string_value,
+    null_value,
+    bool_value,
+    int64_value,
+    uint64_value,
+    half_value,
+    double_value
+};
+
+template <typename CharT>
+std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, staj_event_type tag)
+{
+    static constexpr const CharT* begin_array_name = JSONCONS_CSTRING_CONSTANT(CharT, "begin_array");
+    static constexpr const CharT* end_array_name = JSONCONS_CSTRING_CONSTANT(CharT, "end_array");
+    static constexpr const CharT* begin_object_name = JSONCONS_CSTRING_CONSTANT(CharT, "begin_object");
+    static constexpr const CharT* end_object_name = JSONCONS_CSTRING_CONSTANT(CharT, "end_object");
+    static constexpr const CharT* key_name = JSONCONS_CSTRING_CONSTANT(CharT, "key");
+    static constexpr const CharT* string_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "string_value");
+    static constexpr const CharT* byte_string_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "byte_string_value");
+    static constexpr const CharT* null_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "null_value");
+    static constexpr const CharT* bool_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "bool_value");
+    static constexpr const CharT* uint64_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "uint64_value");
+    static constexpr const CharT* int64_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "int64_value");
+    static constexpr const CharT* half_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "half_value");
+    static constexpr const CharT* double_value_name = JSONCONS_CSTRING_CONSTANT(CharT, "double_value");
+
+    switch (tag)
+    {
+        case staj_event_type::begin_array:
+        {
+            os << begin_array_name;
+            break;
+        }
+        case staj_event_type::end_array:
+        {
+            os << end_array_name;
+            break;
+        }
+        case staj_event_type::begin_object:
+        {
+            os << begin_object_name;
+            break;
+        }
+        case staj_event_type::end_object:
+        {
+            os << end_object_name;
+            break;
+        }
+        case staj_event_type::key:
+        {
+            os << key_name;
+            break;
+        }
+        case staj_event_type::string_value:
+        {
+            os << string_value_name;
+            break;
+        }
+        case staj_event_type::byte_string_value:
+        {
+            os << byte_string_value_name;
+            break;
+        }
+        case staj_event_type::null_value:
+        {
+            os << null_value_name;
+            break;
+        }
+        case staj_event_type::bool_value:
+        {
+            os << bool_value_name;
+            break;
+        }
+        case staj_event_type::int64_value:
+        {
+            os << int64_value_name;
+            break;
+        }
+        case staj_event_type::uint64_value:
+        {
+            os << uint64_value_name;
+            break;
+        }
+        case staj_event_type::half_value:
+        {
+            os << half_value_name;
+            break;
+        }
+        case staj_event_type::double_value:
+        {
+            os << double_value_name;
+            break;
+        }
+    }
+    return os;
+}
+
+template <typename CharT>
+class basic_staj_event
+{
+    staj_event_type event_type_;
+    semantic_tag tag_;
+    uint64_t ext_tag_{0};
+    union
+    {
+        bool bool_value_;
+        int64_t int64_value_;
+        uint64_t uint64_value_;
+        uint16_t half_value_;
+        double double_value_;
+        const CharT* string_data_;
+        const uint8_t* byte_string_data_;
+    } value_;
+    std::size_t length_{0};
+public:
+    using string_view_type = jsoncons::basic_string_view<CharT>;
+
+    basic_staj_event(staj_event_type event_type, semantic_tag tag = semantic_tag::none)
+        : event_type_(event_type), tag_(tag), value_()
+    {
+    }
+
+    basic_staj_event(staj_event_type event_type, std::size_t length, semantic_tag tag = semantic_tag::none)
+        : event_type_(event_type), tag_(tag), value_(), length_(length)
+    {
+    }
+
+    basic_staj_event(null_type, semantic_tag tag)
+        : event_type_(staj_event_type::null_value), tag_(tag), value_()
+    {
+    }
+
+    basic_staj_event(bool value, semantic_tag tag)
+        : event_type_(staj_event_type::bool_value), tag_(tag)
+    {
+        value_.bool_value_ = value;
+    }
+
+    basic_staj_event(int64_t value, semantic_tag tag)
+        : event_type_(staj_event_type::int64_value), tag_(tag)
+    {
+        value_.int64_value_ = value;
+    }
+
+    basic_staj_event(uint64_t value, semantic_tag tag)
+        : event_type_(staj_event_type::uint64_value), tag_(tag)
+    {
+        value_.uint64_value_ = value;
+    }
+
+    basic_staj_event(half_arg_t, uint16_t value, semantic_tag tag)
+        : event_type_(staj_event_type::half_value), tag_(tag)
+    {
+        value_.half_value_ = value;
+    }
+
+    basic_staj_event(double value, semantic_tag tag)
+        : event_type_(staj_event_type::double_value), tag_(tag)
+    {
+        value_.double_value_ = value;
+    }
+
+    basic_staj_event(const string_view_type& s,
+        staj_event_type event_type,
+        semantic_tag tag = semantic_tag::none)
+        : event_type_(event_type), tag_(tag), length_(s.length())
+    {
+        value_.string_data_ = s.data();
+    }
+
+    basic_staj_event(const byte_string_view& s,
+        staj_event_type event_type,
+        semantic_tag tag = semantic_tag::none)
+        : event_type_(event_type), tag_(tag), length_(s.size())
+    {
+        value_.byte_string_data_ = s.data();
+    }
+
+    basic_staj_event(const byte_string_view& s,
+        staj_event_type event_type,
+        uint64_t ext_tag)
+        : event_type_(event_type), tag_(semantic_tag::ext), ext_tag_(ext_tag), length_(s.size())
+    {
+        value_.byte_string_data_ = s.data();
+    }
+    
+    ~basic_staj_event() = default;
+
+    std::size_t size() const
+    {
+        return length_;
+    }
+
+    template <typename T>
+    T get() const
+    {
+        std::error_code ec;
+        T val = get<T>(ec);
+        if (ec)
+        {
+            JSONCONS_THROW(ser_error(ec));
+        }
+        return val;
+    }
+
+    template <typename T>
+    T get(std::error_code& ec) const
+    {
+        return get_<T>(std::allocator<char>{}, ec);
+    }
+
+    template <typename T,typename Allocator,typename CharT_ = CharT>
+    typename std::enable_if<extension_traits::is_string<T>::value && std::is_same<typename T::value_type, CharT_>::value, T>::type
+    get_(Allocator,std::error_code& ec) const
+    {
+        switch (event_type_)
+        {
+            case staj_event_type::key:
+            case staj_event_type::string_value:
+            {
+                value_converter<jsoncons::basic_string_view<CharT>,T> converter;
+                return converter.convert(jsoncons::basic_string_view<CharT>(value_.string_data_, length_), tag(), ec);
+            }
+            case staj_event_type::byte_string_value:
+            {
+                value_converter<jsoncons::byte_string_view,T> converter;
+                return converter.convert(byte_string_view(value_.byte_string_data_,length_),tag(),ec);
+            }
+            case staj_event_type::uint64_value:
+            {
+                value_converter<uint64_t,T> converter;
+                return converter.convert(value_.uint64_value_, tag(), ec);
+            }
+            case staj_event_type::int64_value:
+            {
+                value_converter<int64_t,T> converter;
+                return converter.convert(value_.int64_value_, tag(), ec);
+            }
+            case staj_event_type::half_value:
+            {
+                value_converter<half_arg_t,T> converter;
+                return converter.convert(value_.half_value_, tag(), ec);
+            }
+            case staj_event_type::double_value:
+            {
+                value_converter<double,T> converter;
+                return converter.convert(value_.double_value_, tag(), ec);
+            }
+            case staj_event_type::bool_value:
+            {
+                value_converter<bool,T> converter;
+                return converter.convert(value_.bool_value_,tag(),ec);
+            }
+            case staj_event_type::null_value:
+            {
+                value_converter<null_type,T> converter;
+                return converter.convert(tag(), ec);
+            }
+            default:
+            {
+                ec = conv_errc::not_string;
+                return T{};
+            }
+        }
+    }
+
+    template <typename T,typename Allocator,typename CharT_ = CharT>
+    typename std::enable_if<extension_traits::is_string_view<T>::value && std::is_same<typename T::value_type, CharT_>::value, T>::type
+        get_(Allocator, std::error_code& ec) const
+    {
+        T s;
+        switch (event_type_)
+        {
+        case staj_event_type::key:
+        case staj_event_type::string_value:
+            s = T(value_.string_data_, length_);
+            break;
+        default:
+            ec = conv_errc::not_string_view;
+            break;        
+        }
+        return s;
+    }
+
+    template <typename T,typename Allocator>
+    typename std::enable_if<std::is_same<T, byte_string_view>::value, T>::type
+        get_(Allocator, std::error_code& ec) const
+    {
+        T s;
+        switch (event_type_)
+        {
+            case staj_event_type::byte_string_value:
+                s = T(value_.byte_string_data_, length_);
+                break;
+            default:
+                ec = conv_errc::not_byte_string_view;
+                break;
+        }
+        return s;
+    }
+
+    template <typename T,typename Allocator>
+    typename std::enable_if<extension_traits::is_array_like<T>::value &&
+                            std::is_same<typename T::value_type,uint8_t>::value,T>::type
+    get_(Allocator, std::error_code& ec) const
+    {
+        switch (event_type_)
+        {
+        case staj_event_type::byte_string_value:
+            {
+                value_converter<byte_string_view,T> converter;
+                return converter.convert(byte_string_view(value_.byte_string_data_, length_), tag(), ec);
+            }
+        case staj_event_type::string_value:
+            {
+                value_converter<jsoncons::basic_string_view<CharT>,T> converter;
+                return converter.convert(jsoncons::basic_string_view<CharT>(value_.string_data_, length_), tag(), ec);
+            }
+            default:
+                ec = conv_errc::not_byte_string;
+                return T{};
+        }
+    }
+
+    template <typename IntegerType,typename Allocator>
+    typename std::enable_if<extension_traits::is_integer<IntegerType>::value, IntegerType>::type
+    get_(Allocator, std::error_code& ec) const
+    {
+        switch (event_type_)
+        {
+            case staj_event_type::string_value:
+            {
+                IntegerType val;
+                auto result = jsoncons::detail::to_integer(value_.string_data_, length_, val);
+                if (!result)
+                {
+                    ec = conv_errc::not_integer;
+                    return IntegerType();
+                }
+                return val;
+            }
+            case staj_event_type::half_value:
+                return static_cast<IntegerType>(value_.half_value_);
+            case staj_event_type::double_value:
+                return static_cast<IntegerType>(value_.double_value_);
+            case staj_event_type::int64_value:
+                return static_cast<IntegerType>(value_.int64_value_);
+            case staj_event_type::uint64_value:
+                return static_cast<IntegerType>(value_.uint64_value_);
+            case staj_event_type::bool_value:
+                return static_cast<IntegerType>(value_.bool_value_ ? 1 : 0);
+            default:
+                ec = conv_errc::not_integer;
+                return IntegerType();
+        }
+    }
+
+    template <typename T,typename Allocator>
+    typename std::enable_if<std::is_floating_point<T>::value, T>::type
+        get_(Allocator, std::error_code& ec) const
+    {
+        return static_cast<T>(as_double(ec));
+    }
+
+    template <typename T,typename Allocator>
+    typename std::enable_if<extension_traits::is_bool<T>::value, T>::type
+        get_(Allocator, std::error_code& ec) const
+    {
+        return as_bool(ec);
+    }
+
+    staj_event_type event_type() const noexcept { return event_type_; }
+
+    semantic_tag tag() const noexcept { return tag_; }
+
+    uint64_t ext_tag() const noexcept { return ext_tag_; }
+
+private:
+
+    double as_double(std::error_code& ec) const
+    {
+        switch (event_type_)
+        {
+            case staj_event_type::key:
+            case staj_event_type::string_value:
+            {
+                jsoncons::detail::chars_to f;
+                return f(value_.string_data_, length_);
+            }
+            case staj_event_type::double_value:
+                return value_.double_value_;
+            case staj_event_type::int64_value:
+                return static_cast<double>(value_.int64_value_);
+            case staj_event_type::uint64_value:
+                return static_cast<double>(value_.uint64_value_);
+            case staj_event_type::half_value:
+            {
+                double x = binary::decode_half(value_.half_value_);
+                return static_cast<double>(x);
+            }
+            default:
+                ec = conv_errc::not_double;
+                return double();
+        }
+    }
+
+    bool as_bool(std::error_code& ec) const
+    {
+        switch (event_type_)
+        {
+            case staj_event_type::bool_value:
+                return value_.bool_value_;
+            case staj_event_type::double_value:
+                return value_.double_value_ != 0.0;
+            case staj_event_type::int64_value:
+                return value_.int64_value_ != 0;
+            case staj_event_type::uint64_value:
+                return value_.uint64_value_ != 0;
+            default:
+                ec = conv_errc::not_bool;
+                return bool();
+        }
+    }
+public:
+    bool send_json_event(basic_json_visitor<CharT>& visitor,
+        const ser_context& context,
+        std::error_code& ec) const
+    {
+        switch (event_type())
+        {
+            case staj_event_type::begin_array:
+                return visitor.begin_array(tag(), context);
+            case staj_event_type::end_array:
+                return visitor.end_array(context);
+            case staj_event_type::begin_object:
+                return visitor.begin_object(tag(), context, ec);
+            case staj_event_type::end_object:
+                return visitor.end_object(context, ec);
+            case staj_event_type::key:
+                return visitor.key(string_view_type(value_.string_data_,length_), context);
+            case staj_event_type::string_value:
+                return visitor.string_value(string_view_type(value_.string_data_,length_), tag(), context);
+            case staj_event_type::byte_string_value:
+                return visitor.byte_string_value(byte_string_view(value_.byte_string_data_,length_), tag(), context);
+            case staj_event_type::null_value:
+                return visitor.null_value(tag(), context);
+            case staj_event_type::bool_value:
+                return visitor.bool_value(value_.bool_value_, tag(), context);
+            case staj_event_type::int64_value:
+                return visitor.int64_value(value_.int64_value_, tag(), context);
+            case staj_event_type::uint64_value:
+                return visitor.uint64_value(value_.uint64_value_, tag(), context);
+            case staj_event_type::half_value:
+                return visitor.half_value(value_.half_value_, tag(), context);
+            case staj_event_type::double_value:
+                return visitor.double_value(value_.double_value_, tag(), context);
+            default:
+                return false;
+        }
+    }
+    
+    bool send_value_event(basic_item_event_visitor<CharT>& visitor,
+        const ser_context& context,
+        std::error_code& ec) const
+    {
+        switch (event_type())
+        {
+            case staj_event_type::key:
+                return visitor.string_value(string_view_type(value_.string_data_,length_), tag(), context);
+            case staj_event_type::begin_array:
+                return visitor.begin_array(tag(), context);
+            case staj_event_type::end_array:
+                return visitor.end_array(context);
+            case staj_event_type::begin_object:
+                return visitor.begin_object(tag(), context, ec);
+            case staj_event_type::end_object:
+                return visitor.end_object(context, ec);
+            case staj_event_type::string_value:
+                return visitor.string_value(string_view_type(value_.string_data_,length_), tag(), context);
+            case staj_event_type::byte_string_value:
+                return visitor.byte_string_value(byte_string_view(value_.byte_string_data_,length_), tag(), context);
+            case staj_event_type::null_value:
+                return visitor.null_value(tag(), context);
+            case staj_event_type::bool_value:
+                return visitor.bool_value(value_.bool_value_, tag(), context);
+            case staj_event_type::int64_value:
+                return visitor.int64_value(value_.int64_value_, tag(), context);
+            case staj_event_type::uint64_value:
+                return visitor.uint64_value(value_.uint64_value_, tag(), context);
+            case staj_event_type::half_value:
+                return visitor.half_value(value_.half_value_, tag(), context);
+            case staj_event_type::double_value:
+                return visitor.double_value(value_.double_value_, tag(), context);
+            default:
+                return false;
+        }
+    }
+
+};
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_STAJ_EVENT_HPP

--- a/velox/external/jsoncons/staj_event_reader.hpp
+++ b/velox/external/jsoncons/staj_event_reader.hpp
@@ -1,0 +1,754 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_STAJ_EVENT_READER_HPP
+#define JSONCONS_STAJ_EVENT_READER_HPP
+
+#include <array> // std::array
+#include <cstddef>
+#include <cstdint>
+#include <functional> // std::function
+#include <ios>
+#include <memory> // std::allocator
+#include <system_error>
+
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/item_event_visitor.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/staj_event.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+#include "velox/external/jsoncons/typed_array_view.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/value_converter.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // basic_item_event_receiver
+
+    enum class item_event_reader_state
+    {
+        typed_array = 1,
+        multi_dim,
+        shape
+    };
+
+    template <typename CharT>
+    class basic_item_event_receiver : public basic_item_event_visitor<CharT>
+    {
+        using super_type = basic_item_event_visitor<CharT>;
+    public:
+        using char_type = CharT;
+        using typename super_type::string_view_type;
+    private:
+        std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred_;
+        basic_staj_event<CharT> event_;
+
+        item_event_reader_state state_;
+        typed_array_view data_;
+        jsoncons::span<const size_t> shape_;
+        std::size_t index_;
+    public:
+        basic_item_event_receiver()
+            : pred_(accept), event_(staj_event_type::null_value),
+              state_(), data_(), shape_(), index_(0)
+        {
+        }
+
+        basic_item_event_receiver(std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+            : pred_(pred), event_(staj_event_type::null_value),
+              state_(), data_(), shape_(), index_(0)
+        {
+        }
+
+        void reset()
+        {
+            event_ = staj_event_type::null_value;
+            state_ = {};
+            data_ = {};
+            shape_ = {};
+            index_ = 0;
+        }
+
+        const basic_staj_event<CharT>& event() const
+        {
+            return event_;
+        }
+
+        bool in_available() const
+        {
+            return state_ != item_event_reader_state();
+        }
+
+        void send_available(std::error_code& ec)
+        {
+            switch (state_)
+            {
+                case item_event_reader_state::typed_array:
+                    advance_typed_array(ec);
+                    break;
+                case item_event_reader_state::multi_dim:
+                case item_event_reader_state::shape:
+                    advance_multi_dim(ec);
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        bool is_typed_array() const
+        {
+            return data_.type() != typed_array_type();
+        }
+
+        item_event_reader_state state() const
+        {
+            return state_;
+        }
+
+        void advance_typed_array(std::error_code& ec)
+        {
+            if (is_typed_array())
+            {
+                if (index_ < data_.size())
+                {
+                    switch (data_.type())
+                    {
+                        case typed_array_type::uint8_value:
+                        {
+                            this->uint64_value(data_.data(uint8_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::uint16_value:
+                        {
+                            this->uint64_value(data_.data(uint16_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::uint32_value:
+                        {
+                            this->uint64_value(data_.data(uint32_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::uint64_value:
+                        {
+                            this->uint64_value(data_.data(uint64_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::int8_value:
+                        {
+                            this->int64_value(data_.data(int8_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::int16_value:
+                        {
+                            this->int64_value(data_.data(int16_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::int32_value:
+                        {
+                            this->int64_value(data_.data(int32_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::int64_value:
+                        {
+                            this->int64_value(data_.data(int64_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::half_value:
+                        {
+                            this->half_value(data_.data(half_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::float_value:
+                        {
+                            this->double_value(data_.data(float_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        case typed_array_type::double_value:
+                        {
+                            this->double_value(data_.data(double_array_arg)[index_], semantic_tag::none, ser_context(), ec);
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                    ++index_;
+                }
+                else
+                {
+                    this->end_array();
+                    state_ = item_event_reader_state();
+                    data_ = typed_array_view();
+                    index_ = 0;
+                }
+            }
+        }
+
+        void advance_multi_dim(std::error_code& ec)
+        {
+            if (shape_.size() != 0)
+            {
+                if (state_ == item_event_reader_state::multi_dim)
+                {
+                    this->begin_array(shape_.size(), semantic_tag::none, ser_context(), ec);
+                    state_ = item_event_reader_state::shape;
+                }
+                else if (index_ < shape_.size())
+                {
+                    this->uint64_value(shape_[index_], semantic_tag::none, ser_context(), ec);
+                    ++index_;
+                }
+                else
+                {
+                    state_ = item_event_reader_state();
+                    this->end_array(ser_context(), ec);
+                    shape_ = jsoncons::span<const size_t>();
+                    index_ = 0;
+                }
+            }
+        }
+
+        bool dump(basic_item_event_visitor<CharT>& visitor, const ser_context& context, std::error_code& ec)
+        {
+            bool more = true;
+            if (is_typed_array())
+            {
+                if (index_ != 0)
+                {
+                    more = event().send_value_event(visitor, context, ec);
+                    while (more && is_typed_array())
+                    {
+                        if (index_ < data_.size())
+                        {
+                            switch (data_.type())
+                            {
+                                case typed_array_type::uint8_value:
+                                {
+                                    more = visitor.uint64_value(data_.data(uint8_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::uint16_value:
+                                {
+                                    more = visitor.uint64_value(data_.data(uint16_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::uint32_value:
+                                {
+                                    more = visitor.uint64_value(data_.data(uint32_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::uint64_value:
+                                {
+                                    more = visitor.uint64_value(data_.data(uint64_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::int8_value:
+                                {
+                                    more = visitor.int64_value(data_.data(int8_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::int16_value:
+                                {
+                                    more = visitor.int64_value(data_.data(int16_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::int32_value:
+                                {
+                                    more = visitor.int64_value(data_.data(int32_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::int64_value:
+                                {
+                                    more = visitor.int64_value(data_.data(int64_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::float_value:
+                                {
+                                    more = visitor.double_value(data_.data(float_array_arg)[index_]);
+                                    break;
+                                }
+                                case typed_array_type::double_value:
+                                {
+                                    more = visitor.double_value(data_.data(double_array_arg)[index_]);
+                                    break;
+                                }
+                                default:
+                                    break;
+                            }
+                            ++index_;
+                        }
+                        else
+                        {
+                            more = visitor.end_array();
+                            state_ = item_event_reader_state();
+                            data_ = typed_array_view();
+                            index_ = 0;
+                        }
+                    }
+                }
+                else
+                {
+                    switch (data_.type())
+                    {
+                        case typed_array_type::uint8_value:
+                        {
+                            more = visitor.typed_array(data_.data(uint8_array_arg));
+                            break;
+                        }
+                        case typed_array_type::uint16_value:
+                        {
+                            more = visitor.typed_array(data_.data(uint16_array_arg));
+                            break;
+                        }
+                        case typed_array_type::uint32_value:
+                        {
+                            more = visitor.typed_array(data_.data(uint32_array_arg));
+                            break;
+                        }
+                        case typed_array_type::uint64_value:
+                        {
+                            more = visitor.typed_array(data_.data(uint64_array_arg));
+                            break;
+                        }
+                        case typed_array_type::int8_value:
+                        {
+                            more = visitor.typed_array(data_.data(int8_array_arg));
+                            break;
+                        }
+                        case typed_array_type::int16_value:
+                        {
+                            more = visitor.typed_array(data_.data(int16_array_arg));
+                            break;
+                        }
+                        case typed_array_type::int32_value:
+                        {
+                            more = visitor.typed_array(data_.data(int32_array_arg));
+                            break;
+                        }
+                        case typed_array_type::int64_value:
+                        {
+                            more = visitor.typed_array(data_.data(int64_array_arg));
+                            break;
+                        }
+                        case typed_array_type::float_value:
+                        {
+                            more = visitor.typed_array(data_.data(float_array_arg));
+                            break;
+                        }
+                        case typed_array_type::double_value:
+                        {
+                            more = visitor.typed_array(data_.data(double_array_arg));
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+
+                    state_ = item_event_reader_state();
+                    data_ = typed_array_view();
+                }
+            }
+            else
+            {
+                more = event().send_value_event(visitor, context, ec);
+            }
+            return more;
+        }
+
+    private:
+        static constexpr bool accept(const basic_staj_event<CharT>&, const ser_context&) 
+        {
+            return true;
+        }
+
+        bool visit_begin_object(semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::begin_object, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_begin_object(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::begin_object, length, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_end_object(const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::end_object);
+            return !pred_(event_, context);
+        }
+
+        bool visit_begin_array(semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::begin_array, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_begin_array(std::size_t length, semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::begin_array, length, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_end_array(const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::end_array);
+            return !pred_(event_, context);
+        }
+
+        bool visit_null(semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(staj_event_type::null_value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_bool(bool value, semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_string(const string_view_type& s, semantic_tag tag, const ser_context& context, std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(s, staj_event_type::string_value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_byte_string(const byte_string_view& s, 
+                               semantic_tag tag,
+                               const ser_context& context,
+                               std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(s, staj_event_type::byte_string_value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_byte_string(const byte_string_view& s, 
+                               uint64_t ext_tag,
+                               const ser_context& context,
+                               std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(s, staj_event_type::byte_string_value, ext_tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_uint64(uint64_t value, 
+                             semantic_tag tag, 
+                             const ser_context& context,
+                             std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_int64(int64_t value, 
+                      semantic_tag tag,
+                      const ser_context& context,
+                      std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_half(uint16_t value, 
+                     semantic_tag tag,
+                     const ser_context& context,
+                     std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(half_arg, value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_double(double value, 
+                       semantic_tag tag, 
+                       const ser_context& context,
+                       std::error_code&) override
+        {
+            event_ = basic_staj_event<CharT>(value, tag);
+            return !pred_(event_, context);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint8_t>& v, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(v.data(), v.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint16_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint32_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const uint64_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int8_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int16_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int32_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const int64_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(half_arg_t, const jsoncons::span<const uint16_t>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const float>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+
+        bool visit_typed_array(const jsoncons::span<const double>& data, 
+                            semantic_tag tag,
+                            const ser_context& context,
+                            std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::typed_array;
+            data_ = typed_array_view(data.data(), data.size());
+            index_ = 0;
+            return this->begin_array(tag, context, ec);
+        }
+    /*
+        bool visit_typed_array(const jsoncons::span<const float128_type>&, 
+                            semantic_tag,
+                            const ser_context&,
+                            std::error_code&) override
+        {
+            return true;
+        }
+    */
+        bool visit_begin_multi_dim(const jsoncons::span<const size_t>& shape,
+                                semantic_tag tag,
+                                const ser_context& context, 
+                                std::error_code& ec) override
+        {
+            state_ = item_event_reader_state::multi_dim;
+            shape_ = shape;
+            return this->begin_array(2, tag, context, ec);
+        }
+
+        bool visit_end_multi_dim(const ser_context& context,
+                              std::error_code& ec) override
+        {
+            return this->end_array(context, ec);
+        }
+
+        void visit_flush() override
+        {
+        }
+    };
+
+    // basic_staj_event_reader
+
+    template <typename CharT>
+    class basic_staj_event_reader
+    {
+    public:
+        virtual ~basic_staj_event_reader() = default;
+
+        virtual void array_expected(std::error_code& ec)
+        {
+            if (!(current().event_type() == staj_event_type::begin_array || current().event_type() == staj_event_type::byte_string_value))
+            {
+                ec = conv_errc::not_vector;
+            }
+        }
+
+        virtual bool done() const = 0;
+
+        virtual const basic_staj_event<CharT>& current() const = 0;
+
+        virtual void read_to(basic_item_event_visitor<CharT>& visitor) = 0;
+
+        virtual void read_to(basic_item_event_visitor<CharT>& visitor,
+                             std::error_code& ec) = 0;
+
+        virtual void next() = 0;
+
+        virtual void next(std::error_code& ec) = 0;
+
+        virtual const ser_context& context() const = 0;
+    };
+
+    template <typename CharT>
+    class basic_staj2_filter_view : basic_staj_event_reader<CharT>
+    {
+        basic_staj_event_reader<CharT>* cursor_;
+        std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred_;
+    public:
+        basic_staj2_filter_view(basic_staj_event_reader<CharT>& cursor,
+                         std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+            : cursor_(std::addressof(cursor)), pred_(pred)
+        {
+            while (!done() && !pred_(current(),context()))
+            {
+                cursor_->next();
+            }
+        }
+
+        bool done() const override
+        {
+            return cursor_->done();
+        }
+
+        const basic_staj_event<CharT>& current() const override
+        {
+            return cursor_->current();
+        }
+
+        void read_to(basic_item_event_visitor<CharT>& visitor) override
+        {
+            cursor_->read_to(visitor);
+        }
+
+        void read_to(basic_item_event_visitor<CharT>& visitor,
+                     std::error_code& ec) override
+        {
+            cursor_->read_to(visitor, ec);
+        }
+
+        void next() override
+        {
+            cursor_->next();
+            while (!done() && !pred_(current(),context()))
+            {
+                cursor_->next();
+            }
+        }
+
+        void next(std::error_code& ec) override
+        {
+            cursor_->next(ec);
+            while (!done() && !pred_(current(),context()) && !ec)
+            {
+                cursor_->next(ec);
+            }
+        }
+
+        const ser_context& context() const override
+        {
+            return cursor_->context();
+        }
+
+        friend
+            basic_staj2_filter_view<CharT> operator|(basic_staj2_filter_view& cursor,
+                                          std::function<bool(const basic_staj_event<CharT>&, const ser_context&)> pred)
+        {
+            return basic_staj2_filter_view<CharT>(cursor, pred);
+        }
+    };
+
+    using item_event = basic_staj_event<char>;
+    using witem_event = basic_staj_event<wchar_t>;
+
+    using staj_event_reader = basic_staj_event_reader<char>;
+    using wstaj_event_reader = basic_staj_event_reader<wchar_t>;
+
+    using staj2_filter_view = basic_staj2_filter_view<char>;
+    using wstaj2_filter_view = basic_staj2_filter_view<wchar_t>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_STAJ_EVENT_READER_HPP

--- a/velox/external/jsoncons/staj_iterator.hpp
+++ b/velox/external/jsoncons/staj_iterator.hpp
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_STAJ_ITERATOR_HPP
+#define JSONCONS_STAJ_ITERATOR_HPP
+
+#include <exception>
+#include <ios>
+#include <iterator> // std::input_iterator_tag
+#include <memory>
+#include <new> // placement new
+#include <string>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/basic_json.hpp"
+#include "velox/external/jsoncons/decode_traits.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+#include "velox/external/jsoncons/staj_event.hpp"
+#include "velox/external/jsoncons/staj_cursor.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    template <typename T,typename Json>
+    class staj_array_view;
+
+    template <typename T,typename Json>
+    class staj_array_iterator
+    {
+        using char_type = typename Json::char_type;
+
+        staj_array_view<T, Json>* view_;
+        std::exception_ptr eptr_;
+
+    public:
+        using value_type = T;
+        using difference_type = std::ptrdiff_t;
+        using pointer = T*;
+        using reference = T&;
+        using iterator_category = std::input_iterator_tag;
+
+        staj_array_iterator() noexcept
+            : view_(nullptr)
+        {
+        }
+
+        staj_array_iterator(staj_array_view<T, Json>& view)
+            : view_(std::addressof(view))
+        {
+            if (view_->cursor_->current().event_type() == staj_event_type::begin_array)
+            {
+                next();
+            }
+            else
+            {
+                view_->cursor_ = nullptr;
+            }
+        }
+
+        staj_array_iterator(staj_array_view<T, Json>& view,
+                            std::error_code& ec)
+            : view_(std::addressof(view))
+        {
+            if (view_->cursor_->current().event_type() == staj_event_type::begin_array)
+            {
+                next(ec);
+                if (ec) {view_ = nullptr;}
+            }
+            else
+            {
+                view_ = nullptr;
+            }
+        }
+
+        ~staj_array_iterator() noexcept
+        {
+        }
+
+        bool has_value() const
+        {
+            return !eptr_;
+        }
+
+        const T& operator*() const
+        {
+            if (eptr_)
+            {
+                 std::rethrow_exception(eptr_);
+            }
+            else
+            {
+                return *view_->value_;
+            }
+        }
+
+        const T* operator->() const
+        {
+            if (eptr_)
+            {
+                 std::rethrow_exception(eptr_);
+            }
+            else
+            {
+                return view_->value_.operator->();
+            }
+        }
+
+        staj_array_iterator& operator++()
+        {
+            next();
+            return *this;
+        }
+
+        staj_array_iterator& increment(std::error_code& ec)
+        {
+            next(ec);
+            if (ec) {view_ = nullptr;}
+            return *this;
+        }
+
+        staj_array_iterator operator++(int) // postfix increment
+        {
+            staj_array_iterator temp(*this);
+            next();
+            return temp;
+        }
+
+        friend bool operator==(const staj_array_iterator& a, const staj_array_iterator& b)
+        {
+            return (!a.view_ && !b.view_)
+                || (!a.view_ && b.done())
+                || (!b.view_ && a.done());
+        }
+
+        friend bool operator!=(const staj_array_iterator& a, const staj_array_iterator& b)
+        {
+            return !(a == b);
+        }
+
+    private:
+
+        bool done() const
+        {
+            return view_->cursor_->done() || view_->cursor_->current().event_type() == staj_event_type::end_array;
+        }
+
+        void next()
+        {
+            std::error_code ec;
+            next(ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, view_->cursor_->context().line(), view_->cursor_->context().column()));
+            }
+        }
+
+        void next(std::error_code& ec)
+        {
+            if (!done())
+            {
+                view_->cursor_->next(ec);
+                if (ec)
+                {
+                    return;
+                }
+                if (!done())
+                {
+                    eptr_ = std::exception_ptr();
+                    JSONCONS_TRY
+                    {
+                        view_->value_ = decode_traits<T,char_type>::decode(*view_->cursor_, view_->decoder_, ec);
+                    }
+                    JSONCONS_CATCH(const conv_error&)
+                    {
+                        eptr_ = std::current_exception();
+                    }
+                }
+            }
+        }
+    };
+
+    template <typename Key,typename Json,typename T=Json>
+    class staj_object_view;
+
+    template <typename Key,typename T,typename Json>
+    class staj_object_iterator
+    {
+        using char_type = typename Json::char_type;
+
+        staj_object_view<Key, T, Json>* view_;
+        std::exception_ptr eptr_;
+    public:
+        using key_type = std::basic_string<char_type>;
+        using value_type = std::pair<key_type,T>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+        using iterator_category = std::input_iterator_tag;
+
+    public:
+
+        staj_object_iterator() noexcept
+            : view_(nullptr)
+        {
+        }
+
+        staj_object_iterator(staj_object_view<Key, T, Json>& view)
+            : view_(std::addressof(view))
+        {
+            if (view_->cursor_->current().event_type() == staj_event_type::begin_object)
+            {
+                next();
+            }
+            else
+            {
+                view_ = nullptr;
+            }
+        }
+
+        staj_object_iterator(staj_object_view<Key, T, Json>& view, 
+                             std::error_code& ec)
+            : view_(std::addressof(view))
+        {
+            if (view_->cursor_->current().event_type() == staj_event_type::begin_object)
+            {
+                next(ec);
+                if (ec) {view_ = nullptr;}
+            }
+            else
+            {
+                view_ = nullptr;
+            }
+        }
+
+        ~staj_object_iterator() noexcept
+        {
+        }
+
+        bool has_value() const
+        {
+            return !eptr_;
+        }
+
+        const value_type& operator*() const
+        {
+            if (eptr_)
+            {
+                 std::rethrow_exception(eptr_);
+            }
+            else
+            {
+                return *view_->key_value_;
+            }
+        }
+
+        const value_type* operator->() const
+        {
+            if (eptr_)
+            {
+                 std::rethrow_exception(eptr_);
+            }
+            else
+            {
+                return view_->key_value_.operator->();
+            }
+        }
+
+        staj_object_iterator& operator++()
+        {
+            next();
+            return *this;
+        }
+
+        staj_object_iterator& increment(std::error_code& ec)
+        {
+            next(ec);
+            if (ec)
+            {
+                view_ = nullptr;
+            }
+            return *this;
+        }
+
+        staj_object_iterator operator++(int) // postfix increment
+        {
+            staj_object_iterator temp(*this);
+            next();
+            return temp;
+        }
+
+        friend bool operator==(const staj_object_iterator& a, const staj_object_iterator& b)
+        {
+            return (!a.view_ && !b.view_)
+                   || (!a.view_ && b.done())
+                   || (!b.view_ && a.done());
+        }
+
+        friend bool operator!=(const staj_object_iterator& a, const staj_object_iterator& b)
+        {
+            return !(a == b);
+        }
+
+    private:
+
+        bool done() const
+        {
+            return view_->cursor_->done() || view_->cursor_->current().event_type() == staj_event_type::end_object;
+        }
+
+        void next()
+        {
+            std::error_code ec;
+            next(ec);
+            if (ec)
+            {
+                JSONCONS_THROW(ser_error(ec, view_->cursor_->context().line(), view_->cursor_->context().column()));
+            }
+        }
+
+        void next(std::error_code& ec)
+        {
+            view_->cursor_->next(ec);
+            if (ec)
+            {
+                return;
+            }
+            if (!done())
+            {
+                JSONCONS_ASSERT(view_->cursor_->current().event_type() == staj_event_type::key);
+                auto key = view_->cursor_->current(). template get<key_type>();
+                view_->cursor_->next(ec);
+                if (ec)
+                {
+                    return;
+                }
+                if (!done())
+                {
+                    eptr_ = std::exception_ptr();
+                    JSONCONS_TRY
+                    {
+                        view_->key_value_ = value_type(std::move(key),decode_traits<T,char_type>::decode(*view_->cursor_, view_->decoder_, ec));
+                    }
+                    JSONCONS_CATCH(const conv_error&)
+                    {
+                        eptr_ = std::current_exception();
+                    }
+                }
+            }
+        }
+    };
+
+    // staj_array_view
+
+    template <typename T,typename Json>
+    class staj_array_view
+    {
+        friend class staj_array_iterator<T, Json>;
+    public:
+        using char_type = typename Json::char_type;
+        using iterator = staj_array_iterator<T, Json>;
+    private:
+        basic_staj_cursor<char_type>* cursor_;
+        json_decoder<Json> decoder_;
+        jsoncons::optional<T> value_;
+    public:
+        staj_array_view(basic_staj_cursor<char_type>& cursor) 
+            : cursor_(std::addressof(cursor))
+        {
+        }
+
+        iterator begin()
+        {
+            return staj_array_iterator<T, Json>(*this);
+        }
+
+        iterator end()
+        {
+            return staj_array_iterator<T, Json>();
+        }
+    };
+
+    // staj_object_view
+
+    template <typename Key,typename T,typename Json>
+    class staj_object_view
+    {
+        friend class staj_object_iterator<Key,T,Json>;
+    public:
+        using char_type = typename Json::char_type;
+        using iterator = staj_object_iterator<Key,T,Json>;
+        using key_type = std::basic_string<char_type>;
+        using value_type = std::pair<key_type,T>;
+    private:
+        basic_staj_cursor<char_type>* cursor_;
+        json_decoder<Json> decoder_;
+        jsoncons::optional<value_type> key_value_;
+    public:
+        staj_object_view(basic_staj_cursor<char_type>& cursor) 
+            : cursor_(std::addressof(cursor))
+        {
+        }
+
+        iterator begin()
+        {
+            return staj_object_iterator<Key,T,Json>(*this);
+        }
+
+        iterator end()
+        {
+            return staj_object_iterator<Key,T,Json>();
+        }
+    };
+
+    template <typename T,typename CharT,typename Json=typename std::conditional<extension_traits::is_basic_json<T>::value,T,basic_json<CharT>>::type>
+    staj_array_view<T, Json> staj_array(basic_staj_cursor<CharT>& cursor)
+    {
+        return staj_array_view<T, Json>(cursor);
+    }
+
+    template <typename Key,typename T,typename CharT,typename Json=typename std::conditional<extension_traits::is_basic_json<T>::value,T,basic_json<CharT>>::type>
+    staj_object_view<Key, T, Json> staj_object(basic_staj_cursor<CharT>& cursor)
+    {
+        return staj_object_view<Key, T, Json>(cursor);
+    }
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_STAJ_ITERATOR_HPP

--- a/velox/external/jsoncons/tag_type.hpp
+++ b/velox/external/jsoncons/tag_type.hpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_TAG_TYPE_HPP
+#define JSONCONS_TAG_TYPE_HPP
+
+#include <cstdint>
+#include <ostream>
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+
+namespace facebook::velox::jsoncons {
+
+struct null_type
+{
+    explicit null_type() = default; 
+};
+
+constexpr null_type null_arg{};
+
+struct temp_allocator_arg_t
+{
+    explicit temp_allocator_arg_t() = default; 
+};
+
+constexpr temp_allocator_arg_t temp_allocator_arg{};
+
+struct half_arg_t
+{
+    explicit half_arg_t() = default; 
+};
+
+constexpr half_arg_t half_arg{};
+
+struct json_array_arg_t
+{
+    explicit json_array_arg_t() = default; 
+};
+
+constexpr json_array_arg_t json_array_arg{};
+
+struct json_object_arg_t
+{
+    explicit json_object_arg_t() = default; 
+};
+
+constexpr json_object_arg_t json_object_arg{};
+
+struct byte_string_arg_t
+{
+    explicit byte_string_arg_t() = default; 
+};
+
+constexpr byte_string_arg_t byte_string_arg{};
+
+struct json_const_pointer_arg_t
+{
+    explicit json_const_pointer_arg_t() = default; 
+};
+
+constexpr json_const_pointer_arg_t json_const_pointer_arg{};
+
+struct json_pointer_arg_t
+{
+    explicit json_pointer_arg_t() = default; 
+};
+
+constexpr json_pointer_arg_t json_pointer_arg{};
+ 
+enum class semantic_tag : uint8_t 
+{
+    none = 0,                  // 00000000     
+    undefined = 1,             // 00000001
+    datetime = 2,              // 00000010
+    epoch_second = 3,          // 00000011
+    epoch_milli = 4,           // 00000100
+    epoch_nano = 5,            // 00000101
+    base16 = 6,                // 00000110
+    base64 = 7,                // 00000111
+    base64url = 8,             // 00001000
+    uri = 9,
+    multi_dim_row_major = 10,
+    multi_dim_column_major = 11,
+    bigint = 12,                // 00001100
+    bigdec = 13,                // 00001101
+    bigfloat = 14,              // 00001110
+    float128 = 15,              // 00001111
+    clamped = 16,
+    ext = 17,
+    id = 18,
+    regex = 19,
+    code = 20
+};
+
+inline bool is_number_tag(semantic_tag tag) noexcept
+{
+    static const uint8_t mask{ uint8_t(semantic_tag::bigint) & uint8_t(semantic_tag::bigdec) 
+        & uint8_t(semantic_tag::bigfloat) & uint8_t(semantic_tag::float128) };
+    return (uint8_t(tag) & mask) == mask;
+}
+
+template <typename CharT>
+std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, semantic_tag tag)
+{
+    static constexpr const CharT* na_name = JSONCONS_CSTRING_CONSTANT(CharT, "n/a");
+    static constexpr const CharT* undefined_name = JSONCONS_CSTRING_CONSTANT(CharT, "undefined");
+    static constexpr const CharT* datetime_name = JSONCONS_CSTRING_CONSTANT(CharT, "datetime");
+    static constexpr const CharT* epoch_second_name = JSONCONS_CSTRING_CONSTANT(CharT, "epoch-second");
+    static constexpr const CharT* epoch_milli_name = JSONCONS_CSTRING_CONSTANT(CharT, "epoch-milli");
+    static constexpr const CharT* epoch_nano_name = JSONCONS_CSTRING_CONSTANT(CharT, "epoch-nano");
+    static constexpr const CharT* bigint_name = JSONCONS_CSTRING_CONSTANT(CharT, "bigint");
+    static constexpr const CharT* bigdec_name = JSONCONS_CSTRING_CONSTANT(CharT, "bigdec");
+    static constexpr const CharT* bigfloat_name = JSONCONS_CSTRING_CONSTANT(CharT, "bigfloat");
+    static constexpr const CharT* base16_name = JSONCONS_CSTRING_CONSTANT(CharT, "base16");
+    static constexpr const CharT* base64_name = JSONCONS_CSTRING_CONSTANT(CharT, "base64");
+    static constexpr const CharT* base64url_name = JSONCONS_CSTRING_CONSTANT(CharT, "base64url");
+    static constexpr const CharT* uri_name = JSONCONS_CSTRING_CONSTANT(CharT, "uri");
+    static constexpr const CharT* clamped_name = JSONCONS_CSTRING_CONSTANT(CharT, "clamped");
+    static constexpr const CharT* multi_dim_row_major_name = JSONCONS_CSTRING_CONSTANT(CharT, "multi-dim-row-major");
+    static constexpr const CharT* multi_dim_column_major_name = JSONCONS_CSTRING_CONSTANT(CharT, "multi-dim-column-major");
+    static constexpr const CharT* ext_name = JSONCONS_CSTRING_CONSTANT(CharT, "ext");
+    static constexpr const CharT* id_name = JSONCONS_CSTRING_CONSTANT(CharT, "id");
+    static constexpr const CharT*  float128_name = JSONCONS_CSTRING_CONSTANT(CharT, "float128");
+    static constexpr const CharT*  regex_name = JSONCONS_CSTRING_CONSTANT(CharT, "regex");
+    static constexpr const CharT*  code_name = JSONCONS_CSTRING_CONSTANT(CharT, "code");
+
+    switch (tag)
+    {
+        case semantic_tag::none:
+        {
+            os << na_name;
+            break;
+        }
+        case semantic_tag::undefined:
+        {
+            os << undefined_name;
+            break;
+        }
+        case semantic_tag::datetime:
+        {
+            os << datetime_name;
+            break;
+        }
+        case semantic_tag::epoch_second:
+        {
+            os << epoch_second_name;
+            break;
+        }
+        case semantic_tag::epoch_milli:
+        {
+            os << epoch_milli_name;
+            break;
+        }
+        case semantic_tag::epoch_nano:
+        {
+            os << epoch_nano_name;
+            break;
+        }
+        case semantic_tag::bigint:
+        {
+            os << bigint_name;
+            break;
+        }
+        case semantic_tag::bigdec:
+        {
+            os << bigdec_name;
+            break;
+        }
+        case semantic_tag::bigfloat:
+        {
+            os << bigfloat_name;
+            break;
+        }
+        case semantic_tag::float128:
+        {
+            os << float128_name;
+            break;
+        }
+        case semantic_tag::base16:
+        {
+            os << base16_name;
+            break;
+        }
+        case semantic_tag::base64:
+        {
+            os << base64_name;
+            break;
+        }
+        case semantic_tag::base64url:
+        {
+            os << base64url_name;
+            break;
+        }
+        case semantic_tag::uri:
+        {
+            os << uri_name;
+            break;
+        }
+        case semantic_tag::clamped:
+        {
+            os << clamped_name;
+            break;
+        }
+        case semantic_tag::multi_dim_row_major:
+        {
+            os << multi_dim_row_major_name;
+            break;
+        }
+        case semantic_tag::multi_dim_column_major:
+        {
+            os << multi_dim_column_major_name;
+            break;
+        }
+        case semantic_tag::ext:
+        {
+            os << ext_name;
+            break;
+        }
+        case semantic_tag::id:
+        {
+            os << id_name;
+            break;
+        }
+        case semantic_tag::regex:
+        {
+            os << regex_name;
+            break;
+        }
+        case semantic_tag::code:
+        {
+            os << code_name;
+            break;
+        }
+    }
+    return os;
+}
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_TAG_TYPE_HPP

--- a/velox/external/jsoncons/text_source_adaptor.hpp
+++ b/velox/external/jsoncons/text_source_adaptor.hpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_TEXT_SOURCE_ADAPTOR_HPP
+#define JSONCONS_TEXT_SOURCE_ADAPTOR_HPP
+
+#include <cstddef>
+#include <system_error>
+
+#include "velox/external/jsoncons/json_error.hpp" // json_errc
+#include "velox/external/jsoncons/source.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // unicode_source_adaptor
+
+    template <typename Source,typename Allocator>
+    class unicode_source_adaptor 
+    {
+    public:
+        using value_type = typename Source::value_type;
+        using source_type = Source;
+    private:
+        source_type source_;
+        bool bof_;
+
+
+    public:
+        template <typename Sourceable>
+        unicode_source_adaptor(Sourceable&& source)
+            : source_(std::forward<Sourceable>(source)),
+              bof_(true)
+        {
+        }
+
+        bool is_error() const
+        {
+            return source_.is_error();  
+        }
+
+        bool eof() const
+        {
+            return source_.eof();  
+        }
+
+        span<const value_type> read_buffer(std::error_code& ec)
+        {
+            if (source_.eof())
+            {
+                return span<const value_type>();
+            }
+
+            auto s = source_.read_buffer();
+            const value_type* data = s.data();
+            std::size_t length = s.size();
+
+            if (bof_ && length > 0)
+            {
+                auto r = unicode_traits::detect_encoding_from_bom(data, length);
+                if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+                {
+                    ec = json_errc::illegal_unicode_character;
+                    return;
+                }
+                length -= (r.ptr - data);
+                data = r.ptr;
+                bof_ = false;
+            }
+            return span<const value_type>(data, length);            
+        }
+    };
+
+    // json_source_adaptor
+
+    template <typename Source,typename Allocator>
+    class json_source_adaptor 
+    {
+    public:
+        using value_type = typename Source::value_type;
+        using value_type = typename Source::value_type;
+        using source_type = Source;
+    private:
+        source_type source_;
+        bool bof_;
+
+    public:
+
+        template <typename Sourceable>
+        json_source_adaptor(Sourceable&& source)
+            : source_(std::forward<Sourceable>(source)),
+              bof_(true)
+        {
+        }
+
+        bool is_error() const
+        {
+            return source_.is_error();  
+        }
+
+        bool eof() const
+        {
+            return source_.eof();  
+        }
+
+        span<const value_type> read_buffer(std::error_code& ec)
+        {
+            if (source_.eof())
+            {
+                return span<const value_type>();
+            }
+
+            auto s = source_.read_buffer();
+            const value_type* data = s.data(); 
+            std::size_t length = s.size();
+
+            if (bof_ && length > 0)
+            {
+                auto r = unicode_traits::detect_json_encoding(data, length);
+                if (!(r.encoding == unicode_traits::encoding_kind::utf8 || r.encoding == unicode_traits::encoding_kind::undetected))
+                {
+                    ec = json_errc::illegal_unicode_character;
+                    return span<const value_type>();
+                }
+                length -= (r.ptr - data);
+                data = r.ptr;
+                bof_ = false;
+            }
+            return span<const value_type>(data, length);            
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_TEXT_SOURCE_ADAPTOR_HPP

--- a/velox/external/jsoncons/typed_array_view.hpp
+++ b/velox/external/jsoncons/typed_array_view.hpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_TYPED_ARRAY_VIEW_HPP
+#define JSONCONS_TYPED_ARRAY_VIEW_HPP
+
+#include <array> // std::array
+#include <cstddef>
+#include <cstdint>
+#include <functional> // std::function
+#include <ios>
+#include <system_error>
+
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_parser.hpp"
+#include "velox/external/jsoncons/json_type_traits.hpp"
+#include "velox/external/jsoncons/json_visitor.hpp"
+#include "velox/external/jsoncons/ser_context.hpp"
+#include "velox/external/jsoncons/sink.hpp"
+#include "velox/external/jsoncons/utility/bigint.hpp"
+#include "velox/external/jsoncons/value_converter.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    struct uint8_array_arg_t {explicit uint8_array_arg_t() = default; };
+    constexpr uint8_array_arg_t uint8_array_arg = uint8_array_arg_t();
+    struct uint16_array_arg_t {explicit uint16_array_arg_t() = default; };
+    struct uint32_array_arg_t {explicit uint32_array_arg_t() = default; };
+    constexpr uint32_array_arg_t uint32_array_arg = uint32_array_arg_t();
+    struct uint64_array_arg_t {explicit uint64_array_arg_t() = default; };
+    constexpr uint64_array_arg_t uint64_array_arg = uint64_array_arg_t();
+    struct int8_array_arg_t {explicit int8_array_arg_t() = default; };
+    constexpr int8_array_arg_t int8_array_arg = int8_array_arg_t();
+    struct int16_array_arg_t {explicit int16_array_arg_t() = default; };
+    constexpr int16_array_arg_t int16_array_arg = int16_array_arg_t();
+    struct int32_array_arg_t {explicit int32_array_arg_t() = default; };
+    constexpr int32_array_arg_t int32_array_arg = int32_array_arg_t();
+    struct int64_array_arg_t {explicit int64_array_arg_t() = default; };
+    constexpr int64_array_arg_t int64_array_arg = int64_array_arg_t();
+    constexpr uint16_array_arg_t uint16_array_arg = uint16_array_arg_t();
+    struct half_array_arg_t {explicit half_array_arg_t() = default; };
+    constexpr half_array_arg_t half_array_arg = half_array_arg_t();
+    struct float_array_arg_t {explicit float_array_arg_t() = default; };
+    constexpr float_array_arg_t float_array_arg = float_array_arg_t();
+    struct double_array_arg_t {explicit double_array_arg_t() = default; };
+    constexpr double_array_arg_t double_array_arg = double_array_arg_t();
+    struct float128_array_arg_t {explicit float128_array_arg_t() = default; };
+    constexpr float128_array_arg_t float128_array_arg = float128_array_arg_t();
+
+    enum class typed_array_type{uint8_value=1,uint16_value,uint32_value,uint64_value,
+                                int8_value,int16_value,int32_value,int64_value, 
+                                half_value, float_value,double_value};
+
+    class typed_array_view
+    {
+        typed_array_type type_;
+        union 
+        {
+            const uint8_t* uint8_data_;
+            const uint16_t* uint16_data_;
+            const uint32_t* uint32_data_;
+            const uint64_t* uint64_data_;
+            const int8_t* int8_data_;
+            const int16_t* int16_data_;
+            const int32_t* int32_data_;
+            const int64_t* int64_data_;
+            const float* float_data_;
+            const double* double_data_;
+        } data_;
+        std::size_t size_;
+    public:
+
+        typed_array_view()
+            : type_(), data_(), size_(0)
+        {
+        }
+
+        typed_array_view(const typed_array_view& other)
+            : type_(other.type_), data_(other.data_), size_(other.size())
+        {
+        }
+
+        typed_array_view(typed_array_view&& other) noexcept
+        {
+            swap(*this,other);
+        }
+
+        typed_array_view(const uint8_t* data, std::size_t size)
+            : type_(typed_array_type::uint8_value), size_(size)
+        {
+            data_.uint8_data_ = data;
+        }
+
+        typed_array_view(const uint16_t* data, std::size_t size)
+            : type_(typed_array_type::uint16_value), size_(size)
+        {
+            data_.uint16_data_ = data;
+        }
+
+        typed_array_view(const uint32_t* data, std::size_t size)
+            : type_(typed_array_type::uint32_value), size_(size)
+        {
+            data_.uint32_data_ = data;
+        }
+
+        typed_array_view(const uint64_t* data, std::size_t size)
+            : type_(typed_array_type::uint64_value), size_(size)
+        {
+            data_.uint64_data_ = data;
+        }
+
+        typed_array_view(const int8_t* data, std::size_t size)
+            : type_(typed_array_type::int8_value), size_(size)
+        {
+            data_.int8_data_ = data;
+        }
+
+        typed_array_view(const int16_t* data, std::size_t size)
+            : type_(typed_array_type::int16_value), size_(size)
+        {
+            data_.int16_data_ = data;
+        }
+
+        typed_array_view(const int32_t* data, std::size_t size)
+            : type_(typed_array_type::int32_value), size_(size)
+        {
+            data_.int32_data_ = data;
+        }
+
+        typed_array_view(const int64_t* data, std::size_t size)
+            : type_(typed_array_type::int64_value), size_(size)
+        {
+            data_.int64_data_ = data;
+        }
+
+        typed_array_view(half_array_arg_t, const uint16_t* data, std::size_t size)
+            : type_(typed_array_type::half_value), size_(size)
+        {
+            data_.uint16_data_ = data;
+        }
+
+        typed_array_view(const float* data, std::size_t size)
+            : type_(typed_array_type::float_value), size_(size)
+        {
+            data_.float_data_ = data;
+        }
+
+        typed_array_view(const double* data, std::size_t size)
+            : type_(typed_array_type::double_value), size_(size)
+        {
+            data_.double_data_ = data;
+        }
+
+        typed_array_view& operator=(const typed_array_view& other)
+        {
+            typed_array_view temp(other);
+            swap(*this,temp);
+            return *this;
+        }
+
+        typed_array_type type() const {return type_;}
+
+        std::size_t size() const
+        {
+            return size_;
+        }
+
+        jsoncons::span<const uint8_t> data(uint8_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::uint8_value);
+            return jsoncons::span<const uint8_t>(data_.uint8_data_, size_);
+        }
+
+        jsoncons::span<const uint16_t> data(uint16_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::uint16_value);
+            return jsoncons::span<const uint16_t>(data_.uint16_data_, size_);
+        }
+
+        jsoncons::span<const uint32_t> data(uint32_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::uint32_value);
+            return jsoncons::span<const uint32_t>(data_.uint32_data_, size_);
+        }
+
+        jsoncons::span<const uint64_t> data(uint64_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::uint64_value);
+            return jsoncons::span<const uint64_t>(data_.uint64_data_, size_);
+        }
+
+        jsoncons::span<const int8_t> data(int8_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::int8_value);
+            return jsoncons::span<const int8_t>(data_.int8_data_, size_);
+        }
+
+        jsoncons::span<const int16_t> data(int16_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::int16_value);
+            return jsoncons::span<const int16_t>(data_.int16_data_, size_);
+        }
+
+        jsoncons::span<const int32_t> data(int32_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::int32_value);
+            return jsoncons::span<const int32_t>(data_.int32_data_, size_);
+        }
+
+        jsoncons::span<const int64_t> data(int64_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::int64_value);
+            return jsoncons::span<const int64_t>(data_.int64_data_, size_);
+        }
+
+        jsoncons::span<const uint16_t> data(half_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::half_value);
+            return jsoncons::span<const uint16_t>(data_.uint16_data_, size_);
+        }
+
+        jsoncons::span<const float> data(float_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::float_value);
+            return jsoncons::span<const float>(data_.float_data_, size_);
+        }
+
+        jsoncons::span<const double> data(double_array_arg_t) const
+        {
+            JSONCONS_ASSERT(type_ == typed_array_type::double_value);
+            return jsoncons::span<const double>(data_.double_data_, size_);
+        }
+
+        friend void swap(typed_array_view& a, typed_array_view& b) noexcept
+        {
+            std::swap(a.data_,b.data_);
+            std::swap(a.type_,b.type_);
+            std::swap(a.size_,b.size_);
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_TYPED_ARRAY_VIEW_HPP

--- a/velox/external/jsoncons/utility/bigint.hpp
+++ b/velox/external/jsoncons/utility/bigint.hpp
@@ -1,0 +1,1627 @@
+// Copyright 2018 vDaniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_UTILITY_BIGINT_HPP
+#define JSONCONS_UTILITY_BIGINT_HPP
+
+#include <algorithm> // std::max, std::min, std::reverse
+#include <cassert> // assert
+#include <climits>
+#include <cmath> // std::fmod
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <iostream>
+#include <limits> // std::numeric_limits
+#include <memory> // std::allocator
+#include <string> // std::string
+#include <type_traits> // std::enable_if
+#include <vector> // std::vector
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+
+namespace facebook::velox::jsoncons {
+
+/*
+This implementation is based on Chapter 2 and Appendix A of
+Ammeraal, L. (1996) Algorithms and Data Structures in C++,
+Chichester: John Wiley.
+
+*/
+
+namespace detail {
+
+    template <typename Allocator>
+    class basic_bigint_base
+    {
+    public:
+        using allocator_type = Allocator;
+        using basic_type_allocator_type = typename std::allocator_traits<allocator_type>:: template rebind_alloc<uint64_t>;
+
+    private:
+        basic_type_allocator_type alloc_;
+    public:
+       using allocator_traits_type = std::allocator_traits<basic_type_allocator_type>;
+       using stored_allocator_type = allocator_type;
+       using pointer = typename allocator_traits_type::pointer;
+       using value_type = typename allocator_traits_type::value_type;
+       using size_type = std::size_t;
+       using pointer_traits = std::pointer_traits<pointer>;
+
+        basic_bigint_base()
+            : alloc_()
+        {
+        }
+        explicit basic_bigint_base(const allocator_type& alloc)
+            : alloc_(basic_type_allocator_type(alloc))
+        {
+        }
+
+        basic_type_allocator_type get_allocator() const
+        {
+            return alloc_;
+        }
+    };
+
+} // namespace detail
+
+template <typename Allocator = std::allocator<uint64_t>>
+class basic_bigint : protected detail::basic_bigint_base<Allocator>
+{
+    using base_t = detail::basic_bigint_base<Allocator>;
+
+    static constexpr uint64_t max_short_storage_size = 2;
+public:
+
+    using size_type = typename base_t::size_type;
+    using value_type = typename base_t::value_type;
+    using base_t::get_allocator;
+    using bigint_type = basic_bigint<Allocator>;
+
+    static constexpr uint64_t max_basic_type = (std::numeric_limits<uint64_t>::max)();
+    static constexpr uint64_t basic_type_bits = sizeof(uint64_t) * 8;  // Number of bits
+    static constexpr uint64_t basic_type_halfBits = basic_type_bits/2;
+
+    static constexpr uint16_t word_length = 4; // Use multiples of word_length words
+    static constexpr uint64_t r_mask = (uint64_t(1) << basic_type_halfBits) - 1;
+    static constexpr uint64_t l_mask = max_basic_type - r_mask;
+    static constexpr uint64_t l_bit = max_basic_type - (max_basic_type >> 1);
+
+private:
+
+    struct common_storage
+    {
+        uint8_t is_dynamic_:1; 
+        uint8_t is_negative_:1; 
+        size_type length_;
+    };
+
+    struct short_storage
+    {
+        uint8_t is_dynamic_:1; 
+        uint8_t is_negative_:1; 
+        size_type length_;
+        uint64_t values_[max_short_storage_size];
+
+        short_storage()
+            : is_dynamic_(false), 
+              is_negative_(false),
+              length_(0),
+              values_{0,0}
+        {
+        }
+
+        template <typename T>
+        short_storage(T n, 
+                      typename std::enable_if<std::is_integral<T>::value &&
+                                              sizeof(T) <= sizeof(int64_t) &&
+                                              std::is_signed<T>::value>::type* = 0)
+            : is_dynamic_(false), 
+              is_negative_(n < 0),
+              length_(n == 0 ? 0 : 1)
+        {
+            values_[0] = n < 0 ? (uint64_t(0)-static_cast<uint64_t>(n)) : static_cast<uint64_t>(n);
+            values_[1] = 0;
+        }
+
+        template <typename T>
+        short_storage(T n, 
+                      typename std::enable_if<std::is_integral<T>::value &&
+                                              sizeof(T) <= sizeof(int64_t) &&
+                                              !std::is_signed<T>::value>::type* = 0)
+            : is_dynamic_(false), 
+              is_negative_(false),
+              length_(n == 0 ? 0 : 1)
+        {
+            values_[0] = n;
+            values_[1] = 0;
+        }
+
+        template <typename T>
+        short_storage(T n, 
+                      typename std::enable_if<std::is_integral<T>::value &&
+                                              sizeof(int64_t) < sizeof(T) &&
+                                              std::is_signed<T>::value>::type* = 0)
+            : is_dynamic_(false), 
+              is_negative_(n < 0),
+              length_(n == 0 ? 0 : max_short_storage_size)
+        {
+            using unsigned_type = typename std::make_unsigned<T>::type;
+
+            auto u = n < 0 ? (unsigned_type(0)-static_cast<unsigned_type>(n)) : static_cast<unsigned_type>(n);
+            values_[0] = uint64_t(u & max_basic_type);;
+            u >>= basic_type_bits;
+            values_[1] = uint64_t(u & max_basic_type);;
+        }
+
+        template <typename T>
+        short_storage(T n, 
+                      typename std::enable_if<std::is_integral<T>::value &&
+                                              sizeof(int64_t) < sizeof(T) &&
+                                              !std::is_signed<T>::value>::type* = 0)
+            : is_dynamic_(false), 
+              is_negative_(false),
+              length_(n == 0 ? 0 : max_short_storage_size)
+        {
+            values_[0] = uint64_t(n & max_basic_type);;
+            n >>= basic_type_bits;
+            values_[1] = uint64_t(n & max_basic_type);;
+        }
+
+        short_storage(const short_storage& stor)
+            : is_dynamic_(false), 
+              is_negative_(stor.is_negative_),
+              length_(stor.length_)
+        {
+            values_[0] = stor.values_[0];
+            values_[1] = stor.values_[1];
+        }
+
+        short_storage& operator=(const short_storage& stor) = delete;
+        short_storage& operator=(short_storage&& stor) = delete;
+    };
+
+    struct dynamic_storage
+    {
+        using real_allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<uint64_t>;
+        using pointer = typename std::allocator_traits<real_allocator_type>::pointer;
+
+        uint8_t is_dynamic_:1; 
+        uint8_t is_negative_:1; 
+        size_type length_;
+        size_type capacity_;
+        pointer data_;
+
+        dynamic_storage()
+            : is_dynamic_(true), 
+              is_negative_(false),
+              length_(0),
+              capacity_(0),
+              data_(nullptr)
+        {
+        }
+
+        dynamic_storage(const dynamic_storage& stor, real_allocator_type alloc)
+            : is_dynamic_(true), 
+              is_negative_(stor.is_negative_),
+              length_(stor.length_),
+              capacity_(round_up(stor.length_)),
+              data_(nullptr)
+        {
+            data_ = std::allocator_traits<real_allocator_type>::allocate(alloc, capacity_);
+            JSONCONS_TRY
+            {
+                std::allocator_traits<real_allocator_type>::construct(alloc, extension_traits::to_plain_pointer(data_));
+            }
+            JSONCONS_CATCH(...)
+            {
+                std::allocator_traits<real_allocator_type>::deallocate(alloc, data_, capacity_);
+                JSONCONS_RETHROW;
+            }
+            std::memcpy(data_, stor.data_, size_type(stor.length_*sizeof(uint64_t)));
+        }
+
+        dynamic_storage(dynamic_storage&& stor) noexcept
+            : is_dynamic_(true), 
+              is_negative_(stor.is_negative_),
+              length_(stor.length_),
+              capacity_(stor.capacity_),
+              data_(stor.data_)
+        {
+            stor.length_ = 0;
+            stor.capacity_ = 0;
+            stor.data_ = nullptr;
+        }
+
+        void destroy(const real_allocator_type& a) noexcept
+        {
+            if (data_ != nullptr)
+            {
+                real_allocator_type alloc(a);
+
+                std::allocator_traits<real_allocator_type>::destroy(alloc, extension_traits::to_plain_pointer(data_));
+                std::allocator_traits<real_allocator_type>::deallocate(alloc, data_,capacity_);
+            }
+        }
+
+        void reserve(size_type n, const real_allocator_type& a)
+        {
+            real_allocator_type alloc(a);
+
+            size_type capacity_new = round_up(n);
+            uint64_t* data_old = data_;
+            data_ = std::allocator_traits<real_allocator_type>::allocate(alloc, capacity_new);
+            if (length_ > 0)
+            {
+                std::memcpy( data_, data_old, size_type(length_*sizeof(uint64_t)));
+            }
+            if (capacity_ > 0 && data_ != nullptr)
+            {
+                std::allocator_traits<real_allocator_type>::deallocate(alloc, data_old, capacity_);
+            }
+            capacity_ = capacity_new;
+        }
+
+        // Find suitable new block size
+        constexpr size_type round_up(size_type i) const noexcept 
+        {
+            return (i/word_length + 1) * word_length;
+        }
+    };
+
+    union
+    {
+        common_storage common_stor_;
+        short_storage short_stor_;
+        dynamic_storage dynamic_stor_;
+    };
+
+public:
+    basic_bigint()
+    {
+        ::new (&short_stor_) short_storage();
+    }
+
+    explicit basic_bigint(const Allocator& alloc)
+        : base_t(alloc)
+    {
+        ::new (&short_stor_) short_storage();
+    }
+
+
+    basic_bigint(const basic_bigint<Allocator>& n)
+        : base_t(n.get_allocator())
+    {
+        if (!n.is_dynamic())
+        {
+            ::new (&short_stor_) short_storage(n.short_stor_);
+        }
+        else
+        {
+            ::new (&dynamic_stor_) dynamic_storage(n.dynamic_stor_, get_allocator());
+        }
+    }
+
+    basic_bigint(basic_bigint<Allocator>&& other) noexcept
+        : base_t(other.get_allocator())
+    {
+        if (!other.is_dynamic())
+        {
+            ::new (&short_stor_) short_storage(other.short_stor_);
+        }
+        else
+        {
+            ::new (&dynamic_stor_) dynamic_storage(std::move(other.dynamic_stor_));
+        }
+    }
+
+    template <typename Integer>
+    basic_bigint(Integer n, 
+                 typename std::enable_if<std::is_integral<Integer>::value>::type* = 0)
+    {
+        ::new (&short_stor_) short_storage(n);
+    }
+
+    ~basic_bigint() noexcept
+    {
+        destroy();
+    }
+
+    constexpr bool is_dynamic() const
+    {
+        return common_stor_.is_dynamic_;
+    }
+
+    constexpr size_type length() const
+    {
+        return common_stor_.length_;
+    }
+
+    constexpr size_type capacity() const
+    {
+        return is_dynamic() ? dynamic_stor_.capacity_ : max_short_storage_size;
+    }
+
+    bool is_negative() const
+    {
+        return common_stor_.is_negative_;
+    }
+
+    void is_negative(bool value) 
+    {
+        common_stor_.is_negative_ = value;
+    }
+
+    constexpr const uint64_t* data() const
+    {
+        return is_dynamic() ? dynamic_stor_.data_ : short_stor_.values_;
+    }
+
+    uint64_t* data() 
+    {
+        return is_dynamic() ? dynamic_stor_.data_ : short_stor_.values_;
+    }
+
+    template <typename CharT>
+    static basic_bigint<Allocator> from_string(const std::basic_string<CharT>& s)
+    {
+        return from_string(s.data(), s.length());
+    }
+
+    template <typename CharT>
+    static basic_bigint<Allocator> from_string(const CharT* s)
+    {
+        return from_string(s, std::char_traits<CharT>::length(s));
+    }
+
+    template <typename CharT>
+    static basic_bigint<Allocator> from_string(const CharT* data, size_type length)
+    {
+        bool neg;
+        if (*data == '-')
+        {
+            neg = true;
+            data++;
+            --length;
+        }
+        else
+        {
+            neg = false;
+        }
+
+        basic_bigint<Allocator> v = 0;
+        for (size_type i = 0; i < length; i++)
+        {
+            CharT c = data[i];
+            switch (c)
+            {
+                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                    v = (v * 10) + (uint64_t)(c - '0');
+                    break;
+                default:
+                    JSONCONS_THROW(std::runtime_error(std::string("Invalid digit ") + "\'" + (char)c + "\'"));
+            }
+        }
+
+        if (neg)
+        {
+            v.common_stor_.is_negative_ = true;
+        }
+
+        return v;
+    }
+
+    template <typename CharT>
+    static basic_bigint<Allocator> from_string_radix(const CharT* data, size_type length, uint8_t radix)
+    {
+        if (!(radix >= 2 && radix <= 16))
+        {
+            JSONCONS_THROW(std::runtime_error("Unsupported radix"));
+        }
+
+        bool neg;
+        if (*data == '-')
+        {
+            neg = true;
+            data++;
+            --length;
+        }
+        else
+        {
+            neg = false;
+        }
+
+        basic_bigint<Allocator> v = 0;
+        for (size_type i = 0; i < length; i++)
+        {
+            CharT c = data[i];
+            uint64_t d;
+            switch (c)
+            {
+                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9':
+                    d = (uint64_t)(c - '0');
+                    break;
+                case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                    d = (uint64_t)(c - ('a' - 10));
+                    break;
+                case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                    d = (uint64_t)(c - ('A' - 10));
+                    break;
+                default:
+                    JSONCONS_THROW(std::runtime_error(std::string("Invalid digit in radix ") + std::to_string(radix) + ": \'" + (char)c + "\'"));
+            }
+            if (d >= radix)
+            {
+                JSONCONS_THROW(std::runtime_error(std::string("Invalid digit in radix ") + std::to_string(radix) + ": \'" + (char)c + "\'"));
+            }
+            v = (v * radix) + d;
+        }
+
+        if ( neg )
+        {
+            v.common_stor_.is_negative_ = true;
+        }
+        return v;
+    }
+
+    static basic_bigint from_bytes_be(int signum, const uint8_t* str, std::size_t n)
+    {
+        static const double radix_log2 = std::log2(next_power_of_two(256));
+        // Estimate how big the result will be, so we can pre-allocate it.
+        double bits = radix_log2 * n;
+        double big_digits = std::ceil(bits / 64.0);
+        //std::cout << "ESTIMATED: " << big_digits << "\n";
+
+        bigint_type v = 0;
+        v.reserve(static_cast<std::size_t>(big_digits));
+
+        if (n > 0)
+        {
+            for (std::size_t i = 0; i < n; i++)
+            {
+                v = (v * 256) + (uint64_t)(str[i]);
+            }
+        }
+        //std::cout << "ACTUAL: " << v.length() << "\n";
+
+        if (signum < 0)
+        {
+            v.common_stor_.is_negative_ = true;
+        }
+
+        return v;
+    }
+
+    uint64_t* begin() { return is_dynamic() ? dynamic_stor_.data_ : short_stor_.values_; }
+    const uint64_t* begin() const { return is_dynamic() ? dynamic_stor_.data_ : short_stor_.values_; }
+    uint64_t* end() { return begin() + length(); }
+    const uint64_t* end() const { return begin() + length(); }
+
+    void resize(size_type new_length)
+    {
+        size_type old_length = common_stor_.length_;
+        reserve(new_length);
+        common_stor_.length_ = new_length;
+
+        if (old_length < new_length)
+        {
+            if (is_dynamic())
+            {
+                std::memset(dynamic_stor_.data_+old_length, 0, size_type((new_length-old_length)*sizeof(uint64_t)));
+            }
+            else
+            {
+                JSONCONS_ASSERT(new_length <= max_short_storage_size);
+                for (size_type i = old_length; i < max_short_storage_size; ++i)
+                {
+                    short_stor_.values_[i] = 0;
+                }
+            }
+        }
+    }
+
+    void reserve(size_type n)
+    {
+       if (capacity() < n)
+       {
+           if (!is_dynamic())
+           {
+               size_type size = short_stor_.length_;
+               size_type is_neg = short_stor_.is_negative_;
+               uint64_t values[max_short_storage_size] = {short_stor_.values_[0], short_stor_.values_[1]};
+
+               ::new (&dynamic_stor_) dynamic_storage();
+               dynamic_stor_.reserve(n, get_allocator());
+               dynamic_stor_.length_ = size;
+               dynamic_stor_.is_negative_ = is_neg;
+               dynamic_stor_.data_[0] = values[0];
+               dynamic_stor_.data_[1] = values[1];
+           }
+           else
+           {
+               dynamic_stor_.reserve(n, get_allocator());
+           }
+       }
+    }
+
+    // operators
+
+    bool operator!() const
+    {
+        return length() == 0 ? true : false;
+    }
+
+    basic_bigint operator-() const
+    {
+        basic_bigint<Allocator> v(*this);
+        v.common_stor_.is_negative_ = !v.is_negative();
+        return v;
+    }
+
+    basic_bigint& operator=( const basic_bigint<Allocator>& y )
+    {
+        if ( this != &y )
+        {
+            resize( y.length() );
+            common_stor_.is_negative_ = y.is_negative();
+            if ( y.length() > 0 )
+            {
+                std::memcpy( data(), y.data(), size_type(y.length()*sizeof(uint64_t)) );
+            }
+        }
+        return *this;
+    }
+
+    basic_bigint& operator+=( const basic_bigint<Allocator>& y )
+    {
+        if ( is_negative() != y.is_negative() )
+            return *this -= -y;
+        uint64_t d;
+        uint64_t carry = 0;
+
+        resize( (std::max)(y.length(), length()) + 1 );
+
+        for (size_type i = 0; i < length(); i++ )
+        {
+            if ( i >= y.length() && carry == 0 )
+                break;
+            d = data()[i] + carry;
+            carry = d < carry;
+            if ( i < y.length() )
+            {
+                data()[i] = d + y.data()[i];
+                if ( data()[i] < d )
+                    carry = 1;
+            }
+            else
+                data()[i] = d;
+        }
+        reduce();
+        return *this;
+    }
+
+    basic_bigint& operator-=( const basic_bigint<Allocator>& y )
+    {
+        if ( is_negative() != y.is_negative() )
+            return *this += -y;
+        if ( (!is_negative() && y > *this) || (is_negative() && y < *this) )
+            return *this = -(y - *this);
+        uint64_t borrow = 0;
+        uint64_t d;
+        for (size_type i = 0; i < length(); i++ )
+        {
+            if ( i >= y.length() && borrow == 0 )
+                break;
+            d = data()[i] - borrow;
+            borrow = d > data()[i];
+            if ( i < y.length())
+            {
+                data()[i] = d - y.data()[i];
+                if ( data()[i] > d )
+                    borrow = 1;
+            }
+            else 
+                data()[i] = d;
+        }
+        reduce();
+        return *this;
+    }
+
+    basic_bigint& operator*=( int64_t y )
+    {
+        *this *= uint64_t(y < 0 ? -y : y);
+        if ( y < 0 )
+            common_stor_.is_negative_ = !is_negative();
+        return *this;
+    }
+
+    basic_bigint& operator*=( uint64_t y )
+    {
+        size_type len0 = length();
+        uint64_t hi;
+        uint64_t lo;
+        uint64_t dig = data()[0];
+        uint64_t carry = 0;
+
+        resize( length() + 1 );
+
+        size_type i = 0;
+        for (i = 0; i < len0; i++ )
+        {
+            DDproduct( dig, y, hi, lo );
+            data()[i] = lo + carry;
+            dig = data()[i+1];
+            carry = hi + (data()[i] < lo);
+        }
+        data()[i] = carry;
+        reduce();
+        return *this;
+    }
+
+    basic_bigint& operator*=( basic_bigint<Allocator> y )
+    {
+        if ( length() == 0 || y.length() == 0 )
+                    return *this = 0;
+        bool difSigns = is_negative() != y.is_negative();
+        if ( length() + y.length() == max_short_storage_size ) // length() = y.length() = 1
+        {
+            uint64_t a = data()[0], b = y.data()[0];
+            data()[0] = a * b;
+            if ( data()[0] / a != b )
+            {
+                resize( max_short_storage_size );
+                DDproduct( a, b, data()[1], data()[0] );
+            }
+            common_stor_.is_negative_ = difSigns;
+            return *this;
+        }
+        if ( length() == 1 )  //  && y.length() > 1
+        {
+            uint64_t digit = data()[0];
+            *this = y;
+            *this *= digit;
+        }
+        else
+        {
+            if ( y.length() == 1 )
+                *this *= y.data()[0];
+            else
+            {
+                size_type lenProd = length() + y.length(), jA, jB;
+                uint64_t sumHi = 0, sumLo, hi, lo,
+                sumLo_old, sumHi_old, carry=0;
+                basic_bigint<Allocator> x = *this;
+                resize( lenProd ); // Give *this length lenProd
+
+                for (size_type i = 0; i < lenProd; i++ )
+                {
+                    sumLo = sumHi;
+                    sumHi = carry;
+                    carry = 0;
+                    for ( jA=0; jA < x.length(); jA++ )
+                    {
+                        jB = i - jA;
+                        if ( jB >= 0 && jB < y.length() )
+                        {
+                            DDproduct( x.data()[jA], y.data()[jB], hi, lo );
+                            sumLo_old = sumLo;
+                            sumHi_old = sumHi;
+                            sumLo += lo;
+                            if ( sumLo < sumLo_old )
+                                sumHi++;
+                            sumHi += hi;
+                            carry += (sumHi < sumHi_old);
+                        }
+                    }
+                    data()[i] = sumLo;
+                }
+            }
+        }
+       reduce();
+       common_stor_.is_negative_ = difSigns;
+       return *this;
+    }
+
+    basic_bigint& operator/=( const basic_bigint<Allocator>& divisor )
+    {
+        basic_bigint<Allocator> r;
+        divide( divisor, *this, r, false );
+        return *this;
+    }
+
+    basic_bigint& operator%=( const basic_bigint<Allocator>& divisor )
+    {
+        basic_bigint<Allocator> q;
+        divide( divisor, q, *this, true );
+        return *this;
+    }
+
+    basic_bigint& operator<<=( uint64_t k )
+    {
+        size_type q = size_type(k / basic_type_bits);
+        if ( q ) // Increase common_stor_.length_ by q:
+        {
+            resize(length() + q);
+            for (size_type i = length(); i-- > 0; )
+                data()[i] = ( i < q ? 0 : data()[i - q]);
+            k %= basic_type_bits;
+        }
+        if ( k )  // 0 < k < basic_type_bits:
+        {
+            uint64_t k1 = basic_type_bits - k;
+            uint64_t mask = (uint64_t(1) << k) - uint64_t(1);
+            resize( length() + 1 );
+            for (size_type i = length(); i-- > 0; )
+            {
+                data()[i] <<= k;
+                if ( i > 0 )
+                    data()[i] |= (data()[i-1] >> k1) & mask;
+            }
+        }
+        reduce();
+        return *this;
+    }
+
+    basic_bigint& operator>>=(uint64_t k)
+    {
+        size_type q = size_type(k / basic_type_bits);
+        if ( q >= length() )
+        {
+            resize( 0 );
+            return *this;
+        }
+        if (q > 0)
+        {
+            memmove( data(), data()+q, size_type((length() - q)*sizeof(uint64_t)) );
+            resize( size_type(length() - q) );
+            k %= basic_type_bits;
+            if ( k == 0 )
+            {
+                reduce();
+                return *this;
+            }
+        }
+
+        size_type n = size_type(length() - 1);
+        int64_t k1 = basic_type_bits - k;
+        uint64_t mask = (uint64_t(1) << k) - 1;
+        for (size_type i = 0; i <= n; i++)
+        {
+            data()[i] >>= k;
+            if ( i < n )
+                data()[i] |= ((data()[i+1] & mask) << k1);
+        }
+        reduce();
+        return *this;
+    }
+
+    basic_bigint& operator++()
+    {
+        *this += 1;
+        return *this;
+    }
+
+    basic_bigint<Allocator> operator++(int)
+    {
+        basic_bigint<Allocator> old = *this;
+        ++(*this);
+        return old;
+    }
+
+    basic_bigint<Allocator>& operator--()
+    {
+        *this -= 1;
+        return *this;
+    }
+
+    basic_bigint<Allocator> operator--(int)
+    {
+        basic_bigint<Allocator> old = *this;
+        --(*this);
+        return old;
+    }
+
+    basic_bigint& operator|=( const basic_bigint<Allocator>& a )
+    {
+        if ( length() < a.length() )
+        {
+            resize( a.length() );
+        }
+
+        const uint64_t* qBegin = a.begin();
+        const uint64_t* q =      a.end() - 1;
+        uint64_t*       p =      begin() + a.length() - 1;
+
+        while ( q >= qBegin )
+        {
+            *p-- |= *q--;
+        }
+
+        reduce();
+
+        return *this;
+    }
+
+    basic_bigint& operator^=( const basic_bigint<Allocator>& a )
+    {
+        if ( length() < a.length() )
+        {
+            resize( a.length() );
+        }
+
+        const uint64_t* qBegin = a.begin();
+        const uint64_t* q = a.end() - 1;
+        uint64_t* p = begin() + a.length() - 1;
+
+        while ( q >= qBegin )
+        {
+            *p-- ^= *q--;
+        }
+
+        reduce();
+
+        return *this;
+    }
+
+    basic_bigint& operator&=( const basic_bigint<Allocator>& a )
+    {
+        size_type old_length = length();
+
+        resize( (std::min)( length(), a.length() ) );
+
+        const uint64_t* pBegin = begin();
+        uint64_t* p = end() - 1;
+        const uint64_t* q = a.begin() + length() - 1;
+
+        while ( p >= pBegin )
+        {
+            *p-- &= *q--;
+        }
+
+        const size_type new_length = length();
+        if ( old_length > new_length )
+        {
+            if (is_dynamic())
+            {
+                std::memset( dynamic_stor_.data_ + new_length, 0, size_type(old_length - new_length*sizeof(uint64_t)) );
+            }
+            else
+            {
+                JSONCONS_ASSERT(new_length <= max_short_storage_size);
+                for (size_type i = new_length; i < max_short_storage_size; ++i)
+                {
+                    short_stor_.values_[i] = 0;
+                }
+            }
+        }
+
+        reduce();
+
+        return *this;
+    }
+
+    explicit operator bool() const
+    {
+       return length() != 0 ? true : false;
+    }
+
+    explicit operator int64_t() const
+    {
+       int64_t x = 0;
+       if ( length() > 0 )
+       {
+           x = data() [0];
+       }
+
+       return is_negative() ? -x : x;
+    }
+
+    explicit operator uint64_t() const
+    {
+       uint64_t u = 0;
+       if ( length() > 0 )
+       {
+           u = data() [0];
+       }
+
+       return u;
+    }
+
+    explicit operator double() const
+    {
+        double x = 0.0;
+        double factor = 1.0;
+        double values = (double)max_basic_type + 1.0;
+
+        const uint64_t* p = begin();
+        const uint64_t* pEnd = end();
+        while ( p < pEnd )
+        {
+            x += *p*factor;
+            factor *= values;
+            ++p;
+        }
+
+       return is_negative() ? -x : x;
+    }
+
+    explicit operator long double() const
+    {
+        long double x = 0.0;
+        long double factor = 1.0;
+        long double values = (long double)max_basic_type + 1.0;
+
+        const uint64_t* p = begin();
+        const uint64_t* pEnd = end();
+        while ( p < pEnd )
+        {
+            x += *p*factor;
+            factor *= values;
+            ++p;
+        }
+
+       return is_negative() ? -x : x;
+    }
+
+    template <typename Alloc>
+    void write_bytes_be(int& signum, std::vector<uint8_t,Alloc>& data) const
+    {
+        basic_bigint<Allocator> n(*this);
+        signum = (n < 0) ? -1 : (n > 0 ? 1 : 0); 
+
+        basic_bigint<Allocator> divisor(256);
+
+        while (n >= 256)
+        {
+            basic_bigint<Allocator> q;
+            basic_bigint<Allocator> r;
+            n.divide(divisor, q, r, true);
+            n = q;
+            data.push_back((uint8_t)(uint64_t)r);
+        }
+        if (n >= 0)
+        {
+            data.push_back((uint8_t)(uint64_t)n);
+        }
+        std::reverse(data.begin(),data.end());
+    }
+
+    std::string to_string() const
+    {
+        std::string s;
+        write_string(s);
+        return s;
+    }
+
+    template <typename Ch,typename Traits,typename Alloc>
+    void write_string(std::basic_string<Ch,Traits,Alloc>& data) const
+    {
+        basic_bigint<Allocator> v(*this);
+
+        std::size_t len = (v.length() * basic_type_bits / 3) + 2;
+        data.reserve(len);
+
+        static uint64_t p10 = 1;
+        static uint64_t ip10 = 0;
+
+        if ( v.length() == 0 )
+        {
+            data.push_back('0');
+        }
+        else
+        {
+            uint64_t r;
+            if ( p10 == 1 )
+            {
+                while ( p10 <= (std::numeric_limits<uint64_t>::max)()/10 )
+                {
+                    p10 *= 10;
+                    ip10++;
+                }
+            }                     
+            // p10 is max unsigned power of 10
+            basic_bigint<Allocator> R;
+            basic_bigint<Allocator> LP10 = p10; // LP10 = p10 = ::pow(10, ip10)
+
+            do
+            {
+                v.divide( LP10, v, R, true );
+                r = (R.length() ? R.data()[0] : 0);
+                for ( size_type j=0; j < ip10; j++ )
+                {
+                    data.push_back(char(r % 10 + '0'));
+                    r /= 10;
+                    if ( r + v.length() == 0 )
+                        break;
+                }
+            } 
+            while ( v.length() );
+            if (is_negative())
+            {
+                data.push_back('-');
+            }
+            std::reverse(data.begin(),data.end());
+        }
+    }
+
+    std::string to_string_hex() const
+    {
+        std::string s;
+        write_string_hex(s);
+        return s;
+    }
+
+    template <typename Ch,typename Traits,typename Alloc>
+    void write_string_hex(std::basic_string<Ch,Traits,Alloc>& data) const
+    {
+        basic_bigint<Allocator> v(*this);
+
+        std::size_t len = (v.length() * basic_bigint<Allocator>::basic_type_bits / 3) + 2;
+        data.reserve(len);
+        // 1/3 > ln(2)/ln(10)
+        static uint64_t p10 = 1;
+        static uint64_t ip10 = 0;
+
+        if ( v.length() == 0 )
+        {
+            data.push_back('0');
+        }
+        else
+        {
+            uint64_t r;
+            if ( p10 == 1 )
+            {
+                while ( p10 <= (std::numeric_limits<uint64_t>::max)()/16 )
+                {
+                    p10 *= 16;
+                    ip10++;
+                }
+            }                     // p10 is max unsigned power of 16
+            basic_bigint<Allocator> R;
+            basic_bigint<Allocator> LP10 = p10; // LP10 = p10 = ::pow(16, ip10)
+            do
+            {
+                v.divide( LP10, v, R, true );
+                r = (R.length() ? R.data()[0] : 0);
+                for ( size_type j=0; j < ip10; j++ )
+                {
+                    uint8_t c = r % 16;
+                    data.push_back((c < 10) ? ('0' + c) : ('A' - 10 + c));
+                    r /= 16;
+                    if ( r + v.length() == 0 )
+                        break;
+                }
+            } 
+            while (v.length());
+
+            if (is_negative())
+            {
+                data.push_back('-');
+            }
+            std::reverse(data.begin(),data.end());
+        }
+    }
+
+//  Global Operators
+
+    friend bool operator==( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+        return x.compare(y) == 0 ? true : false;
+    }
+
+    friend bool operator==( const basic_bigint<Allocator>& x, int y ) noexcept
+    {
+        return x.compare(y) == 0 ? true : false;
+    }
+
+    friend bool operator!=( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+        return x.compare(y) != 0 ? true : false;
+    }
+
+    friend bool operator!=( const basic_bigint<Allocator>& x, int y ) noexcept
+    {
+        return x.compare(basic_bigint<Allocator>(y)) != 0 ? true : false;
+    }
+
+    friend bool operator<( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+       return x.compare(y) < 0 ? true : false;
+    }
+
+    friend bool operator<( const basic_bigint<Allocator>& x, int64_t y ) noexcept
+    {
+       return x.compare(y) < 0 ? true : false;
+    }
+
+    friend bool operator>( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+        return x.compare(y) > 0 ? true : false;
+    }
+
+    friend bool operator>( const basic_bigint<Allocator>& x, int y ) noexcept
+    {
+        return x.compare(basic_bigint<Allocator>(y)) > 0 ? true : false;
+    }
+
+    friend bool operator<=( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+        return x.compare(y) <= 0 ? true : false;
+    }
+
+    friend bool operator<=( const basic_bigint<Allocator>& x, int y ) noexcept
+    {
+        return x.compare(y) <= 0 ? true : false;
+    }
+
+    friend bool operator>=( const basic_bigint<Allocator>& x, const basic_bigint<Allocator>& y ) noexcept
+    {
+        return x.compare(y) >= 0 ? true : false;
+    }
+
+    friend bool operator>=( const basic_bigint<Allocator>& x, int y ) noexcept
+    {
+        return x.compare(y) >= 0 ? true : false;
+    }
+
+    friend basic_bigint<Allocator> operator+( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x += y;
+    }
+
+    friend basic_bigint<Allocator> operator+( basic_bigint<Allocator> x, int64_t y )
+    {
+        return x += y;
+    }
+
+    friend basic_bigint<Allocator> operator-( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x -= y;
+    }
+
+    friend basic_bigint<Allocator> operator-( basic_bigint<Allocator> x, int64_t y )
+    {
+        return x -= y;
+    }
+
+    friend basic_bigint<Allocator> operator*( int64_t x, const basic_bigint<Allocator>& y )
+    {
+        return basic_bigint<Allocator>(y) *= x;
+    }
+
+    friend basic_bigint<Allocator> operator*( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x *= y;
+    }
+
+    friend basic_bigint<Allocator> operator*( basic_bigint<Allocator> x, int64_t y )
+    {
+        return x *= y;
+    }
+
+    friend basic_bigint<Allocator> operator/( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x /= y;
+    }
+
+    friend basic_bigint<Allocator> operator/( basic_bigint<Allocator> x, int y )
+    {
+        return x /= y;
+    }
+
+    friend basic_bigint<Allocator> operator%( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x %= y;
+    }
+
+    friend basic_bigint<Allocator> operator<<( basic_bigint<Allocator> u, unsigned k )
+    {
+        return u <<= k;
+    }
+
+    friend basic_bigint<Allocator> operator<<( basic_bigint<Allocator> u, int k )
+    {
+        return u <<= k;
+    }
+
+    friend basic_bigint<Allocator> operator>>( basic_bigint<Allocator> u, unsigned k )
+    {
+        return u >>= k;
+    }
+
+    friend basic_bigint<Allocator> operator>>( basic_bigint<Allocator> u, int k )
+    {
+        return u >>= k;
+    }
+
+    friend basic_bigint<Allocator> operator|( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x |= y;
+    }
+
+    friend basic_bigint<Allocator> operator|( basic_bigint<Allocator> x, int y )
+    {
+        return x |= y;
+    }
+
+    friend basic_bigint<Allocator> operator|( basic_bigint<Allocator> x, unsigned y )
+    {
+        return x |= y;
+    }
+
+    friend basic_bigint<Allocator> operator^( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x ^= y;
+    }
+
+    friend basic_bigint<Allocator> operator^( basic_bigint<Allocator> x, int y )
+    {
+        return x ^= y;
+    }
+
+    friend basic_bigint<Allocator> operator^( basic_bigint<Allocator> x, unsigned y )
+    {
+        return x ^= y;
+    }
+
+    friend basic_bigint<Allocator> operator&( basic_bigint<Allocator> x, const basic_bigint<Allocator>& y )
+    {
+        return x &= y;
+    }
+
+    friend basic_bigint<Allocator> operator&( basic_bigint<Allocator> x, int y )
+    {
+        return x &= y;
+    }
+
+    friend basic_bigint<Allocator> operator&( basic_bigint<Allocator> x, unsigned y )
+    {
+        return x &= y;
+    }
+
+    friend basic_bigint<Allocator> abs( const basic_bigint<Allocator>& a )
+    {
+        if ( a.is_negative() )
+        {
+            return -a;
+        }
+        return a;
+    }
+
+    friend basic_bigint<Allocator> power( basic_bigint<Allocator> x, unsigned n )
+    {
+        basic_bigint<Allocator> y = 1;
+
+        while ( n )
+        {
+            if ( n & 1 )
+            {
+                y *= x;
+            }
+            x *= x;
+            n >>= 1;
+        }
+
+        return y;
+    }
+
+    friend basic_bigint<Allocator> sqrt( const basic_bigint<Allocator>& a )
+    {
+        basic_bigint<Allocator> x = a;
+        basic_bigint<Allocator> b = a;
+        basic_bigint<Allocator> q;
+
+        b <<= 1;
+        while ( b >>= 2, b > 0 )
+        {
+            x >>= 1;
+        }
+        while ( x > (q = a/x) + 1 || x < q - 1 )
+        {
+            x += q;
+            x >>= 1;
+        }
+        return x < q ? x : q;
+    }
+
+    template <typename CharT>
+    friend std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, const basic_bigint<Allocator>& v)
+    {
+        std::basic_string<CharT> s;
+        v.write_string(s); 
+        os << s;
+
+        return os;
+    }
+
+    int compare( const basic_bigint<Allocator>& y ) const noexcept
+    {
+        if ( is_negative() != y.is_negative() )
+            return y.is_negative() - is_negative();
+        int code = 0;
+        if ( length() == 0 && y.length() == 0 )
+            code = 0;
+        else if ( length() < y.length() )
+            code = -1;
+        else if ( length() > y.length() )
+            code = +1;
+        else
+        {
+            for (size_type i = length(); i-- > 0; )
+            {
+                if (data()[i] > y.data()[i])
+                {
+                    code = 1;
+                    break;
+                }
+                else if (data()[i] < y.data()[i])
+                {
+                    code = -1;
+                    break;
+                }
+            }
+        }
+        return is_negative() ? -code : code;
+    }
+
+    void divide( basic_bigint<Allocator> denom, basic_bigint<Allocator>& quot, basic_bigint<Allocator>& rem, bool remDesired ) const
+    {
+        if ( denom.length() == 0 )
+        {
+            JSONCONS_THROW(std::runtime_error( "Zero divide." ));
+        }
+        bool quot_neg = is_negative() ^ denom.is_negative();
+        bool rem_neg = is_negative();
+        int x = 0;
+        basic_bigint<Allocator> num = *this;
+        num.common_stor_.is_negative_ = denom.common_stor_.is_negative_ = false;
+        if ( num < denom )
+        {
+            quot = uint64_t(0);
+            rem = num;
+            rem.common_stor_.is_negative_ = rem_neg;
+            return;
+        }
+        if ( denom.length() == 1 && num.length() == 1 )
+        {
+            quot = uint64_t( num.data()[0]/denom.data()[0] );
+            rem = uint64_t( num.data()[0]%denom.data()[0] );
+            quot.common_stor_.is_negative_ = quot_neg;
+            rem.common_stor_.is_negative_ = rem_neg;
+            return;
+        }
+        else if (denom.length() == 1 && (denom.data()[0] & l_mask) == 0 )
+        {
+            // Denominator fits into a half word
+            uint64_t divisor = denom.data()[0], dHi = 0,
+                     q1, r, q2, dividend;
+            quot.resize(length());
+            for (size_type i=length(); i-- > 0; )
+            {
+                dividend = (dHi << basic_type_halfBits) | (data()[i] >> basic_type_halfBits);
+                q1 = dividend/divisor;
+                r = dividend % divisor;
+                dividend = (r << basic_type_halfBits) | (data()[i] & r_mask);
+                q2 = dividend/divisor;
+                dHi = dividend % divisor;
+                quot.data()[i] = (q1 << basic_type_halfBits) | q2;
+            }
+            quot.reduce();
+            rem = dHi;
+            quot.common_stor_.is_negative_ = quot_neg;
+            rem.common_stor_.is_negative_ = rem_neg;
+            return;
+        }
+        basic_bigint<Allocator> num0 = num, denom0 = denom;
+        int second_done = normalize(denom, num, x);
+        size_type l = denom.length() - 1;
+        size_type n = num.length() - 1;
+        quot.resize(n - l);
+        for (size_type i=quot.length(); i-- > 0; )
+            quot.data()[i] = 0;
+        rem = num;
+        if ( rem.data()[n] >= denom.data()[l] )
+        {
+            rem.resize(rem.length() + 1);
+            n++;
+            quot.resize(quot.length() + 1);
+        }
+        uint64_t d = denom.data()[l];
+        for ( size_type k = n; k > l; k-- )
+        {
+            uint64_t q = DDquotient(rem.data()[k], rem.data()[k-1], d);
+            subtractmul( rem.data() + k - l - 1, denom.data(), l + 1, q );
+            quot.data()[k - l - 1] = q;
+        }
+        quot.reduce();
+        quot.common_stor_.is_negative_ = quot_neg;
+        if ( remDesired )
+        {
+            unnormalize(rem, x, second_done);
+            rem.common_stor_.is_negative_ = rem_neg;
+        }
+    }
+private:
+    void destroy() noexcept
+    {
+        if (is_dynamic())
+        {
+            dynamic_stor_.destroy(get_allocator());
+        }
+    }
+    void DDproduct( uint64_t A, uint64_t B,
+                    uint64_t& hi, uint64_t& lo ) const
+    // Multiplying two digits: (hi, lo) = A * B
+    {
+        uint64_t hiA = A >> basic_type_halfBits, loA = A & r_mask,
+                   hiB = B >> basic_type_halfBits, loB = B & r_mask,
+                   mid1, mid2, old;
+
+        lo = loA * loB;
+        hi = hiA * hiB;
+        mid1 = loA * hiB;
+        mid2 = hiA * loB;
+        old = lo;
+        lo += mid1 << basic_type_halfBits;
+            hi += (lo < old) + (mid1 >> basic_type_halfBits);
+        old = lo;
+        lo += mid2 << basic_type_halfBits;
+            hi += (lo < old) + (mid2 >> basic_type_halfBits);
+    }
+
+    uint64_t DDquotient( uint64_t A, uint64_t B, uint64_t d ) const
+    // Divide double word (A, B) by d. Quotient = (qHi, qLo)
+    {
+        uint64_t left, middle, right, qHi, qLo, x, dLo1,
+                   dHi = d >> basic_type_halfBits, dLo = d & r_mask;
+        qHi = A/(dHi + 1);
+        // This initial guess of qHi may be too small.
+        middle = qHi * dLo;
+        left = qHi * dHi;
+        x = B - (middle << basic_type_halfBits);
+        A -= (middle >> basic_type_halfBits) + left + (x > B);
+        B = x;
+        dLo1 = dLo << basic_type_halfBits;
+        // Increase qHi if necessary:
+        while ( A > dHi || (A == dHi && B >= dLo1) )
+        {
+            x = B - dLo1;
+            A -= dHi + (x > B);
+            B = x;
+            qHi++;
+        }
+        qLo = ((A << basic_type_halfBits) | (B >> basic_type_halfBits))/(dHi + 1);
+        // This initial guess of qLo may be too small.
+        right = qLo * dLo;
+        middle = qLo * dHi;
+        x = B - right;
+        A -= (x > B);
+        B = x;
+        x = B - (middle << basic_type_halfBits);
+            A -= (middle >> basic_type_halfBits) + (x > B);
+        B = x;
+        // Increase qLo if necessary:
+        while ( A || B >= d )
+        {
+            x = B - d;
+            A -= (x > B);
+            B = x;
+            qLo++;
+        }
+        return (qHi << basic_type_halfBits) + qLo;
+    }
+
+    void subtractmul( uint64_t* a, uint64_t* b, size_type n, uint64_t& q ) const
+    // a -= q * b: b in n positions; correct q if necessary
+    {
+        uint64_t hi, lo, d, carry = 0;
+        size_type i;
+        for ( i = 0; i < n; i++ )
+        {
+            DDproduct( b[i], q, hi, lo );
+            d = a[i];
+            a[i] -= lo;
+            if ( a[i] > d )
+                carry++;
+            d = a[i + 1];
+            a[i + 1] -= hi + carry;
+            carry = a[i + 1] > d;
+        }
+        if ( carry ) // q was too large
+        {
+            q--;
+            carry = 0;
+            for ( i = 0; i < n; i++ )
+            {
+                d = a[i] + carry;
+                carry = d < carry;
+                a[i] = d + b[i];
+                if ( a[i] < d )
+                    carry = 1;
+            }
+            a[n] = 0;
+        }
+    }
+
+    int normalize( basic_bigint<Allocator>& denom, basic_bigint<Allocator>& num, int& x ) const
+    {
+        size_type r = denom.length() - 1;
+        uint64_t y = denom.data()[r];
+
+        x = 0;
+        while ( (y & l_bit) == 0 )
+        {
+            y <<= 1;
+            x++;
+        }
+        denom <<= x;
+        num <<= x;
+        if ( r > 0 && denom.data()[r] < denom.data()[r-1] )
+        {
+            denom *= max_basic_type;
+                    num *= max_basic_type;
+            return 1;
+        }
+        return 0;
+    }
+
+    void unnormalize( basic_bigint<Allocator>& rem, int x, int secondDone ) const
+    {
+        if ( secondDone )
+        {
+            rem /= max_basic_type;
+        }
+        if ( x > 0 )
+        {
+            rem >>= x;
+        }
+        else
+        {
+            rem.reduce();
+        }
+    }
+
+    size_type round_up(size_type i) const // Find suitable new block size
+    {
+        return (i/word_length + 1) * word_length;
+    }
+
+    void reduce()
+    {
+        uint64_t* p = end() - 1;
+        uint64_t* pBegin = begin();
+        while ( p >= pBegin )
+        {
+            if ( *p )
+            {
+                break;
+            }
+            --common_stor_.length_;
+            --p;
+        }
+        if ( length() == 0 )
+        {
+            common_stor_.is_negative_ = false;
+        }
+    }
+ 
+    static uint64_t next_power_of_two(uint64_t n) {
+        n = n - 1;
+        n |= n >> 1;
+        n |= n >> 2;
+        n |= n >> 4;
+        n |= n >> 8;
+        n |= n >> 16;
+        n |= n >> 32;
+        return n + 1;
+    }
+};
+
+using bigint = basic_bigint<std::allocator<uint8_t>>;
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_UTILITY_BIGINT_HPP

--- a/velox/external/jsoncons/utility/binary.hpp
+++ b/velox/external/jsoncons/utility/binary.hpp
@@ -1,0 +1,223 @@
+#ifndef JSONCONS_UTILITY_BINARY_HPP
+#define JSONCONS_UTILITY_BINARY_HPP
+
+#include <cfloat> 
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <type_traits> // std::enable_if
+
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+
+namespace facebook::velox::jsoncons { 
+namespace binary { 
+
+    // byte_swap
+
+    template<class T>
+    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == sizeof(uint8_t),T>::type
+    byte_swap(T val)
+    {
+        return val;
+    }
+
+    template<class T>
+    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == sizeof(uint16_t),T>::type
+    byte_swap(T val)
+    {
+    #if defined(JSONCONS_BYTE_SWAP_16)
+        return JSONCONS_BYTE_SWAP_16(val);
+    #else
+        return (static_cast<uint16_t>(val) >> 8) | (static_cast<uint16_t>(val) << 8);
+    #endif
+    }
+     
+    template<class T>
+    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == sizeof(uint32_t),T>::type
+    byte_swap(T val)
+    {
+    #if defined(JSONCONS_BYTE_SWAP_32)
+        return JSONCONS_BYTE_SWAP_32(val);
+    #else
+        uint32_t tmp = ((static_cast<uint32_t>(val) << 8) & 0xff00ff00) | ((static_cast<uint32_t>(val) >> 8) & 0xff00ff);
+        return (tmp << 16) | (tmp >> 16);
+    #endif
+    }
+
+    template<class T>
+    typename std::enable_if<std::is_integral<T>::value && sizeof(T) == sizeof(uint64_t),T>::type
+    byte_swap(T val)
+    {
+    #if defined(JSONCONS_BYTE_SWAP_64)
+        return JSONCONS_BYTE_SWAP_64(val);
+    #else
+        uint64_t tmp = ((static_cast<uint64_t>(val) & 0x00000000ffffffffull) << 32) | ((static_cast<uint64_t>(val) & 0xffffffff00000000ull) >> 32);
+        tmp = ((tmp & 0x0000ffff0000ffffull) << 16) | ((tmp & 0xffff0000ffff0000ull) >> 16);
+        return ((tmp & 0x00ff00ff00ff00ffull) << 8)  | ((tmp & 0xff00ff00ff00ff00ull) >> 8);
+    #endif
+    }
+
+    template<class T>
+    typename std::enable_if<std::is_floating_point<T>::value && sizeof(T) == sizeof(uint32_t),T>::type
+    byte_swap(T val)
+    {
+        uint32_t x;
+        std::memcpy(&x,&val,sizeof(uint32_t));
+        uint32_t y = byte_swap(x);
+        T val2;
+        std::memcpy(&val2,&y,sizeof(uint32_t));
+        return val2;
+    }
+
+    template<class T>
+    typename std::enable_if<std::is_floating_point<T>::value && sizeof(T) == sizeof(uint64_t),T>::type
+    byte_swap(T val)
+    {
+        uint64_t x;
+        std::memcpy(&x,&val,sizeof(uint64_t));
+        uint64_t y = byte_swap(x);
+        T val2;
+        std::memcpy(&val2,&y,sizeof(uint64_t));
+        return val2;
+    }
+
+    struct uint128_holder
+    {
+        uint64_t lo;
+        uint64_t hi;
+    };
+
+    template<class T>
+    typename std::enable_if<std::is_floating_point<T>::value && sizeof(T) == 2*sizeof(uint64_t),T>::type
+    byte_swap(T val)
+    {
+        uint128_holder x;
+        uint8_t buf[2*sizeof(uint64_t)];
+        std::memcpy(buf,&val,2*sizeof(uint64_t));
+        std::memcpy(&x.lo,buf,sizeof(uint64_t));
+        std::memcpy(&x.hi,buf+sizeof(uint64_t),sizeof(uint64_t));
+
+        uint128_holder y;
+        y.lo = byte_swap(x.hi);
+        y.hi = byte_swap(x.lo);
+
+        T val2;
+        std::memcpy(&val2,&y,2*sizeof(uint64_t));
+
+        return val2;
+    }
+    // native_to_big
+
+    template <typename T,typename OutputIt,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::big,void>::type
+    native_to_big(T val, OutputIt d_first)
+    {
+        uint8_t buf[sizeof(T)];
+        std::memcpy(buf, &val, sizeof(T));
+        for (auto item : buf)
+        {
+            *d_first++ = item;
+        }
+    }
+
+    template <typename T,typename OutputIt,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::little,void>::type
+    native_to_big(T val, OutputIt d_first)
+    {
+        T val2 = byte_swap(val);
+        uint8_t buf[sizeof(T)];
+        std::memcpy(buf, &val2, sizeof(T));
+        for (auto item : buf)
+        {
+            *d_first++ = item;
+        }
+    }
+
+    // native_to_little
+
+    template <typename T,typename OutputIt,typename Endian = endian>
+    typename std::enable_if<Endian::native == Endian::little,void>::type
+    native_to_little(T val, OutputIt d_first)
+    {
+        uint8_t buf[sizeof(T)];
+        std::memcpy(buf, &val, sizeof(T));
+        for (auto item : buf)
+        {
+            *d_first++ = item;
+        }
+    }
+
+    template <typename T,typename OutputIt,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::big, void>::type
+    native_to_little(T val, OutputIt d_first)
+    {
+        T val2 = byte_swap(val);
+        uint8_t buf[sizeof(T)];
+        std::memcpy(buf, &val2, sizeof(T));
+        for (auto item : buf)
+        {
+            *d_first++ = item;
+        }
+    }
+
+    // big_to_native
+
+    template <typename T,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::big,T>::type
+    big_to_native(const uint8_t* first, std::size_t count)
+    {
+        if (sizeof(T) > count)
+        {
+            return T{};
+        }
+        T val;
+        std::memcpy(&val,first,sizeof(T));
+        return val;
+    }
+
+    template <typename T,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::little,T>::type
+    big_to_native(const uint8_t* first, std::size_t count)
+    {
+        if (sizeof(T) > count)
+        {
+            return T{};
+        }
+        T val;
+        std::memcpy(&val,first,sizeof(T));
+        return byte_swap(val);
+    }
+
+    // little_to_native
+
+    template <typename T,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::little,T>::type
+    little_to_native(const uint8_t* first, std::size_t count)
+    {
+        if (sizeof(T) > count)
+        {
+            return T{};
+        }
+        T val;
+        std::memcpy(&val,first,sizeof(T));
+        return val;
+    }
+
+    template <typename T,typename Endian=endian>
+    typename std::enable_if<Endian::native == Endian::big,T>::type
+    little_to_native(const uint8_t* first, std::size_t count)
+    {
+        if (sizeof(T) > count)
+        {
+            return T{};
+        }
+        T val;
+        std::memcpy(&val,first,sizeof(T));
+        return byte_swap(val);
+    }
+
+} // namespace binary
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_UTILITY_BINARY_HPP

--- a/velox/external/jsoncons/utility/byte_string.hpp
+++ b/velox/external/jsoncons/utility/byte_string.hpp
@@ -1,0 +1,822 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_BYTE_STRING_HPP
+#define JSONCONS_BYTE_STRING_HPP
+
+#include <cmath>
+#include <cstdint>
+#include <cstring> // std::memcmp
+#include <initializer_list>
+#include <iomanip> // std::setw
+#include <iterator>
+#include <memory> // std::allocator
+#include <ostream>
+#include <sstream>
+#include <type_traits>
+#include <utility> // std::move
+#include <vector>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    // Algorithms
+
+namespace detail {
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<std::is_same<typename std::iterator_traits<InputIt>::value_type,uint8_t>::value,size_t>::type
+    encode_base64_generic(InputIt first, InputIt last, const char alphabet[65], Container& result)
+    {
+        std::size_t count = 0;
+        unsigned char a3[3];
+        unsigned char a4[4];
+        unsigned char fill = alphabet[64];
+        int i = 0;
+        int j = 0;
+
+        while (first != last)
+        {
+            a3[i++] = *first++;
+            if (i == 3)
+            {
+                a4[0] = (a3[0] & 0xfc) >> 2;
+                a4[1] = ((a3[0] & 0x03) << 4) + ((a3[1] & 0xf0) >> 4);
+                a4[2] = ((a3[1] & 0x0f) << 2) + ((a3[2] & 0xc0) >> 6);
+                a4[3] = a3[2] & 0x3f;
+
+                for (i = 0; i < 4; i++) 
+                {
+                    result.push_back(alphabet[a4[i]]);
+                    ++count;
+                }
+                i = 0;
+            }
+        }
+
+        if (i > 0)
+        {
+            for (j = i; j < 3; ++j) 
+            {
+                a3[j] = 0;
+            }
+
+            a4[0] = (a3[0] & 0xfc) >> 2;
+            a4[1] = ((a3[0] & 0x03) << 4) + ((a3[1] & 0xf0) >> 4);
+            a4[2] = ((a3[1] & 0x0f) << 2) + ((a3[2] & 0xc0) >> 6);
+
+            for (j = 0; j < i + 1; ++j) 
+            {
+                result.push_back(alphabet[a4[j]]);
+                ++count;
+            }
+
+            if (fill != 0)
+            {
+                while (i++ < 3) 
+                {
+                    result.push_back(fill);
+                    ++count;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    template <typename InputIt,typename F,typename Container>
+    typename std::enable_if<extension_traits::is_back_insertable_byte_container<Container>::value,decode_result<InputIt>>::type 
+    decode_base64_generic(InputIt first, InputIt last, 
+                          const uint8_t reverse_alphabet[256],
+                          F f,
+                          Container& result)
+    {
+        uint8_t a4[4], a3[3];
+        uint8_t i = 0;
+        uint8_t j = 0;
+
+        while (first != last && *first != '=')
+        {
+            if (!f(*first))
+            {
+                return decode_result<InputIt>{first, conv_errc::conversion_failed};
+            }
+
+            a4[i++] = static_cast<uint8_t>(*first++); 
+            if (i == 4)
+            {
+                for (i = 0; i < 4; ++i) 
+                {
+                    a4[i] = reverse_alphabet[a4[i]];
+                }
+
+                a3[0] = (a4[0] << 2) + ((a4[1] & 0x30) >> 4);
+                a3[1] = ((a4[1] & 0xf) << 4) + ((a4[2] & 0x3c) >> 2);
+                a3[2] = ((a4[2] & 0x3) << 6) +   a4[3];
+
+                for (i = 0; i < 3; i++) 
+                {
+                    result.push_back(a3[i]);
+                }
+                i = 0;
+            }
+        }
+
+        if (i > 0)
+        {
+            for (j = 0; j < i; ++j) 
+            {
+                a4[j] = reverse_alphabet[a4[j]];
+            }
+
+            a3[0] = (a4[0] << 2) + ((a4[1] & 0x30) >> 4);
+            a3[1] = ((a4[1] & 0xf) << 4) + ((a4[2] & 0x3c) >> 2);
+
+            for (j = 0; j < i - 1; ++j) 
+            {
+                result.push_back(a3[j]);
+            }
+        }
+        return decode_result<InputIt>{last, conv_errc::success};
+    }
+
+} // namespace detail
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<std::is_same<typename std::iterator_traits<InputIt>::value_type,uint8_t>::value,size_t>::type
+    encode_base16(InputIt first, InputIt last, Container& result)
+    {
+        static constexpr char characters[] = "0123456789ABCDEF";
+
+        for (auto it = first; it != last; ++it)
+        {
+            uint8_t c = *it;
+            result.push_back(characters[c >> 4]);
+            result.push_back(characters[c & 0xf]);
+        }
+        return (last-first)*2;
+    }
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<std::is_same<typename std::iterator_traits<InputIt>::value_type,uint8_t>::value,size_t>::type
+    encode_base64url(InputIt first, InputIt last, Container& result)
+    {
+        static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                      "abcdefghijklmnopqrstuvwxyz"
+                                                      "0123456789-_"
+                                                      "\0";
+        return detail::encode_base64_generic(first, last, alphabet, result);
+    }
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<std::is_same<typename std::iterator_traits<InputIt>::value_type,uint8_t>::value,size_t>::type
+    encode_base64(InputIt first, InputIt last, Container& result)
+    {
+        static constexpr char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                                   "abcdefghijklmnopqrstuvwxyz"
+                                                   "0123456789+/"
+                                                   "=";
+        return detail::encode_base64_generic(first, last, alphabet, result);
+    }
+
+    template <typename Char>
+    bool is_base64(Char c) 
+    {
+        return (c >= 0 && c < 128) && (isalnum((int)c) || c == '+' || c == '/');
+    }
+
+    template <typename Char>
+    bool is_base64url(Char c) 
+    {
+        return (c >= 0 && c < 128) && (isalnum((int)c) || c == '-' || c == '_');
+    }
+
+    inline 
+    static bool is_base64url(int c) 
+    {
+        return isalnum(c) || c == '-' || c == '_';
+    }
+
+    // decode
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<extension_traits::is_back_insertable_byte_container<Container>::value,decode_result<InputIt>>::type 
+    decode_base64url(InputIt first, InputIt last, Container& result)
+    {
+        static constexpr uint8_t reverse_alphabet[256] = {
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 62,   0xff, 0xff,
+            52,   53,   54,   55,   56,   57,   58,   59,   60,   61,   0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0,    1,    2,    3,    4,    5,    6,    7,    8,    9,    10,   11,   12,   13,   14,
+            15,   16,   17,   18,   19,   20,   21,   22,   23,   24,   25,   0xff, 0xff, 0xff, 0xff, 63,
+            0xff, 26,   27,   28,   29,   30,   31,   32,   33,   34,   35,   36,   37,   38,   39,   40,
+            41,   42,   43,   44,   45,   46,   47,   48,   49,   50,   51,   0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+        };
+        auto retval = jsoncons::detail::decode_base64_generic(first, last, reverse_alphabet, 
+                                                              is_base64url<typename std::iterator_traits<InputIt>::value_type>, 
+                                                              result);
+        return retval.ec == conv_errc::success ? retval : decode_result<InputIt>{retval.it, conv_errc::not_base64url};
+    }
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<extension_traits::is_back_insertable_byte_container<Container>::value,decode_result<InputIt>>::type 
+    decode_base64(InputIt first, InputIt last, Container& result)
+    {
+        static constexpr uint8_t reverse_alphabet[256] = {
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 62,   0xff, 0xff, 0xff, 63,
+            52,   53,   54,   55,   56,   57,   58,   59,   60,   61,   0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0,    1,    2,    3,    4,    5,    6,    7,    8,    9,    10,   11,   12,   13,   14,
+            15,   16,   17,   18,   19,   20,   21,   22,   23,   24,   25,   0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 26,   27,   28,   29,   30,   31,   32,   33,   34,   35,   36,   37,   38,   39,   40,
+            41,   42,   43,   44,   45,   46,   47,   48,   49,   50,   51,   0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff
+        };
+        auto retval = jsoncons::detail::decode_base64_generic(first, last, reverse_alphabet, 
+                                                             is_base64<typename std::iterator_traits<InputIt>::value_type>, 
+                                                             result);
+        return retval.ec == conv_errc::success ? retval : decode_result<InputIt>{retval.it, conv_errc::not_base64};
+    }
+
+    template <typename InputIt,typename Container>
+    typename std::enable_if<extension_traits::is_back_insertable_byte_container<Container>::value,decode_result<InputIt>>::type 
+    decode_base16(InputIt first, InputIt last, Container& result)
+    {
+        std::size_t len = std::distance(first,last);
+        if (len & 1) 
+        {
+            return decode_result<InputIt>{first, conv_errc::not_base16};
+        }
+
+        InputIt it = first;
+        while (it != last)
+        {
+            uint8_t val;
+            auto a = *it++;
+            if (a >= '0' && a <= '9') 
+            {
+                val = static_cast<uint8_t>(a - '0') << 4;
+            } 
+            else if ((a | 0x20) >= 'a' && (a | 0x20) <= 'f') 
+            {
+                val = (static_cast<uint8_t>((a | 0x20) - 'a') + 10) << 4;
+            } 
+            else 
+            {
+                return decode_result<InputIt>{first, conv_errc::not_base16};
+            }
+
+            auto b = *it++;
+            if (b >= '0' && b <= '9') 
+            {
+                val |= (b - '0');
+            } 
+            else if ((b | 0x20) >= 'a' && (b | 0x20) <= 'f') 
+            {
+                val |= ((b | 0x20) - 'a' + 10);
+            } 
+            else 
+            {
+                return decode_result<InputIt>{first, conv_errc::not_base16};
+            }
+
+            result.push_back(val);
+        }
+        return decode_result<InputIt>{last, conv_errc::success};
+    }
+
+    struct byte_traits
+    {
+        using char_type = uint8_t;
+
+        static constexpr int eof() 
+        {
+            return std::char_traits<char>::eof();
+        }
+
+        static int compare(const char_type* s1, const char_type* s2, std::size_t count) noexcept
+        {
+            return std::memcmp(s1,s2,count);
+        }
+    };
+
+    // basic_byte_string
+
+    template <typename Allocator>
+    class basic_byte_string;
+
+    // byte_string_view
+    class byte_string_view
+    {
+        const uint8_t* data_;
+        std::size_t size_; 
+    public:
+        using traits_type = byte_traits;
+
+        using const_iterator = const uint8_t*;
+        using iterator = const_iterator;
+        using size_type = std::size_t;
+        using value_type = uint8_t;
+        using reference = uint8_t&;
+        using const_reference = const uint8_t&;
+        using difference_type = std::ptrdiff_t;
+        using pointer = uint8_t*;
+        using const_pointer = const uint8_t*;
+
+        constexpr byte_string_view() noexcept
+            : data_(nullptr), size_(0)
+        {
+        }
+
+        constexpr byte_string_view(const uint8_t* data, std::size_t length) noexcept
+            : data_(data), size_(length)
+        {
+        }
+    
+        template <typename Container>
+        constexpr explicit byte_string_view(const Container& cont,
+                          typename std::enable_if<extension_traits::is_byte_sequence<Container>::value,int>::type = 0) 
+            : data_(reinterpret_cast<const uint8_t*>(cont.data())), size_(cont.size())
+        {
+        }
+    
+        template <typename Allocator>
+        constexpr byte_string_view(const basic_byte_string<Allocator>& bytes);
+
+        constexpr byte_string_view(const byte_string_view&) = default;
+
+        JSONCONS_CPP14_CONSTEXPR byte_string_view(byte_string_view&& other) noexcept
+            : data_(nullptr), size_(0)
+        {
+            const_pointer temp_data = data_;
+            data_ = other.data_;
+            other.data_ = temp_data;
+
+            size_type temp_size = size_;
+            size_ = other.size_;
+            other.size_ = temp_size;
+        }
+
+        byte_string_view& operator=(const byte_string_view&) = default;
+
+        byte_string_view& operator=(byte_string_view&& other) noexcept
+        {
+            std::swap(data_, other.data_);
+            std::swap(size_, other.size_);
+            return *this;
+        }
+
+        constexpr const uint8_t* data() const noexcept
+        {
+            return data_;
+        }
+        constexpr size_t size() const noexcept
+        {
+            return size_;
+        }
+
+        // iterator support 
+        constexpr const_iterator begin() const noexcept
+        {
+            return data_;
+        }
+        constexpr const_iterator end() const noexcept
+        {
+            return data_ + size_;
+        }
+        constexpr const_iterator cbegin() const noexcept
+        {
+            return data_;
+        }
+        constexpr const_iterator cend() const noexcept
+        {
+            return data_ + size_;
+        }
+
+        constexpr uint8_t operator[](size_type pos) const 
+        { 
+            return data_[pos]; 
+        }
+
+        JSONCONS_CPP14_CONSTEXPR byte_string_view substr(size_type pos) const 
+        {
+            if (pos > size_)
+            {
+                JSONCONS_THROW(std::out_of_range("pos exceeds size"));
+            }
+            std::size_t n = size_ - pos;
+            return byte_string_view(data_ + pos, n);
+        }
+
+        byte_string_view substr(size_type pos, size_type n) const 
+        {
+            if (pos > size_)
+            {
+                JSONCONS_THROW(std::out_of_range("pos exceeds size"));
+            }
+            if (pos + n > size_)
+            {
+                n = size_ - pos;
+            }
+            return byte_string_view(data_ + pos, n);
+        }
+
+        int compare(const byte_string_view& s) const noexcept 
+        {
+            const int rc = traits_type::compare(data_, s.data(), (std::min)(size_, s.size()));
+            return rc != 0 ? rc : (size_ == s.size() ? 0 : size_ < s.size() ? -1 : 1);
+        }
+
+        template <typename Allocator>
+        int compare(const basic_byte_string<Allocator>& s) const noexcept 
+        {
+            const int rc = traits_type::compare(data_, s.data(), (std::min)(size_, s.size()));
+            return rc != 0 ? rc : (size_ == s.size() ? 0 : size_ < s.size() ? -1 : 1);
+        }
+
+        template <typename CharT>
+        friend std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, const byte_string_view& bstr)
+        {
+            std::basic_ostringstream<CharT> ss;
+            ss.flags(std::ios::hex);
+            ss.fill('0');
+
+            bool first = true;
+            for (auto b : bstr)
+            {
+                if (first)
+                {
+                    first = false;
+                }
+                else 
+                {
+                    ss << ',';
+                }
+                ss << std::setw(2) << static_cast<int>(b);
+            }
+            os << ss.str();
+            return os;
+        }
+    };
+
+    // basic_byte_string
+    template <typename Allocator = std::allocator<uint8_t>>
+    class basic_byte_string
+    {
+        using byte_allocator_type = typename std::allocator_traits<Allocator>:: template rebind_alloc<uint8_t>;
+        std::vector<uint8_t,byte_allocator_type> data_;
+    public:
+        using traits_type = byte_traits;
+        using allocator_type = byte_allocator_type;
+
+        using value_type = typename std::vector<uint8_t,byte_allocator_type>::value_type;
+        using size_type = typename std::vector<uint8_t,byte_allocator_type>::size_type;
+        using difference_type = typename std::vector<uint8_t,byte_allocator_type>::difference_type;
+        using reference = typename std::vector<uint8_t,byte_allocator_type>::reference;
+        using const_reference = typename std::vector<uint8_t,byte_allocator_type>::const_reference;
+        using pointer = typename std::vector<uint8_t,byte_allocator_type>::pointer;
+        using const_pointer = typename std::vector<uint8_t,byte_allocator_type>::const_pointer;
+        using iterator = typename std::vector<uint8_t,byte_allocator_type>::iterator;
+        using const_iterator = typename std::vector<uint8_t,byte_allocator_type>::const_iterator;
+
+        basic_byte_string() = default;
+
+        explicit basic_byte_string(const Allocator& alloc)
+            : data_(alloc)
+        {
+        }
+
+        basic_byte_string(std::initializer_list<uint8_t> init)
+            : data_(std::move(init))
+        {
+        }
+
+        basic_byte_string(std::initializer_list<uint8_t> init, const Allocator& alloc)
+            : data_(std::move(init), alloc)
+        {
+        }
+
+        explicit basic_byte_string(const byte_string_view& v)
+            : data_(v.begin(),v.end())
+        {
+        }
+
+        basic_byte_string(const basic_byte_string<Allocator>& v)
+            : data_(v.data_)
+        {
+        }
+
+        basic_byte_string(basic_byte_string<Allocator>&& v) noexcept
+            : data_(std::move(v.data_))
+        {
+        }
+
+        basic_byte_string(const byte_string_view& v, const Allocator& alloc)
+            : data_(v.begin(),v.end(),alloc)
+        {
+        }
+
+        basic_byte_string(const uint8_t* data, std::size_t length, const Allocator& alloc = Allocator())
+            : data_(data, data+length,alloc)
+        {
+        }
+
+        Allocator get_allocator() const
+        {
+            return data_.get_allocator();
+        }
+
+        basic_byte_string& operator=(const basic_byte_string& s) = default;
+
+        basic_byte_string& operator=(basic_byte_string&& other) noexcept
+        {
+            data_.swap(other.data_);
+            return *this;
+        }
+
+        void reserve(std::size_t new_cap)
+        {
+            data_.reserve(new_cap);
+        }
+
+        void push_back(uint8_t b)
+        {
+            data_.push_back(b);
+        }
+
+        void assign(const uint8_t* s, std::size_t count)
+        {
+            data_.clear();
+            data_.insert(data_.end(), s, s+count);
+        }
+
+        void append(const uint8_t* s, std::size_t count)
+        {
+            data_.insert(data_.end(), s, s+count);
+        }
+
+        void clear()
+        {
+            data_.clear();
+        }
+
+        uint8_t operator[](size_type pos) const 
+        { 
+            return data_[pos]; 
+        }
+
+        // iterator support 
+        iterator begin() noexcept
+        {
+            return data_.begin();
+        }
+        iterator end() noexcept
+        {
+            return data_.end();
+        }
+
+        const_iterator begin() const noexcept
+        {
+            return data_.begin();
+        }
+        const_iterator end() const noexcept
+        {
+            return data_.end();
+        }
+
+        uint8_t* data()
+        {
+            return data_.data();
+        }
+
+        const uint8_t* data() const
+        {
+            return data_.data();
+        }
+
+        std::size_t size() const
+        {
+            return data_.size();
+        }
+
+        int compare(const byte_string_view& s) const noexcept 
+        {
+            const int rc = traits_type::compare(data(), s.data(), (std::min)(size(), s.size()));
+            return rc != 0 ? rc : (size() == s.size() ? 0 : size() < s.size() ? -1 : 1);
+        }
+
+        int compare(const basic_byte_string& s) const noexcept 
+        {
+            const int rc = traits_type::compare(data(), s.data(), (std::min)(size(), s.size()));
+            return rc != 0 ? rc : (size() == s.size() ? 0 : size() < s.size() ? -1 : 1);
+        }
+
+        template <typename CharT>
+        friend std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, const basic_byte_string& o)
+        {
+            os << byte_string_view(o);
+            return os;
+        }
+    };
+
+    template <typename Allocator>
+    constexpr byte_string_view::byte_string_view(const basic_byte_string<Allocator>& bytes) 
+        : data_(bytes.data()), size_(bytes.size())
+    {
+    }
+
+    // ==
+    inline
+    bool operator==(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+    template <typename Allocator>
+    bool operator==(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) == 0;
+    }
+    template <typename Allocator>
+    bool operator==(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+    template <typename Allocator>
+    bool operator==(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) == 0;
+    }
+
+    // !=
+
+    inline
+    bool operator!=(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+    template <typename Allocator>
+    bool operator!=(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) != 0;
+    }
+    template <typename Allocator>
+    bool operator!=(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+    template <typename Allocator>
+    bool operator!=(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) != 0;
+    }
+
+    // <=
+
+    inline
+    bool operator<=(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+    template <typename Allocator>
+    bool operator<=(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) <= 0;
+    }
+    template <typename Allocator>
+    bool operator<=(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+    template <typename Allocator>
+    bool operator<=(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) >= 0;
+    }
+
+    // <
+
+    inline
+    bool operator<(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+    template <typename Allocator>
+    bool operator<(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) < 0;
+    }
+    template <typename Allocator>
+    bool operator<(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+    template <typename Allocator>
+    bool operator<(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) > 0;
+    }
+
+    // >=
+
+    inline
+    bool operator>=(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+    template <typename Allocator>
+    bool operator>=(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) >= 0;
+    }
+    template <typename Allocator>
+    bool operator>=(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+    template <typename Allocator>
+    bool operator>=(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) <= 0;
+    }
+
+    // >
+
+    inline
+    bool operator>(const byte_string_view& lhs, const byte_string_view& rhs) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+    template <typename Allocator>
+    bool operator>(const byte_string_view& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return lhs.compare(rhs) > 0;
+    }
+    template <typename Allocator>
+    bool operator>(const basic_byte_string<Allocator>& lhs, const byte_string_view& rhs) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+    template <typename Allocator>
+    bool operator>(const basic_byte_string<Allocator>& lhs, const basic_byte_string<Allocator>& rhs) noexcept
+    {
+        return rhs.compare(lhs) < 0;
+    }
+
+    using byte_string = basic_byte_string<std::allocator<uint8_t>>;
+
+    namespace extension_traits {
+
+        template <typename T>
+        struct is_basic_byte_string
+        : std::false_type
+        {};
+
+        template <typename Allocator>
+        struct is_basic_byte_string<basic_byte_string<Allocator>>
+        : std::true_type
+        {};
+
+    } // namespace extension_traits
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_BYTE_STRING_HPP

--- a/velox/external/jsoncons/utility/extension_traits.hpp
+++ b/velox/external/jsoncons/utility/extension_traits.hpp
@@ -1,0 +1,938 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_UTILITY_EXTENSION_TRAITS_HPP
+#define JSONCONS_UTILITY_EXTENSION_TRAITS_HPP
+
+#include <array> // std::array
+#include <climits> // CHAR_BIT
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+#include <cstddef> // std::byte
+#include <iterator> // std::iterator_traits
+#include <memory>
+#include <string>
+#include <type_traits> // std::enable_if, std::true_type
+#include <utility> // std::declval
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+
+#if defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR)
+#include <memory_resource> 
+#endif
+
+namespace facebook::velox::jsoncons {
+namespace extension_traits {
+
+    // is_char8
+    template <typename CharT,typename Enable=void>
+    struct is_char8 : std::false_type {};
+
+    template <typename CharT>
+    struct is_char8<CharT,typename std::enable_if<std::is_integral<CharT>::value &&
+                                                   !std::is_same<CharT,bool>::value &&
+                                                   sizeof(uint8_t) == sizeof(CharT)>::type> : std::true_type {};
+
+    // is_char16
+    template <typename CharT,typename Enable=void>
+    struct is_char16 : std::false_type {};
+
+    template <typename CharT>
+    struct is_char16<CharT,typename std::enable_if<std::is_integral<CharT>::value &&
+                                                   !std::is_same<CharT,bool>::value &&
+                                                   (std::is_same<CharT,char16_t>::value || sizeof(uint16_t) == sizeof(CharT))>::type> : std::true_type {};
+
+    // is_char32
+    template <typename CharT,typename Enable=void>
+    struct is_char32 : std::false_type {};
+
+    template <typename CharT>
+    struct is_char32<CharT,typename std::enable_if<std::is_integral<CharT>::value &&
+                                                   !std::is_same<CharT,bool>::value &&
+                                                   (std::is_same<CharT,char32_t>::value || (!std::is_same<CharT,char16_t>::value && sizeof(uint32_t) == sizeof(CharT)))>::type> : std::true_type {};
+
+    // is_int128
+
+    template <typename T,typename Enable=void>
+    struct is_int128_type : std::false_type {};
+
+#if defined(JSONCONS_HAS_INT128)
+    template <typename T>
+    struct is_int128_type<T,typename std::enable_if<std::is_same<T,int128_type>::value>::type> : std::true_type {};
+#endif
+
+    // is_unsigned_integer
+
+    template <typename T,typename Enable=void>
+    struct is_uint128_type : std::false_type {};
+
+#if defined (JSONCONS_HAS_INT128)
+    template <typename T>
+    struct is_uint128_type<T,typename std::enable_if<std::is_same<T,uint128_type>::value>::type> : std::true_type {};
+#endif
+
+    template <typename T,typename Enable = void>
+    class integer_limits
+    {
+    public:
+        static constexpr bool is_specialized = false;
+    };
+
+    template <typename T>
+    class integer_limits<T,typename std::enable_if<std::is_integral<T>::value && !std::is_same<T,bool>::value>::type>
+    {
+    public:
+        static constexpr bool is_specialized = true;
+        static constexpr bool is_signed = std::numeric_limits<T>::is_signed;
+        static constexpr int digits =  std::numeric_limits<T>::digits;
+        static constexpr std::size_t buffer_size = static_cast<std::size_t>(sizeof(T)*CHAR_BIT*0.302) + 3;
+
+        static constexpr T(max)() noexcept
+        {
+            return (std::numeric_limits<T>::max)();
+        }
+        static constexpr T(min)() noexcept
+        {
+            return (std::numeric_limits<T>::min)();
+        }
+        static constexpr T lowest() noexcept
+        {
+            return std::numeric_limits<T>::lowest();
+        }
+    };
+
+    template <typename T>
+    class integer_limits<T,typename std::enable_if<!std::is_integral<T>::value && is_int128_type<T>::value>::type>
+    {
+    public:
+        static constexpr bool is_specialized = true;
+        static constexpr bool is_signed = true;
+        static constexpr int digits =  sizeof(T)*CHAR_BIT - 1;
+        static constexpr std::size_t buffer_size = (sizeof(T)*CHAR_BIT*0.302) + 3;
+
+        static constexpr T(max)() noexcept
+        {
+            return (((((T)1 << (digits - 1)) - 1) << 1) + 1);
+        }
+        static constexpr T(min)() noexcept
+        {
+            return -(max)() - 1;
+        }
+        static constexpr T lowest() noexcept
+        {
+            return (min)();
+        }
+    };
+
+    template <typename T>
+    class integer_limits<T,typename std::enable_if<!std::is_integral<T>::value && is_uint128_type<T>::value>::type>
+    {
+    public:
+        static constexpr bool is_specialized = true;
+        static constexpr bool is_signed = false;
+        static constexpr int digits =  sizeof(T)*CHAR_BIT;
+
+        static constexpr T(max)() noexcept
+        {
+            return T(T(~0));
+        }
+        static constexpr T(min)() noexcept
+        {
+            return 0;
+        }
+        static constexpr T lowest() noexcept
+        {
+            return std::numeric_limits<T>::lowest();
+        }
+    };
+
+    #ifndef JSONCONS_HAS_VOID_T
+    // follows https://en.cppreference.com/w/cpp/types/void_t
+    template <typename... Ts> struct make_void { typedef void type;};
+    template <typename... Ts> using void_t = typename make_void<Ts...>::type;
+    #else
+    using void_t = std::void_t; 
+    #endif
+
+    // follows http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4436.pdf
+
+    // detector
+
+    // primary template handles all types not supporting the archetypal Op
+    template< 
+        class Default, 
+        class, // always void; supplied externally
+        template <typename...> class Op, 
+        typename... Args
+    >
+    struct detector
+    {
+        constexpr static auto value = false;
+        using type = Default;
+    };
+
+    // specialization recognizes and handles only types supporting Op
+    template< 
+        class Default, 
+        template <typename...> class Op, 
+        typename... Args
+    >
+    struct detector<Default, void_t<Op<Args...>>, Op, Args...>
+    {
+        constexpr static auto value = true;
+        using type = Op<Args...>;
+    };
+
+    // is_detected, is_detected_t
+
+    template< template <typename...> class Op,typename... Args >
+    using
+    is_detected = detector<void, void, Op, Args...>;
+
+    template< template <typename...> class Op,typename... Args >
+    using
+    is_detected_t = typename is_detected<Op, Args...>::type;
+
+    // detected_or, detected_or_t
+
+    template <typename Default, template <typename...> class Op,typename... Args >
+    using
+    detected_or = detector<Default, void, Op, Args...>;
+
+    template <typename Default, template <typename...> class Op,typename... Args >
+    using
+    detected_or_t = typename detected_or<Default, Op, Args...>::type;
+
+    // is_detected_exact
+
+   template< class Expected, template <typename...> class Op,typename... Args >
+   using
+   is_detected_exact = std::is_same< Expected, is_detected_t<Op, Args...> >;
+
+    // is_detected_convertible
+
+    template< class To, template <typename...> class Op,typename... Args >
+    using
+    is_detected_convertible = std::is_convertible< is_detected_t<Op, Args...>, To >;
+
+    // to_plain_pointer
+
+    template <typename Pointer> inline
+    typename std::pointer_traits<Pointer>::element_type* to_plain_pointer(Pointer ptr)
+    {       
+        return (std::addressof(*ptr));
+    }
+
+    template <typename T> inline
+    T * to_plain_pointer(T * ptr)
+    {       
+        return (ptr);
+    }  
+
+    // is_std_byte
+
+    template <typename T,typename Enable=void>
+    struct is_std_byte : std::false_type {};
+#if defined(JSONCONS_HAS_STD_BYTE)
+    template <typename T>
+    struct is_std_byte<T, 
+           typename std::enable_if<std::is_same<T,std::byte>::value
+    >::type> : std::true_type {};
+#endif
+    // is_byte
+
+    template <typename T,typename Enable=void>
+    struct is_byte : std::false_type {};
+
+    template <typename T>
+    struct is_byte<T, 
+           typename std::enable_if<std::is_same<T,char>::value ||
+                                   std::is_same<T,signed char>::value ||
+                                   std::is_same<T,unsigned char>::value ||
+                                   is_std_byte<T>::value
+    >::type> : std::true_type {};
+
+    // is_character
+
+    template <typename T,typename Enable=void>
+    struct is_character : std::false_type {};
+
+    template <typename T>
+    struct is_character<T, 
+           typename std::enable_if<std::is_same<T,char>::value ||
+#ifdef __cpp_char8_t
+                                   std::is_same<T,char8_t>::value ||
+#endif
+                                   std::is_same<T,wchar_t>::value
+    >::type> : std::true_type {};
+
+    // is_narrow_character
+
+    template <typename T,typename Enable=void>
+    struct is_narrow_character : std::false_type {};
+
+    template <typename T>
+    struct is_narrow_character<T, 
+           typename std::enable_if<is_character<T>::value && (sizeof(T) == sizeof(char))
+    >::type> : std::true_type {};
+
+    // is_wide_character
+
+    template <typename T,typename Enable=void>
+    struct is_wide_character : std::false_type {};
+
+    template <typename T>
+    struct is_wide_character<T, 
+           typename std::enable_if<is_character<T>::value && (sizeof(T) != sizeof(char))
+    >::type> : std::true_type {};
+
+    // From boost
+    namespace ut_detail {
+
+    template <typename T>
+    struct is_cstring_impl : public std::false_type {};
+
+    template <typename T>
+    struct is_cstring_impl<T const*> : public is_cstring_impl<T*> {};
+
+    template <typename T>
+    struct is_cstring_impl<T const* const> : public is_cstring_impl<T*> {};
+
+    template<>
+    struct is_cstring_impl<char*> : public std::true_type {};
+
+#ifdef __cpp_char8_t
+    template<>
+    struct is_cstring_impl<char8_t*> : public std::true_type {};
+#endif
+
+    template<>
+    struct is_cstring_impl<wchar_t*> : public std::true_type {};
+
+    } // namespace ut_detail
+
+    template <typename T>
+    struct is_cstring : public ut_detail::is_cstring_impl<typename std::decay<T>::type> {};
+
+    // is_bool
+
+    template <typename T,typename Enable=void>
+    struct is_bool : std::false_type {};
+
+    template <typename T>
+    struct is_bool<T, 
+                   typename std::enable_if<std::is_same<T,bool>::value
+    >::type> : std::true_type {};
+
+    // is_u8_u16_u32_or_u64
+
+    template <typename T,typename Enable=void>
+    struct is_u8_u16_u32_or_u64 : std::false_type {};
+
+    template <typename T>
+    struct is_u8_u16_u32_or_u64<T, 
+                                typename std::enable_if<std::is_same<T,uint8_t>::value ||
+                                                        std::is_same<T,uint16_t>::value ||
+                                                        std::is_same<T,uint32_t>::value ||
+                                                        std::is_same<T,uint64_t>::value
+    >::type> : std::true_type {};
+
+    // is_int
+
+    template <typename T,typename Enable=void>
+    struct is_i8_i16_i32_or_i64 : std::false_type {};
+
+    template <typename T>
+    struct is_i8_i16_i32_or_i64<T, 
+                                typename std::enable_if<std::is_same<T,int8_t>::value ||
+                                                        std::is_same<T,int16_t>::value ||
+                                                        std::is_same<T,int32_t>::value ||
+                                                        std::is_same<T,int64_t>::value
+    >::type> : std::true_type {};
+
+    // is_float_or_double
+
+    template <typename T,typename Enable=void>
+    struct is_float_or_double : std::false_type {};
+
+    template <typename T>
+    struct is_float_or_double<T, 
+                              typename std::enable_if<std::is_same<T,float>::value ||
+                                                      std::is_same<T,double>::value
+    >::type> : std::true_type {};
+
+    // make_unsigned
+    template <typename T>
+    struct make_unsigned_impl {using type = typename std::make_unsigned<T>::type;};
+
+    #if defined(JSONCONS_HAS_INT128)
+    template <> 
+    struct make_unsigned_impl<int128_type> {using type = uint128_type;};
+    template <> 
+    struct make_unsigned_impl<uint128_type> {using type = uint128_type;};
+    #endif
+
+    template <typename T>
+    struct make_unsigned
+       : make_unsigned_impl<typename std::remove_cv<T>::type>
+    {};
+
+    // is_integer
+
+    template <typename T,typename Enable=void>
+    struct is_integer : std::false_type {};
+
+    template <typename T>
+    struct is_integer<T,typename std::enable_if<integer_limits<T>::is_specialized>::type> : std::true_type {};
+
+    // is_signed_integer
+
+    template <typename T,typename Enable=void>
+    struct is_signed_integer : std::false_type {};
+
+    template <typename T>
+    struct is_signed_integer<T,typename std::enable_if<integer_limits<T>::is_specialized && 
+                                                        integer_limits<T>::is_signed>::type> : std::true_type {};
+
+    // is_unsigned_integer
+
+    template <typename T,typename Enable=void>
+    struct is_unsigned_integer : std::false_type {};
+
+    template <typename T>
+    struct is_unsigned_integer<T, 
+                               typename std::enable_if<integer_limits<T>::is_specialized && 
+                               !integer_limits<T>::is_signed>::type> : std::true_type {};
+
+    // is_primitive
+
+    template <typename T,typename Enable=void>
+    struct is_primitive : std::false_type {};
+
+    template <typename T>
+    struct is_primitive<T, 
+           typename std::enable_if<is_integer<T>::value ||
+                                   is_bool<T>::value ||
+                                   std::is_floating_point<T>::value
+    >::type> : std::true_type {};
+
+    // Containers
+
+    template <typename Container>
+    using 
+    container_npos_t = decltype(Container::npos);
+
+    template <typename Container>
+    using 
+    container_allocator_type_t = typename Container::allocator_type;
+
+    template <typename Container>
+    using 
+    container_mapped_type_t = typename Container::mapped_type;
+
+    template <typename Container>
+    using 
+    container_key_type_t = typename Container::key_type;
+
+    template <typename Container>
+    using 
+    container_value_type_t = typename std::iterator_traits<typename Container::iterator>::value_type;
+
+    template <typename Container>
+    using 
+    container_char_traits_t = typename Container::traits_type::char_type;
+
+    template <typename Container>
+    using
+    container_push_back_t = decltype(std::declval<Container>().push_back(std::declval<typename Container::value_type>()));
+
+    template <typename Container>
+    using
+    container_push_front_t = decltype(std::declval<Container>().push_front(std::declval<typename Container::value_type>()));
+
+    template <typename Container>
+    using
+    container_insert_t = decltype(std::declval<Container>().insert(std::declval<typename Container::value_type>()));
+
+    template <typename Container>
+    using
+    container_reserve_t = decltype(std::declval<Container>().reserve(typename Container::size_type()));
+
+    template <typename Container>
+    using
+    container_data_t = decltype(std::declval<Container>().data());
+
+    template <typename Container>
+    using
+    container_size_t = decltype(std::declval<Container>().size());
+
+    // has_allocator_type
+
+    template <typename T,typename Enable=void>
+    struct has_allocator_type : std::false_type {};
+
+    template <typename T>
+    struct has_allocator_type<T, 
+        typename std::enable_if<is_detected<container_allocator_type_t,T>::value
+    >::type> : std::true_type {};
+
+    // is_string_or_string_view
+
+    template <typename T,typename Enable=void>
+    struct is_string_or_string_view : std::false_type {};
+
+    template <typename T>
+    struct is_string_or_string_view<T, 
+                     typename std::enable_if<is_character<typename T::value_type>::value &&
+                                             is_detected_exact<typename T::value_type,container_char_traits_t,T>::value &&
+                                             is_detected<container_npos_t,T>::value
+    >::type> : std::true_type {};
+
+    // is_string
+
+    template <typename T,typename Enable=void>
+    struct is_string : std::false_type {};
+
+    template <typename T>
+    struct is_string<T, 
+                     typename std::enable_if<is_string_or_string_view<T>::value &&
+                                             has_allocator_type<T>::value
+    >::type> : std::true_type {};
+
+    // is_string_view
+
+    template <typename T,typename Enable=void>
+    struct is_string_view : std::false_type {};
+
+    template <typename T>
+    struct is_string_view<T, 
+                          typename std::enable_if<is_string_or_string_view<T>::value &&
+                                                  !is_detected<container_allocator_type_t,T>::value
+    >::type> : std::true_type {};
+
+    // is_map_like
+
+    template <typename T,typename Enable=void>
+    struct is_map_like : std::false_type {};
+
+    template <typename T>
+    struct is_map_like<T, 
+                       typename std::enable_if<is_detected<container_mapped_type_t,T>::value &&
+                                               is_detected<container_allocator_type_t,T>::value &&
+                                               is_detected<container_key_type_t,T>::value &&
+                                               is_detected<container_value_type_t,T>::value 
+        >::type> 
+        : std::true_type {};
+
+    // is_std_array
+    template <typename T>
+    struct is_std_array : std::false_type {};
+
+    template <typename E, std::size_t N>
+    struct is_std_array<std::array<E, N>> : std::true_type {};
+
+    // is_array_like
+
+    template <typename T,typename Enable=void>
+    struct is_array_like : std::false_type {};
+
+    template <typename T>
+    struct is_array_like<T, 
+                          typename std::enable_if<is_detected<container_value_type_t,T>::value &&
+                                                  is_detected<container_allocator_type_t,T>::value &&
+                                                  !is_std_array<T>::value && 
+                                                  !is_detected_exact<typename T::value_type,container_char_traits_t,T>::value &&
+                                                  !is_map_like<T>::value 
+    >::type> 
+        : std::true_type {};
+
+    // is_constructible_from_const_pointer_and_size
+
+    template <typename T,typename Enable=void>
+    struct is_constructible_from_const_pointer_and_size : std::false_type {};
+
+    template <typename T>
+    struct is_constructible_from_const_pointer_and_size<T, 
+        typename std::enable_if<std::is_constructible<T,typename T::const_pointer,typename T::size_type>::value
+    >::type> 
+        : std::true_type {};
+
+    // has_reserve
+
+    template <typename Container>
+    using
+    has_reserve = is_detected<container_reserve_t, Container>;
+
+    // is_back_insertable
+
+    template <typename Container>
+    using
+    is_back_insertable = is_detected<container_push_back_t, Container>;
+
+    // is_front_insertable
+
+    template <typename Container>
+    using
+    is_front_insertable = is_detected<container_push_front_t, Container>;
+
+    // is_insertable
+
+    template <typename Container>
+    using
+    is_insertable = is_detected<container_insert_t, Container>;
+
+    // has_data, has_data_exact
+
+    template <typename Container>
+    using
+    has_data = is_detected<container_data_t, Container>;
+
+    template <typename Ret,typename Container>
+    using
+    has_data_exact = is_detected_exact<Ret, container_data_t, Container>;
+
+    // has_size
+
+    template <typename Container>
+    using
+    has_size = is_detected<container_size_t, Container>;
+
+    // has_data_and_size
+
+    template <typename Container>
+    struct has_data_and_size
+    {
+        static constexpr bool value = has_data<Container>::value && has_size<Container>::value;
+    };
+
+    // is_byte_sequence
+
+    template <typename Container,typename Enable=void>
+    struct is_byte_sequence : std::false_type {};
+
+    template <typename Container>
+    struct is_byte_sequence<Container, 
+           typename std::enable_if<has_data_exact<const typename Container::value_type*,const Container>::value &&
+                                   has_size<Container>::value &&
+                                   is_byte<typename Container::value_type>::value
+    >::type> : std::true_type {};
+
+    // is_char_sequence
+
+    template <typename Container,typename Enable=void>
+    struct is_char_sequence : std::false_type {};
+
+    template <typename Container>
+    struct is_char_sequence<Container, 
+           typename std::enable_if<has_data_exact<const typename Container::value_type*,const Container>::value &&
+                                   has_size<Container>::value &&
+                                   is_character<typename Container::value_type>::value
+    >::type> : std::true_type {};
+
+    // is_sequence_of
+
+    template <typename Container,typename ValueT,typename Enable=void>
+    struct is_sequence_of : std::false_type {};
+
+    template <typename Container,typename ValueT>
+    struct is_sequence_of<Container,ValueT, 
+           typename std::enable_if<has_data_exact<const typename Container::value_type*,const Container>::value &&
+                                   has_size<Container>::value &&
+                                   std::is_same<typename Container::value_type,ValueT>::value
+    >::type> : std::true_type {};
+
+    // is_back_insertable_byte_container
+
+    template <typename Container,typename Enable=void>
+    struct is_back_insertable_byte_container : std::false_type {};
+
+    template <typename Container>
+    struct is_back_insertable_byte_container<Container, 
+           typename std::enable_if<is_back_insertable<Container>::value &&
+                                   is_byte<typename Container::value_type>::value
+    >::type> : std::true_type {};
+
+    // is_back_insertable_char_container
+
+    template <typename Container,typename Enable=void>
+    struct is_back_insertable_char_container : std::false_type {};
+
+    template <typename Container>
+    struct is_back_insertable_char_container<Container, 
+           typename std::enable_if<is_back_insertable<Container>::value &&
+                                   is_character<typename Container::value_type>::value
+    >::type> : std::true_type {};
+
+    // is_back_insertable_container_of
+
+    template <typename Container,typename ValueT,typename Enable=void>
+    struct is_back_insertable_container_of : std::false_type {};
+
+    template <typename Container,typename ValueT>
+    struct is_back_insertable_container_of<Container, ValueT,
+           typename std::enable_if<is_back_insertable<Container>::value &&
+                                   std::is_same<typename Container::value_type,ValueT>::value
+    >::type> : std::true_type {};
+
+    // is_c_array
+
+    template <typename T>
+    struct is_c_array : std::false_type {};
+
+    template <typename T>
+    struct is_c_array<T[]> : std::true_type {};
+
+    template <typename T, std::size_t N>
+    struct is_c_array<T[N]> : std::true_type {};
+
+namespace impl {
+
+    template <typename C,typename Enable=void>
+    struct is_typed_array : std::false_type {};
+
+    template <typename T>
+    struct is_typed_array
+    <
+        T, 
+        typename std::enable_if<is_array_like<T>::value && 
+                                (std::is_same<typename std::decay<typename T::value_type>::type,uint8_t>::value ||  
+                                 std::is_same<typename std::decay<typename T::value_type>::type,uint16_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,uint32_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,uint64_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,int8_t>::value ||  
+                                 std::is_same<typename std::decay<typename T::value_type>::type,int16_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,int32_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,int64_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,float_t>::value ||
+                                 std::is_same<typename std::decay<typename T::value_type>::type,double_t>::value)>::type
+    > : std::true_type{};
+
+} // namespace impl
+    
+    template <typename T>
+    using is_typed_array = impl::is_typed_array<typename std::decay<T>::type>;
+
+    // is_compatible_element
+
+    template <typename Container,typename Element,typename Enable=void>
+    struct is_compatible_element : std::false_type {};
+
+    template <typename Container,typename Element>
+    struct is_compatible_element
+    <
+        Container, Element, 
+        typename std::enable_if<has_data<Container>::value>::type>
+            : std::is_convertible< typename std::remove_pointer<decltype(std::declval<Container>().data() )>::type(*)[], Element(*)[]>
+    {};
+
+    template <typename T>
+    using
+    construct_from_string_t = decltype(T(std::string{}));
+
+
+    template <typename T>
+    using
+    is_constructible_from_string = is_detected<construct_from_string_t,T>;
+
+    template <typename T,typename Data,typename Size>
+    using
+    construct_from_data_size_t = decltype(T(static_cast<Data>(nullptr),Size{}));
+
+
+    template <typename T,typename Data,typename Size>
+    using
+    is_constructible_from_data_size = is_detected<construct_from_data_size_t,T,Data,Size>;
+
+    // is_unary_function_object
+    // is_unary_function_object_exact
+
+    template <typename FunctionObject,typename Arg>
+        using
+        unary_function_object_t = decltype(std::declval<FunctionObject>()(std::declval<Arg>()));
+
+    template <typename FunctionObject,typename Arg>
+        using
+        is_unary_function_object = is_detected<unary_function_object_t, FunctionObject, Arg>;
+
+    template <typename FunctionObject,typename T,typename Arg>
+    using
+    is_unary_function_object_exact = is_detected_exact<T,unary_function_object_t, FunctionObject, Arg>;
+
+    // is_binary_function_object
+    // is_binary_function_object_exact
+
+    template <typename FunctionObject,typename Arg1,typename Arg2>
+        using
+        binary_function_object_t = decltype(std::declval<FunctionObject>()(std::declval<Arg1>(),std::declval<Arg2>()));
+
+    template <typename FunctionObject,typename Arg1,typename Arg2>
+        using
+        is_binary_function_object = is_detected<binary_function_object_t, FunctionObject, Arg1, Arg2>;
+
+    template <typename FunctionObject,typename T,typename Arg1,typename Arg2>
+    using
+    is_binary_function_object_exact = is_detected_exact<T,binary_function_object_t, FunctionObject, Arg1, Arg2>;
+
+    template <typename Source,typename Enable=void>
+    struct is_convertible_to_string_view : std::false_type {};
+
+    template <typename Source>
+    struct is_convertible_to_string_view<Source,typename std::enable_if<is_string_or_string_view<Source>::value ||
+                                                               is_cstring<Source>::value
+        >::type> : std::true_type {};
+
+    #if defined(JSONCONS_HAS_2017)
+        template <typename T>
+        using is_nothrow_swappable = std::is_nothrow_swappable<T>;
+    #else
+        template <typename T>
+        struct is_nothrow_swappable {
+            static const bool value = noexcept(swap(std::declval<T&>(), std::declval<T&>()));
+        };
+    #endif
+
+    #if defined(JSONCONS_HAS_2014)
+        template <typename T>
+        using alignment_of = std::alignment_of<T>;
+
+        template< typename T, T... Ints >
+        using integer_sequence = std::integer_sequence<T,Ints...>;
+
+        template <T ... Inds>
+        using index_sequence = std::index_sequence<Inds...>;
+
+        template <typename T, T N>
+        using make_integer_sequence = std::make_integer_sequence<T,N>;
+
+        template <std::size_t N>
+        using make_index_sequence = std::make_index_sequence<N>;
+
+        template <typename... T>
+        using index_sequence_for = std::index_sequence_for<T...>;
+
+    #else
+       template <typename T>
+        struct alignment_of
+            : std::integral_constant<std::size_t, alignof(typename std::remove_all_extents<T>::type)> {};
+
+        template <typename T, T... Ints>
+        class integer_sequence 
+        {
+        public:
+           using value_type = T;
+           static_assert(std::is_integral<value_type>::value, "not integral type");
+           static constexpr std::size_t size() noexcept 
+           {
+               return sizeof...(Ints);
+           }
+        };
+
+        template <std::size_t... Inds>
+        using index_sequence = integer_sequence<std::size_t, Inds...>;
+        namespace detail_ {
+        template <typename T, T Begin, T End, bool>
+        struct IntSeqImpl {
+            using TValue = T;
+            static_assert(std::is_integral<TValue>::value, "not integral type");
+            static_assert(Begin >= 0 && Begin < End, "unexpected argument (Begin<0 || Begin<=End)");
+
+            template <typename,typename>
+            struct IntSeqCombiner;
+
+            template <TValue... Inds0, TValue... Inds1>
+            struct IntSeqCombiner<integer_sequence<TValue, Inds0...>, integer_sequence<TValue, Inds1...>> {
+                using TResult = integer_sequence<TValue, Inds0..., Inds1...>;
+            };
+
+            using TResult =
+                typename IntSeqCombiner<typename IntSeqImpl<TValue, Begin, Begin + (End - Begin) / 2,
+                                                            (End - Begin) / 2 == 1>::TResult,
+                                        typename IntSeqImpl<TValue, Begin + (End - Begin) / 2, End,
+                                                            (End - Begin + 1) / 2 == 1>::TResult>::TResult;
+        };
+
+        template <typename T, T Begin>
+        struct IntSeqImpl<T, Begin, Begin, false> {
+            using TValue = T;
+            static_assert(std::is_integral<TValue>::value, "not integral type");
+            static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+            using TResult = integer_sequence<TValue>;
+        };
+
+        template <typename T, T Begin, T End>
+        struct IntSeqImpl<T, Begin, End, true> {
+            using TValue = T;
+            static_assert(std::is_integral<TValue>::value, "not integral type");
+            static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+            using TResult = integer_sequence<TValue, Begin>;
+        };
+        } // namespace detail_
+
+        template <typename T, T N>
+        using make_integer_sequence = typename detail_::IntSeqImpl<T, 0, N, (N - 0) == 1>::TResult;
+
+        template <std::size_t N>
+        using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+        template <typename... T>
+        using index_sequence_for = make_index_sequence<sizeof...(T)>;
+    
+
+    #endif
+
+    // is_propagating_allocator
+
+    template <typename Allocator>
+    using 
+    allocator_outer_allocator_type_t = typename Allocator::outer_allocator_type;
+
+    template <typename Allocator>
+    using 
+    allocator_inner_allocator_type_t = typename Allocator::inner_allocator_type;
+
+    template <typename T,typename Enable=void>
+    struct is_propagating_allocator : std::false_type {};
+
+    template <typename T,typename Enable=void>
+    struct is_polymorphic_allocator : std::false_type {};
+
+#if defined(JSONCONS_HAS_POLYMORPHIC_ALLOCATOR)
+    template <typename T>
+    struct is_polymorphic_allocator
+    <
+        T, 
+        typename std::enable_if<(std::is_same<T,std::pmr::polymorphic_allocator<char>>::value) >::type
+    > : std::true_type{};
+#endif
+    template <typename T>
+    struct is_propagating_allocator
+    <
+        T, 
+        typename std::enable_if<(is_polymorphic_allocator<T>::value) || 
+            (is_detected<allocator_outer_allocator_type_t,T>::value && is_detected<allocator_inner_allocator_type_t,T>::value)>::type
+    > : std::true_type{};
+
+    
+} // extension_traits
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_UTILITY_EXTENSION_TRAITS_HPP

--- a/velox/external/jsoncons/utility/heap_string.hpp
+++ b/velox/external/jsoncons/utility/heap_string.hpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_UTILITY_HEAP_STRING_HPP
+#define JSONCONS_UTILITY_HEAP_STRING_HPP
+
+#include <cstdint>
+#include <cstring> // std::memcpy
+#include <memory> // std::allocator
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+
+namespace facebook::velox::jsoncons {
+namespace utility {
+
+    inline char*
+    align_up(char* ptr, std::size_t alignment) noexcept
+    {
+        return reinterpret_cast<char*>(~(alignment - 1) &
+            (reinterpret_cast<uintptr_t>(ptr) + alignment - 1));
+    }
+
+    template <typename Extra,typename Allocator>
+    struct heap_string_base
+    {
+        Extra extra_;
+        Allocator alloc_;
+
+        Allocator& get_allocator()
+        {
+            return alloc_;
+        }
+
+        const Allocator& get_allocator() const
+        {
+            return alloc_;
+        }
+
+        heap_string_base(const Extra& extra, const Allocator& alloc)
+            : extra_(extra), alloc_(alloc)
+        {
+        }
+
+        ~heap_string_base() = default;
+    };
+
+    template <typename CharT,typename Extra,typename Allocator>
+    struct heap_string : public heap_string_base<Extra,Allocator>
+    {
+        using char_type = CharT;
+        using allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<CharT>;
+        using allocator_traits_type = std::allocator_traits<allocator_type>;
+        using pointer = typename allocator_traits_type::pointer;
+
+        pointer p_;
+        std::size_t length_{0};
+        uint8_t offset_{0};
+        uint8_t align_pad_{0};
+
+        heap_string(const heap_string&) = delete;
+        heap_string(heap_string&&) = delete;
+
+        heap_string(Extra extra, const Allocator& alloc)
+            : heap_string_base<Extra,Allocator>(extra, alloc), p_(nullptr)
+        {
+        }
+
+        ~heap_string() = default;
+
+        const char_type* c_str() const { return extension_traits::to_plain_pointer(p_); }
+        const char_type* data() const { return extension_traits::to_plain_pointer(p_); }
+        std::size_t length() const { return length_; }
+        Extra extra() const { return this->extra_; }
+
+        heap_string& operator=(const heap_string&) = delete;
+        heap_string& operator=(heap_string&&) = delete;
+
+    };
+
+    template<std::size_t Len, std::size_t Align>
+    struct jsoncons_aligned_storage
+    {
+        struct type
+        {
+            alignas(Align) unsigned char data[Len];
+        };
+    };
+
+    // From boost 1_71
+    template <typename T,typename U>
+    T launder_cast(U* u)
+    {
+    #if defined(__cpp_lib_launder) && __cpp_lib_launder >= 201606
+        return std::launder(reinterpret_cast<T>(u));
+    #elif defined(__GNUC__) &&  (__GNUC__ * 100 + __GNUC_MINOR__) > 800
+        return __builtin_launder(reinterpret_cast<T>(u));
+    #else
+        return reinterpret_cast<T>(u);
+    #endif
+    }
+
+    // heap_string_factory
+
+    template <typename CharT,typename Extra,typename Allocator>
+    class heap_string_factory
+    {
+    public:
+        using char_type = CharT;
+        using heap_string_type = heap_string<CharT,Extra,Allocator>;
+    private:
+
+        using byte_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<char>;
+        using byte_pointer = typename std::allocator_traits<byte_allocator_type>::pointer;
+
+        using heap_string_allocator_type = typename std::allocator_traits<Allocator>::template rebind_alloc<heap_string_type>;
+    public:
+        using pointer = typename std::allocator_traits<heap_string_allocator_type>::pointer;
+
+        struct storage_t
+        {
+            heap_string_type data;
+            char_type c[1];
+        };
+        typedef typename jsoncons_aligned_storage<sizeof(storage_t), alignof(storage_t)>::type storage_type;
+
+        static size_t aligned_size(std::size_t n)
+        {
+            return sizeof(storage_type) + n;
+        }
+
+    public:
+
+        static pointer create(const char_type* s, std::size_t length, Extra extra, const Allocator& alloc)
+        {
+            std::size_t len = aligned_size(length*sizeof(char_type));
+
+            std::size_t align = alignof(storage_type);
+            char* q = nullptr;
+            char* storage = nullptr;
+            byte_allocator_type byte_alloc(alloc);
+            uint8_t align_pad = 0;
+
+            if (align <= 8) {
+                byte_pointer ptr = byte_alloc.allocate(len);
+                q = extension_traits::to_plain_pointer(ptr);
+
+                if (reinterpret_cast<uintptr_t>(q) % align == 0) {
+                    storage = q;
+                } else {
+                    byte_alloc.deallocate(ptr, len);
+                }
+            }
+
+            if (storage == nullptr) {
+                align_pad = uint8_t(align-1);
+                byte_pointer ptr = byte_alloc.allocate(align_pad+len);
+                q = extension_traits::to_plain_pointer(ptr);
+                storage = align_up(q, align);
+                JSONCONS_ASSERT(storage >= q);
+            }
+
+            heap_string_type* ps = new(storage)heap_string_type(extra, byte_alloc);
+
+            auto psa = launder_cast<storage_t*>(storage);
+
+            CharT* p = new(&psa->c)char_type[length + 1];
+            std::memcpy(p, s, length*sizeof(char_type));
+            p[length] = 0;
+            ps->p_ = std::pointer_traits<typename heap_string_type::pointer>::pointer_to(*p);
+            ps->length_ = length;
+            ps->offset_ = (uint8_t)(storage - q);
+            ps->align_pad_ = align_pad;
+            return std::pointer_traits<pointer>::pointer_to(*ps);
+        }
+
+        static void destroy(pointer ptr)
+        {
+            if (ptr != nullptr)
+            {
+                heap_string_type* rawp = extension_traits::to_plain_pointer(ptr);
+
+                char* q = launder_cast<char*>(rawp);
+
+                char* p = q - ptr->offset_;
+
+                std::size_t mem_size = ptr->align_pad_ + aligned_size(ptr->length_*sizeof(char_type));
+                byte_allocator_type byte_alloc(ptr->get_allocator());
+                byte_alloc.deallocate(p,mem_size + ptr->offset_);
+            }
+        }
+    };
+
+} // namespace utility
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_UTILITY_HEAP_STRING_HPP

--- a/velox/external/jsoncons/utility/unicode_traits.hpp
+++ b/velox/external/jsoncons/utility/unicode_traits.hpp
@@ -1,0 +1,1347 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/unicode_traits for latest version
+
+/*
+ * Includes code derived from Unicode, Inc decomposition code in ConvertUTF.h and ConvertUTF.c 
+ * http://www.unicode.org/  
+ *  
+ * "Unicode, Inc. hereby grants the right to freely use the information
+ * supplied in this file in the creation of products supporting the
+ * Unicode Standard."
+*/
+
+#ifndef JSONCONS_UTILITY_UNICODE_TRAITS_HPP
+#define JSONCONS_UTILITY_UNICODE_TRAITS_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+#include <string>
+#include <system_error>
+#include <type_traits>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+
+namespace facebook::velox::jsoncons { namespace unicode_traits {
+
+    enum class encoding_kind {undetected,utf8,utf16le,utf16be,utf32le,utf32be};
+
+    inline
+    std::string to_string(encoding_kind encoding)
+    {
+        switch (encoding)
+        {
+            case encoding_kind::utf8:
+                return "utf8";
+            case encoding_kind::utf16le:
+                return "utf16le";
+            case encoding_kind::utf16be:
+                return "utf16be";
+            case encoding_kind::utf32le:
+                return "utf32le";
+            case encoding_kind::utf32be:
+                return "utf32be";
+            default:
+                return "undetected";
+        }
+    }
+
+    template <typename Byte>
+    struct detect_encoding_result
+    {
+        const Byte* ptr;
+        encoding_kind encoding;
+    };
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value,detect_encoding_result<CharT>>::type
+    detect_encoding_from_bom(const CharT* data, std::size_t length)
+    {
+        const uint8_t bom_utf8[] = {0xef,0xbb,0xbf}; 
+        const uint8_t bom_utf16le[] = {0xff,0xfe}; 
+        const uint8_t bom_utf16be[] = {0xfe,0xff}; 
+        const uint8_t bom_utf32le[] = {0xff,0xfe,0x00,0x00}; 
+        const uint8_t bom_utf32be[] = {0x00,0x00,0xfe,0xff}; 
+
+        if (length >= 4 && !memcmp(data,bom_utf32le,4))
+        {
+            return detect_encoding_result<CharT>{data+4,encoding_kind::utf32le};
+        }
+        else if (length >= 4 && !memcmp(data,bom_utf32be,4))
+        {
+            return detect_encoding_result<CharT>{data+4,encoding_kind::utf32be};
+        }
+        else if (length >= 2 && !memcmp(data,bom_utf16le,2))
+        {
+            return detect_encoding_result<CharT>{data+2,encoding_kind::utf16le};
+        }
+        else if (length >= 2 && !memcmp(data,bom_utf16be,2))
+        {
+            return detect_encoding_result<CharT>{data+2,encoding_kind::utf16be};
+        }
+        else if (length >= 3 && !memcmp(data,bom_utf8,3))
+        {
+            return detect_encoding_result<CharT>{data+3,encoding_kind::utf8};
+        }
+        else
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::undetected};
+        }
+    }
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value || extension_traits::is_char32<CharT>::value,detect_encoding_result<CharT>>::type
+    detect_encoding_from_bom(const CharT* data, std::size_t)
+    {
+        return detect_encoding_result<CharT>{data,encoding_kind::undetected};
+    }
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value,detect_encoding_result<CharT>>::type
+    detect_json_encoding(const CharT* data, std::size_t length)
+    {
+        detect_encoding_result<CharT> r = detect_encoding_from_bom(data,length);
+        if (r.encoding != encoding_kind::undetected)
+        {
+            return r;
+        }
+        else if (length < 4)
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf8};
+        }
+        else if (*data == 0 && *(data+1) == 0 && *(data+2) == 0)
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf32be};
+        }
+        else if (*data == 0 && *(data+2) == 0)
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf16be};
+        }
+        else if (*(data+1) == 0 && *(data+2) == 0 && *(data+3) == 0)
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf32le};
+        }
+        else if (*(data+1) == 0 && *(data+3) == 0)
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf16le};
+        }
+        else
+        {
+            return detect_encoding_result<CharT>{data,encoding_kind::utf8};
+        }
+    }
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value || extension_traits::is_char32<CharT>::value,detect_encoding_result<CharT>>::type
+    detect_json_encoding(const CharT* data, std::size_t)
+    {
+        return detect_encoding_result<CharT>{data,encoding_kind::undetected};
+    }
+
+    /*
+     * Magic values subtracted from a buffer value during UTF8 conversion.
+     * This table contains as many values as there might be trailing bytes
+     * in a UTF-8 sequence. Source: ConvertUTF.c
+     */
+    const uint32_t offsets_from_utf8[6] = { 0x00000000UL, 0x00003080UL, 0x000E2080UL, 
+                  0x03C82080UL, 0xFA082080UL, 0x82082080UL };
+
+    /*
+     * Once the bits are split out into bytes of UTF-8, this is a mask OR-ed
+     * into the first byte, depending on how many bytes follow.  There are
+     * as many entries in this table as there are UTF-8 sequence types.
+     * (I.e., one byte sequence, two byte... etc.). Remember that sequencs
+     * for *legal* UTF-8 will be 4 or fewer bytes total. Source: ConvertUTF.c
+     */
+    const uint8_t first_byte_mark[7] = { 0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+    /*
+     * Index into the table below with the first byte of a UTF-8 sequence to
+     * get the number of trailing bytes that are supposed to follow it.
+     * Note that *legal* UTF-8 values can't have 4 or 5-bytes. The table is
+     * left as-is for anyone who may want to do such conversion, which was
+     * allowed in earlier algorithms. Source: ConvertUTF.c
+     */
+    const uint8_t trailing_bytes_for_utf8[256] = {
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
+        2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
+    };
+
+    // Some fundamental constants.  Source: ConvertUTF.h 
+    const uint32_t replacement_char = 0x0000FFFD;
+    const uint32_t max_bmp = 0x0000FFFF;
+    const uint32_t max_utf16 = 0x0010FFFF;
+    const uint32_t max_utf32 = 0x7FFFFFFF;
+    const uint32_t max_legal_utf32 = 0x0010FFFF;
+
+    const int half_shift  = 10; // used for shifting by 10 bits
+    const uint32_t half_base = 0x0010000UL;
+    const uint32_t half_mask = 0x3FFUL;
+
+    const uint16_t sur_high_start = 0xD800;
+    const uint16_t sur_high_end = 0xDBFF;
+    const uint16_t sur_low_start = 0xDC00;
+    const uint16_t sur_low_end = 0xDFFF;
+
+    inline
+    static bool is_continuation_byte(unsigned char ch)
+    {
+        return (ch & 0xC0) == 0x80;
+    }
+
+    inline
+    bool is_high_surrogate(uint32_t ch) noexcept
+    {
+        return (ch >= sur_high_start && ch <= sur_high_end);
+    }
+
+    inline
+    bool is_low_surrogate(uint32_t ch) noexcept
+    {
+        return (ch >= sur_low_start && ch <= sur_low_end);
+    }
+
+    inline
+    bool is_surrogate(uint32_t ch) noexcept
+    {
+        return (ch >= sur_high_start && ch <= sur_low_end);
+    }
+
+    enum class conv_flags 
+    {
+        strict = 0,
+        lenient
+    };
+
+    // conv_errc
+
+    enum class conv_errc 
+    {
+        success = 0,
+        over_long_utf8_sequence = 1, // over long utf8 sequence
+        expected_continuation_byte,  // expected continuation byte    
+        unpaired_high_surrogate,     // unpaired high surrogate UTF-16
+        illegal_surrogate_value,     // UTF-16 surrogate values are illegal in UTF-32
+        source_exhausted,            // partial character in source, but hit end
+        source_illegal               // source sequence is illegal/malformed
+    };
+
+    class Unicode_traits_error_category_impl_
+       : public std::error_category
+    {
+    public:
+        virtual const char* name() const noexcept
+        {
+            return "unicode_traits conversion error";
+        }
+        virtual std::string message(int ev) const
+        {
+            switch (static_cast<conv_errc>(ev))
+            {
+            case conv_errc::over_long_utf8_sequence:
+                return "Over long utf8 sequence";
+            case conv_errc::expected_continuation_byte:
+                return "Expected continuation byte";
+            case conv_errc::unpaired_high_surrogate:
+                return "Unpaired high surrogate UTF-16";
+            case conv_errc::illegal_surrogate_value:
+                return "UTF-16 surrogate values are illegal in UTF-32";
+            case conv_errc::source_exhausted:
+                return "Partial character in source, but hit end";
+            case conv_errc::source_illegal:
+                return "Source sequence is illegal/malformed";
+            default:
+                return "";
+                break;
+            }
+        }
+    };
+
+    inline
+    const std::error_category& unicode_traits_error_category()
+    {
+      static Unicode_traits_error_category_impl_ instance;
+      return instance;
+    }
+
+    inline 
+    std::error_code make_error_code(conv_errc result)
+    {
+        return std::error_code(static_cast<int>(result),unicode_traits_error_category());
+    }
+
+} // unicode_traits
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::unicode_traits::conv_errc> : public true_type
+    {
+    };
+} // namespace std
+
+namespace facebook::velox::jsoncons { namespace unicode_traits {
+
+    // utf8
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value, conv_errc>::type
+    is_legal_utf8(const CharT* first, std::size_t length) 
+    {
+        uint8_t a;
+        const CharT* srcptr = first+length;
+        switch (length) {
+        default:
+            return conv_errc::over_long_utf8_sequence;
+        case 4:
+            if (((a = (*--srcptr))& 0xC0) != 0x80)
+                return conv_errc::expected_continuation_byte;
+            JSONCONS_FALLTHROUGH;
+        case 3:
+            if (((a = (*--srcptr))& 0xC0) != 0x80)
+                return conv_errc::expected_continuation_byte;
+            JSONCONS_FALLTHROUGH;
+        case 2:
+            if (((a = (*--srcptr))& 0xC0) != 0x80)
+                return conv_errc::expected_continuation_byte;
+
+            switch (static_cast<uint8_t>(*first)) 
+            {
+                // no fall-through in this inner switch
+                case 0xE0: if (a < 0xA0) return conv_errc::source_illegal; break;
+                case 0xED: if (a > 0x9F) return conv_errc::source_illegal; break;
+                case 0xF0: if (a < 0x90) return conv_errc::source_illegal; break;
+                case 0xF4: if (a > 0x8F) return conv_errc::source_illegal; break;
+                default:   if (a < 0x80) return conv_errc::source_illegal;
+            }
+
+            JSONCONS_FALLTHROUGH;
+        case 1:
+            if (static_cast<uint8_t>(*first) >= 0x80 && static_cast<uint8_t>(*first) < 0xC2)
+                return conv_errc::source_illegal;
+            break;
+        }
+        if (static_cast<uint8_t>(*first) > 0xF4) 
+            return conv_errc::source_illegal;
+
+        return conv_errc();
+    }
+
+    template <typename...> using void_t = void;
+
+    template <typename,typename,typename = void>
+    struct is_output_iterator : std::false_type {};
+
+    template <typename I,typename E>
+    struct is_output_iterator<I, E, void_t<
+        typename std::iterator_traits<I>::iterator_category,
+        decltype(*std::declval<I>() = std::declval<E>())>> : std::true_type {};
+
+    // is_same_size fixes issue with vs2013
+
+    // primary template
+    template <typename T1,typename T2,typename Enable = void>
+    struct is_same_size : std::false_type 
+    {
+    };
+     
+    // specialization for non void types
+    template <typename T1,typename T2>
+    struct is_same_size<T1, T2,typename std::enable_if<!std::is_void<T1>::value && !std::is_void<T2>::value>::type>
+    {
+        static constexpr bool value = (sizeof(T1) == sizeof(T2));
+    }; 
+
+    // convert
+
+    template <typename CharT>
+    struct convert_result
+    {
+        const CharT* ptr;
+        conv_errc ec;
+    };
+
+    // to_codepoint
+
+    template <typename CharT,typename CodepointT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value && extension_traits::is_char32<CodepointT>::value,
+                            convert_result<CharT>>::type 
+    to_codepoint(const CharT* first, const CharT* last, 
+                 CodepointT& ch, 
+                 conv_flags flags = conv_flags::strict) noexcept
+    {
+        ch = 0;
+        if (first >= last)
+        {
+            return convert_result<CharT>{first, conv_errc::source_exhausted};
+        }
+        conv_errc  result = conv_errc();
+
+        unsigned short extra_bytes_to_read = trailing_bytes_for_utf8[static_cast<uint8_t>(*first)];
+        if (extra_bytes_to_read >= last - first) 
+        {
+            result = conv_errc::source_exhausted; 
+            return convert_result<CharT>{first, result};
+        }
+        // Do this check whether lenient or strict 
+        if ((result=is_legal_utf8(first, extra_bytes_to_read+1)) != conv_errc()) 
+        {
+            return convert_result<CharT>{first, result};
+        }
+        // The cases all fall through. See "Note A" below.
+        switch (extra_bytes_to_read) 
+        {
+            case 5: 
+                ch += static_cast<uint8_t>(*first++); 
+                ch <<= 6;
+                JSONCONS_FALLTHROUGH;
+            case 4: 
+                ch += static_cast<uint8_t>(*first++); 
+                ch <<= 6;
+                JSONCONS_FALLTHROUGH;
+            case 3: 
+                ch += static_cast<uint8_t>(*first++); 
+                ch <<= 6;
+                JSONCONS_FALLTHROUGH;
+            case 2: 
+                ch += static_cast<uint8_t>(*first++); 
+                ch <<= 6;
+                JSONCONS_FALLTHROUGH;
+            case 1: 
+                ch += static_cast<uint8_t>(*first++); 
+                ch <<= 6;
+                JSONCONS_FALLTHROUGH;
+            case 0: 
+                ch += static_cast<uint8_t>(*first++);
+                break;
+        }
+        ch -= offsets_from_utf8[extra_bytes_to_read];
+
+        if (ch <= max_legal_utf32) {
+            /*
+             * UTF-16 surrogate values are illegal in UTF-32, and anything
+             * over Plane 17 (> 0x10FFFF) is illegal.
+             */
+            if (is_surrogate(ch) ) 
+            {
+                if (flags == conv_flags::strict) 
+                {
+                    first -= (extra_bytes_to_read+1); // return to the illegal value itself
+                    result = conv_errc::source_illegal;
+                    return convert_result<CharT>{first, result};
+                } 
+                else
+                {
+                    ch = replacement_char;
+                }
+            }
+        } 
+        else // i.e., ch > max_legal_utf32
+        { 
+            result = conv_errc::source_illegal;
+            ch = replacement_char;
+        }
+
+        return convert_result<CharT>{first,result} ;
+    }
+
+    template <typename CharT,typename CodepointT>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value && extension_traits::is_char32<CodepointT>::value,
+                            convert_result<CharT>>::type 
+    to_codepoint(const CharT* first, const CharT* last, 
+                 CodepointT& ch, 
+                 conv_flags flags = conv_flags::strict) noexcept
+    {
+        ch = 0;
+        if (first >= last)
+        {
+            return convert_result<CharT>{first, conv_errc::source_exhausted};
+        }
+        conv_errc  result = conv_errc();
+
+        ch = *first++;
+        // If we have a surrogate pair, convert to UTF32 first. 
+        if (is_high_surrogate(ch)) 
+        {
+            // If the 16 bits following the high surrogate are in the first buffer... 
+            if (first < last) 
+            {
+                uint32_t ch2 = *first;
+                // If ptr's a low surrogate, convert to UTF32. 
+                if (ch2 >= sur_low_start && ch2 <= sur_low_end ) 
+                {
+                    ch = ((ch - sur_high_start) << half_shift)
+                        + (ch2 - sur_low_start) + half_base;
+                    ++first;
+                } 
+                else if (flags == conv_flags::strict) // ptr's an unpaired high surrogate 
+                { 
+                    --first; /* return to the illegal value itself */
+                    result = conv_errc::source_illegal;
+                    return convert_result<CharT>{first, result};
+                }
+            } 
+            else 
+            { /* We don't have the 16 bits following the high surrogate. */
+                --first; /* return to the high surrogate */
+                result = conv_errc::source_exhausted;
+                return convert_result<CharT>{first, result};
+            }
+        } else if (flags == conv_flags::strict) {
+            /* UTF-16 surrogate values are illegal in UTF-32 */
+            if (is_low_surrogate(ch) ) 
+            {
+                --first; /* return to the illegal value itself */
+                result = conv_errc::source_illegal;
+                return convert_result<CharT>{first, result};
+            }
+        }
+        
+        return convert_result<CharT>{first,result} ;
+    }
+
+    template <typename CharT,typename CodepointT>
+    typename std::enable_if<extension_traits::is_char32<CharT>::value && extension_traits::is_char32<CodepointT>::value,
+                            convert_result<CharT>>::type 
+    to_codepoint(const CharT* first, const CharT* last, 
+                 CodepointT& ch, 
+                 conv_flags flags = conv_flags::strict) noexcept
+    {
+        ch = 0;
+        if (first >= last)
+        {
+            return convert_result<CharT>{first, conv_errc::source_exhausted};
+        }
+        conv_errc  result = conv_errc();
+
+        ch = *first++;
+        if (flags == conv_flags::strict ) 
+        {
+            /* UTF-16 surrogate values are illegal in UTF-32 */
+            if (is_surrogate(ch)) 
+            {
+                --first; /* return to the illegal value itself */
+                result = conv_errc::illegal_surrogate_value;
+                return convert_result<CharT>{first,result} ;
+            }
+        }
+        if (!(ch <= max_legal_utf32))
+        {
+            ch = replacement_char;
+            result = conv_errc::source_illegal;
+        }
+
+        return convert_result<CharT>{first,result} ;
+    }
+
+    // convert
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char8<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, Container& target, conv_flags flags=conv_flags::strict) 
+    {
+        (void)flags;
+
+        conv_errc  result = conv_errc();
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            std::size_t len = trailing_bytes_for_utf8[static_cast<uint8_t>(*data)] + 1;
+            if (len > (std::size_t)(last - data))
+            {
+                return convert_result<CharT>{data, conv_errc::source_exhausted};
+            }
+            if ((result=is_legal_utf8(data, len)) != conv_errc())
+            {
+                return convert_result<CharT>{data,result};
+            }
+
+            switch (len) {
+                case 4: target.push_back(static_cast<uint8_t>(*data++));
+                    JSONCONS_FALLTHROUGH;
+                case 3: target.push_back(static_cast<uint8_t>(*data++));
+                    JSONCONS_FALLTHROUGH;
+                case 2: target.push_back(static_cast<uint8_t>(*data++));
+                    JSONCONS_FALLTHROUGH;
+                case 1: target.push_back(static_cast<uint8_t>(*data++));
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char16<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            unsigned short extra_bytes_to_read = trailing_bytes_for_utf8[static_cast<uint8_t>(*data)];
+            if (extra_bytes_to_read >= last - data) 
+            {
+                result = conv_errc::source_exhausted; 
+                break;
+            }
+            /* Do this check whether lenient or strict */
+            if ((result=is_legal_utf8(data, extra_bytes_to_read+1)) != conv_errc())
+            {
+                break;
+            }
+            /*
+             * The cases all fall through. See "Note A" below.
+             */
+            uint32_t ch = 0;
+            switch (extra_bytes_to_read) {
+                case 5: ch += static_cast<uint8_t>(*data++); ch <<= 6; /* remember, illegal UTF-8 */
+                    JSONCONS_FALLTHROUGH;
+                case 4: ch += static_cast<uint8_t>(*data++); ch <<= 6; /* remember, illegal UTF-8 */
+                    JSONCONS_FALLTHROUGH;
+                case 3: ch += static_cast<uint8_t>(*data++); ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 2: ch += static_cast<uint8_t>(*data++); ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 1: ch += static_cast<uint8_t>(*data++); ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 0: ch += static_cast<uint8_t>(*data++);
+                    break;
+            }
+            ch -= offsets_from_utf8[extra_bytes_to_read];
+
+            if (ch <= max_bmp) { /* Target is a character <= 0xFFFF */
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                if (is_surrogate(ch) ) 
+                {
+                    if (flags == conv_flags::strict) {
+                        data -= (extra_bytes_to_read+1); /* return to the illegal value itself */
+                        result = conv_errc::source_illegal;
+                        break;
+                    } else {
+                        target.push_back(replacement_char);
+                    }
+                } else {
+                    target.push_back((uint16_t)ch); /* normal case */
+                }
+            } else if (ch > max_utf16) {
+                if (flags == conv_flags::strict) {
+                    result = conv_errc::source_illegal;
+                    data -= (extra_bytes_to_read+1); /* return to the start */
+                    break; /* Bail out; shouldn't continue */
+                } else {
+                    target.push_back(replacement_char);
+                }
+            } else {
+                /* target is a character in range 0xFFFF - 0x10FFFF. */
+                ch -= half_base;
+                target.push_back((uint16_t)((ch >> half_shift) + sur_high_start));
+                target.push_back((uint16_t)((ch & half_mask) + sur_low_start));
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char32<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data < last) 
+        {
+            uint32_t ch = 0;
+            unsigned short extra_bytes_to_read = trailing_bytes_for_utf8[static_cast<uint8_t>(*data)];
+            if (extra_bytes_to_read >= last - data) 
+            {
+                result = conv_errc::source_exhausted; 
+                break;
+            }
+            /* Do this check whether lenient or strict */
+            if ((result=is_legal_utf8(data, extra_bytes_to_read+1)) != conv_errc()) 
+            {
+                break;
+            }
+            /*
+             * The cases all fall through. See "Note A" below.
+             */
+            switch (extra_bytes_to_read) 
+            {
+                case 5: 
+                    ch += static_cast<uint8_t>(*data++); 
+                    ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 4: 
+                    ch += static_cast<uint8_t>(*data++); 
+                    ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 3: 
+                    ch += static_cast<uint8_t>(*data++); 
+                    ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 2: 
+                    ch += static_cast<uint8_t>(*data++); 
+                    ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 1: 
+                    ch += static_cast<uint8_t>(*data++); 
+                    ch <<= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 0: 
+                    ch += static_cast<uint8_t>(*data++);
+                    break;
+            }
+            ch -= offsets_from_utf8[extra_bytes_to_read];
+
+            if (ch <= max_legal_utf32) {
+                /*
+                 * UTF-16 surrogate values are illegal in UTF-32, and anything
+                 * over Plane 17 (> 0x10FFFF) is illegal.
+                 */
+                if (is_surrogate(ch) ) 
+                {
+                    if (flags == conv_flags::strict) {
+                        data -= (extra_bytes_to_read+1); /* return to the illegal value itself */
+                        result = conv_errc::source_illegal;
+                        break;
+                    } else {
+                        target.push_back(replacement_char);
+                    }
+                } else {
+                    target.push_back(ch);
+                }
+            } else { /* i.e., ch > max_legal_utf32 */
+                result = conv_errc::source_illegal;
+                target.push_back(replacement_char);
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    // utf16
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char8<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+                     Container& target, 
+                     conv_flags flags = conv_flags::strict) {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data < last) {
+            unsigned short bytes_to_write = 0;
+            const uint32_t byteMask = 0xBF;
+            const uint32_t byteMark = 0x80; 
+            uint32_t ch = *data++;
+            /* If we have a surrogate pair, convert to uint32_t data. */
+            if (is_high_surrogate(ch)) 
+            {
+                /* If the 16 bits following the high surrogate are in the data buffer... */
+                if (data < last) {
+                    uint32_t ch2 = *data;
+                    /* If ptr's a low surrogate, convert to uint32_t. */
+                    if (ch2 >= sur_low_start && ch2 <= sur_low_end) {
+                        ch = ((ch - sur_high_start) << half_shift)
+                            + (ch2 - sur_low_start) + half_base;
+                        ++data;
+                    } else if (flags == conv_flags::strict) { /* ptr's an unpaired high surrogate */
+                        --data; /* return to the illegal value itself */
+                        result = conv_errc::unpaired_high_surrogate;
+                        break;
+                    }
+                } else { /* We don't have the 16 bits following the high surrogate. */
+                    --data; /* return to the high surrogate */
+                    result = conv_errc::source_exhausted;
+                    break;
+                }
+            } else if (flags == conv_flags::strict) {
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                if (is_low_surrogate(ch)) 
+                {
+                    --data; /* return to the illegal value itself */
+                    result = conv_errc::source_illegal;
+                    break;
+                }
+            }
+            /* Figure out how many bytes the result will require */
+            if (ch < (uint32_t)0x80) {      
+                bytes_to_write = 1;
+            } else if (ch < (uint32_t)0x800) {     
+                bytes_to_write = 2;
+            } else if (ch < (uint32_t)0x10000) {   
+                bytes_to_write = 3;
+            } else if (ch < (uint32_t)0x110000) {  
+                bytes_to_write = 4;
+            } else {                            
+                bytes_to_write = 3;
+                ch = replacement_char;
+            }
+            
+            uint8_t byte1 = 0;
+            uint8_t byte2 = 0;
+            uint8_t byte3 = 0;
+            uint8_t byte4 = 0;
+
+            switch (bytes_to_write) { // note: everything falls through
+                case 4: byte4 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 3: byte3 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 2: byte2 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                    JSONCONS_FALLTHROUGH;
+                case 1: byte1 = (uint8_t)(ch | first_byte_mark[bytes_to_write]);
+                    break;
+            }
+            switch (bytes_to_write) 
+            {
+            case 4: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                target.push_back(byte3);
+                target.push_back(byte4);
+                break;
+            case 3: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                target.push_back(byte3);
+                break;
+            case 2: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                break;
+            case 1: 
+                target.push_back(byte1);
+                break;
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char16<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            /* If we have a surrogate pair, convert to uint32_t data. */
+            if (is_high_surrogate(ch)) 
+            {
+                /* If the 16 bits following the high surrogate are in the data buffer... */
+                if (data < last) {
+                    uint32_t ch2 = *data;
+                    /* If ptr's a low surrogate, */
+                    if (ch2 >= sur_low_start && ch2 <= sur_low_end) {
+                        target.push_back((uint16_t)ch);
+                        target.push_back((uint16_t)ch2);
+                        ++data;
+                    } else if (flags == conv_flags::strict) { /* ptr's an unpaired high surrogate */
+                        --data; /* return to the illegal value itself */
+                        result = conv_errc::unpaired_high_surrogate;
+                        break;
+                    }
+                } else { /* We don't have the 16 bits following the high surrogate. */
+                    --data; /* return to the high surrogate */
+                    result = conv_errc::source_exhausted;
+                    break;
+                }
+            } else if (is_low_surrogate(ch)) 
+            {
+                // illegal leading low surrogate
+                if (flags == conv_flags::strict) {
+                    --data; /* return to the illegal value itself */
+                    result = conv_errc::source_illegal;
+                    break;
+                }
+                else
+                {
+                    target.push_back((uint16_t)ch);
+                }
+            }
+            else
+            {
+                target.push_back((uint16_t)ch);
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char32<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            /* If we have a surrogate pair, convert to UTF32 data. */
+            if (is_high_surrogate(ch)) 
+            {
+                /* If the 16 bits following the high surrogate are in the data buffer... */
+                if (data < last) {
+                    uint32_t ch2 = *data;
+                    /* If ptr's a low surrogate, convert to UTF32. */
+                    if (ch2 >= sur_low_start && ch2 <= sur_low_end ) 
+                    {
+                        ch = ((ch - sur_high_start) << half_shift)
+                            + (ch2 - sur_low_start) + half_base;
+                        ++data;
+                    } else if (flags == conv_flags::strict) { /* ptr's an unpaired high surrogate */
+                        --data; /* return to the illegal value itself */
+                        result = conv_errc::source_illegal;
+                        break;
+                    }
+                } else { /* We don't have the 16 bits following the high surrogate. */
+                    --data; /* return to the high surrogate */
+                    result = conv_errc::source_exhausted;
+                    break;
+                }
+            } else if (flags == conv_flags::strict) {
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                if (is_low_surrogate(ch) ) 
+                {
+                    --data; /* return to the illegal value itself */
+                    result = conv_errc::source_illegal;
+                    break;
+                }
+            }
+            target.push_back(ch);
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    // utf32
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char32<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char8<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+        const CharT* last = data + length;
+        while (data < last) 
+        {
+            unsigned short bytes_to_write = 0;
+            const uint32_t byteMask = 0xBF;
+            const uint32_t byteMark = 0x80; 
+            uint32_t ch = *data++;
+            if (flags == conv_flags::strict ) 
+            {
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                if (is_surrogate(ch)) 
+                {
+                    --data; /* return to the illegal value itself */
+                    result = conv_errc::illegal_surrogate_value;
+                    break;
+                }
+            }
+            /*
+             * Figure out how many bytes the result will require. Turn any
+             * illegally large UTF32 things (> Plane 17) into replacement chars.
+             */
+            if (ch < (uint32_t)0x80) {      bytes_to_write = 1;
+            } else if (ch < (uint32_t)0x800) {     bytes_to_write = 2;
+            } else if (ch < (uint32_t)0x10000) {   bytes_to_write = 3;
+            } else if (ch <= max_legal_utf32) {  bytes_to_write = 4;
+            } else {                            
+                bytes_to_write = 3;
+                ch = replacement_char;
+                result = conv_errc::source_illegal;
+            }
+
+            uint8_t byte1 = 0;
+            uint8_t byte2 = 0;
+            uint8_t byte3 = 0;
+            uint8_t byte4 = 0;
+
+            switch (bytes_to_write) {
+            case 4:
+                byte4 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                JSONCONS_FALLTHROUGH;
+            case 3:
+                byte3 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                JSONCONS_FALLTHROUGH;
+            case 2:
+                byte2 = (uint8_t)((ch | byteMark) & byteMask); ch >>= 6;
+                JSONCONS_FALLTHROUGH;
+            case 1:
+                byte1 = (uint8_t) (ch | first_byte_mark[bytes_to_write]);
+                break;
+            }
+
+            switch (bytes_to_write) 
+            {
+            case 4: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                target.push_back(byte3);
+                target.push_back(byte4);
+                break;
+            case 3: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                target.push_back(byte3);
+                break;
+            case 2: 
+                target.push_back(byte1);
+                target.push_back(byte2);
+                break;
+            case 1: 
+                target.push_back(byte1);
+                break;
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char32<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char16<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            if (ch <= max_bmp) { /* Target is a character <= 0xFFFF */
+                /* UTF-16 surrogate values are illegal in UTF-32; 0xffff or 0xfffe are both reserved values */
+                if (is_surrogate(ch) ) 
+                {
+                    if (flags == conv_flags::strict) {
+                        --data; /* return to the illegal value itself */
+                        result = conv_errc::source_illegal;
+                        break;
+                    } else {
+                        target.push_back(replacement_char);
+                    }
+                } else {
+                    target.push_back((uint16_t)ch); /* normal case */
+                }
+            } else if (ch > max_legal_utf32) {
+                if (flags == conv_flags::strict) {
+                    result = conv_errc::source_illegal;
+                } else {
+                    target.push_back(replacement_char);
+                }
+            } else {
+                /* target is a character in range 0xFFFF - 0x10FFFF. */
+                ch -= half_base;
+                target.push_back((uint16_t)((ch >> half_shift) + sur_high_start));
+                target.push_back((uint16_t)((ch & half_mask) + sur_low_start));
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    template <typename CharT,typename Container>
+    typename std::enable_if<extension_traits::is_char32<CharT>::value                            
+                            && extension_traits::is_back_insertable<Container>::value
+                            && extension_traits::is_char32<typename Container::value_type>::value,
+                            convert_result<CharT>>::type 
+    convert(const CharT* data, std::size_t length, 
+            Container& target, 
+            conv_flags flags = conv_flags::strict) 
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            if (flags == conv_flags::strict ) 
+            {
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                if (is_surrogate(ch)) 
+                {
+                    --data; /* return to the illegal value itself */
+                    result = conv_errc::illegal_surrogate_value;
+                    break;
+                }
+            }
+            if (ch <= max_legal_utf32)
+            {
+                target.push_back(ch);
+            }
+            else
+            {
+                target.push_back(replacement_char);
+                result = conv_errc::source_illegal;
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    // validate
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value,
+                            convert_result<CharT>>::type 
+    validate(const CharT* data, std::size_t length) noexcept
+    {
+        conv_errc  result = conv_errc();
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            std::size_t len = static_cast<std::size_t>(trailing_bytes_for_utf8[static_cast<uint8_t>(*data)]) + 1;
+            if (len > (std::size_t)(last - data))
+            {
+                return convert_result<CharT>{data, conv_errc::source_exhausted};
+            }
+            if ((result=is_legal_utf8(data, len)) != conv_errc())
+            {
+                return convert_result<CharT>{data,result} ;
+            }
+            data += len;
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    // utf16
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char16<CharT>::value,
+                            convert_result<CharT>>::type 
+    validate(const CharT* data, std::size_t length)  noexcept
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            /* If we have a surrogate pair, validate to uint32_t data. */
+            if (is_high_surrogate(ch)) 
+            {
+                /* If the 16 bits following the high surrogate are in the data buffer... */
+                if (data < last) {
+                    uint32_t ch2 = *data;
+                    /* If ptr's a low surrogate, */
+                    if (ch2 >= sur_low_start && ch2 <= sur_low_end) {
+                        ++data;
+                    } else {
+                        --data; /* return to the illegal value itself */
+                        result = conv_errc::unpaired_high_surrogate;
+                        break;
+                    }
+                } 
+                else // We don't have the 16 bits following the high surrogate.  
+                { 
+                    --data; /* return to the high surrogate */
+                    result = conv_errc::source_exhausted;
+                    break;
+                }
+            } 
+            else if (is_low_surrogate(ch)) 
+            {
+                /* UTF-16 surrogate values are illegal in UTF-32 */
+                --data; /* return to the illegal value itself */
+                result = conv_errc::source_illegal;
+                break;
+            }
+        }
+        return convert_result<CharT>{data,result} ;
+    }
+
+    // utf32
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char32<CharT>::value,
+                            convert_result<CharT>>::type 
+    validate(const CharT* data, std::size_t length) noexcept
+    {
+        conv_errc  result = conv_errc();
+
+        const CharT* last = data + length;
+        while (data != last) 
+        {
+            uint32_t ch = *data++;
+            /* UTF-16 surrogate values are illegal in UTF-32 */
+            if (is_surrogate(ch)) 
+            {
+                --data; /* return to the illegal value itself */
+                result = conv_errc::illegal_surrogate_value;
+                break;
+            }
+            if (!(ch <= max_legal_utf32))
+            {
+                result = conv_errc::source_illegal;
+            }
+        }
+        return convert_result<CharT>{data, result} ;
+    }
+
+    enum class encoding {u8,u16le,u16be,u32le,u32be,undetected};
+
+    template <typename Iterator>
+    struct determine_encoding_result
+    {
+        Iterator it;
+        encoding ec;
+    };
+
+    template <typename Iterator>
+    typename std::enable_if<std::is_integral<typename std::iterator_traits<Iterator>::value_type>::value && sizeof(typename std::iterator_traits<Iterator>::value_type) == sizeof(uint8_t),
+                            determine_encoding_result<Iterator>>::type 
+    detect_encoding(Iterator first, Iterator last) noexcept
+    {
+        Iterator it1 = first;
+        if (std::distance(first,last) < 4)
+        {
+            if (std::distance(first,last) == 3)
+            {
+                Iterator it2 = ++first;
+                Iterator it3 = ++first;
+                if (static_cast<uint8_t>(*it1) == 0xEF && static_cast<uint8_t>(*it2) == 0xBB && static_cast<uint8_t>(*it3) == 0xBF)
+                {
+                    return determine_encoding_result<Iterator>{last,encoding::u8};
+                }
+            }
+            return determine_encoding_result<Iterator>{it1,encoding::undetected};
+        }
+        else
+        {
+            Iterator it2 = ++first;
+            Iterator it3 = ++first;
+            Iterator it4 = ++first;
+
+            uint32_t bom = static_cast<uint8_t>(*it1) | (static_cast<uint8_t>(*it2) << 8) | (static_cast<uint8_t>(*it3) << 16) | (static_cast<uint8_t>(*it4) << 24);
+            if (bom == 0xFFFE0000)                  
+            { 
+                return determine_encoding_result<Iterator>{it4++,encoding::u32be};
+            }
+            else if (bom == 0x0000FEFF) 
+            {
+                return determine_encoding_result<Iterator>{first,encoding::u32le};
+            }
+            else if ((bom & 0xFFFF) == 0xFFFE)     
+            {
+                return determine_encoding_result<Iterator>{it3,encoding::u16be};
+            }
+            else if ((bom & 0xFFFF) == 0xFEFF)      
+            {
+                return determine_encoding_result<Iterator>{it3,encoding::u16le};
+            }
+            else if ((bom & 0xFFFFFF) == 0xBFBBEF)  
+            {
+                return determine_encoding_result<Iterator>{it4,encoding::u8};
+            }
+            else
+            {
+                uint32_t pattern = (static_cast<uint8_t>(*it1) ? 1 : 0) | (static_cast<uint8_t>(*it2) ? 2 : 0) | (static_cast<uint8_t>(*it3) ? 4 : 0) | (static_cast<uint8_t>(*it4) ? 8 : 0);
+                switch (pattern) {
+                case 0x08: 
+                    return determine_encoding_result<Iterator>{it1,encoding::u32be};
+                case 0x0A: 
+                    return determine_encoding_result<Iterator>{it1,encoding::u16be};
+                case 0x01: 
+                    return determine_encoding_result<Iterator>{it1,encoding::u32le};
+                case 0x05: 
+                    return determine_encoding_result<Iterator>{it1,encoding::u16le};
+                case 0x0F: 
+                    return determine_encoding_result<Iterator>{it1,encoding::u8};
+                default:
+                    return determine_encoding_result<Iterator>{it1,encoding::undetected};
+                }
+            }
+        }
+    }
+
+    // count_codepoints
+
+    template <typename CharT>
+    typename std::enable_if<extension_traits::is_char8<CharT>::value || extension_traits::is_char16<CharT>::value || extension_traits::is_char32<CharT>::value, std::size_t>::type 
+    count_codepoints(const CharT* data, std::size_t length, 
+                     conv_flags flags = conv_flags::strict) noexcept
+    {
+        conv_errc ec = conv_errc();
+
+        std::size_t count = 0;
+        const CharT* ptr = data;
+        const CharT* last = data + length;
+
+        for (; ptr < last; ++count) 
+        {
+            uint32_t cp = 0;
+            auto r = to_codepoint(ptr, last, cp, flags);
+            if (r.ec != conv_errc())
+            {
+                ec = r.ec;
+                break;
+            }
+            ptr = r.ptr;
+        }
+        return ec == conv_errc() && ptr == last ? count : 0;
+    }
+
+} // unicode_traits
+} // namespace facebook::velox::jsoncons
+
+#endif //JSONCONS_UTILITY_UNICODE_TRAITS_HPP

--- a/velox/external/jsoncons/utility/uri.hpp
+++ b/velox/external/jsoncons/utility/uri.hpp
@@ -1,0 +1,1740 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_UTILITY_URI_HPP
+#define JSONCONS_UTILITY_URI_HPP
+
+#include <algorithm> 
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string> // std::string
+#include <system_error>
+#include <type_traits>
+#include <utility>
+
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/config/jsoncons_config.hpp"
+#include "velox/external/jsoncons/detail/parse_number.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp"
+#include "velox/external/jsoncons/json_exception.hpp"
+
+namespace facebook::velox::jsoncons { 
+
+    enum class uri_errc
+    {
+        success = 0,
+        invalid_uri = 1,
+        invalid_character_in_scheme = 2,
+        invalid_port = 3,
+        invalid_character_in_userinfo = 4,
+        invalid_character_in_host = 5,
+        invalid_character_in_path = 6,
+        invalid_character_in_fragment = 7
+    };
+
+
+    class uri_error_category_impl
+        : public std::error_category
+    {
+    public:
+        const char* name() const noexcept override
+        {
+            return "jsoncons/uri";
+        }
+        std::string message(int ev) const override
+        {
+            switch (static_cast<uri_errc>(ev))
+            {
+                case uri_errc::invalid_uri:
+                    return "Invalid URI";
+                case uri_errc::invalid_character_in_scheme:
+                    return "Invalid characters in scheme";
+                case uri_errc::invalid_port:
+                    return "'port' argument must be a number >= 0 and < 65536";
+                case uri_errc::invalid_character_in_userinfo:
+                    return "Invalid characters in userinfo";
+                case uri_errc::invalid_character_in_host:
+                    return "Invalid characters in host";
+                case uri_errc::invalid_character_in_path:
+                    return "Invalid characters in path";
+                case uri_errc::invalid_character_in_fragment:
+                    return "Invalid characters in fragment";
+                default:
+                    return "Unknown uri error";
+            }
+        }
+    };
+
+    inline
+        const std::error_category& uri_error_category()
+    {
+        static uri_error_category_impl instance;
+        return instance;
+    }
+
+    inline
+        std::error_code make_error_code(uri_errc result)
+    {
+        return std::error_code(static_cast<int>(result), uri_error_category());
+    }
+
+} // namespace facebook::velox::jsoncons
+
+namespace std {
+    template<>
+    struct is_error_code_enum<facebook::velox::jsoncons::uri_errc> : public true_type
+    {
+    };
+} // namespace std
+
+namespace facebook::velox::jsoncons {
+
+    struct uri_fragment_part_t
+    {
+        explicit uri_fragment_part_t() = default; 
+    };
+
+    constexpr uri_fragment_part_t uri_fragment_part{};
+
+    struct uri_encoded_part_t
+    {
+        explicit uri_encoded_part_t() = default; 
+    };
+
+    constexpr uri_encoded_part_t uri_encoded_part{};
+
+    class uri
+    {
+        using part_type = std::pair<std::size_t,std::size_t>;
+
+        std::string uri_string_;
+        part_type scheme_part_;
+        part_type userinfo_part_;
+        part_type host_part_;
+        part_type port_part_;
+        part_type path_part_;
+        part_type query_part_;
+        part_type fragment_part_;
+    public:
+
+        uri()
+            : uri_string_{}, scheme_part_{0,0},userinfo_part_{0,0},host_part_{0,0},port_part_{0,0},path_part_{0,0},query_part_{0,0},fragment_part_{0,0} 
+        {
+        }
+
+        uri(const uri& other)
+            : uri_string_(other.uri_string_), scheme_part_(other.scheme_part_), userinfo_part_(other.userinfo_part_), host_part_(other.host_part_), 
+              port_part_(other.port_part_), path_part_(other.path_part_), query_part_(other.query_part_), fragment_part_(other.fragment_part_)
+        {
+        }
+
+        uri(uri&& other) noexcept
+            : uri_string_(std::move(other.uri_string_)), scheme_part_(other.scheme_part_), userinfo_part_(other.userinfo_part_), host_part_(other.host_part_), 
+              port_part_(other.port_part_), path_part_(other.path_part_), query_part_(other.query_part_), fragment_part_(other.fragment_part_)
+        {
+        }
+
+        uri(const uri& other, uri_fragment_part_t, jsoncons::string_view fragment)
+            : uri_string_(other.uri_string_), scheme_part_(other.scheme_part_), userinfo_part_(other.userinfo_part_), host_part_(other.host_part_), 
+              port_part_(other.port_part_), path_part_(other.path_part_), query_part_(other.query_part_)
+        {
+            uri_string_.erase(query_part_.second);
+            if (!fragment.empty()) 
+            {
+                uri_string_.append("#");
+                fragment_part_.first = uri_string_.length();
+                encode_illegal_characters(fragment, uri_string_);
+                fragment_part_.second = uri_string_.length();
+            }
+            else
+            {
+                fragment_part_.first = fragment_part_.second = uri_string_.length();
+            }
+        }
+
+        explicit uri(jsoncons::string_view str)
+        {
+            std::error_code ec;
+            *this = parse(str, ec);
+            if (ec)
+            {
+                JSONCONS_THROW(std::system_error(ec));
+            }
+        }
+
+        uri(jsoncons::string_view scheme,
+            jsoncons::string_view userinfo,
+            jsoncons::string_view host,
+            jsoncons::string_view port,
+            jsoncons::string_view path,
+            jsoncons::string_view query = "",
+            jsoncons::string_view fragment = "")
+        {
+            if (!scheme.empty()) 
+            {
+                uri_string_.append(scheme.data(), scheme.size());
+                scheme_part_.second = uri_string_.length();
+            }
+            if (!userinfo.empty() || !host.empty() || !port.empty()) 
+            {
+                if (!scheme.empty()) 
+                {
+                    uri_string_.append("://");
+                }
+
+                if (!userinfo.empty()) 
+                {
+                    userinfo_part_.first = uri_string_.length();
+                    encode_userinfo(userinfo, uri_string_);
+                    userinfo_part_.second = uri_string_.length();
+                    uri_string_.append("@");
+                }
+                else
+                {
+                    userinfo_part_.first = userinfo_part_.second = uri_string_.length();
+                }
+
+                if (!host.empty()) 
+                {
+                    host_part_.first = uri_string_.length();
+                    uri_string_.append(host.data(), host.size());
+                    host_part_.second = uri_string_.length();
+                } 
+                else 
+                {
+                    JSONCONS_THROW(json_runtime_error<std::invalid_argument>("uri error."));
+                }
+
+                if (!port.empty()) 
+                {
+                    if (!validate_port(port))
+                    {
+                        JSONCONS_THROW(std::system_error(uri_errc::invalid_port));
+                    }
+
+                    uri_string_.append(":");
+                    port_part_.first = uri_string_.length();
+                    uri_string_.append(port.data(), port.size());
+                    port_part_.second = uri_string_.length();
+                }
+                else
+                {
+                    port_part_.first = port_part_.second = uri_string_.length();
+                }
+            }
+            else 
+            {
+                userinfo_part_.first = userinfo_part_.second = uri_string_.length();
+                host_part_.first = host_part_.second = uri_string_.length();
+                port_part_.first = port_part_.second = uri_string_.length();
+                if (!scheme.empty())
+                {
+                    if (!path.empty() || !query.empty() || !fragment.empty()) 
+                    {
+                        uri_string_.append(":");
+                    } 
+                    else 
+                    {
+                        JSONCONS_THROW(json_runtime_error<std::invalid_argument>("uri error."));
+                    }
+                }
+            }
+
+            if (!path.empty()) 
+            {
+                // if the URI is not opaque and the path is not already prefixed
+                // with a '/', add one.
+                path_part_.first = uri_string_.length();
+                if (!host.empty() && (path.front() != '/')) 
+                {
+                    uri_string_.push_back('/');
+                }
+                encode_path(path, uri_string_);
+                path_part_.second = uri_string_.length();
+            }
+            else
+            {
+                path_part_.first = path_part_.second = uri_string_.length();
+            }
+
+            if (!query.empty()) 
+            {
+                uri_string_.append("?");
+                query_part_.first = uri_string_.length();
+                encode_illegal_characters(query, uri_string_);
+                query_part_.second = uri_string_.length();
+            }
+            else
+            {
+                query_part_.first = query_part_.second = uri_string_.length();
+            }
+
+            if (!fragment.empty()) 
+            {
+                uri_string_.append("#");
+                fragment_part_.first = uri_string_.length();
+                encode_illegal_characters(fragment, uri_string_);
+                fragment_part_.second = uri_string_.length();
+            }
+            else
+            {
+                fragment_part_.first = fragment_part_.second = uri_string_.length();
+            }
+        }
+
+        uri(uri_encoded_part_t,
+            jsoncons::string_view scheme,
+            jsoncons::string_view userinfo,
+            jsoncons::string_view host,
+            jsoncons::string_view port,
+            jsoncons::string_view path,
+            jsoncons::string_view query,
+            jsoncons::string_view fragment)
+        {
+            if (!scheme.empty()) 
+            {
+                uri_string_.append(scheme.data(), scheme.size());
+                scheme_part_.second = uri_string_.length();
+            }
+            if (!userinfo.empty() || !host.empty() || !port.empty()) 
+            {
+                if (!scheme.empty()) 
+                {
+                    uri_string_.append("://");
+                }
+
+                if (!userinfo.empty()) 
+                {
+                    userinfo_part_.first = uri_string_.length();
+                    uri_string_.append(userinfo.data(), userinfo.size());
+                    userinfo_part_.second = uri_string_.length();
+                    uri_string_.append("@");
+                }
+                else
+                {
+                    userinfo_part_.first = userinfo_part_.second = uri_string_.length();
+                }
+
+                if (!host.empty()) 
+                {
+                    host_part_.first = uri_string_.length();
+                    uri_string_.append(host.data(), host.size());
+                    host_part_.second = uri_string_.length();
+                } 
+                else 
+                {
+                    JSONCONS_THROW(json_runtime_error<std::invalid_argument>("uri error."));
+                }
+
+                if (!port.empty()) 
+                {
+                    uri_string_.append(":");
+                    port_part_.first = uri_string_.length();
+                    uri_string_.append(port.data(), port.size());
+                    port_part_.second = uri_string_.length();
+                }
+                else
+                {
+                    port_part_.first = port_part_.second = uri_string_.length();
+                }
+            }
+            else 
+            {
+                userinfo_part_.first = userinfo_part_.second = uri_string_.length();
+                host_part_.first = host_part_.second = uri_string_.length();
+                port_part_.first = port_part_.second = uri_string_.length();
+                if (!scheme.empty())
+                {
+                    if (!path.empty() || !query.empty() || !fragment.empty()) 
+                    {
+                        uri_string_.append(":");
+                    } 
+                    else 
+                    {
+                        JSONCONS_THROW(json_runtime_error<std::invalid_argument>("uri error."));
+                    }
+                }
+            }
+
+            if (!path.empty()) 
+            {
+                // if the URI is not opaque and the path is not already prefixed
+                // with a '/', add one.
+                path_part_.first = uri_string_.length();
+                if (!host.empty() && (path.front() != '/')) 
+                {
+                    uri_string_.push_back('/');
+                }
+                uri_string_.append(path.data(), path.size());
+                path_part_.second = uri_string_.length();
+            }
+            else
+            {
+                path_part_.first = path_part_.second = uri_string_.length();
+            }
+
+            if (!query.empty()) 
+            {
+                uri_string_.append("?");
+                query_part_.first = uri_string_.length();
+                uri_string_.append(query.data(), query.size());
+                query_part_.second = uri_string_.length();
+            }
+            else
+            {
+                query_part_.first = query_part_.second = uri_string_.length();
+            }
+
+            if (!fragment.empty()) 
+            {
+                uri_string_.append("#");
+                fragment_part_.first = uri_string_.length();
+                uri_string_.append(fragment.data(), fragment.size());
+                fragment_part_.second = uri_string_.length();
+            }
+            else
+            {
+                fragment_part_.first = fragment_part_.second = uri_string_.length();
+            }
+        }
+
+        uri& operator=(const uri& other) 
+        {
+            if (&other != this)
+            {
+                uri_string_ = other.uri_string_;
+                scheme_part_ = other.scheme_part_;
+                userinfo_part_ = other.userinfo_part_;
+                host_part_ = other.host_part_;
+                port_part_ = other.port_part_;
+                path_part_ = other.path_part_;
+                query_part_ = other.query_part_;
+                fragment_part_ = other.fragment_part_;
+            }
+            return *this;
+        }
+
+        uri& operator=(uri&& other) noexcept
+        {
+            if (&other != this)
+            {
+                uri_string_ = std::move(other.uri_string_);
+                scheme_part_ = other.scheme_part_;
+                userinfo_part_ = other.userinfo_part_;
+                host_part_ = other.host_part_;
+                port_part_ = other.port_part_;
+                path_part_ = other.path_part_;
+                query_part_ = other.query_part_;
+                fragment_part_ = other.fragment_part_;
+            }
+            return *this;
+        }
+
+
+        const std::string& string() const noexcept
+        {
+            return uri_string_;
+        }
+
+        bool is_absolute() const noexcept
+        {
+            return scheme_part_.second > scheme_part_.first;
+        }
+
+        bool is_opaque() const noexcept 
+        {
+          return is_absolute() && !encoded_authority().empty();
+        }
+
+        uri base() const noexcept 
+        { 
+            return uri{uri_encoded_part, scheme(), encoded_userinfo(), host(), port(), encoded_path(), 
+                jsoncons::string_view{}, jsoncons::string_view{}};
+        }
+
+        string_view scheme() const noexcept { return string_view(uri_string_.data()+scheme_part_.first,(scheme_part_.second-scheme_part_.first)); }
+
+        std::string userinfo() const 
+        {
+            return decode_part(encoded_userinfo());
+        }
+
+        string_view encoded_userinfo() const noexcept { return string_view(uri_string_.data()+userinfo_part_.first,(userinfo_part_.second-userinfo_part_.first)); }
+
+        string_view host() const noexcept { return string_view(uri_string_.data()+host_part_.first,(host_part_.second-host_part_.first)); }
+
+        string_view port() const noexcept { return string_view(uri_string_.data()+port_part_.first,(port_part_.second-port_part_.first)); }
+
+        std::string authority() const
+        {
+            return decode_part(encoded_authority());
+        }
+
+        string_view encoded_authority() const noexcept { return string_view(uri_string_.data()+userinfo_part_.first,(port_part_.second-userinfo_part_.first)); }
+
+        std::string path() const
+        {
+            return decode_part(encoded_path());
+        }
+
+        string_view encoded_path() const noexcept { return string_view(uri_string_.data()+path_part_.first,(path_part_.second-path_part_.first)); }
+
+        std::string query() const
+        {
+            return decode_part(encoded_query());
+        }
+
+        string_view encoded_query() const noexcept { return string_view(uri_string_.data()+query_part_.first,(query_part_.second-query_part_.first)); }
+
+        std::string fragment() const
+        {
+            return decode_part(encoded_fragment());
+        }
+
+        string_view encoded_fragment() const noexcept 
+        { 
+            return string_view(uri_string_.data()+fragment_part_.first,(fragment_part_.second-fragment_part_.first)); 
+        }
+
+        bool has_scheme() const noexcept
+        {
+            return !scheme().empty();
+        }
+
+        bool has_userinfo() const noexcept
+        {
+            return !encoded_userinfo().empty();
+        }
+
+        bool has_authority() const noexcept
+        {
+            return !encoded_authority().empty();
+        }
+
+        bool has_host() const noexcept
+        {
+            return !host().empty();
+        }
+
+        bool has_port() const noexcept
+        {
+            return !port().empty();
+        }
+
+        bool has_path() const noexcept
+        {
+            return !encoded_path().empty();
+        }
+
+        bool has_query() const noexcept
+        {
+            return !encoded_query().empty();
+        }
+
+        bool has_fragment() const noexcept
+        {
+            return !encoded_fragment().empty();
+        }
+
+        uri resolve(string_view reference) const
+        {
+            return resolve(uri(reference));
+        }
+        
+        uri resolve(const uri& reference) const
+        {
+            // This implementation uses the psuedo-code given in
+            // http://tools.ietf.org/html/rfc3986#section-5.2.2
+
+            if (reference.is_absolute() && !reference.is_opaque()) 
+            {
+                return reference;
+            }
+
+            if (reference.is_opaque()) 
+            {
+                return reference;
+            }
+
+            std::string userinfo, host, port, path, query, fragment;
+
+            if (reference.has_authority()) 
+            {
+              // g -> http://g
+              if (reference.has_userinfo()) 
+              {
+                  userinfo = std::string(reference.encoded_userinfo());
+              }
+
+              if (reference.has_host()) 
+              {
+                  host = std::string(reference.host());
+              }
+
+              if (reference.has_port()) 
+              {
+                  port = std::string(reference.port());
+              }
+
+              if (reference.has_path()) 
+              {
+                  path = remove_dot_segments(std::string(reference.encoded_path()));
+              }
+
+              if (reference.has_query()) 
+              {
+                  query = std::string(reference.encoded_query());
+              }
+            } 
+            else 
+            {
+              if (!reference.has_path()) 
+              {
+                if (has_path()) 
+                {
+                    path = std::string(encoded_path());
+                }
+
+                if (reference.has_query()) 
+                {
+                    query = std::string(reference.encoded_query());
+                } 
+                else if (has_query()) 
+                {
+                    query = std::string(encoded_query());
+                }
+              } 
+              else 
+              {
+                  if (reference.encoded_path().front() == '/') 
+                  {
+                    path = remove_dot_segments(std::string(reference.encoded_path()));
+                  } 
+                  else 
+                  {
+                      path = merge_paths(*this, reference);
+                  }
+
+                  if (reference.has_query()) 
+                  {
+                      query = std::string(reference.encoded_query());
+                  }
+              }
+
+              if (has_userinfo()) 
+              {
+                  userinfo = std::string(encoded_userinfo());
+              }
+
+              if (has_host()) 
+              {
+                  host = std::string(this->host());
+              }
+
+              if (has_port()) 
+              {
+                  port = std::string(this->port());
+              }
+            }
+
+            if (reference.has_fragment()) 
+            {
+                fragment = std::string(reference.encoded_fragment());
+            }
+
+            return uri(uri_encoded_part, std::string(scheme()), userinfo, host, port, path, query, fragment);
+        }
+
+        int compare(const uri& other) const
+        {
+            int result = scheme().compare(other.scheme());
+            if (result != 0) return result;
+            result = encoded_userinfo().compare(other.encoded_userinfo());
+            if (result != 0) return result;
+            result = host().compare(other.host());
+            if (result != 0) return result;
+            result = port().compare(other.port());
+            if (result != 0) return result;
+            result = encoded_path().compare(other.encoded_path());
+            if (result != 0) return result;
+            result = encoded_query().compare(other.encoded_query());
+            if (result != 0) return result;
+            result = encoded_fragment().compare(other.encoded_fragment());
+
+            return result;
+        }
+
+        friend bool operator==(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) == 0;
+        }
+
+        friend bool operator!=(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) != 0;
+        }
+
+        friend bool operator<(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) < 0;
+        }
+
+        friend bool operator<=(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) <= 0;
+        }
+
+        friend bool operator>(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) > 0;
+        }
+
+        friend bool operator>=(const uri& lhs, const uri& rhs)
+        {
+            return lhs.compare(rhs) >= 0;
+        }
+
+        static std::string decode_part(const jsoncons::string_view& encoded)
+        {
+            std::string decoded;
+
+            std::size_t length = encoded.size();
+            for (std::size_t i = 0; i < length;)
+            {
+                if (encoded[i] == '%' && (length - i) >= 3)
+                {
+                    auto hex = encoded.substr(i + 1, 2);
+
+                    uint8_t n;
+                    jsoncons::detail::hex_to_integer(hex.data(), hex.size(), n);
+                    decoded.push_back((char)n);
+                    i += 3;
+                }
+                else
+                {
+                    decoded.push_back(encoded[i]);
+                    ++i;
+                }
+            }
+            return decoded;
+        }
+        static uri parse(string_view str, std::error_code& ec)
+        {
+            part_type scheme_part{ 0,0 };
+            part_type userinfo_part{0,0};
+            part_type host_part{0,0};
+            part_type port_part{0,0};
+            part_type path_part{0,0};
+            part_type query_part{0,0};
+            part_type fragment_part{0,0};
+
+            std::size_t start = 0;
+
+            parse_state state = parse_state::start;
+            std::size_t colon_pos = 0; 
+            
+            std::size_t i = 0;
+            while (i < str.size())
+            {
+                char c = str[i];
+                switch (state)
+                {
+                    case parse_state::start:
+                        switch (c)
+                        {
+                            case '/':
+                                state = parse_state::expect_path;
+                                break;
+                            case '#':
+                                state = parse_state::expect_fragment;
+                                start = ++i; 
+                                break;
+                            default:
+                                state = parse_state::expect_scheme;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_scheme:
+                        switch (c)
+                        {
+                            case ':':
+                                if (!validate_scheme(string_view{str.data() + start, i-start}))
+                                {
+                                    ec = uri_errc::invalid_character_in_scheme;
+                                    return uri{};
+                                }
+                                else
+                                {
+                                    scheme_part = std::make_pair(start,i);
+                                    state = parse_state::expect_first_slash;
+                                    start = i;
+                                }
+                                ++i;
+                                break;
+                            case '?':
+                                path_part = std::make_pair(start, i);
+                                state = parse_state::expect_query;
+                                start = i + 1;
+                                ++i;
+                                break;
+                            case '#':
+                                userinfo_part = std::make_pair(start,start);
+                                host_part = std::make_pair(start,start);
+                                port_part = std::make_pair(start,start);
+                                path_part = std::make_pair(start,i);
+                                query_part = std::make_pair(i,i);
+                                state = parse_state::expect_fragment;
+                                start = i+1; 
+                                ++i;
+                                break;
+                            default:
+                                if (++i == str.size()) // end of string, haven't found a colon, try path_part
+                                {
+                                    i = 0;
+                                    state = parse_state::expect_path;
+                                }
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_first_slash:
+                        switch (c)
+                        {
+                            case '/':
+                                state = parse_state::expect_second_slash;
+                                ++i;
+                                break;
+                            default:
+                                start = i;
+                                state = parse_state::expect_path;
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_second_slash:
+                        switch (c)
+                        {
+                            case '/':
+                                state = parse_state::expect_authority;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_authority:
+                        switch (c)
+                        {
+                            case '[':
+                                state = parse_state::expect_host_ipv6;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                                state = parse_state::expect_userinfo;
+                                start = i;
+                                // i unchanged;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_host_ipv6:
+                        switch (c)
+                        {
+                            case ']':
+                                userinfo_part = std::make_pair(start,start);
+                                host_part = std::make_pair(start,i);
+                                port_part = std::make_pair(i,i);
+                                state = parse_state::expect_path;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_userinfo:
+                        switch (c)
+                        {
+                            case '@':
+                                if (!validate_userinfo(string_view{str.data() + start, i-start}))
+                                {
+                                    ec = uri_errc::invalid_character_in_userinfo;
+                                    return uri{};
+                                }
+                                userinfo_part = std::make_pair(start,i);
+                                state = parse_state::expect_host;
+                                start = i+1;
+                                ++i;
+                                break;
+                            case ':':
+                                colon_pos = i;
+                                state = parse_state::expect_password;
+                                ++i;
+                                break;
+                            case '/':
+                                userinfo_part = std::make_pair(start,start);
+                                host_part = std::make_pair(start,i);
+                                port_part = std::make_pair(i,i);
+                                state = parse_state::expect_path;
+                                start = i;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_password:
+                        switch (c)
+                        {
+                            case '@':
+                                if (!validate_host(string_view{str.data() + start, i-start}))
+                                {
+                                    ec = uri_errc::invalid_character_in_host;
+                                    return uri{};
+                                }
+                                userinfo_part = std::make_pair(start,i);
+                                state = parse_state::expect_host;
+                                start = i+1;
+                                ++i;
+                                break;
+                            case '/':
+                            {
+                                if (!validate_host(string_view{str.data() + start, colon_pos-start}))
+                                {
+                                    ec = uri_errc::invalid_character_in_host;
+                                    return uri{};
+                                }
+                                if (!validate_port(string_view{str.data() + (colon_pos+1), i-(colon_pos+1)}))
+                                {
+                                    ec = uri_errc::invalid_port;
+                                    return uri{};
+                                }
+                                userinfo_part = std::make_pair(start,start);
+                                host_part = std::make_pair(start,colon_pos);
+                                port_part = std::make_pair(colon_pos+1,i);
+                                state = parse_state::expect_path;
+                                start = i;
+                                ++i;
+                                break;
+                            }
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_host:
+                        switch (c)
+                        {
+                            case ':':
+                                if (!validate_host(string_view{str.data() + start, i-start}))
+                                {
+                                    ec = uri_errc::invalid_character_in_host;
+                                    return uri{};
+                                }
+                                host_part = std::make_pair(start,i);
+                                state = parse_state::expect_port;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_port:
+                        switch (c)
+                        {
+                            case '/':
+                                if (!validate_port(string_view{str.data() + start, i-start}))
+                                {
+                                    ec = uri_errc::invalid_port;
+                                    return uri{};
+                                }
+                                port_part = std::make_pair(start,i);
+                                state = parse_state::expect_path;
+                                start = i;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_path:
+                        switch (c)
+                        {
+                            case '?':
+                                path_part = std::make_pair(start,i);
+                                state = parse_state::expect_query;
+                                start = i+1;
+                                ++i;
+                                break;
+                            case '#':
+                                path_part = std::make_pair(start,i);
+                                query_part = std::make_pair(i,i);
+                                state = parse_state::expect_fragment;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                            {
+                                auto first = str.cbegin() + i;
+                                auto result = is_pchar(first, str.cend());
+                                if (result.second)
+                                {
+                                    i += (result.first - first);
+                                }
+                                else if (c == '/')
+                                {
+                                    ++i;
+                                }
+                                else
+                                {
+                                    ec = uri_errc::invalid_character_in_path;
+                                    return uri{};
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    case parse_state::expect_query:
+                        switch (c)
+                        {
+                            case '#':
+                                query_part = std::make_pair(start,i);
+                                state = parse_state::expect_fragment;
+                                start = i+1;
+                                ++i;
+                                break;
+                            default:
+                                ++i;
+                                break;
+                        }
+                        break;
+                    case parse_state::expect_fragment:
+                        ++i;
+                        break;
+                }
+            }
+            switch (state)
+            {
+                case parse_state::expect_userinfo:
+                    userinfo_part = std::make_pair(start,start);
+                    if (!validate_host(string_view{str.data() + start, str.size()-start}))
+                    {
+                        ec = uri_errc::invalid_character_in_host;
+                        return uri{};
+                    }
+                    host_part = std::make_pair(start,str.size());
+                    port_part = std::make_pair(str.size(), str.size());
+                    path_part = std::make_pair(str.size(), str.size());
+                    query_part = std::make_pair(str.size(), str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_password:
+                    userinfo_part = std::make_pair(start,start);
+                    if (!validate_host(string_view{str.data() + start, colon_pos-start}))
+                    {
+                        ec = uri_errc::invalid_character_in_host;
+                        return uri{};
+                    }
+                    host_part = std::make_pair(start,colon_pos);
+                    if (!validate_port(string_view{str.data() + (colon_pos+1), str.size() - (colon_pos+1)}))
+                    {
+                        ec = uri_errc::invalid_port;
+                        return uri{};
+                    }
+                    port_part = std::make_pair(colon_pos+1, str.size());
+                    path_part = std::make_pair(str.size(), str.size());
+                    query_part = std::make_pair(str.size(), str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_host:
+                    if (!validate_host(string_view{str.data() + start, str.size()-start}))
+                    {
+                        ec = uri_errc::invalid_character_in_host;
+                        return uri{};
+                    }
+                    host_part = std::make_pair(start, str.size());
+                    port_part = std::make_pair(str.size(), str.size());
+                    path_part = std::make_pair(str.size(), str.size());
+                    query_part = std::make_pair(str.size(), str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_port:
+                    if (!validate_port(string_view{str.data() + start, str.size() - start}))
+                    {
+                        ec = uri_errc::invalid_port;
+                        return uri{};
+                    }
+                    port_part = std::make_pair(start, str.size());
+                    path_part = std::make_pair(str.size(), str.size());
+                    query_part = std::make_pair(str.size(), str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_path:
+                    path_part = std::make_pair(start,str.size());
+                    query_part = std::make_pair(str.size(), str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_query:
+                    query_part = std::make_pair(start,str.size());
+                    fragment_part = std::make_pair(str.size(), str.size());
+                    break;
+                case parse_state::expect_fragment:
+                    fragment_part = std::make_pair(start,str.size());
+                    if (!validate_fragment(string_view{str.data() + fragment_part.first, (fragment_part.second - fragment_part.first)}))
+                    {
+                        ec = uri_errc::invalid_character_in_fragment;
+                        return uri{};
+                    }
+                    break;
+                default:
+                    ec = uri_errc::invalid_uri;
+                    break;
+            }
+
+            return uri(std::string(str), scheme_part, userinfo_part, host_part, port_part, path_part, query_part, fragment_part);
+        }
+
+    private:
+        enum class parse_state {
+            start,
+            expect_scheme,
+            expect_first_slash,
+            expect_second_slash,
+            expect_authority,
+            expect_host_ipv6,
+            expect_userinfo,
+            expect_password,
+            expect_host,
+            expect_port,
+            expect_path,
+            expect_query,
+            expect_fragment};
+
+        uri(const std::string& uri, part_type scheme, part_type userinfo, 
+            part_type host, part_type port, part_type path, 
+            part_type query, part_type fragment)
+            : uri_string_(uri), scheme_part_(scheme), userinfo_part_(userinfo), 
+              host_part_(host), port_part_(port), path_part_(path), 
+              query_part_(query), fragment_part_(fragment)
+        {
+        }
+
+/*
+5.2.4.  Remove Dot Segments
+
+   The pseudocode also refers to a "remove_dot_segments" routine for
+   interpreting and removing the special "." and ".." complete path
+   segments from a referenced path.  This is done after the path is
+   extracted from a reference, whether or not the path was relative, in
+   order to remove any invalid or extraneous dot-segments prior to
+   forming the target URI.  Although there are many ways to accomplish
+   this removal process, we describe a simple method using two string
+   buffers.
+
+   1.  The input buffer is initialized with the now-appended path
+       components and the output buffer is initialized to the empty
+       string.
+
+   2.  While the input buffer is not empty, loop as follows:
+
+       A.  If the input buffer begins with a prefix of "../" or "./",
+           then remove that prefix from the input buffer; otherwise,
+
+       B.  if the input buffer begins with a prefix of "/./" or "/.",
+           where "." is a complete path segment, then replace that
+           prefix with "/" in the input buffer; otherwise,
+
+       C.  if the input buffer begins with a prefix of "/../" or "/..",
+           where ".." is a complete path segment, then replace that
+           prefix with "/" in the input buffer and remove the last
+           segment and its preceding "/" (if any) from the output
+           buffer; otherwise,
+
+       D.  if the input buffer consists only of "." or "..", then remove
+           that from the input buffer; otherwise,
+
+       E.  move the first path segment in the input buffer to the end of
+           the output buffer, including the initial "/" character (if
+           any) and any subsequent characters up to, but not including,
+           the next "/" character or the end of the input buffer.
+
+   3.  Finally, the output buffer is returned as the result of
+       remove_dot_segments.
+*/
+
+        static std::string remove_dot_segments(std::string input)
+        {
+            std::string output;
+             
+            std::size_t rel = 0;
+            const std::size_t buflen = input.size();
+            while (rel < buflen)
+            {
+                char* data = &input[0]+rel;
+                const std::size_t length = buflen - rel;
+
+                if (length >= 3 && data[0] == '.' && data[1] == '.' && data[2] == '/')
+                { 
+                    rel += 3;
+                }
+                else if (length >= 2 && data[0] == '.' && data[1] == '/')
+                {
+                    rel += 2;
+                }
+                else if (length >= 3 && data[0] == '/' && data[1] == '.' && data[2] == '/')
+                { 
+                    rel += 2;
+                    data[2] = '/';
+                }
+                else if (length == 2 && data[0] == '/' && data[1] == '.')
+                {
+                    ++rel;
+                    data[1] = '/';
+                }
+                else if (length >= 4 && data[0] == '/' && data[1] == '.' && data[2] == '.' && data[3] == '/')
+                { 
+                    rel += 3;
+                    data[3] = '/';
+                    auto rslash = output.rfind('/');
+                    if (rslash != std::string::npos)
+                    {
+                        output.erase(rslash);
+                    }
+                }
+                else if (length >= 3 && data[0] == '/' && data[1] == '.' && data[2] == '.')
+                { 
+                    rel += 2;
+                    data[2] = '/';
+                    auto rslash = output.rfind('/');
+                    if (rslash != std::string::npos)
+                    {
+                        output.erase(rslash);
+                    }
+                }
+                else if (length == 1 && data[0] == '.')
+                {
+                    ++rel;
+                }
+                else if (length == 2 && data[0] == '.' && data[1] == '.')
+                {
+                    rel += 2;
+                }
+                else
+                {
+                    const auto last = data+length;
+                    auto it = std::find(data+1, last, '/');
+                    if (it != last)
+                    {
+                        output.append(data, it - data);
+                        rel += (it - data);
+                    }
+                    else
+                    {
+                        output.append(data, length);
+                        rel += length;
+                    }
+                }
+            }
+
+            //std::cout << "path: " << path << ", output: " << output << "\n";
+            
+            return output;
+        }
+
+        static std::string merge_paths(const uri& base, const uri& relative)
+        {
+            std::string result;
+            
+            if (!base.encoded_authority().empty() && base.encoded_path().empty()) 
+            {
+                result = "/";
+                //result.append(relative.encoded_path().data(), relative.encoded_path().length());
+            } 
+            else 
+            {
+                const auto& base_path = base.encoded_path();
+                auto last_slash = base_path.rfind('/');
+                result.append(std::string(base_path.substr(0,last_slash+1)));
+            }
+            if (!relative.encoded_path().empty()) 
+            {
+                result.append(relative.encoded_path().begin(), relative.encoded_path().end());
+            }
+            return remove_dot_segments(std::move(result));
+        }
+
+        static bool is_alpha(char ch)
+        {
+            return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z'); 
+        }
+
+        static bool is_digit(char ch)
+        {
+            return (ch >= '0' && ch <= '9'); 
+        }
+
+        static bool is_alphanum(char ch)
+        {
+            return is_alpha(ch) || is_digit(ch); 
+        }
+
+        static bool is_unreserved(char ch)
+        {
+            switch (ch)
+            {
+                case '_':
+                case '-':
+                case '!':
+                case '.':
+                case '~':
+                case '\'':
+                case '(':
+                case ')':
+                case '*':
+                    return true;
+                default:
+                    return is_alphanum(ch);
+            }
+        }
+
+        static bool is_punct(char ch)
+        {
+            switch (ch)
+            {
+                case ',':
+                case ';':
+                case ':':
+                case '$':
+                case '&':
+                case '+':
+                case '=':
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        static bool is_reserved(char ch)
+        {
+            switch (ch)
+            { 
+                case '?':
+                case '/':
+                case '[':
+                case ']':
+                case '@':
+                    return true;
+                default:
+                    return is_punct(ch);
+            }
+        }
+
+        static bool is_hex(char ch)
+        {
+            switch(ch)
+            {
+                case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8': case '9': 
+                case 'a':case 'b':case 'c':case 'd':case 'e':case 'f':
+                case 'A':case 'B':case 'C':case 'D':case 'E':case 'F':
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        static bool is_pct_encoded(const char* s, std::size_t length)
+        {
+            return length < 3 ? false : s[0] == '%' && is_hex(s[1]) && is_hex(s[2]);
+        }
+        
+        // sub-delims    = "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        static bool is_sub_delim(char c)
+        {
+            switch (c)
+            {
+                case '!':
+                    return true;
+                case '$':
+                    return true;
+                case '&':
+                    return true;
+                case '\'':
+                    return true;
+                case '(':
+                    return true;
+                case ')':
+                    return true;
+                case '*':
+                    return true;
+                case '+':
+                    return true;
+                case ',':
+                    return true;
+                case ';':
+                    return true;
+                case '=':
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+    public:
+
+        // Any character not in the unreserved, punct or escaped categories, and not equal 
+        // to the slash character ('/') or the  commercial-at character ('@'), is quoted.
+
+        static void encode_path(const jsoncons::string_view& sv, std::string& encoded)
+        {
+            const std::size_t length1 = sv.size() <= 2 ? 0 : sv.size() - 2;
+
+            std::size_t i = 0;
+            for (; i < length1; ++i)
+            {
+                char ch = sv[i];
+
+                switch (ch)
+                {
+                    case '/':
+                    case '@':
+                        encoded.push_back(sv[i]);
+                        break;
+                    default:
+                    {
+                        bool escaped = is_pct_encoded(sv.data()+i,3);
+                        if (!is_unreserved(ch) && !is_punct(ch) && !escaped)
+                        {
+                            encoded.push_back('%');
+                            if (uint8_t(ch) <= 15)
+                            {
+                                encoded.push_back('0');
+                            }
+                            jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                        }
+                        else if (escaped)
+                        {
+                            encoded.push_back(ch);
+                            encoded.push_back(sv[++i]);
+                            encoded.push_back(sv[++i]);
+                        }
+                        else
+                        {
+                            encoded.push_back(ch);
+                        }
+                        break;
+                    }
+                }
+            }
+ 
+            const std::size_t length2 = sv.size();
+            for (; i < length2; ++i)
+            {
+                char ch = sv[i];
+
+                switch (ch)
+                {
+                    case '/':
+                    case '@':
+                        encoded.push_back(ch);
+                        break;
+                    default:
+                    {
+                        if (!is_unreserved(ch) && !is_punct(ch))
+                        {
+                            encoded.push_back('%');
+                            jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                        }
+                        else
+                        {
+                            encoded.push_back(ch);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
+
+        // Any character not in the unreserved, punct, or escaped categories is quoted.
+
+        static void encode_userinfo(const jsoncons::string_view& sv, std::string& encoded)
+        {
+            const std::size_t length1 = sv.size() <= 2 ? 0 : sv.size() - 2;
+
+            std::size_t i = 0;
+            for (; i < length1; ++i)
+            {
+                char ch = sv[i];
+
+                bool escaped = is_pct_encoded(sv.data()+i,3);
+                if (!is_unreserved(ch) && !is_punct(ch) && !escaped)
+                {
+                    encoded.push_back('%');
+                    if (uint8_t(ch) <= 15)
+                    {
+                        encoded.push_back('0');
+                    }
+                    jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                }
+                else if (escaped)
+                {
+                    encoded.push_back(ch);
+                    encoded.push_back(sv[++i]);
+                    encoded.push_back(sv[++i]);
+                }
+                else
+                {
+                    encoded.push_back(ch);
+                }
+            }
+ 
+            const std::size_t length2 = sv.size();
+            for (; i < length2; ++i)
+            {
+                char ch = sv[i];
+
+                if (!is_unreserved(ch) && !is_punct(ch))
+                {
+                    encoded.push_back('%');
+                    jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                }
+                else
+                {
+                    encoded.push_back(ch);
+                }
+            }
+        }
+
+        // The set of all legal URI characters consists of the unreserved, reserved, escaped characters.
+
+        static void encode_illegal_characters(const jsoncons::string_view& sv, std::string& encoded)
+        {
+            const std::size_t length1 = sv.size() <= 2 ? 0 : sv.size() - 2;
+
+            std::size_t i = 0;
+            for (; i < length1; ++i)
+            {
+                char ch = sv[i];
+
+                bool escaped = is_pct_encoded(sv.data()+i,3);
+                if (!is_unreserved(ch) && !is_reserved(ch) && !escaped)
+                {
+                    encoded.push_back('%');
+                    if (uint8_t(ch) <= 15)
+                    {
+                        encoded.push_back('0');
+                    }
+                    jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                }
+                else if (escaped)
+                {
+                    encoded.push_back(ch);
+                    encoded.push_back(sv[++i]);
+                    encoded.push_back(sv[++i]);
+                }
+                else
+                {
+                    encoded.push_back(ch);
+                }
+            }
+ 
+            const std::size_t length2 = sv.size();
+            for (; i < length2; ++i)
+            {
+                char ch = sv[i];
+
+                if (!is_unreserved(ch) && !is_reserved(ch))
+                {
+                    encoded.push_back('%');
+                    jsoncons::detail::integer_to_hex((uint8_t)ch, encoded);
+                }
+                else
+                {
+                    encoded.push_back(ch);
+                }
+            }
+        }
+
+        // rel_segment   = 1*( unreserved | escaped | ";" | "@" | "&" | "=" | "+" | "$" | "," )
+        static bool is_rel_segment(char c, const char* s, std::size_t length)
+        {
+            return is_unreserved(c) || is_pct_encoded(s,length) || c == ';' || c == '@' || c == '&' || c == '=' || c == '+' || c == '$' || c == ',';
+        }
+
+        // userinfo      = *( unreserved | escaped | ";" | ":" | "&" | "=" | "+" | "$" | "," )
+
+        static bool is_userinfo(char c, const char* s, std::size_t length)
+        {
+            return is_unreserved(c) || is_pct_encoded(s,length) || c == ';' || c == ':' || c == '&' || c == '=' || c == '+' || c == '$' || c == ',';
+        }
+
+        static std::pair<string_view::const_iterator,bool> is_pct_encoded(string_view::const_iterator first, 
+            string_view::const_iterator last)
+        {
+            if ((last-first) < 3)
+            {
+                return std::pair<string_view::const_iterator,bool>{first+1,false};
+            }
+            bool result = first[0] == '%' && is_hex(first[1]) && is_hex(first[2]);
+            
+            return result ? std::pair<string_view::const_iterator,bool>{first+3,true} : std::pair<string_view::const_iterator,bool>{first+1,false};
+        }
+
+        static std::pair<string_view::const_iterator,bool> is_pchar(string_view::iterator first, string_view::iterator last)
+        {
+            JSONCONS_ASSERT(first != last);
+            
+            const char c = *first;
+            if (is_unreserved(c))
+            {
+                return std::pair<string_view::const_iterator,bool>{first+1,true};
+            }
+            auto result = is_pct_encoded(first,last);
+            if (result.second)
+            {
+                return result;
+            }
+            
+            return std::pair<string_view::const_iterator,bool>{first+1,is_sub_delim(c) || c == ':' || c == '@'};
+        }
+        
+        static bool validate_fragment(string_view fragment)
+        {
+            if (fragment.length() == 0)
+            {
+                return true;
+            }
+            bool valid = true;
+            
+            auto cur = fragment.begin();
+            auto last = fragment.end();
+            while (valid && cur != last)
+            {
+                auto result = is_pchar(cur,last);
+                if (!result.second && !(*cur == '?' || *cur == '/'))
+                {
+                    valid = false;
+                }
+                else
+                {
+                    cur = result.first;
+                }
+            }
+            return valid;
+        }       
+
+        static bool validate_userinfo(string_view userinfo)
+        {
+            if (userinfo.length() == 0)
+            {
+                return true;
+            }
+            
+            bool valid = true;
+            auto cur = userinfo.begin();
+            auto last = userinfo.end();
+            while (valid && cur != last)
+            {
+                auto unreserved = is_unreserved(*cur);
+                auto pct_encoded = is_pct_encoded(cur,last);
+                auto sub_delim = is_sub_delim(*cur);
+                if (!unreserved && !pct_encoded.second && !sub_delim && !(*cur == ':'))
+                {
+                    valid = false;
+                }
+                if (pct_encoded.second)
+                {
+                    cur = pct_encoded.first;
+                }
+                else
+                {
+                    ++cur;
+                }
+            }
+            return valid;
+        }
+
+        static bool validate_port(string_view port)
+        {
+            uint16_t p;
+            auto result = jsoncons::detail::to_integer(port.data(), port.length(), p);
+            return static_cast<bool>(result);
+        }
+        
+        static bool validate_host(string_view userinfo)
+        {
+            if (userinfo.length() == 0)
+            {
+                return true;
+            }
+
+            bool valid = true;
+            auto cur = userinfo.begin();
+            auto last = userinfo.end();
+            while (valid && cur != last)
+            {
+                if (*cur == ' ')
+                {
+                    valid = false;
+                }
+                ++cur;
+            }
+            return valid;
+        }
+
+        static bool validate_scheme(string_view scheme)
+        {
+            if (scheme.length() == 0)
+            {
+                return true;
+            }
+        
+            bool valid = isalpha(scheme[0]);
+            auto cur = scheme.begin();
+            auto last = scheme.end();
+            while (valid && cur != last)
+            {
+                char c  = *cur;
+                if (!(isalnum(c) || c == '+' || c == '.' || c == '-'))
+                {
+                    valid = false;
+                }
+                ++cur;
+            }
+            return valid;
+        }
+        
+        friend std::ostream& operator<<(std::ostream& os, const uri& a_uri)
+        {
+            return os << a_uri.string();
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_UTILITY_URI_HPP

--- a/velox/external/jsoncons/value_converter.hpp
+++ b/velox/external/jsoncons/value_converter.hpp
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Copyright 2013-2025 Daniel Parker
+// Distributed under the Boost license, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// See https://github.com/danielaparker/jsoncons for latest version
+
+#ifndef JSONCONS_VALUE_CONVERTER_HPP
+#define JSONCONS_VALUE_CONVERTER_HPP
+
+#include <memory>
+#include <string>
+#include <system_error> // std::error_code
+
+#include "velox/external/jsoncons/utility/byte_string.hpp"
+#include "velox/external/jsoncons/config/compiler_support.hpp"
+#include "velox/external/jsoncons/conv_error.hpp"
+#include "velox/external/jsoncons/detail/write_number.hpp" // from_integer
+#include "velox/external/jsoncons/utility/extension_traits.hpp"
+#include "velox/external/jsoncons/utility/unicode_traits.hpp"
+#include "velox/external/jsoncons/json_type.hpp"
+#include "velox/external/jsoncons/tag_type.hpp"
+
+namespace facebook::velox::jsoncons {
+
+    template <typename From,typename Into,typename Enable = void>
+    class value_converter
+    {
+    };
+
+    template <typename Into>
+    class value_converter_base
+    {
+    public:
+        using allocator_type = typename std::conditional<extension_traits::has_allocator_type<Into>::value,typename Into::allocator_type, std::allocator<char>>::type;
+    private:
+        allocator_type alloc_;
+
+    public:
+        value_converter_base(const allocator_type& alloc = allocator_type())
+            : alloc_(alloc)
+        {
+        }
+
+        allocator_type get_allocator() const noexcept
+        {
+            return alloc_;
+        }
+    };
+
+    // From any byte sequence, Into string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_byte_sequence<From>::value && !extension_traits::is_string_or_string_view<From>::value &&
+            extension_traits::is_string<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        template <typename CharT = typename Into::value_type>
+        typename std::enable_if<extension_traits::is_narrow_character<CharT>::value,Into>::type
+        convert(const From& value, semantic_tag tag, std::error_code&)
+        {
+            Into s(this->get_allocator());
+            switch (tag)
+            {
+                case semantic_tag::base64:
+                    encode_base64(value.begin(), value.end(), s);
+                    break;
+                case semantic_tag::base16:
+                    encode_base16(value.begin(), value.end(), s);
+                    break;
+                default:
+                    encode_base64url(value.begin(), value.end(), s);
+                    break;
+            }
+            return s;
+        }
+        template <typename CharT = typename Into::value_type>
+        typename std::enable_if<extension_traits::is_wide_character<CharT>::value,Into>::type
+        convert(const From& value, semantic_tag tag, std::error_code& ec)
+        {
+            std::string s;
+            switch (tag)
+            {
+                case semantic_tag::base64:
+                    encode_base64(value.begin(), value.end(), s);
+                    break;
+                case semantic_tag::base16:
+                    encode_base16(value.begin(), value.end(), s);
+                    break;
+                default:
+                    encode_base64url(value.begin(), value.end(), s);
+                    break;
+            }
+
+            Into ws(this->get_allocator());
+            auto retval = unicode_traits::convert(s.data(), s.size(), ws);
+            if (retval.ec != unicode_traits::conv_errc())
+            {
+                ec = conv_errc::not_wide_char;
+            }
+
+            return ws;
+        }
+    };
+
+    // From byte string, Into byte string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_byte_sequence<From>::value && 
+            !extension_traits::is_string_or_string_view<From>::value &&
+            !extension_traits::is_string_or_string_view<Into>::value && 
+            extension_traits::is_back_insertable_byte_container<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(const From& value, semantic_tag, std::error_code&)
+        {
+            Into s(value.begin(),value.end(),this->get_allocator());
+            return s;
+        }
+    };
+    
+    // From string or string_view, Into string, same character type
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_string_or_string_view<From>::value &&
+            extension_traits::is_string<Into>::value && 
+            std::is_same<typename From::value_type,typename Into::value_type>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(const From& value, semantic_tag, std::error_code&)
+        {
+            return Into(value.begin(),value.end(),this->get_allocator());
+        }
+    };
+
+    // From string or string_view, Into string, different character type
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_string_or_string_view<From>::value &&
+            extension_traits::is_string<Into>::value && 
+            !std::is_same<typename From::value_type,typename Into::value_type>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(const From& value, semantic_tag, std::error_code& ec)
+        {
+            Into ws(this->get_allocator());
+            auto retval = unicode_traits::convert(value.data(), value.size(), ws);
+            if (retval.ec != unicode_traits::conv_errc())
+            {
+                ec = conv_errc::not_wide_char;
+            }
+
+            return ws;
+        }
+    };
+
+    // From string, Into byte_string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_char_sequence<From>::value &&
+            !extension_traits::is_string_or_string_view<Into>::value && 
+            extension_traits::is_back_insertable_byte_container<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        template <typename CharT = typename From::value_type>
+        typename std::enable_if<extension_traits::is_narrow_character<CharT>::value,Into>::type
+        convert(const From& value, semantic_tag tag, std::error_code& ec)
+        {
+            Into bytes(this->get_allocator());
+            switch (tag)
+            {
+                case semantic_tag::base16:
+                {
+                    auto res = decode_base16(value.begin(), value.end(), bytes);
+                    if (res.ec != conv_errc::success)
+                    {
+                        ec = conv_errc::not_byte_string;
+                    }
+                    break;
+                }
+                case semantic_tag::base64:
+                {
+                    decode_base64(value.begin(), value.end(), bytes);
+                    break;
+                }
+                case semantic_tag::base64url:
+                {
+                    decode_base64url(value.begin(), value.end(), bytes);
+                    break;
+                }
+                default:
+                {
+                    ec = conv_errc::not_byte_string;
+                    break;
+                }
+            }
+            return bytes;
+        }
+
+        template <typename CharT = typename From::value_type>
+        typename std::enable_if<extension_traits::is_wide_character<CharT>::value,Into>::type
+        convert(const From& value, semantic_tag tag, std::error_code& ec)
+        {
+            Into bytes(this->get_allocator());
+
+            std::string s(this->get_allocator());
+            auto retval = unicode_traits::convert(value.data(), value.size(), s);
+            if (retval.ec != unicode_traits::conv_errc())
+            {
+                ec = conv_errc::not_wide_char;
+            }
+            switch (tag)
+            {
+                case semantic_tag::base16:
+                {
+                    auto res = decode_base16(s.begin(), s.end(), bytes);
+                    if (res.ec != conv_errc::success)
+                    {
+                        ec = conv_errc::not_byte_string;
+                    }
+                    break;
+                }
+                case semantic_tag::base64:
+                {
+                    decode_base64(s.begin(), s.end(), bytes);
+                    break;
+                }
+                case semantic_tag::base64url:
+                {
+                    decode_base64url(s.begin(), s.end(), bytes);
+                    break;
+                }
+                default:
+                {
+                    ec = conv_errc::not_byte_string;
+                    break;
+                }
+            }
+            return bytes;
+        }
+    };
+
+    // From integer, Into string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_integer<From>::value &&
+            extension_traits::is_string<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(From value, semantic_tag, std::error_code&)
+        {
+            Into s(this->get_allocator());
+            jsoncons::detail::from_integer(value, s);
+            return s;
+        }
+    };
+
+    // From integer, Into string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<std::is_floating_point<From>::value &&
+            extension_traits::is_string<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(From value, semantic_tag, std::error_code&)
+        {
+            Into s(this->get_allocator());
+            jsoncons::detail::write_double f{float_chars_format::general,0};
+            f(value, s);
+            return s;
+        }
+    };
+
+    // From half, Into string
+    template <typename Into>
+    class value_converter<half_arg_t, Into,
+        typename std::enable_if<extension_traits::is_string<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+
+        Into convert(uint16_t value, semantic_tag, std::error_code&)
+        {
+            Into s(this->get_allocator());
+            jsoncons::detail::write_double f{float_chars_format::general,0};
+            double x = binary::decode_half(value);
+            f(x, s);
+            return s;
+        }
+    };
+
+    // From bool, Into string
+    template <typename From,typename Into>
+    class value_converter<From, Into, 
+        typename std::enable_if<extension_traits::is_bool<From>::value &&
+            extension_traits::is_string<Into>::value>::type> : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+        using char_type = typename Into::value_type;
+
+        JSONCONS_CPP14_CONSTEXPR 
+        Into convert(From value, semantic_tag, std::error_code&)
+        {
+            constexpr const char_type* true_constant = JSONCONS_CSTRING_CONSTANT(char_type,"true"); 
+            constexpr const char_type* false_constant = JSONCONS_CSTRING_CONSTANT(char_type,"false"); 
+
+            return value ? Into(true_constant,4) : Into(false_constant,5);
+        }
+    };
+
+    // From null, Into string
+    template <typename Into>
+    class value_converter<null_type, Into, void>  : value_converter_base<Into>
+    {
+    public:
+        using allocator_type = typename value_converter_base<Into>::allocator_type;
+        using char_type = typename Into::value_type;
+
+        JSONCONS_CPP14_CONSTEXPR 
+        Into convert(semantic_tag, std::error_code&)
+        {
+            constexpr const char_type* null_constant = JSONCONS_CSTRING_CONSTANT(char_type,"null"); 
+
+            return Into(null_constant,4);
+        }
+    };
+
+} // namespace facebook::velox::jsoncons
+
+#endif // JSONCONS_VALUE_CONVERTER_HPP


### PR DESCRIPTION
Summary:
This is part of an effort to add support for complete set of json path tokens (See https://github.com/facebookincubator/velox/discussions/12394 for more details).
As a first step we add jsoncons as a vendored library and in the upcoming changes we will start to incrementally use it.

The code for the library has been pulled from https://github.com/danielaparker/jsoncons with some changes. The changes include:

- Only files relevant to json and json parsing have been included
- The #include directives have been updated to point to local paths
- Prepend Apache license while preserving the existing boost license
- The namespaces have been prepended with facebook::velox to avoid namespace conflict if velox is included in projects that already use jsoncons
- Made changes to the json path parser to conform with jayway library which is a json library currently used by presto java.
- Added a flag to the json path parser that returns an error for paths not currently supported by velox.

Changes made to the parser include:
- Added support for unquoted identifier after bracket `$[<identifier>]` that can also start with a number like `$[Key]` or `$[30day]`
- Added support for bracket (`[`) after dot `$.['key']` (redundant use of dot operator)
- Added support for dash (`-`) in the middle of an unquoted string
- Added support for prepending by default `$.` in not included at the beginning of the path. This is to support cases like `[0]` or `key` which will now be equivalent to `$.[0]` or `$.key`

Differential Revision: D68564596
