### PR TITLE
fix: Recursive selector in json path used with scalar json

### DIFF
--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -135,7 +135,9 @@ simdjson::error_code SIMDJsonExtractor::extract(
       return consumer(jsonDoc);
     }
     VELOX_CHECK_GT(tokens_.size(), 0);
-    if (tokens_[0].selector == JsonPathTokenizer::Selector::WILDCARD) {
+    auto& selector = tokens_[0].selector;
+    if (tokens_[0].selector == JsonPathTokenizer::Selector::WILDCARD ||
+        selector == JsonPathTokenizer::Selector::RECURSIVE) {
       isDefinitePath = false;
     }
     return simdjson::SUCCESS;

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -1035,11 +1035,19 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   EXPECT_EQ(std::nullopt, jsonExtract("null", "$.foo"));
   EXPECT_EQ(std::nullopt, jsonExtract("null", "$.[0]"));
 
-  // Recurssive opearator
+  // Recursive opearator
   EXPECT_EQ("[8.95,12.99,8.99,22.99,19.95]", jsonExtract(kJson, "$..price"));
   EXPECT_EQ(
       "[8.95,12.99,8.99,22.99,19.95,8.95,12.99,8.99,22.99,19.95,8.95,12.99,8.99,22.99]",
       jsonExtract(kJson, "$..*..price"));
+  EXPECT_EQ("[]", jsonExtract(kJson, "$..nonExistentKey"));
+  EXPECT_EQ(std::nullopt, jsonExtract(kJson, "$.nonExistentKey..price"));
+  EXPECT_EQ(
+      std::nullopt, jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.c..[0]"));
+
+  // Calling Recursive opearator on a scalar
+  EXPECT_EQ("[]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a.b.[0]..[0]"));
+  EXPECT_EQ("[]", jsonExtract("1", "$..key"));
 
   // non-definite paths that end up being evaluated vs. not evaluated
   EXPECT_EQ(


### PR DESCRIPTION
Summary:
Ensure that empty array is returned if the recursive selector is encountered while a
json path even if the current node is a scalar.

Differential Revision: D70926386


