### PR TITLE
fix: Fix error type of arbitration failure

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -89,10 +89,14 @@ inline constexpr auto kNotImplemented = "NOT_IMPLEMENTED"_fs;
 /// An error raised when memory pool exceeds limits.
 inline constexpr auto kMemCapExceeded = "MEM_CAP_EXCEEDED"_fs;
 
+/// An error raised when memory request failed due to arbitration failures. This
+/// is normally caused by insufficient global memory resource.
+inline constexpr auto kMemArbitrationFailure = "MEM_ARBITRATION_FAILURE"_fs;
+
 /// An error raised when memory pool is aborted.
 inline constexpr auto kMemAborted = "MEM_ABORTED"_fs;
 
-/// An error raised when memory arbitration is timed out.
+/// An error raised when memory arbitration times out.
 inline constexpr auto kMemArbitrationTimeout = "MEM_ARBITRATION_TIMEOUT"_fs;
 
 /// Error caused by memory allocation failure (inclusive of allocator memory cap

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -249,9 +249,9 @@ class TestStatsReportMemoryArbitrator : public memory::MemoryArbitrator {
 
   void removePool(memory::MemoryPool* /*unused*/) override {}
 
-  bool growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
+  void growCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
       override {
-    return false;
+    VELOX_FAIL("Cannot grow capacity.");
   }
 
   uint64_t shrinkCapacity(memory::MemoryPool* /*unused*/, uint64_t /*unused*/)
@@ -396,7 +396,7 @@ class TestMemoryPool : public memory::MemoryPool {
     return false;
   }
 
-  std::string toString() const override {
+  std::string toString(bool /* unused */) const override {
     return "";
   }
 

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -80,10 +80,10 @@ class NoopArbitrator : public MemoryArbitrator {
  public:
   explicit NoopArbitrator(const Config& config) : MemoryArbitrator(config) {
     VELOX_CHECK(config.kind.empty());
-    if (capacity_ != kMaxMemory) {
-      LOG(WARNING) << "Query memory capacity[" << succinctBytes(capacity_)
-                   << "] is set for " << kind()
-                   << " arbitrator which has no capacity enforcement";
+    if (config_.capacity != kMaxMemory) {
+      LOG(WARNING) << "Query memory capacity["
+                   << succinctBytes(config_.capacity) << "] is set for "
+                   << kind() << " arbitrator which has no capacity enforcement";
     }
   }
 
@@ -104,8 +104,8 @@ class NoopArbitrator : public MemoryArbitrator {
 
   // Noop arbitrator has no memory capacity limit so no operation needed for
   // memory pool capacity grow.
-  bool growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
-    return false;
+  void growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
+    VELOX_MEM_POOL_CAP_EXCEEDED("Exceeded memory pool capacity.");
   }
 
   // Noop arbitrator has no memory capacity limit so no operation needed for
@@ -134,7 +134,8 @@ class NoopArbitrator : public MemoryArbitrator {
     return fmt::format(
         "ARBIRTATOR[{} CAPACITY[{}]]",
         kind(),
-        capacity_ == kMaxMemory ? "UNLIMITED" : succinctBytes(capacity_));
+        config_.capacity == kMaxMemory ? "UNLIMITED"
+                                       : succinctBytes(config_.capacity));
   }
 };
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -38,27 +38,6 @@ class ParallelMemoryReclaimer;
 
 namespace facebook::velox::memory {
 class TestArbitrator;
-}
-
-namespace facebook::velox::memory {
-#define VELOX_MEM_POOL_CAP_EXCEEDED(errorMessage)                   \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "{}",                                                         \
-      errorMessage);
-
-#define VELOX_MEM_POOL_ABORTED(errorMessage)                        \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemAborted.c_str(),           \
-      /* isRetriable */ true,                                       \
-      "{}",                                                         \
-      errorMessage);
-
 class MemoryManager;
 
 constexpr int64_t kMaxMemory = std::numeric_limits<int64_t>::max();
@@ -458,7 +437,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Returns the stats of this memory pool.
   virtual Stats stats() const = 0;
 
-  virtual std::string toString() const = 0;
+  virtual std::string toString(bool detail = false) const = 0;
 
   /// Invoked to generate a descriptive memory usage summary of the entire tree.
   /// If 'skipEmptyPool' is true, then skip print out the child memory pools
@@ -660,9 +639,16 @@ class MemoryPoolImpl : public MemoryPool {
 
   void setDestructionCallback(const DestructionCallback& callback);
 
-  std::string toString() const override {
-    std::lock_guard<std::mutex> l(mutex_);
-    return toStringLocked();
+  std::string toString(bool detail = false) const override {
+    std::string result;
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      result = toStringLocked();
+    }
+    if (detail) {
+      result += "\n" + treeMemoryUsage();
+    }
+    return result;
   }
 
   /// Detailed debug pool state printout by traversing the pool structure from
@@ -819,27 +805,19 @@ class MemoryPoolImpl : public MemoryPool {
 
   void reserveThreadSafe(uint64_t size, bool reserveOnly = false);
 
-  // Increments the reservation and checks against limits at root tracker. Calls
-  // root tracker's 'growCallback_' if it is set and limit exceeded. Should be
-  // called without holding 'mutex_'. This function returns true if reservation
-  // succeeds. It returns false if there is concurrent reservation increment
-  // requests and need a retry from the leaf memory usage tracker. The function
-  // throws if a limit is exceeded and there is no corresponding GrowCallback or
-  // the GrowCallback fails.
-  bool incrementReservationThreadSafe(MemoryPool* requestor, uint64_t size);
+  // Increments the reservation and checks against limits at root memory pool.
+  // Provokes root memory pool to grow capacity through arbitrator if exceeds
+  // capacity. Should be called without holding 'mutex_'. This function throws
+  // if max capacity is exceeded or arbitration fails.
+  void incrementReservationThreadSafe(MemoryPool* requestor, uint64_t size);
 
-  FOLLY_ALWAYS_INLINE bool incrementReservationNonThreadSafe(
+  FOLLY_ALWAYS_INLINE void incrementReservationNonThreadSafe(
       MemoryPool* requestor,
       uint64_t size) {
     VELOX_CHECK_NOT_NULL(parent_);
     VELOX_CHECK(isLeaf());
-
-    if (!toImpl(parent_)->incrementReservationThreadSafe(requestor, size)) {
-      return false;
-    }
-
+    toImpl(parent_)->incrementReservationThreadSafe(requestor, size);
     reservationBytes_ += size;
-    return true;
   }
 
   // Returns the needed reservation size. If there is sufficient unused memory
@@ -875,7 +853,7 @@ class MemoryPoolImpl : public MemoryPool {
   // Invoked to grow capacity of the root memory pool from the memory
   // arbitrator. 'requestor' is the leaf memory pool that triggers the memory
   // capacity growth. 'size' is the memory capacity growth in bytes.
-  bool growCapacity(MemoryPool* requestor, uint64_t size);
+  void growCapacity(MemoryPool* requestor, uint64_t size);
 
   FOLLY_ALWAYS_INLINE void releaseNonThreadSafe(
       uint64_t size,

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -249,7 +249,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   void removePool(MemoryPool* pool) final;
 
-  bool growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
+  void growCapacity(MemoryPool* pool, uint64_t requestBytes) final;
 
   /// NOTE: only support shrinking away all the unused free capacity for now.
   uint64_t shrinkCapacity(MemoryPool* pool, uint64_t requestBytes) final;
@@ -352,7 +352,7 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Run arbitration to grow capacity for 'op'. The function returns true on
   // success.
-  bool growCapacity(ArbitrationOperation& op);
+  void growCapacity(ArbitrationOperation& op);
 
   // Invoked to start execution of 'op'. It waits for the serialized execution
   // on the same arbitration participant and returns when 'op' is ready to run.
@@ -415,9 +415,9 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Invoked to run global arbitration to reclaim free or used memory from other
   // queries. The global arbitration run is protected by the exclusive lock of
-  // 'arbitrationLock_' for serial execution mode. The function returns true on
-  // success, false on failure.
-  bool startAndWaitGlobalArbitration(ArbitrationOperation& op);
+  // 'arbitrationLock_' for serial execution mode. The function throws on
+  // failure.
+  void startAndWaitGlobalArbitration(ArbitrationOperation& op);
 
   // Invoked to get stats of candidate participants for arbitration. If
   // 'freeCapacityOnly' is true, then we only get reclaimable free capacity from
@@ -595,6 +595,8 @@ class SharedArbitrator : public memory::MemoryArbitrator {
       uint64_t arbitrationTimeNs,
       uint64_t arbitrationBytes);
 
+  const uint64_t capacity_;
+  const MemoryArbitrationStateCheckCB arbitrationStateCheckCb_;
   const uint64_t reservedCapacity_;
   const bool checkUsageLeak_;
   const uint64_t maxArbitrationTimeNs_;

--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -63,11 +63,10 @@ class TestArbitrator : public MemoryArbitrator {
 
   void removePool(MemoryPool* /*unused*/) override {}
 
-  bool growCapacity(MemoryPool* memoryPool, uint64_t requestBytes) override {
+  void growCapacity(MemoryPool* memoryPool, uint64_t requestBytes) override {
     VELOX_CHECK_LE(
         memoryPool->capacity() + requestBytes, memoryPool->maxCapacity());
     memoryPool->grow(requestBytes, requestBytes);
-    return true;
   }
 
   uint64_t shrinkCapacity(uint64_t /*unused*/, bool /*unused*/, bool /*unused*/)

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -132,23 +132,24 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
     auto rootPool =
         manager.addRootPool("root-1", 8L << 20, MemoryReclaimer::create());
     ASSERT_EQ(rootPool->capacity(), 1 << 20);
-    ASSERT_TRUE(manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20));
+    ASSERT_NO_THROW(
+        manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20));
     ASSERT_EQ(rootPool->capacity(), 1 << 20);
-    ASSERT_FALSE(manager.arbitrator()->growCapacity(rootPool.get(), 6 << 20));
+    VELOX_ASSERT_THROW(
+        manager.arbitrator()->growCapacity(rootPool.get(), 6 << 20),
+        "Exceeded memory pool capacity");
     ASSERT_EQ(rootPool->capacity(), 1 << 20);
-    ASSERT_TRUE(manager.arbitrator()->growCapacity(rootPool.get(), 2 << 20));
-    ASSERT_TRUE(manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20));
+    ASSERT_NO_THROW(
+        manager.arbitrator()->growCapacity(rootPool.get(), 2 << 20));
+    ASSERT_NO_THROW(
+        manager.arbitrator()->growCapacity(rootPool.get(), 1 << 20));
     ASSERT_EQ(rootPool->capacity(), 4 << 20);
     ASSERT_EQ(manager.arbitrator()->stats().freeCapacityBytes, 2 << 20);
     ASSERT_EQ(manager.arbitrator()->stats().freeReservedCapacityBytes, 2 << 20);
 
     auto leafPool = rootPool->addLeafChild("leaf-1.0");
     VELOX_ASSERT_THROW(
-        leafPool->allocate(7L << 20),
-        "Exceeded memory pool capacity after attempt to grow capacity through "
-        "arbitration. Requestor pool name 'leaf-1.0', request size 7.00MB, "
-        "current usage 0B, memory pool capacity 4.00MB, memory pool max "
-        "capacity 8.00MB");
+        leafPool->allocate(7L << 20), "Exceeded memory pool capacity");
     ASSERT_EQ(manager.arbitrator()->shrinkCapacity(rootPool.get(), 0), 0);
     VELOX_ASSERT_THROW(
         manager.arbitrator()->shrinkCapacity(leafPool.get(), 0), "");
@@ -341,7 +342,7 @@ class FakeTestArbitrator : public MemoryArbitrator {
 
   void removePool(MemoryPool* /*unused*/) override {}
 
-  bool growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
+  void growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
     VELOX_NYI();
   }
 

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -68,10 +68,25 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   // We look for these lines separately, since their order can change (not sure
   // why).
   std::vector<std::string> expectedTexts = {
-      "Exceeded memory pool capacity after attempt to grow capacity through "
-      "arbitration. Requestor pool name 'op.2.0.0.Aggregation', request size "
-      "2.00MB, current usage 3.70MB, memory pool capacity 5.00MB, memory pool "
-      "max capacity 5.00MB, memory manager capacity 8.00GB"};
+      "Can't grow ",
+      "capacity with 2.00MB. This will exceed its max capacity 5.00MB, current "
+      "capacity 5.00MB.\n"
+      "ARBITRATOR[SHARED CAPACITY[6.00GB] STATS[numRequests 1 numRunning 1 "
+      "numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 "
+      "reclaimedFreeCapacity 0B reclaimedUsedCapacity 0B maxCapacity 6.00GB "
+      "freeCapacity 5.50GB freeReservedCapacity 0B] CONFIG[kind=SHARED;"
+      "capacity=6.00GB;arbitrationStateCheckCb=(set);"
+      "memory-pool-abort-capacity-limit=0B;memory-pool-reserved-capacity=0B;"
+      "memory-pool-initial-capacity=536870912B;"
+      "global-arbitration-enabled=true;memory-pool-min-reclaim-bytes=0B;"
+      "reserved-capacity=0B;]]"
+      "\n\n"
+      "Memory Pool[",
+      " AGGREGATE root[",
+      "] parent[null] MALLOC track-usage thread-safe]<max capacity 5.00MB "
+      "capacity 5.00MB used 3.71MB available 0B reservation [used 0B, reserved "
+      "5.00MB, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, "
+      "collisions 0])>"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 12.00KB reserved 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB reserved 1.00MB peak 12.00KB",
@@ -110,19 +125,19 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
     const auto errorMessage = e.message();
     for (const auto& expectedText : expectedTexts) {
       ASSERT_TRUE(errorMessage.find(expectedText) != std::string::npos)
-          << "Expected error message to contain '" << expectedText
-          << "', but received '" << errorMessage << "'.";
+          << "Expected error message to contain \n'" << expectedText
+          << "',\n but received \n'" << errorMessage << "'.";
     }
     for (const auto& expectedText : expectedDetailedTexts) {
       LOG(ERROR) << expectedText;
       if (!GetParam()) {
         ASSERT_TRUE(someLineMatches(errorMessage, expectedText))
-            << "Expected error message to contain '" << expectedText
-            << "', but received '" << errorMessage << "'.";
+            << "Expected error message to contain \n'" << expectedText
+            << "',\n but received \n'" << errorMessage << "'.";
       } else {
         ASSERT_TRUE(errorMessage.find(expectedText) == std::string::npos)
-            << "Unexpected error message to contain '" << expectedText
-            << "', but received '" << errorMessage << "'.";
+            << "Unexpected error message to contain \n'" << expectedText
+            << "',\n but received \n'" << errorMessage << "'.";
       }
     }
   }

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -98,7 +98,14 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_EQ(arbitrator->stats().maxCapacityBytes, kCapacity);
     ASSERT_EQ(
         manager.toString(),
-        "Memory Manager[capacity 4.00GB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__sys_root__\nMemory Allocator[MALLOC capacity 4.00GB allocated bytes 0 allocated pages 0 mapped pages 0]\nARBITRATOR[SHARED CAPACITY[4.00GB] numRequests 0 numRunning 0 numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 reclaimedFreeCapacity 0B reclaimedUsedCapacity 0B maxCapacity 4.00GB freeCapacity 4.00GB freeReservedCapacity 0B]]");
+        "Memory Manager[capacity 4.00GB alignment 64B usedBytes 0B number of "
+        "pools 3\nList of root pools:\n\t__sys_root__\nMemory Allocator[MALLOC "
+        "capacity 4.00GB allocated bytes 0 allocated pages 0 mapped pages 0]\n"
+        "ARBITRATOR[SHARED CAPACITY[4.00GB] STATS[numRequests 0 numRunning 0 "
+        "numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 "
+        "reclaimedFreeCapacity 0B reclaimedUsedCapacity 0B maxCapacity 4.00GB "
+        "freeCapacity 4.00GB freeReservedCapacity 0B] "
+        "CONFIG[kind=SHARED;capacity=4.00GB;arbitrationStateCheckCb=(unset);]]]");
   }
 }
 
@@ -122,7 +129,7 @@ class FakeTestArbitrator : public MemoryArbitrator {
 
   void removePool(MemoryPool* /*unused*/) override {}
 
-  bool growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
+  void growCapacity(MemoryPool* /*unused*/, uint64_t /*unused*/) override {
     VELOX_NYI();
   }
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -722,13 +722,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
         ASSERT_EQ(error_source::kErrorSourceRuntime.c_str(), ex.errorSource());
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
-        ASSERT_EQ(
-            "Exceeded memory pool capacity after attempt to grow capacity "
-            "through arbitration. Requestor pool name 'static_quota', request "
-            "size 136.00MB, current usage 0B, memory pool capacity 128.00MB, "
-            "memory pool max capacity 128.00MB, memory manager capacity "
-            "128.00MB\nMemoryCapExceptions usage 0B reserved 0B peak 0B\n",
-            ex.message());
+        ASSERT_EQ("Exceeded memory pool capacity.", ex.message());
       }
     }
   }

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -214,7 +214,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
-  std::string toString() const override {
+  std::string toString(bool /* unused */) const override {
     return fmt::format(
         "Mock Memory Pool[{}]",
         velox::memory::MemoryAllocator::kindString(allocator_->kind()));

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -207,8 +207,7 @@ TEST_F(WindowTest, rowBasedStreamingWindowOOM) {
               .planNode();
 
       VELOX_ASSERT_THROW(
-          readCursor(params, [](Task*) {}),
-          "Exceeded memory pool capacity after attempt to grow capacity through arbitration.");
+          readCursor(params, [](Task*) {}), "Exceeded memory pool capacity");
     }
   };
   // RowStreamingWindow will not OOM.


### PR DESCRIPTION
Summary: This fix changes the error type from OOM to arbitration related error message when the reserved memory of the memory pool is less than its max capacity, to reduce confusion. It also adds the arbitrator configs information to the error message to give more efficient debug experience.

Differential Revision: D70471428


