### PR TITLE
feat: Add Spark concat(array) function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -100,8 +100,8 @@ Array Functions
     Returns minimum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.
     When E is DOUBLE or REAL, NaN value is considered greater than any non-NaN value. ::
 
-        SELECT array_min(array(1, 2, 3）); -- 1
-        SELECT array_min(array(-1, -2, -2）); -- -2
+        SELECT array_min(array(1, 2, 3)); -- 1
+        SELECT array_min(array(-1, -2, -2)); -- -2
         SELECT array_min(array(-1, -2, NULL)); -- -2
         SELECT array_min(array(NULL, NULL)); -- NULL
         SELECT array_min(array()); -- NULL
@@ -161,9 +161,13 @@ Array Functions
 
 .. spark:function:: concat(array1, array2, ..., arrayN) -> array
 
-    Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. This function provides the same functionality as the SQL-standard concatenation operator (``||``). ::
+    Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. This function provides the same functionality as the SQL-standard concatenation operator (``||``).
+    Fails if the result array size exceeds INT_MAX - 15. ::
 
         SELECT concat(array(1, 2, 3), array(4, 5), array(6)); -- [1, 2, 3, 4, 5, 6]
+        SELECT concat(array(1, 2, 3), null); -- NULL
+        SELECT concat(array(1, 2), array(1, 2), array(1, null)); -- [1, 2, 1, 2, 1, NULL]
+        SELECT concat(array(array(1, 2)), array(array(1, null))); -- [[1, 2], [1, NULL]]
 
 .. spark:function:: exists(array(T), function(T, boolean)) → boolean
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -159,9 +159,9 @@ Array Functions
 
         SELECT arrays_zip(ARRAY[1, 2], ARRAY['1b', null, '3b']); -- [ROW(1, '1b'), ROW(2, null), ROW(null, '3b')]
 
-.. spark:function:: concat(array(E), array(E1), ..., array(En)) -> array(E, E1, ..., En)
+.. spark:function:: concat(array1, array2, ..., arrayN) -> array
 
-    Returns the concatenation of array(E), array(E1), ..., array(En). ::
+    Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. This function provides the same functionality as the SQL-standard concatenation operator (``||``). ::
 
         SELECT concat(array(1, 2, 3), array(4, 5), array(6)); -- [1, 2, 3, 4, 5, 6]
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -161,7 +161,8 @@ Array Functions
 
 .. spark:function:: concat(array1, array2, ..., arrayN) -> array
 
-    Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. This function provides the same functionality as the SQL-standard concatenation operator (``||``).
+    Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. All parameters have the same type.
+    This function provides the same functionality as the SQL-standard concatenation operator (``||``).
     Fails if the result array size exceeds INT_MAX - 15. ::
 
         SELECT concat(array(1, 2, 3), array(4, 5), array(6)); -- [1, 2, 3, 4, 5, 6]

--- a/velox/functions/sparksql/ArrayConcat.h
+++ b/velox/functions/sparksql/ArrayConcat.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// concat(array1, array2, ..., arrayN) → array
+/// Concatenates the arrays array1, array2, ..., arrayN. This function
+/// provides the same functionality as the SQL-standard concatenation
+/// operator (||).
+template <typename TExec, typename T>
+struct ArrayConcatFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec)
+
+  static constexpr int32_t kMaxElements = INT32_MAX - 15;
+
+  void call(
+      out_type<Array<T>>& out,
+      const arg_type<Variadic<Array<T>>>& arrays) {
+    int64_t elementCount = 0;
+    for (const auto& array : arrays) {
+      elementCount += array.value().size();
+    }
+    VELOX_USER_CHECK_LE(
+        elementCount,
+        kMaxElements,
+        "Unsuccessful try to concat arrays with {} elements due to exceeding the array size limit {}.",
+        elementCount,
+        kMaxElements);
+    out.reserve(elementCount);
+    for (const auto& array : arrays) {
+      out.add_items(array.value());
+    }
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/ArrayConcat.h
+++ b/velox/functions/sparksql/ArrayConcat.h
@@ -32,7 +32,7 @@ struct ArrayConcatFunction {
   void call(
       out_type<Array<T>>& out,
       const arg_type<Variadic<Array<T>>>& arrays) {
-    int64_t elementCount = 0;
+    size_t elementCount = 0;
     for (const auto& array : arrays) {
       elementCount += array.value().size();
     }

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/lib/Slice.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
 #include "velox/functions/sparksql/ArrayAppend.h"
+#include "velox/functions/sparksql/ArrayConcat.h"
 #include "velox/functions/sparksql/ArrayFlattenFunction.h"
 #include "velox/functions/sparksql/ArrayInsert.h"
 #include "velox/functions/sparksql/ArrayMinMaxFunction.h"
@@ -47,6 +48,28 @@ void registerSparkArrayFunctions(const std::string& prefix) {
 }
 
 namespace sparksql {
+template <typename T>
+inline void registerArrayConcatFunctions(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<ArrayConcatFunction, T>,
+      Array<T>,
+      Variadic<Array<T>>>({prefix + "concat"});
+}
+
+void registerArrayConcatFunctions(const std::string& prefix) {
+  registerArrayConcatFunctions<int8_t>(prefix);
+  registerArrayConcatFunctions<int16_t>(prefix);
+  registerArrayConcatFunctions<int32_t>(prefix);
+  registerArrayConcatFunctions<int64_t>(prefix);
+  registerArrayConcatFunctions<int128_t>(prefix);
+  registerArrayConcatFunctions<float>(prefix);
+  registerArrayConcatFunctions<double>(prefix);
+  registerArrayConcatFunctions<bool>(prefix);
+  registerArrayConcatFunctions<Varchar>(prefix);
+  registerArrayConcatFunctions<Timestamp>(prefix);
+  registerArrayConcatFunctions<Date>(prefix);
+  registerArrayConcatFunctions<Generic<T1>>(prefix);
+}
 
 inline void registerArrayJoinFunctions(const std::string& prefix) {
   registerFunction<
@@ -110,6 +133,7 @@ inline void registerArrayRemoveFunctions(const std::string& prefix) {
 }
 
 void registerArrayFunctions(const std::string& prefix) {
+  registerArrayConcatFunctions(prefix);
   registerArrayJoinFunctions(prefix);
   registerArrayMinMaxFunctions(prefix);
   registerArrayRemoveFunctions(prefix);

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -49,7 +49,7 @@ void registerSparkArrayFunctions(const std::string& prefix) {
 
 namespace sparksql {
 template <typename T>
-inline void registerArrayConcatFunctions(const std::string& prefix) {
+inline void registerArrayConcatFunction(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayConcatFunction, T>,
       Array<T>,
@@ -57,18 +57,19 @@ inline void registerArrayConcatFunctions(const std::string& prefix) {
 }
 
 void registerArrayConcatFunctions(const std::string& prefix) {
-  registerArrayConcatFunctions<int8_t>(prefix);
-  registerArrayConcatFunctions<int16_t>(prefix);
-  registerArrayConcatFunctions<int32_t>(prefix);
-  registerArrayConcatFunctions<int64_t>(prefix);
-  registerArrayConcatFunctions<int128_t>(prefix);
-  registerArrayConcatFunctions<float>(prefix);
-  registerArrayConcatFunctions<double>(prefix);
-  registerArrayConcatFunctions<bool>(prefix);
-  registerArrayConcatFunctions<Varchar>(prefix);
-  registerArrayConcatFunctions<Timestamp>(prefix);
-  registerArrayConcatFunctions<Date>(prefix);
-  registerArrayConcatFunctions<Generic<T1>>(prefix);
+  registerArrayConcatFunction<int8_t>(prefix);
+  registerArrayConcatFunction<int16_t>(prefix);
+  registerArrayConcatFunction<int32_t>(prefix);
+  registerArrayConcatFunction<int64_t>(prefix);
+  registerArrayConcatFunction<int128_t>(prefix);
+  registerArrayConcatFunction<float>(prefix);
+  registerArrayConcatFunction<double>(prefix);
+  registerArrayConcatFunction<bool>(prefix);
+  registerArrayConcatFunction<Varchar>(prefix);
+  registerArrayConcatFunction<Timestamp>(prefix);
+  registerArrayConcatFunction<Date>(prefix);
+  registerArrayConcatFunction<UnknownValue>(prefix);
+  registerArrayConcatFunction<Generic<T1>>(prefix);
 }
 
 inline void registerArrayJoinFunctions(const std::string& prefix) {

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -65,6 +65,7 @@ void registerArrayConcatFunctions(const std::string& prefix) {
   registerArrayConcatFunction<float>(prefix);
   registerArrayConcatFunction<double>(prefix);
   registerArrayConcatFunction<bool>(prefix);
+  registerArrayConcatFunction<Varbinary>(prefix);
   registerArrayConcatFunction<Varchar>(prefix);
   registerArrayConcatFunction<Timestamp>(prefix);
   registerArrayConcatFunction<Date>(prefix);

--- a/velox/functions/sparksql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayConcatTest.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayConcatTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+/// Concatenate two integer arrays.
+TEST_F(ArrayConcatTest, intArray) {
+  const auto intArray = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
+  const auto emptyArray = makeArrayVector<int64_t>({{9, 8}, {}, {777}, {}});
+  VectorPtr expected;
+
+  expected = makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 9, 8},
+      {3, 4, 5},
+      {7, 8, 9, 777},
+      {10, 20, 30},
+  });
+  testExpression("concat(c0, c1)", {intArray, emptyArray}, expected);
+
+  expected = makeArrayVector<int64_t>({
+      {9, 8, 1, 2, 3, 4},
+      {3, 4, 5},
+      {777, 7, 8, 9},
+      {10, 20, 30},
+  });
+  testExpression("concat(c0, c1)", {emptyArray, intArray}, expected);
+}
+
+/// Concatenate two integer arrays with null.
+TEST_F(ArrayConcatTest, nullArray) {
+  const auto intArray =
+      makeArrayVector<int64_t>({{1, 2, 3, 4}, {7, 8, 9}, {10, 20, 30}});
+  const auto nullArray = makeNullableArrayVector<int64_t>({
+      {{std::nullopt, std::nullopt}},
+      std::nullopt,
+      {{1}},
+  });
+  VectorPtr expected;
+
+  expected = makeNullableArrayVector<int64_t>({
+      {{1, 2, 3, 4, std::nullopt, std::nullopt}},
+      std::nullopt,
+      {{10, 20, 30, 1}},
+  });
+  testExpression("concat(c0, c1)", {intArray, nullArray}, expected);
+
+  expected = makeNullableArrayVector<int64_t>({
+      {{std::nullopt, std::nullopt, 1, 2, 3, 4}},
+      std::nullopt,
+      {{1, 10, 20, 30}},
+  });
+  testExpression("concat(c0, c1)", {nullArray, intArray}, expected);
+}
+
+TEST_F(ArrayConcatTest, arity) {
+  const auto array1 =
+      makeArrayVector<int64_t>({{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}});
+  const auto array2 = makeArrayVector<int64_t>({{9, 8}, {}, {777}});
+  const auto array3 = makeArrayVector<int64_t>({{123, 42}, {55}, {10, 20, 30}});
+  const auto array4 = makeNullableArrayVector<int64_t>({
+      {{std::nullopt, std::nullopt}},
+      std::nullopt,
+      {{std::nullopt, std::nullopt, std::nullopt}},
+  });
+
+  testExpression("concat(c0)", {array1}, array1);
+
+  VectorPtr expected;
+
+  expected = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4, 9, 8, 123, 42}, {3, 4, 5, 55}, {7, 8, 9, 777, 10, 20, 30}});
+  testExpression("concat(c0, c1, c2)", {array1, array2, array3}, expected);
+
+  expected = makeArrayVector<int64_t>(
+      {{123, 42, 9, 8, 1, 2, 3, 4, 9, 8},
+       {55, 3, 4, 5},
+       {10, 20, 30, 777, 7, 8, 9, 777}});
+  testExpression(
+      "concat(c0, c1, c2, c3)", {array3, array2, array1, array2}, expected);
+
+  expected = makeNullableArrayVector<int64_t>(
+      {{{1, 2, 3, 4, std::nullopt, std::nullopt, 123, 42, 9, 8}},
+       std::nullopt,
+       {{7, 8, 9, std::nullopt, std::nullopt, std::nullopt, 10, 20, 30, 777}}});
+  testExpression(
+      "concat(c0, c1, c2, c3)", {array1, array4, array3, array2}, expected);
+}
+
+/// Concatenate complex types.
+TEST_F(ArrayConcatTest, complexTypes) {
+  auto baseVector = makeArrayVector<int64_t>(
+      {{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
+
+  // Create arrays of array vector using above base vector.
+  // [[1, 1], [2, 2]]
+  // [[3, 3], [4, 4]]
+  // [[5, 5], [6, 6]]
+  auto arrayOfArrays1 = makeArrayVector({0, 2, 4}, baseVector);
+  // [[1, 1], [2, 2], [3, 3]]
+  // [[4, 4]]
+  // [[5, 5], [6, 6]]
+  auto arrayOfArrays2 = makeArrayVector({0, 3, 4}, baseVector);
+
+  // [[1, 1], [2, 2], [1, 1], [2, 2], [3, 3]]
+  // [[3, 3], [4, 4], [4, 4]]
+  // [[5, 5], [6, 6], [5, 5], [6, 6]]
+  auto expected = makeArrayVector(
+      {0, 5, 8},
+      makeArrayVector<int64_t>(
+          {{1, 1},
+           {2, 2},
+           {1, 1},
+           {2, 2},
+           {3, 3},
+           {3, 3},
+           {4, 4},
+           {4, 4},
+           {5, 5},
+           {6, 6},
+           {5, 5},
+           {6, 6}}));
+
+  testExpression("concat(c0, c1)", {arrayOfArrays1, arrayOfArrays2}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayConcatTest.cpp
@@ -37,9 +37,8 @@ TEST_F(ArrayConcatTest, intArray) {
   const auto intArray = makeArrayVector<int64_t>(
       {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
   const auto emptyArray = makeArrayVector<int64_t>({{9, 8}, {}, {777}, {}});
-  VectorPtr expected;
 
-  expected = makeArrayVector<int64_t>({
+  VectorPtr expected = makeArrayVector<int64_t>({
       {1, 2, 3, 4, 9, 8},
       {3, 4, 5},
       {7, 8, 9, 777},
@@ -65,9 +64,8 @@ TEST_F(ArrayConcatTest, nullArray) {
       std::nullopt,
       {{1}},
   });
-  VectorPtr expected;
 
-  expected = makeNullableArrayVector<int64_t>({
+  VectorPtr expected = makeNullableArrayVector<int64_t>({
       {{1, 2, 3, 4, std::nullopt, std::nullopt}},
       std::nullopt,
       {{10, 20, 30, 1}},

--- a/velox/functions/sparksql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayConcatTest.cpp
@@ -95,9 +95,7 @@ TEST_F(ArrayConcatTest, arity) {
 
   testExpression("concat(c0)", {array1}, array1);
 
-  VectorPtr expected;
-
-  expected = makeArrayVector<int64_t>(
+  VectorPtr expected = makeArrayVector<int64_t>(
       {{1, 2, 3, 4, 9, 8, 123, 42}, {3, 4, 5, 55}, {7, 8, 9, 777, 10, 20, 30}});
   testExpression("concat(c0, c1, c2)", {array1, array2, array3}, expected);
 

--- a/velox/functions/sparksql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayConcatTest.cpp
@@ -32,7 +32,7 @@ class ArrayConcatTest : public SparkFunctionBaseTest {
   }
 };
 
-/// Concatenate two integer arrays.
+// Concatenate two integer arrays.
 TEST_F(ArrayConcatTest, intArray) {
   const auto intArray = makeArrayVector<int64_t>(
       {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
@@ -56,7 +56,7 @@ TEST_F(ArrayConcatTest, intArray) {
   testExpression("concat(c0, c1)", {emptyArray, intArray}, expected);
 }
 
-/// Concatenate two integer arrays with null.
+// Concatenate two integer arrays with null.
 TEST_F(ArrayConcatTest, nullArray) {
   const auto intArray =
       makeArrayVector<int64_t>({{1, 2, 3, 4}, {7, 8, 9}, {10, 20, 30}});
@@ -116,7 +116,7 @@ TEST_F(ArrayConcatTest, arity) {
       "concat(c0, c1, c2, c3)", {array1, array4, array3, array2}, expected);
 }
 
-/// Concatenate complex types.
+// Concatenate complex types.
 TEST_F(ArrayConcatTest, complexTypes) {
   auto baseVector = makeArrayVector<int64_t>(
       {{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});

--- a/velox/functions/sparksql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayConcatTest.cpp
@@ -153,5 +153,14 @@ TEST_F(ArrayConcatTest, complexTypes) {
   testExpression("concat(c0, c1)", {arrayOfArrays1, arrayOfArrays2}, expected);
 }
 
+TEST_F(ArrayConcatTest, unknown) {
+  const auto array1 = makeArrayVectorFromJson<UnknownValue>({"[null, null]"});
+  const auto array2 = makeArrayVectorFromJson<UnknownValue>({"[null]"});
+
+  const auto expected =
+      makeArrayVectorFromJson<UnknownValue>({"[null, null, null]"});
+  testExpression("concat(c0, c1)", {array1, array2}, expected);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
   ArrayAppendTest.cpp
+  ArrayConcatTest.cpp
   ArrayFlattenTest.cpp
   ArrayGetTest.cpp
   ArrayInsertTest.cpp


### PR DESCRIPTION
Spark code: https://github.com/apache/spark/blob/14c13788b5871ad1454237ae0d90a799f9fb6be6/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L2918
In Spark's implementation, there is no restriction on the number of parameters. 
Instead, it requires the number of result elements to be ≤ Int.MaxValue - 15.
