### PR TITLE
fix(json): Add backslash to unescaped character list

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -262,6 +262,9 @@ int32_t getEscapedChar(std::string_view view, size_t& pos) {
       case 't':
         pos += 2;
         return '\t';
+      case '\\':
+        pos += 2;
+        return '\\';
 
       default:
         // Presto java ignores bad escape sequences.

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -231,6 +231,7 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   EXPECT_EQ(jsonParse(R"(["k1", "v1"])"), R"(["k1","v1"])");
   testJsonParse(R"({ "abc" : "\/"})", R"({"abc":"/"})");
   testJsonParse(R"({ "abc" : "\\/"})", R"({"abc":"\\/"})");
+  testJsonParse("{\"\\\\\":null, \"\\\\\":null}", R"({"\\":null,"\\":null})");
   testJsonParse(R"({ "abc" : [1, 2, 3, 4    ]})", R"({"abc":[1,2,3,4]})");
   // Test out with unicodes and empty keys.
   testJsonParse(


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/issues/12389

Fix json_parse error due to lacking switch case for backslash.

Differential Revision: D70132773


