### PR TITLE
feat: Support boolean in Velox approx_distinct

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -34,6 +34,11 @@ bool isPartialOutput(core::AggregationNode::Step step) {
       step == core::AggregationNode::Step::kIntermediate;
 }
 
+bool isPartialInput(core::AggregationNode::Step step) {
+  return step == core::AggregationNode::Step::kIntermediate ||
+      step == core::AggregationNode::Step::kFinal;
+}
+
 AggregateFunctionMap& aggregateFunctions() {
   static AggregateFunctionMap functions;
   return functions;

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -32,13 +32,17 @@ namespace facebook::velox::exec {
 
 class AggregateFunctionSignature;
 
-// Returns true if aggregation receives raw (unprocessed) input, e.g. partial
-// and single aggregation.
+/// Returns true if aggregation receives raw (unprocessed) input, e.g. partial
+/// and single aggregation.
 bool isRawInput(core::AggregationNode::Step step);
 
-// Returns false if aggregation produces final result, e.g. final
-// and single aggregation.
+/// Returns false if aggregation produces final result, e.g. final
+/// and single aggregation.
 bool isPartialOutput(core::AggregationNode::Step step);
+
+/// Returns true if aggregation receives intermediate states as input,
+/// e.g. intermediate and final aggregation steps.
+bool isPartialInput(core::AggregationNode::Step step);
 
 class Aggregate {
  protected:


### PR DESCRIPTION
Summary:
approx_distinct(boolean type) behaves differently than Java as its intermediate type is varbinary and same as other types. This causes plan node types mismatch and query failure.

In Java it is implemented more efficiently for boolean type by only using a byte to record the exact number of distinct values (only true or false). In Velox it is treated the same as others and inefficient.

This diff fixes it by:
- Use a template specialized version of accumulator to deal with bool type. It is used when boolean is raw input type or tinyint is in intermediate/final step.
- Similar as Java, use only a `tinyint (int8_t)` to store the state in the accumulator, thus intermediate output is also `tinyint`, matching Java
- Extend `cardinality` to support `tinyint` intermediate type

Differential Revision: D70181203


