### PR TITLE
feat: Add filter pushdown to sequence storage table handle

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -48,7 +48,7 @@ class ITypedExpr;
 }
 
 namespace facebook::velox::core {
-struct IndexJoinCondition;
+struct IndexLookupCondition;
 }
 
 namespace facebook::velox::connector {
@@ -604,7 +604,7 @@ class Connector {
   virtual std::shared_ptr<IndexSource> createIndexSource(
       const RowTypePtr& inputType,
       size_t numJoinKeys,
-      const std::vector<std::shared_ptr<core::IndexJoinCondition>>&
+      const std::vector<std::shared_ptr<core::IndexLookupCondition>>&
           joinConditions,
       const RowTypePtr& outputType,
       const std::shared_ptr<ConnectorTableHandle>& tableHandle,

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -41,29 +41,29 @@ std::vector<PlanNodePtr> deserializeSources(
 }
 
 namespace {
-IndexJoinConditionPtr createIndexJoinCondition(
+IndexLookupConditionPtr createIndexJoinCondition(
     const folly::dynamic& obj,
     void* context) {
   VELOX_USER_CHECK_EQ(obj.count("type"), 1);
   if (obj["type"] == "in") {
-    return InIndexJoinCondition::create(obj, context);
+    return InIndexLookupCondition::create(obj, context);
   }
   if (obj["type"] == "between") {
-    return BetweenIndexJoinCondition::create(obj, context);
+    return BetweenIndexLookupCondition::create(obj, context);
   }
   VELOX_USER_FAIL(
       "Unknown index join condition type {}", obj["type"].asString());
 }
 } // namespace
 
-std::vector<IndexJoinConditionPtr> deserializeJoinConditions(
+std::vector<IndexLookupConditionPtr> deserializeJoinConditions(
     const folly::dynamic& obj,
     void* context) {
   if (obj.count("joinConditions") == 0) {
     return {};
   }
 
-  std::vector<IndexJoinConditionPtr> joinConditions;
+  std::vector<IndexLookupConditionPtr> joinConditions;
   joinConditions.reserve(obj.count("joinConditions"));
   for (const auto& joinCondition : obj["joinConditions"]) {
     joinConditions.push_back(createIndexJoinCondition(joinCondition, context));
@@ -2900,40 +2900,40 @@ PlanNodePtr FilterNode::create(const folly::dynamic& obj, void* context) {
       deserializePlanNodeId(obj), filter, std::move(source));
 }
 
-folly::dynamic IndexJoinCondition::serialize() const {
+folly::dynamic IndexLookupCondition::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["key"] = key->serialize();
   return obj;
 }
 
-folly::dynamic InIndexJoinCondition::serialize() const {
-  folly::dynamic obj = IndexJoinCondition::serialize();
+folly::dynamic InIndexLookupCondition::serialize() const {
+  folly::dynamic obj = IndexLookupCondition::serialize();
   obj["type"] = "in";
   obj["in"] = list->serialize();
   return obj;
 }
 
-std::string InIndexJoinCondition::toString() const {
+std::string InIndexLookupCondition::toString() const {
   return fmt::format("{} IN {}", key->toString(), list->toString());
 }
 
-IndexJoinConditionPtr InIndexJoinCondition::create(
+IndexLookupConditionPtr InIndexLookupCondition::create(
     const folly::dynamic& obj,
     void* context) {
-  return std::make_shared<InIndexJoinCondition>(
+  return std::make_shared<InIndexLookupCondition>(
       ISerializable::deserialize<FieldAccessTypedExpr>(obj["key"], context),
       ISerializable::deserialize<FieldAccessTypedExpr>(obj["in"], context));
 }
 
-folly::dynamic BetweenIndexJoinCondition::serialize() const {
-  folly::dynamic obj = IndexJoinCondition::serialize();
+folly::dynamic BetweenIndexLookupCondition::serialize() const {
+  folly::dynamic obj = IndexLookupCondition::serialize();
   obj["type"] = "between";
   obj["lower"] = lower->serialize();
   obj["upper"] = upper->serialize();
   return obj;
 }
 
-std::string BetweenIndexJoinCondition::toString() const {
+std::string BetweenIndexLookupCondition::toString() const {
   return fmt::format(
       "{} BETWEEN {} AND {}",
       key->toString(),
@@ -2941,10 +2941,10 @@ std::string BetweenIndexJoinCondition::toString() const {
       upper->toString());
 }
 
-IndexJoinConditionPtr BetweenIndexJoinCondition::create(
+IndexLookupConditionPtr BetweenIndexLookupCondition::create(
     const folly::dynamic& obj,
     void* context) {
-  return std::make_shared<BetweenIndexJoinCondition>(
+  return std::make_shared<BetweenIndexLookupCondition>(
       ISerializable::deserialize<FieldAccessTypedExpr>(obj["key"], context),
       ISerializable::deserialize<ITypedExpr>(obj["lower"], context),
       ISerializable::deserialize<ITypedExpr>(obj["upper"], context));

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -94,7 +94,7 @@ bool addBetweenConditionBound(
 // types, and updating the lookup input channels and type to include the probe
 // input columns which contain the between condition bounds.
 void addBetweenCondition(
-    const core::BetweenIndexJoinConditionPtr& betweenCondition,
+    const core::BetweenIndexLookupConditionPtr& betweenCondition,
     const RowTypePtr& inputType,
     const TypePtr& indexKeyType,
     std::vector<std::string>& lookupInputNames,
@@ -238,7 +238,7 @@ void IndexLookupJoin::initLookupInput() {
     const auto indexKeyType = lookupType_->findChild(indexKeyName);
 
     if (const auto inCondition =
-            std::dynamic_pointer_cast<const core::InIndexJoinCondition>(
+            std::dynamic_pointer_cast<const core::InIndexLookupCondition>(
                 lookupCondition)) {
       const auto conditionInputName = getColumnName(inCondition->list);
       const auto conditionInputChannel =
@@ -259,7 +259,7 @@ void IndexLookupJoin::initLookupInput() {
     }
 
     if (const auto betweenCondition =
-            std::dynamic_pointer_cast<core::BetweenIndexJoinCondition>(
+            std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
                 lookupCondition)) {
       addBetweenCondition(
           betweenCondition,

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -92,7 +92,7 @@ class IndexLookupJoin : public Operator {
   const RowTypePtr probeType_;
   const RowTypePtr lookupType_;
   const std::shared_ptr<connector::ConnectorTableHandle> lookupTableHandle_;
-  const std::vector<core::IndexJoinConditionPtr> lookupConditions_;
+  const std::vector<core::IndexLookupConditionPtr> lookupConditions_;
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       lookupColumnHandles_;
   const std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<HiveBucketProperty> buildHiveBucketProperty(
       sortBy);
 }
 
-core::IndexJoinConditionPtr parseJoinCondition(
+core::IndexLookupConditionPtr parseJoinCondition(
     const std::string& joinCondition,
     const RowTypePtr& rowType,
     const parse::ParseOptions& options,
@@ -86,7 +86,7 @@ core::IndexJoinConditionPtr parseJoinCondition(
         std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
             typedCallExpr->inputs()[0]);
     VELOX_CHECK_NOT_NULL(conditionColumnExpr);
-    return std::make_shared<core::InIndexJoinCondition>(
+    return std::make_shared<core::InIndexLookupCondition>(
         std::move(keyColumnExpr), std::move(conditionColumnExpr));
   }
 
@@ -98,7 +98,7 @@ core::IndexJoinConditionPtr parseJoinCondition(
     VELOX_CHECK_NOT_NULL(keyColumnExpr);
     const auto& lowerExpr = typedCallExpr->inputs()[1];
     const auto& upperExpr = typedCallExpr->inputs()[2];
-    return std::make_shared<core::BetweenIndexJoinCondition>(
+    return std::make_shared<core::BetweenIndexLookupCondition>(
         std::move(keyColumnExpr), lowerExpr, upperExpr);
   }
   VELOX_USER_FAIL(
@@ -1630,7 +1630,7 @@ PlanBuilder& PlanBuilder::indexLookupJoin(
   auto leftKeyFields = fields(planNode_->outputType(), leftKeys);
   auto rightKeyFields = fields(right->outputType(), rightKeys);
 
-  std::vector<core::IndexJoinConditionPtr> joinConditionPtrs{};
+  std::vector<core::IndexLookupConditionPtr> joinConditionPtrs{};
   joinConditionPtrs.reserve(joinConditions.size());
   for (const auto& joinCondition : joinConditions) {
     joinConditionPtrs.push_back(

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -24,7 +24,7 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::exec::test {
 namespace {
 core::TypedExprPtr toJoinConditionExpr(
-    const std::vector<std::shared_ptr<core::IndexJoinCondition>>&
+    const std::vector<std::shared_ptr<core::IndexLookupCondition>>&
         joinConditions,
     const std::shared_ptr<TestIndexTable>& indexTable,
     const RowTypePtr& inputType,
@@ -41,7 +41,8 @@ core::TypedExprPtr toJoinConditionExpr(
     auto indexColumnExpr = std::make_shared<core::FieldAccessTypedExpr>(
         keyType->findChild(condition->key->name()), condition->key->name());
     if (auto inCondition =
-            std::dynamic_pointer_cast<core::InIndexJoinCondition>(condition)) {
+            std::dynamic_pointer_cast<core::InIndexLookupCondition>(
+                condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
           BOOLEAN(),
           std::vector<core::TypedExprPtr>{
@@ -50,7 +51,7 @@ core::TypedExprPtr toJoinConditionExpr(
       continue;
     }
     if (auto betweenCondition =
-            std::dynamic_pointer_cast<core::BetweenIndexJoinCondition>(
+            std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
                 condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
           BOOLEAN(),
@@ -412,7 +413,7 @@ TestIndexConnector::TestIndexConnector(
 std::shared_ptr<connector::IndexSource> TestIndexConnector::createIndexSource(
     const RowTypePtr& inputType,
     size_t numJoinKeys,
-    const std::vector<core::IndexJoinConditionPtr>& joinConditions,
+    const std::vector<core::IndexLookupConditionPtr>& joinConditions,
     const RowTypePtr& outputType,
     const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
     const std::unordered_map<

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -282,7 +282,7 @@ class TestIndexConnector : public connector::Connector {
   std::shared_ptr<connector::IndexSource> createIndexSource(
       const RowTypePtr& inputType,
       size_t numJoinKeys,
-      const std::vector<core::IndexJoinConditionPtr>& joinConditions,
+      const std::vector<core::IndexLookupConditionPtr>& joinConditions,
       const RowTypePtr& outputType,
       const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
       const std::unordered_map<


### PR DESCRIPTION
Summary:
Add filters to sequence storage table handle to express static filter pushdown.
We currently only allow index column static filter pushdown and requires each index column at least involve
in either one of join condition or static filter pushdown. The filter type is defined the same as the join condition
(which rename from IndexJoinCondition to IndexLookupCondition) but all the conditions are provided as
constants.

Differential Revision: D71154885


