### PR TITLE
feat: Add field access resolving hook

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -27,6 +27,8 @@ namespace facebook::velox::core {
 
 // static
 Expressions::TypeResolverHook Expressions::resolverHook_;
+// static
+Expressions::FieldAccessHook Expressions::fieldAccessHook_;
 
 namespace {
 
@@ -226,6 +228,12 @@ TypedExprPtr Expressions::inferTypes(
   }
 
   if (auto fae = std::dynamic_pointer_cast<const FieldAccessExpr>(expr)) {
+    if (fieldAccessHook_) {
+      auto result = fieldAccessHook_(fae, children);
+      if (result) {
+        return result;
+      }
+    }
     VELOX_CHECK(
         !fae->getFieldName().empty(), "Anonymous columns are not supported");
     VELOX_CHECK_EQ(

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -24,6 +24,7 @@ namespace facebook::velox::core {
 
 class CallExpr;
 class LambdaExpr;
+class FieldAccessExpr;
 
 class Expressions {
  public:
@@ -31,6 +32,10 @@ class Expressions {
       const std::vector<core::TypedExprPtr>& inputs,
       const std::shared_ptr<const core::CallExpr>& expr,
       bool nullOnFailure)>;
+
+  using FieldAccessHook = std::function<core::TypedExprPtr(
+      std::shared_ptr<const FieldAccessExpr> fae,
+      std::vector<core::TypedExprPtr>& children)>;
 
   static TypedExprPtr inferTypes(
       const std::shared_ptr<const IExpr>& expr,
@@ -46,6 +51,14 @@ class Expressions {
 
   static TypeResolverHook getResolverHook() {
     return resolverHook_;
+  }
+
+  static void setFieldAccessHook(FieldAccessHook hook) {
+    fieldAccessHook_ = hook;
+  }
+
+  static FieldAccessHook getFieldAccessHook() {
+    return fieldAccessHook_;
   }
 
   static TypedExprPtr inferTypes(
@@ -70,6 +83,7 @@ class Expressions {
       const VectorPtr& complexConstants = nullptr);
 
   static TypeResolverHook resolverHook_;
+  static FieldAccessHook fieldAccessHook_;
 };
 
 class InputExpr : public core::IExpr {


### PR DESCRIPTION
Adds a possibility to register a custom handler for field access. Used in verax tests to instantiate DereferenceTypedExpr, i.e. a field reference to a struct with unnamed fields, such as returned by a struct constructor or struct valued function.