### PR TITLE
feat: Extract hive connector ID from task meta

### DIFF
--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -186,6 +186,36 @@ std::string getNodeName(
   }
 }
 
+std::string getHiveConnectorId(
+    const std::string& nodeId,
+    const std::string& taskMetaFilePath,
+    const std::shared_ptr<filesystems::FileSystem>& fs,
+    memory::MemoryPool* pool) {
+  try {
+    const auto file = fs->openFileForRead(taskMetaFilePath);
+    VELOX_CHECK_NOT_NULL(file);
+    const auto taskMeta = file->pread(0, file->size());
+    VELOX_USER_CHECK(!taskMeta.empty());
+    folly::dynamic metaObj = folly::parseJson(taskMeta);
+    const auto planFragment = ISerializable::deserialize<core::PlanNode>(
+        metaObj[TraceTraits::kPlanNodeKey], pool);
+    const auto* traceNode = core::PlanNode::findFirstNode(
+        planFragment.get(),
+        [&nodeId](const core::PlanNode* node) { return node->id() == nodeId; });
+    const auto* tableScanNode =
+        dynamic_cast<const core::TableScanNode*>(traceNode);
+    VELOX_CHECK_NOT_NULL(tableScanNode);
+    const auto connectorId = tableScanNode->tableHandle()->connectorId();
+    VELOX_CHECK(!connectorId.empty());
+    return connectorId;
+  } catch (const std::exception& e) {
+    VELOX_FAIL(
+        "Failed to get the hive connector id from '{}' with error: {}",
+        taskMetaFilePath,
+        e.what());
+  }
+}
+
 RowTypePtr getDataType(
     const core::PlanNodePtr& tracedPlan,
     const std::string& tracedNodeId,

--- a/velox/exec/TraceUtil.h
+++ b/velox/exec/TraceUtil.h
@@ -88,6 +88,14 @@ std::string getNodeName(
     const std::shared_ptr<filesystems::FileSystem>& fs,
     memory::MemoryPool* pool);
 
+/// Extracts the hive connector from the trace metadata file, return empty if
+/// it does not exist.
+std::string getHiveConnectorId(
+    const std::string& nodeId,
+    const std::string& taskMetaFilePath,
+    const std::shared_ptr<filesystems::FileSystem>& fs,
+    memory::MemoryPool* pool);
+
 /// Extracts the input data type for the trace scan operator. The function first
 /// uses the traced node id to find traced operator's plan node from the traced
 /// plan fragment. Then it uses the specified source node index to find the

--- a/velox/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableScanReplayerTest.cpp
@@ -129,6 +129,12 @@ TEST_F(TableScanReplayerTest, runner) {
 
   const auto taskTraceDir =
       exec::trace::getTaskTraceDirectory(traceRoot, *task);
+  const auto connectorId = exec::trace::getHiveConnectorId(
+      traceNodeId_,
+      exec::trace::getTaskTraceMetaFilePath(taskTraceDir),
+      fs,
+      memory::MemoryManager::getInstance()->tracePool());
+  ASSERT_EQ("test-hive", connectorId);
   const auto opTraceDir = exec::trace::getOpTraceDirectory(
       taskTraceDir,
       traceNodeId_,


### PR DESCRIPTION
Extracts the hive connector ID from the task meta and registers
the hive connector using it when replaying the `TableScan` operator.
Hence, the query trace replayer can register the right hive connector
instead of the default 'test-hive' connector.

Resolve #12586 