### PR TITLE
fix: Constructor of std::vector requires type to be complete

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -18,10 +18,9 @@
 #include <string>
 
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 
 namespace facebook::velox::connector::hive::iceberg {
-
-struct IcebergDeleteFile;
 
 struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;


### PR DESCRIPTION
Summary:
This default argument in `std::vector<IcebergDeleteFile> deletes = {}` causes `vector::~vector` to be instantiated. libc++ enforces that the type argument must be complete by the time its members are referenced. This code should have been ill-formed. 

This is fixable by just including the necessary headers.

Differential Revision: D71142041


