### PR TITLE
fix: Force use index-based column mapping for old ORC file

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -797,7 +797,8 @@ DwrfReader::DwrfReader(
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping()) &&
+  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping() ||
+       readerBase_->isOldSchema()) &&
       (readerBase_->readerOptions().fileSchema() != nullptr)) {
     updateColumnNamesFromTableSchema();
   }

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -146,6 +146,15 @@ class ReaderBase {
     return schemaWithId_;
   }
 
+  // An ORC file written by an old version of Hive has no field names in the
+  // physical schema.
+  const bool isOldSchema() const {
+    return std::all_of(
+        schema_->names().begin(),
+        schema_->names().end(),
+        [](const std::string& name) { return name.find("_col") == 0; });
+  }
+
   dwio::common::BufferedInput& bufferedInput() const {
     return *input_;
   }


### PR DESCRIPTION
An ORC file written by an old version has no field names in the physical schema, always map column names by index.