### PR TITLE
feat: Add new stats to to track decompression and compression times

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -190,6 +190,10 @@ class DataSink {
     uint64_t numWrittenBytes{0};
     uint32_t numWrittenFiles{0};
     uint64_t writeIOTimeUs{0};
+    uint64_t numCompressedBytes{0};
+    uint64_t wallRecodeTimeNs{0};
+    uint64_t compressionTimeNs{0};
+
     common::SpillStats spillStats;
 
     bool empty() const;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -293,6 +293,17 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
         "writeIOTime",
         RuntimeCounter(
             stats.writeIOTimeUs * 1000, RuntimeCounter::Unit::kNanos));
+    if (stats.wallRecodeTimeNs != 0) {
+      lockedStats->addRuntimeStat(
+          "wallRecodeTime",
+          RuntimeCounter(stats.wallRecodeTimeNs, RuntimeCounter::Unit::kNanos));
+    }
+    if (stats.compressionTimeNs != 0) {
+      lockedStats->addRuntimeStat(
+          "compressionTime",
+          RuntimeCounter(
+              stats.compressionTimeNs, RuntimeCounter::Unit::kNanos));
+    }
   }
   if (!stats.spillStats.empty()) {
     *spillStats_.wlock() += stats.spillStats;


### PR DESCRIPTION
Summary: For internal tests we are tracking the compression times within the table writer.

Differential Revision: D70910856


