### PR TITLE
fix(fuzz): Fix ssd cache o_direct flag in cache fuzz test

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -968,8 +968,12 @@ void SsdFile::readCheckpoint() {
         memory::memoryManager()->cachePool());
   } catch (std::exception& e) {
     ++stats_.openCheckpointErrors;
-    VELOX_SSD_CACHE_LOG(WARNING)
-        << fmt::format("Error openning checkpoint file {}: ", e.what());
+    // Either the checkpoint file is corrupted or the file is just created, we
+    // can start here and the writer threads will create the checkpoint file
+    // later on flush
+    VELOX_SSD_CACHE_LOG(WARNING) << fmt::format(
+        "Error openning checkpoint file {}: Starting without checkpoint",
+        e.what());
     return;
   }
 

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -972,7 +972,7 @@ void SsdFile::readCheckpoint() {
     // can start here and the writer threads will create the checkpoint file
     // later on flush
     VELOX_SSD_CACHE_LOG(WARNING) << fmt::format(
-        "Error openning checkpoint file {}: Starting without checkpoint",
+        "Error opening checkpoint file {}: Starting without checkpoint",
         e.what());
     return;
   }

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -66,8 +66,6 @@ DEFINE_int32(
     -1,
     "Number of SSD cache shards. When set to -1, a random value from 1 to 4 will be used, inclusively.");
 
-DEFINE_bool(velox_ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
-
 DEFINE_int64(
     ssd_checkpoint_interval_bytes,
     -1,

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -66,6 +66,8 @@ DEFINE_int32(
     -1,
     "Number of SSD cache shards. When set to -1, a random value from 1 to 4 will be used, inclusively.");
 
+DECLARE_bool(velox_ssd_odirect);
+
 DEFINE_int64(
     ssd_checkpoint_interval_bytes,
     -1,

--- a/velox/exec/fuzzer/CacheFuzzer.cpp
+++ b/velox/exec/fuzzer/CacheFuzzer.cpp
@@ -66,7 +66,7 @@ DEFINE_int32(
     -1,
     "Number of SSD cache shards. When set to -1, a random value from 1 to 4 will be used, inclusively.");
 
-DEFINE_bool(ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
+DEFINE_bool(velox_ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
 
 DEFINE_int64(
     ssd_checkpoint_interval_bytes,
@@ -505,7 +505,7 @@ void CacheFuzzer::go() {
   // filesystem and kernel version.
   //
   // TODO: add this support if needed later.
-  FLAGS_ssd_odirect = false;
+  FLAGS_velox_ssd_odirect = false;
   auto startTime = std::chrono::system_clock::now();
   size_t iteration = 0;
 


### PR DESCRIPTION
the flag for should be `velox_ssd_odirect`
https://github.com/facebookincubator/velox/blob/main/velox/flag_definitions/flags.cpp#L128