### PR TITLE
fix(UUID): Incorrect results when cast between UUID and VARBINARY

### DIFF
--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -44,9 +44,9 @@ class UuidCastOperator : public exec::CastOperator {
     context.ensureWritable(rows, resultType, result);
 
     if (input.typeKind() == TypeKind::VARCHAR) {
-      castFromString(input, context, rows, *result);
+      castFromTypeKind<TypeKind::VARCHAR>(input, context, rows, *result);
     } else if (input.typeKind() == TypeKind::VARBINARY) {
-      castFromVarbinary(input, context, rows, *result);
+      castFromTypeKind<TypeKind::VARBINARY>(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
           "Cast from {} to UUID not yet supported", input.type()->toString());
@@ -62,9 +62,9 @@ class UuidCastOperator : public exec::CastOperator {
     context.ensureWritable(rows, resultType, result);
 
     if (resultType->kind() == TypeKind::VARCHAR) {
-      castToString(input, context, rows, *result);
+      castToTypeKind<TypeKind::VARCHAR>(input, context, rows, *result);
     } else if (resultType->kind() == TypeKind::VARBINARY) {
-      castToVarbinary(input, context, rows, *result);
+      castToTypeKind<TypeKind::VARBINARY>(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(
           "Cast from UUID to {} not yet supported", resultType->toString());
@@ -72,53 +72,36 @@ class UuidCastOperator : public exec::CastOperator {
   }
 
  private:
-  static void castToString(
+  template <TypeKind KIND>
+  static void castFromTypeKind(
       const BaseVector& input,
       exec::EvalCtx& context,
       const SelectivityVector& rows,
       BaseVector& result) {
-    auto* flatResult = result.as<FlatVector<StringView>>();
-    const auto* uuids = input.as<SimpleVector<int128_t>>();
+    auto* flatResult = result.as<FlatVector<int128_t>>();
+    const auto* uuidInput = input.as<SimpleVector<StringView>>();
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
-      // Ensure UUID bytes are big endian when building the string.
-      const auto uuid = DecimalUtil::bigEndian(uuids->valueAt(row));
+      const auto uuidValue = uuidInput->valueAt(row);
 
-      const uint8_t* uuidBytes = reinterpret_cast<const uint8_t*>(&uuid);
+      int128_t u;
 
-      // Do not use boost::lexical_cast. It is very slow.
-
-      // 2 hex digits per each value in [0, 127] range (1 byte).
-      static const char* const kHexTable =
-          "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-          "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-          "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
-          "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
-          "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
-          "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
-          "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-          "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
-
-      exec::StringWriter result(flatResult, row);
-      result.resize(36);
-
-      size_t offset = 0;
-      for (auto i = 0; i < 16; ++i) {
-        result.data()[offset] = kHexTable[uuidBytes[i] * 2];
-        result.data()[offset + 1] = kHexTable[uuidBytes[i] * 2 + 1];
-
-        offset += 2;
-        if (i == 3 || i == 5 || i == 7 || i == 9) {
-          result.data()[offset] = '-';
-          offset++;
-        }
+      if (KIND == TypeKind::VARCHAR) {
+        auto uuid = boost::lexical_cast<boost::uuids::uuid>(uuidValue);
+        memcpy(&u, &uuid, 16);
+      } else if (KIND == TypeKind::VARBINARY) {
+        memcpy(&u, uuidValue.data(), 16);
       }
 
-      result.finalize();
+      // Convert a big endian value from Boost to native byte-order.
+      u = DecimalUtil::bigEndian(u);
+
+      flatResult->set(row, u);
     });
   }
 
-  static void castToVarbinary(
+  template <TypeKind KIND>
+  static void castToTypeKind(
       const BaseVector& input,
       exec::EvalCtx& context,
       const SelectivityVector& rows,
@@ -131,54 +114,40 @@ class UuidCastOperator : public exec::CastOperator {
       const auto uuid = DecimalUtil::bigEndian(uuids->valueAt(row));
       const auto* uuidBytes = reinterpret_cast<const uint8_t*>(&uuid);
 
-      exec::StringWriter result(flatResult, row);
-      result.resize(16);
+      exec::StringWriter writer(flatResult, row);
 
-      memcpy(result.data(), uuidBytes, 16);
+      if constexpr (KIND == TypeKind::VARCHAR) {
+        writer.resize(36);
+        // Do not use boost::lexical_cast. It is very slow.
 
-      result.finalize();
-    });
-  }
+        // 2 hex digits per each value in [0, 127] range (1 byte).
+        static const char* const kHexTable =
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+            "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+            "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
+            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+            "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+            "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+            "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+            "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
 
-  static void castFromString(
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const SelectivityVector& rows,
-      BaseVector& result) {
-    auto* flatResult = result.as<FlatVector<int128_t>>();
-    const auto* uuidStrings = input.as<SimpleVector<StringView>>();
+        size_t offset = 0;
+        for (auto i = 0; i < 16; ++i) {
+          writer.data()[offset] = kHexTable[uuidBytes[i] * 2];
+          writer.data()[offset + 1] = kHexTable[uuidBytes[i] * 2 + 1];
 
-    context.applyToSelectedNoThrow(rows, [&](auto row) {
-      const auto uuidString = uuidStrings->valueAt(row);
+          offset += 2;
+          if (i == 3 || i == 5 || i == 7 || i == 9) {
+            writer.data()[offset] = '-';
+            offset++;
+          }
+        }
+      } else if constexpr (KIND == TypeKind::VARBINARY) {
+        writer.resize(16);
+        memcpy(writer.data(), uuidBytes, 16);
+      }
 
-      auto uuid = boost::lexical_cast<boost::uuids::uuid>(uuidString);
-
-      int128_t u;
-      memcpy(&u, &uuid, 16);
-
-      // Convert a big endian value from Boost to native byte-order.
-      u = DecimalUtil::bigEndian(u);
-
-      flatResult->set(row, u);
-    });
-  }
-
-  static void castFromVarbinary(
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const SelectivityVector& rows,
-      BaseVector& result) {
-    auto* flatResult = result.as<FlatVector<int128_t>>();
-    const auto* uuidBinaries = input.as<SimpleVector<StringView>>();
-
-    context.applyToSelectedNoThrow(rows, [&](auto row) {
-      const auto uuidBinary = uuidBinaries->valueAt(row);
-
-      int128_t u;
-      memcpy(&u, uuidBinary.data(), 16);
-      u = DecimalUtil::bigEndian(u);
-
-      flatResult->set(row, u);
+      writer.finalize();
     });
   }
 };

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -25,6 +25,75 @@
 
 namespace facebook::velox {
 namespace {
+template <TypeKind>
+struct UuidWriter {
+  static void write(exec::StringWriter& writer, const uint8_t* uuidBytes) =
+      delete;
+};
+
+template <TypeKind>
+struct UuidParser {
+  static int128_t parse(const StringView& uuidValue) = delete;
+};
+
+template <>
+struct UuidWriter<TypeKind::VARCHAR> {
+  static void write(exec::StringWriter& writer, const uint8_t* uuidBytes) {
+    writer.resize(36);
+    // Do not use boost::lexical_cast. It is very slow.
+
+    // 2 hex digits per each value in [0, 127] range (1 byte).
+    static const char* const kHexTable =
+        "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+        "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+        "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
+        "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+        "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+        "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+        "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+        "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
+
+    size_t offset = 0;
+    for (auto i = 0; i < 16; ++i) {
+      writer.data()[offset] = kHexTable[uuidBytes[i] * 2];
+      writer.data()[offset + 1] = kHexTable[uuidBytes[i] * 2 + 1];
+
+      offset += 2;
+      if (i == 3 || i == 5 || i == 7 || i == 9) {
+        writer.data()[offset] = '-';
+        offset++;
+      }
+    }
+  }
+};
+
+template <>
+struct UuidParser<TypeKind::VARCHAR> {
+  static int128_t parse(const StringView& uuidValue) {
+    auto uuid = boost::lexical_cast<boost::uuids::uuid>(uuidValue);
+    int128_t u;
+    memcpy(&u, &uuid, 16);
+    return u;
+  }
+};
+
+template <>
+struct UuidWriter<TypeKind::VARBINARY> {
+  static void write(exec::StringWriter& writer, const uint8_t* uuidBytes) {
+    writer.resize(16);
+    memcpy(writer.data(), uuidBytes, 16);
+  }
+};
+
+template <>
+struct UuidParser<TypeKind::VARBINARY> {
+  static int128_t parse(const StringView& uuidValue) {
+    int128_t u;
+    memcpy(&u, uuidValue.data(), 16);
+    return u;
+  }
+};
+
 class UuidCastOperator : public exec::CastOperator {
  public:
   bool isSupportedFromType(const TypePtr& other) const override {
@@ -87,38 +156,7 @@ class UuidCastOperator : public exec::CastOperator {
       const auto* uuidBytes = reinterpret_cast<const uint8_t*>(&uuid);
 
       exec::StringWriter writer(flatResult, row);
-
-      if constexpr (KIND == TypeKind::VARCHAR) {
-        writer.resize(36);
-        // Do not use boost::lexical_cast. It is very slow.
-
-        // 2 hex digits per each value in [0, 127] range (1 byte).
-        static const char* const kHexTable =
-            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-            "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
-            "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f"
-            "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
-            "808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
-            "a0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
-            "c0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
-            "e0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
-
-        size_t offset = 0;
-        for (auto i = 0; i < 16; ++i) {
-          writer.data()[offset] = kHexTable[uuidBytes[i] * 2];
-          writer.data()[offset + 1] = kHexTable[uuidBytes[i] * 2 + 1];
-
-          offset += 2;
-          if (i == 3 || i == 5 || i == 7 || i == 9) {
-            writer.data()[offset] = '-';
-            offset++;
-          }
-        }
-      } else if constexpr (KIND == TypeKind::VARBINARY) {
-        writer.resize(16);
-        memcpy(writer.data(), uuidBytes, 16);
-      }
-
+      UuidWriter<KIND>::write(writer, uuidBytes);
       writer.finalize();
     });
   }
@@ -134,19 +172,9 @@ class UuidCastOperator : public exec::CastOperator {
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto uuidValue = uuidInput->valueAt(row);
-
-      int128_t u;
-
-      if (KIND == TypeKind::VARCHAR) {
-        auto uuid = boost::lexical_cast<boost::uuids::uuid>(uuidValue);
-        memcpy(&u, &uuid, 16);
-      } else if (KIND == TypeKind::VARBINARY) {
-        memcpy(&u, uuidValue.data(), 16);
-      }
-
-      // Convert a big endian value from Boost to native byte-order.
+      auto u = UuidParser<KIND>::parse(uuidValue);
+      // Convert a big endian value to native byte-order.
       u = DecimalUtil::bigEndian(u);
-
       flatResult->set(row, u);
     });
   }


### PR DESCRIPTION
The support for cast between UUID and VARBINARY was added in  #12544. However, there is a mismatch in the results between Prestissimo and Presto Java, which results in the following e2e test failure in https://github.com/prestodb/presto/pull/23301.
```
java.lang.AssertionError: For query:
SELECT CAST(CAST(c_uuid AS uuid) AS VARBINARY) FROM tmp_presto_68ac2ed72d41449bba7c9de1f0530413
actual column types:
[varbinary]
expected column types:
[varbinary]

not equal
Actual rows (4 of 4 extra rows shown, 5 rows in total):
[java.nio.HeapByteBuffer[pos=0 lim=36 cap=36]]
[java.nio.HeapByteBuffer[pos=0 lim=36 cap=36]]
[java.nio.HeapByteBuffer[pos=0 lim=36 cap=36]]
[java.nio.HeapByteBuffer[pos=0 lim=36 cap=36]]
Expected rows (4 of 4 missing rows shown, 5 rows in total):
[java.nio.HeapByteBuffer[pos=0 lim=16 cap=16]]
[java.nio.HeapByteBuffer[pos=0 lim=16 cap=16]]
[java.nio.HeapByteBuffer[pos=0 lim=16 cap=16]]
[java.nio.HeapByteBuffer[pos=0 lim=16 cap=16]]
```

The reason is that #12544 called the castToString and castFromString functions for VARBINARY which is incorrect. Although VARCHAR and VARBINARY are both represented by StringView, we don't need the lexical cast for VARBINARY.
This PR will fix this issue.