### PR TITLE
fix: Add a patch to fix folly build on arm64 + Linux

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -38,8 +38,10 @@ FetchContent_Declare(
   folly
   URL ${VELOX_FOLLY_SOURCE_URL}
   URL_HASH ${VELOX_FOLLY_BUILD_SHA256_CHECKSUM}
-  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch
-                ${glog_patch} OVERRIDE_FIND_PACKAGE SYSTEM EXCLUDE_FROM_ALL)
+  PATCH_COMMAND
+    git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch && git apply
+    ${CMAKE_CURRENT_LIST_DIR}/folly-fix-aarch64-cmake-build.patch ${glog_patch}
+    OVERRIDE_FIND_PACKAGE SYSTEM EXCLUDE_FROM_ALL)
 
 set(BUILD_SHARED_LIBS ${VELOX_BUILD_SHARED})
 

--- a/CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch
+++ b/CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -85,6 +85,12 @@ else()
+   set(IS_X86_64_ARCH FALSE)
+ endif()
+ 
++if(NOT DEFINED IS_AARCH64_ARCH AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
++  set(IS_AARCH64_ARCH TRUE)
++else()
++  set(IS_AARCH64_ARCH FALSE)
++endif()
++
+ if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+   # Check target architecture
+   if (NOT CMAKE_SIZEOF_VOID_P EQUAL 8)
+@@ -372,6 +378,25 @@ if (IS_X86_64_ARCH AND NOT MSVC)
+   )
+ endif()
+ 
++set(ARM_AOR_ASM_FILES
++  ${FOLLY_DIR}/external/aor/memcpy-advsimd.S
++  ${FOLLY_DIR}/external/aor/memcpy-armv8.S
++  ${FOLLY_DIR}/external/aor/memcpy_sve.S
++  ${FOLLY_DIR}/external/aor/memset-advsimd.S
++)
++if (IS_AARCH64_ARCH)
++  foreach (AOR_FILE IN LISTS ARM_AOR_ASM_FILES)
++    set_property(
++      SOURCE
++      ${AOR_FILE}
++      APPEND PROPERTY COMPILE_OPTIONS "-x" "assembler-with-cpp"
++    )
++    list(APPEND folly_base_files
++      ${AOR_FILE}
++    )
++  endforeach()
++endif()
++
+ add_library(folly_base OBJECT
+   ${folly_base_files}
+   ${CMAKE_CURRENT_BINARY_DIR}/folly/folly-config.h

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -158,6 +158,9 @@ function install_fizz {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
+  # Apply the fix for Linux + ARM64 build.
+  # See issue https://github.com/facebookincubator/velox/issues/12450.
+  apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -186,16 +186,19 @@ function wget_and_untar {
 }
 
 function apply_patch {
-  local PATCH_FILE=$1
+  local PATCH_FILE; PATCH_FILE=$(readlink -f "$1")
   local TARGET_DIR=$2
-  if [ ! -f "${TARGET_DIR}" ]; then
+  if [ ! -f "${PATCH_FILE}" ]; then
     echo "Patch file doesn't exist: $PATCH_FILE"; exit 1;
   fi
+  pushd "${DEPENDENCY_DIR}"
   if [ ! -d "${TARGET_DIR}" ]; then
     echo "Target source directory doesn't exist: $TARGET_DIR"; exit 1;
   fi
-  pushd "$TARGET_DIR"
+  pushd "${TARGET_DIR}"
   git apply "$PATCH_FILE"
+  echo "Successfully applied patch $PATCH_FILE to source of dependency $TARGET_DIR."
+  popd
   popd
 }
 

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -186,7 +186,7 @@ function wget_and_untar {
 }
 
 function apply_patch {
-  local PATCH_FILE; PATCH_FILE=$(readlink -f "$1")
+  local PATCH_FILE; PATCH_FILE="$(realpath "$1")"
   local TARGET_DIR=$2
   if [ ! -f "${PATCH_FILE}" ]; then
     echo "Patch file doesn't exist: $PATCH_FILE"; exit 1;

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -185,6 +185,20 @@ function wget_and_untar {
   popd
 }
 
+function apply_patch {
+  local PATCH_FILE=$1
+  local TARGET_DIR=$2
+  if [ ! -f "${TARGET_DIR}" ]; then
+    echo "Patch file doesn't exist: $PATCH_FILE"; exit 1;
+  fi
+  if [ ! -d "${TARGET_DIR}" ]; then
+    echo "Target source directory doesn't exist: $TARGET_DIR"; exit 1;
+  fi
+  pushd "$TARGET_DIR"
+  git apply "$PATCH_FILE"
+  popd
+}
+
 function cmake_install_dir {
   pushd "${DEPENDENCY_DIR}/$1"
   # remove the directory argument

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -119,7 +119,6 @@ function install_fmt {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
 }
 

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -119,6 +119,7 @@ function install_fmt {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
+  apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
 }
 

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -155,6 +155,8 @@ function install_fizz {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
+  # Apply the fix for Linux + ARM64 build.
+  # See issue https://github.com/facebookincubator/velox/issues/12450.
   apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -155,6 +155,7 @@ function install_fizz {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
+  apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -183,6 +183,9 @@ function install_protobuf {
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
+  # Apply the fix for Linux + ARM64 build.
+  # See issue https://github.com/facebookincubator/velox/issues/12450.
+  apply_patch "${SCRIPTDIR}/../CMake/resolve_dependency_modules/folly/folly-fix-aarch64-cmake-build.patch" folly
   cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
 }
 


### PR DESCRIPTION
Chery-pick [this change](https://github.com/facebook/folly/commit/c30d49dcdc877b38d99b253b8c66ad1853085e09) as a folly patch to fix https://github.com/facebookincubator/velox/issues/12450 (Linux + arm64 build).

This is an alternative solution to https://github.com/facebookincubator/velox/pull/12451.