### PR TITLE
feat(fuzzer): Add cogwheel expression fuzzer sot test

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -179,6 +179,7 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     }
     sql << ")";
   } else if (call->name() == "like") {
+    sql << "(";
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << " like ";
     toCallInputsSql({call->inputs()[1]}, sql);
@@ -186,6 +187,7 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
       sql << " escape ";
       toCallInputsSql({call->inputs()[2]}, sql);
     }
+    sql << ")";
   } else if (call->name() == "or" || call->name() == "and") {
     sql << "(";
     const auto& inputs = call->inputs();


### PR DESCRIPTION
Summary:
Adds cogwheel expression fuzzer sot test now that we have added Presto flag as an input to the internal expression fuzzer runs:
D70211086: feat(fuzzer): Add presto_url to presto_expression_fuzzer.

Reviewed By: kagamiori

Differential Revision: D70417936


