### PR TITLE
fix: Fix ambiguous `sources` serde logic for `TableWriteNode` and `TableWriteMergeNode`

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2176,7 +2176,6 @@ void TableWriteNode::addDetails(std::stringstream& stream) const {
 
 folly::dynamic TableWriteNode::serialize() const {
   auto obj = PlanNode::serialize();
-  obj["sources"] = sources_.front()->serialize();
   obj["columns"] = columns_->serialize();
   obj["columnNames"] = ISerializable::serialize(columnNames_);
   if (aggregationNode_ != nullptr) {
@@ -2212,7 +2211,6 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
   auto outputType = deserializeRowType(obj["outputType"]);
   auto commitStrategy =
       connector::stringToCommitStrategy(obj["commitStrategy"].asString());
-  auto source = ISerializable::deserialize<PlanNode>(obj["sources"], context);
   return std::make_shared<TableWriteNode>(
       id,
       columns,
@@ -2223,7 +2221,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       hasPartitioningScheme,
       outputType,
       commitStrategy,
-      source);
+      deserializeSingleSource(obj, context));
 }
 
 void TableWriteMergeNode::addDetails(std::stringstream& /* stream */) const {}
@@ -2232,7 +2230,6 @@ folly::dynamic TableWriteMergeNode::serialize() const {
   auto obj = PlanNode::serialize();
   VELOX_CHECK_EQ(
       sources_.size(), 1, "TableWriteMergeNode can only have one source");
-  obj["sources"] = sources_.front()->serialize();
   if (aggregationNode_ != nullptr) {
     obj["aggregationNode"] = aggregationNode_->serialize();
   }
@@ -2251,9 +2248,8 @@ PlanNodePtr TableWriteMergeNode::create(
     aggregationNode = std::const_pointer_cast<AggregationNode>(
         ISerializable::deserialize<AggregationNode>(obj["aggregationNode"]));
   }
-  auto source = ISerializable::deserialize<PlanNode>(obj["sources"], context);
   return std::make_shared<TableWriteMergeNode>(
-      id, outputType, aggregationNode, source);
+      id, outputType, aggregationNode, deserializeSingleSource(obj, context));
 }
 
 MergeExchangeNode::MergeExchangeNode(


### PR DESCRIPTION
Related to #5553 and #5176

`PlanNode::serialize()` already does serialization for common member variable `sources` in a `PlanNode`. So serialization code 
 like `sources_.front()->serialize()` is not needed.

This is a benign issue in velox's code base itself because `obj["sources"] = sources_.front()->serialize()` will overwrite `obj["sources"] = serializedSources` (in `PlanNode::serialize()`) so nothing wrong from velox's UT. However a user application / a downstream project may need certain JSON field mapping to make serde integration work correctly. For example, [velox4j](https://github.com/velox4j/velox4j) uses the Jackson JSON library which has harder checks for field ambiguities, and it will raise `Conflicting getter definitions for property "sources"` when I was trying to add a `TableWriteNode` because the definition of [PlanNode](https://github.com/velox4j/velox4j/blob/main/src/main/java/io/github/zhztheplayer/velox4j/plan/PlanNode.java#L20-L22) in velox4j has a fixed `sources` JSON getter already.

The patch is a simple fix by just making `TableWriteNode` / `TableWriteMergeNode`'s serde code align with other plan nodes on the field `sources`.