### PR TITLE
misc: Add ability to remove a function from all registries

### DIFF
--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -68,6 +68,11 @@ bool SimpleFunctionRegistry::registerFunctionInternal(
   });
 }
 
+void SimpleFunctionRegistry::removeFunction(const std::string& name) {
+  const auto sanitizedName = sanitizeName(name);
+  registeredFunctions_.withWLock([&](auto& map) { map.erase(sanitizedName); });
+}
+
 namespace {
 // This function is not thread safe. It should be called only from within a
 // synchronized read region of registeredFunctions_.

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -91,6 +91,8 @@ class SimpleFunctionRegistry {
     }
   }
 
+  void removeFunction(const std::string& name);
+
   std::vector<std::string> getFunctionNames() const {
     std::vector<std::string> result;
     registeredFunctions_.withRLock([&](const auto& map) {

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -181,4 +181,10 @@ resolveVectorFunctionWithMetadata(
   return exec::resolveVectorFunctionWithMetadata(functionName, argTypes);
 }
 
+void removeFunction(const std::string& functionName) {
+  exec::mutableSimpleFunctions().removeFunction(functionName);
+  exec::vectorFunctionFactories().withWLock(
+      [&](auto& functionMap) { functionMap.erase(functionName); });
+}
+
 } // namespace facebook::velox

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -97,6 +97,10 @@ resolveVectorFunctionWithMetadata(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Given name of a function, removes it from both the simple and vector
+/// function registries (including all signatures).
+void removeFunction(const std::string& functionName);
+
 /// Clears the function registry.
 void clearFunctionRegistry();
 


### PR DESCRIPTION
Summary:
This addresses an internal use-case where, during initialization,
all Presto functions are registered before some are overwritten
with custom implementations. Since vector functions are prioritized
over simple functions, this approach enables replacing a previously
registered vector function with a simple function. To simplify the
API and prevent confusion between removing specific signatures versus
all, this API is designed to remove all signatures, providing a clean
slate for the user.

Reviewed By: kgpai

Differential Revision: D70594709


