### PR TITLE
fix(json): Enhance json extract implementation to conform to jayway

### DIFF
--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -73,7 +73,12 @@ class JsonExtractor {
 
     while (kTokenizer.hasNext()) {
       if (auto token = kTokenizer.getNext()) {
-        tokens_.emplace_back(token.value());
+        auto& tk = token.value();
+        if (tk.selector == JsonPathTokenizer::Selector::WILDCARD) {
+          tokens_.emplace_back("*");
+        } else {
+          tokens_.emplace_back(tk.value);
+        }
       } else {
         tokens_.clear();
         return false;

--- a/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
@@ -20,9 +20,10 @@
 #include "gtest/gtest.h"
 
 using namespace std::string_literals;
-using TokenList = std::vector<std::string>;
 
 namespace facebook::velox::functions {
+using Selector = JsonPathTokenizer::Selector;
+using TokenList = std::vector<JsonPathTokenizer::Token>;
 namespace {
 
 std::optional<TokenList> getTokens(std::string_view path) {
@@ -51,8 +52,13 @@ void assertValidPath(std::string_view path, const TokenList& expectedTokens) {
   if (!tokens.has_value()) {
     return;
   }
-
-  EXPECT_EQ(expectedTokens, tokens.value());
+  EXPECT_EQ(expectedTokens.size(), tokens.value().size());
+  for (auto i = 0; i < expectedTokens.size(); ++i) {
+    EXPECT_EQ(expectedTokens[i], tokens.value()[i])
+        << "Tokens mismatch at " << i << ": Expected "
+        << expectedTokens[i].toString() << ", got "
+        << tokens.value()[i].toString() << " for path " << path;
+  }
 }
 
 void assertQuotedToken(
@@ -62,66 +68,329 @@ void assertQuotedToken(
   assertValidPath(quotedPath, expectedTokens);
 
   auto invalidPath = "$." + token;
-  EXPECT_FALSE(getTokens(invalidPath));
+  EXPECT_FALSE(getTokens(invalidPath))
+      << "Expected no tokens for path: " << invalidPath;
 }
 
 // The test is ported from Presto for compatibility.
 TEST(JsonPathTokenizerTest, validPaths) {
   assertValidPath("$"s, TokenList());
-  assertValidPath("$.foo"s, TokenList{"foo"s});
-  assertValidPath("$[\"foo\"]"s, TokenList{"foo"s});
-  assertValidPath("$[\"foo.bar\"]"s, TokenList{"foo.bar"s});
-  assertValidPath("$[42]"s, TokenList{"42"s});
-  assertValidPath("$[-1]"s, TokenList{"-1"s});
-  assertValidPath("$.42"s, TokenList{"42"s});
-  assertValidPath("$.42.63"s, TokenList{"42"s, "63"s});
-  assertValidPath("$.foo.42.bar.63"s, TokenList{"foo"s, "42"s, "bar"s, "63"s});
-  assertValidPath("$.x.foo"s, TokenList{"x"s, "foo"s});
-  assertValidPath("$.x[\"foo\"]"s, TokenList{"x"s, "foo"s});
-  assertValidPath("$.x[42]"s, TokenList{"x"s, "42"s});
-  assertValidPath("$.foo_42._bar63"s, TokenList{"foo_42"s, "_bar63"s});
-  assertValidPath("$[foo_42][_bar63]"s, TokenList{"foo_42"s, "_bar63"s});
-  assertValidPath("$.foo:42.:bar63"s, TokenList{"foo:42"s, ":bar63"s});
+  assertValidPath("$.foo"s, TokenList{{"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath("$[\"foo\"]"s, TokenList{{"foo", Selector::KEY}});
+  assertValidPath("$[\"foo.bar\"]"s, TokenList{{"foo.bar", Selector::KEY}});
+  assertValidPath("$[42]"s, TokenList{{"42", Selector::KEY_OR_INDEX}});
+  assertValidPath("$[-1]"s, TokenList{{"-1", Selector::KEY_OR_INDEX}});
+  assertValidPath("$.42"s, TokenList{{"42", Selector::KEY_OR_INDEX}});
   assertValidPath(
-      "$[\"foo:42\"][\":bar63\"]"s, TokenList{"foo:42"s, ":bar63"s});
-  assertValidPath("$['foo:42'][':bar63']"s, TokenList{"foo:42"s, ":bar63"s});
+      "$.42.63"s,
+      TokenList{
+          {"42", Selector::KEY_OR_INDEX}, {"63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo.42.bar.63"s,
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"42", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.x.foo"s,
+      TokenList{
+          {"x", Selector::KEY_OR_INDEX}, {"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.x[\"foo\"]"s,
+      TokenList{{"x", Selector::KEY_OR_INDEX}, {"foo", Selector::KEY}});
+  assertValidPath(
+      "$.x[42]"s,
+      TokenList{{"x", Selector::KEY_OR_INDEX}, {"42", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo_42._bar63"s,
+      TokenList{
+          {"foo_42", Selector::KEY_OR_INDEX},
+          {"_bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[foo_42][_bar63]"s,
+      TokenList{
+          {"foo_42", Selector::KEY_OR_INDEX},
+          {"_bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo:42.:bar63"s,
+      TokenList{
+          {"foo:42", Selector::KEY_OR_INDEX},
+          {":bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[\"foo:42\"][\":bar63\"]"s,
+      TokenList{{"foo:42", Selector::KEY}, {":bar63", Selector::KEY}});
+  assertValidPath(
+      "$['foo:42'][':bar63']"s,
+      TokenList{{"foo:42", Selector::KEY}, {":bar63", Selector::KEY}});
   assertValidPath(
       "$.store.fruit[*].weight",
-      TokenList{"store"s, "fruit"s, "*"s, "weight"s});
+      TokenList{
+          {"store", Selector::KEY_OR_INDEX},
+          {"fruit", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"weight", Selector::KEY_OR_INDEX}});
   assertValidPath(
-      "$.store.book[*].author", TokenList{"store", "book", "*", "author"});
-  assertValidPath("$.store.*", TokenList({"store", "*"}));
+      "$.store.fruit.[*].weight",
+      TokenList{
+          {"store", Selector::KEY_OR_INDEX},
+          {"fruit", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"weight", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.store.*",
+      TokenList{{"store", Selector::KEY_OR_INDEX}, {"", Selector::WILDCARD}});
 
   // Paths without leading '$'.
-  assertValidPath("foo", TokenList({"foo"}));
-  assertValidPath("foo[12].bar", TokenList({"foo", "12", "bar"}));
-  assertValidPath("foo.bar.baz", TokenList({"foo", "bar", "baz"}));
-  assertValidPath(R"(["foo"])", TokenList({"foo"}));
-  assertValidPath(R"(["foo"].bar)", TokenList({"foo", "bar"}));
-  assertValidPath(R"([0][1].foo)", TokenList({"0", "1", "foo"}));
+  assertValidPath("foo", TokenList{{"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "foo[12].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"12", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "foo.bar.baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"baz", Selector::KEY_OR_INDEX}});
+  assertValidPath(R"(["foo"])", TokenList{{"foo", Selector::KEY}});
+  assertValidPath(
+      R"(["foo"].bar)",
+      TokenList{{"foo", Selector::KEY}, {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      R"([0][1].foo)",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX}});
 
   // Paths with redundant '.'s.
-  assertValidPath("$.[0].[1].[2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$[0].[1].[2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$[0].[1][2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$.[0].[1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
-  assertValidPath("$[0].[1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
-  assertValidPath("$[0][1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
+  assertValidPath(
+      "$.[0].[1].[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1].[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1][2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.[0].[1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0][1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
 
-  assertQuotedToken("!@#$%^&*()[]{}/?'"s, TokenList{"!@#$%^&*()[]{}/?'"s});
-  assertQuotedToken("ab\u0001c"s, TokenList{"ab\u0001c"s});
-  assertQuotedToken("ab\0c"s, TokenList{"ab\0c"s});
-  assertQuotedToken("ab\t\n\rc"s, TokenList{"ab\t\n\rc"s});
-  assertQuotedToken("."s, TokenList{"."s});
-  assertQuotedToken("$"s, TokenList{"$"s});
-  assertQuotedToken("]"s, TokenList{"]"s});
-  assertQuotedToken("["s, TokenList{"["s});
-  assertQuotedToken("'"s, TokenList{"'"s});
+  // * as an identifier or wildcard operator.
+  assertValidPath(
+      "$[*]",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.[*]",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.*",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$['*']",
+      TokenList{
+          {"*", Selector::KEY},
+      });
+  assertValidPath(
+      "$[*a]",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.[*a]",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.*a",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$['*a']",
+      TokenList{
+          {"*a", Selector::KEY},
+      });
+  assertValidPath(
+      "$[a*a]",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.[a*a]",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.a*a",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$['a*a']",
+      TokenList{
+          {"a*a", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo[*]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.foo[*].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+
+  // String after dot operator.
+  assertValidPath(
+      "$.$",
+      TokenList{
+          {"$", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.@",
+      TokenList{
+          {"@", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.'abc'",
+      TokenList{
+          {"'abc'", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.\"abc\"",
+      TokenList{
+          {"\"abc\"", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.:",
+      TokenList{
+          {":", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.,",
+      TokenList{
+          {",", Selector::KEY_OR_INDEX},
+      });
+
+  // Whitespaces between identifiers and brackets like $.[  1   ].
+  assertValidPath(
+      "$.foo[  1   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[1   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[  1].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo[  'bar'   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo['bar'   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo[  'bar'].baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+          {"baz", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo[  bar   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[bar   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[  bar].baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"baz", Selector::KEY_OR_INDEX}});
+
+  // Using @ instead of $ at the beginning of the path.
+  assertValidPath(
+      "@.foo",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+      });
+
+  assertQuotedToken(
+      "!@#$%^&*()[]{}/?'"s, TokenList{{"!@#$%^&*()[]{}/?'"s, Selector::KEY}});
+  assertQuotedToken("ab\u0001c"s, TokenList{{"ab\u0001c"s, Selector::KEY}});
+  assertQuotedToken("ab\0c"s, TokenList{{"ab\0c"s, Selector::KEY}});
+  assertQuotedToken("ab\t\n\rc"s, TokenList{{"ab\t\n\rc"s, Selector::KEY}});
+  assertQuotedToken("."s, TokenList{{"."s, Selector::KEY}});
+  assertQuotedToken("]"s, TokenList{{"]"s, Selector::KEY}});
+  assertQuotedToken("["s, TokenList{{"["s, Selector::KEY}});
   assertQuotedToken(
       "!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s,
-      TokenList{"!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s});
-  assertQuotedToken("a\\\\b\\\""s, TokenList{"a\\b\""s});
-  assertQuotedToken("ab\\\"cd\\\"ef"s, TokenList{"ab\"cd\"ef"s});
+      TokenList{{"!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s, Selector::KEY}});
+  assertQuotedToken("a\\\\b\\\""s, TokenList{{"a\\b\""s, Selector::KEY}});
+  assertQuotedToken(
+      "ab\\\"cd\\\"ef"s, TokenList{{"ab\"cd\"ef"s, Selector::KEY}});
 }
 
 TEST(JsonPathTokenizerTest, invalidPaths) {
@@ -145,15 +414,41 @@ TEST(JsonPathTokenizerTest, invalidPaths) {
   // Unmatched single quote.
   EXPECT_FALSE(getTokens(R"($['foo"])"));
 
+  // Whitespace in after dot operator.
+  EXPECT_FALSE(getTokens("$. foo"s));
+  EXPECT_FALSE(getTokens("$. 1"s));
+
+  // Unicode characters after dot operator.
+  EXPECT_FALSE(getTokens("$.[屬性]"));
+
   // Unsupported deep scan operator.
   EXPECT_FALSE(getTokens("$..store"));
   EXPECT_FALSE(getTokens("..store"));
   EXPECT_FALSE(getTokens("$..[3].foo"));
   EXPECT_FALSE(getTokens("..[3].foo"));
 
-  // Paths without leading '$'.
+  // Paths without leading '$' which essentially translates to "$.." and is
+  // unsupported.
   EXPECT_FALSE(getTokens(".[1].foo"));
   EXPECT_FALSE(getTokens(".foo.bar.baz"));
+
+  // Array Slice
+  EXPECT_FALSE(getTokens("$[1:3]"));
+  EXPECT_FALSE(getTokens("$[0:4:2]"));
+  EXPECT_FALSE(getTokens("$[1:3:]"));
+  EXPECT_FALSE(getTokens("$[::2]"));
+
+  // Union
+  EXPECT_FALSE(getTokens("$[0,1]"));
+  EXPECT_FALSE(getTokens("$['a','a']"));
+  EXPECT_FALSE(getTokens("$.*['c','d']"));
+
+  // Filter Expr
+  EXPECT_FALSE(getTokens("$[?(@.key)]"));
+  EXPECT_FALSE(getTokens("$[?(@.key>0 && false)]"));
+
+  // Script expression
+  EXPECT_FALSE(getTokens("$[(@.length-1)]"));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
This change modifies the JSON extract mechanism, including the parser and the extractor,
to align with Jayway semantics. However, in cases where Jayway's behavior changes due
to edge cases, we prioritize consistency in Velox, making it more permissive and predictable.
These special cases are documented in the JsonPathTokenizer method comments.

A summary of the changes include:
- Adding the concept of selector types
- Handling whitespace within brackets
- Updating allowed characters after dot notation
- Partial support for '@' character
- Adding extensive unit test cases
- Documenting differences in path interpretation between jayway and velox

Differential Revision: D70365790


