### PR TITLE
fix(iceberg): Position delete bug while doing upper bound check

### DIFF
--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -251,7 +251,7 @@ void PositionalDeleteFileReader::updateDeleteBitmap(
       static_cast<uint64_t>(deleteBitmapBuffer->size()),
       deletePositionsOffset_ == 0 ||
               (deletePositionsOffset_ < deletePositionsVector->size() &&
-               deletePositions[deletePositionsOffset_] > rowNumberUpperBound)
+               deletePositions[deletePositionsOffset_] >= rowNumberUpperBound)
           ? 0
           : bits::nbytes(
                 deletePositions[deletePositionsOffset_ - 1] + 1 -

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -689,6 +689,10 @@ TEST_F(HiveIcebergTest, positionalDeletesMultipleSplits) {
         {{"data_file_1", makeRandomIncreasingValues(0, 20000)}}}},
       0,
       3);
+
+  // Include only upper bound(which is exclusive) in delete positions for the
+  // second 10k batch of rows.
+  assertMultipleSplits({1000, 9000, 20000}, 1, 0, 20000, 3);
 }
 
 TEST_F(HiveIcebergTest, testPartitionedRead) {


### PR DESCRIPTION
  While updating the bitmap for delete positions, we are including the exclusive upper bound, leading to incorrectly
  setting the buffer size.