### PR TITLE
fix: Type JSON not registered in velox_example_simple_functions

### DIFF
--- a/velox/examples/CMakeLists.txt
+++ b/velox/examples/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(velox_example_simple_functions SimpleFunctions.cpp)
 target_link_libraries(
   velox_example_simple_functions
   velox_functions_lib
+  velox_presto_types
   velox_core
   velox_expression
   re2::re2

--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -17,8 +17,8 @@
 #include <re2/re2.h>
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
-#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 
 using namespace facebook::velox;
 

--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/Udf.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/JsonRegistration.h"
 
 using namespace facebook::velox;
 
@@ -617,6 +618,7 @@ struct JsonOutTest {
 };
 
 void register10() {
+  registerJsonType();
   registerFunction<JsonOutTest, Json>({"json_out"});
 }
 } // namespace


### PR DESCRIPTION
Receive signal SIGABRT when running velox_example_simple_functions

```
libc++abi: terminating due to uncaught exception of type facebook::velox::VeloxUserError: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Type doesn't exist: 'JSON'
Retriable: False
Expression: hasType(typeName)
Function: validateBaseTypeAndCollectTypeParams
File: ./velox/expression/FunctionSignature.cpp
Line: 124
Stack trace:
Stack trace has been disabled. Use --velox_exception_user_stacktrace_enabled=true to enable it.

fish: Job 1, './build/velox/examples/velox_ex…' terminated by signal SIGABRT (Abort)
```