### PR TITLE
misc: Backing out "Ensure input is parsed as json for json extract functions"

### DIFF
--- a/velox/docs/functions/presto/json.rst
+++ b/velox/docs/functions/presto/json.rst
@@ -156,8 +156,6 @@ JSON Functions
         SELECT json_extract(json, '$.store.book');
 
     Current implementation supports limited subset of JSONPath syntax.
-    If ``json`` is a varchar then it is expected to conform to `RFC 7159`_ and will be converted to its canonical
-    format before extraction.
 
     .. _JSONPath: http://goessner.net/articles/JsonPath/
 
@@ -170,10 +168,6 @@ JSON Functions
 
         SELECT json_extract_scalar('[1, 2, 3]', '$[2]');
         SELECT json_extract_scalar(json, '$.store.book[0].author');
-
-    Current implementation supports limited subset of JSONPath syntax.
-    If ``json`` is a varchar then it is expected to conform to `RFC 7159`_ and will be converted to its canonical
-    format before extraction.
 
     .. _JSONPath: http://goessner.net/articles/JsonPath/
 
@@ -189,9 +183,8 @@ JSON Functions
 
 .. function:: json_parse(varchar) -> json
 
-    Expects a JSON text conforming to `RFC 7159`_, and returns the JSON value (in its canonical form) deserialized
-    from the JSON text. The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, ``true``,
-    ``false`` or ``null``::
+    expects a JSON text conforming to `RFC 7159`_, and returns the JSON value deserialized from the JSON text.
+    The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, ``true``, ``false`` or ``null``::
 
         SELECT json_parse('[1, 2, 3]'); -- JSON '[1,2,3]'
         SELECT json_parse('"abc"'); -- JSON '"abc"'

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -26,14 +26,6 @@
 #include "velox/functions/prestosql/types/JsonRegistration.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 
-namespace facebook::velox::functions {
-void registerJsonVectorFunctions() {
-  VELOX_REGISTER_VECTOR_FUNCTION(
-      udf_json_extract_scalar, "json_extract_scalar");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_extract, "json_extract");
-}
-} // namespace facebook::velox::functions
-
 namespace facebook::velox::functions::prestosql {
 namespace {
 
@@ -196,14 +188,17 @@ class JsonBenchmark : public velox::functions::test::FunctionBenchmarkBase {
         {"json_array_length"});
     registerFunction<FollyJsonArrayLengthFunction, int64_t, Json>(
         {"folly_json_array_length"});
+    registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
+        {"json_extract_scalar"});
     registerFunction<FollyJsonExtractScalarFunction, Varchar, Json, Varchar>(
         {"folly_json_extract_scalar"});
+    registerFunction<JsonExtractFunction, Varchar, Json, Varchar>(
+        {"json_extract"});
     registerFunction<FollyJsonExtractFunction, Varchar, Json, Varchar>(
         {"folly_json_extract"});
     registerFunction<JsonSizeFunction, int64_t, Json, Varchar>({"json_size"});
     registerFunction<FollyJsonSizeFunction, int64_t, Json, Varchar>(
         {"folly_json_size"});
-    registerJsonVectorFunctions();
   }
 
   std::string prepareData(int jsonSize) {

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -31,7 +31,7 @@ class SIMDJsonExtractor {
  public:
   /**
    * Extract element(s) from a JSON object using the given path.
-   * @param json: A json string of type simdjson::padded_string
+   * @param json: A JSON object
    * @param path: Path to locate a JSON object. Following operators are
    * supported.
    *              "$"      Root member of a JSON structure no matter if it's an
@@ -43,12 +43,10 @@ class SIMDJsonExtractor {
    * @param consumer: Function to consume the extracted elements. Should be able
    *                  to take an argument that can either be a
    *                  simdjson::ondemand::document or a
-   *                  simdjson::ondemand::value. Note: If the consumer holds
-   *                  onto string_view(s) generated from applying
-   *                  simdjson::to_json_string to the arguments, then those
-   *                  string_view(s) will reference the original `json`
-   *                  padded_string and remain valid as long as it remains
-   *                  in scope.
+   *                  simdjson::ondemand::value. Note that once consumer
+   *                  returns, it should be assumed that the argument passed in
+   *                  is no longer valid, so do not attempt to store it as is
+   *                  in the consumer.
    * @param isDefinitePath is an output param that will get set to
    *                       false if a token is evaluated which can return
    *                       multiple results like '*'.
@@ -57,7 +55,7 @@ class SIMDJsonExtractor {
    */
   template <typename TConsumer>
   simdjson::error_code extract(
-      const simdjson::padded_string& json,
+      const velox::StringView& json,
       TConsumer& consumer,
       bool& isDefinitePath);
 
@@ -106,9 +104,10 @@ simdjson::error_code extractArray(
 
 template <typename TConsumer>
 simdjson::error_code SIMDJsonExtractor::extract(
-    const simdjson::padded_string& paddedJson,
+    const velox::StringView& json,
     TConsumer& consumer,
     bool& isDefinitePath) {
+  simdjson::padded_string paddedJson(json.data(), json.size());
   SIMDJSON_ASSIGN_OR_RAISE(auto jsonDoc, simdjsonParse(paddedJson));
   SIMDJSON_ASSIGN_OR_RAISE(auto isScalar, jsonDoc.is_scalar());
   if (isScalar) {

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -32,9 +32,10 @@ simdjson::error_code simdJsonExtract(
     TConsumer&& consumer) {
   auto& extractor = SIMDJsonExtractor::getInstance(path);
   bool isDefinitePath = true;
-  simdjson::padded_string paddedJson(json.data(), json.size());
   return extractor.extract(
-      paddedJson, std::forward<TConsumer>(consumer), isDefinitePath);
+      velox::StringView(json),
+      std::forward<TConsumer>(consumer),
+      isDefinitePath);
 }
 
 class SIMDJsonExtractorTest : public testing::Test {

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -27,6 +27,16 @@ void registerJsonFunctions(const std::string& prefix) {
   registerFunction<IsJsonScalarFunction, bool, Varchar>(
       {prefix + "is_json_scalar"});
 
+  registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
+      {prefix + "json_extract_scalar"});
+  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
+      {prefix + "json_extract_scalar"});
+
+  registerFunction<JsonExtractFunction, Json, Json, Varchar>(
+      {prefix + "json_extract"});
+  registerFunction<JsonExtractFunction, Json, Varchar, Varchar>(
+      {prefix + "json_extract"});
+
   registerFunction<JsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
   registerFunction<JsonArrayLengthFunction, int64_t, Varchar>(
@@ -58,11 +68,6 @@ void registerJsonFunctions(const std::string& prefix) {
       {prefix + "json_size"});
   registerFunction<JsonSizeFunction, int64_t, Varchar, Varchar>(
       {prefix + "json_size"});
-
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_extract, prefix + "json_extract");
-
-  VELOX_REGISTER_VECTOR_FUNCTION(
-      udf_json_extract_scalar, prefix + "json_extract_scalar");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");
 

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -162,27 +162,6 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
     exprSet.eval(rows, evalCtx, result);
     velox::test::assertEqualVectors(expected, result[0]);
   };
-
-  // Utility function to evaluate json_extract both with and without constant
-  // inputs. Ensures that the results are same in both cases. 'wrapInTry' is
-  // used to test the cases where json_extract throws a user error and verify
-  // that they are captured by the TRY operator. The inputs are expected to have
-  // only one row.
-  std::optional<std::string>
-  jsonExtract(VectorPtr json, VectorPtr path, bool wrapInTry = false) {
-    std::string expr =
-        !wrapInTry ? "json_extract(c0, c1)" : "try(json_extract(c0, c1))";
-
-    auto result = evaluateOnce<std::string>(expr, makeRowVector({json, path}));
-    auto resultConstantInput = evaluateOnce<std::string>(
-        expr,
-        makeRowVector(
-            {BaseVector::wrapInConstant(1, 0, json),
-             BaseVector::wrapInConstant(1, 0, path)}));
-    EXPECT_EQ(result, resultConstantInput)
-        << "Equal results expected for constant and non constant inputs";
-    return result;
-  }
 };
 
 TEST_F(JsonFunctionsTest, jsonFormat) {
@@ -953,11 +932,11 @@ TEST_F(JsonFunctionsTest, invalidPath) {
 
 TEST_F(JsonFunctionsTest, jsonExtract) {
   auto jsonExtract = [&](std::optional<std::string> json,
-                         const std::string& path,
-                         bool wrapInTry = false) {
-    auto jsonInput = makeJsonVector(json);
-    auto pathInput = makeFlatVector<std::string>({path});
-    return JsonFunctionsTest::jsonExtract(jsonInput, pathInput, wrapInTry);
+                         const std::string& path) {
+    return evaluateOnce<std::string>(
+        "json_extract(c0, c1)",
+        makeRowVector(
+            {makeJsonVector(json), makeFlatVector<std::string>({path})}));
   };
 
   EXPECT_EQ(
@@ -1046,50 +1025,6 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   VELOX_ASSERT_THROW(
       jsonExtract(kJson, "concat($..category)"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonExtract(kJson, "$.store.keys()"), "Invalid JSON path");
-
-  // Ensure User errors are captured in try() and not thrown.
-  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "$..price", true));
-  EXPECT_EQ(
-      std::nullopt,
-      jsonExtract(kJson, "$.store.book[?(@.price <10)].title", true));
-  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "max($..price)", true));
-  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "concat($..category)", true));
-  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "$.store.keys()", true));
-}
-
-TEST_F(JsonFunctionsTest, jsonExtractVarcharInput) {
-  auto jsonExtract = [&](std::optional<std::string> json,
-                         const std::string& path,
-                         bool wrapInTry = false) {
-    std::optional<StringView> s = json.has_value()
-        ? std::make_optional(StringView(json.value()))
-        : std::nullopt;
-    auto varcharInput = makeNullableFlatVector<std::string>({s}, VARCHAR());
-    auto pathInput = makeFlatVector<std::string>({path});
-    return JsonFunctionsTest::jsonExtract(varcharInput, pathInput, wrapInTry);
-  };
-
-  // Valid json
-  EXPECT_EQ(
-      R"({"x":{"a":1,"b":2}})",
-      jsonExtract(R"({"x": {"a" : 1, "b" : 2} })", "$"));
-  EXPECT_EQ(
-      R"({"a":1,"b":2})", jsonExtract(R"({"x": {"a" : 1, "b" : 2} })", "$.x"));
-
-  // Invalid JSON
-  EXPECT_EQ(std::nullopt, jsonExtract(R"({"x": {"a" : 1, "b" : "2""} })", "$"));
-  // Non-canonicalized json
-  EXPECT_EQ(
-      R"({"x":{"a":1,"b":2}})",
-      jsonExtract(R"({"x": {"b" : 2, "a" : 1} })", "$"));
-  // Input has escape characters
-  EXPECT_EQ(
-      R"({"x":{"a":"/1","b":"/2"}})",
-      jsonExtract(R"({"x": {"a" : "\/1", "b" : "\/2"} })", "$"));
-  // Invalid path
-  VELOX_ASSERT_THROW(jsonExtract(kJson, "$..price"), "Invalid JSON path");
-  // Ensure User error is captured in try() and not thrown.
-  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "$..price", true));
 }
 
 // The following tests ensure that the internal json functions


### PR DESCRIPTION
Summary: Temporarily backing out this change as it is failing some internal unit tests.

Differential Revision: D70498020


