### PR TITLE
misc: Add runtime stats to track and report the index lookup wait time

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -370,7 +370,7 @@ class IndexSource {
   virtual std::shared_ptr<LookupResultIterator> lookup(
       const LookupRequest& request) = 0;
 
-  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+  virtual std::unordered_map<std::string, RuntimeMetric> runtimeStats() = 0;
 };
 
 /// Collection of context data for use in a DataSource, IndexSource or DataSink.

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -131,6 +131,28 @@ These stats are reported only by TableWriter operator
      -
      - The number of times that we scale writers for a non-partitioned table.
 
+LookupIndexJoin
+---------------
+These stats are reported only by IndexLookupJoin operator
+
+.. list-table::
+   :widths: 50 25 50
+   :header-rows: 1
+
+   * - Stats
+     - Unit
+     - Description
+   * - lookupWaitWallNanos
+     - nanos
+     - The walltime in nanoseconds the lookup operator blocked waiting for the lookup
+       result from the index source.
+   * - lookupWallNanos
+     - nanos
+     - The walltime in nanoseconds that the index connector do the lookup.
+   * - lookupCpuNanos
+     - nanos
+     - The cpu time in nanoseconds that the index connector do the lookup.
+
 Spilling
 --------
 These stats are reported by operators that support spilling.

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -46,6 +46,15 @@ class IndexLookupJoin : public Operator {
 
   void close() override;
 
+  /// Defines lookup runtime stats.
+  /// The walltime the lookup operator blocked waiting for the lookup result
+  /// from the index source.
+  static inline const std::string kLookupBlockWaitTime{"lookupWaitWallNanos"};
+  /// The walltime time that the index connector do the lookup.
+  static inline const std::string kConnectorLookupWallTime{"lookupWallNanos"};
+  /// The cpu time that the index connector do the lookup.
+  static inline const std::string kConnectorLookupCpuTime{"lookupCpuNanos"};
+
  private:
   // Initialize the lookup input and output type, and the output projections.
   void initLookupInput();
@@ -83,6 +92,12 @@ class IndexLookupJoin : public Operator {
   void prepareOutputRowMappings(size_t outputBatchSize);
   // Prepare 'output_' for the next output batch with size of 'numOutputRows'.
   void prepareOutput(vector_size_t numOutputRows);
+
+  void startLookupBlockWait();
+  void endLookupBlockWait();
+
+  // Invoked at operator close to record the lookup stats.
+  void recordConnectorStats();
 
   // Maximum number of rows in the output batch.
   const vector_size_t outputBatchSize_;
@@ -156,5 +171,9 @@ class IndexLookupJoin : public Operator {
 
   // The reusable output vector for the join output.
   RowVectorPtr output_;
+
+  // The start time of the current lookup driver block wait, and reset after the
+  // driver wait completes.
+  std::optional<size_t> blockWaitStartNs_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -120,10 +120,7 @@ class TestIndexSource : public connector::IndexSource,
   std::shared_ptr<LookupResultIterator> lookup(
       const LookupRequest& request) override;
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
-    // TODO: add runtime stats.
-    return {};
-  }
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats() override;
 
   memory::MemoryPool* pool() const {
     return pool_.get();
@@ -232,6 +229,8 @@ class TestIndexSource : public connector::IndexSource,
   // Initialize the condition filter input type and projections if configured.
   void initConditionProjections();
 
+  void recordCpuTiming(const CpuWallTiming& timing);
+
   const std::shared_ptr<TestIndexTableHandle> tableHandle_;
   const RowTypePtr inputType_;
   const RowTypePtr outputType_;
@@ -242,6 +241,8 @@ class TestIndexSource : public connector::IndexSource,
   const std::unique_ptr<exec::ExprSet> conditionExprSet_;
   const std::shared_ptr<memory::MemoryPool> pool_;
   folly::Executor* const executor_;
+
+  mutable std::mutex mutex_;
 
   // Join condition filter input type.
   RowTypePtr conditionInputType_;
@@ -257,6 +258,7 @@ class TestIndexSource : public connector::IndexSource,
   std::vector<IdentityProjection> conditionInputProjections_;
   std::vector<IdentityProjection> conditionTableProjections_;
   std::vector<IdentityProjection> lookupOutputProjections_;
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
 };
 
 class TestIndexConnector : public connector::Connector {


### PR DESCRIPTION
Summary:
Add runtime stats to track index join operator driver block time, the background connector cpu and walltime, and also
record the connector cpu and walltime as operator's background timing.

Differential Revision: D71216057


