### PR TITLE
fix: Fix unsafe deserialization code of `HiveConnectorSplit::bucketConversion`

### DIFF
--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -71,7 +71,7 @@ folly::dynamic HiveConnectorSplit::serialize() const {
     obj["bucketConversion"] = bucketConversionObj;
   } else {
     obj["bucketConversion"] = nullptr;
-    }
+  }
 
   folly::dynamic customSplitInfoObj = folly::dynamic::object;
   for (const auto& [key, value] : customSplitInfo) {

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
       : std::optional<int32_t>(obj["tableBucketNumber"].asInt());
 
   std::optional<HiveBucketConversion> bucketConversion = std::nullopt;
-  if (obj.count("bucketConversion")) {
+  if (!obj["bucketConversion"].isNull()) {
     const auto& bucketConversionObj = obj["bucketConversion"];
     std::vector<std::shared_ptr<HiveColumnHandle>> bucketColumnHandles;
     for (const auto& bucketColumnHandleObj :

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -143,7 +143,7 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
       : std::optional<int32_t>(obj["tableBucketNumber"].asInt());
 
   std::optional<HiveBucketConversion> bucketConversion = std::nullopt;
-  if (!obj["bucketConversion"].isNull()) {
+  if (obj.count("bucketConversion") && !obj["bucketConversion"].isNull()) {
     const auto& bucketConversionObj = obj["bucketConversion"];
     std::vector<std::shared_ptr<HiveColumnHandle>> bucketColumnHandles;
     for (const auto& bucketColumnHandleObj :

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -69,7 +69,9 @@ folly::dynamic HiveConnectorSplit::serialize() const {
     }
     bucketConversionObj["bucketColumnHandles"] = bucketColumnHandlesArray;
     obj["bucketConversion"] = bucketConversionObj;
-  }
+  } else {
+    obj["bucketConversion"] = nullptr;
+    }
 
   folly::dynamic customSplitInfoObj = folly::dynamic::object;
   for (const auto& [key, value] : customSplitInfo) {


### PR DESCRIPTION
API `folly::dynamic::count` counts on null values as well so it's not enough if the subsequent code assumes the value is not null. Add `!obj["bucketConversion"].isNull()` for the checking.

This fixes https://github.com/facebookincubator/velox/issues/12508.