### PR TITLE
fix(function): Support Spark legacy behavior for central moments functions

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -333,6 +333,12 @@ class QueryConfig {
   static constexpr const char* kSparkLegacyDateFormatter =
       "spark.legacy_date_formatter";
 
+  /// If true, Spark statistical aggregation functions including skewness,
+  /// kurtosis, will return NaN instead of NULL when dividing by zero during
+  /// expression evaluation.
+  static constexpr const char* kSparkLegacyStatisticalAggregate =
+      "spark.legacy_statistical_aggregate";
+
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
 
@@ -844,6 +850,10 @@ class QueryConfig {
 
   bool sparkLegacyDateFormatter() const {
     return get<bool>(kSparkLegacyDateFormatter, false);
+  }
+
+  bool sparkLegacyStatisticalAggregate() const {
+    return get<bool>(kSparkLegacyStatisticalAggregate, false);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -901,6 +901,12 @@ Spark-specific Configuration
        Joda date formatter performs strict checking of its input and uses different pattern string.
        For example, the 2015-07-22 10:00:00 timestamp cannot be parsed if pattern is yyyy-MM-dd because the parser does not consume whole input.
        Another example is that the 'W' pattern, which means week in month, is not supported. For more differences, see :issue:`10354`.
+   * - spark.legacy_statistical_aggregate
+     - bool
+     - false
+     - If true, Spark statistical aggregation functions including skewness, kurtosis will return NaN instead of NULL
+       when dividing by zero during expression evaluation. Please note that Spark statistical aggregation functions
+       including stddev, stddev_samp, variance, var_samp, covar_samp and corr should be supported to respect this configuration.
 
 Tracing
 --------

--- a/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
@@ -15,28 +15,58 @@
  */
 
 #include "velox/functions/sparksql/aggregates/CentralMomentsAggregate.h"
+
+#include <limits>
 #include "velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
-
 namespace {
+
+// Calculate the skewness value from m2, count and m3.
+//
+// @tparam nullOnDivideByZero If true, return NULL instead of NaN when dividing
+// by zero during the calculating.
+template <bool nullOnDivideByZero>
 struct SkewnessResultAccessor {
   static bool hasResult(const CentralMomentsAccumulator& accumulator) {
-    return accumulator.count() >= 1 && accumulator.m2() != 0;
+    if constexpr (nullOnDivideByZero) {
+      return accumulator.count() >= 1 && accumulator.m2() != 0;
+    }
+    return accumulator.count() >= 1;
   }
 
   static double result(const CentralMomentsAccumulator& accumulator) {
+    if (accumulator.m2() == 0) {
+      VELOX_CHECK(
+          !nullOnDivideByZero,
+          "NaN is returned only when m2 is 0 and nullOnDivideByZero is false.");
+      return std::numeric_limits<double>::quiet_NaN();
+    }
     return std::sqrt(accumulator.count()) * accumulator.m3() /
         std::pow(accumulator.m2(), 1.5);
   }
 };
 
+// Calculate the kurtosis value from m2, count and m4.
+//
+// @tparam nullOnDivideByZero If true, return NULL instead of NaN when dividing
+// by zero during the calculating.
+template <bool nullOnDivideByZero>
 struct KurtosisResultAccessor {
   static bool hasResult(const CentralMomentsAccumulator& accumulator) {
-    return accumulator.count() >= 1 && accumulator.m2() != 0;
+    if constexpr (nullOnDivideByZero) {
+      return accumulator.count() >= 1 && accumulator.m2() != 0;
+    }
+    return accumulator.count() >= 1;
   }
 
   static double result(const CentralMomentsAccumulator& accumulator) {
+    if (accumulator.m2() == 0) {
+      VELOX_CHECK(
+          !nullOnDivideByZero,
+          "NaN is returned only when m2 is 0 and nullOnDivideByZero is false.");
+      return std::numeric_limits<double>::quiet_NaN();
+    }
     double count = accumulator.count();
     double m2 = accumulator.m2();
     double m4 = accumulator.m4();
@@ -44,7 +74,7 @@ struct KurtosisResultAccessor {
   }
 };
 
-template <typename TResultAccessor>
+template <template <bool> typename TResultAccessor>
 exec::AggregateRegistrationResult registerCentralMoments(
     const std::string& name,
     bool withCompanionFunctions,
@@ -64,29 +94,37 @@ exec::AggregateRegistrationResult registerCentralMoments(
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
-          -> std::unique_ptr<exec::Aggregate> {
+          const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes only one argument", name);
         const auto& inputType = argTypes[0];
         if (exec::isRawInput(step)) {
-          if (inputType->kind() == TypeKind::DOUBLE) {
-            return std::make_unique<
-                CentralMomentsAggregatesBase<double, TResultAccessor>>(
-                resultType);
-          }
-          VELOX_UNSUPPORTED(
+          VELOX_USER_CHECK_EQ(
+              inputType->kind(),
+              TypeKind::DOUBLE,
               "Unsupported input type: {}. "
               "Expected DOUBLE.",
               inputType->toString());
-        } else {
-          checkAccumulatorRowType(
-              inputType,
-              "Input type for final aggregation must be "
-              "(count:bigint, m1:double, m2:double, m3:double, m4:double) struct");
+          if (config.sparkLegacyStatisticalAggregate()) {
+            return std::make_unique<
+                CentralMomentsAggregatesBase<double, TResultAccessor<false>>>(
+                resultType);
+          }
+          return std::make_unique<
+              CentralMomentsAggregatesBase<double, TResultAccessor<true>>>(
+              resultType);
+        }
+        checkAccumulatorRowType(
+            inputType,
+            "Input type for final aggregation must be "
+            "(count:bigint, m1:double, m2:double, m3:double, m4:double) struct");
+        if (config.sparkLegacyStatisticalAggregate()) {
           return std::make_unique<CentralMomentsAggregatesBase<
               int64_t /*unused*/,
-              TResultAccessor>>(resultType);
+              TResultAccessor<false>>>(resultType);
         }
+        return std::make_unique<
+            CentralMomentsAggregatesBase<double, TResultAccessor<true>>>(
+            resultType);
       },
       withCompanionFunctions,
       overwrite);


### PR DESCRIPTION
In Spark `skewness` and `kurtosis` functions, the result should be Double.NaN 
instead of NULL if spark.legacy_statistical_aggregate is set to true when 
dividing by zero during expression evaluation.

This PR adds the template parameter 'nullOnDivideByZero' to the 
'SkewnessResultAccessor' and 'KurtosisResultAccessor', which controls whether 
NULL or NaN is returned when dividing by zero.
   
Part of: https://github.com/facebookincubator/velox/issues/12542