### PR TITLE
feat: Allow Spark get_json_object function to parse incomplete json

### DIFF
--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -34,3 +34,5 @@ if(${VELOX_SIMDJSON_SKIPUTF8VALIDATION})
 endif()
 
 FetchContent_MakeAvailable(simdjson)
+target_compile_definitions(simdjson
+                           PUBLIC SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON)

--- a/velox/functions/prestosql/json/SIMDJsonUtil.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.cpp
@@ -38,6 +38,12 @@ simdjson::padded_string_view reusePaddedStringView(
     const std::string_view& json) {
   return simdjson::padded_string_view(
       json.data(), json.length(), json.length() + simdjson::SIMDJSON_PADDING);
-};
+}
+
+simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParseIncomplete(
+    const simdjson::padded_string_view& json) {
+  thread_local simdjson::ondemand::parser parser;
+  return parser.iterate_allow_incomplete_json(json);
+}
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/json/SIMDJsonUtil.h
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.h
@@ -54,4 +54,9 @@ simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParse(
 simdjson::padded_string_view reusePaddedStringView(
     const std::string_view& json);
 
+/// Parse the input json string using a thread local on demand parser. Allow
+/// incomplete json input.
+simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParseIncomplete(
+    const simdjson::padded_string_view& json);
+
 } // namespace facebook::velox

--- a/velox/functions/sparksql/GetJsonObject.h
+++ b/velox/functions/sparksql/GetJsonObject.h
@@ -54,7 +54,7 @@ struct GetJsonObjectFunction {
     }
     simdjson::ondemand::document jsonDoc;
     simdjson::padded_string paddedJson(json.data(), json.size());
-    if (simdjsonParse(paddedJson).get(jsonDoc)) {
+    if (simdjsonParseIncomplete(paddedJson).get(jsonDoc)) {
       return false;
     }
     const auto formattedJsonPath = jsonPath_.has_value()

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -119,5 +119,34 @@ TEST_F(GetJsonObjectTest, nullResult) {
       std::nullopt);
 }
 
+TEST_F(GetJsonObjectTest, incompleteJson) {
+  EXPECT_EQ(getJsonObject(R"({"hello": "3.5"},)", "$.hello"), "3.5");
+  EXPECT_EQ(getJsonObject(R"({"hello": "3.5",,,,})", "$.hello"), "3.5");
+  EXPECT_EQ(
+      getJsonObject(R"({"hello": "3.5",,,,"taskSort":"2"})", "$.hello"), "3.5");
+  EXPECT_EQ(
+      getJsonObject(
+          R"({"hello": "3.5","taskSort":"2",,,,,"taskSort",})", "$.hello"),
+      "3.5");
+  EXPECT_EQ(
+      getJsonObject(R"({"hello": "3.5","taskSort":"2",,,,,,})", "$.hello"),
+      "3.5");
+  EXPECT_EQ(
+      getJsonObject(R"({"hello": "boy","taskSort":"2"},,,,,)", "$.hello"),
+      "boy");
+  EXPECT_EQ(getJsonObject(R"({"hello": "boy\n"},)", "$.hello"), "boy\n");
+  EXPECT_EQ(getJsonObject(R"({"hello": "boy\n\t"},)", "$.hello"), "boy\n\t");
+  EXPECT_EQ(
+      getJsonObject(
+          R"([{"my": {"info": {"name": "Alice"}}}, {"other": ["v1", "v2"]}],)",
+          "$[1].other[1]"),
+      "v2");
+  EXPECT_EQ(
+      getJsonObject(
+          R"({"my": {"info": {"name": "Alice", "age": "5", "id": "001"}}},)",
+          "$['my']['info']"),
+      R"({"name": "Alice", "age": "5", "id": "001"})");
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Spark get_json_object function allows incomplete json, for example: "select 
get_json_object('{"hello": "3.5"},', '$.'hello)" returns 3.5, but Velox returns 
null. This PR adds 'simdjsonParseIncomplete' to allow incomplete json input 
for Spark.