### PR TITLE
feat: Add printPlanWithStats and planFragment APIs for Task

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2435,11 +2435,9 @@ ContinueFuture Task::taskDeletionFuture() {
 }
 
 std::string Task::printPlanWithStats(bool includeCustomStats) const {
-  if (planFragment_.planNode) {
-    return exec::printPlanWithStats(
-        *planFragment_.planNode, taskStats_, includeCustomStats);
-  }
-  return "";
+  VELOX_CHECK_NOT_NULL(planFragment_.planNode, "PlanFragment has no planNode");
+  return exec::printPlanWithStats(
+      *planFragment_.planNode, taskStats_, includeCustomStats);
 }
 
 std::string Task::toString() const {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -30,6 +30,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/TraceUtil.h"
 
@@ -2431,6 +2432,14 @@ ContinueFuture Task::taskDeletionFuture() {
       fmt::format("Task::taskDeletionFuture {}", taskId_));
   taskDeletionPromises_.emplace_back(std::move(promise));
   return std::move(future);
+}
+
+std::string Task::printPlanWithStats(bool includeCustomStats) const {
+  if (planFragment_.planNode) {
+    return exec::printPlanWithStats(
+        *planFragment_.planNode, taskStats_, includeCustomStats);
+  }
+  return "";
 }
 
 std::string Task::toString() const {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -149,9 +149,7 @@ std::unordered_map<core::PlanNodeId, SplitsState> buildSplitStates(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   std::unordered_set<core::PlanNodeId> allIds;
   std::unordered_map<core::PlanNodeId, SplitsState> splitStateMap;
-  if (planNode.get() != nullptr) {
-    buildSplitStates(planNode.get(), allIds, splitStateMap);
-  }
+  buildSplitStates(planNode.get(), allIds, splitStateMap);
   return splitStateMap;
 }
 
@@ -249,6 +247,7 @@ std::shared_ptr<Task> Task::create(
     Consumer consumer,
     int32_t memoryArbitrationPriority,
     std::function<void(std::exception_ptr)> onError) {
+  VELOX_CHECK_NOT_NULL(planFragment.planNode);
   return Task::create(
       taskId,
       std::move(planFragment),
@@ -271,6 +270,7 @@ std::shared_ptr<Task> Task::create(
     ConsumerSupplier consumerSupplier,
     int32_t memoryArbitrationPriority,
     std::function<void(std::exception_ptr)> onError) {
+  VELOX_CHECK_NOT_NULL(planFragment.planNode);
   auto task = std::shared_ptr<Task>(new Task(
       taskId,
       std::move(planFragment),
@@ -2437,7 +2437,6 @@ ContinueFuture Task::taskDeletionFuture() {
 }
 
 std::string Task::printPlanWithStats(bool includeCustomStats) const {
-  VELOX_CHECK_NOT_NULL(planFragment_.planNode, "PlanFragment has no planNode");
   return exec::printPlanWithStats(
       *planFragment_.planNode, taskStats_, includeCustomStats);
 }
@@ -2452,10 +2451,7 @@ std::string Task::toString() const {
     out << "Error: " << errorMessageLocked() << std::endl;
   }
 
-  if (planFragment_.planNode) {
-    out << "Plan:\n"
-        << planFragment_.planNode->toString(true, true) << std::endl;
-  }
+  out << "Plan:\n" << planFragment_.planNode->toString(true, true) << std::endl;
 
   size_t numRemainingDrivers{0};
   for (const auto& driver : drivers_) {
@@ -2531,9 +2527,7 @@ folly::dynamic Task::toJson() const {
     obj["exception"] = errorMessageLocked();
   }
 
-  if (planFragment_.planNode) {
-    obj["plan"] = planFragment_.planNode->toString(true, true);
-  }
+  obj["plan"] = planFragment_.planNode->toString(true, true);
 
   folly::dynamic drivers = folly::dynamic::object;
   for (auto i = 0; i < drivers_.size(); ++i) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -149,7 +149,9 @@ std::unordered_map<core::PlanNodeId, SplitsState> buildSplitStates(
     const std::shared_ptr<const core::PlanNode>& planNode) {
   std::unordered_set<core::PlanNodeId> allIds;
   std::unordered_map<core::PlanNodeId, SplitsState> splitStateMap;
-  buildSplitStates(planNode.get(), allIds, splitStateMap);
+  if (planNode.get() != nullptr) {
+    buildSplitStates(planNode.get(), allIds, splitStateMap);
+  }
   return splitStateMap;
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -116,6 +116,10 @@ class Task : public std::enable_shared_from_this<Task> {
     spillDirectoryCallback_ = std::move(spillDirectoryCallback);
   }
 
+  /// Returns human-friendly representation of the plan augmented with runtime
+  /// statistics. The implementation invokes exec::printPlanWithStats().
+  ///
+  /// @param includeCustomStats If true, prints operator-specific counters.
   std::string printPlanWithStats(bool includeCustomStats = false) const;
 
   std::string toString() const;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -116,6 +116,8 @@ class Task : public std::enable_shared_from_this<Task> {
     spillDirectoryCallback_ = std::move(spillDirectoryCallback);
   }
 
+  std::string printPlanWithStats(bool includeCustomStats = false) const;
+
   std::string toString() const;
 
   folly::dynamic toJson() const;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -138,6 +138,11 @@ class Task : public std::enable_shared_from_this<Task> {
     return taskId_;
   }
 
+  /// Returns plan fragment specified in the constructor.
+  const core::PlanFragment& planFragment() const {
+    return planFragment_;
+  }
+
   const int destination() const {
     return destination_;
   }

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -378,17 +378,6 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
 }
 
 TEST_F(PrintPlanWithStatsTest, taskAPI) {
-  // Test nullptr PlanNode.
-  core::PlanFragment planFragment;
-  auto taskWithNoPlanNode = exec::Task::create(
-      "taskId",
-      planFragment,
-      0,
-      core::QueryCtx::create(),
-      exec::Task::ExecutionMode::kSerial);
-  VELOX_ASSERT_THROW(
-      taskWithNoPlanNode->printPlanWithStats(), "PlanFragment has no planNode");
-
   // Test various task states.
   auto checkOutput = [](exec::Task* task) {
     compareOutputs(
@@ -401,8 +390,8 @@ TEST_F(PrintPlanWithStatsTest, taskAPI) {
   };
 
   const auto data = makeRowVector({
-      makeFlatVector<int64_t>(50, [](auto row) { return row; }),
-      makeFlatVector<int64_t>(50, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(50, folly::identity),
+      makeFlatVector<int64_t>(50, folly::identity),
   });
 
   const auto plan = PlanBuilder()

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -133,7 +133,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
   ensureTaskCompletion(task.get());
   compareOutputs(
       ::testing::UnitTest::GetInstance()->current_test_info()->name(),
-      printPlanWithStats(*op, task->taskStats()),
+      task->printPlanWithStats(),
       {{"-- Project\\[4\\]\\[expressions: \\(c0:INTEGER, ROW\\[\"c0\"\\]\\), \\(p1:BIGINT, plus\\(ROW\\[\"c1\"\\],1\\)\\), \\(p2:BIGINT, plus\\(ROW\\[\"c1\"\\],ROW\\[\"u_c1\"\\]\\)\\)\\] -> c0:INTEGER, p1:BIGINT, p2:BIGINT"},
        {"   Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        {"  -- HashJoin\\[3\\]\\[INNER c0=u_c0\\] -> c0:INTEGER, c1:BIGINT, u_c1:BIGINT"},

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2128,6 +2128,8 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
   // Fail the task to finish test.
   task->requestAbort();
   ASSERT_TRUE(waitForTaskAborted(task.get()));
+  ASSERT_EQ(
+      task->planFragment().planNode->toString(), plan.planNode->toString());
   task.reset();
   waitForAllTasksToBeDeleted();
 }


### PR DESCRIPTION
Client such as Prestissimo create the Task with planNode and access the Task
 at various points. The planNode is not accessible everywhere.
Since the planNode is stored in the Task, it helps to add printPlanWithStats API to Task.