### PR TITLE
misc(dwio): Fix error message in DWIO_ENSURE_NE/DWIO_ENSURE_EQ

### DIFF
--- a/velox/dwio/common/exception/Exception.h
+++ b/velox/dwio/common/exception/Exception.h
@@ -194,66 +194,66 @@ containing information about the file, line, and function where it happened.
       ##__VA_ARGS__)
 
 #define DWIO_ENSURE_NOT_NULL(p, ...) \
-  DWIO_ENSURE(p != nullptr, "[Null pointer] : ", ##__VA_ARGS__);
+  DWIO_ENSURE(p != nullptr, "[Null pointer]: ", ##__VA_ARGS__);
 
-#define DWIO_ENSURE_NE(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l != r,                           \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      "!=",                             \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_NE(l, r, ...)         \
+  DWIO_ENSURE(                            \
+      l != r,                             \
+      "[Equality Constraint Violation: ", \
+      l,                                  \
+      "!=",                               \
+      r,                                  \
+      "]: ",                              \
       ##__VA_ARGS__);
 
-#define DWIO_ENSURE_EQ(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l == r,                           \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      "==",                             \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_EQ(l, r, ...)         \
+  DWIO_ENSURE(                            \
+      l == r,                             \
+      "[Equality Constraint Violation: ", \
+      l,                                  \
+      "==",                               \
+      r,                                  \
+      "]: ",                              \
       ##__VA_ARGS__);
 
-#define DWIO_ENSURE_LT(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l < r,                            \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      "<",                              \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_LT(l, r, ...)      \
+  DWIO_ENSURE(                         \
+      l < r,                           \
+      "[Range Constraint Violation: ", \
+      l,                               \
+      "<",                             \
+      r,                               \
+      "]: ",                           \
       ##__VA_ARGS__);
 
-#define DWIO_ENSURE_LE(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l <= r,                           \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      "<=",                             \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_LE(l, r, ...)      \
+  DWIO_ENSURE(                         \
+      l <= r,                          \
+      "[Range Constraint Violation: ", \
+      l,                               \
+      "<=",                            \
+      r,                               \
+      "]: ",                           \
       ##__VA_ARGS__);
 
-#define DWIO_ENSURE_GT(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l > r,                            \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      ">",                              \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_GT(l, r, ...)      \
+  DWIO_ENSURE(                         \
+      l > r,                           \
+      "[Range Constraint Violation: ", \
+      l,                               \
+      ">",                             \
+      r,                               \
+      "]: ",                           \
       ##__VA_ARGS__);
 
-#define DWIO_ENSURE_GE(l, r, ...)       \
-  DWIO_ENSURE(                          \
-      l >= r,                           \
-      "[Range Constraint Violation : ", \
-      l,                                \
-      ">=",                             \
-      r,                                \
-      "] : ",                           \
+#define DWIO_ENSURE_GE(l, r, ...)      \
+  DWIO_ENSURE(                         \
+      l >= r,                          \
+      "[Range Constraint Violation: ", \
+      l,                               \
+      ">=",                            \
+      r,                               \
+      "]: ",                           \
       ##__VA_ARGS__);
 
 } // namespace dwio


### PR DESCRIPTION
Summary:
1. Replace confusing `Range Constraint Violation` with `Equality Constraint Violation` for DWIO_ENSURE_NE/DWIO_ENSURE_EQ.
2. Remove spaces before the colons.

Differential Revision: D71201024


