### PR TITLE
fix(s3): Handle trailing slash for AWS endpoint values

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -76,10 +76,11 @@ S3Config::S3Config(
 std::optional<std::string> S3Config::endpointRegion() const {
   auto region = config_.find(Keys::kEndpointRegion)->second;
   if (!region.has_value()) {
-    // If region is not set, try inferring from the endpoint.
+    // If region is not set, try inferring from the endpoint value for AWS
+    // endpoints.
     auto endpointValue = endpoint();
     if (endpointValue.has_value()) {
-      region = parseStandardRegionName(endpointValue.value());
+      region = parseAWSStandardRegionName(endpointValue.value());
     }
   }
   return region;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.cpp
@@ -149,9 +149,17 @@ std::optional<folly::Uri> S3ProxyConfigurationBuilder::build() {
   return proxyUri;
 }
 
-std::optional<std::string> parseStandardRegionName(std::string_view endpoint) {
+std::optional<std::string> parseAWSStandardRegionName(
+    std::string_view endpoint) {
+  // The assumption is that the endpoint ends with
+  // ".amazonaws.com" or ".amazonaws.com/". That means for AWS we don't
+  // expect a port in the endpoint.
   const std::string_view kAmazonHostSuffix = ".amazonaws.com";
   auto index = endpoint.size() - kAmazonHostSuffix.size();
+  // Handle the case where the endpoint ends in a trailing slash.
+  if (endpoint.back() == '/') {
+    index--;
+  }
   if (endpoint.rfind(kAmazonHostSuffix) != index) {
     return std::nullopt;
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -195,7 +195,9 @@ std::string getNoProxyEnvVar();
 // Endpoint can be 'service.[region].amazonaws.com' or
 // 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'
 // Return value is a region string value if present.
-std::optional<std::string> parseStandardRegionName(std::string_view endpoint);
+// The endpoint may contain a trailing '/' that is handled.
+std::optional<std::string> parseAWSStandardRegionName(
+    std::string_view endpoint);
 
 class S3ProxyConfigurationBuilder {
  public:

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -127,17 +127,25 @@ TEST(S3UtilTest, isDomainExcludedFromProxy) {
   }
 }
 
-TEST(S3UtilTest, parseRegion) {
+TEST(S3UtilTest, parseAWSRegion) {
   // bucket.s3.[region]
-  EXPECT_EQ(parseStandardRegionName("foo.s3.region.amazonaws.com"), "region");
+  EXPECT_EQ(
+      parseAWSStandardRegionName("foo.s3.region.amazonaws.com"), "region");
+  EXPECT_EQ(
+      parseAWSStandardRegionName("foo.s3.region.amazonaws.com/"), "region");
   // bucket.s3-[region]
-  EXPECT_EQ(parseStandardRegionName("foo.s3-region.amazonaws.com"), "region");
+  EXPECT_EQ(
+      parseAWSStandardRegionName("foo.s3-region.amazonaws.com"), "region");
+  EXPECT_EQ(
+      parseAWSStandardRegionName("foo.s3-region.amazonaws.com/"), "region");
   // service.[region]
-  EXPECT_EQ(parseStandardRegionName("foo.a3-reg.amazonaws.com"), "a3-reg");
+  EXPECT_EQ(parseAWSStandardRegionName("foo.a3-reg.amazonaws.com"), "a3-reg");
+  EXPECT_EQ(parseAWSStandardRegionName("foo.a3-reg.amazonaws.com/"), "a3-reg");
   // Not the right suffix
-  EXPECT_EQ(parseStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
-  EXPECT_EQ(parseStandardRegionName(""), std::nullopt);
-  EXPECT_EQ(parseStandardRegionName("velox"), std::nullopt);
+  EXPECT_EQ(
+      parseAWSStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName(""), std::nullopt);
+  EXPECT_EQ(parseAWSStandardRegionName("velox"), std::nullopt);
 }
 
 TEST(S3UtilTest, isIpExcludedFromProxy) {


### PR DESCRIPTION
For flexibility of handling user input the region extraction should handle if the endpoint for for AWS ends in a trailing slash. Users may accidentally copy&paste the endpoint including a slash which may not be easily fixable in deployments.