### PR TITLE
refactor: Have RowDeserializer::deserialize() templated on iterator type

### DIFF
--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -90,7 +90,7 @@ void CompactRowVectorSerde::deserialize(
     const Options* options) {
   std::vector<std::string_view> serializedRows;
   std::vector<std::unique_ptr<std::string>> serializedBuffers;
-  RowDeserializer<std::string_view>::deserialize(
+  RowDeserializer<std::string_view>::deserialize<RowIteratorImpl>(
       source, serializedRows, serializedBuffers, options);
 
   if (serializedRows.empty()) {

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -46,8 +46,8 @@ void UnsafeRowVectorSerde::deserialize(
     const Options* options) {
   std::vector<std::optional<std::string_view>> serializedRows;
   std::vector<std::unique_ptr<std::string>> serializedBuffers;
-  RowDeserializer<std::optional<std::string_view>>::deserialize(
-      source, serializedRows, serializedBuffers, options);
+  RowDeserializer<std::optional<std::string_view>>::deserialize<
+      RowIteratorImpl>(source, serializedRows, serializedBuffers, options);
 
   if (serializedRows.empty()) {
     *result = BaseVector::create<RowVector>(type, 0, pool);


### PR DESCRIPTION
Summary:
This diff does only refactoring
- Have `RowDeserializer::deserialize` templated on a Iterator type. `RowDeserializer::deserialize` will create an iterator of the templated type, and use this iterator to read the input `ByteInputStream*`
- Provide an interface class `SourceIterator`, and it's derived class `UncompressedSourceIterator` providing implementations used for `compactRowSerde` and `UnsafeRowSerde`

Reviewed By: xiaoxmeng

Differential Revision: D69754777


