### PR TITLE
feat: Register Spark array_min/max functions with orderable types

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -94,6 +94,7 @@ Array Functions
         SELECT array_max(array(-1, -2, NULL)); -- -1
         SELECT array_max(array()); -- NULL
         SELECT array_max(array(-0.0001, -0.0002, -0.0003, float('nan'))); -- NaN
+        SELECT array_max(array(array(1), array(NULL))) -- array(1)
 
 .. spark:function:: array_min(array(E)) -> E
 
@@ -105,8 +106,9 @@ Array Functions
         SELECT array_min(array(-1, -2, NULL)); -- -2
         SELECT array_min(array(NULL, NULL)); -- NULL
         SELECT array_min(array()); -- NULL
-        SELECT array_min(array(4.0, float('nan')]); -- 4.0
+        SELECT array_min(array(4.0, float('nan'))); -- 4.0
         SELECT array_min(array(NULL, float('nan'))); -- NaN
+        SELECT array_min(array(array(1), array(NULL))) -- array(NULL)
 
 .. spark:function:: array_position(x, element) -> bigint
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -94,7 +94,9 @@ Array Functions
         SELECT array_max(array(-1, -2, NULL)); -- -1
         SELECT array_max(array()); -- NULL
         SELECT array_max(array(-0.0001, -0.0002, -0.0003, float('nan'))); -- NaN
-        SELECT array_max(array(array(1), array(NULL))) -- array(1)
+        SELECT array_max(array(array(1), array(NULL))); -- array(1)
+        SELECT array_max(array(array(1), array(2, 1), array(2))); -- array(2, 1)
+        SELECT array_max(array(array(1.0), array(1.0, 2.0), array(cast('NaN' as double)))); --array(NaN)
 
 .. spark:function:: array_min(array(E)) -> E
 
@@ -108,7 +110,9 @@ Array Functions
         SELECT array_min(array()); -- NULL
         SELECT array_min(array(4.0, float('nan'))); -- 4.0
         SELECT array_min(array(NULL, float('nan'))); -- NaN
-        SELECT array_min(array(array(1), array(NULL))) -- array(NULL)
+        SELECT array_min(array(array(1), array(NULL))); -- array(NULL)
+        SELECT array_min(array(array(1), array(1, 2), array(2))); -- array(1)
+        SELECT array_min(array(array(1.0), array(1.0, 2.0), array(cast('NaN' as double)))); --array(1.0)
 
 .. spark:function:: array_position(x, element) -> bigint
 

--- a/velox/functions/sparksql/ArrayMinMaxFunction.h
+++ b/velox/functions/sparksql/ArrayMinMaxFunction.h
@@ -28,44 +28,6 @@ struct ArrayMinMaxFunction {
   // Results refer to strings in the first argument.
   static constexpr int32_t reuse_strings_from_arg = 0;
 
-  template <typename T>
-  void update(T& currentValue, const T& candidateValue) {
-    // NaN is greater than any non-NaN elements for double/float type.
-    if constexpr (std::is_floating_point_v<T>) {
-      if constexpr (isMax) {
-        if (std::isnan(candidateValue) ||
-            (!std::isnan(currentValue) && candidateValue > currentValue)) {
-          currentValue = candidateValue;
-        }
-      } else {
-        if (std::isnan(currentValue) ||
-            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
-          currentValue = candidateValue;
-        }
-      }
-      return;
-    }
-
-    if constexpr (isMax) {
-      if (candidateValue > currentValue) {
-        currentValue = candidateValue;
-      }
-    } else {
-      if (candidateValue < currentValue) {
-        currentValue = candidateValue;
-      }
-    }
-  }
-
-  template <typename T>
-  void assign(T& out, const T& value) {
-    out = value;
-  }
-
-  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
-    out.setNoCopy(value);
-  }
-
   template <typename TReturn, typename TInput>
   bool call(TReturn& out, const TInput& array) {
     // Result is null if array is empty.
@@ -107,20 +69,6 @@ struct ArrayMinMaxFunction {
     return true;
   }
 
-  bool compare(
-      exec::GenericView currentValue,
-      exec::GenericView candidateValue) {
-    static constexpr CompareFlags kFlags = {
-        .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue};
-
-    auto compareResult = candidateValue.compare(currentValue, kFlags).value();
-    if constexpr (isMax) {
-      return compareResult > 0;
-    } else {
-      return compareResult < 0;
-    }
-  }
-
   bool call(
       out_type<Orderable<T1>>& out,
       const arg_type<Array<Orderable<T1>>>& array) {
@@ -149,6 +97,59 @@ struct ArrayMinMaxFunction {
     }
     out.copy_from(array[currentIndex].value());
     return true;
+  }
+
+ private:
+  template <typename T>
+  void update(T& currentValue, const T& candidateValue) {
+    // NaN is greater than any non-NaN elements for double/float type.
+    if constexpr (std::is_floating_point_v<T>) {
+      if constexpr (isMax) {
+        if (std::isnan(candidateValue) ||
+            (!std::isnan(currentValue) && candidateValue > currentValue)) {
+          currentValue = candidateValue;
+        }
+      } else {
+        if (std::isnan(currentValue) ||
+            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
+          currentValue = candidateValue;
+        }
+      }
+      return;
+    }
+
+    if constexpr (isMax) {
+      if (candidateValue > currentValue) {
+        currentValue = candidateValue;
+      }
+    } else {
+      if (candidateValue < currentValue) {
+        currentValue = candidateValue;
+      }
+    }
+  }
+
+  template <typename T>
+  void assign(T& out, const T& value) {
+    out = value;
+  }
+
+  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
+    out.setNoCopy(value);
+  }
+
+  bool compare(
+      exec::GenericView currentValue,
+      exec::GenericView candidateValue) {
+    static constexpr CompareFlags kFlags = {
+        .nullHandlingMode = CompareFlags::NullHandlingMode::kNullAsValue};
+
+    auto compareResult = candidateValue.compare(currentValue, kFlags).value();
+    if constexpr (isMax) {
+      return compareResult > 0;
+    } else {
+      return compareResult < 0;
+    }
   }
 };
 

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -103,9 +103,11 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerArrayMinMaxFunctions<float>(prefix);
   registerArrayMinMaxFunctions<double>(prefix);
   registerArrayMinMaxFunctions<bool>(prefix);
+  registerArrayMinMaxFunctions<Varbinary>(prefix);
   registerArrayMinMaxFunctions<Varchar>(prefix);
   registerArrayMinMaxFunctions<Timestamp>(prefix);
   registerArrayMinMaxFunctions<Date>(prefix);
+  registerArrayMinMaxFunctions<Orderable<T1>>(prefix);
 }
 
 template <typename T>

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -29,9 +29,11 @@ namespace {
 class ArrayMaxTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  std::optional<T> arrayMax(const std::vector<std::optional<T>>& input) {
+  std::optional<T> arrayMax(
+      const std::vector<std::optional<T>>& input,
+      const TypePtr& type = ARRAY(CppToType<T>::create())) {
     auto row = makeRowVector({makeNullableArrayVector(
-        std::vector<std::vector<std::optional<T>>>{input})});
+        std::vector<std::vector<std::optional<T>>>{input}, type)});
     return evaluateOnce<T>("array_max(C0)", row);
   }
 };
@@ -45,6 +47,17 @@ TEST_F(ArrayMaxTest, boolean) {
   EXPECT_EQ(arrayMax<bool>({std::nullopt, true, false, true}), true);
   EXPECT_EQ(arrayMax<bool>({false, false, false}), false);
   EXPECT_EQ(arrayMax<bool>({true, true, true}), true);
+}
+
+TEST_F(ArrayMaxTest, varbinary) {
+  EXPECT_EQ(arrayMax<std::string>({"red", "blue"}, ARRAY(VARBINARY())), "red");
+  EXPECT_EQ(
+      arrayMax<std::string>(
+          {std::nullopt, "blue", "yellow", "orange"}, ARRAY(VARBINARY())),
+      "yellow");
+  EXPECT_EQ(arrayMax<std::string>({}, ARRAY(VARBINARY())), std::nullopt);
+  EXPECT_EQ(
+      arrayMax<std::string>({std::nullopt}, ARRAY(VARBINARY())), std::nullopt);
 }
 
 TEST_F(ArrayMaxTest, varchar) {
@@ -85,6 +98,26 @@ TEST_F(ArrayMaxTest, timestamp) {
       Timestamp::max());
   EXPECT_EQ(arrayMax<Timestamp>({}), std::nullopt);
   EXPECT_EQ(arrayMax<Timestamp>({ts(0), std::nullopt}), ts(0));
+}
+
+TEST_F(ArrayMaxTest, complexTypes) {
+  auto testExpression = [&](const VectorPtr& input, const VectorPtr& expected) {
+    auto result = evaluate("array_max(c0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  };
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, 1, 1], [1, 2, 2], [1, 3, 1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, 3, 1]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, null], [null, 2], [null, null]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, null]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[null, null]"}),
+      makeArrayVectorFromJson<int64_t>({"null"}));
 }
 
 template <typename Type>

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -111,8 +111,12 @@ TEST_F(ArrayMaxTest, complexTypes) {
       makeArrayVectorFromJson<int64_t>({"[1, 3, 1]"}));
 
   testExpression(
-      makeNestedArrayVectorFromJson<int64_t>(
-          {"[[1, null], [null, 2], [null, null]]"}),
+      makeNestedArrayVectorFromJson<double>(
+          {"[[2.0, null], [null, 2.0], [NaN, 1.0]]"}),
+      makeArrayVectorFromJson<double>({"[NaN, 1.0]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1, null], [null, 2], [1]]"}),
       makeArrayVectorFromJson<int64_t>({"[1, null]"}));
 
   testExpression(

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -30,9 +30,11 @@ namespace {
 class ArrayMinTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
-  std::optional<T> arrayMin(const std::vector<std::optional<T>>& input) {
+  std::optional<T> arrayMin(
+      const std::vector<std::optional<T>>& input,
+      const TypePtr& type = ARRAY(CppToType<T>::create())) {
     auto row = makeRowVector({makeNullableArrayVector(
-        std::vector<std::vector<std::optional<T>>>{input})});
+        std::vector<std::vector<std::optional<T>>>{input}, type)});
     return evaluateOnce<T>("array_min(C0)", row);
   }
 };
@@ -46,7 +48,18 @@ TEST_F(ArrayMinTest, boolean) {
   EXPECT_EQ(arrayMin<bool>({std::nullopt, true, false, true}), false);
   EXPECT_EQ(arrayMin<bool>({false, false, false}), false);
   EXPECT_EQ(arrayMin<bool>({true, true, true}), true);
-} // namespace
+}
+
+TEST_F(ArrayMinTest, varbinary) {
+  EXPECT_EQ(arrayMin<std::string>({"red", "blue"}, ARRAY(VARBINARY())), "blue");
+  EXPECT_EQ(
+      arrayMin<std::string>(
+          {std::nullopt, "blue", "yellow", "orange"}, ARRAY(VARBINARY())),
+      "blue");
+  EXPECT_EQ(arrayMin<std::string>({}, ARRAY(VARBINARY())), std::nullopt);
+  EXPECT_EQ(
+      arrayMin<std::string>({std::nullopt}, ARRAY(VARBINARY())), std::nullopt);
+}
 
 TEST_F(ArrayMinTest, varchar) {
   EXPECT_EQ(arrayMin<std::string>({"red", "blue"}), "blue");
@@ -86,6 +99,30 @@ TEST_F(ArrayMinTest, timestamp) {
       Timestamp::min());
   EXPECT_EQ(arrayMin<Timestamp>({}), std::nullopt);
   EXPECT_EQ(arrayMin<Timestamp>({ts(0), std::nullopt}), ts(0));
+}
+
+TEST_F(ArrayMinTest, complexTypes) {
+  auto testExpression = [&](const VectorPtr& input, const VectorPtr& expected) {
+    auto result = evaluate("array_min(c0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  };
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, 1, 1], [1, 1, 2], [1, 3, 1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1, 1, 1]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>(
+          {"[[1, null], [null, 2], [null, null]]"}),
+      makeArrayVectorFromJson<int64_t>({"[null, null]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1], [null], []]"}),
+      makeArrayVectorFromJson<int64_t>({"[]"}));
+
+  testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[null, null]"}),
+      makeArrayVectorFromJson<int64_t>({"null"}));
 }
 
 template <typename Type>

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -117,6 +117,10 @@ TEST_F(ArrayMinTest, complexTypes) {
       makeArrayVectorFromJson<int64_t>({"[null, null]"}));
 
   testExpression(
+      makeNestedArrayVectorFromJson<int64_t>({"[[1, null], [1, 2], [1]]"}),
+      makeArrayVectorFromJson<int64_t>({"[1]"}));
+
+  testExpression(
       makeNestedArrayVectorFromJson<int64_t>({"[[1], [null], []]"}),
       makeArrayVectorFromJson<int64_t>({"[]"}));
 


### PR DESCRIPTION
https://github.com/apache/spark/blob/84f5fd99fef1ad3a2b2c41dbee09c60560479c11/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L2341