### PR TITLE
build: FormatFractionOfSecond: suppress a -Wvla-cxx-extension warning

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/lib/DateTimeFormatter.h"
+#include <folly/CPortability.h>
 #include <folly/String.h>
 #include <charconv>
 #include <cstring>
@@ -626,7 +627,10 @@ int64_t parseHalfDayOfDay(const char* cur, const char* end, Date& date) {
 std::string formatFractionOfSecond(
     uint16_t subseconds,
     size_t minRepresentDigits) {
+  FOLLY_PUSH_WARNING
+  FOLLY_GNU_DISABLE_WARNING("-Wvla-cxx-extension")
   char toAdd[minRepresentDigits > 3 ? minRepresentDigits + 1 : 4];
+  FOLLY_POP_WARNING
 
   if (subseconds < 10) {
     toAdd[0] = '0';


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/functions/lib/DateTimeFormatter.cpp:629:14: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]

Reviewed By: dmm-fb

Differential Revision: D70068347


