### PR TITLE
test(fuzzer): Skip MapKeysByTopNValues test

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -198,6 +198,8 @@ int main(int argc, char** argv) {
         "current_date", // Non-deterministic
         "xxhash64_internal",
         "combine_hash_internal",
+        "map_keys_by_top_n_values", // requires
+                                    // https://github.com/prestodb/presto/pull/24570
     });
 
     referenceQueryRunner = std::make_shared<PrestoQueryRunner>(


### PR DESCRIPTION
Summary:
The fuzzer test for map_keys_by_top_n_values should be skipped until the presto array comparison null catch patch is fully released to the public. 

The only failure scenario occurs when the input value is an array with a null element, which is low risk and has already been fixed in this  https://github.com/prestodb/presto/pull/24570. Once the patch is fully rolled out, we can remove the method from the skip list.

Reviewed By: HeidiHan0000

Differential Revision: D70198160


