### PR TITLE
fix: Untangle some strange code in `PlanBuilder::finalAggregation()`

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -760,14 +760,10 @@ PlanBuilder& PlanBuilder::finalAggregation() {
   if (!exec::isRawInput(aggNode->step())) {
     // If aggregation node is not the partial aggregation, keep looking again.
     aggNode = findPartialAggregation(aggNode->sources()[0].get());
-    if (!exec::isRawInput(aggNode->step())) {
-      VELOX_CHECK_NOT_NULL(
-          aggNode,
-          "Plan node before current plan node must be a partial aggregation.");
-      VELOX_CHECK(exec::isRawInput(aggNode->step()));
-      VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
-    }
   }
+
+  VELOX_CHECK(exec::isRawInput(aggNode->step()));
+  VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
 
   auto step = core::AggregationNode::Step::kFinal;
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -762,6 +762,7 @@ PlanBuilder& PlanBuilder::finalAggregation() {
     aggNode = findPartialAggregation(aggNode->sources()[0].get());
   }
 
+  VELOX_CHECK_NOT_NULL(aggNode);
   VELOX_CHECK(exec::isRawInput(aggNode->step()));
   VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -760,9 +760,9 @@ PlanBuilder& PlanBuilder::finalAggregation() {
   if (!exec::isRawInput(aggNode->step())) {
     // If aggregation node is not the partial aggregation, keep looking again.
     aggNode = findPartialAggregation(aggNode->sources()[0].get());
+    VELOX_CHECK_NOT_NULL(aggNode);
   }
 
-  VELOX_CHECK_NOT_NULL(aggNode);
   VELOX_CHECK(exec::isRawInput(aggNode->step()));
   VELOX_CHECK(exec::isPartialOutput(aggNode->step()));
 


### PR DESCRIPTION
The problematic code was brought in #1419.

The code block is actually 

```cpp
if (!a) {
  VELOX_CHECK(a);
}
```

which is apparently wrong. The code was intentionally to find an aggregation with `Step::kPartial`. The patch recovers the right 
 readable logic.

