### PR TITLE
build: Add support for `find_package(Arrow REQUIRED)`

### DIFF
--- a/CMake/FindArrow.cmake
+++ b/CMake/FindArrow.cmake
@@ -12,29 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(FindPackageHandleStandardArgs)
+
 find_library(ARROW_LIB libarrow.a)
 find_library(ARROW_TESTING_LIB libarrow_testing.a)
-if("${ARROW_LIB}" STREQUAL "ARROW_LIB-NOTFOUND"
-   OR "${ARROW_TESTING_LIB}" STREQUAL "ARROW_TESTING_LIB-NOTFOUND")
-  set(Arrow_FOUND false)
-  return()
-endif()
+find_path(ARROW_INCLUDE_PATH arrow/api.h)
 find_package(Thrift)
-if(NOT Thrift_FOUND)
-  # Requires building arrow from source with thrift bundled.
-  set(Arrow_FOUND false)
-  return()
-endif()
-add_library(thrift ALIAS thrift::thrift)
 
-set(Arrow_FOUND true)
+find_package_handle_standard_args(
+  Arrow
+  DEFAULT_MSG
+  ARROW_LIB
+  ARROW_TESTING_LIB
+  ARROW_INCLUDE_PATH
+  Thrift_FOUND)
 
 # Only add the libraries once.
-if(NOT TARGET arrow)
+if(Arrow_FOUND AND NOT TARGET arrow)
   add_library(arrow STATIC IMPORTED GLOBAL)
   add_library(arrow_testing STATIC IMPORTED GLOBAL)
+  add_library(thrift ALIAS thrift::thrift)
 
-  find_path(ARROW_INCLUDE_PATH arrow/api.h)
   set_target_properties(
     arrow arrow_testing PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                    ${ARROW_INCLUDE_PATH})


### PR DESCRIPTION
The current `CMake/FindArrow.cmake` ignores `REQUIRED` argument in
`find_package(Arrow REQUIRED)`. If `-DArrow_SOURCE=SYSTEM` is
specified but system Arrow isn't found, `FindArrow.cmake` finishes
without an error.

With this change, `-DArrow_SOURCE=SYSTEM` and no system Arrow reports
an error.

`find_package_handle_standard_args()` is a standard function provided
by CMake to handle `REQUIRED`:
https://cmake.org/cmake/help/latest/module/FindPackageHandleStandardArgs.html

Our other `FindXXX.cmake`s also use it.
