### PR TITLE
build(re2): Add support for RE2 2023-06-01

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1840,13 +1840,13 @@ std::vector<std::string> PatternMetadata::parseSubstrings(
   // Not support substrings-search with '_' for best performance.
   static const re2::RE2 fullPattern(R"((%+[^%_#\\]+)+%+)");
   static const re2::RE2 subPattern(R"((?:%+)([^%_#\\]+))");
-  re2::StringPiece full(pattern);
+  re2::StringPiece full(pattern.data(), pattern.size());
   re2::StringPiece cur;
   std::vector<std::string> substrings;
   if (RE2::FullMatch(full, fullPattern)) {
     while (RE2::PartialMatch(full, subPattern, &cur)) {
-      substrings.push_back(cur.as_string());
-      full.set(cur.end(), full.end() - cur.end());
+      substrings.push_back(std::string(cur));
+      full = re2::StringPiece(cur.end(), full.end() - cur.end());
     }
   }
   return substrings;

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -500,16 +500,16 @@ FOLLY_ALWAYS_INLINE std::string prepareRegexpReplaceReplacement(
       RE2::UNANCHORED,
       groupName,
       2)) {
-    auto groupIter = re.NamedCapturingGroups().find(groupName[1].as_string());
+    auto groupIter = re.NamedCapturingGroups().find(std::string(groupName[1]));
     if (groupIter == re.NamedCapturingGroups().end()) {
       VELOX_USER_FAIL(
           "Invalid replacement sequence: unknown group {{ {} }}.",
-          groupName[1].as_string());
+          std::string(groupName[1]));
     }
 
     RE2::GlobalReplace(
         &newReplacement,
-        fmt::format(R"(\${{{}}})", groupName[1].as_string()),
+        fmt::format(R"(\${{{}}})", std::string(groupName[1])),
         fmt::format("${}", groupIter->second));
   }
 


### PR DESCRIPTION
`re2::StringPiece` in RE2 2023-06-01 or later is an alias of
`absl::string_view`/`std::string_view`. So we can't use
`re2::StringPiece::as_string()` and`re2::StringPiece::set()`. We can
use `re2::StringPiece::operator std::string()` and copy constructor
instead of them. They work with old and new RE2.