### PR TITLE
build(cmake): Change FetchContent name of `gtest` to `googletest` as `gtest_SOURCE_DIR` is used internally by googletest

### DIFF
--- a/CMake/resolve_dependency_modules/gtest.cmake
+++ b/CMake/resolve_dependency_modules/gtest.cmake
@@ -24,12 +24,12 @@ velox_resolve_dependency_url(GTEST)
 
 message(STATUS "Building gtest from source")
 FetchContent_Declare(
-  gtest
+  googletest
   URL ${VELOX_GTEST_SOURCE_URL}
   URL_HASH ${VELOX_GTEST_BUILD_SHA256_CHECKSUM}
   OVERRIDE_FIND_PACKAGE SYSTEM EXCLUDE_FROM_ALL)
 
-FetchContent_MakeAvailable(gtest)
+FetchContent_MakeAvailable(googletest)
 
 # Mask compilation warning in clang 16.
 target_compile_options(gtest PRIVATE -Wno-implicit-int-float-conversion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -594,7 +594,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
   velox_set_source(GTest)
   velox_resolve_dependency(GTest)
   set(VELOX_GTEST_INCUDE_DIR
-      "${gtest_SOURCE_DIR}/googletest/include"
+      "${gtest_SOURCE_DIR}/include"
       PARENT_SCOPE)
 endif()
 


### PR DESCRIPTION
Project name `gtest` is [used internally](https://github.com/google/googletest/blob/3fbe4db9a39291ae8d7a9c5f1d75896bb4c5a18f/googletest/CMakeLists.txt#L50) for `googletest/googletest` in googletest's source code

Currently Velox imports gtest by `FetchContent_Declare(gtest)`, which means `gtest_SOURCE_DIR` will overwrite the one defined by googletest itself from `googletest/googletest` to `googletest`.

This would lead to weird issues when using bundled googletest. For example in [velox4j](https://github.com/velox4j/velox4j) when importing velox's source code, the following error will be caused:

```
CMake Error: File /opt/velox4j/src/main/cpp/cmake-build-debug/_deps/gtest-src/cmake/Config.cmake.in does not exist.
CMake Error at /opt/cmake/share/cmake-3.29/Modules/CMakePackageConfigHelpers.cmake:482 (configure_file):
  configure_file Problem configuring file
Call Stack (most recent call first):
  cmake-build-debug/_deps/gtest-src/googletest/CMakeLists.txt:106 (configure_package_config_file)
```

The patch fixes the issue by simply changing `FetchContent_Declare(gtest` to `FetchContent_Declare(googletest` so there is no chance that the project names collide.

See also a similar issue: https://github.com/google/googletest/issues/2457.