### PR TITLE
refactor: Remove "extern void registerXxxAggregate" declarations from RegisterAggregateFunctions.cpp

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -23,6 +23,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h"
 #include "velox/functions/prestosql/types/HyperLogLogRegistration.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerApproxDistinctAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/Strings.h"

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerApproxMostFrequentAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace facebook::velox::aggregate::prestosql {
 
 enum ApproxPercentileIntermediateTypeChildIndex {
@@ -29,5 +31,10 @@ enum ApproxPercentileIntermediateTypeChildIndex {
   kItems = 7,
   kLevels = 8,
 };
+
+void registerApproxPercentileAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/AverageAggregate.h"
 #include "velox/functions/lib/aggregates/AverageAggregateBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 

--- a/velox/functions/prestosql/aggregates/AverageAggregate.h
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerAverageAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/BitwiseAggregates.h"
 #include "velox/functions/lib/aggregates/BitwiseAggregateBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.h
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.h
@@ -20,20 +20,9 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerBitwiseAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
+    bool onlyPrestoSignatures,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/BitwiseXorAggregate.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.h
@@ -20,20 +20,9 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerBitwiseXorAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
+    bool onlyPrestoSignatures,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/BoolAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"

--- a/velox/functions/prestosql/aggregates/BoolAggregates.h
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerBoolAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/CentralMomentsAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/CentralMomentsAggregates.h
+++ b/velox/functions/prestosql/aggregates/CentralMomentsAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerCentralMomentsAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/ChecksumAggregate.h"
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.h
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerChecksumAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/ClassificationAggregation.h"
 #include "velox/common/base/IOUtils.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.h
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerClassificationFunctions(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/CountAggregate.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"

--- a/velox/functions/prestosql/aggregates/CountAggregate.h
+++ b/velox/functions/prestosql/aggregates/CountAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerCountAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/CountIfAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.h
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerCountIfAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/CovarianceAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.h
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerCovarianceAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/EntropyAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.h
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerEntropyAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/GeometricMeanAggregate.h"
 #include <cmath>
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.h
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerGeometricMeanAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -21,6 +21,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/HistogramAggregate.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.h
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerHistogramAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/MapAggAggregate.h"
 #include "velox/functions/lib/CheckNestedNulls.h"
 #include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
 

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMapAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/MapUnionAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
 
 namespace facebook::velox::aggregate::prestosql {

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMapUnionAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/MapUnionSumAggregate.h"
 #include "velox/exec/AddressableNonNullValueList.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMapUnionSumAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/MaxByAggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
 

--- a/velox/functions/prestosql/aggregates/MaxByAggregate.h
+++ b/velox/functions/prestosql/aggregates/MaxByAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMaxByAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMaxDataSizeForStatsAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MinByAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/MinByAggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
 

--- a/velox/functions/prestosql/aggregates/MinByAggregate.h
+++ b/velox/functions/prestosql/aggregates/MinByAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMinByAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
 #include <limits>
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregationHook.h"

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.h
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMinMaxAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
 #include "velox/exec/AddressableNonNullValueList.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerMultiMapAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/ReduceAgg.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/Expr.h"

--- a/velox/functions/prestosql/aggregates/ReduceAgg.h
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerReduceAgg(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -14,135 +14,40 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h"
+#include "velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h"
+#include "velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h"
 #include "velox/functions/prestosql/aggregates/ArbitraryAggregate.h"
 #include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/AverageAggregate.h"
+#include "velox/functions/prestosql/aggregates/BitwiseAggregates.h"
+#include "velox/functions/prestosql/aggregates/BitwiseXorAggregate.h"
+#include "velox/functions/prestosql/aggregates/BoolAggregates.h"
+#include "velox/functions/prestosql/aggregates/CentralMomentsAggregates.h"
+#include "velox/functions/prestosql/aggregates/ChecksumAggregate.h"
+#include "velox/functions/prestosql/aggregates/ClassificationAggregation.h"
+#include "velox/functions/prestosql/aggregates/CountAggregate.h"
+#include "velox/functions/prestosql/aggregates/CountIfAggregate.h"
+#include "velox/functions/prestosql/aggregates/CovarianceAggregates.h"
+#include "velox/functions/prestosql/aggregates/EntropyAggregates.h"
+#include "velox/functions/prestosql/aggregates/GeometricMeanAggregate.h"
+#include "velox/functions/prestosql/aggregates/HistogramAggregate.h"
+#include "velox/functions/prestosql/aggregates/MapAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/MapUnionAggregate.h"
+#include "velox/functions/prestosql/aggregates/MapUnionSumAggregate.h"
+#include "velox/functions/prestosql/aggregates/MaxByAggregate.h"
+#include "velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h"
+#include "velox/functions/prestosql/aggregates/MinByAggregate.h"
+#include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
+#include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/ReduceAgg.h"
+#include "velox/functions/prestosql/aggregates/SetAggregates.h"
+#include "velox/functions/prestosql/aggregates/SumAggregate.h"
+#include "velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h"
+#include "velox/functions/prestosql/aggregates/VarianceAggregates.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
 
 namespace facebook::velox::aggregate::prestosql {
-
-extern void registerApproxMostFrequentAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerApproxPercentileAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerAverageAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerBitwiseXorAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool onlyPrestoSignatures,
-    bool overwrite);
-extern void registerChecksumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerClassificationFunctions(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCountAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCountIfAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerEntropyAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerGeometricMeanAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerHistogramAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapUnionAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMapUnionSumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMultiMapAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSumDataSizeForStatsAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerReduceAgg(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSetAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSetUnionAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-
-extern void registerApproxDistinctAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerBitwiseAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool onlyPrestoSignatures,
-    bool overwrite);
-extern void registerBoolAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCentralMomentsAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerCovarianceAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMinMaxAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMaxByAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerMinByAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerSumAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerVarianceAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
 
 void registerAllAggregateFunctions(
     const std::string& prefix,
@@ -188,15 +93,6 @@ void registerAllAggregateFunctions(
   registerSumAggregate(prefix, withCompanionFunctions, overwrite);
   registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
 }
-
-extern void registerCountDistinctAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
-extern void registerInternalArrayAggAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
 
 void registerInternalAggregateFunctions(const std::string& prefix) {
   bool withCompanionFunctions = false;

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/SetAggregates.h"
 #include "velox/functions/lib/aggregates/SetBaseAggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 

--- a/velox/functions/prestosql/aggregates/SetAggregates.h
+++ b/velox/functions/prestosql/aggregates/SetAggregates.h
@@ -20,20 +20,18 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerSetAggAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
 
+void registerSetUnionAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerCountDistinctAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/SumAggregate.h"
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerSumAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerSumDataSizeForStatsAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/aggregates/VarianceAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.h
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.h
@@ -20,20 +20,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-/// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
-/// @param withCompanionFunctions Also register companion functions, defaults
-/// to true.
-/// @param overwrite Whether to overwrite existing entry in the function
-/// registry, defaults to true.
-void registerArrayAggAggregate(
-    const std::string& prefix = "",
-    bool withCompanionFunctions = true,
-    bool overwrite = true);
-
-void registerInternalArrayAggAggregate(
+void registerVarianceAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Registering all aggregate functions increases build size too much.
closes #12538 