### PR TITLE
fix(tpch): Properly generate rows for lineitem

### DIFF
--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -103,6 +103,8 @@ class TpchDataSource : public DataSource {
   }
 
  private:
+  bool isLineItem() const;
+
   RowVectorPtr projectOutputColumns(RowVectorPtr vector);
 
   velox::tpch::Table tpchTable_;

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -196,7 +196,14 @@ TEST_F(TpchConnectorTest, lineitemTinyRowCount) {
                   .singleAggregation({}, {"count(1)"})
                   .planNode();
 
-  auto output = getResults(plan, {makeTpchSplit()});
+  std::vector<exec::Split> splits;
+  const size_t numParts = 4;
+
+  for (size_t i = 0; i < numParts; ++i) {
+    splits.push_back(makeTpchSplit(numParts, i));
+  }
+
+  auto output = getResults(plan, std::move(splits));
   EXPECT_EQ(60'175, output->childAt(0)->asFlatVector<int64_t>()->valueAt(0));
 }
 


### PR DESCRIPTION
Summary:
When using dbgen, the number of lineitems generated for each order is
chosen at random. To be able to control rows ids and generate data in parallel
given the definition on splits, lineitem data is generated based on the number
of associated orders, so it needs special handling logic on the reader. Adding
the required logic so that lineitem data can be generated in parallel as
expected.

Differential Revision: D70029685


