### PR TITLE
feat: Add support for Unknown Value in map_entries

### DIFF
--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -51,7 +51,7 @@ class MapEntriesFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     // map(K,V) -> array(row(K,V))
     return {exec::FunctionSignatureBuilder()
-                .knownTypeVariable("K")
+                .typeVariable("K")
                 .typeVariable("V")
                 .returnType("array(row(K,V))")
                 .argumentType("map(K,V)")

--- a/velox/functions/prestosql/tests/MapEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapEntriesTest.cpp
@@ -125,6 +125,25 @@ TEST_F(MapEntriesTest, constant) {
   test::assertEqualVectors(expected, result);
 }
 
+TEST_F(MapEntriesTest, unknownType) {
+  auto mapVector = makeMapVector<UnknownValue, UnknownValue>({
+      {},
+  });
+  auto result = evaluate("map_entries(c0)", makeRowVector({mapVector}));
+  auto keyVector = makeNullableFlatVector<UnknownValue>({});
+  auto valueVector = makeNullableFlatVector<UnknownValue>({});
+  auto elementVector = makeRowVector({keyVector, valueVector});
+  auto arrayVector = makeSingleRowArrayVector(elementVector);
+  test::assertEqualVectors(arrayVector, result);
+}
+
+TEST_F(MapEntriesTest, unknownTypeNonNullValue) {
+  auto mapVector = makeAllNullMapVector(1, UNKNOWN(), BIGINT());
+  auto result = evaluate("map_entries(c0)", makeRowVector({mapVector}));
+  auto expected = makeAllNullArrayVector(1, ROW({UNKNOWN(), BIGINT()}));
+  test::assertEqualVectors(expected, result);
+}
+
 TEST_F(MapEntriesTest, outputSizeIsBoundBySelectedRows) {
   // This test makes sure that map_entries output vector size is `rows.end()`
   // and not `rows.size()`. This is important for this function because it


### PR DESCRIPTION
Add support for Unknown type in Velox function map_entries

Prestissimo output matches Presto
 Following query match Presto output. The error is the same for 3 invalid values that are commented out below.
```
SELECT
           ->     MAP_ENTRIES(MAP(x, y))
           -> FROM (
           ->     VALUES
           ->
           ->         (NULL, ARRAY[]),
           ->         (NULL, ARRAY[3]),
           ->         (NULL, ARRAY[3, 4, 5]),
           ->         (ARRAY[], NULL),
           ->         (ARRAY[], ARRAY[]),
           ->         (ARRAY[1, 2, 3], ARRAY[4, 5, 6])
           ->         -- (NULL) -- not a valid case
           ->         -- (ARRAY[NULL], ARRAY[1]) -- Key cannot be null
           ->         -- (ARRAY[NULL, 2], ARRAY[1,2]) -- Key cannot be null
           -> ) AS t(x, y);
```

> Output
>                              _col0
> NULL
> NULL
> NULL
> NULL
> []
> [{field0=1, field1=4}, {field0=2, field1=5}, {field0=3, field1=6}]