### PR TITLE
fix: Remaining llvm-19-exposed -Wmissing-template-arg-list-after-template-kw warnings

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -203,7 +203,7 @@ void CastExpr::applyToSelectedNoThrowLocal(
     VectorPtr& result,
     Func&& func) {
   if (setNullInResultAtError()) {
-    rows.template applyToSelected([&](auto row) INLINE_LAMBDA {
+    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
       try {
         func(row);
       } catch (const VeloxException& e) {
@@ -216,7 +216,7 @@ void CastExpr::applyToSelectedNoThrowLocal(
       }
     });
   } else {
-    rows.template applyToSelected([&](auto row) INLINE_LAMBDA {
+    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
       try {
         func(row);
       } catch (const VeloxException& e) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -292,7 +292,7 @@ class EvalCtx {
       const SelectivityVector& rows,
       Callable func,
       OnError onErrorFunc) {
-    rows.template applyToSelected([&](auto row) INLINE_LAMBDA {
+    rows.applyToSelected([&](auto row) INLINE_LAMBDA {
       try {
         func(row);
       } catch (const VeloxException& e) {

--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -124,7 +124,7 @@ class DecimalAggregate : public exec::Aggregate {
     if (decodedRaw_.isConstantMapping()) {
       if (!decodedRaw_.isNullAt(0)) {
         auto value = decodedRaw_.valueAt<TInputType>(0);
-        rows.template applyToSelected([&](vector_size_t i) {
+        rows.applyToSelected([&](vector_size_t i) {
           updateNonNullValue(group, TResultType(value));
         });
       }

--- a/velox/functions/lib/aggregates/SimpleNumericAggregate.h
+++ b/velox/functions/lib/aggregates/SimpleNumericAggregate.h
@@ -219,7 +219,7 @@ class SimpleNumericAggregate : public exec::Aggregate {
       if (numSelected != arg->size()) {
         pushdownCustomIndices_.resize(numSelected);
         vector_size_t tgtIndex{0};
-        rows.template applyToSelected([&](vector_size_t i) {
+        rows.applyToSelected([&](vector_size_t i) {
           pushdownCustomIndices_[tgtIndex++] = indices[i];
         });
         indices = pushdownCustomIndices_.data();

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -290,7 +290,7 @@ class SimpleVector : public BaseVector {
     auto rlockedAsciiComputedRows{asciiInfo.readLockedAsciiComputedRows()};
     if (rlockedAsciiComputedRows->hasSelections()) {
       if (rowMappings) {
-        bool isSubset = rows.template testSelected([&](auto row) {
+        bool isSubset = rows.testSelected([&](auto row) {
           return rlockedAsciiComputedRows->isValid(rowMappings[row]);
         });
         return isSubset ? std::optional(asciiInfo.isAllAscii()) : std::nullopt;
@@ -328,7 +328,7 @@ class SimpleVector : public BaseVector {
     }
     ensureIsAsciiCapacity();
     bool isAllAscii = true;
-    rows.template applyToSelected([&](auto row) {
+    rows.applyToSelected([&](auto row) {
       if (!isNullAt(row)) {
         auto string = valueAt(row);
         isAllAscii &=


### PR DESCRIPTION
Summary:
This avoids the following errors and fixes all similar instances with changes induced by running this:
  fbgs -sl 'rows.template '|xargs perl -pi -e 's{rows\.template }{rows.}'

Here are some of the errors:

  velox/expression/CastExpr-inl.h:206:19: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  velox/expression/CastExpr-inl.h:219:19: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

Removing the template keyword is fine, because the compiler can deduce the type of the lambda.

Reviewed By: dtolnay

Differential Revision: D70046654


