### PR TITLE
feat: Add encodedVectorCopy

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -1079,6 +1079,16 @@ std::string printIndices(
     const BufferPtr& indices,
     vector_size_t maxIndicesToPrint = 10);
 
+template <typename OutputStream>
+OutputStream& operator<<(
+    OutputStream& out,
+    const BaseVector::CopyRange& range) {
+  out << "{sourceIndex=" << range.sourceIndex
+      << " targetIndex=" << range.targetIndex << " count=" << range.count
+      << "}";
+  return out;
+}
+
 } // namespace facebook::velox
 
 namespace folly {

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   ComplexVector.cpp
   ConstantVector.cpp
   DecodedVector.cpp
+  EncodedVectorCopy.cpp
   FlatVector.cpp
   LazyVector.cpp
   SelectivityVector.cpp

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -200,7 +200,7 @@ void RowVector::copy(
   DecodedVector decodedSource(*source);
   if (decodedSource.isIdentityMapping()) {
     if (source->mayHaveNulls()) {
-      auto rawNulls = source->rawNulls();
+      auto* rawNulls = source->loadedVector()->rawNulls();
       rows.applyToSelected([&](auto row) {
         auto idx = toSourceRow ? toSourceRow[row] : row;
         VELOX_DCHECK_GT(source->size(), idx);

--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -1,0 +1,1116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/EncodedVectorCopy.h"
+
+#include "velox/vector/ConstantVector.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/VectorTypeUtils.h"
+
+namespace facebook::velox {
+
+namespace {
+
+void copyImpl(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable);
+
+// Calculate the expected target size given the old target size and the copy
+// ranges.
+vector_size_t targetSize(
+    vector_size_t size,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  for (auto& range : ranges) {
+    size = std::max(size, range.targetIndex + range.count);
+  }
+  return size;
+}
+
+// Calculate the expected target size for a newly created target (no old
+// existing target vector).
+vector_size_t newTargetSize(
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  vector_size_t size = 0;
+  vector_size_t minIndex = std::numeric_limits<vector_size_t>::max();
+  for (auto& range : ranges) {
+    size = std::max(size, range.targetIndex + range.count);
+    minIndex = std::min(minIndex, range.targetIndex);
+  }
+  VELOX_CHECK_EQ(
+      minIndex,
+      0,
+      "Index from 0 to {} (exclusive) is uninitialized during the copy",
+      minIndex);
+  return size;
+}
+
+template <typename T>
+BufferPtr tryReuse(const BufferPtr& source, vector_size_t size) {
+  auto byteSize = BaseVector::byteSize<T>(size);
+  if (source->isMutable() && byteSize <= source->capacity()) {
+    source->setSize(byteSize);
+    return source;
+  }
+  return nullptr;
+}
+
+void fillIndices(
+    vector_size_t value,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    vector_size_t* target) {
+  for (auto& range : ranges) {
+    auto* t = target + range.targetIndex;
+    std::fill(t, t + range.count, value);
+  }
+}
+
+void copyIndices(
+    const vector_size_t* source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    vector_size_t shift,
+    vector_size_t* target) {
+  for (auto& range : ranges) {
+    auto* t = target + range.targetIndex;
+    std::memcpy(
+        t, source + range.sourceIndex, sizeof(vector_size_t) * range.count);
+    if (shift != 0) {
+      for (vector_size_t i = 0; i < range.count; ++i) {
+        t[i] += shift;
+      }
+    }
+  }
+}
+
+template <typename MutableNulls>
+void setSourceNullsImpl(
+    const uint64_t* source,
+    const uint64_t* target,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    MutableNulls&& mutableNulls) {
+  if (source) {
+    BaseVector::copyNulls(mutableNulls(), source, ranges);
+  } else if (target) {
+    BaseVector::setNulls(mutableNulls(), ranges, false);
+  }
+}
+
+void setSourceNulls(
+    const uint64_t* source,
+    const uint64_t* target,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    uint64_t* mutableNulls) {
+  setSourceNullsImpl(source, target, ranges, [&] { return mutableNulls; });
+}
+
+void setSourceNulls(
+    const uint64_t* source,
+    BaseVector& target,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  setSourceNullsImpl(source, target.rawNulls(), ranges, [&] {
+    return target.mutableRawNulls();
+  });
+}
+
+BufferPtr combineNulls(
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    const uint64_t* target,
+    vector_size_t oldTargetSize,
+    const uint64_t* source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  auto nulls = allocateNulls(size, pool);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  if (target) {
+    std::memcpy(rawNulls, target, bits::nbytes(oldTargetSize));
+  }
+  setSourceNulls(source, target, ranges, rawNulls);
+  return nulls;
+}
+
+BufferPtr newNulls(
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    const uint64_t* source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  if (!source) {
+    return nullptr;
+  }
+  return combineNulls(size, pool, nullptr, 0, source, ranges);
+}
+
+vector_size_t baseSize(DecodedVector& dictionary) {
+  auto* nulls = dictionary.nulls();
+  auto* indices = dictionary.indices();
+  vector_size_t result = 0;
+  if (nulls) {
+    for (vector_size_t i = 0; i < dictionary.size(); ++i) {
+      if (!bits::isBitNull(nulls, i)) {
+        result = std::max(result, 1 + indices[i]);
+      }
+    }
+  } else {
+    for (vector_size_t i = 0; i < dictionary.size(); ++i) {
+      result = std::max(result, 1 + indices[i]);
+    }
+  }
+  return result;
+}
+
+template <typename NextTargetBaseIndex>
+std::vector<BaseVector::CopyRange> toBaseRangesImpl(
+    const DecodedVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& outer,
+    vector_size_t* indices,
+    NextTargetBaseIndex&& nextTargetBaseIndex) {
+  VELOX_DCHECK(!source.isConstantMapping());
+  std::vector<uint64_t> copied(bits::nwords(source.base()->size()));
+  for (auto& range : outer) {
+    for (vector_size_t i = 0; i < range.count; ++i) {
+      auto j = range.sourceIndex + i;
+      if (!source.isNullAt(j)) {
+        auto k = source.index(j);
+        bits::setBit(copied.data(), k);
+        indices[range.targetIndex + i] = k;
+      }
+    }
+  }
+  std::vector<BaseVector::CopyRange> inner;
+  // Mapping from source base indices to target base indices.
+  std::vector<vector_size_t> mapping(source.base()->size());
+  vector_size_t targetBaseIndex = nextTargetBaseIndex();
+  bits::forEachSetBit(copied.data(), 0, source.base()->size(), [&](auto i) {
+    mapping[i] = targetBaseIndex;
+    if (!inner.empty() && inner.back().sourceIndex + inner.back().count == i &&
+        inner.back().targetIndex + inner.back().count == targetBaseIndex) {
+      ++inner.back().count;
+    } else {
+      auto& r = inner.emplace_back();
+      r.sourceIndex = i;
+      r.targetIndex = targetBaseIndex;
+      r.count = 1;
+    }
+    targetBaseIndex = nextTargetBaseIndex();
+  });
+  for (auto& range : outer) {
+    for (vector_size_t i = 0; i < range.count; ++i) {
+      auto j = range.targetIndex + i;
+      indices[j] =
+          source.isNullAt(range.sourceIndex + i) ? 0 : mapping[indices[j]];
+    }
+  }
+  return inner;
+}
+
+std::vector<BaseVector::CopyRange> toBaseRanges(
+    const DecodedVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& outer,
+    vector_size_t targetBaseIndexStart,
+    vector_size_t* indices) {
+  auto targetBaseIndex = targetBaseIndexStart - 1;
+  return toBaseRangesImpl(
+      source, outer, indices, [&] { return ++targetBaseIndex; });
+}
+
+std::vector<BaseVector::CopyRange> toBaseRanges(
+    const DecodedVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    const DecodedVector& target,
+    vector_size_t* indices) {
+  std::vector<uint64_t> targetOverwritten(bits::nwords(target.size()));
+  for (auto& range : ranges) {
+    bits::fillBits(
+        targetOverwritten.data(),
+        range.targetIndex,
+        std::min(target.size(), range.targetIndex + range.count),
+        true);
+  }
+  std::vector<uint64_t> targetBaseOverwritten(
+      bits::nwords(target.base()->size()), -1ll);
+  bits::forEachUnsetBit(
+      targetOverwritten.data(), 0, target.size(), [&](auto i) {
+        if (!target.isNullAt(i)) {
+          bits::clearBit(targetBaseOverwritten.data(), indices[i]);
+        }
+      });
+  std::vector<BaseVector::CopyRange> baseRanges;
+  if (source.isConstantMapping()) {
+    auto& baseRange = baseRanges.emplace_back();
+    baseRange.sourceIndex = source.index(0);
+    baseRange.targetIndex = bits::findFirstBit(
+        targetBaseOverwritten.data(), 0, target.base()->size());
+    if (baseRange.targetIndex < 0) {
+      baseRange.targetIndex = target.base()->size();
+    }
+    baseRange.count = 1;
+    fillIndices(baseRange.targetIndex, ranges, indices);
+  } else {
+    vector_size_t begin = 0;
+    baseRanges = toBaseRangesImpl(source, ranges, indices, [&] {
+      if (begin < target.base()->size()) {
+        begin = bits::findFirstBit(
+            targetBaseOverwritten.data(), begin, target.base()->size());
+        if (begin < 0) {
+          begin = target.base()->size();
+        }
+      }
+      return begin++;
+    });
+  }
+  return baseRanges;
+}
+
+void compactNestedRangesImpl(
+    std::vector<BaseVector::CopyRange>& nested,
+    vector_size_t targetNestedStart,
+    vector_size_t* newOffsets,
+    vector_size_t* newSizes) {
+  std::sort(nested.begin(), nested.end(), [](auto& x, auto& y) {
+    return x.sourceIndex < y.sourceIndex;
+  });
+  vector_size_t size = 0;
+  for (auto& r : nested) {
+    newOffsets[r.targetIndex] = targetNestedStart;
+    newSizes[r.targetIndex] = r.count;
+    if (r.count == 0) {
+      continue;
+    }
+    if (size > 0 &&
+        nested[size - 1].sourceIndex + nested[size - 1].count ==
+            r.sourceIndex) {
+      nested[size - 1].count += r.count;
+    } else {
+      nested[size] = r;
+      nested[size].targetIndex = targetNestedStart;
+      ++size;
+    }
+    targetNestedStart += r.count;
+  }
+  nested.resize(size);
+}
+
+std::vector<BaseVector::CopyRange> toNestedRanges(
+    const ArrayVectorBase& source,
+    const folly::Range<const BaseVector::CopyRange*>& outer,
+    vector_size_t targetNestedStart,
+    vector_size_t* newOffsets,
+    vector_size_t* newSizes) {
+  std::vector<BaseVector::CopyRange> nested;
+  vector_size_t size = 0;
+  for (auto& range : outer) {
+    size += range.count;
+  }
+  nested.reserve(size);
+  for (auto& range : outer) {
+    for (vector_size_t i = 0; i < range.count; ++i) {
+      auto j = range.sourceIndex + i;
+      auto& r = nested.emplace_back();
+      if (source.isNullAt(j)) {
+        r.count = 0;
+      } else {
+        r.sourceIndex = source.offsetAt(j);
+        r.count = source.sizeAt(j);
+      }
+      // Store the outer target index temporarily.
+      r.targetIndex = range.targetIndex + i;
+    }
+  }
+  compactNestedRangesImpl(nested, targetNestedStart, newOffsets, newSizes);
+  return nested;
+}
+
+bool needCompactNested(
+    const EncodedVectorCopyOptions& options,
+    const ArrayVectorBase& vector,
+    vector_size_t nestedSize) {
+  vector_size_t used = 0;
+  for (vector_size_t i = 0; i < vector.size(); ++i) {
+    if (!vector.isNullAt(i)) {
+      used += vector.sizeAt(i);
+    }
+  }
+  return used < options.compactNestedThreshold * nestedSize;
+}
+
+std::vector<BaseVector::CopyRange> compactNestedRanges(
+    const ArrayVectorBase& vector,
+    vector_size_t* newOffsets,
+    vector_size_t* newSizes) {
+  std::vector<BaseVector::CopyRange> nested;
+  nested.reserve(vector.size());
+  for (vector_size_t i = 0; i < vector.size(); ++i) {
+    auto& r = nested.emplace_back();
+    if (vector.isNullAt(i)) {
+      r.count = 0;
+    } else {
+      r.sourceIndex = vector.offsetAt(i);
+      r.count = vector.sizeAt(i);
+    }
+    r.targetIndex = i;
+  }
+  compactNestedRangesImpl(nested, 0, newOffsets, newSizes);
+  return nested;
+}
+
+void compactNestedVector(
+    const EncodedVectorCopyOptions& options,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& vector,
+    bool mutableVector) {
+  if (mutableVector) {
+    if (ranges.empty()) {
+      vector->resize(0);
+      return;
+    }
+    if (ranges.size() == 1 && ranges[0].sourceIndex == 0) {
+      VELOX_CHECK_EQ(ranges[0].targetIndex, 0);
+      vector->resize(ranges[0].count);
+      return;
+    }
+  }
+  VectorPtr newVector;
+  copyImpl(options, vector, ranges, newVector, false);
+  vector = std::move(newVector);
+}
+
+bool needFlatten(const DecodedVector& decoded) {
+  auto& type = decoded.base()->type();
+  return type->isFixedWidth() &&
+      type->cppSizeInBytes() <= sizeof(vector_size_t);
+}
+
+template <TypeKind kKind>
+VectorPtr newConstantImpl(
+    const EncodedVectorCopyOptions& options,
+    const DecodedVector& source,
+    const VectorPtr& sourceBase,
+    vector_size_t size) {
+  using T = typename KindToFlatVector<kKind>::WrapperType;
+  if (source.isNullAt(0)) {
+    return std::make_shared<ConstantVector<T>>(
+        options.pool, size, true, sourceBase->type(), T());
+  }
+  if constexpr (!std::is_same_v<T, ComplexType>) {
+    return std::make_shared<ConstantVector<T>>(
+        options.pool, size, false, sourceBase->type(), source.valueAt<T>(0));
+  } else {
+    VectorPtr targetBase;
+    BaseVector::CopyRange range = {source.index(0), 0, 1};
+    copyImpl(options, sourceBase, folly::Range(&range, 1), targetBase, false);
+    return std::make_shared<ConstantVector<T>>(
+        options.pool, size, 0, std::move(targetBase));
+  }
+}
+
+VectorPtr newConstant(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase) {
+  auto size = newTargetSize(ranges);
+  if (options.reuseSource) {
+    if (size == source->size()) {
+      return source;
+    } else {
+      return BaseVector::wrapInConstant(size, 0, source);
+    }
+  } else {
+    return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+        newConstantImpl,
+        source->typeKind(),
+        options,
+        decodedSource,
+        sourceBase,
+        size);
+  }
+}
+
+VectorPtr newDictionary(
+    const EncodedVectorCopyOptions& options,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase) {
+  auto size = newTargetSize(ranges);
+  auto nulls = newNulls(size, options.pool, decodedSource.nulls(), ranges);
+  auto indices = allocateIndices(size, options.pool);
+  VectorPtr alphabet;
+  if (options.reuseSource) {
+    copyIndices(
+        decodedSource.indices(),
+        ranges,
+        0,
+        indices->asMutable<vector_size_t>());
+    alphabet = sourceBase;
+  } else {
+    auto baseRanges = toBaseRanges(
+        decodedSource, ranges, 0, indices->asMutable<vector_size_t>());
+    copyImpl(options, sourceBase, baseRanges, alphabet, false);
+  }
+  return BaseVector::wrapInDictionary(
+      std::move(nulls), std::move(indices), size, std::move(alphabet));
+}
+
+VectorPtr newFlat(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  if (options.reuseSource && ranges.size() == 1) {
+    if (ranges[0].sourceIndex == 0 && ranges[0].count == source->size()) {
+      return source;
+    } else {
+      return source->slice(ranges[0].sourceIndex, ranges[0].count);
+    }
+  } else {
+    auto target =
+        BaseVector::create(source->type(), newTargetSize(ranges), options.pool);
+    target->copyRanges(source.get(), ranges);
+    return target;
+  }
+}
+
+VectorPtr newRow(
+    const EncodedVectorCopyOptions& options,
+    const RowVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  auto size = newTargetSize(ranges);
+  auto nulls = newNulls(size, options.pool, source.rawNulls(), ranges);
+  std::vector<VectorPtr> children(source.childrenSize());
+  for (column_index_t i = 0; i < children.size(); ++i) {
+    copyImpl(options, source.childAt(i), ranges, children[i], false);
+  }
+  return std::make_shared<RowVector>(
+      options.pool, source.type(), std::move(nulls), size, std::move(children));
+}
+
+VectorPtr newMap(
+    const EncodedVectorCopyOptions& options,
+    const MapVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  auto size = newTargetSize(ranges);
+  auto nulls = newNulls(size, options.pool, source.rawNulls(), ranges);
+  auto offsets = allocateIndices(size, options.pool);
+  auto sizes = allocateIndices(size, options.pool);
+  auto nestedRanges = toNestedRanges(
+      source,
+      ranges,
+      0,
+      offsets->asMutable<vector_size_t>(),
+      sizes->asMutable<vector_size_t>());
+  VectorPtr keys, values;
+  copyImpl(options, source.mapKeys(), nestedRanges, keys, false);
+  copyImpl(options, source.mapValues(), nestedRanges, values, false);
+  return std::make_shared<MapVector>(
+      options.pool,
+      source.type(),
+      std::move(nulls),
+      size,
+      std::move(offsets),
+      std::move(sizes),
+      std::move(keys),
+      std::move(values));
+}
+
+VectorPtr newArray(
+    const EncodedVectorCopyOptions& options,
+    const ArrayVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges) {
+  auto size = newTargetSize(ranges);
+  auto nulls = newNulls(size, options.pool, source.rawNulls(), ranges);
+  auto offsets = allocateIndices(size, options.pool);
+  auto sizes = allocateIndices(size, options.pool);
+  auto nestedRanges = toNestedRanges(
+      source,
+      ranges,
+      0,
+      offsets->asMutable<vector_size_t>(),
+      sizes->asMutable<vector_size_t>());
+  VectorPtr elements;
+  copyImpl(options, source.elements(), nestedRanges, elements, false);
+  return std::make_shared<ArrayVector>(
+      options.pool,
+      source.type(),
+      std::move(nulls),
+      size,
+      std::move(offsets),
+      std::move(sizes),
+      std::move(elements));
+}
+
+void copyIntoFlat(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  auto size = targetSize(target->size(), ranges);
+  if (!targetMutable) {
+    FB_LOG_EVERY_MS(WARNING, 1000)
+        << "Reallocating target vector in encodedVectorCopy";
+    auto newTarget = BaseVector::create(target->type(), size, options.pool);
+    newTarget->copy(target.get(), 0, 0, target->size());
+    target = std::move(newTarget);
+  } else if (target->size() != size) {
+    target->resize(size);
+  }
+  target->ensureWritable(SelectivityVector::empty());
+  target->copyRanges(source.get(), ranges);
+}
+
+void copyIntoConstant(
+    const EncodedVectorCopyOptions& options,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    const VectorPtr& source,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase,
+    DecodedVector& decodedTarget,
+    VectorPtr& target,
+    bool targetMutable) {
+  const auto size = targetSize(target->size(), ranges);
+  if (decodedSource.isConstantMapping() &&
+      decodedSource.base()->equalValueAt(
+          decodedTarget.base(),
+          decodedSource.index(0),
+          decodedTarget.index(0))) {
+    if (target->size() != size) {
+      if (targetMutable) {
+        target->resize(size);
+        target->resetDataDependentFlags(nullptr);
+      } else {
+        target = BaseVector::wrapInConstant(size, 0, target);
+      }
+    }
+    return;
+  }
+  if (needFlatten(decodedSource)) {
+    copyIntoFlat(options, source, ranges, target, false);
+    return;
+  }
+  BufferPtr nulls;
+  auto indices = allocateIndices(size, options.pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  std::fill(rawIndices, rawIndices + target->size(), 0);
+  VectorPtr alphabet;
+  if (decodedSource.isConstantMapping()) {
+    fillIndices(1, ranges, rawIndices);
+    alphabet = BaseVector::create(target->type(), 2, options.pool);
+    alphabet->copy(decodedTarget.base(), 0, decodedTarget.index(0), 1);
+    alphabet->copy(decodedSource.base(), 1, decodedSource.index(0), 1);
+  } else {
+    nulls = newNulls(size, options.pool, decodedSource.nulls(), ranges);
+    auto baseRanges = toBaseRanges(decodedSource, ranges, 1, rawIndices);
+    alphabet = BaseVector::create(target->type(), 1, options.pool);
+    alphabet->copy(decodedTarget.base(), 0, decodedTarget.index(0), 1);
+    copyImpl(options, sourceBase, baseRanges, alphabet, true);
+  }
+  target = BaseVector::wrapInDictionary(
+      std::move(nulls), std::move(indices), size, std::move(alphabet));
+}
+
+void copyIntoDictionary(
+    const EncodedVectorCopyOptions& options,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase,
+    DecodedVector& decodedTarget,
+    VectorPtr&& targetBase,
+    VectorPtr& target,
+    bool targetMutable) {
+  // DecodedVector::decodeAndGetBase returns a copy of VectorPtr, increasing the
+  // reference count of targetBase by 1.
+  const bool targetBaseMutable = targetMutable && targetBase.use_count() <= 2;
+  const auto size = targetSize(target->size(), ranges);
+  const auto targetBaseSize = targetBaseMutable ? baseSize(decodedTarget) : -1;
+  BufferPtr nulls;
+  auto* targetNulls = decodedTarget.nulls();
+  auto* sourceNulls = decodedSource.nulls();
+  if (targetNulls || sourceNulls) {
+    if (targetMutable && target->nulls()) {
+      nulls = tryReuse<uint64_t>(target->nulls(), bits::nwords(size));
+    }
+    if (!nulls) {
+      nulls = allocateNulls(size, options.pool);
+    }
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+    if (targetNulls && rawNulls != targetNulls) {
+      std::memcpy(rawNulls, targetNulls, bits::nbytes(decodedTarget.size()));
+    }
+    setSourceNulls(sourceNulls, targetNulls, ranges, rawNulls);
+  }
+  BufferPtr indices;
+  if (targetMutable &&
+      target->encoding() == VectorEncoding::Simple::DICTIONARY) {
+    indices = tryReuse<vector_size_t>(target->wrapInfo(), size);
+  }
+  if (!indices) {
+    indices = allocateIndices(size, options.pool);
+  }
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  if (rawIndices != decodedTarget.indices()) {
+    std::memcpy(
+        rawIndices,
+        decodedTarget.indices(),
+        sizeof(vector_size_t) * decodedTarget.size());
+  }
+  auto baseRanges =
+      toBaseRanges(decodedSource, ranges, decodedTarget, rawIndices);
+  if (targetBaseMutable) {
+    targetBase->resize(targetBaseSize);
+  }
+  copyImpl(options, sourceBase, baseRanges, targetBase, targetBaseMutable);
+  target = BaseVector::wrapInDictionary(
+      std::move(nulls), std::move(indices), size, std::move(targetBase));
+}
+
+void copyIntoRow(
+    const EncodedVectorCopyOptions& options,
+    const RowVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  const auto size = targetSize(target->size(), ranges);
+  auto* targetRow = target->asUnchecked<RowVector>();
+  auto* sourceNulls = source.rawNulls();
+  if (targetMutable) {
+    const auto oldSize = target->size();
+    targetRow->unsafeResize(size);
+    targetRow->resetDataDependentFlags(nullptr);
+    setSourceNulls(sourceNulls, *target, ranges);
+    for (column_index_t i = 0; i < targetRow->childrenSize(); ++i) {
+      auto& targetChild = targetRow->childAt(i);
+      bool targetChildMutable = targetChild.use_count() == 1;
+      if (targetChildMutable && targetChild->size() > oldSize) {
+        // Shrink the size to allow unreferenced nested rows to be released.
+        targetChild->resize(oldSize);
+      }
+      copyImpl(
+          options, source.childAt(i), ranges, targetChild, targetChildMutable);
+    }
+    targetRow->updateContainsLazyNotLoaded();
+  } else {
+    BufferPtr nulls;
+    if (target->rawNulls() || sourceNulls) {
+      nulls = combineNulls(
+          size,
+          options.pool,
+          target->rawNulls(),
+          target->size(),
+          sourceNulls,
+          ranges);
+    }
+    auto children = targetRow->children();
+    for (column_index_t i = 0; i < children.size(); ++i) {
+      copyImpl(options, source.childAt(i), ranges, children[i], false);
+    }
+    target = std::make_shared<RowVector>(
+        options.pool,
+        target->type(),
+        std::move(nulls),
+        size,
+        std::move(children));
+  }
+}
+
+void copyIntoMap(
+    const EncodedVectorCopyOptions& options,
+    const MapVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  const auto size = targetSize(target->size(), ranges);
+  auto* targetMap = target->asUnchecked<MapVector>();
+  auto* sourceNulls = source.rawNulls();
+
+  if (targetMutable) {
+    target->resize(size);
+    target->resetDataDependentFlags(nullptr);
+    auto offsets = targetMap->mutableOffsets(size);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto sizes = targetMap->mutableSizes(size);
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    bool mutableKeys = targetMap->mapKeys().use_count() == 1;
+    bool mutableValues = targetMap->mapValues().use_count() == 1;
+    auto keys = targetMap->mapKeys();
+    auto values = targetMap->mapValues();
+    auto nestedSize = std::min(keys->size(), values->size());
+    if (needCompactNested(options, *targetMap, nestedSize)) {
+      auto compactRanges =
+          compactNestedRanges(*targetMap, rawOffsets, rawSizes);
+      compactNestedVector(options, compactRanges, keys, mutableKeys);
+      compactNestedVector(options, compactRanges, values, mutableValues);
+      nestedSize = std::min(keys->size(), values->size());
+    }
+    auto nestedRanges =
+        toNestedRanges(source, ranges, nestedSize, rawOffsets, rawSizes);
+    copyImpl(options, source.mapKeys(), nestedRanges, keys, mutableKeys);
+    copyImpl(options, source.mapValues(), nestedRanges, values, mutableValues);
+    targetMap->mapKeys() = std::move(keys);
+    targetMap->mapValues() = std::move(values);
+    setSourceNulls(sourceNulls, *target, ranges);
+
+  } else {
+    BufferPtr nulls;
+    if (target->rawNulls() || sourceNulls) {
+      nulls = combineNulls(
+          size,
+          options.pool,
+          target->rawNulls(),
+          target->size(),
+          sourceNulls,
+          ranges);
+    }
+    auto offsets = allocateIndices(size, options.pool);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    std::memcpy(
+        rawOffsets,
+        targetMap->rawOffsets(),
+        sizeof(vector_size_t) * targetMap->size());
+    auto sizes = allocateIndices(size, options.pool);
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    std::memcpy(
+        rawSizes,
+        targetMap->rawSizes(),
+        sizeof(vector_size_t) * targetMap->size());
+    VectorPtr newKeys;
+    VectorPtr newValues;
+    {
+      auto compactRanges =
+          compactNestedRanges(*targetMap, rawOffsets, rawSizes);
+      copyImpl(options, targetMap->mapKeys(), compactRanges, newKeys, false);
+      copyImpl(
+          options, targetMap->mapValues(), compactRanges, newValues, false);
+    }
+    auto nestedRanges = toNestedRanges(
+        source,
+        ranges,
+        std::min(newKeys->size(), newValues->size()),
+        rawOffsets,
+        rawSizes);
+    copyImpl(options, source.mapKeys(), nestedRanges, newKeys, false);
+    copyImpl(options, source.mapValues(), nestedRanges, newValues, false);
+    target = std::make_shared<MapVector>(
+        options.pool,
+        target->type(),
+        std::move(nulls),
+        size,
+        std::move(offsets),
+        std::move(sizes),
+        std::move(newKeys),
+        std::move(newValues));
+  }
+}
+
+void copyIntoArray(
+    const EncodedVectorCopyOptions& options,
+    const ArrayVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  const auto size = targetSize(target->size(), ranges);
+  auto* targetArray = target->asUnchecked<ArrayVector>();
+  auto* sourceNulls = source.rawNulls();
+
+  if (targetMutable) {
+    target->resize(size);
+    target->resetDataDependentFlags(nullptr);
+    auto offsets = targetArray->mutableOffsets(size);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    auto sizes = targetArray->mutableSizes(size);
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    bool mutableElements = targetArray->elements().use_count() == 1;
+    auto elements = targetArray->elements();
+    if (needCompactNested(options, *targetArray, elements->size())) {
+      auto compactRanges =
+          compactNestedRanges(*targetArray, rawOffsets, rawSizes);
+      compactNestedVector(options, compactRanges, elements, mutableElements);
+    }
+    auto nestedRanges =
+        toNestedRanges(source, ranges, elements->size(), rawOffsets, rawSizes);
+    copyImpl(
+        options, source.elements(), nestedRanges, elements, mutableElements);
+    targetArray->elements() = std::move(elements);
+    setSourceNulls(sourceNulls, *target, ranges);
+
+  } else {
+    BufferPtr nulls;
+    if (target->rawNulls() || sourceNulls) {
+      nulls = combineNulls(
+          size,
+          options.pool,
+          target->rawNulls(),
+          target->size(),
+          sourceNulls,
+          ranges);
+    }
+    auto offsets = allocateIndices(size, options.pool);
+    auto* rawOffsets = offsets->asMutable<vector_size_t>();
+    std::memcpy(
+        rawOffsets,
+        targetArray->rawOffsets(),
+        sizeof(vector_size_t) * targetArray->size());
+    auto sizes = allocateIndices(size, options.pool);
+    auto* rawSizes = sizes->asMutable<vector_size_t>();
+    std::memcpy(
+        rawSizes,
+        targetArray->rawSizes(),
+        sizeof(vector_size_t) * targetArray->size());
+    VectorPtr newElements;
+    {
+      auto compactRanges =
+          compactNestedRanges(*targetArray, rawOffsets, rawSizes);
+      copyImpl(
+          options, targetArray->elements(), compactRanges, newElements, false);
+    }
+    auto nestedRanges = toNestedRanges(
+        source, ranges, newElements->size(), rawOffsets, rawSizes);
+    copyImpl(options, source.elements(), nestedRanges, newElements, false);
+    target = std::make_shared<ArrayVector>(
+        options.pool,
+        target->type(),
+        std::move(nulls),
+        size,
+        std::move(offsets),
+        std::move(sizes),
+        std::move(newElements));
+  }
+}
+
+void copyIntoComplex(
+    const EncodedVectorCopyOptions& options,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  if (decodedSource.isIdentityMapping()) {
+    switch (target->encoding()) {
+      case VectorEncoding::Simple::ROW:
+        copyIntoRow(
+            options,
+            *sourceBase->asChecked<RowVector>(),
+            ranges,
+            target,
+            targetMutable);
+        break;
+      case VectorEncoding::Simple::MAP:
+        copyIntoMap(
+            options,
+            *sourceBase->asChecked<MapVector>(),
+            ranges,
+            target,
+            targetMutable);
+        break;
+      case VectorEncoding::Simple::ARRAY:
+        copyIntoArray(
+            options,
+            *sourceBase->asChecked<ArrayVector>(),
+            ranges,
+            target,
+            targetMutable);
+        break;
+      default:
+        VELOX_UNREACHABLE();
+    }
+    return;
+  }
+  const auto size = targetSize(target->size(), ranges);
+  BufferPtr nulls;
+  auto indices = allocateIndices(size, options.pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  std::iota(rawIndices, rawIndices + target->size(), 0);
+  BaseVector::CopyRange baseRange;
+  baseRange.targetIndex = target->size();
+  if (decodedSource.isConstantMapping()) {
+    fillIndices(target->size(), ranges, rawIndices);
+    baseRange.sourceIndex = decodedSource.index(0);
+    baseRange.count = 1;
+  } else {
+    nulls = newNulls(size, options.pool, decodedSource.nulls(), ranges);
+    copyIndices(decodedSource.indices(), ranges, target->size(), rawIndices);
+    baseRange.sourceIndex = 0;
+    baseRange.count = sourceBase->size();
+  }
+  copyImpl(
+      options, sourceBase, folly::Range(&baseRange, 1), target, targetMutable);
+  target = BaseVector::wrapInDictionary(
+      std::move(nulls), std::move(indices), size, target);
+}
+
+void copyIntoLazy(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  auto* lazyTarget = target->asUnchecked<LazyVector>();
+  if (!lazyTarget->isLoaded()) {
+    target.reset();
+    copyImpl(options, source, ranges, target, false);
+  } else {
+    auto& loaded = lazyTarget->loadedVectorShared();
+    copyImpl(
+        options,
+        source,
+        ranges,
+        loaded,
+        targetMutable && loaded.use_count() == 1);
+    target = loaded;
+  }
+}
+
+void copyIntoExisting(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase,
+    VectorPtr& target,
+    bool targetMutable) {
+  DecodedVector decodedTarget;
+  auto targetBase = decodedTarget.decodeAndGetBase(target);
+  if (decodedTarget.isConstantMapping()) {
+    copyIntoConstant(
+        options,
+        ranges,
+        source,
+        decodedSource,
+        sourceBase,
+        decodedTarget,
+        target,
+        targetMutable);
+    return;
+  }
+  if (!decodedTarget.isIdentityMapping()) {
+    if (needFlatten(decodedTarget)) {
+      auto newTarget = BaseVector::copy(*target, options.pool);
+      copyIntoFlat(options, source, ranges, newTarget, true);
+      target = std::move(newTarget);
+    } else {
+      copyIntoDictionary(
+          options,
+          ranges,
+          decodedSource,
+          sourceBase,
+          decodedTarget,
+          std::move(targetBase),
+          target,
+          targetMutable);
+    }
+    return;
+  }
+  switch (target->encoding()) {
+    case VectorEncoding::Simple::FLAT:
+      copyIntoFlat(options, source, ranges, target, targetMutable);
+      break;
+    case VectorEncoding::Simple::ROW:
+    case VectorEncoding::Simple::MAP:
+    case VectorEncoding::Simple::ARRAY:
+      copyIntoComplex(
+          options, decodedSource, sourceBase, ranges, target, targetMutable);
+      break;
+    case VectorEncoding::Simple::LAZY:
+      copyIntoLazy(options, source, ranges, target, targetMutable);
+      break;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported encoding in encodedVectorCopy: {}", source->encoding());
+  }
+}
+
+void copyImpl(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target,
+    bool targetMutable) {
+  if (ranges.empty()) {
+    if (!target) {
+      target = BaseVector::create(source->type(), 0, options.pool);
+    }
+    return;
+  }
+  VELOX_CHECK_GT(source->size(), 0);
+  DecodedVector decodedSource;
+  auto sourceBase = decodedSource.decodeAndGetBase(source);
+  if (target) {
+    copyIntoExisting(
+        options,
+        source,
+        ranges,
+        decodedSource,
+        sourceBase,
+        target,
+        targetMutable);
+    return;
+  }
+  if (decodedSource.isConstantMapping()) {
+    target = newConstant(options, source, ranges, decodedSource, sourceBase);
+    return;
+  }
+  if (!decodedSource.isIdentityMapping()) {
+    if (needFlatten(decodedSource)) {
+      target = newFlat(options, source, ranges);
+    } else {
+      target = newDictionary(options, ranges, decodedSource, sourceBase);
+    }
+    return;
+  }
+  switch (source->encoding()) {
+    case VectorEncoding::Simple::FLAT:
+      target = newFlat(options, source, ranges);
+      break;
+    case VectorEncoding::Simple::ROW:
+      target = newRow(options, *source->asUnchecked<RowVector>(), ranges);
+      break;
+    case VectorEncoding::Simple::MAP:
+      target = newMap(options, *source->asUnchecked<MapVector>(), ranges);
+      break;
+    case VectorEncoding::Simple::ARRAY:
+      target = newArray(options, *source->asUnchecked<ArrayVector>(), ranges);
+      break;
+    case VectorEncoding::Simple::LAZY:
+      VELOX_CHECK(!sourceBase->isLazy());
+      copyImpl(options, sourceBase, ranges, target, targetMutable);
+      break;
+    default:
+      VELOX_UNSUPPORTED(
+          "Unsupported encoding in encodedVectorCopy: {}", source->encoding());
+  }
+}
+
+} // namespace
+
+void encodedVectorCopy(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target) {
+  if (options.reuseSource) {
+    VELOX_CHECK(source->pool() == options.pool);
+  }
+  if (target) {
+    VELOX_CHECK(*target->type() == *source->type());
+    VELOX_CHECK(target->pool() == options.pool);
+  }
+  VELOX_CHECK(
+      0 <= options.compactNestedThreshold &&
+      options.compactNestedThreshold <= 1);
+  copyImpl(options, source, ranges, target, target.use_count() == 1);
+}
+
+} // namespace facebook::velox

--- a/velox/vector/EncodedVectorCopy.h
+++ b/velox/vector/EncodedVectorCopy.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox {
+
+struct EncodedVectorCopyOptions {
+  /// The memory pool used to create new target vector.  If target is set, the
+  /// memory pool must be the same as this one.
+  memory::MemoryPool* pool;
+
+  /// Whether we can reuse any part from the source vector in target.  If this
+  /// is true, the source and target must have the same memory pool.
+  bool reuseSource;
+
+  /// How many nested rows in ARRAY or MAP need to be referenced in order to
+  /// avoid a compaction on it.
+  double compactNestedThreshold = 0.5;
+};
+
+/// Copy the vector while try to preserve the encoding on `target' (with
+/// exceptions listed below), mainly to reduce the memory usage of `target'.  If
+/// `target' is nullptr, preserve the encoding on `source'.
+///
+/// `ranges' should not have any overlaps in target (overlaps in source are
+/// allowed).  If target ranges exceeds the old target vector size, the vector
+/// will be automatically extended; in this case, the target ranges must cover
+/// all the missing part from the old vector.
+///
+/// In the following cases we do not preserve the exact encoding on `target':
+/// - We merge multiple adjacent layers of dictionary and constant wrappers into
+///   one.
+/// - When the values type size in dictionary is no larger than the index type,
+///   we flatten the vector to save memory.
+/// - When `target' is constant, we convert it to dictionary to allow different
+///   values in `source'.
+/// - When `target' is flat ROW, MAP, or ARRAY, and `source' is constant or
+///   dictionary encoded, the result will be dictionary encoded, to avoid
+///   flattening the child vectors.  Once the target becomes dictionary, it can
+///   stay that way and we can keep adding new content to it while keeping the
+///   encoding, this is a typical use case for encoding preserved merging.
+void encodedVectorCopy(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target);
+
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   velox_vector_test
   CopyPreserveEncodingsTest.cpp
   DecodedVectorTest.cpp
+  EncodedVectorCopyTest.cpp
   EncodingTest.cpp
   EnsureWritableVectorTest.cpp
   IsWritableVectorTest.cpp
@@ -43,11 +44,13 @@ target_link_libraries(
   velox_vector_test_lib
   velox_buffer
   velox_vector
+  velox_vector_fuzzer
   velox_serialization
   velox_memory
   velox_presto_serializer
   velox_presto_types
   velox_temp_path
+  velox_test_util
   velox_type_test_lib
   velox_vector_fuzzer
   Boost::atomic

--- a/velox/vector/tests/EncodedVectorCopyTest.cpp
+++ b/velox/vector/tests/EncodedVectorCopyTest.cpp
@@ -1,0 +1,671 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/EncodedVectorCopy.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/RandomSeed.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox {
+namespace {
+
+struct TestParams {
+  using Type = std::tuple<bool>;
+};
+
+template <typename T>
+bool bufferEqual(
+    const Buffer& actual,
+    const Buffer& expected,
+    vector_size_t size) {
+  return std::memcmp(actual.as<T>(), expected.as<T>(), size * sizeof(T)) == 0;
+}
+
+void compareVectors(const VectorPtr& actual, const VectorPtr& expected) {
+  if (expected->isLazy()) {
+    compareVectors(actual, BaseVector::loadedVectorShared(expected));
+    return;
+  }
+  ASSERT_EQ(actual->encoding(), expected->encoding());
+  ASSERT_EQ(actual->size(), expected->size());
+  if (expected->rawNulls()) {
+    ASSERT_TRUE(actual->rawNulls());
+    for (vector_size_t i = 0; i < actual->size(); ++i) {
+      ASSERT_EQ(
+          bits::isBitNull(actual->rawNulls(), i),
+          bits::isBitNull(expected->rawNulls(), i));
+    }
+  } else {
+    ASSERT_FALSE(actual->rawNulls());
+  }
+  switch (actual->encoding()) {
+    case VectorEncoding::Simple::DICTIONARY:
+      ASSERT_TRUE(bufferEqual<vector_size_t>(
+          *actual->wrapInfo(), *expected->wrapInfo(), actual->size()));
+      compareVectors(actual->valueVector(), expected->valueVector());
+      break;
+    case VectorEncoding::Simple::ROW: {
+      auto* actualRow = actual->asChecked<RowVector>();
+      auto* expectedRow = expected->asChecked<RowVector>();
+      for (column_index_t i = 0; i < actualRow->childrenSize(); ++i) {
+        compareVectors(actualRow->childAt(i), expectedRow->childAt(i));
+      }
+      break;
+    }
+    case VectorEncoding::Simple::MAP: {
+      auto* actualMap = actual->asChecked<MapVector>();
+      auto* expectedMap = expected->asChecked<MapVector>();
+      ASSERT_TRUE(bufferEqual<vector_size_t>(
+          *actualMap->offsets(), *expectedMap->offsets(), actualMap->size()));
+      ASSERT_TRUE(bufferEqual<vector_size_t>(
+          *actualMap->sizes(), *expectedMap->sizes(), actualMap->size()));
+      compareVectors(actualMap->mapKeys(), expectedMap->mapKeys());
+      compareVectors(actualMap->mapValues(), expectedMap->mapValues());
+      break;
+    }
+    case VectorEncoding::Simple::ARRAY: {
+      auto* actualArray = actual->asChecked<ArrayVector>();
+      auto* expectedArray = expected->asChecked<ArrayVector>();
+      ASSERT_TRUE(bufferEqual<vector_size_t>(
+          *actualArray->offsets(),
+          *expectedArray->offsets(),
+          actualArray->size()));
+      ASSERT_TRUE(bufferEqual<vector_size_t>(
+          *actualArray->sizes(), *expectedArray->sizes(), actualArray->size()));
+      compareVectors(actualArray->elements(), expectedArray->elements());
+      break;
+    }
+    default:
+      test::assertEqualVectors(expected, actual);
+  }
+}
+
+class EncodedVectorCopyTest : public testing::TestWithParam<TestParams::Type>,
+                              public test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void copy(
+      const VectorPtr& source,
+      const folly::Range<const BaseVector::CopyRange*>& ranges,
+      VectorPtr& target) {
+    EncodedVectorCopyOptions options;
+    options.pool = pool();
+    options.reuseSource = reuseSource();
+    withSource(source, [&](auto& source) {
+      encodedVectorCopy(options, source, ranges, target);
+    });
+  }
+
+  void runTests(
+      const VectorPtr& source,
+      const folly::Range<const BaseVector::CopyRange*>& ranges,
+      VectorPtr& target,
+      const VectorPtr& expected,
+      VectorPtr expectedNewSliceCopy = nullptr) {
+    {
+      SCOPED_TRACE("New full copy");
+      BaseVector::CopyRange range = {0, 0, source->size()};
+      VectorPtr actual;
+      copy(source, folly::Range(&range, 1), actual);
+      compareVectors(actual, source);
+    }
+    {
+      SCOPED_TRACE("New slice copy");
+      VELOX_CHECK_GE(source->size(), 3);
+      BaseVector::CopyRange range = {1, 0, source->size() - 2};
+      VectorPtr actual;
+      copy(source, folly::Range(&range, 1), actual);
+      if (!expectedNewSliceCopy) {
+        expectedNewSliceCopy = source->slice(range.sourceIndex, range.count);
+      }
+      compareVectors(actual, expectedNewSliceCopy);
+    }
+    {
+      SCOPED_TRACE("Immutable target");
+      auto actual = target;
+      copy(source, ranges, actual);
+      compareVectors(actual, expected);
+      ASSERT_NE(actual.get(), target.get());
+    }
+    {
+      SCOPED_TRACE("Mutable target");
+      VELOX_CHECK_EQ(target.use_count(), 1);
+      copy(source, ranges, target);
+      compareVectors(target, expected);
+    }
+  }
+
+  bool reuseSource() {
+    return std::get<0>(GetParam());
+  }
+
+ private:
+  template <typename F>
+  void withSource(const VectorPtr& source, F&& f) {
+    std::shared_ptr<memory::MemoryPool> sourcePool;
+    VectorPtr sourceCopy;
+    if (reuseSource()) {
+      sourceCopy = source;
+    } else {
+      sourcePool = rootPool_->addLeafChild("SourcePool");
+      sourceCopy = source->copyPreserveEncodings(sourcePool.get());
+    }
+    f(sourceCopy);
+  }
+};
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    ,
+    EncodedVectorCopyTest,
+    testing::Combine(testing::Bool()));
+
+TEST_P(EncodedVectorCopyTest, constantToConstant) {
+  auto source = makeConstant<int64_t>(42, 10);
+  auto target = makeConstant<int64_t>(43, 10);
+  BaseVector::CopyRange ranges[] = {{0, 1, 1}, {4, 3, 2}};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 0, 1, 1, 0, 0, 0, 0, 0}),
+      makeFlatVector<int64_t>({43, 42}));
+  runTests(source, folly::Range(ranges, 2), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, constantToConstantSameValue) {
+  auto source = makeConstant<int64_t>(42, 10);
+  auto target = makeConstant<int64_t>(42, 5);
+  BaseVector::CopyRange range = {2, 2, 9};
+  auto expected = makeConstant<int64_t>(42, 11);
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, constantToDictionary) {
+  auto source = makeConstant<int64_t>(42, 10);
+  auto target =
+      wrapInDictionary(makeIndices({1, 0}), makeFlatVector<int64_t>({43, 44}));
+  BaseVector::CopyRange range = {3, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({1, 0, 2, 2}), makeFlatVector<int64_t>({43, 44, 42}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, constantToFlat) {
+  auto source = makeConstant<int64_t>(42, 10);
+  VectorPtr target = makeFlatVector<int64_t>({43, 44});
+  BaseVector::CopyRange range = {3, 1, 2};
+  auto expected = makeFlatVector<int64_t>({43, 42, 42});
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryToConstant) {
+  auto source = wrapInDictionary(
+      makeIndices({1, 0, 1, 0}), makeFlatVector<int64_t>({43, 44}));
+  auto target = makeConstant<int64_t>(42, 5);
+  BaseVector::CopyRange range = {0, 1, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 2, 1, 0, 0}), makeFlatVector<int64_t>({42, 43, 44}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryToDictionary) {
+  auto source = wrapInDictionary(
+      makeIndices({1, 0, 1, 0}), makeFlatVector<int64_t>({42, 43}));
+  auto target = wrapInDictionary(
+      makeIndices({0, 1, 0}), makeFlatVector<int64_t>({44, 45}));
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 2, 3}), makeFlatVector<int64_t>({44, 45, 42, 43}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryToFlat) {
+  auto source = wrapInDictionary(
+      makeIndices({1, 0, 1, 0}), makeFlatVector<int64_t>({42, 43}));
+  VectorPtr target = makeFlatVector<int64_t>({44, 45});
+  BaseVector::CopyRange range = {0, 1, 2};
+  auto expected = makeFlatVector<int64_t>({44, 43, 42});
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryCompactBase) {
+  auto sourceBase = makeFlatVector<int64_t>({42, 43});
+  auto source = wrapInDictionary(makeIndices({1, 0, 1, 0}), sourceBase);
+  {
+    SCOPED_TRACE("New full base");
+    BaseVector::CopyRange ranges[] = {{0, 1, 1}, {1, 0, 1}};
+    VectorPtr target;
+    copy(source, folly::Range(ranges, 2), target);
+    auto expected = wrapInDictionary(
+        makeIndices({0, 1}), makeFlatVector<int64_t>({42, 43}));
+    compareVectors(target, expected);
+  }
+  {
+    SCOPED_TRACE("New compacted base");
+    BaseVector::CopyRange ranges[] = {{1, 0, 1}, {3, 1, 1}};
+    VectorPtr target;
+    copy(source, folly::Range(ranges, 2), target);
+    auto expectedBase =
+        reuseSource() ? sourceBase : makeFlatVector(std::vector<int64_t>({42}));
+    auto expected = wrapInDictionary(makeIndices({0, 0}), expectedBase);
+    compareVectors(target, expected);
+    if (reuseSource()) {
+      ASSERT_EQ(target->valueVector().get(), sourceBase.get());
+    }
+  }
+  {
+    SCOPED_TRACE("Compact target base");
+    auto target = wrapInDictionary(
+        makeIndices({0, 0, 2, 2}), makeFlatVector<int64_t>({44, 45, 46}));
+    BaseVector::CopyRange range = {0, 2, 4};
+    copy(source, folly::Range(&range, 1), target);
+    auto expected = wrapInDictionary(
+        makeIndices({0, 0, 2, 1, 2, 1}), makeFlatVector<int64_t>({44, 42, 43}));
+    compareVectors(target, expected);
+  }
+  {
+    SCOPED_TRACE("Drop unused target base tail");
+    auto targetBase = makeFlatVector<int64_t>({44, 45, 46});
+    auto* targetBasePtr = targetBase.get();
+    auto target =
+        wrapInDictionary(makeIndices({0, 1, 2}), std::move(targetBase));
+    target->resize(0);
+    BaseVector::CopyRange range = {0, 0, 4};
+    copy(source, folly::Range(&range, 1), target);
+    compareVectors(target, source);
+    ASSERT_EQ(target->valueVector().get(), targetBasePtr);
+  }
+}
+
+TEST_P(EncodedVectorCopyTest, allNullsDictionary) {
+  auto source = BaseVector::wrapInDictionary(
+      makeNulls({true, true, true}),
+      makeIndices({0, 1, 2}),
+      3,
+      makeFlatVector<int64_t>({42, 43, 44}));
+  {
+    SCOPED_TRACE("New full copy");
+    BaseVector::CopyRange range = {0, 0, source->size()};
+    VectorPtr actual;
+    copy(source, folly::Range(&range, 1), actual);
+    test::assertEqualVectors(source, actual);
+  }
+  {
+    SCOPED_TRACE("New slice copy");
+    BaseVector::CopyRange range = {1, 0, source->size() - 2};
+    VectorPtr actual;
+    copy(source, folly::Range(&range, 1), actual);
+    test::assertEqualVectors(
+        source->slice(range.sourceIndex, range.count), actual);
+  }
+  auto target =
+      wrapInDictionary(makeIndices({0, 1}), makeFlatVector<int64_t>({45, 46}));
+  std::vector<BaseVector::CopyRange> ranges = {{0, 2, 3}};
+  auto expected = BaseVector::wrapInDictionary(
+      makeNulls({false, false, true, true, true}),
+      makeIndices({0, 1, 0, 0, 0}),
+      5,
+      makeFlatVector<int64_t>({45, 46}));
+  {
+    SCOPED_TRACE("Immutable target");
+    auto actual = target;
+    copy(source, ranges, actual);
+    compareVectors(actual, expected);
+    ASSERT_NE(actual.get(), target.get());
+  }
+  {
+    SCOPED_TRACE("Mutable target");
+    VELOX_CHECK_EQ(target.use_count(), 1);
+    copy(source, ranges, target);
+    compareVectors(target, expected);
+  }
+}
+
+TEST_P(EncodedVectorCopyTest, flatToConstant) {
+  auto source = makeFlatVector<int64_t>({43, 44, 45});
+  auto target = makeConstant<int64_t>(42, 5);
+  BaseVector::CopyRange range = {0, 1, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 2, 0, 0}), makeFlatVector<int64_t>({42, 43, 44}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, flatToDictionary) {
+  auto source = makeFlatVector<int64_t>({42, 43, 44});
+  auto target = wrapInDictionary(
+      makeIndices({0, 1, 0}), makeFlatVector<int64_t>({45, 46}));
+  BaseVector::CopyRange range = {0, 1, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 2}), makeFlatVector<int64_t>({45, 42, 43}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, flatToFlat) {
+  VectorPtr source = makeFlatVector<int64_t>({42, 43, 44});
+  VectorPtr target = makeFlatVector<int64_t>({45, 46, 47});
+  BaseVector::CopyRange range = {0, 1, 2};
+  auto expected = makeFlatVector<int64_t>({45, 42, 43});
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, flatRow) {
+  auto source = makeRowVector({makeFlatVector<int64_t>({1, 2, 3})});
+  VectorPtr target = makeRowVector({makeFlatVector<int64_t>({4, 5, 6})});
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = makeRowVector({makeFlatVector<int64_t>({4, 5, 2, 3})});
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, constantRow) {
+  auto type = ROW({"c0"}, {BIGINT()});
+  auto source = makeConstantRow(type, variant::row({42ll}), 3);
+  auto target = makeConstantRow(type, variant::row({43ll}), 2);
+  BaseVector::CopyRange range = {0, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeRowVector({makeFlatVector<int64_t>({43, 42})}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryOfRow) {
+  auto source = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeRowVector({makeFlatVector<int64_t>({42, 43})}));
+  auto target = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeRowVector({makeFlatVector<int64_t>({44, 45})}));
+  BaseVector::CopyRange range = {0, 4, 4};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 0, 1, 1, 2, 2, 3, 3}),
+      makeRowVector({makeFlatVector<int64_t>({44, 45, 42, 43})}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, rowOfDictionary) {
+  auto source = makeRowVector({
+      wrapInDictionary(
+          makeIndices({0, 0, 1, 1}), makeFlatVector<int64_t>({42, 43})),
+  });
+  VectorPtr target = makeRowVector({
+      wrapInDictionary(
+          makeIndices({0, 0, 1, 1}), makeFlatVector<int64_t>({44, 45})),
+  });
+  BaseVector::CopyRange range = {0, 4, 4};
+  auto expected = makeRowVector({
+      wrapInDictionary(
+          makeIndices({0, 0, 1, 1, 2, 2, 3, 3}),
+          makeFlatVector<int64_t>({44, 45, 42, 43})),
+  });
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, constantRowToFlat) {
+  VectorPtr target = makeRowVector({makeFlatVector<int64_t>({42, 43, 44})});
+  auto source =
+      makeConstantRow(asRowType(target->type()), variant::row({45ll}), 3);
+  BaseVector::CopyRange range = {0, 2, 3};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 3, 3, 3}),
+      makeRowVector({makeFlatVector<int64_t>({42, 43, 44, 45})}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryRowToFlat) {
+  auto source = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeRowVector({makeFlatVector<int64_t>({42, 43})}));
+  VectorPtr target = makeRowVector({makeFlatVector<int64_t>({44, 45})});
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 1, 2, 3}),
+      makeRowVector({makeFlatVector<int64_t>({44, 45, 42, 43})}));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, flatMap) {
+  auto sourceElements = makeFlatVector<int64_t>({1, 2, 3});
+  auto targetElements = makeFlatVector<int64_t>({4, 5, 6});
+  auto source = makeMapVector({0, 1, 2}, sourceElements, sourceElements);
+  VectorPtr target = makeMapVector({0, 1, 2}, targetElements, targetElements);
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expectedElements = makeFlatVector<int64_t>({4, 5, 6, 2, 3});
+  auto expected = std::make_shared<MapVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      4,
+      makeIndices({0, 1, 3, 4}),
+      makeIndices({1, 1, 1, 1}),
+      expectedElements,
+      expectedElements);
+  auto expectedNewSliceCopy = std::make_shared<MapVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      1,
+      makeIndices({0}),
+      makeIndices({1}),
+      makeFlatVector(std::vector<int64_t>({2})),
+      makeFlatVector(std::vector<int64_t>({2})));
+  runTests(
+      source, folly::Range(&range, 1), target, expected, expectedNewSliceCopy);
+}
+
+TEST_P(EncodedVectorCopyTest, constantMap) {
+  auto sourceElements = makeFlatVector<int64_t>({42, 43});
+  auto source = BaseVector::wrapInConstant(
+      3, 1, makeMapVector({0, 1}, sourceElements, sourceElements));
+  auto targetElements = makeFlatVector<int64_t>({44, 45});
+  auto target = BaseVector::wrapInConstant(
+      3, 1, makeMapVector({0, 1}, targetElements, targetElements));
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeMapVector(
+          {0, 1},
+          makeFlatVector<int64_t>({45, 43}),
+          makeFlatVector<int64_t>({45, 43})));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryMap) {
+  auto sourceElements = makeFlatVector<int64_t>({42, 43});
+  auto source = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeMapVector({0, 1}, sourceElements, sourceElements));
+  auto targetElements = makeFlatVector<int64_t>({44, 45});
+  auto target = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeMapVector({0, 1}, targetElements, targetElements));
+  BaseVector::CopyRange range = {1, 1, 2};
+  auto expectedElements = makeFlatVector<int64_t>({44, 45, 42, 43});
+  auto expected = wrapInDictionary(
+      makeIndices({0, 2, 3, 1}),
+      makeMapVector({0, 1, 2, 3}, expectedElements, expectedElements));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, mapCompact) {
+  auto sourceElements = makeFlatVector<int64_t>({42, 43, 44});
+  auto source = makeMapVector({0, 1, 2}, sourceElements, sourceElements);
+  VectorPtr target = std::make_shared<MapVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      1,
+      makeIndices({1}),
+      makeIndices({1}),
+      makeFlatVector<int64_t>({45, 46, 47}),
+      makeFlatVector<int64_t>({45, 46, 47}));
+  BaseVector::CopyRange range = {1, 1, 1};
+  auto expectedNewSliceCopy = std::make_shared<MapVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      1,
+      makeIndices({0}),
+      makeIndices({1}),
+      makeFlatVector(std::vector<int64_t>({43})),
+      makeFlatVector(std::vector<int64_t>({43})));
+  auto expected = std::make_shared<MapVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      2,
+      makeIndices({0, 1}),
+      makeIndices({1, 1}),
+      makeFlatVector<int64_t>({46, 43}),
+      makeFlatVector<int64_t>({46, 43}));
+  runTests(
+      source, folly::Range(&range, 1), target, expected, expectedNewSliceCopy);
+}
+
+TEST_P(EncodedVectorCopyTest, arrayCompactFullReplacement) {
+  auto source =
+      makeArrayVector({0, 1, 2}, makeFlatVector<int64_t>({42, 43, 44}));
+  auto targetElements = makeFlatVector<int64_t>({45, 46, 47});
+  auto* targetElementsPtr = targetElements.get();
+  VectorPtr target = makeArrayVector({0, 1, 2}, std::move(targetElements));
+  target->resize(0);
+  BaseVector::CopyRange range = {0, 0, 3};
+  copy(source, folly::Range(&range, 1), target);
+  compareVectors(target, source);
+  ASSERT_EQ(
+      target->asChecked<ArrayVector>()->elements().get(), targetElementsPtr);
+}
+
+TEST_P(EncodedVectorCopyTest, allNullsMap) {
+  auto source = makeAllNullMapVector(3, BIGINT(), BIGINT());
+  VectorPtr target = makeAllNullMapVector(3, BIGINT(), BIGINT());
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = makeAllNullMapVector(4, BIGINT(), BIGINT());
+  ;
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, flatArray) {
+  auto sourceElements = makeFlatVector<int64_t>({1, 2, 3});
+  auto targetElements = makeFlatVector<int64_t>({4, 5, 6});
+  auto source = makeArrayVector({0, 1, 2}, sourceElements);
+  VectorPtr target = makeArrayVector({0, 1, 2}, targetElements);
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expectedElements = makeFlatVector<int64_t>({4, 5, 6, 2, 3});
+  auto expected = std::make_shared<ArrayVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      4,
+      makeIndices({0, 1, 3, 4}),
+      makeIndices({1, 1, 1, 1}),
+      expectedElements);
+  auto expectedNewSliceCopy = std::make_shared<ArrayVector>(
+      pool(),
+      source->type(),
+      nullptr,
+      1,
+      makeIndices({0}),
+      makeIndices({1}),
+      makeFlatVector(std::vector<int64_t>({2})));
+  runTests(
+      source, folly::Range(&range, 1), target, expected, expectedNewSliceCopy);
+}
+
+TEST_P(EncodedVectorCopyTest, constantArray) {
+  auto sourceElements = makeFlatVector<int64_t>({42, 43});
+  auto source =
+      BaseVector::wrapInConstant(3, 1, makeArrayVector({0, 1}, sourceElements));
+  auto targetElements = makeFlatVector<int64_t>({44, 45});
+  auto target =
+      BaseVector::wrapInConstant(3, 1, makeArrayVector({0, 1}, targetElements));
+  BaseVector::CopyRange range = {1, 2, 2};
+  auto expected = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}),
+      makeArrayVector({0, 1}, makeFlatVector<int64_t>({45, 43})));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, dictionaryArray) {
+  auto sourceElements = makeFlatVector<int64_t>({42, 43});
+  auto source = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}), makeArrayVector({0, 1}, sourceElements));
+  auto targetElements = makeFlatVector<int64_t>({44, 45});
+  auto target = wrapInDictionary(
+      makeIndices({0, 0, 1, 1}), makeArrayVector({0, 1}, targetElements));
+  BaseVector::CopyRange range = {1, 1, 2};
+  auto expectedElements = makeFlatVector<int64_t>({44, 45, 42, 43});
+  auto expected = wrapInDictionary(
+      makeIndices({0, 2, 3, 1}),
+      makeArrayVector({0, 1, 2, 3}, expectedElements));
+  runTests(source, folly::Range(&range, 1), target, expected);
+}
+
+TEST_P(EncodedVectorCopyTest, fuzzer) {
+  VectorFuzzer::Options fuzzerOptions;
+  fuzzerOptions.allowLazyVector = reuseSource();
+  fuzzerOptions.nullRatio = 0.05;
+  auto seed = common::testutil::getRandomSeed(42);
+  VectorFuzzer fuzzer(fuzzerOptions, pool(), seed);
+  fuzzer::FuzzerGenerator rng(seed);
+#ifndef NDEBUG
+  constexpr int kNumIterations = 20;
+#else
+  constexpr int kNumIterations = 1000;
+#endif
+  for (int i = 0; i < kNumIterations; ++i) {
+    auto type = fuzzer.randType();
+    SCOPED_TRACE(fmt::format("i={} type={}", i, type->toString()));
+    auto source = fuzzer.fuzz(type);
+    BaseVector::CopyRange range;
+    range.sourceIndex = folly::Random::rand32(source->size() - 1, rng);
+    range.count =
+        folly::Random::rand32(1, source->size() - range.sourceIndex, rng);
+    {
+      SCOPED_TRACE("Null target");
+      VectorPtr target;
+      range.targetIndex = 0;
+      copy(source, folly::Range(&range, 1), target);
+      test::assertEqualVectors(
+          source->slice(range.sourceIndex, range.count), target);
+    }
+    auto target = fuzzer.fuzz(type);
+    range.targetIndex = folly::Random::rand32(0, target->size() - 1, rng);
+    auto makeExpected = [&](auto& expected) {
+      if (expected->size() < range.targetIndex + range.count) {
+        expected->resize(range.targetIndex + range.count);
+      }
+      expected->copyRanges(source.get(), folly::Range(&range, 1));
+    };
+    {
+      SCOPED_TRACE("Immutable target");
+      auto actual = target;
+      copy(source, folly::Range(&range, 1), actual);
+      auto expected = BaseVector::copy(*target);
+      makeExpected(expected);
+      test::assertEqualVectors(expected, actual);
+    }
+    {
+      SCOPED_TRACE("Mutable target");
+      auto expected = BaseVector::copy(*target);
+      copy(source, folly::Range(&range, 1), target);
+      makeExpected(expected);
+      test::assertEqualVectors(expected, target);
+    }
+  }
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
Implement `encodedVectorCopy`, a generic vector copy utility that preserves
encodings for memory saving purpose.

## Encoding Preservation

There are mainly 2 use cases for this new function.  One is to merge multiple
encoded vectors (`source`s) into one large encoded vector (`target`); the other
is to update specific rows (`source`) in a large vector (`target`), while
keeping the encodings.  Both use cases requires us to keep the encoding on
`target`, so it is decided as the behavior of this function.

There are some exceptions to this rule:

- We merge multiple adjacent layers of dictionary and constant wrappers into
  one.
- When `target` is constant, we convert it to dictionary to allow different
  values in `source`.
- When `target` is flat ROW, MAP, or ARRAY, and `source` is constant or
  dictionary encoded, the result will be dictionary encoded, to avoid flattening
  the child vectors.  Once the target becomes dictionary, it can stay that way
  and we can keep adding new content to it while keeping the encoding, this is a
  typical use case for encoding preserved merging.

## Inner Vector Compaction

Other than encoding, we also pay special attention to avoid holding on memory
that is no longer needed.  This is especially important for the merging use
case, as the `target` gets updated, majority rows of its inner vectors will be
dereferenced and no longer used.  There are 2 cases where we need to take care
of this.

The first is for dictionary encoding, some rows in the alphabet (base/value)
vector become no longer referenced by the indices, so we should recycle them.
This is done properly that when we translate the copy ranges on dictionary
indices to the copy ranges on alphabet, we overwrite the unused rows in alphabet
using the new alphabet rows from source.  This way we efficiently reuse the
memory in alphabet without both reallocation and memory leaking.

The second case is for `ARRAY`/`MAP`, the elements/keys/values vector can have
rows that are no longer referenced from the parent.  This is a little harder to
solve than in the dictionary case, since the nested rows need to be contiguous
for one parent row (offset/size pair), which means we cannot move them around
easily.  Our approach is to allow some unused nested rows, but keep track of the
percentage of them, and once they exceed certain threshold (50% in the
implementation), we make a new copy of the nested vector and copy only the used
rows over.  This allows us to reuse the nested rows to a certain degree while
keep some bounds on the memory usage.

Differential Revision: D70867237


