### PR TITLE
fix: Fix resolving protobuf dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO}
 
   # Locate or build protobuf.
   velox_set_source(Protobuf)
-  velox_resolve_dependency(Protobuf CONFIG 3.21.7 REQUIRED)
+  velox_resolve_dependency(Protobuf 3.21.8 REQUIRED)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,7 +495,7 @@ if(${VELOX_BUILD_MINIMAL_WITH_DWIO}
 
   # Locate or build protobuf.
   velox_set_source(Protobuf)
-  velox_resolve_dependency(Protobuf 3.21.8 REQUIRED)
+  velox_resolve_dependency(Protobuf 3.21.7 REQUIRED)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
According to the log of  CI job "Fuzzer Jobs / Build (pull_request)", the installed protobuf by Velox's setup script cannot be found when `CONFIG` is used in resolving protobuf dependency.

Without this pr, 
```
-- Setting Protobuf source to AUTO
-- Could NOT find Protobuf (missing: Protobuf_DIR)
```

With this pr,
```
-- Setting Protobuf source to AUTO
-- [Protobuf] Found Protobuf: /usr/local/lib/libprotobuf.so (found suitable version "3.21.8", minimum required is "3.21.7")