### PR TITLE
refactor: Cleanup old arbitration time config

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -133,17 +133,6 @@ uint64_t SharedArbitrator::ExtraConfig::maxMemoryArbitrationTimeNs(
       .count();
 }
 
-// TODO: Remove after name change complete
-uint64_t SharedArbitrator::ExtraConfig::memoryReclaimMaxWaitTimeNs(
-    const std::unordered_map<std::string, std::string>& configs) {
-  return std::chrono::duration_cast<std::chrono::nanoseconds>(
-             config::toDuration(getConfig<std::string>(
-                 configs,
-                 kMemoryReclaimMaxWaitTime,
-                 std::string(kDefaultMemoryReclaimMaxWaitTime))))
-      .count();
-}
-
 uint64_t SharedArbitrator::ExtraConfig::memoryPoolMinFreeCapacity(
     const std::unordered_map<std::string, std::string>& configs) {
   return config::toCapacity(

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -87,13 +87,6 @@ class SharedArbitrator : public memory::MemoryArbitrator {
     static uint64_t maxMemoryArbitrationTimeNs(
         const std::unordered_map<std::string, std::string>& configs);
 
-    // TODO: Remove after name change complete
-    static constexpr std::string_view kMemoryReclaimMaxWaitTime{
-        "memory-reclaim-max-wait-time"};
-    static constexpr std::string_view kDefaultMemoryReclaimMaxWaitTime{"5m"};
-    static uint64_t memoryReclaimMaxWaitTimeNs(
-        const std::unordered_map<std::string, std::string>& configs);
-
     /// When shrinking capacity, the shrink bytes will be adjusted in a way such
     /// that AFTER shrink, the stricter (whichever is smaller) of the following
     /// conditions is met, in order to better fit the pool's current memory


### PR DESCRIPTION
Summary: Remove the unused old config, which has been renamed.

Reviewed By: xiaoxmeng

Differential Revision: D71079041


