### PR TITLE
feat: Implement fb_unescape Function in Velox

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -360,4 +360,21 @@ class JsonInputGenerator : public AbstractInputGenerator {
   folly::json::serialization_opts opts_;
 };
 
+class StringEscapingInputGenerator : public AbstractInputGenerator {
+ public:
+  StringEscapingInputGenerator(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      std::unique_ptr<AbstractInputGenerator>&& randomStrGenerator);
+
+  ~StringEscapingInputGenerator() override = default;
+
+  variant generate() override;
+
+ private:
+  void makeRandomVariation(std::string& str);
+  std::unique_ptr<AbstractInputGenerator> randomStrGenerator_;
+};
+
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ArgValuesGenerators.h
+++ b/velox/expression/fuzzer/ArgValuesGenerators.h
@@ -30,4 +30,15 @@ class JsonParseArgValuesGenerator : public ArgValuesGenerator {
       ExpressionFuzzerState& state) override;
 };
 
+class StringEscapeArgValuesGenerator : public ArgValuesGenerator {
+ public:
+  ~StringEscapeArgValuesGenerator() override = default;
+
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
+};
+
 } // namespace facebook::velox::fuzzer


### PR DESCRIPTION
Summary:
Implementing the fb_unescape function in velox based on presto's implementation. 
[FacebookEscapeFunctions java code](https://www.internalfb.com/code/fbsource/[4a8b76c84fcb]/fbcode/github/presto-facebook-trunk/presto-facebook-functions/src/main/java/com/facebook/presto/facebook/FacebookEscapeFunctions.java)

Differential Revision: D69147813


