### PR TITLE
fix: Prevent memory leak caused by cyclic reference of driver in DriverBlockingState

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3239,7 +3239,7 @@ void Task::DriverBlockingState::setDriverFuture(ContinueFuture& driverFuture) {
   }
   std::move(driverFuture)
       .via(&folly::InlineExecutor::instance())
-      .thenValue([&, holder = shared_from_this()](auto&& /* unused */) {
+      .thenValue([this, holder = shared_from_this()](auto&& /* unused */) {
         std::vector<std::unique_ptr<ContinuePromise>> promises;
         {
           std::lock_guard<std::mutex> l(mutex_);
@@ -3254,8 +3254,9 @@ void Task::DriverBlockingState::setDriverFuture(ContinueFuture& driverFuture) {
       })
       .thenError(
           folly::tag_t<std::exception>{},
-          [&, holder = shared_from_this(), taskId = driver_->task()->taskId()](
-              std::exception const& e) {
+          [this,
+           holder = shared_from_this(),
+           taskId = driver_->task()->taskId()](std::exception const& e) {
             std::lock_guard<std::mutex> l(mutex_);
             VELOX_CHECK(blocked_);
             VELOX_CHECK_NULL(error_);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1121,7 +1121,8 @@ class Task : public std::enable_shared_from_this<Task> {
   std::vector<std::shared_ptr<Driver>> drivers_;
 
   // Tracks the blocking state for each driver under serialized execution mode.
-  class DriverBlockingState {
+  class DriverBlockingState
+      : public enable_shared_from_this<DriverBlockingState> {
    public:
     explicit DriverBlockingState(const Driver* driver) : driver_(driver) {
       VELOX_CHECK_NOT_NULL(driver_);
@@ -1150,7 +1151,7 @@ class Task : public std::enable_shared_from_this<Task> {
   };
 
   // Tracks the driver blocking state under serialized execution mode.
-  std::vector<std::unique_ptr<DriverBlockingState>> driverBlockingStates_;
+  std::vector<std::shared_ptr<DriverBlockingState>> driverBlockingStates_;
 
   // When Drivers are closed by the Task, there is a chance that race and/or
   // bugs can cause such Drivers to be held forever, in turn holding a pointer


### PR DESCRIPTION
`Task::DriverBlockingState::setDriverFuture` captures `driver_->shared_from_this` then pass to lambdas. In practice this could easily cause cyclic references on `std::shared_ptr<Driver>` because the physical operators could at the same time hold the associated promises that refer to the `driverFuture` instances. Hence, in the case, the reference link will be as following:

Operator -> Promise -> [Driver](https://github.com/facebookincubator/velox/blob/c550daba47db2a17221c8ec0144450f32bd9a56a/velox/exec/Task.cpp#L3242-L3255) -> Query Plan -> Operator

If the operator may have some cleanup logic in its destructor, say, to close the remote connection then to set the promise to unblock the future, this reference cycle will cause the cleanup logic never to run. Then memory leak will be led.

The patch reduces the capture granularity to make the driver be always correctly destructed. Then the query plan can be destructed, then the cleanup logic can be run, etc.