### PR TITLE
fix(fuzzer): Fix ApproxDistinctResultVerifier for approx_set

### DIFF
--- a/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
@@ -254,7 +254,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
       return largeGaps.size() <= 0.05 * numGroups;
     }
 
-    return largeGaps.empty();
+    return numGroups == 1 || largeGaps.empty();
   }
 
   void reset() override {
@@ -324,7 +324,8 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
     std::vector<std::string> projectColumns = columnNames;
     for (auto& projectColumn : projectColumns) {
       if (projectColumn == name_) {
-        projectColumn = fmt::format("cardinality({}) as {}", name_, name_);
+        projectColumn =
+            fmt::format("coalesce(cardinality({}), 0) as {}", name_, name_);
       }
     }
     return projectColumns;


### PR DESCRIPTION
Summary:
The ApproxDistinctReusltVerifier didn't handle approx_set properly for window fuzzer resutls. This 
causes window fuzzer test failures in opt mode. The bug is because cardinality(approx_set(null)) 
returns NULL when count(distinct null) returns 0, but the result verifier didn't check the result of 
cardinality(approx_set(null)) being NULL. This diff fixes this problem by calcaulting 
coalesce(cardinality(approx_set(null)), 0) instead in the result verifier. This diff also makes the 
check in verifyWindow() consisten with verify().

Differential Revision: D71130903


