### PR TITLE
fix: Disable dynamic filter push-down for Hive tables that do not support it

### DIFF
--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/ScaledScanController.h"
@@ -45,7 +46,15 @@ class TableScan : public SourceOperator {
   void close() override;
 
   bool canAddDynamicFilter() const override {
-    return connector_->canAddDynamicFilter();
+    std::shared_ptr<connector::hive::HiveTableHandle> hiveTableHandle_ =
+        std::dynamic_pointer_cast<connector::hive::HiveTableHandle>(
+            tableHandle_);
+    if (hiveTableHandle_ == nullptr) {
+      return connector_->canAddDynamicFilter();
+    } else {
+      return connector_->canAddDynamicFilter() &&
+          hiveTableHandle_->isFilterPushdownEnabled();
+    }
   }
 
   void addDynamicFilter(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -114,7 +114,8 @@ PlanBuilder& PlanBuilder::tableScan(
     const RowTypePtr& dataColumns,
     const std::unordered_map<
         std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
+        std::shared_ptr<connector::ColumnHandle>>& assignments,
+    bool filterPushdown) {
   return TableScanBuilder(*this)
       .outputType(outputType)
       .assignments(assignments)
@@ -122,6 +123,7 @@ PlanBuilder& PlanBuilder::tableScan(
       .remainingFilter(remainingFilter)
       .dataColumns(dataColumns)
       .assignments(assignments)
+      .filterPushdown(filterPushdown)
       .endTableScan();
 }
 
@@ -134,7 +136,8 @@ PlanBuilder& PlanBuilder::tableScan(
     const RowTypePtr& dataColumns,
     const std::unordered_map<
         std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
+        std::shared_ptr<connector::ColumnHandle>>& assignments,
+    bool filterPushdown) {
   return TableScanBuilder(*this)
       .tableName(tableName)
       .outputType(outputType)
@@ -143,6 +146,7 @@ PlanBuilder& PlanBuilder::tableScan(
       .remainingFilter(remainingFilter)
       .dataColumns(dataColumns)
       .assignments(assignments)
+      .filterPushdown(filterPushdown)
       .endTableScan();
 }
 
@@ -258,7 +262,7 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
     tableHandle_ = std::make_shared<HiveTableHandle>(
         connectorId_,
         tableName_,
-        true,
+        filterPushdown_,
         std::move(filters),
         remainingFilterExpr,
         dataColumns_);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -138,7 +138,8 @@ class PlanBuilder {
       const RowTypePtr& dataColumns = nullptr,
       const std::unordered_map<
           std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+          std::shared_ptr<connector::ColumnHandle>>& assignments = {},
+      bool filterPushdown = true);
 
   /// Add a TableScanNode to scan a Hive table.
   ///
@@ -170,7 +171,8 @@ class PlanBuilder {
       const RowTypePtr& dataColumns = nullptr,
       const std::unordered_map<
           std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+          std::shared_ptr<connector::ColumnHandle>>& assignments = {},
+      bool filterPushdown = true);
 
   /// Add a TableScanNode to scan a TPC-H table.
   ///
@@ -279,6 +281,11 @@ class PlanBuilder {
       return *this;
     }
 
+    TableScanBuilder& filterPushdown(bool filterPushdown) {
+      filterPushdown_ = filterPushdown;
+      return *this;
+    }
+
     /// Stop the TableScanBuilder.
     PlanBuilder& endTableScan() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -300,6 +307,7 @@ class PlanBuilder {
     std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
     std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
         assignments_;
+    bool filterPushdown_{true};
   };
 
   /// Start a TableScanBuilder.


### PR DESCRIPTION
`TableScan#canAddDynamicFilter` always returns true for Hive table regardless of whether the format reader supports this feature. If the filters are pushed down to a format reader that does not support filter push-down, they would not be applied to any rows. While all hive format readers in Velox currently support this feature, this case could happen in the future.

Relates: [gluten#issue](https://github.com/apache/incubator-gluten/issues/8787#issuecomment-2674100600)