### PR TITLE
feat(json): Add support for recursive json path operator

### DIFF
--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -73,7 +73,12 @@ class JsonExtractor {
 
     while (kTokenizer.hasNext()) {
       if (auto token = kTokenizer.getNext()) {
-        tokens_.emplace_back(token.value());
+        auto& tk = token.value();
+        if (tk.selector == JsonPathTokenizer::Selector::WILDCARD) {
+          tokens_.emplace_back("*");
+        } else {
+          tokens_.emplace_back(tk.value);
+        }
       } else {
         tokens_.clear();
         return false;

--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -76,6 +76,10 @@ class JsonExtractor {
         auto& tk = token.value();
         if (tk.selector == JsonPathTokenizer::Selector::WILDCARD) {
           tokens_.emplace_back("*");
+        } else if (tk.selector == JsonPathTokenizer::Selector::RECURSIVE) {
+          // Not supported in this implementation of json_extract
+          tokens_.clear();
+          return false;
         } else {
           tokens_.emplace_back(tk.value);
         }

--- a/velox/functions/prestosql/json/JsonPathTokenizer.h
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.h
@@ -79,7 +79,8 @@ namespace facebook::velox::functions {
 /// make the behavior of ignoring whitespaces more consistent as whitespaces are
 /// ignored if there is a quoted string within brackets.
 ///
-/// (5) Dot and Bracket notation are interpreted the same after a wildcard:
+/// (5) Dot and Bracket notation are interpreted the same after a wildcard or
+///     recursive operator:
 /// Jayway changes how it inteprets unquoted strings after dot and bracket
 /// notations. That is, tokens after dot notation are considered as either a
 /// key(if there is an object) or an index(if there is an array), however
@@ -108,7 +109,7 @@ namespace facebook::velox::functions {
 /// TODO: Add support for unicode charaters after dot notation.
 class JsonPathTokenizer {
  public:
-  enum class Selector { KEY, WILDCARD, KEY_OR_INDEX };
+  enum class Selector { KEY, WILDCARD, KEY_OR_INDEX, RECURSIVE };
 
   struct Token {
     std::string value;
@@ -153,6 +154,13 @@ class JsonPathTokenizer {
 
   // The path specified in 'reset'.
   std::string_view path_;
+
+  // Intermediate state variable used to signify that we previous processed the
+  // DOT operator. This is used in cases where the path does not start with a
+  // '$' where we assume the path starts with '$.' OR when we have just
+  // processed the recursive operator '..' and expect either a dotKey or a
+  // bracket.
+  bool previouslyProcessedDotOp_ = false;
 };
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -31,6 +31,9 @@ class SIMDJsonExtractor {
  public:
   /**
    * Extract element(s) from a JSON object using the given path.
+   * See class comments in JsonPathTokenizer.h for more details on how json path
+   * is interpreted and has notable differences compared to Jayway (used by
+   * Presto java).
    * @param json: A json string of type simdjson::padded_string
    * @param path: Path to locate a JSON object. Following operators are
    * supported.
@@ -40,6 +43,10 @@ class SIMDJsonExtractor {
    *              "[]"     Subscript operator for array or object.
    *              "*"      Wildcard operator, gets all the elements of an array
    *                       or all values in an object.
+   *              ".."     Recursive descent operator, where it visits the input
+   *                       node and each of its descendants such that nodes of
+   * any array are visited in array order, and nodes are visited before their
+   * descendants.
    * @param consumer: Function to consume the extracted elements. Should be able
    *                  to take an argument that can either be a
    *                  simdjson::ondemand::document or a
@@ -82,11 +89,21 @@ class SIMDJsonExtractor {
   bool tokenize(const std::string& path);
 
   template <typename TConsumer>
-  simdjson::error_code extract(
+  simdjson::error_code extractInternal(
       simdjson::ondemand::value& json,
       TConsumer& consumer,
       bool& isDefinitePath,
       size_t tokenStartIndex = 0);
+
+  // Implementation for the recursive operator (..) where it visits the input
+  // node and each of its descendants such that nodes of any array are visited
+  // in array order, and nodes are visited before their descendants.
+  template <typename TConsumer>
+  simdjson::error_code visitRecursive(
+      simdjson::ondemand::value& json,
+      TConsumer& consumer,
+      bool& isDefinitePath,
+      size_t startTokenIdx);
 
   // Max number of extractors cached in extractorCache.
   static const uint32_t kMaxCacheSize{32};
@@ -124,11 +141,11 @@ simdjson::error_code SIMDJsonExtractor::extract(
     return simdjson::SUCCESS;
   }
   SIMDJSON_ASSIGN_OR_RAISE(auto value, jsonDoc.get_value());
-  return extract(value, consumer, isDefinitePath, 0);
+  return extractInternal(value, consumer, isDefinitePath, 0);
 }
 
 template <typename TConsumer>
-simdjson::error_code SIMDJsonExtractor::extract(
+simdjson::error_code SIMDJsonExtractor::extractInternal(
     simdjson::ondemand::value& json,
     TConsumer& consumer,
     bool& isDefinitePath,
@@ -136,51 +153,56 @@ simdjson::error_code SIMDJsonExtractor::extract(
   simdjson::ondemand::value input = json;
   // Temporary extraction result holder.
   std::optional<simdjson::ondemand::value> result;
-
   for (int tokenIndex = tokenStartIndex; tokenIndex < tokens_.size();
        tokenIndex++) {
     auto& token = tokens_[tokenIndex];
-    if (token.selector == JsonPathTokenizer::Selector::WILDCARD) {
+    auto& selector = token.selector;
+    if (selector == JsonPathTokenizer::Selector::WILDCARD ||
+        selector == JsonPathTokenizer::Selector::RECURSIVE) {
       isDefinitePath = false;
     }
     if (input.type() == simdjson::ondemand::json_type::object) {
-      if (token.selector == JsonPathTokenizer::Selector::WILDCARD) {
+      if (selector == JsonPathTokenizer::Selector::WILDCARD) {
         SIMDJSON_ASSIGN_OR_RAISE(auto jsonObj, input.get_object());
         for (auto field : jsonObj) {
           simdjson::ondemand::value val = field.value();
           if (tokenIndex == tokens_.size() - 1) {
-            // If this is the last token in the path, consume each element in
-            // the object.
+            // Consume each element in the object.
             SIMDJSON_TRY(consumer(val));
           } else {
-            // If not, then recursively call the extract function on each
-            // element in the object.
+            // If not, then recursively call the extractInternal function on
+            // each element in the object.
             SIMDJSON_TRY(
-                extract(val, consumer, isDefinitePath, tokenIndex + 1));
+                extractInternal(val, consumer, isDefinitePath, tokenIndex + 1));
           }
         }
         return simdjson::SUCCESS;
+      } else if (selector == JsonPathTokenizer::Selector::RECURSIVE) {
+        SIMDJSON_TRY(
+            visitRecursive(input, consumer, isDefinitePath, tokenIndex + 1));
       } else if (
-          token.selector == JsonPathTokenizer::Selector::KEY ||
-          token.selector == JsonPathTokenizer::Selector::KEY_OR_INDEX) {
+          selector == JsonPathTokenizer::Selector::KEY ||
+          selector == JsonPathTokenizer::Selector::KEY_OR_INDEX) {
         SIMDJSON_TRY(extractObject(input, token.value, result));
       }
     } else if (input.type() == simdjson::ondemand::json_type::array) {
-      if (token.selector == JsonPathTokenizer::Selector::WILDCARD) {
+      if (selector == JsonPathTokenizer::Selector::WILDCARD) {
         for (auto child : input.get_array()) {
           if (tokenIndex == tokens_.size() - 1) {
-            // If this is the last token in the path, consume each element in
-            // the array.
+            // Consume each element in the object.
             SIMDJSON_TRY(consumer(child.value()));
           } else {
-            // If not, then recursively call the extract function on each
-            // element in the array.
-            SIMDJSON_TRY(extract(
+            // If not, then recursively call the extractInternal function on
+            // each element in the array.
+            SIMDJSON_TRY(extractInternal(
                 child.value(), consumer, isDefinitePath, tokenIndex + 1));
           }
         }
         return simdjson::SUCCESS;
-      } else if (token.selector == JsonPathTokenizer::Selector::KEY_OR_INDEX) {
+      } else if (selector == JsonPathTokenizer::Selector::RECURSIVE) {
+        SIMDJSON_TRY(
+            visitRecursive(input, consumer, isDefinitePath, tokenIndex + 1));
+      } else if (selector == JsonPathTokenizer::Selector::KEY_OR_INDEX) {
         SIMDJSON_TRY(extractArray(input, token.value, result));
       }
     }
@@ -194,4 +216,54 @@ simdjson::error_code SIMDJsonExtractor::extract(
 
   return consumer(input);
 };
+
+template <typename TConsumer>
+simdjson::error_code SIMDJsonExtractor::visitRecursive(
+    simdjson::ondemand::value& json,
+    TConsumer& consumer,
+    bool& isDefinitePath,
+    size_t startTokenIdx) {
+  // SIMDJson doesn't support iterating and extracting an ondemand value
+  // multiple times which is required for the recursive operator. Therefore, we
+  // need to extract the json string and use it with a new local parser object.
+  // Moreover, since the extracted string was already padded we can avoid
+  // creating a new copy with padding and utilize reusePaddedStringView() to
+  // create a no-copy padded_string_view.
+  SIMDJSON_ASSIGN_OR_RAISE(auto jsonString, simdjson::to_json_string(json));
+  simdjson::padded_string_view paddedJson = reusePaddedStringView(jsonString);
+  simdjson::ondemand::parser localParser;
+  SIMDJSON_ASSIGN_OR_RAISE(auto jsonDoc, localParser.iterate(paddedJson));
+  simdjson::ondemand::value jsonDocVal = jsonDoc.get_value();
+  // Visit the current node.
+  SIMDJSON_TRY(
+      extractInternal(jsonDocVal, consumer, isDefinitePath, startTokenIdx));
+
+  // Reset the local parser for the next round of iteration where we visit the
+  // children.
+  SIMDJSON_ASSIGN_OR_RAISE(jsonDoc, localParser.iterate(paddedJson));
+  jsonDocVal = jsonDoc.get_value();
+  if (jsonDocVal.type() == simdjson::ondemand::json_type::object) {
+    SIMDJSON_ASSIGN_OR_RAISE(auto jsonObj, jsonDocVal.get_object());
+    for (auto field : jsonObj) {
+      simdjson::ondemand::value val = field.value();
+      if (val.type() != simdjson::ondemand::json_type::object &&
+          val.type() != simdjson::ondemand::json_type::array) {
+        continue;
+      }
+      SIMDJSON_TRY(
+          visitRecursive(val, consumer, isDefinitePath, startTokenIdx));
+    }
+  } else if (jsonDocVal.type() == simdjson::ondemand::json_type::array) {
+    for (auto child : jsonDocVal.get_array()) {
+      simdjson::ondemand::value val = child.value();
+      if (val.type() != simdjson::ondemand::json_type::object &&
+          val.type() != simdjson::ondemand::json_type::array) {
+        continue;
+      }
+      SIMDJSON_TRY(
+          visitRecursive(val, consumer, isDefinitePath, startTokenIdx));
+    }
+  }
+  return simdjson::SUCCESS;
+}
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/SIMDJsonUtil.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.cpp
@@ -34,4 +34,10 @@ simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParse(
   return parser.iterate(json);
 }
 
+simdjson::padded_string_view reusePaddedStringView(
+    const std::string_view& json) {
+  return simdjson::padded_string_view(
+      json.data(), json.length(), json.length() + simdjson::SIMDJSON_PADDING);
+};
+
 } // namespace facebook::velox

--- a/velox/functions/prestosql/json/SIMDJsonUtil.h
+++ b/velox/functions/prestosql/json/SIMDJsonUtil.h
@@ -47,4 +47,11 @@ void simdjsonErrorsToExceptions(
 simdjson::simdjson_result<simdjson::ondemand::document> simdjsonParse(
     const simdjson::padded_string_view& json);
 
+/// Returns a simdjson::padded_string_view object from the input
+/// std::string_view object to avoid creating a new copy of the
+/// std::string_view. NOTE: The user MUST ensure that the input 'json' already
+/// has simdjson::SIMDJSON_PADDING at the end.
+simdjson::padded_string_view reusePaddedStringView(
+    const std::string_view& json);
+
 } // namespace facebook::velox

--- a/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonPathTokenizerTest.cpp
@@ -20,9 +20,10 @@
 #include "gtest/gtest.h"
 
 using namespace std::string_literals;
-using TokenList = std::vector<std::string>;
 
 namespace facebook::velox::functions {
+using Selector = JsonPathTokenizer::Selector;
+using TokenList = std::vector<JsonPathTokenizer::Token>;
 namespace {
 
 std::optional<TokenList> getTokens(std::string_view path) {
@@ -51,8 +52,13 @@ void assertValidPath(std::string_view path, const TokenList& expectedTokens) {
   if (!tokens.has_value()) {
     return;
   }
-
-  EXPECT_EQ(expectedTokens, tokens.value());
+  EXPECT_EQ(expectedTokens.size(), tokens.value().size());
+  for (auto i = 0; i < expectedTokens.size(); ++i) {
+    EXPECT_EQ(expectedTokens[i], tokens.value()[i])
+        << "Tokens mismatch at " << i << ": Expected "
+        << expectedTokens[i].toString() << ", got "
+        << tokens.value()[i].toString() << " for path " << path;
+  }
 }
 
 void assertQuotedToken(
@@ -62,66 +68,329 @@ void assertQuotedToken(
   assertValidPath(quotedPath, expectedTokens);
 
   auto invalidPath = "$." + token;
-  EXPECT_FALSE(getTokens(invalidPath));
+  EXPECT_FALSE(getTokens(invalidPath))
+      << "Expected no tokens for path: " << invalidPath;
 }
 
 // The test is ported from Presto for compatibility.
 TEST(JsonPathTokenizerTest, validPaths) {
   assertValidPath("$"s, TokenList());
-  assertValidPath("$.foo"s, TokenList{"foo"s});
-  assertValidPath("$[\"foo\"]"s, TokenList{"foo"s});
-  assertValidPath("$[\"foo.bar\"]"s, TokenList{"foo.bar"s});
-  assertValidPath("$[42]"s, TokenList{"42"s});
-  assertValidPath("$[-1]"s, TokenList{"-1"s});
-  assertValidPath("$.42"s, TokenList{"42"s});
-  assertValidPath("$.42.63"s, TokenList{"42"s, "63"s});
-  assertValidPath("$.foo.42.bar.63"s, TokenList{"foo"s, "42"s, "bar"s, "63"s});
-  assertValidPath("$.x.foo"s, TokenList{"x"s, "foo"s});
-  assertValidPath("$.x[\"foo\"]"s, TokenList{"x"s, "foo"s});
-  assertValidPath("$.x[42]"s, TokenList{"x"s, "42"s});
-  assertValidPath("$.foo_42._bar63"s, TokenList{"foo_42"s, "_bar63"s});
-  assertValidPath("$[foo_42][_bar63]"s, TokenList{"foo_42"s, "_bar63"s});
-  assertValidPath("$.foo:42.:bar63"s, TokenList{"foo:42"s, ":bar63"s});
+  assertValidPath("$.foo"s, TokenList{{"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath("$[\"foo\"]"s, TokenList{{"foo", Selector::KEY}});
+  assertValidPath("$[\"foo.bar\"]"s, TokenList{{"foo.bar", Selector::KEY}});
+  assertValidPath("$[42]"s, TokenList{{"42", Selector::KEY_OR_INDEX}});
+  assertValidPath("$[-1]"s, TokenList{{"-1", Selector::KEY_OR_INDEX}});
+  assertValidPath("$.42"s, TokenList{{"42", Selector::KEY_OR_INDEX}});
   assertValidPath(
-      "$[\"foo:42\"][\":bar63\"]"s, TokenList{"foo:42"s, ":bar63"s});
-  assertValidPath("$['foo:42'][':bar63']"s, TokenList{"foo:42"s, ":bar63"s});
+      "$.42.63"s,
+      TokenList{
+          {"42", Selector::KEY_OR_INDEX}, {"63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo.42.bar.63"s,
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"42", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.x.foo"s,
+      TokenList{
+          {"x", Selector::KEY_OR_INDEX}, {"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.x[\"foo\"]"s,
+      TokenList{{"x", Selector::KEY_OR_INDEX}, {"foo", Selector::KEY}});
+  assertValidPath(
+      "$.x[42]"s,
+      TokenList{{"x", Selector::KEY_OR_INDEX}, {"42", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo_42._bar63"s,
+      TokenList{
+          {"foo_42", Selector::KEY_OR_INDEX},
+          {"_bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[foo_42][_bar63]"s,
+      TokenList{
+          {"foo_42", Selector::KEY_OR_INDEX},
+          {"_bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo:42.:bar63"s,
+      TokenList{
+          {"foo:42", Selector::KEY_OR_INDEX},
+          {":bar63", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[\"foo:42\"][\":bar63\"]"s,
+      TokenList{{"foo:42", Selector::KEY}, {":bar63", Selector::KEY}});
+  assertValidPath(
+      "$['foo:42'][':bar63']"s,
+      TokenList{{"foo:42", Selector::KEY}, {":bar63", Selector::KEY}});
   assertValidPath(
       "$.store.fruit[*].weight",
-      TokenList{"store"s, "fruit"s, "*"s, "weight"s});
+      TokenList{
+          {"store", Selector::KEY_OR_INDEX},
+          {"fruit", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"weight", Selector::KEY_OR_INDEX}});
   assertValidPath(
-      "$.store.book[*].author", TokenList{"store", "book", "*", "author"});
-  assertValidPath("$.store.*", TokenList({"store", "*"}));
+      "$.store.fruit.[*].weight",
+      TokenList{
+          {"store", Selector::KEY_OR_INDEX},
+          {"fruit", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"weight", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.store.*",
+      TokenList{{"store", Selector::KEY_OR_INDEX}, {"", Selector::WILDCARD}});
 
   // Paths without leading '$'.
-  assertValidPath("foo", TokenList({"foo"}));
-  assertValidPath("foo[12].bar", TokenList({"foo", "12", "bar"}));
-  assertValidPath("foo.bar.baz", TokenList({"foo", "bar", "baz"}));
-  assertValidPath(R"(["foo"])", TokenList({"foo"}));
-  assertValidPath(R"(["foo"].bar)", TokenList({"foo", "bar"}));
-  assertValidPath(R"([0][1].foo)", TokenList({"0", "1", "foo"}));
+  assertValidPath("foo", TokenList{{"foo", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "foo[12].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"12", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "foo.bar.baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"baz", Selector::KEY_OR_INDEX}});
+  assertValidPath(R"(["foo"])", TokenList{{"foo", Selector::KEY}});
+  assertValidPath(
+      R"(["foo"].bar)",
+      TokenList{{"foo", Selector::KEY}, {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      R"([0][1].foo)",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX}});
 
   // Paths with redundant '.'s.
-  assertValidPath("$.[0].[1].[2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$[0].[1].[2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$[0].[1][2]", TokenList({"0", "1", "2"}));
-  assertValidPath("$.[0].[1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
-  assertValidPath("$[0].[1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
-  assertValidPath("$[0][1].foo.[2]", TokenList({"0", "1", "foo", "2"}));
+  assertValidPath(
+      "$.[0].[1].[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1].[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1][2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.[0].[1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0].[1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$[0][1].foo.[2]",
+      TokenList{
+          {"0", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"foo", Selector::KEY_OR_INDEX},
+          {"2", Selector::KEY_OR_INDEX}});
 
-  assertQuotedToken("!@#$%^&*()[]{}/?'"s, TokenList{"!@#$%^&*()[]{}/?'"s});
-  assertQuotedToken("ab\u0001c"s, TokenList{"ab\u0001c"s});
-  assertQuotedToken("ab\0c"s, TokenList{"ab\0c"s});
-  assertQuotedToken("ab\t\n\rc"s, TokenList{"ab\t\n\rc"s});
-  assertQuotedToken("."s, TokenList{"."s});
-  assertQuotedToken("$"s, TokenList{"$"s});
-  assertQuotedToken("]"s, TokenList{"]"s});
-  assertQuotedToken("["s, TokenList{"["s});
-  assertQuotedToken("'"s, TokenList{"'"s});
+  // * as an identifier or wildcard operator.
+  assertValidPath(
+      "$[*]",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.[*]",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.*",
+      TokenList{
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$['*']",
+      TokenList{
+          {"*", Selector::KEY},
+      });
+  assertValidPath(
+      "$[*a]",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.[*a]",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.*a",
+      TokenList{
+          {"*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$['*a']",
+      TokenList{
+          {"*a", Selector::KEY},
+      });
+  assertValidPath(
+      "$[a*a]",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.[a*a]",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.a*a",
+      TokenList{
+          {"a*a", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$['a*a']",
+      TokenList{
+          {"a*a", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo[*]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+      });
+  assertValidPath(
+      "$.foo[*].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"", Selector::WILDCARD},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+
+  // String after dot operator.
+  assertValidPath(
+      "$.$",
+      TokenList{
+          {"$", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.@",
+      TokenList{
+          {"@", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.'abc'",
+      TokenList{
+          {"'abc'", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.\"abc\"",
+      TokenList{
+          {"\"abc\"", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.:",
+      TokenList{
+          {":", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.,",
+      TokenList{
+          {",", Selector::KEY_OR_INDEX},
+      });
+
+  // Whitespaces between identifiers and brackets like $.[  1   ].
+  assertValidPath(
+      "$.foo[  1   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[1   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[  1].bar",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"1", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo[  'bar'   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo['bar'   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+      });
+  assertValidPath(
+      "$.foo[  'bar'].baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY},
+          {"baz", Selector::KEY_OR_INDEX}});
+  assertValidPath(
+      "$.foo[  bar   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[bar   ]",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+      });
+  assertValidPath(
+      "$.foo[  bar].baz",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+          {"bar", Selector::KEY_OR_INDEX},
+          {"baz", Selector::KEY_OR_INDEX}});
+
+  // Using @ instead of $ at the beginning of the path.
+  assertValidPath(
+      "@.foo",
+      TokenList{
+          {"foo", Selector::KEY_OR_INDEX},
+      });
+
+  assertQuotedToken(
+      "!@#$%^&*()[]{}/?'"s, TokenList{{"!@#$%^&*()[]{}/?'"s, Selector::KEY}});
+  assertQuotedToken("ab\u0001c"s, TokenList{{"ab\u0001c"s, Selector::KEY}});
+  assertQuotedToken("ab\0c"s, TokenList{{"ab\0c"s, Selector::KEY}});
+  assertQuotedToken("ab\t\n\rc"s, TokenList{{"ab\t\n\rc"s, Selector::KEY}});
+  assertQuotedToken("."s, TokenList{{"."s, Selector::KEY}});
+  assertQuotedToken("]"s, TokenList{{"]"s, Selector::KEY}});
+  assertQuotedToken("["s, TokenList{{"["s, Selector::KEY}});
   assertQuotedToken(
       "!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s,
-      TokenList{"!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s});
-  assertQuotedToken("a\\\\b\\\""s, TokenList{"a\\b\""s});
-  assertQuotedToken("ab\\\"cd\\\"ef"s, TokenList{"ab\"cd\"ef"s});
+      TokenList{{"!@#$%^&*(){}[]<>?/|.,`~\r\n\t \0"s, Selector::KEY}});
+  assertQuotedToken("a\\\\b\\\""s, TokenList{{"a\\b\""s, Selector::KEY}});
+  assertQuotedToken(
+      "ab\\\"cd\\\"ef"s, TokenList{{"ab\"cd\"ef"s, Selector::KEY}});
 }
 
 TEST(JsonPathTokenizerTest, invalidPaths) {
@@ -145,15 +414,41 @@ TEST(JsonPathTokenizerTest, invalidPaths) {
   // Unmatched single quote.
   EXPECT_FALSE(getTokens(R"($['foo"])"));
 
+  // Whitespace in after dot operator.
+  EXPECT_FALSE(getTokens("$. foo"s));
+  EXPECT_FALSE(getTokens("$. 1"s));
+
+  // Unicode characters after dot operator.
+  EXPECT_FALSE(getTokens("$.[屬性]"));
+
   // Unsupported deep scan operator.
   EXPECT_FALSE(getTokens("$..store"));
   EXPECT_FALSE(getTokens("..store"));
   EXPECT_FALSE(getTokens("$..[3].foo"));
   EXPECT_FALSE(getTokens("..[3].foo"));
 
-  // Paths without leading '$'.
+  // Paths without leading '$' which essentially translates to "$.." and is
+  // unsupported.
   EXPECT_FALSE(getTokens(".[1].foo"));
   EXPECT_FALSE(getTokens(".foo.bar.baz"));
+
+  // Array Slice
+  EXPECT_FALSE(getTokens("$[1:3]"));
+  EXPECT_FALSE(getTokens("$[0:4:2]"));
+  EXPECT_FALSE(getTokens("$[1:3:]"));
+  EXPECT_FALSE(getTokens("$[::2]"));
+
+  // Union
+  EXPECT_FALSE(getTokens("$[0,1]"));
+  EXPECT_FALSE(getTokens("$['a','a']"));
+  EXPECT_FALSE(getTokens("$.*['c','d']"));
+
+  // Filter Expr
+  EXPECT_FALSE(getTokens("$[?(@.key)]"));
+  EXPECT_FALSE(getTokens("$[?(@.key>0 && false)]"));
+
+  // Script expression
+  EXPECT_FALSE(getTokens("$[(@.length-1)]"));
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -191,15 +191,6 @@ TEST_F(JsonExtractScalarTest, invalidPath) {
       jsonExtractScalar(R"({"k1":"v1"})", "$.k1]"), "Invalid JSON path");
   VELOX_ASSERT_THROW(
       jsonExtractScalar(R"({"k1":"v1)", "$.k1]"), "Invalid JSON path");
-
-  // Paths without leading '$'.
-  VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"([1,2])", ".[0]"), "Invalid JSON path");
-  VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"({"k1":"v1"})", ".k1"), "Invalid JSON path");
-  VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"({"k1":{"k2": 999}})", ".k1.k2"),
-      "Invalid JSON path");
 }
 
 // simdjson, like Presto java, returns the large number as-is as a string,


### PR DESCRIPTION
Summary:
Adds changes to the json tokenizer and the extract implementation
for supporting the recursive operator (..) where it visits the input
node and each of its descendants such that nodes of any array are visited
in array order, and nodes are visited before their descendants.

Differential Revision: D70726450


