### PR TITLE
fix: Fix incorrect result from casting double to decimal

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -271,16 +271,11 @@ class DecimalUtil {
       if (isOverflow) {
         return Status::UserError("Result overflows.");
       }
-    } else if (fractionDigits > scale) {
+    } else {
       const auto scalingFactor =
           DecimalUtil::kPowersOfTen[fractionDigits - scale];
-      const TOutput remainder = rescaledValue % scalingFactor;
-      rescaledValue /= scalingFactor;
-      if (rescaledValue >= 0 && remainder >= scalingFactor / 2) {
-        ++rescaledValue;
-      } else if (remainder <= -scalingFactor / 2) {
-        --rescaledValue;
-      }
+      divideWithRoundUp<TOutput, TOutput, int128_t>(
+          rescaledValue, rescaledValue, scalingFactor, false, 0, 0);
     }
 
     if (!valueInPrecisionRange<TOutput>(rescaledValue, precision)) {

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -258,17 +258,31 @@ class DecimalUtil {
     // LONG_DOUBLE_MAX.
     long double scaledValue = std::round(
         (long double)value * DecimalUtil::kPowersOfTen[fractionDigits]);
-    if (scale > fractionDigits) {
-      scaledValue *= DecimalUtil::kPowersOfTen[scale - fractionDigits];
-    } else {
-      scaledValue /= DecimalUtil::kPowersOfTen[fractionDigits - scale];
-    }
-
-    const auto result = folly::tryTo<TOutput>(std::round(scaledValue));
+    const auto result = folly::tryTo<TOutput>(scaledValue);
     if (result.hasError()) {
       return Status::UserError("Result overflows.");
     }
-    const TOutput rescaledValue = result.value();
+    TOutput rescaledValue = result.value();
+    if (scale > fractionDigits) {
+      bool isOverflow = __builtin_mul_overflow(
+          rescaledValue,
+          DecimalUtil::kPowersOfTen[scale - fractionDigits],
+          &rescaledValue);
+      if (isOverflow) {
+        return Status::UserError("Result overflows.");
+      }
+    } else if (fractionDigits > scale) {
+      const auto scalingFactor =
+          DecimalUtil::kPowersOfTen[fractionDigits - scale];
+      const TOutput remainder = rescaledValue % scalingFactor;
+      rescaledValue /= scalingFactor;
+      if (rescaledValue >= 0 && remainder >= scalingFactor / 2) {
+        ++rescaledValue;
+      } else if (remainder <= -scalingFactor / 2) {
+        --rescaledValue;
+      }
+    }
+
     if (!valueInPrecisionRange<TOutput>(rescaledValue, precision)) {
       return Status::UserError(
           "Result cannot fit in the given precision {}.", precision);

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -406,6 +406,13 @@ TEST(DecimalTest, rescaleDouble) {
 
   assertRescaleDouble(std::numeric_limits<double>::min(), DECIMAL(38, 2), 0);
 
+  assertRescaleDouble(0.9999999999999999, DECIMAL(17, 2), 100);
+
+  assertRescaleDouble(-0.9999999999999999, DECIMAL(17, 2), -100);
+
+  assertRescaleDouble(
+      kMaxDoubleBelowInt64Max, DECIMAL(19, 0), 9'223'372'036'854'774'784);
+
   // Test for overflows.
   std::vector<double> invalidInputs = {
       9999999999999999999999.99,

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -397,6 +397,8 @@ TEST(DecimalTest, rescaleDouble) {
       10.03, DECIMAL(38, 18), HugeInt::parse("1003" + zeros(16)));
   assertRescaleDouble(0.034567890, DECIMAL(38, 18), 34'567'890'000'000'000);
   assertRescaleDouble(
+      0.03456789, DECIMAL(38, 33), HugeInt::parse("3456789" + zeros(25)));
+  assertRescaleDouble(
       0.999999999999999, DECIMAL(38, 18), 999'999'999'999'999'000);
   assertRescaleDouble(
       0.123456789123123, DECIMAL(38, 18), 123'456'789'123'123'000);


### PR DESCRIPTION
When converting 0.03456789 to DECIMAL(38, 33), the result generated by Velox is 
inconsistent with Spark and Presto. This discrepancy is caused by precision 
errors due to long double multiplication. I propose fixing this issue by first 
converting the result to the target type(int64_t / int128_t) and then applying rescaling.

Velox
```
spark.sql("select cast(0.03456789d as decimal(38, 33))").collect
res18: Array[org.apache.spark.sql.Row] = Array([0.034567889999999999999845079187456])
```
Spark
```
spark.sql("select cast(0.03456789d as decimal(38, 33))").collect
res16: Array[org.apache.spark.sql.Row] = Array([0.034567890000000000000000000000000])
```
Presto
```
presto> select cast(0.03456789 as decimal(38, 33));
                _col0
-------------------------------------
 0.034567890000000000000000000000000
(1 row)
```