### PR TITLE
feat: Support ORC indices columns name mapping behavior in Spark

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -93,7 +93,8 @@ bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
 }
 
-bool HiveConfig::isOrcUseNestedColumnNames(const config::ConfigBase* session) const {
+bool HiveConfig::isOrcUseNestedColumnNames(
+    const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcUseNestedColumnNamesSession,
       config_->get<bool>(kOrcUseNestedColumnNames, false));

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -93,6 +93,10 @@ bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
 }
 
+bool HiveConfig::isOrcUseNestedColumnNames() const {
+  return config_->get<bool>(kOrcUseNestedColumnNames, false);
+}
+
 bool HiveConfig::isParquetUseColumnNames(
     const config::ConfigBase* session) const {
   return session->get<bool>(

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -93,8 +93,10 @@ bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
 }
 
-bool HiveConfig::isOrcUseNestedColumnNames() const {
-  return config_->get<bool>(kOrcUseNestedColumnNames, false);
+bool HiveConfig::isOrcUseNestedColumnNames(const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kOrcUseNestedColumnNamesSession,
+      config_->get<bool>(kOrcUseNestedColumnNames, false));
 }
 
 bool HiveConfig::isParquetUseColumnNames(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -74,7 +74,7 @@ class HiveConfig {
   static constexpr const char* kOrcUseColumnNamesSession =
       "hive_orc_use_column_names";
 
-  /// Maps nested column using names if kOrcUseColumnNames disabled.
+  /// Maps nested field using names. And map top-level field using indices.
   static constexpr const char* kOrcUseNestedColumnNames =
       "hive.orc.use-nested-column-names";
   static constexpr const char* kOrcUseNestedColumnNamesSession =

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -68,11 +68,12 @@ class HiveConfig {
   static constexpr const char* kGcsMaxRetryTime = "hive.gcs.max-retry-time";
 
   /// Maps table field names to file field names using names, not indices.
-  // TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
-  // right now this is only used for testing.
   static constexpr const char* kOrcUseColumnNames = "hive.orc.use-column-names";
   static constexpr const char* kOrcUseColumnNamesSession =
       "hive_orc_use_column_names";
+
+  /// Always maps nested column using names even if kOrcUseColumnNames disabled.
+  static constexpr const char* kOrcUseNestedColumnNames = "hive.orc.use-nested-column-names";
 
   /// Maps table field names to file field names using names, not indices.
   static constexpr const char* kParquetUseColumnNames =
@@ -199,6 +200,8 @@ class HiveConfig {
   std::optional<std::string> gcsMaxRetryTime() const;
 
   bool isOrcUseColumnNames(const config::ConfigBase* session) const;
+
+  bool isOrcUseNestedColumnNames() const;
 
   bool isParquetUseColumnNames(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -68,6 +68,8 @@ class HiveConfig {
   static constexpr const char* kGcsMaxRetryTime = "hive.gcs.max-retry-time";
 
   /// Maps table field names to file field names using names, not indices.
+  // TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
+  // right now this is only used for testing.
   static constexpr const char* kOrcUseColumnNames = "hive.orc.use-column-names";
   static constexpr const char* kOrcUseColumnNamesSession =
       "hive_orc_use_column_names";

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -73,7 +73,8 @@ class HiveConfig {
       "hive_orc_use_column_names";
 
   /// Always maps nested column using names even if kOrcUseColumnNames disabled.
-  static constexpr const char* kOrcUseNestedColumnNames = "hive.orc.use-nested-column-names";
+  static constexpr const char* kOrcUseNestedColumnNames =
+      "hive.orc.use-nested-column-names";
 
   /// Maps table field names to file field names using names, not indices.
   static constexpr const char* kParquetUseColumnNames =

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -74,8 +74,10 @@ class HiveConfig {
   static constexpr const char* kOrcUseColumnNamesSession =
       "hive_orc_use_column_names";
 
-  /// Always maps nested column using names even if kOrcUseColumnNames disabled.
+  /// Maps nested column using names if kOrcUseColumnNames disabled.
   static constexpr const char* kOrcUseNestedColumnNames =
+      "hive.orc.use-nested-column-names";
+  static constexpr const char* kOrcUseNestedColumnNamesSession =
       "hive.orc.use-nested-column-names";
 
   /// Maps table field names to file field names using names, not indices.
@@ -204,7 +206,7 @@ class HiveConfig {
 
   bool isOrcUseColumnNames(const config::ConfigBase* session) const;
 
-  bool isOrcUseNestedColumnNames() const;
+  bool isOrcUseNestedColumnNames(const config::ConfigBase* session) const;
 
   bool isParquetUseColumnNames(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -567,7 +567,8 @@ void configureReaderOptions(
         useColumnNamesForColumnMapping = false;
       }
 
-      readerOptions.setUseNestedColumnNamesForColumnMapping(hiveConfig->isOrcUseNestedColumnNames());
+      readerOptions.setUseNestedColumnNamesForColumnMapping(
+          hiveConfig->isOrcUseNestedColumnNames());
       break;
     }
     case dwio::common::FileFormat::PARQUET: {

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -566,6 +566,8 @@ void configureReaderOptions(
           folly::to<bool>(forcePositionalIt->second)) {
         useColumnNamesForColumnMapping = false;
       }
+
+      readerOptions.setUseNestedColumnNamesForColumnMapping(hiveConfig->isOrcUseNestedColumnNames());
       break;
     }
     case dwio::common::FileFormat::PARQUET: {

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -560,6 +560,12 @@ void configureReaderOptions(
     case dwio::common::FileFormat::ORC: {
       useColumnNamesForColumnMapping =
           hiveConfig->isOrcUseColumnNames(sessionProperties);
+
+      auto forcePositionalIt = tableParameters.find("force_positional");
+      if (forcePositionalIt != tableParameters.end() &&
+          folly::to<bool>(forcePositionalIt->second)) {
+        useColumnNamesForColumnMapping = false;
+      }
       break;
     }
     case dwio::common::FileFormat::PARQUET: {

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -560,13 +560,6 @@ void configureReaderOptions(
     case dwio::common::FileFormat::ORC: {
       useColumnNamesForColumnMapping =
           hiveConfig->isOrcUseColumnNames(sessionProperties);
-
-      auto forcePositionalIt = tableParameters.find("force_positional");
-      if (forcePositionalIt != tableParameters.end() &&
-          folly::to<bool>(forcePositionalIt->second)) {
-        useColumnNamesForColumnMapping = false;
-      }
-
       readerOptions.setUseNestedColumnNamesForColumnMapping(
           hiveConfig->isOrcUseNestedColumnNames());
       break;

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -561,7 +561,7 @@ void configureReaderOptions(
       useColumnNamesForColumnMapping =
           hiveConfig->isOrcUseColumnNames(sessionProperties);
       readerOptions.setUseNestedColumnNamesForColumnMapping(
-          hiveConfig->isOrcUseNestedColumnNames());
+          hiveConfig->isOrcUseNestedColumnNames(sessionProperties));
       break;
     }
     case dwio::common::FileFormat::PARQUET: {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -573,6 +573,9 @@ class ReaderOptions : public io::ReaderOptions {
   }
 
   bool useNestedColumnNamesForColumnMapping() const {
+    if (useNestedColumnNamesForColumnMapping_) {
+      VELOX_CHECK(!useColumnNamesForColumnMapping_);
+    }
     return useNestedColumnNamesForColumnMapping_;
   }
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -497,6 +497,11 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
+  ReaderOptions& setUseNestedColumnNamesForColumnMapping(bool flag) {
+    useNestedColumnNamesForColumnMapping_ = flag;
+    return *this;
+  }
+
   ReaderOptions& setIOExecutor(std::shared_ptr<folly::Executor> executor) {
     ioExecutor_ = std::move(executor);
     return *this;
@@ -567,6 +572,10 @@ class ReaderOptions : public io::ReaderOptions {
     return useColumnNamesForColumnMapping_;
   }
 
+  bool useNestedColumnNamesForColumnMapping() const {
+    return useNestedColumnNamesForColumnMapping_;
+  }
+
   const std::shared_ptr<random::RandomSkipTracker>& randomSkip() const {
     return randomSkip_;
   }
@@ -609,6 +618,7 @@ class ReaderOptions : public io::ReaderOptions {
   uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
   bool fileColumnNamesReadAsLowerCase_{false};
   bool useColumnNamesForColumnMapping_{false};
+  bool useNestedColumnNamesForColumnMapping_{false};
   std::shared_ptr<folly::Executor> ioExecutor_;
   std::shared_ptr<random::RandomSkipTracker> randomSkip_;
   std::shared_ptr<velox::common::ScanSpec> scanSpec_;

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -278,9 +278,11 @@ TypePtr updateColumnNamesImpl(
 } // namespace
 
 TypePtr Reader::updateColumnNames(
-    const RowTypePtr& fileType,
-    const RowTypePtr& tableType,
+    const TypePtr& fileType,
+    const TypePtr& tableType,
     bool recursive) {
+  VELOX_CHECK(fileType->isRow());
+  VELOX_CHECK(tableType->isRow());
   return updateColumnNamesImpl<RowType>(fileType, tableType, recursive);
 }
 

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -202,7 +202,8 @@ TypePtr updateColumnNamesImpl(
 template <typename T>
 TypePtr updateColumnNamesImpl(
     const TypePtr& fileType,
-    const TypePtr& tableType) {
+    const TypePtr& tableType,
+    bool recursive = true) {
   const auto fileRowType = std::dynamic_pointer_cast<const T>(fileType);
   const auto tableRowType = std::dynamic_pointer_cast<const T>(tableType);
 
@@ -216,11 +217,15 @@ TypePtr updateColumnNamesImpl(
       break;
     }
 
-    newFileFieldTypes.push_back(updateColumnNamesImpl(
-        fileRowType->childAt(childIdx),
-        tableRowType->childAt(childIdx),
-        fileRowType->nameOf(childIdx),
-        tableRowType->nameOf(childIdx)));
+    if (recursive) {
+      newFileFieldTypes.push_back(updateColumnNamesImpl(
+          fileRowType->childAt(childIdx),
+          tableRowType->childAt(childIdx),
+          fileRowType->nameOf(childIdx),
+          tableRowType->nameOf(childIdx)));
+    } else {
+      newFileFieldTypes.push_back(fileRowType->childAt(childIdx));
+    }
 
     newFileFieldNames.push_back(tableRowType->nameOf(childIdx));
   }
@@ -273,9 +278,10 @@ TypePtr updateColumnNamesImpl(
 } // namespace
 
 TypePtr Reader::updateColumnNames(
-    const TypePtr& fileType,
-    const TypePtr& tableType) {
-  return updateColumnNamesImpl(fileType, tableType, "", "");
+    const RowTypePtr& fileType,
+    const RowTypePtr& tableType,
+    bool recursive) {
+  return updateColumnNamesImpl<RowType>(fileType, tableType, recursive);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -208,8 +208,8 @@ class Reader {
       const RowReaderOptions& options = {}) const = 0;
 
   static TypePtr updateColumnNames(
-      const RowTypePtr& fileType,
-      const RowTypePtr& tableType,
+      const TypePtr& fileType,
+      const TypePtr& tableType,
       bool recursive = true);
 };
 

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -208,8 +208,9 @@ class Reader {
       const RowReaderOptions& options = {}) const = 0;
 
   static TypePtr updateColumnNames(
-      const TypePtr& fileType,
-      const TypePtr& tableType);
+      const RowTypePtr& fileType,
+      const RowTypePtr& tableType,
+      bool recursive = true);
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -807,8 +807,11 @@ DwrfReader::DwrfReader(
 void DwrfReader::updateColumnNamesFromTableSchema() {
   const auto& tableSchema = readerBase_->readerOptions().fileSchema();
   const auto& fileSchema = readerBase_->schema();
+
+  auto updateRecursive =
+      !readerBase_->readerOptions().useNestedColumnNamesForColumnMapping();
   readerBase_->setSchema(std::dynamic_pointer_cast<const RowType>(
-      updateColumnNames(fileSchema, tableSchema)));
+      updateColumnNames(fileSchema, tableSchema, updateRecursive)));
 }
 
 std::unique_ptr<StripeInformation> DwrfReader::getStripe(

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -797,8 +797,7 @@ DwrfReader::DwrfReader(
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping() ||
-       readerBase_->isOldSchema()) &&
+  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping()) &&
       (readerBase_->readerOptions().fileSchema() != nullptr)) {
     updateColumnNamesFromTableSchema();
   }

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -797,7 +797,8 @@ DwrfReader::DwrfReader(
   // code. So we rename column names in the file schema to match table schema.
   // We test the options to have 'fileSchema' (actually table schema) as most
   // of the unit tests fail to provide it.
-  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping()) &&
+  if ((!readerBase_->readerOptions().useColumnNamesForColumnMapping() ||
+       readerBase_->isOldSchema()) &&
       (readerBase_->readerOptions().fileSchema() != nullptr)) {
     updateColumnNamesFromTableSchema();
   }

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -146,6 +146,15 @@ class ReaderBase {
     return schemaWithId_;
   }
 
+  // An ORC file written by an old version of Hive has no field names in the
+  // physical schema.
+  const bool isOldSchema() const {
+    return std::all_of(
+        schema_->names().begin(),
+        schema_->names().end(),
+        [](const std::string& name) { return name.find("_col") == 0; });
+  }
+
   dwio::common::BufferedInput& bufferedInput() const {
     return *input_;
   }

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -146,15 +146,6 @@ class ReaderBase {
     return schemaWithId_;
   }
 
-  // An ORC file written by an old version of Hive has no field names in the
-  // physical schema.
-  const bool isOldSchema() const {
-    return std::all_of(
-        schema_->names().begin(),
-        schema_->names().end(),
-        [](const std::string& name) { return name.find("_col") == 0; });
-  }
-
   dwio::common::BufferedInput& bufferedInput() const {
     return *input_;
   }


### PR DESCRIPTION
Spark support ORC forced positional evolution (https://github.com/apache/spark/commit/00d43b1f829fb5f79f0355afbbacc804162648e5), which map top level columns names in table schema. This pr added an option `HiveConfig::kOrcUseNestedColumnNames` to always maps nested column using names if kOrcUseColumnNames disabled.