### PR TITLE
fix(function): Fix getTimestamp to parse fractional seconds correctly for Spark

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -903,6 +903,8 @@ int32_t parseFromPattern(
         ++cur;
         ++count;
       }
+      // If the number of digits is less than 3, a simple formatter interprets
+      // it as the whole number; otherwise, it pads the number with zeros.
       if (type != DateTimeFormatterType::STRICT_SIMPLE &&
           type != DateTimeFormatterType::LENIENT_SIMPLE) {
         number *= std::pow(10, 3 - count);

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -903,7 +903,10 @@ int32_t parseFromPattern(
         ++cur;
         ++count;
       }
-      number *= std::pow(10, 3 - count);
+      if (type != DateTimeFormatterType::STRICT_SIMPLE &&
+          type != DateTimeFormatterType::LENIENT_SIMPLE) {
+        number *= std::pow(10, 3 - count);
+      }
     } else if (
         (curPattern.specifier == DateTimeFormatSpecifier::YEAR ||
          curPattern.specifier == DateTimeFormatSpecifier::YEAR_OF_ERA ||

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -847,13 +847,19 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
       getTimestamp("2023-07-13 21:34", "yyyy-MM-dd HH:II"),
       "Specifier I is not supported");
 
+
+  enableLegacyFormatter();
   // Returns null for invalid datetime format when legacy date formatter is
   // used.
-  enableLegacyFormatter();
+
   // Empty format.
   EXPECT_EQ(getTimestamp("0", ""), std::nullopt);
   // Unsupported specifier.
   EXPECT_EQ(getTimestamp("0", "l"), std::nullopt);
+
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.2", "yyyy-MM-dd HH:mm:ss.SSS"),
+      Timestamp::fromMillis(2));
 }
 
 TEST_F(DateTimeFunctionsTest, hour) {

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -791,6 +791,10 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
   EXPECT_EQ(
       getTimestamp("1970-01-01 00:00:00.010", "yyyy-MM-dd HH:mm:ss.SSS"),
       Timestamp::fromMillis(10));
+  // Representing milliseconds with one digit.
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.2", "yyyy-MM-dd HH:mm:ss.SSS"),
+      Timestamp::fromMillis(200));
   auto milliSeconds = (6 * 60 * 60 + 10 * 60 + 59) * 1000 + 19;
   EXPECT_EQ(
       getTimestamp("1970-01-01 06:10:59.019", "yyyy-MM-dd HH:mm:ss.SSS"),
@@ -856,6 +860,7 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
   // Unsupported specifier.
   EXPECT_EQ(getTimestamp("0", "l"), std::nullopt);
 
+  // Representing milliseconds with one digit.
   EXPECT_EQ(
       getTimestamp("1970-01-01 00:00:00.2", "yyyy-MM-dd HH:mm:ss.SSS"),
       Timestamp::fromMillis(2));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -847,7 +847,6 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
       getTimestamp("2023-07-13 21:34", "yyyy-MM-dd HH:II"),
       "Specifier I is not supported");
 
-
   enableLegacyFormatter();
   // Returns null for invalid datetime format when legacy date formatter is
   // used.


### PR DESCRIPTION
In `getTimestamp` function, the fractional seconds of "1970-01-01 00:00:00.2"  
should be parsed as 2 milliseconds instead of 200 milliseconds to be consistent 
with Spark.

Part of: #10354  
Fixes: [gluten issue](https://github.com/apache/incubator-gluten/issues/8858)