### PR TITLE
feat: Support the ability to enforce the max size of a write to spill file

### DIFF
--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -129,6 +129,13 @@ void SpillState::setPartitionSpilled(uint32_t partition) {
   common::incrementGlobalSpilledPartitionStats();
 }
 
+/*static*/
+void SpillState::validateSpillBytesSize(uint64_t bytes) {
+  static constexpr uint64_t kMaxSpillBytesPerWrite =
+      std::numeric_limits<int32_t>::max();
+  VELOX_CHECK_LT(bytes, kMaxSpillBytesPerWrite, "Spill bytes will overflow.");
+}
+
 void SpillState::updateSpilledInputBytes(uint64_t bytes) {
   auto statsLocked = stats_->wlock();
   statsLocked->spilledInputBytes += bytes;
@@ -164,7 +171,9 @@ uint64_t SpillState::appendToPartition(
         stats_);
   }
 
-  updateSpilledInputBytes(rows->estimateFlatSize());
+  const uint64_t bytes = rows->estimateFlatSize();
+  validateSpillBytesSize(bytes);
+  updateSpilledInputBytes(bytes);
 
   IndexRange range{0, rows->size()};
   return partitionWriters_[partition]->write(

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -434,6 +434,13 @@ class SpillState {
   SpillPartitionNumSet testingNonEmptySpilledPartitionSet() const;
 
  private:
+  // Ensures that the bytes to spill is within the limit of
+  // maxSpillBytesPerWrite_ for a given spill write/appendToPartition call.
+  // NOTE: the Presto serializer used for spill serialization can't handle more
+  // than 2GB data size. Hence we can't spill a vector which exceeds
+  // 2GB serialized buffer.
+  void validateSpillBytesSize(uint64_t bytes);
+
   void updateSpilledInputBytes(uint64_t bytes);
 
   SpillWriter* partitionWriter(uint32_t partition) const;


### PR DESCRIPTION
Summary:
In PrestoSQL,  spilling can expose degenerate structures which are over 2GB (int32_t) in size. While being over int32_t does not have intrinsic issues, the Presto wired format requires that the size of the payload be at most 4 bytes. This means that for PrestoSQL case, we cannot spill if the payload is > int32_t.

This PR adds a query config which allows clients to specify the max size on a per write basis. The default will be (1 << 64) - 1, which is the current behavior.

Will follow up on the presto-native PRs for the session properties.

Differential Revision: D70187465


