### PR TITLE
feat: Add special form expression optimizations

### DIFF
--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -53,6 +53,9 @@ class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
       std::vector<ExprPtr>&& compiledChildren,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
+
+ private:
+  ExprPtr optimize(std::vector<ExprPtr>& compiledChildren);
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -123,6 +123,10 @@ class ConjunctCallToSpecialForm : public FunctionCallToSpecialForm {
       const core::QueryConfig& config) override;
 
  private:
+  ExprPtr optimizeAnd(std::vector<ExprPtr>& compiledChildren);
+
+  ExprPtr optimizeOr(std::vector<ExprPtr>& compiledChildren);
+
   bool isAnd_;
 };
 

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -86,5 +86,14 @@ class SwitchCallToSpecialForm : public FunctionCallToSpecialForm {
 class IfCallToSpecialForm : public SwitchCallToSpecialForm {
  public:
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+
+ private:
+  ExprPtr optimize(std::vector<ExprPtr>& compiledChildren);
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   SimpleFunctionInitTest.cpp
   SimpleFunctionPresetNullsTest.cpp
   SimpleFunctionTest.cpp
+  SpecialFormExprOptimizationTest.cpp
   StringWriterTest.cpp
   TryExprTest.cpp
   VariadicViewTest.cpp

--- a/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
+++ b/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/FieldReference.h"
 #include "velox/expression/RegisterSpecialForm.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
@@ -52,8 +53,10 @@ TEST_F(FunctionCallToSpecialFormTest, andCall) {
       BOOLEAN(),
       {std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<bool>({true})),
-       std::make_shared<ConstantExpr>(
-           vectorMaker_.constantVector<bool>({false}))},
+       std::make_shared<exec::FieldReference>(
+           BOOLEAN(), std::vector<ExprPtr>{}, "a"),
+       std::make_shared<exec::FieldReference>(
+           BOOLEAN(), std::vector<ExprPtr>{}, "b")},
       false,
       config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
@@ -83,8 +86,12 @@ TEST_F(FunctionCallToSpecialFormTest, coalesceCall) {
   auto specialForm = constructSpecialForm(
       "coalesce",
       INTEGER(),
-      {std::make_shared<ConstantExpr>(
-          vectorMaker_.constantVector<int32_t>({0}))},
+      {std::make_shared<exec::FieldReference>(
+           INTEGER(), std::vector<ExprPtr>{}, "a"),
+       std::make_shared<exec::FieldReference>(
+           INTEGER(), std::vector<ExprPtr>{}, "b"),
+       std::make_shared<ConstantExpr>(
+           vectorMaker_.constantVector<int32_t>({0}))},
       false,
       config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const CoalesceExpr&));
@@ -100,8 +107,8 @@ TEST_F(FunctionCallToSpecialFormTest, ifCall) {
   auto specialForm = constructSpecialForm(
       "if",
       INTEGER(),
-      {std::make_shared<ConstantExpr>(
-           vectorMaker_.constantVector<bool>({true})),
+      {std::make_shared<exec::FieldReference>(
+           BOOLEAN(), std::vector<ExprPtr>{}, "a"),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<int32_t>({0})),
        std::make_shared<ConstantExpr>(
@@ -120,8 +127,10 @@ TEST_F(FunctionCallToSpecialFormTest, orCall) {
   auto specialForm = constructSpecialForm(
       "or",
       BOOLEAN(),
-      {std::make_shared<ConstantExpr>(
-           vectorMaker_.constantVector<bool>({true})),
+      {std::make_shared<exec::FieldReference>(
+           BOOLEAN(), std::vector<ExprPtr>{}, "a"),
+       std::make_shared<exec::FieldReference>(
+           BOOLEAN(), std::vector<ExprPtr>{}, "b"),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<bool>({false}))},
       false,
@@ -216,10 +225,10 @@ TEST_F(FunctionCallToSpecialFormSanitizeNameTest, sanitizeName) {
     auto specialForm = constructSpecialForm(
         name,
         BOOLEAN(),
-        {std::make_shared<ConstantExpr>(
-             vectorMaker_.constantVector<bool>({true})),
-         std::make_shared<ConstantExpr>(
-             vectorMaker_.constantVector<bool>({false}))},
+        {std::make_shared<exec::FieldReference>(
+             BOOLEAN(), std::vector<ExprPtr>{}, "a"),
+         std::make_shared<exec::FieldReference>(
+             BOOLEAN(), std::vector<ExprPtr>{}, "b")},
         false,
         core::QueryConfig{{}});
     ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));

--- a/velox/expression/tests/SpecialFormExprOptimizationTest.cpp
+++ b/velox/expression/tests/SpecialFormExprOptimizationTest.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprCompiler.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/expression/RegisterSpecialForm.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/parse/TypeResolver.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using functions::test::FunctionBaseTest;
+
+class SpecialFormExprOptimizationTest : public FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    parse::registerTypeResolver();
+    exec::registerFunctionCallToSpecialForms();
+    functions::prestosql::registerAllScalarFunctions();
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  const core::QueryConfig config_{{}};
+};
+
+TEST_F(SpecialFormExprOptimizationTest, conjunct) {
+  // true AND false AND a -> false
+  auto compiledExpr =
+      compileExpression("(1 = 1) AND (2 != 2) AND a", ROW({"a"}, {BOOLEAN()}))
+          ->exprs()
+          .front();
+  ASSERT_TRUE(compiledExpr->isConstant());
+  ASSERT_EQ(compiledExpr->type(), BOOLEAN());
+  assertEqualVectors(
+      vectorMaker_.constantVector<bool>({false}),
+      compiledExpr->as<ConstantExpr>()->value());
+
+  // false OR true OR a -> true
+  compiledExpr =
+      compileExpression("(1 != 1) OR (2 = 2) OR a", ROW({"a"}, {BOOLEAN()}))
+          ->exprs()
+          .front();
+  ASSERT_TRUE(compiledExpr->isConstant());
+  ASSERT_TRUE(compiledExpr->type()->isBoolean());
+  assertEqualVectors(
+      vectorMaker_.constantVector<bool>({true}),
+      compiledExpr->as<ConstantExpr>()->value());
+
+  // true AND true AND a -> a
+  auto compiledExprs =
+      compileExpression("(2 != 3) AND (1 = 1) AND a", ROW({"a"}, {BOOLEAN()}))
+          ->exprs();
+  ASSERT_EQ(compiledExprs.size(), 1);
+  compiledExpr = compiledExprs.front();
+  ASSERT_EQ(compiledExpr->name(), "a");
+  ASSERT_EQ(compiledExpr->type(), BOOLEAN());
+
+  // false OR false OR a -> a
+  compiledExprs =
+      compileExpression("(2 = 3) OR (1 != 1) OR a", ROW({"a"}, {BOOLEAN()}))
+          ->exprs();
+  ASSERT_EQ(compiledExprs.size(), 1);
+  compiledExpr = compiledExprs.front();
+  ASSERT_TRUE(compiledExpr->type()->isBoolean());
+  ASSERT_EQ(compiledExpr->name(), "a");
+}
+
+TEST_F(SpecialFormExprOptimizationTest, conditional) {
+  // if(true, a, b) -> a
+  auto compiledExpr =
+      compileExpression(
+          "if((1 = 1), a, b)", ROW({"a", "b"}, {INTEGER(), INTEGER()}))
+          ->exprs()
+          .front();
+  ASSERT_TRUE(compiledExpr->type()->isInteger());
+  ASSERT_EQ(compiledExpr->name(), "a");
+
+  // if(false, a, b) -> b
+  compiledExpr =
+      compileExpression(
+          "if((1 = 2), a, b)", ROW({"a", "b"}, {INTEGER(), INTEGER()}))
+          ->exprs()
+          .front();
+  ASSERT_TRUE(compiledExpr->type()->isInteger());
+  ASSERT_EQ(compiledExpr->name(), "b");
+
+  // coalesce((NULL OR false), (NULL AND true), a) -> a
+  compiledExpr =
+      compileExpression(
+          "coalesce((cast(NULL as BOOLEAN) OR false), (cast(NULL as BOOLEAN) AND true), a)",
+          ROW({"a"}, {BOOLEAN()}))
+          ->exprs()
+          .front();
+  ASSERT_EQ(compiledExpr->inputs().size(), 1);
+  auto input = compiledExpr->inputs().front();
+  ASSERT_TRUE(input->type()->isBoolean());
+  ASSERT_EQ(input->name(), "a");
+
+  // coalesce((NULL OR false), (NULL AND true), a, NULL, b) -> COALESCE(a, b)
+  compiledExpr =
+      compileExpression(
+          "coalesce((cast(NULL as BOOLEAN) OR false), (cast(NULL as BOOLEAN) AND true), a, cast(NULL as BOOLEAN), b)",
+          ROW({"a", "b"}, {BOOLEAN(), BOOLEAN()}))
+          ->exprs()
+          .front();
+  ASSERT_EQ(compiledExpr->inputs().size(), 2);
+  input = compiledExpr->inputs().at(0);
+  ASSERT_TRUE(input->type()->isBoolean());
+  ASSERT_EQ(input->name(), "a");
+  input = compiledExpr->inputs().at(1);
+  ASSERT_TRUE(input->type()->isBoolean());
+  ASSERT_EQ(input->name(), "b");
+}


### PR DESCRIPTION
Optimizes special form expressions `AND`, `IF`, `COALESCE`, and `IF` during compilation. 

When any of the inputs to `AND` conjunct expression is `false` or has been constant folded to `false` during compilation, it will be simplified to `false`. Similarly, the result of `OR` conjunct expression will be simplified to `true` if any of its inputs is `true` or has been constant folded to `true` during compilation. For these cases, the `ConjunctExpr` will be simplified to a `ConstantExpr` during compilation. 
The inputs to conjunct expressions `AND` and `OR` that are or have been constant folded to `true` and `false` respectively will be removed from the expression’s inputs since they will not affect the result. If there is only one input expression left after pruning such redundant inputs, the `ConjunctExpr` will be simplified to this input expression. Pruning inputs will simplify the evaluation of the conjunct expression. 

Any inputs to `COALESCE` that are `NULL` will be removed so they are skipped during expression evaluation. The `COALESCE` expression will also be simplified to the first non `NULL` constant input if all inputs seen before were `NULL`. 
`IF` conditional expression has three inputs: `IF(condition, value1, value2)`. If the condition is or has been constant folded to a boolean value during compilation, the conditional expression will be simplified to `value1` or `value2`.