### PR TITLE
feat: Register Spark sign function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -266,7 +266,7 @@ Mathematical Functions
 
     Returns the secant of ``x``.
 
-.. function:: sign(x) -> double
+.. spark:function:: sign(x) -> double
 
     Returns the signum function of ``x``. It returns:
     * 0.0 if the argument is 0.0,

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -268,7 +268,7 @@ Mathematical Functions
 
 .. spark:function:: sign(x) -> double
 
-    Returns the signum function of ``x``. Supported type for ``x`` is DOUBLE.
+    Returns the signum of ``x``. Supported type for ``x`` is DOUBLE.
     It returns:
     * 0.0 if the argument is 0.0,
     * 1.0 if the argument is greater than 0.0,

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -266,6 +266,16 @@ Mathematical Functions
 
     Returns the secant of ``x``.
 
+.. function:: sign(x) -> double
+
+    Returns the signum function of ``x``. It returns:
+    * 0.0 if the argument is 0.0,
+    * 1.0 if the argument is greater than 0.0,
+    * -1.0 if the argument is less than 0.0,
+    * NaN if the argument is NaN,
+    * 1.0 if the argument is +Infinity,
+    * -1.0 if the argument is -Infinity.
+
 .. spark:function:: sinh(x) -> double
 
     Returns hyperbolic sine of ``x``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -268,7 +268,8 @@ Mathematical Functions
 
 .. spark:function:: sign(x) -> double
 
-    Returns the signum function of ``x``. It returns:
+    Returns the signum function of ``x``. Supported type for ``x`` is DOUBLE.
+    It returns:
     * 0.0 if the argument is 0.0,
     * 1.0 if the argument is greater than 0.0,
     * -1.0 if the argument is less than 0.0,

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -29,6 +29,7 @@ Mathematical Functions
 .. spark:function:: atan2(y, x) -> double
 
     Returns the arc tangent of ``y / x``. For compatibility with Spark, returns 0 for the following corner cases:
+
     * atan2(0.0, 0.0)
     * atan2(-0.0, -0.0)
     * atan2(-0.0, 0.0)
@@ -270,6 +271,7 @@ Mathematical Functions
 
     Returns the signum of ``x``. Supported type for ``x`` is DOUBLE.
     It returns:
+
     * 0.0 if the argument is 0.0,
     * 1.0 if the argument is greater than 0.0,
     * -1.0 if the argument is less than 0.0,

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -96,6 +96,7 @@ void registerMathFunctions(const std::string& prefix) {
       {prefix + "rand", prefix + "random"});
   registerFunction<RandFunction, double, Constant<int64_t>>(
       {prefix + "rand", prefix + "random"});
+  registerFunction<SignFunction, double, double>({prefix + "sign"});
 
   // Operators.
   registerBinaryNumeric<PlusFunction>({prefix + "add"});


### PR DESCRIPTION
Returns -1.0, 0.0 or 1.0 as input is negative, 0 or positive.

Spark's implementation: https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L758