### PR TITLE
feat(UUID): Add between function

### DIFF
--- a/velox/functions/prestosql/UuidFunctions.h
+++ b/velox/functions/prestosql/UuidFunctions.h
@@ -52,8 +52,9 @@ struct BetweenFunctionUuid {
       const arg_type<Uuid>& value,
       const arg_type<Uuid>& low,
       const arg_type<Uuid>& high) {
-    result = static_cast<uint128_t>(value) >= static_cast<uint128_t>(low) &&
-        static_cast<uint128_t>(value) <= static_cast<uint128_t>(high);
+    auto castValue = static_cast<uint128_t>(value);
+    result = castValue >= static_cast<uint128_t>(low) &&
+        castValue <= static_cast<uint128_t>(high);
   }
 };
 

--- a/velox/functions/prestosql/UuidFunctions.h
+++ b/velox/functions/prestosql/UuidFunctions.h
@@ -44,6 +44,20 @@ VELOX_GEN_BINARY_EXPR_UUID(GteFunction, (uint128_t)lhs >= (uint128_t)rhs);
 #undef VELOX_GEN_BINARY_EXPR_UUID
 
 template <typename T>
+struct BetweenFunctionUuid {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      bool& result,
+      const arg_type<Uuid>& value,
+      const arg_type<Uuid>& low,
+      const arg_type<Uuid>& high) {
+    result = static_cast<uint128_t>(value) >= static_cast<uint128_t>(low) &&
+        static_cast<uint128_t>(value) <= static_cast<uint128_t>(high);
+  }
+};
+
+template <typename T>
 struct UuidFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
@@ -65,6 +79,8 @@ inline void registerUuidFunctions(const std::string& prefix) {
   registerFunction<GtFunctionUuid, bool, Uuid, Uuid>({prefix + "gt"});
   registerFunction<LteFunctionUuid, bool, Uuid, Uuid>({prefix + "lte"});
   registerFunction<GteFunctionUuid, bool, Uuid, Uuid>({prefix + "gte"});
+  registerFunction<BetweenFunctionUuid, bool, Uuid, Uuid, Uuid>(
+      {prefix + "between"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/UuidFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/UuidFunctionsTest.cpp
@@ -275,5 +275,60 @@ TEST_F(UuidFunctionsTest, comparisons) {
   }
 }
 
+TEST_F(UuidFunctionsTest, between) {
+  const auto uuidEval = [&](const std::optional<std::string>& value,
+                            const std::optional<std::string>& low,
+                            const std::optional<std::string>& high) {
+    return evaluateOnce<bool>(
+        "cast(c0 as uuid) between cast(c1 as uuid) and cast(c2 as uuid)",
+        value,
+        low,
+        high);
+  };
+
+  ASSERT_EQ(
+      true,
+      uuidEval(
+          "33355449-2c7d-43d7-967a-f53cd23215ad",
+          "00000000-0000-0000-0000-000000000000",
+          "ffffffff-ffff-ffff-ffff-ffffffffffff"));
+  ASSERT_EQ(
+      false,
+      uuidEval(
+          "33355449-2c7d-43d7-967a-f53cd23215ad",
+          "ffffffff-ffff-ffff-ffff-ffffffffffff",
+          "00000000-0000-0000-0000-000000000000"));
+  ASSERT_EQ(
+      true,
+      uuidEval(
+          "00000000-0000-0000-2200-000000000011",
+          "00000000-0000-0000-0000-000000000022",
+          "11000000-0000-0000-0000-000000000000"));
+  ASSERT_EQ(
+      false,
+      uuidEval(
+          "00000000-0000-0000-0000-000000000022",
+          "00000000-0000-0000-2200-000000000011",
+          "11000000-0000-0000-0000-000000000000"));
+  ASSERT_EQ(
+      false,
+      uuidEval(
+          "11000000-0000-0000-0000-000000000000",
+          "00000000-0000-0000-2200-000000000011",
+          "00000000-0000-0000-0000-000000000022"));
+  ASSERT_EQ(
+      true,
+      uuidEval(
+          "00000000-0000-0000-2200-000000000011",
+          "00000000-0000-0000-2200-000000000011",
+          "11000000-0000-0000-0000-000000000000"));
+  ASSERT_EQ(
+      true,
+      uuidEval(
+          "11000000-0000-0000-0000-000000000000",
+          "00000000-0000-0000-2200-000000000011",
+          "11000000-0000-0000-0000-000000000000"));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::prestosql


### PR DESCRIPTION
As comparison functions for UUID have been supported in #10791, we should also support the between function.