### PR TITLE
fix: Suppress template-id-cdtor warnings

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -68,7 +68,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -84,8 +84,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>
         encodings_{encodings},
         randomStrVariationOptions_{randomStrVariationOptions} {}
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, StringView>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -112,7 +111,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -129,8 +128,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>
         containAtIndex_{containAtIndex},
         containGenerator_{std::move(containGenerator)} {}
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, ArrayType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -166,7 +164,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       double nullRatio,
@@ -193,8 +191,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>
     }
   }
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, MapType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {
@@ -234,7 +231,7 @@ template <typename T>
 class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>
     : public AbstractInputGenerator {
  public:
-  RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>(
+  RandomInputGenerator(
       size_t seed,
       const TypePtr& type,
       std::vector<std::unique_ptr<AbstractInputGenerator>> fieldGenerators,
@@ -253,8 +250,7 @@ class RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>
     }
   }
 
-  ~RandomInputGenerator<T, std::enable_if_t<std::is_same_v<T, RowType>>>()
-      override = default;
+  ~RandomInputGenerator() override = default;
 
   variant generate() override {
     if (coinToss(rng_, nullRatio_)) {

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -115,7 +115,7 @@ struct ConstantVectorReader {
 
   std::optional<exec_in_t> value;
 
-  explicit ConstantVectorReader<T>(ConstantVector<exec_in_t>& vector) {
+  explicit ConstantVectorReader(ConstantVector<exec_in_t>& vector) {
     if (!vector.isNullAt(0)) {
       value = *vector.rawValues();
     }
@@ -160,7 +160,7 @@ struct FlatVectorReader {
   const exec_in_t* values;
   FlatVector<exec_in_t>* vector;
 
-  explicit FlatVectorReader<T>(FlatVector<exec_in_t>& baseVector)
+  explicit FlatVectorReader(FlatVector<exec_in_t>& baseVector)
       : values(baseVector.rawValues()), vector(&baseVector) {}
 
   exec_in_t operator[](vector_size_t offset) const {


### PR DESCRIPTION
We can't specify template ID in constructor/destructor in C++20.

Here is a sample warning message with g++ 14.2.0:

    velox/expression/VectorReaders.h:118:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
      118 |   explicit ConstantVectorReader<T>(ConstantVector<exec_in_t>& vector) {
          |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
    velox/expression/VectorReaders.h:118:36: note: remove the '< >'