### PR TITLE
misc: Let VectorStream::children_ use StlAllocator

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -501,6 +501,7 @@ class ByteOutputStream {
   bool isNegated_ = false;
 
   std::vector<ByteRange> ranges_;
+
   // The total number of bytes allocated from 'arena_' in 'ranges_'.
   int64_t allocatedBytes_{0};
 

--- a/velox/serializers/PrestoIterativeVectorSerializer.cpp
+++ b/velox/serializers/PrestoIterativeVectorSerializer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/serializers/PrestoIterativeVectorSerializer.h"
+#include "velox/serializers/PrestoSerializerSerializationUtils.h"
 
 namespace facebook::velox::serializer::presto::detail {
 PrestoIterativeVectorSerializer::PrestoIterativeVectorSerializer(
@@ -24,7 +25,8 @@ PrestoIterativeVectorSerializer::PrestoIterativeVectorSerializer(
     const PrestoVectorSerde::PrestoOptions& opts)
     : opts_(opts),
       streamArena_(streamArena),
-      codec_(common::compressionKindToCodec(opts.compressionKind)) {
+      codec_(common::compressionKindToCodec(opts.compressionKind)),
+      streams_(memory::StlAllocator<VectorStream>(*streamArena->pool())) {
   const auto types = rowType->children();
   const auto numTypes = types.size();
   streams_.reserve(numTypes);

--- a/velox/serializers/PrestoIterativeVectorSerializer.h
+++ b/velox/serializers/PrestoIterativeVectorSerializer.h
@@ -56,7 +56,7 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
   const std::unique_ptr<folly::compression::Codec> codec_;
 
   int32_t numRows_{0};
-  std::vector<VectorStream> streams_;
+  std::vector<VectorStream, memory::StlAllocator<VectorStream>> streams_;
 
   // Count of forthcoming compressions to skip.
   int32_t numCompressionToSkip_{0};

--- a/velox/serializers/VectorStream.cpp
+++ b/velox/serializers/VectorStream.cpp
@@ -16,7 +16,10 @@
 
 #include "velox/serializers/VectorStream.h"
 
+#include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/serializers/PrestoSerializerSerializationUtils.h"
 
 namespace facebook::velox::serializer::presto::detail {
 namespace {
@@ -73,7 +76,8 @@ VectorStream::VectorStream(
       encoding_(getEncoding(encoding, vector)),
       nulls_(streamArena, true, true),
       lengths_(streamArena),
-      values_(streamArena) {
+      values_(streamArena),
+      children_(memory::StlAllocator<VectorStream>(*streamArena->pool())) {
   if (initialNumRows == 0) {
     initializeHeader(typeToEncodingName(type), *streamArena);
     if (type_->size() > 0 && !isIpPrefix_) {

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -17,7 +17,6 @@
 
 #include "velox/common/memory/StreamArena.h"
 #include "velox/serializers/PrestoSerializer.h"
-#include "velox/serializers/PrestoSerializerSerializationUtils.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::serializer::presto::detail {
@@ -216,7 +215,7 @@ class VectorStream {
   ByteOutputStream nulls_;
   ByteOutputStream lengths_;
   ByteOutputStream values_;
-  std::vector<VectorStream> children_;
+  std::vector<VectorStream, memory::StlAllocator<VectorStream>> children_;
   bool isDictionaryStream_{false};
   bool isConstantStream_{false};
 };

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -908,19 +908,19 @@ TEST_P(PrestoSerializerTest, initMemory) {
     ASSERT_EQ(pool_->usedBytes() - poolMemUsage, expectedBytes);
   };
 
-  testFunc(BOOLEAN(), 0);
-  testFunc(TINYINT(), 0);
-  testFunc(SMALLINT(), 0);
-  testFunc(INTEGER(), 0);
-  testFunc(BIGINT(), 0);
-  testFunc(REAL(), 0);
-  testFunc(DOUBLE(), 0);
-  testFunc(VARCHAR(), 0);
-  testFunc(TIMESTAMP(), 0);
+  testFunc(BOOLEAN(), 384);
+  testFunc(TINYINT(), 384);
+  testFunc(SMALLINT(), 384);
+  testFunc(INTEGER(), 384);
+  testFunc(BIGINT(), 384);
+  testFunc(REAL(), 384);
+  testFunc(DOUBLE(), 384);
+  testFunc(VARCHAR(), 384);
+  testFunc(TIMESTAMP(), 384);
   // For nested types, 2 pages allocation quantum for first offset (0).
-  testFunc(ROW({VARCHAR()}), 8192);
-  testFunc(ARRAY(INTEGER()), 8192);
-  testFunc(MAP(VARCHAR(), INTEGER()), 8192);
+  testFunc(ROW({VARCHAR()}), 8960);
+  testFunc(ARRAY(INTEGER()), 8960);
+  testFunc(MAP(VARCHAR(), INTEGER()), 9280);
 }
 
 TEST_P(PrestoSerializerTest, serializeNoRowsSelected) {


### PR DESCRIPTION
Summary: For wide structure (thousands of columns) shuffle, the basic std structures quickly sucks in large amount of memory directly from uncontrolled Jemalloc to cause server OOM crash. Absorb these memory to velox controlled memory to avoid this situation.

Differential Revision: D70130662


