### PR TITLE
feat(tpch): Add flag velox_tpch_text_pool_size_mb for text pool size

### DIFF
--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -22,6 +22,8 @@
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
+DECLARE_int32(velox_tpch_text_pool_size_mb);
+
 namespace {
 
 using namespace facebook::velox;
@@ -35,6 +37,7 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
   const std::string kTpchConnectorId = "test-tpch";
 
   void SetUp() override {
+    FLAGS_velox_tpch_text_pool_size_mb = 10;
     OperatorTestBase::SetUp();
     connector::registerConnectorFactory(
         std::make_shared<connector::tpch::TpchConnectorFactory>());
@@ -97,11 +100,11 @@ TEST_F(TpchConnectorTest, simple) {
       makeFlatVector<int64_t>({0, 1, 1, 1, 4}),
       // n_comment
       makeFlatVector<StringView>({
-          " haggle. carefully final deposits detect slyly agai",
-          "al foxes promise slyly according to the regular accounts. bold requests alon",
-          "y alongside of the pending deposits. carefully special packages are about the ironic forges. slyly special ",
-          "eas hang ironic, silent packages. slyly regular packages are furiously over the tithes. fluffily bold",
-          "y above the carefully unusual theodolites. final dugouts are quickly across the furiously regular d",
+          "furiously regular requests. platelets affix furious",
+          "instructions wake quickly. final deposits haggle. final, silent theodolites ",
+          "asymptotes use fluffily quickly bold instructions. slyly bold dependencies sleep carefully pending accounts",
+          "ss deposits wake across the pending foxes. packages after the carefully bold requests integrate caref",
+          "usly ironic, pending foxes. even, special instructions nag. sly, final foxes detect slyly fluffily ",
       }),
   });
   test::assertEqualVectors(expected, output);

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -131,3 +131,9 @@ DEFINE_bool(
     velox_ssd_verify_write,
     false,
     "Read back data after writing to SSD");
+
+// Used in /connectors/tpch
+DEFINE_int32(
+    velox_tpch_text_pool_size_mb,
+    300,
+    "TPC-H DBGen text pool size in MB");

--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -37,7 +37,7 @@ class DBGenBackend {
     // structures required by dbgen are populated.
     DBGenContext dbgenCtx;
     load_dists(
-        300 * 1024 * 1024,
+        FLAGS_velox_tpch_text_pool_size_mb * 1024 * 1024,
         &dbgenCtx); // 300 MB buffer size for text generation.
 
     // Initialize global dbgen buffers required to generate data.

--- a/velox/tpch/gen/DBGenIterator.h
+++ b/velox/tpch/gen/DBGenIterator.h
@@ -16,11 +16,14 @@
 
 #pragma once
 
+#include <gflags/gflags.h>
 #include <memory>
 #include <mutex>
 
 #include <velox/tpch/gen/dbgen/include/dbgen/dss.h>
 #include <velox/tpch/gen/dbgen/include/dbgen/dsstypes.h>
+
+DECLARE_int32(velox_tpch_text_pool_size_mb);
 
 namespace facebook::velox::tpch {
 


### PR DESCRIPTION
Add flag velox_tpch_text_pool_size_mb for TPC-H text pool size

As per discussion in https://github.com/facebookincubator/velox/pull/12169#issuecomment-2677090713, this PR adds a flag velox_tpch_text_pool_size_mb for TPC-H dbgen text pool size. Default value for this config is 300 MB to match with Presto's. 

Reverted TpchConnectorTest.simple's expected output back to what it was for 10 MB buffer size.