### PR TITLE
feat: BingTile type

### DIFF
--- a/velox/exec/tests/FunctionResolutionTest.cpp
+++ b/velox/exec/tests/FunctionResolutionTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -318,6 +319,22 @@ TEST_F(FunctionResolutionTest, resolveCustomTypeTimestampWithTimeZone) {
   auto type =
       exec::simpleFunctions().resolveFunction("f_timestampzone", {})->type();
   EXPECT_EQ(type->toString(), TIMESTAMP_WITH_TIME_ZONE()->toString());
+}
+
+template <typename T>
+struct FuncBingTile {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  bool call(out_type<BingTile>&) {
+    return false;
+  }
+};
+
+TEST_F(FunctionResolutionTest, resolveCustomTypeBingTile) {
+  registerFunction<FuncBingTile, BingTile>({"f_bing_tile"});
+
+  auto type =
+      exec::simpleFunctions().resolveFunction("f_bing_tile", {})->type();
+  EXPECT_EQ(type->toString(), BINGTILE()->toString());
 }
 
 // A function that takes TInput and returns int, TInput determined at

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -230,6 +230,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "UUID",
           "IPADDRESS",
           "IPPREFIX",
+          "BINGTILE",
       }),
       names);
 
@@ -245,6 +246,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "UUID",
           "IPADDRESS",
           "IPPREFIX",
+          "BINGTILE",
           "FANCY_INT",
       }),
       names);

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
@@ -52,6 +53,9 @@ std::string typeName(const TypePtr& type) {
         const auto& shortDecimal = type->asShortDecimal();
         return fmt::format(
             "decimal({},{})", shortDecimal.precision(), shortDecimal.scale());
+      }
+      if (isBingTileType(type)) {
+        return "bingtile";
       }
       return "bigint";
     case TypeKind::HUGEINT: {

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -23,6 +23,7 @@ velox_add_library(
   ComparisonFunctionsRegistration.cpp
   DateTimeFunctionsRegistration.cpp
   GeneralFunctionsRegistration.cpp
+  GeospatialFunctionsRegistration.cpp
   HyperLogFunctionsRegistration.cpp
   IntegerFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp

--- a/velox/functions/prestosql/registration/GeospatialFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeospatialFunctionsRegistration.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include "velox/functions/prestosql/types/BingTileRegistration.h"
+
+namespace facebook::velox::functions {
+
+void registerGeospatialFunctions(const std::string& prefix) {
+  registerBingTileType();
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -38,6 +38,7 @@ extern void registerURLFunctions(const std::string& prefix);
 extern void registerMapAllowingDuplicates(
     const std::string& name,
     const std::string& prefix);
+extern void registerGeospatialFunctions(const std::string& prefix);
 extern void registerInternalArrayFunctions();
 
 namespace prestosql {
@@ -75,6 +76,10 @@ void registerIntegerFunctions(const std::string& prefix) {
   functions::registerIntegerFunctions(prefix);
 }
 
+void registerGeospatialFunctions(const std::string& prefix) {
+  functions::registerGeospatialFunctions(prefix);
+}
+
 void registerGeneralFunctions(const std::string& prefix) {
   functions::registerGeneralFunctions(prefix);
 }
@@ -108,6 +113,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerJsonFunctions(prefix);
   registerHyperLogFunctions(prefix);
   registerIntegerFunctions(prefix);
+  registerGeospatialFunctions(prefix);
   registerGeneralFunctions(prefix);
   registerDateTimeFunctions(prefix);
   registerURLFunctions(prefix);

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -33,6 +33,8 @@ void registerJsonFunctions(const std::string& prefix = "");
 
 void registerHyperLogFunctions(const std::string& prefix = "");
 
+void registerGeospatialFunctions(const std::string& prefix = "");
+
 void registerGeneralFunctions(const std::string& prefix = "");
 
 void registerDateTimeFunctions(const std::string& prefix = "");

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
@@ -52,6 +53,8 @@ TEST_F(TypeOfTest, basic) {
   EXPECT_EQ("timestamp", typeOf(TIMESTAMP()));
   EXPECT_EQ("timestamp with time zone", typeOf(TIMESTAMP_WITH_TIME_ZONE()));
   EXPECT_EQ("date", typeOf(DATE()));
+
+  EXPECT_EQ("bingtile", typeOf(BINGTILE()));
 
   EXPECT_EQ("json", typeOf(JSON()));
 

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/BingTileRegistration.h"
+
+#include "velox/functions/prestosql/types/BingTileType.h"
+
+namespace facebook::velox {
+
+namespace {
+
+class BingTileTypeFactories : public CustomTypeFactories {
+ public:
+  velox::TypePtr getType(
+      const std::vector<velox::TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
+    return BINGTILE();
+  }
+
+  // TODO: Provide casting to/from BIGINT
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+
+} // namespace
+
+void registerBingTileType() {
+  registerCustomType(
+      "bingtile", std::make_unique<const BingTileTypeFactories>());
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BingTileRegistration.h
+++ b/velox/functions/prestosql/types/BingTileRegistration.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+void registerBingTileType();
+
+}

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include "velox/type/SimpleFunctionApi.h"
+
+namespace facebook::velox {
+
+/// Bing Tile represented by a 64-bit int.
+///
+/// Bing tiles are a quad-tree representation of the earth's surface, allowing
+/// geospatial data to be represented in a hierarchical manner to the desired
+/// granularity. Zoom level 0 is a single square, zoom 1 divides zoom 0 into 4
+/// equal-area squares, and so on recursively. Each point of the Earth's surface
+/// (aside from near the poles) is contained within a single BingTile at each
+/// zoom level (with rules for boundaries). Bing tiles can be referenced by
+/// (zoom, x, y), with (zoom=2, x=0, y=3) being the southwest-most square of 16
+/// squares at zoom level 2. Bing tiles can also be referenced by quadkey, a
+/// string of ['0', '1', '2', '3'] for each level.  Quadkey "" is the only zoom
+/// 0 square, "22" is the southwest-most square at zoom 2, and so on.  Quadkeys
+/// have the nice property that geometrical containment is equivalent to a
+/// string prefix check. Definition and more details:
+/// https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system
+///
+/// In Velox, a Bing Tile is a packed 64 bits.  The packing is:
+/// 0-4: Version (5 bits)
+/// 5-8: 0 (4 bits)
+/// 9-31: x-coordinate (23 bits)
+/// 32-35: Zoom (5 bits)
+/// 36-40: 0 (4 bits)
+/// 41-63: y-coordinate (23 bits)
+/// (high bits first, low bits last). This peculiar arrangement maximizes
+/// low-bit entropy for the Java long hash function.
+class BingTileType : public BigintType {
+  BingTileType() : BigintType() {}
+
+ public:
+  static const std::shared_ptr<const BingTileType>& get() {
+    static const std::shared_ptr<const BingTileType> instance =
+        std::shared_ptr<BingTileType>(new BingTileType());
+
+    return instance;
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "BINGTILE";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    return obj;
+  }
+};
+
+inline bool isBingTileType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return BingTileType::get() == type;
+}
+
+inline std::shared_ptr<const BingTileType> BINGTILE() {
+  return BingTileType::get();
+}
+
+// Type used for function registration.
+struct BingTileT {
+  using type = int64_t;
+  static constexpr const char* typeName = "bingtile";
+};
+
+using BingTile = CustomType<BingTileT, false>;
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 velox_add_library(
   velox_presto_types
+  BingTileRegistration.cpp
   HyperLogLogRegistration.cpp
   IPAddressRegistration.cpp
   IPPrefixRegistration.cpp

--- a/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/BingTileType.h"
+#include "velox/functions/prestosql/types/BingTileRegistration.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class BingTileTypeTest : public testing::Test, public TypeTestBase {
+ public:
+  BingTileTypeTest() {
+    registerBingTileType();
+  }
+};
+
+TEST_F(BingTileTypeTest, basic) {
+  ASSERT_STREQ(BINGTILE()->name(), "BINGTILE");
+  ASSERT_STREQ(BINGTILE()->kindName(), "BIGINT");
+  ASSERT_TRUE(BINGTILE()->parameters().empty());
+  ASSERT_EQ(BINGTILE()->toString(), "BINGTILE");
+
+  ASSERT_TRUE(hasType("BINGTILE"));
+  ASSERT_EQ(*getType("BINGTILE", {}), *BINGTILE());
+}
+
+TEST_F(BingTileTypeTest, serde) {
+  testTypeSerde(BINGTILE());
+}
+
+} // namespace facebook::velox::test

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   velox_presto_types_test
+  BingTileTypeTest.cpp
   HyperLogLogTypeTest.cpp
   JsonTypeTest.cpp
   TimestampWithTimeZoneTypeTest.cpp


### PR DESCRIPTION
Summary:
These are the initial definitions of a BingTile type, which
is a custom type represented by a 64-bit integer.  The integer is
morally unsigned, but for Velox we use a signed integer.

Bing Tiles are described in detail here:
https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system

Differential Revision: D69946400


