### PR TITLE
test: Add InputGenerator for TimestampWithTimeZone

### DIFF
--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
@@ -287,8 +288,9 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
   }
 
   AbstractInputGeneratorPtr getInputGenerator(
-      const InputGeneratorConfig& /*config*/) const override {
-    return nullptr;
+      const InputGeneratorConfig& config) const override {
+    return std::make_shared<fuzzer::TimestampWithTimeZoneInputGenerator>(
+        config.seed_, config.nullRatio_);
   }
 };
 } // namespace

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -11,31 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(
-  velox_presto_types
-  BingTileRegistration.cpp
-  HyperLogLogRegistration.cpp
-  IPAddressRegistration.cpp
-  IPPrefixRegistration.cpp
-  JsonCastOperator.cpp
-  JsonRegistration.cpp
-  TDigestRegistration.cpp
-  TimestampWithTimeZoneRegistration.cpp
-  UuidRegistration.cpp)
+velox_add_library(velox_presto_types_fuzzer_utils
+                  TimestampWithTimeZoneInputGenerator.cpp)
 
 velox_link_libraries(
-  velox_presto_types
+  velox_presto_types_fuzzer_utils
   velox_type
-  velox_memory
-  velox_expression
-  velox_functions_util
-  velox_functions_json
-  velox_functions_lib_date_time_formatter
-  velox_constrained_input_generators
-  velox_presto_types_fuzzer_utils)
+  velox_common_fuzzer_util
+  velox_presto_types
+  velox_type_tz)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
-
-add_subdirectory(fuzzer_utils)

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h"
+
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Variant.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox::fuzzer {
+TimestampWithTimeZoneInputGenerator::TimestampWithTimeZoneInputGenerator(
+    const size_t seed,
+    const double nullRatio)
+    : AbstractInputGenerator(
+          seed,
+          TIMESTAMP_WITH_TIME_ZONE(),
+          nullptr,
+          nullRatio),
+      timeZoneIds_(tz::getTimeZoneIDs()) {}
+
+variant TimestampWithTimeZoneInputGenerator::generate() {
+  if (coinToss(rng_, nullRatio_)) {
+    return variant::null(type_->kind());
+  }
+
+  int16_t timeZoneId =
+      timeZoneIds_[rand<size_t>(rng_, 0, timeZoneIds_.size() - 1)];
+
+  return pack(rand<int64_t>(rng_), timeZoneId);
+}
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::fuzzer {
+class TimestampWithTimeZoneInputGenerator : public AbstractInputGenerator {
+ public:
+  TimestampWithTimeZoneInputGenerator(
+      const size_t seed,
+      const double nullRatio);
+
+  variant generate() override;
+
+ private:
+  const std::vector<int16_t> timeZoneIds_;
+};
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_presto_types_fuzzer_utils_test
+               TimestampWithTimeZoneInputGeneratorTest.cpp)
+
+add_test(velox_presto_types_fuzzer_utils_test
+         velox_presto_types_fuzzer_utils_test)
+
+target_link_libraries(
+  velox_presto_types_fuzzer_utils_test
+  velox_presto_types_fuzzer_utils
+  velox_presto_types
+  velox_type
+  velox_type_tz
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/TimestampWithTimeZoneInputGeneratorTest.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/TimestampWithTimeZoneInputGeneratorTest.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Variant.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox::fuzzer::test {
+
+TEST(TimestampWithTimeZoneInputGeneratorTest, generate) {
+  TimestampWithTimeZoneInputGenerator generator(123456, 0.1);
+
+  size_t numTrials = 100;
+  for (size_t i = 0; i < numTrials; ++i) {
+    variant generated = generator.generate();
+
+    if (generated.isNull()) {
+      continue;
+    }
+
+    generated.checkIsKind(TypeKind::BIGINT);
+    const auto value = generated.value<TypeKind::BIGINT>();
+
+    // The value can be any random int64_t with the one restriction that the
+    // time zone should be valid.
+    auto zoneKey = unpackZoneKeyId(value);
+    EXPECT_NE(tz::locateZone(zoneKey), nullptr);
+  }
+}
+} // namespace facebook::velox::fuzzer::test

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -424,6 +424,21 @@ int16_t getTimeZoneID(int32_t offsetMinutes) {
   }
 }
 
+std::vector<int16_t> getTimeZoneIDs() {
+  const auto& timeZoneDatabase = getTimeZoneDatabase();
+
+  std::vector<int16_t> ids;
+  ids.reserve(timeZoneDatabase.size());
+
+  for (int16_t i = 0; i < timeZoneDatabase.size(); ++i) {
+    if (timeZoneDatabase[i] != nullptr) {
+      ids.push_back(i);
+    }
+  }
+
+  return ids;
+}
+
 TimeZone::seconds TimeZone::to_sys(
     TimeZone::seconds timestamp,
     TimeZone::TChoose choose) const {

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -18,6 +18,7 @@
 
 #include <chrono>
 #include <string>
+#include <vector>
 
 namespace facebook::velox::date {
 class time_zone;
@@ -62,6 +63,9 @@ int16_t getTimeZoneID(std::string_view timeZone, bool failOnError = true);
 /// Returns the timeZoneID for a given offset in minutes. The offset must be in
 /// [-14:00, +14:00] range.
 int16_t getTimeZoneID(int32_t offsetMinutes);
+
+/// Returns all valid time zone IDs.
+std::vector<int16_t> getTimeZoneIDs();
 
 // Validates that the time point can be safely used by the external date
 // library.


### PR DESCRIPTION
Summary:
This diff adds an implementation of AbstractInputGenerator for the TimestampWithTimeZone 
type.  It uses a random int64_t for the number of milliseconds (there may be overflow since we
only have 52 bits for the milliseconds but that doesn't matter since it's random anyway) and
selects a random time zone ID from a list of valid time zone IDs provided by TimeZoneMap.

Differential Revision: D70362561


