### PR TITLE
fix: Fix string copy of Presto array_remove function

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -1161,7 +1161,7 @@ struct ArrayRemoveFunctionString {
       if (item.has_value()) {
         auto result = element.compare(item.value());
         if (result) {
-          out.push_back(item.value());
+          out.add_item().setNoCopy(item.value());
         }
       } else {
         out.add_null();


### PR DESCRIPTION
The array push_back for string was supported in #8334, but the implementation 
copies the original string. This PR changes to use `setNoCopy` to avoid string
copy in the array_remove function.