### PR TITLE
misc: Enable global arbitration by default in code

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -194,7 +194,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     /// memory pools.
     static constexpr std::string_view kGlobalArbitrationEnabled{
         "global-arbitration-enabled"};
-    static constexpr bool kDefaultGlobalArbitrationEnabled{false};
+    static constexpr bool kDefaultGlobalArbitrationEnabled{true};
     static bool globalArbitrationEnabled(
         const std::unordered_map<std::string, std::string>& configs);
 


### PR DESCRIPTION
Summary: Enable global arbitration by default in code after running in prod for a while

Differential Revision: D70370862


