### PR TITLE
feat: Add parse_duration Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -229,6 +229,32 @@ Unit            Description
 
     Returns ``x2 - x1`` in terms of ``unit``. The supported types for ``x`` are TIMESTAMP and DATE.
 
+Duration Function
+-----------------
+
+The ``parse_duration`` function supports the following units:
+
+======= =============
+Unit    Description
+======= =============
+``ns``  Nanoseconds
+``us``  Microseconds
+``ms``  Milliseconds
+``s``   Seconds
+``m``   Minutes
+``h``   Hours
+``d``   Days
+======= =============
+
+.. function:: parse_duration(string) -> interval
+
+    Parses ``string`` of format ``value unit`` into an interval, where
+    ``value`` is fractional number of ``unit`` values::
+
+        SELECT parse_duration('42.8ms'); -- 0 00:00:00.043
+        SELECT parse_duration('3.81 d'); -- 3 19:26:24.000
+        SELECT parse_duration('5m');     -- 0 00:05:00.000
+
 MySQL Date Functions
 --------------------
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -286,6 +286,9 @@ void registerSimpleFunctions(const std::string& prefix) {
 
   registerFunction<XxHash64DateFunction, int64_t, Date>(
       {prefix + "xxhash64_internal"});
+
+  registerFunction<ParseDurationFunction, IntervalDayTime, Varchar>(
+      {prefix + "parse_duration"});
 }
 } // namespace
 


### PR DESCRIPTION
Summary:
Implement the parse_duration(string) Presto function in Velox: https://prestodb.io/docs/current/functions/datetime.html#parse_duration-string-interval

Like in the Java implementation (https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java#L1411), it converts the string representation of a duration to milliseconds with rounding (https://github.com/airlift/units/blob/master/src/main/java/io/airlift/units/Duration.java#L89).

Differential Revision: D70120149


