### PR TITLE
feat(type): Add concatRowTypes to velox/type/TypeUtil.h

### DIFF
--- a/velox/type/TypeUtil.cpp
+++ b/velox/type/TypeUtil.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/TypeUtil.h"
+
+namespace facebook::velox::type {
+
+velox::RowTypePtr concatRowTypes(
+    const std::vector<velox::RowTypePtr>& rowTypes) {
+  std::vector<std::string> columnNames;
+  std::vector<velox::TypePtr> columnTypes;
+  for (auto& rowType : rowTypes) {
+    columnNames.insert(
+        columnNames.end(), rowType->names().begin(), rowType->names().end());
+    columnTypes.insert(
+        columnTypes.end(),
+        rowType->children().begin(),
+        rowType->children().end());
+  }
+  return velox::ROW(std::move(columnNames), std::move(columnTypes));
+}
+
+} // namespace facebook::velox::type

--- a/velox/type/TypeUtil.h
+++ b/velox/type/TypeUtil.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::type {
+
+velox::RowTypePtr concatRowTypes(
+    const std::vector<velox::RowTypePtr>& rowTypes);
+
+} // namespace facebook::velox::type

--- a/velox/type/tests/TypeUtilTest.cpp
+++ b/velox/type/tests/TypeUtilTest.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/TypeUtil.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::type {
+namespace {
+
+TEST(TypeUtilTest, ConcatRowTypes) {
+  auto keyType = velox::ROW({"k0", "k1"}, {velox::BIGINT(), velox::INTEGER()});
+  auto valueType = velox::ROW(
+      {"v0", "v1"}, {velox::VARBINARY(), velox::ARRAY(velox::BIGINT())});
+  auto type = concatRowTypes({keyType, valueType});
+  auto expected = velox::ROW(
+      {"k0", "k1", "v0", "v1"},
+      {velox::BIGINT(),
+       velox::INTEGER(),
+       velox::VARBINARY(),
+       velox::ARRAY(velox::BIGINT())});
+  EXPECT_EQ(type->toString(), expected->toString());
+}
+
+} // namespace
+} // namespace facebook::velox::type


### PR DESCRIPTION
Add concatRowTypes to velox/type/TypeUtil.h.

This function takes a vector of row types and concatenates their columns in order to produce a merged row type.

Reviewed By: xiaoxmeng

Differential Revision: D71012661


