### PR TITLE
feat: Expose file handle expiration as a hive config

### DIFF
--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -74,6 +74,16 @@ struct FileOptions {
       std::nullopt};
 
   File::IoStats* stats{nullptr};
+
+  /// A raw string that client can encode as anything they want to describe the
+  /// file. For example, extraFileInfo can contain serialized file descriptors
+  /// or other specific backend filesystem metadata can be used during for a
+  /// more optimized lookup.
+  std::shared_ptr<std::string> extraFileInfo{nullptr};
+
+  /// A hint to the file system for which region size of the file should be
+  /// read. Specifically, the read length.
+  std::optional<int64_t> readRangeHint{std::nullopt};
 };
 
 /// Defines directory options

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -55,6 +55,8 @@ std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
     options.stats = stats;
     if (properties) {
       options.fileSize = properties->fileSize;
+      options.readRangeHint = properties->readRangeHint;
+      options.extraFileInfo = properties->extraFileInfo;
     }
     fileHandle->file = filesystems::getFileSystem(filename, properties_)
                            ->openFileForRead(filename, options);

--- a/velox/connectors/hive/FileProperties.h
+++ b/velox/connectors/hive/FileProperties.h
@@ -32,6 +32,8 @@ namespace facebook::velox {
 struct FileProperties {
   std::optional<int64_t> fileSize;
   std::optional<int64_t> modificationTime;
+  std::optional<int64_t> readRangeHint{std::nullopt};
+  std::shared_ptr<std::string> extraFileInfo{nullptr};
 };
 
 } // namespace facebook::velox

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -158,6 +158,10 @@ int32_t HiveConfig::numCacheFileHandles() const {
   return config_->get<int32_t>(kNumCacheFileHandles, 20'000);
 }
 
+uint64_t HiveConfig::fileHandleExpirationDurationMs() const {
+  return config_->get<uint64_t>(kFileHandleExpirationDurationMs, 0);
+}
+
 bool HiveConfig::isFileHandleCacheEnabled() const {
   return config_->get<bool>(kEnableFileHandleCache, true);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -120,6 +120,12 @@ class HiveConfig {
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
+  /// Expiration time in ms for a file handle in the cache. A value of 0
+  /// means cache will not evict the handle after kFileHandleExprationDurationMs
+  /// has passed.
+  static constexpr const char* kFileHandleExpirationDurationMs =
+      "file-handle-expiration-duration-ms";
+
   /// Enable file handle cache.
   static constexpr const char* kEnableFileHandleCache =
       "file-handle-cache-enabled";
@@ -214,6 +220,8 @@ class HiveConfig {
   int32_t loadQuantum(const config::ConfigBase* session) const;
 
   int32_t numCacheFileHandles() const;
+
+  uint64_t fileHandleExpirationDurationMs() const;
 
   bool isFileHandleCacheEnabled() const;
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -55,7 +55,9 @@ HiveConnector::HiveConnector(
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with maximum of "
-              << hiveConfig_->numCacheFileHandles() << " cached file handles.";
+              << hiveConfig_->numCacheFileHandles()
+              << " cached file handles with expiration of "
+              << hiveConfig_->fileHandleExpirationDurationMs() << "ms.";
   } else {
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with file handle cache disabled";

--- a/velox/connectors/hive/HiveConnectorSplit.cpp
+++ b/velox/connectors/hive/HiveConnectorSplit.cpp
@@ -185,10 +185,10 @@ std::shared_ptr<HiveConnectorSplit> HiveConnectorSplit::create(
   const auto& propertiesObj = obj.getDefault("properties", nullptr);
   if (propertiesObj != nullptr) {
     properties = FileProperties{
-        propertiesObj["fileSize"].isNull()
+        .fileSize = propertiesObj["fileSize"].isNull()
             ? std::nullopt
             : std::optional(propertiesObj["fileSize"].asInt()),
-        propertiesObj["modificationTime"].isNull()
+        .modificationTime = propertiesObj["modificationTime"].isNull()
             ? std::nullopt
             : std::optional(propertiesObj["modificationTime"].asInt())};
   }

--- a/velox/connectors/hive/tests/FileHandleTest.cpp
+++ b/velox/connectors/hive/tests/FileHandleTest.cpp
@@ -64,7 +64,8 @@ TEST(FileHandleTest, localFileWithProperties) {
       std::make_unique<SimpleLRUCache<std::string, FileHandle>>(1000),
       std::make_unique<FileHandleGenerator>());
   FileProperties properties = {
-      tempFile->fileSize(), tempFile->fileModifiedTime()};
+      .fileSize = tempFile->fileSize(),
+      .modificationTime = tempFile->fileModifiedTime()};
   auto fileHandle = factory.generate(filename, &properties);
   ASSERT_EQ(fileHandle->file->size(), 3);
   char buffer[3];

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -68,6 +68,7 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kMaxCoalescedBytes, "100"},
       {HiveConfig::kMaxCoalescedDistance, "100kB"},
       {HiveConfig::kNumCacheFileHandles, "100"},
+      {HiveConfig::kFileHandleExpirationDurationMs, "200"},
       {HiveConfig::kEnableFileHandleCache, "false"},
       {HiveConfig::kSortWriterMaxOutputRows, "100"},
       {HiveConfig::kSortWriterMaxOutputBytes, "100MB"},
@@ -93,6 +94,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(
       hiveConfig.maxCoalescedDistanceBytes(emptySession.get()), 100 << 10);
   ASSERT_EQ(hiveConfig.numCacheFileHandles(), 100);
+  ASSERT_EQ(hiveConfig.fileHandleExpirationDurationMs(), 200);
   ASSERT_FALSE(hiveConfig.isFileHandleCacheEnabled());
   ASSERT_EQ(hiveConfig.sortWriterMaxOutputRows(emptySession.get()), 100);
   ASSERT_EQ(

--- a/velox/connectors/hive/tests/HiveSplitTest.cpp
+++ b/velox/connectors/hive/tests/HiveSplitTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::connector::hive;
 
 TEST(HiveSplitTest, builder) {
-  FileProperties properties = {11, 1111};
+  FileProperties properties = {.fileSize = 11, .modificationTime = 1111};
   auto extra = std::make_shared<std::string>("extra file info");
   std::unordered_map<std::string, std::string> custom;
   custom["custom1"] = "customValue1";


### PR DESCRIPTION
Summary: Requests can trickle into Presto and the file handles can stay in cache indefinitely. By exposing the TTL, we can help cases where a trickled in request evicts all of the expired cache to reduce memory footprint.

Differential Revision: D70637319


