### PR TITLE
fix(function): Remove unused input types in Spark central moments functions

### DIFF
--- a/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
@@ -73,12 +73,11 @@ exec::AggregateRegistrationResult registerCentralMoments(
             return std::make_unique<
                 CentralMomentsAggregatesBase<double, TResultAccessor>>(
                 resultType);
-          } else {
-            VELOX_UNSUPPORTED(
-                "Unsupported input type: {}. "
-                "Expected SMALLINT, INTEGER, BIGINT, DOUBLE or REAL.",
-                inputType->toString());
           }
+          VELOX_UNSUPPORTED(
+              "Unsupported input type: {}. "
+              "Expected DOUBLE.",
+              inputType->toString());
         } else {
           checkAccumulatorRowType(
               inputType,

--- a/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CentralMomentsAggregate.cpp
@@ -50,16 +50,12 @@ exec::AggregateRegistrationResult registerCentralMoments(
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  std::vector<std::string> inputTypes = {
-      "smallint", "integer", "bigint", "real", "double"};
-  for (const auto& inputType : inputTypes) {
-    signatures.push_back(
-        exec::AggregateFunctionSignatureBuilder()
-            .returnType("double")
-            .intermediateType(CentralMomentsIntermediateResult::type())
-            .argumentType(inputType)
-            .build());
-  }
+  signatures.push_back(
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType(CentralMomentsIntermediateResult::type())
+          .argumentType("double")
+          .build());
 
   return exec::registerAggregateFunction(
       name,
@@ -70,36 +66,18 @@ exec::AggregateRegistrationResult registerCentralMoments(
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_LE(
-            argTypes.size(), 1, "{} takes at most one argument", name);
+        VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes only one argument", name);
         const auto& inputType = argTypes[0];
         if (exec::isRawInput(step)) {
-          switch (inputType->kind()) {
-            case TypeKind::SMALLINT:
-              return std::make_unique<
-                  CentralMomentsAggregatesBase<int16_t, TResultAccessor>>(
-                  resultType);
-            case TypeKind::INTEGER:
-              return std::make_unique<
-                  CentralMomentsAggregatesBase<int32_t, TResultAccessor>>(
-                  resultType);
-            case TypeKind::BIGINT:
-              return std::make_unique<
-                  CentralMomentsAggregatesBase<int64_t, TResultAccessor>>(
-                  resultType);
-            case TypeKind::DOUBLE:
-              return std::make_unique<
-                  CentralMomentsAggregatesBase<double, TResultAccessor>>(
-                  resultType);
-            case TypeKind::REAL:
-              return std::make_unique<
-                  CentralMomentsAggregatesBase<float, TResultAccessor>>(
-                  resultType);
-            default:
-              VELOX_UNSUPPORTED(
-                  "Unsupported input type: {}. "
-                  "Expected SMALLINT, INTEGER, BIGINT, DOUBLE or REAL.",
-                  inputType->toString());
+          if (inputType->kind() == TypeKind::DOUBLE) {
+            return std::make_unique<
+                CentralMomentsAggregatesBase<double, TResultAccessor>>(
+                resultType);
+          } else {
+            VELOX_UNSUPPORTED(
+                "Unsupported input type: {}. "
+                "Expected SMALLINT, INTEGER, BIGINT, DOUBLE or REAL.",
+                inputType->toString());
           }
         } else {
           checkAccumulatorRowType(

--- a/velox/functions/sparksql/aggregates/tests/CentralMomentsAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CentralMomentsAggregationTest.cpp
@@ -44,13 +44,13 @@ class CentralMomentsAggregationTest : public AggregationTestBase {
 
 TEST_F(CentralMomentsAggregationTest, skewnessHasResult) {
   auto agg = "skewness";
-  auto input = makeRowVector({makeFlatVector<int32_t>({1, 2})});
+  auto input = makeRowVector({makeFlatVector<double>({1, 2})});
   // Even when the count is 2, Spark still produces output.
   auto expected =
       makeRowVector({makeFlatVector<double>(std::vector<double>{0.0})});
   testCenteralMomentsAggResult(agg, input, expected);
 
-  input = makeRowVector({makeFlatVector<int32_t>({1, 1})});
+  input = makeRowVector({makeFlatVector<double>({1, 1})});
   expected = makeRowVector({makeNullableFlatVector<double>(
       std::vector<std::optional<double>>{std::nullopt})});
   testCenteralMomentsAggResult(agg, input, expected);
@@ -58,23 +58,23 @@ TEST_F(CentralMomentsAggregationTest, skewnessHasResult) {
 
 TEST_F(CentralMomentsAggregationTest, pearsonKurtosis) {
   auto agg = "kurtosis";
-  auto input = makeRowVector({makeFlatVector<int32_t>({1, 10, 100, 10, 1})});
+  auto input = makeRowVector({makeFlatVector<double>({1, 10, 100, 10, 1})});
   auto expected = makeRowVector(
       {makeFlatVector<double>(std::vector<double>{0.19432323191699075})});
   testCenteralMomentsAggResult(agg, input, expected);
 
-  input = makeRowVector({makeFlatVector<int32_t>({-10, -20, 100, 1000})});
+  input = makeRowVector({makeFlatVector<double>({-10, -20, 100, 1000})});
   expected = makeRowVector(
       {makeFlatVector<double>(std::vector<double>{-0.7014368047529627})});
   testCenteralMomentsAggResult(agg, input, expected);
 
   // Even when the count is 2, Spark still produces non-null result.
-  input = makeRowVector({makeFlatVector<int32_t>({1, 2})});
+  input = makeRowVector({makeFlatVector<double>({1, 2})});
   expected = makeRowVector({makeFlatVector<double>(std::vector<double>{-2.0})});
   testCenteralMomentsAggResult(agg, input, expected);
 
   // Output NULL when m2 equals 0.
-  input = makeRowVector({makeFlatVector<int32_t>({1, 1})});
+  input = makeRowVector({makeFlatVector<double>({1, 1})});
   expected = makeRowVector({makeNullableFlatVector<double>(
       std::vector<std::optional<double>>{std::nullopt})});
   testCenteralMomentsAggResult(agg, input, expected);


### PR DESCRIPTION
Central moments functions, skewness and kurtosis support 
several input types including "smallint", "integer", "bigint",
"real", "double", but Spark only supports double type input,
see [code link](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/CentralMomentAgg.scala#L58C16-L58C24). 

This PR changes skewness and kurtosis functions to support 
only double type input.