### PR TITLE
fix: Fix compiler errors

### DIFF
--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -67,7 +67,7 @@ class OperatorCtx {
     return planNodeId_;
   }
 
-  const int32_t operatorId() const {
+  int32_t operatorId() const {
     return operatorId_;
   }
 
@@ -383,11 +383,11 @@ class Operator : public BaseRuntimeStatWriter {
     return operatorCtx_->planNodeId();
   }
 
-  const int32_t operatorId() const {
+  int32_t operatorId() const {
     return operatorCtx_->operatorId();
   }
 
-  const uint32_t splitGroupId() const {
+  uint32_t splitGroupId() const {
     return operatorCtx_->driverCtx()->splitGroupId;
   }
 

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -70,8 +70,10 @@ using SubfieldFilters = std::unordered_map<Subfield, std::unique_ptr<Filter>>;
  */
 class Filter : public velox::ISerializable {
  protected:
-  Filter(bool deterministic, bool nullAllowed, FilterKind kind)
-      : nullAllowed_(nullAllowed), deterministic_(deterministic), kind_(kind) {}
+  Filter(bool _deterministic, bool _nullAllowed, FilterKind _kind)
+      : nullAllowed_(_nullAllowed),
+        deterministic_(_deterministic),
+        kind_(_kind) {}
 
  public:
   virtual ~Filter() = default;
@@ -1893,7 +1895,7 @@ class TimestampRange : public Filter {
     return upper_;
   }
 
-  const bool nullAllowed() const {
+  bool nullAllowed() const {
     return nullAllowed_;
   }
 


### PR DESCRIPTION
Summary:
Fix compiler errors when running with stricter options enabled.

> velox/type/Filter.h:73:15: error: declaration shadows a static data member of 'facebook::velox::common::Filter' [-Werror,-Wshadow]

> velox/common/memory/ByteStream.h:524:60: error: function 'append<std::shared_ptr<void>>' could be declared with attribute 'noreturn' [-Werror,-Wmissing-noreturn]

> velox/exec/Operator.h:70:3: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]

Differential Revision: D70777879


