### PR TITLE
fix: Presto UDF split_part does not match Presto behavior for empty string delimiter

### DIFF
--- a/velox/functions/prestosql/SplitPart.h
+++ b/velox/functions/prestosql/SplitPart.h
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include "velox/functions/Udf.h"
-#include "velox/functions/lib/string/StringCore.h"
 #include "velox/functions/lib/string/StringImpl.h"
 
 namespace facebook::velox::functions {
@@ -41,7 +39,15 @@ struct SplitPart {
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& delimiter,
       const int64_t& index) {
-    return stringImpl::splitPart(result, input, delimiter, index);
+    return stringImpl::splitPart<false>(result, input, delimiter, index);
+  }
+
+  FOLLY_ALWAYS_INLINE bool callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& delimiter,
+      const int64_t& index) {
+    return stringImpl::splitPart<true>(result, input, delimiter, index);
   }
 };
 


### PR DESCRIPTION
Summary:
This fixes a bunch of behavior inconsistencies between Presto Java's and Velox's split_part UDFs.

In Presto Java, when split_part is called on a string X with an empty string delimiter and index i, it 
returns the i'th character of X or null if X has fewer than i characters. It also validates that every 
character up to and including the i'th character is valid UTF-8 (or all characters if it returns null).

In Velox today, it will return the entire string X if the i is 1 and the empty string otherwise.

In Velox today, we do not check that the index is a positive value, unlike Presto Java.

In Velox today, we do not check that the search string contains valid UTF-8 characters. Note that
Presto does not check this condition when the delimiter is non-empty, Velox maintains this 
behavior after this change.

Differential Revision: D70810224


