### PR TITLE
fix: Re-use output across probe rows for NestedLoopJoin

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -261,6 +261,11 @@ RowVectorPtr NestedLoopJoinProbe::generateOutput() {
   // Try to advance the probe cursor; call finish if no more probe input.
   if (advanceProbe()) {
     finishProbeInput();
+    if (numOutputRows_ == 0) {
+      // output_ can only be re-used across probe rows within the same input_.
+      // Here we have to abandon the emtpy output_ with memory allocated.
+      output_ = nullptr;
+    }
   }
 
   if (!readyToProduceOutput()) {

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -113,12 +113,19 @@ class NestedLoopJoinProbe : public Operator {
   // smaller in some cases - outputs follow the probe side buffer boundaries.
   RowVectorPtr generateOutput();
 
+  // For non cross-join mode, the `output_` can be reused across multible probe
+  // rows. If the input_ has remaining rows and the output_ is not fully filled,
+  // it returns false here.
+  bool readyToProduceOutput();
+
   // Fill in joined output to `output_` by matching the current probeRow_ and
   // successive build vectors (using getNextCrossProductBatch()). Stops when
   // either all build vectors were matched for the current probeRow (returns
   // true), or if the output is full (returns false). If it returns false, a
   // valid vector with more than zero records will be available at `output_`; if
   // it returns true, either nullptr or zero records may be placed at `output_`.
+  // Also if it returns true, it's the caller's responsiblity to deicide when to
+  // set `output_` size.
   //
   // Also updates `buildMatched_` if the build records that received a match, so
   // that they can be used to implement right and full outer join semantic once


### PR DESCRIPTION
Recently, we found the following benchmark sql became much slower after we upgraded our system to latest velox.

```
select
  ps_partkey,
  sum(ps_supplycost * ps_availqty) as value
from
  partsupp,
  supplier,
  nation
where
  ps_suppkey = s_suppkey
  and s_nationkey = n_nationkey
  and n_name = 'GERMANY'
group by
  ps_partkey having
    sum(ps_supplycost * ps_availqty) > ( 
      select
        sum(ps_supplycost * ps_availqty) * 0.000001
      from
        partsupp,
        supplier,
        nation
      where
        ps_suppkey = s_suppkey
        and s_nationkey = n_nationkey
        and n_name = 'GERMANY'
    )   
order by
  value desc;
```

Through the flame-graph investigations, we noticed that ```NestedLoopJoin::generateOutput``` became the bottle-neck. So we went through the most recent changes to NestedLoopJoin relevant files and found this suspicious PR (https://github.com/facebookincubator/velox/pull/10651). 

After reviewing the changes introduced by the PR, I find out that this PR prepares output for each probe row even if the build table has only one row (we have filter defined in our SQL). Even though each probe row only makes use of small part of the output space, a new output is still created for the next probe row.

So my PR here is trying to re-use the output acorss multiple probe rows and avoid un-necessary memory allocating for new output. And with my PR, the beanchmark SQL performance recovers.

