### PR TITLE
build(ci): Enable pyvelox macos

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
-          MACOSX_DEPLOYMENT_TARGET: "13.0"
+          # MACOSX_DEPLOYMENT_TARGET: "13.0"
           CIBW_ARCHS: "native"
           # Only build for 3.12 for now
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp312-*' || 'cp312-*' }}

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Install macOS dependencies
         if: startsWith(matrix.os, 'macos')
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: |
           export INSTALL_PREFIX="$GITHUB_WORKSPACE/dependencies"
           echo "CMAKE_PREFIX_PATH=$INSTALL_PREFIX" >> $GITHUB_ENV
@@ -117,9 +119,8 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
-          # required for preadv/pwritev
-          MACOSX_DEPLOYMENT_TARGET: "11.0"
-          CIBW_ARCHS: "x86_64"
+          MACOSX_DEPLOYMENT_TARGET: "13.0"
+          CIBW_ARCHS: "native"
           # Only build for 3.12 for now
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp312-*' || 'cp312-*' }}
           CIBW_SKIP: "*musllinux* cp36-*"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23.0
         env:
-          # MACOSX_DEPLOYMENT_TARGET: "13.0"
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '14' || '13' }}
           CIBW_ARCHS: "native"
           # Only build for 3.12 for now
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp312-*' || 'cp312-*' }}

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -85,26 +85,40 @@ jobs:
           # NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF++ ; print}')
           echo "build_version=${VERSION}a${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
 
-      - run: mkdir -p ccache
       - name: "Restore ccache"
-        if: false 
-        uses: actions/cache/restore@v3
+        # CCache doesn't hit in cibuildwheel
+        if: startsWith(matrix.os, 'macos')
+        uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
         id: restore-cache
         with:
           path: "ccache"
-          key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: |
-            ccache-wheels-${{ matrix.os }}-
+          key: ccache-wheels-${{ matrix.os }}
+
+      - name: "Restore macOS Dependencies"
+        if: startsWith(matrix.os, 'macos')
+        uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        id: restore-deps
+        with:
+          path: "dependencies"
+          key: dependencies-pyvelox-${{ matrix.os }}-${{ hashFiles('scripts/setup-macos.sh') }}
 
       - name: Install macOS dependencies
-        if: startsWith(matrix.os, 'macos')
+        if: ${{ startsWith(matrix.os, 'macos') && steps.restore-deps.outputs.stash-hit != 'true' }}
         env:
           MACOSX_DEPLOYMENT_TARGET: "13.0"
         run: |
           export INSTALL_PREFIX="$GITHUB_WORKSPACE/dependencies"
           echo "CMAKE_PREFIX_PATH=$INSTALL_PREFIX" >> $GITHUB_ENV
           echo "DYLD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
-          bash scripts/setup-macos.sh 
+          bash scripts/setup-macos.sh
+
+      - name: "Save macOS Dependencies"
+        if: ${{ startsWith(matrix.os, 'macos') && steps.restore-deps.outputs.stash-hit != 'true' }}
+        uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
+        with:
+          path: "dependencies"
+          key: dependencies-pyvelox-${{ matrix.os }}-${{ hashFiles('scripts/setup-macos.sh') }}
+          retention-days: 90
 
       - name: "Create sdist"
         if: matrix.os == '8-core-ubuntu'
@@ -122,22 +136,24 @@ jobs:
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp312-*' || 'cp312-*' }}
           CIBW_SKIP: "*musllinux* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:pyvelox"
-          CIBW_ENVIRONMENT_PASS_LINUX: "CCACHE_DIR BUILD_VERSION CMAKE_PREFIX_PATH"
+          CIBW_ENVIRONMENT_PASS_LINUX:  "BUILD_VERSION"
+          # Don't waste time writing out to cache
+          CIBW_ENVIRONMENT_LINUX: "CCACHE_DISABLE=true"
           CIBW_TEST_EXTRAS: "tests"
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*"
-          # CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/ccache"
+          CCACHE_DIR: "${{ github.workspace }}/ccache" 
           BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         with:
           output-dir: wheelhouse
 
       - name: "Save ccache"
-        if: false
-        uses: actions/cache/save@v3
-        id: cache
+        # CCache doesn't hit in cibuildwheel
+        if: startsWith(matrix.os, 'macos')
+        uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:
           path: "ccache"
-          key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
+          key: ccache-wheels-${{ matrix.os }}
 
       - name: "Rename wheel compatibility tag"
         if: false #startsWith(matrix.os, 'macos')
@@ -148,7 +164,8 @@ jobs:
 
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: wheels
+          name: wheels-${{ matrix.os }}
+          retention-days: 5
           path: |
             ./wheelhouse/*.whl
             ./wheelhouse/*.tar.gz
@@ -161,7 +178,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
           path: ./wheelhouse
 
       - run: ls wheelhouse

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -47,13 +47,14 @@ jobs:
       matrix:
         os: [8-core-ubuntu, macos-13, macos-14]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || github.ref }}
           fetch-depth: 0
           submodules: recursive
+          persist-credentials: false
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: '3.10'
 
@@ -110,7 +111,7 @@ jobs:
           python setup.py sdist --dist-dir wheelhouse
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.0
+        uses: pypa/cibuildwheel@6cccd09a31908ffd175b012fb8bf4e1dbda3bc6c # v2
         env:
           MACOSX_DEPLOYMENT_TARGET: ${{ matrix.os == 'macos-14' && '14' || '13' }}
           CIBW_ARCHS: "native"
@@ -136,13 +137,13 @@ jobs:
           key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
 
       - name: "Rename wheel compatibility tag"
-        if: startsWith(matrix.os, 'macos')
+        if: false #startsWith(matrix.os, 'macos')
         run: |
           brew install rename
           cd wheelhouse
           rename 's/11_0/10_15/g' *.whl
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: wheels
           path: |
@@ -155,19 +156,19 @@ jobs:
     needs: build_wheels
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           name: wheels
           path: ./wheelhouse
 
       - run: ls wheelhouse
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: "3.10"
 
       - name: Publish a Python distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.3
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: wheelhouse

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -30,6 +30,9 @@ on:
         default: false
   # schedule:
   #   - cron: '15 0 * * *'
+  pull_request:
+    paths:
+      - '.github/workflows/build_pyvelox.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [8-core-ubuntu]
+        os: [8-core-ubuntu, macos-13, macos-14]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -104,6 +104,7 @@ jobs:
         run: |
           export INSTALL_PREFIX="$GITHUB_WORKSPACE/dependencies"
           echo "CMAKE_PREFIX_PATH=$INSTALL_PREFIX" >> $GITHUB_ENV
+          echo "DYLD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
           bash scripts/setup-macos.sh 
 
       - name: "Create sdist"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -30,13 +30,6 @@ on:
         default: false
   # schedule:
   #   - cron: '15 0 * * *'
-  pull_request:
-    paths:
-      - 'velox/**'
-      - '!velox/docs/**'
-      - 'third_party/**'
-      - 'pyvelox/**'
-      - '.github/workflows/build_pyvelox.yml'
 
 permissions:
   contents: read

--- a/setup.py
+++ b/setup.py
@@ -125,9 +125,9 @@ class CMakeBuild(build_ext):
             extdir += os.path.sep
 
         if "DEBUG" in os.environ:
-            cfg = "Debug" if os.environ["DEBUG"] == "1" else "Release"
+            cfg = "Debug" if os.environ["DEBUG"] == "1" else "MinSizeRel"
         else:
-            cfg = "Debug" if self.debug else "Release"
+            cfg = "Debug" if self.debug else "MinSizeRel"
 
         exec_path = sys.executable
 


### PR DESCRIPTION
Fixes #12524 

Homebrew builds libraries with a deployment target matching the platform you are on (13/14 in this case) and delocate check this, so we can not build wheels that work on anything lower than macos 13 for intel and 14 for arm. Unless we build all dependencies we pull from brew from source, which doesn't really seem worth it.

Stacked on #12516 