### PR TITLE
misc(test_utils): Add file and directory operations to HiveConnectorTestBase

### DIFF
--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -121,6 +121,25 @@ void HiveConnectorTestBase::writeToFile(
   writer.close();
 }
 
+void HiveConnectorTestBase::createDirectory(const std::string& directoryPath) {
+  auto fs = filesystems::getFileSystem(directoryPath, {});
+  fs->mkdir(directoryPath);
+}
+
+void HiveConnectorTestBase::removeDirectory(const std::string& directoryPath) {
+  auto fs = filesystems::getFileSystem(directoryPath, {});
+  if (fs->exists(directoryPath)) {
+    fs->rmdir(directoryPath);
+  }
+}
+
+void HiveConnectorTestBase::removeFile(const std::string& filePath) {
+  auto fs = filesystems::getFileSystem(filePath, {});
+  if (fs->exists(filePath)) {
+    fs->remove(filePath);
+  }
+}
+
 std::vector<RowVectorPtr> HiveConnectorTestBase::makeVectors(
     const RowTypePtr& rowType,
     int32_t numVectors,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -61,6 +61,18 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()>&
           flushPolicyFactory = nullptr);
 
+  // Creates a directory using matching file system based on directoryPath.
+  // No throw when directory already exists.
+  void createDirectory(const std::string& directoryPath);
+
+  // Removes a directory using matching file system based on directoryPath.
+  // No op when directory does not exist.
+  void removeDirectory(const std::string& directoryPath);
+
+  // Removes a file using matching file system based on filePath.
+  // No op when file does not exist.
+  void removeFile(const std::string& filePath);
+
   std::vector<RowVectorPtr> makeVectors(
       const RowTypePtr& rowType,
       int32_t numVectors,


### PR DESCRIPTION
Summary:
Currently HiveConnectorTestBase has util method for writing to a file, given a file path. Added

1. Create/Remove ops for directories
2. Remove op for files

Differential Revision: D69955818


