### PR TITLE
fix: Remove decl+set of unused variable in PlanNode.cpp

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -932,8 +932,7 @@ void ProjectNode::addSummaryDetails(
 
   for (auto i = 0; i < numFields; ++i) {
     const auto& expr = projections_[i];
-    if (auto* dereference =
-            dynamic_cast<const DereferenceTypedExpr*>(expr.get())) {
+    if (dynamic_cast<const DereferenceTypedExpr*>(expr.get())) {
       dereferences.push_back(i);
     } else {
       auto fae = dynamic_cast<const FieldAccessTypedExpr*>(expr.get());


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/core/PlanNode.cpp:935:15: error: variable 'dereference' set but not used [-Werror,-Wunused-but-set-variable]

Reviewed By: dtolnay

Differential Revision: D70055975


