### PR TITLE
fix: Let HashProbe be able to reclaim in kWaitForPeers state

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -560,6 +560,8 @@ StopReason Driver::runInternal(
         }
 
         withDeltaCpuWallTimer(op, &OperatorStats::isBlockedTiming, [&]() {
+          TestValue::adjust(
+              "facebook::velox::exec::Driver::runInternal::isBlocked", op);
           CALL_OPERATOR(
               blockingReason_ = op->isBlocked(&future),
               op,

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -80,6 +80,10 @@ class HashProbe : public Operator {
     return input_ != nullptr;
   }
 
+  ProbeOperatorState testingState() const {
+    return state_;
+  }
+
  private:
   // Indicates if the join type includes misses from the left side in the
   // output.
@@ -94,6 +98,7 @@ class HashProbe : public Operator {
   void setRunning();
   void checkRunning() const;
   bool isRunning() const;
+  bool isWaitingForPeers() const;
 
   // Invoked to wait for the hash table to be built by the hash build operators
   // asynchronously. The function also sets up the internal state for


### PR DESCRIPTION
Summary: Allow hash probe to be able to spill in state kWaitForPeers.

Differential Revision: D70357799


