### PR TITLE
fix: Improve global arbitration to have fairer abort

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -259,6 +259,21 @@ void ArbitrationParticipant::finishArbitration(ArbitrationOperation* op) {
   }
 }
 
+void ArbitrationParticipant::setPendingArbitrationGrowCapacity(
+    int64_t growCapacity) {
+  VELOX_CHECK_EQ(globalArbitrationGrowCapacity_, 0);
+  globalArbitrationGrowCapacity_ = growCapacity;
+}
+
+void ArbitrationParticipant::clearGlobalArbitrationGrowCapacity() {
+  VELOX_CHECK_NE(globalArbitrationGrowCapacity_, 0);
+  globalArbitrationGrowCapacity_ = 0;
+}
+
+int64_t ArbitrationParticipant::globalArbitrationGrowCapacity() const {
+  return globalArbitrationGrowCapacity_;
+}
+
 uint64_t ArbitrationParticipant::reclaim(
     uint64_t targetBytes,
     uint64_t maxWaitTimeNs,

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -260,6 +260,14 @@ class ArbitrationParticipant
   /// waiting operation to start execution if there is one.
   void finishArbitration(ArbitrationOperation* op);
 
+  /// Invoked to set the capacity 'this' participant attempts to grow through
+  /// global arbitration.
+  void setPendingArbitrationGrowCapacity(int64_t growCapacity);
+
+  void clearGlobalArbitrationGrowCapacity();
+
+  int64_t globalArbitrationGrowCapacity() const;
+
   /// Returns true if there is a running arbitration operation on this
   /// participant.
   bool hasRunningOp() const;
@@ -344,9 +352,14 @@ class ArbitrationParticipant
     ArbitrationOperation* op;
     ContinuePromise waitPromise;
   };
-  /// The resume promises of the arbitration operations on this participant
-  /// waiting for serial execution.
+  // The resume promises of the arbitration operations on this participant
+  // waiting for serial execution.
   std::deque<WaitOp> waitOps_;
+
+  // The additional capacity 'this' participant attempts to grow in global
+  // arbitration. This will be used in addition to its current capacity for
+  // abort candidate selection.
+  tsan_atomic<int64_t> globalArbitrationGrowCapacity_{0};
 
   tsan_atomic<uint32_t> numRequests_{0};
   tsan_atomic<uint32_t> numReclaims_{0};

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -624,10 +624,12 @@ class SharedArbitrator : public memory::MemoryArbitrator {
   // and abort the youngest participant whose capacity is larger than the limit.
   // If there is no such participant, it goes to the next limit and so on.
   std::vector<uint64_t> globalArbitrationAbortCapacityLimits_;
+
   // The global arbitration control thread which runs the global arbitration at
   // the background, and dispatch the actual memory reclaim work on different
   // participants to 'globalArbitrationExecutor_' and collects the results back.
   std::unique_ptr<std::thread> globalArbitrationController_;
+
   // Signal used to wakeup 'globalArbitrationController_' to run global
   // arbitration on-demand.
   std::condition_variable_any globalArbitrationThreadCv_;


### PR DESCRIPTION
Summary: When a small participant requesting for a large amount of capacity, we shall take into consideration of the requesting capacity make it more prone for being killed by global arbitration. This would make global arbitration victim selection more fair.

Differential Revision: D71076051


