### PR TITLE
feat: Support array_join(Unknown)

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -200,6 +200,7 @@ int main(int argc, char** argv) {
         "combine_hash_internal",
         "map_keys_by_top_n_values", // requires
                                     // https://github.com/prestodb/presto/pull/24570
+        "array_join", // https://github.com/facebookincubator/velox/issues/12452
     });
 
     referenceQueryRunner = std::make_shared<PrestoQueryRunner>(

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -226,6 +226,10 @@ struct ArrayJoinFunction {
     result += inputValue.toString(options_);
   }
 
+  void writeValue(out_type<velox::Varchar>& result, const UnknownValue& value) {
+    // Do nothing for unknown values.
+  }
+
   template <typename C>
   void writeOutput(
       out_type<velox::Varchar>& result,
@@ -258,21 +262,19 @@ struct ArrayJoinFunction {
     }
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<velox::Varchar>& result,
       const arg_type<velox::Array<T>>& inputArray,
       const arg_type<velox::Varchar>& delim) {
     createOutputString(result, inputArray, delim);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<velox::Varchar>& result,
       const arg_type<velox::Array<T>>& inputArray,
       const arg_type<velox::Varchar>& delim,
       const arg_type<velox::Varchar>& nullReplacement) {
     createOutputString(result, inputArray, delim, nullReplacement.getString());
-    return true;
   }
 
  private:

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -200,6 +200,7 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayJoinFunctions<Timestamp>(prefix);
   registerArrayJoinFunctions<Date>(prefix);
   registerArrayJoinFunctions<Json>(prefix);
+  registerArrayJoinFunctions<UnknownValue>(prefix);
 
   registerFunction<ArrayAverageFunction, double, Array<double>>(
       {prefix + "array_average"});

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -268,4 +268,15 @@ TEST_F(ArrayJoinTest, jsonTest) {
       false,
       true);
 }
+
+TEST_F(ArrayJoinTest, unknownTest) {
+  testArrayJoinNoReplacement<UnknownValue>(
+      {std::nullopt, std::nullopt, std::nullopt}, ","_sv, ""_sv);
+  testArrayJoinReplacement<UnknownValue>(
+      {std::nullopt, std::nullopt, std::nullopt},
+      ","_sv,
+      "apple"_sv,
+      "apple,apple,apple"_sv);
+}
+
 } // namespace


### PR DESCRIPTION
Support array_join(Unknown). 

Note: `array_join()` has already supported json type. The CI/CD test
failed and threw an exception "No default Hive type provided for
unsupported Hive type: json" in Presto fuzzer test. For more detailed
information, please refer to https://github.com/facebookincubator/velox/issues/12452. 
We fix it by adding this function in `skipFunctions` and it will lose 
fuzzer coverage.