### PR TITLE
refactor: Remove tiny range from StreamArena

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -290,11 +290,6 @@ class HashStringAllocator : public StreamArena {
   /// Allocates a new range of at least 'bytes' size.
   void newContiguousRange(int32_t bytes, ByteRange* range);
 
-  void newTinyRange(int32_t bytes, ByteRange* lastRange, ByteRange* range)
-      override {
-    newRange(bytes, lastRange, range);
-  }
-
   /// Returns the total memory footprint of 'this'.
   int64_t retainedSize() const {
     return state_.pool().allocatedBytes() + state_.sizeFromPool();

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -65,17 +65,6 @@ void StreamArena::newRange(
   }
 }
 
-void StreamArena::newTinyRange(
-    int32_t bytes,
-    ByteRange* /*lastRange*/,
-    ByteRange* range) {
-  VELOX_CHECK_GT(bytes, 0, "StreamArena::newTinyRange can't be zero length");
-  tinyRanges_.emplace_back();
-  tinyRanges_.back().resize(bytes);
-  range->position = 0;
-  range->buffer = reinterpret_cast<uint8_t*>(tinyRanges_.back().data());
-  range->size = bytes;
-}
 void StreamArena::clear() {
   allocations_.clear();
   pool_->freeNonContiguous(allocation_);
@@ -83,7 +72,6 @@ void StreamArena::clear() {
   currentOffset_ = 0;
   largeAllocations_.clear();
   size_ = 0;
-  tinyRanges_.clear();
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -44,14 +44,10 @@ class StreamArena {
   /// its last 8 bytes. When extending, we need to update the entry so
   /// that the next pointer is not seen when reading the content and
   /// is also not counted in the payload size of the multipart entry.
+  ///
+  /// NOTE: The method does not guarantee returned 'range' has size of 'bytes',
+  /// it is caller's responsibility to check.
   virtual void newRange(int32_t bytes, ByteRange* lastRange, ByteRange* range);
-
-  /// sets 'range' to point to a small piece of memory owned by this. These
-  /// always come from the heap. The use case is for headers that may change
-  /// length based on data properties, not for bulk data. See 'newRange' for the
-  /// meaning of 'lastRange'.
-  virtual void
-  newTinyRange(int32_t bytes, ByteRange* lastRange, ByteRange* range);
 
   /// Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {
@@ -68,6 +64,7 @@ class StreamArena {
 
  private:
   memory::MemoryPool* const pool_;
+
   const memory::MachinePageCount allocationQuantum_{2};
 
   // All non-contiguous allocations.
@@ -88,8 +85,6 @@ class StreamArena {
 
   // Tracks all the contiguous and non-contiguous allocations in bytes.
   size_t size_ = 0;
-
-  std::vector<std::string> tinyRanges_;
 };
 
 } // namespace facebook::velox

--- a/velox/common/memory/tests/StreamArenaTest.cpp
+++ b/velox/common/memory/tests/StreamArenaTest.cpp
@@ -127,12 +127,7 @@ TEST_F(StreamArenaTest, randomRange) {
   auto arena = newArena();
   ByteRange range;
   for (int i = 0; i < numRanges; ++i) {
-    if (folly::Random::oneIn(4)) {
-      const int requestSize =
-          1 + folly::Random::rand32() % (2 * AllocationTraits::kPageSize);
-      arena->newTinyRange(requestSize, nullptr, &range);
-      ASSERT_EQ(range.size, requestSize);
-    } else if (folly::Random::oneIn(3)) {
+    if (folly::Random::oneIn(3)) {
       const int requestSize =
           AllocationTraits::pageBytes(pool_->largestSizeClass()) +
           (folly::Random::rand32() % (4 << 20));
@@ -152,9 +147,6 @@ TEST_F(StreamArenaTest, randomRange) {
 TEST_F(StreamArenaTest, error) {
   auto arena = newArena();
   ByteRange range;
-  VELOX_ASSERT_THROW(
-      arena->newTinyRange(0, nullptr, &range),
-      "StreamArena::newTinyRange can't be zero length");
   VELOX_ASSERT_THROW(
       arena->newRange(0, nullptr, &range),
       "StreamArena::newRange can't be zero length");

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -68,7 +68,17 @@ class VectorStream {
   }
 
   void initializeHeader(std::string_view name, StreamArena& streamArena) {
-    streamArena.newTinyRange(50, nullptr, &header_);
+    // Allocations from stream arena must be aligned size.
+    static constexpr uint32_t kHeaderSize = 64;
+    VELOX_CHECK_GE(kHeaderSize, name.size() + sizeof(int32_t));
+    streamArena.newRange(kHeaderSize, nullptr, &header_);
+    if (header_.size < kHeaderSize) {
+      // StreamArena::newRange() does not guarantee the size. If returned range
+      // does not have enough space, allocate a new one. The second arena
+      // allocation will allocate a new slab which must have enough size.
+      streamArena.newRange(kHeaderSize, nullptr, &header_);
+      VELOX_CHECK_EQ(header_.size, kHeaderSize);
+    }
     header_.size = name.size() + sizeof(int32_t);
     folly::storeUnaligned<int32_t>(header_.buffer, name.size());
     ::memcpy(header_.buffer + sizeof(int32_t), &name[0], name.size());

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -908,15 +908,17 @@ TEST_P(PrestoSerializerTest, initMemory) {
     ASSERT_EQ(pool_->usedBytes() - poolMemUsage, expectedBytes);
   };
 
-  testFunc(BOOLEAN(), 384);
-  testFunc(TINYINT(), 384);
-  testFunc(SMALLINT(), 384);
-  testFunc(INTEGER(), 384);
-  testFunc(BIGINT(), 384);
-  testFunc(REAL(), 384);
-  testFunc(DOUBLE(), 384);
-  testFunc(VARCHAR(), 384);
-  testFunc(TIMESTAMP(), 384);
+  // 8192 for slab allocation for 64-bit header + 384 for memory pool allocated
+  // std structures
+  testFunc(BOOLEAN(), 8576);
+  testFunc(TINYINT(), 8576);
+  testFunc(SMALLINT(), 8576);
+  testFunc(INTEGER(), 8576);
+  testFunc(BIGINT(), 8576);
+  testFunc(REAL(), 8576);
+  testFunc(DOUBLE(), 8576);
+  testFunc(VARCHAR(), 8576);
+  testFunc(TIMESTAMP(), 8576);
   // For nested types, 2 pages allocation quantum for first offset (0).
   testFunc(ROW({VARCHAR()}), 8960);
   testFunc(ARRAY(INTEGER()), 8960);


### PR DESCRIPTION
Summary: tinyRanges_ vector with std::string allocates exccessive amount of memory when large amount of queries with ultra wide row run in the system. Remove the structure and use the allocations_ structure to accommodate scattered tiny ranges.

Reviewed By: xiaoxmeng

Differential Revision: D70272119


