### PR TITLE
build: fix llvm-19-exposed -Wmissing-template-arg-list-after-template-kw warning

### DIFF
--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -90,7 +90,7 @@ struct SimdComparator {
       exec::LocalDecodedVector lhsDecoded(context, lhs, rows);
       exec::LocalDecodedVector rhsDecoded(context, rhs, rows);
 
-      context.template applyToSelectedNoThrow(rows, [&](auto row) {
+      context.applyToSelectedNoThrow(rows, [&](auto row) {
         auto l = lhsDecoded->template valueAt<T>(row);
         auto r = rhsDecoded->template valueAt<T>(row);
         auto filtered = compare(l, r);


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/functions/prestosql/Comparisons.cpp:93:24: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

Removing the template keyword is fine, because the compiler can deduce the type of the lambda.

Reviewed By: dtolnay

Differential Revision: D70226049


