### PR TITLE
refactor: Clean up Registration includes from Presto Type headers

### DIFF
--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -18,9 +18,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/HyperLogLogRegistration.h"
-
 namespace facebook::velox {
 
 class HyperLogLogType : public VarbinaryType {

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -20,9 +20,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/IPAddressRegistration.h"
-
 namespace facebook::velox {
 
 namespace ipaddress {

--- a/velox/functions/prestosql/types/IPPrefixType.h
+++ b/velox/functions/prestosql/types/IPPrefixType.h
@@ -22,9 +22,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/IPPrefixRegistration.h"
-
 namespace facebook::velox {
 
 namespace ipaddress {

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -18,9 +18,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/JsonRegistration.h"
-
 namespace facebook::velox {
 
 /// Represents JSON as a string.

--- a/velox/functions/prestosql/types/TDigestType.h
+++ b/velox/functions/prestosql/types/TDigestType.h
@@ -18,9 +18,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/TDigestRegistration.h"
-
 namespace facebook::velox {
 
 class TDigestType : public VarbinaryType {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -18,9 +18,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.h"
-
 namespace facebook::velox {
 
 using TimeZoneKey = int16_t;

--- a/velox/functions/prestosql/types/UuidType.h
+++ b/velox/functions/prestosql/types/UuidType.h
@@ -18,9 +18,6 @@
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
-// TODO: Remove this once Presto is updated.
-#include "velox/functions/prestosql/types/UuidRegistration.h"
-
 namespace facebook::velox {
 
 /// Represents a UUID (Universally Unique IDentifier), also known as a


### PR DESCRIPTION
Summary:
This is a follow up to https://github.com/facebookincubator/velox/pull/12393

The header files in Presto were fixed in https://github.com/prestodb/presto/pull/24622 so we are
now free to separate the Type and Registration files so that Registration depends on Type and
not the other way around.

Differential Revision: D70275631


