### PR TITLE
refactor: Allow to register arbitrary and array_agg functions without registering all Presto aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/ArbitraryAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.h
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+/// Register arbitrary aggregate function.
+/// @param prefix Prefix for the aggregate functions.
+/// @param withCompanionFunctions Also register companion functions, defaults
+/// to true.
+/// @param overwrite Whether to overwrite existing entry in the function
+/// registry, defaults to true.
+void registerArbitraryAggregate(
+    const std::string& prefix = "",
+    bool withCompanionFunctions = true,
+    bool overwrite = true);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/ValueList.h"

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+/// Register array_agg aggregate function.
+/// @param prefix Prefix for the aggregate function.
+/// @param withCompanionFunctions Also register companion functions, defaults
+/// to true.
+/// @param overwrite Whether to overwrite existing entry in the function
+/// registry, defaults to true.
+void registerArrayAggAggregate(
+    const std::string& prefix = "",
+    bool withCompanionFunctions = true,
+    bool overwrite = true);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/aggregates/ArbitraryAggregate.h"
+#include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -23,14 +25,6 @@ extern void registerApproxMostFrequentAggregate(
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerApproxPercentileAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerArbitraryAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerArrayAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);


### PR DESCRIPTION
Registering all aggregate functions increases build size too much.

Differential Revision: D70577522


