### PR TITLE
misc: Add partitioned writer count metrics to hive data sink

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -683,6 +683,9 @@ void HiveDataSink::abort() {
 }
 
 void HiveDataSink::closeInternal() {
+  addThreadLocalRuntimeStat(
+      kNumPartitionedWriters,
+      RuntimeCounter(writers_.size(), RuntimeCounter::Unit::kNone));
   VELOX_CHECK_NE(state_, State::kRunning);
   VELOX_CHECK_NE(state_, State::kFinishing);
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -451,7 +451,12 @@ struct HiveWriterIdEq {
 class HiveDataSink : public DataSink {
  public:
   /// The list of runtime stats reported by hive data sink
+  ///
+  /// Number of bytes pre-maturely flushed from file writers because of memory
+  /// reclaiming.
   static constexpr const char* kEarlyFlushedRawBytes = "earlyFlushedRawBytes";
+  /// The number of partitioned writers in hive data sink
+  static constexpr const char* kNumPartitionedWriters = "numPartitionedWriters";
 
   /// Defines the execution states of a hive data sink running internally.
   enum class State {

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -119,6 +119,9 @@ These stats are reported only by TableWriter operator
    * - earlyFlushedRawBytes
      - bytes
      - Number of bytes pre-maturely flushed from file writers because of memory reclaiming.
+   * - numPartitionedWriters
+     -
+     - The number of partitioned writers in hive data sink
    * - rebalanceTriggers
      -
      - The number of times that we triggers the rebalance of table partitions

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -344,6 +344,7 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
        {"      dataSourceLazyInputBytes\\s+sum: .+, count: .+, min: .+, max: .+"},
        {"      dataSourceLazyWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
        {"      numWrittenFiles\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      numPartitionedWriters\\s+sum: .+, count: .+, min: .+, max: .+"},
        {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},


### PR DESCRIPTION
large number of partitioned writers may cause issues like large number of open files and memory consumption. Adding this runtime metrics to disclose this critical stats for more efficient debugging related issues.