### PR TITLE
feat: Add processedStrides and processedSplits runtime statistics

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -538,6 +538,7 @@ void HiveDataSource::setFromDataSource(
 
   split_ = std::move(source->split_);
   runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
+  runtimeStats_.processedSplits += source->runtimeStats_.processedSplits;
   runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
   readerOutputType_ = std::move(source->readerOutputType_);
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -298,6 +298,7 @@ bool SplitReader::filterOnStats(
           *partitionKeys_,
           hiveConfig_->readTimestampPartitionValueAsLocalTime(
               connectorQueryCtx_->sessionProperties()))) {
+    ++runtimeStats.processedSplits;
     return true;
   }
   ++runtimeStats.skippedSplits;

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -542,11 +542,17 @@ struct RuntimeStatistics {
   // Number of splits skipped based on statistics.
   int64_t skippedSplits{0};
 
+  // Number of splits processed based on statistics.
+  int64_t processedSplits{0};
+
   // Total bytes in splits skipped based on statistics.
   int64_t skippedSplitBytes{0};
 
   // Number of strides (row groups) skipped based on statistics.
   int64_t skippedStrides{0};
+
+  // Number of strides (row groups) processed based on statistics.
+  int64_t processedStrides{0};
 
   int64_t footerBufferOverread{0};
 
@@ -559,6 +565,9 @@ struct RuntimeStatistics {
     if (skippedSplits > 0) {
       result.emplace("skippedSplits", RuntimeCounter(skippedSplits));
     }
+    if (processedSplits > 0) {
+      result.emplace("processedSplits", RuntimeCounter(processedSplits));
+    }
     if (skippedSplitBytes > 0) {
       result.emplace(
           "skippedSplitBytes",
@@ -566,6 +575,9 @@ struct RuntimeStatistics {
     }
     if (skippedStrides > 0) {
       result.emplace("skippedStrides", RuntimeCounter(skippedStrides));
+    }
+    if (processedStrides > 0) {
+      result.emplace("processedStrides", RuntimeCounter(processedStrides));
     }
     if (footerBufferOverread > 0) {
       result.emplace(

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -660,6 +660,7 @@ void DwrfRowReader::loadCurrentStripe() {
   const auto loadUnitIdx = currentStripe_ - firstStripe_;
   currentUnit_ = castDwrfUnit(&unitLoader_->getLoadedUnit(loadUnitIdx));
   rowsInCurrentStripe_ = currentUnit_->getNumRows();
+  ++processedStrides_;
 }
 
 size_t DwrfRowReader::estimatedReaderMemory() const {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -108,6 +108,7 @@ class DwrfRowReader : public StrideIndexProvider,
   void updateRuntimeStats(
       dwio::common::RuntimeStatistics& stats) const override {
     stats.skippedStrides += skippedStrides_;
+    stats.processedStrides += processedStrides_;
     stats.footerBufferOverread += getReader().footerBufferOverread();
     stats.numStripes += stripeCeiling_ - firstStripe_;
     stats.columnReaderStatistics.flattenStringDictionaryValues +=
@@ -203,6 +204,9 @@ class DwrfRowReader : public StrideIndexProvider,
   std::unordered_map<uint32_t, std::vector<uint64_t>> stripeStridesToSkip_;
   // Number of skipped strides.
   int64_t skippedStrides_{0};
+
+  // Number of processed strides.
+  int64_t processedStrides_{0};
 
   // Set to true after clearing filter caches, i.e. adding a dynamic filter.
   // Causes filters to be re-evaluated against stride stats on next stride

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1070,6 +1070,7 @@ class ParquetRowReader::Impl {
 
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
     stats.skippedStrides += skippedStrides_;
+    stats.processedStrides += rowGroupIds_.size();
   }
 
   void resetFilterCaches() {

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -205,6 +205,8 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          prefetchBytes       [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
+       {"          processedSplits[ ]+sum: 20, count: 1, min: 20, max: 20, avg: 20"},
+       {"          processedStrides[ ]+sum: 20, count: 1, min: 20, max: 20, avg: 20"},
        {"          ramReadBytes        [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          readyPreloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
@@ -295,6 +297,8 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B, avg: 0B"},
 
          {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
+         {"        processedSplits  [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
+         {"        processedStrides [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
          {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
           true},
          {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},
@@ -365,6 +369,8 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
        {"        overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B, avg: 0B"},
 
        {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"        processedSplits  [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
+       {"        processedStrides [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
        {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
        {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -60,6 +60,7 @@ void WaveHiveDataSource::setFromDataSource(
   split_ = std::move(source->split_);
   if (source->splitReader_ && source->splitReader_->emptySplit()) {
     runtimeStats_.skippedSplits += source->runtimeStats_.skippedSplits;
+    runtimeStats_.processedSplits += source->runtimeStats_.processedSplits;
     runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
     return;
   }


### PR DESCRIPTION
Metrics of `processedStrides` and `processedSplits` are useful when 
investigating the performance of Scan. This PR added them as RuntimeStatistics.