### PR TITLE
fix(json): Unescape unicode when casting to json

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -498,4 +498,157 @@ size_t normalizedSizeForJsonParse(const char* input, size_t length) {
   return outSize;
 }
 
+size_t unescapeSizeForJsonCast(const char* input, size_t length) {
+  auto* start = input;
+  auto* end = input + length;
+  size_t outSize = 0;
+  while (start < end) {
+    if (FOLLY_UNLIKELY(*start == '\\')) {
+      VELOX_USER_CHECK(
+          start + 1 != end, "Invalid escape sequence at the end of string");
+      switch (*(start + 1)) {
+        case '/':
+          ++outSize;
+          start += 2;
+          continue;
+        case 'u': {
+          VELOX_USER_CHECK(
+              start + 6 <= end, "Invalid escape sequence at the end of string");
+          auto codePoint = parseHex(std::string_view(start + 2, 4));
+          if (isHighSurrogate(codePoint)) {
+            // Skip the next 6 characters.
+            start += 6;
+            // Read the next 6 characters.
+            if (start + 6 > end) {
+              VELOX_USER_FAIL("Invalid escape sequence at the end of string");
+            }
+            auto lowCodePoint = parseHex(std::string_view(start + 2, 4));
+            if (!isLowSurrogate(lowCodePoint)) {
+              VELOX_USER_FAIL("Invalid escape sequence at the end of string");
+            }
+            outSize += 4;
+            start += 6;
+            continue;
+          } else {
+            unsigned char buf[4];
+            auto increment = utf8proc_encode_char(codePoint, buf);
+            outSize += increment;
+          }
+          start += 6;
+          continue;
+        }
+        default:
+          outSize += 2;
+          start += 2;
+          continue;
+      }
+    }
+    if (FOLLY_LIKELY(IS_ASCII(*start))) {
+      ++outSize;
+      ++start;
+      continue;
+    }
+    int32_t codePoint;
+    auto count = tryGetUtf8CharLength(start, end - start, codePoint);
+    switch (count) {
+      case 2:
+      case 3:
+      case 4:
+        outSize += count;
+        start += count;
+        continue;
+      default: {
+        // Invalid character.
+        VELOX_DCHECK_LT(count, 0);
+        count = -count;
+        const auto& replacement =
+            getInvalidUTF8ReplacementString(start, end - start, count);
+        outSize += replacement.size();
+        start += count;
+      }
+    }
+  }
+  return outSize;
+}
+
+void unescapeForJsonCast(const char* input, size_t length, char* output) {
+  char* pos = output;
+  auto* start = input;
+  auto* end = input + length;
+
+  while (start < end) {
+    if (FOLLY_UNLIKELY(*start == '\\')) {
+      VELOX_USER_CHECK(
+          start + 1 != end, "Invalid escape sequence at the end of string");
+      switch (*(start + 1)) {
+        case '/':
+          *pos++ = '/';
+          start += 2;
+          continue;
+        case 'u': {
+          VELOX_USER_CHECK(
+              start + 6 <= end, "Invalid escape sequence at the end of string");
+          auto codePoint = parseHex(std::string_view(start + 2, 4));
+          if (isHighSurrogate(codePoint)) {
+            // Skip the next 6 characters.
+            start += 6;
+            // Read the next 6 characters.
+            if (start + 6 > end) {
+              VELOX_USER_FAIL("Invalid escape sequence at the end of string");
+            }
+            auto lowCodePoint = parseHex(std::string_view(start + 2, 4));
+            if (!isLowSurrogate(lowCodePoint)) {
+              VELOX_USER_FAIL("Invalid escape sequence at the end of string");
+            }
+            auto convertedPoint = (codePoint - 0xD800) * 0x400 +
+                (lowCodePoint - 0xDC00) + 0x10000;
+            auto increment = utf8proc_encode_char(
+                convertedPoint, reinterpret_cast<unsigned char*>(pos));
+            pos += increment;
+            start += 6;
+            continue;
+          } else {
+            auto increment = utf8proc_encode_char(
+                codePoint, reinterpret_cast<unsigned char*>(pos));
+            pos += increment;
+          }
+          start += 6;
+          continue;
+        }
+        default:
+          *pos++ = *start;
+          *pos++ = *(start + 1);
+          start += 2;
+          continue;
+      }
+    }
+    if (FOLLY_LIKELY(IS_ASCII(*start))) {
+      *pos++ = *start++;
+      continue;
+    }
+    int32_t codePoint;
+    auto count = tryGetUtf8CharLength(start, end - start, codePoint);
+    switch (count) {
+      case 2:
+      case 3:
+      case 4: {
+        memcpy(pos, reinterpret_cast<const char*>(start), count);
+        pos += count;
+        start += count;
+        continue;
+      }
+      default: {
+        // Invalid character.
+        VELOX_DCHECK_LT(count, 0);
+        count = -count;
+        const auto& replacement =
+            getInvalidUTF8ReplacementString(start, end - start, count);
+        std::memcpy(pos, replacement.data(), replacement.size());
+        pos += replacement.size();
+        start += count;
+      }
+    }
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/functions/prestosql/json/JsonStringUtil.h
+++ b/velox/functions/prestosql/json/JsonStringUtil.h
@@ -19,6 +19,8 @@
 
 namespace facebook::velox {
 
+/// Note the below function is only used for converting Varchar to JSON
+/// and thus escapes the varchar.
 /// Escape the unicode characters of `input` to make it canonical for JSON
 /// and legal to print in JSON text. It is assumed that the input is UTF-8
 /// encoded.
@@ -85,6 +87,15 @@ inline bool needNormalizeForJsonParse(const char* input, size_t length) {
   }
   return false;
 }
+
+/// Unescape for JSON casting. This is used when going from
+/// JSON  -> ARRAY(JSON) or JSON -> MAP(_, JSON) etc.
+/// In these cases Presto unescapes the string, replacing \\ with \, \n with
+/// newline, etc. The function will return valid utf-8
+void unescapeForJsonCast(const char* input, size_t length, char* output);
+
+/// Size of output buffer required when unescaping for json cast.
+size_t unescapeSizeForJsonCast(const char* input, size_t length);
 
 /// Compares two string views. The comparison takes into account
 /// escape sequences and also unicode characters.


### PR DESCRIPTION
Summary:
Currently when casting to json , we do not confirm to presto behavior. When JSON  contain escaped unicode like \uXXXX a cast unescapes them in Presto and produces the original unicode (For some reason json_parse() on the original json string will escape the unicode). The example below fully illustrates the problem: 

```
SELECT
    JSON_PARSE(x),
    JSON_FORMAT(JSON_PARSE(x)),
    x,
    CAST(JSON_PARSE(x) AS map(varchar,json)),
    cast (CAST(JSON_PARSE(x) AS map(varchar,json)) as json),
    cast (CAST(JSON_PARSE(x) AS map(varchar,json)) as json)
FROM (
    VALUES
        '{"key" : "' || U&'\+01F600' || '"}'
) AS t(x);

```

Presto:

```
_col0                  | _col1                  | x              | _col3             | _col4        | _col5        
------------------------+------------------------+----------------+-------------------+--------------+--------------
 {"key":"\uD83D\uDE00"} | {"key":"\uD83D\uDE00"} | {"key" : "😀"} | { "key": "\"😀\""} | {"key":"😀"} | {"key":"😀"} 
```

Velox:
```
 _col0          |         _col1          |       x        |        _col3         |         _col4          |         _col5          
------------------------+------------------------+----------------+----------------------+------------------------+------------------------
 {"key":"\uD83D\uDE00"} | {"key":"\uD83D\uDE00"} | {"key" : "😀"} | {key="\uD83D\uDE00"} | {"key":"\uD83D\uDE00"} | {"key":"\uD83D\uDE00"} 
```

With this fix the behaviors are similar.

Differential Revision: D71078371


