### PR TITLE
fix: Llvm-19-exposed -Wmissing-template-arg-list-after-template-kw warning in VectorHasher.h

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -457,7 +457,7 @@ class VectorHasher {
     }
 
     bool inRange = true;
-    rows.template testSelected([&](vector_size_t row) {
+    rows.testSelected([&](vector_size_t row) {
       auto int64Value = toInt64(values[row]);
       if (int64Value > max_ || int64Value < min_) {
         inRange = false;
@@ -671,7 +671,7 @@ inline bool VectorHasher::tryMapToRange(
     const bool* values,
     const SelectivityVector& rows,
     uint64_t* result) {
-  rows.template applyToSelected([&](vector_size_t row) {
+  rows.applyToSelected([&](vector_size_t row) {
     auto hash = valueId(values[row]);
     result[row] = multiplier_ == 1 ? hash : result[row] + multiplier_ * hash;
   });


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/exec/VectorHasher.h:460:19: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  velox/exec/VectorHasher.h:674:17: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

Removing the template keyword is fine, because the compiler can deduce the type of the lambda.

Reviewed By: dmm-fb

Differential Revision: D70046455


