### PR TITLE
fix: Fix map_top_n_keys being unnecessarily orderable 

### DIFF
--- a/velox/functions/prestosql/MapTopNImpl.h
+++ b/velox/functions/prestosql/MapTopNImpl.h
@@ -24,11 +24,11 @@ template <typename TExec, typename Compare>
 struct MapTopNImpl {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-  using It = typename arg_type<Map<Orderable<T1>, Orderable<T2>>>::Iterator;
+  using It = typename arg_type<Map<Orderable<T1>, Generic<T2>>>::Iterator;
 
   void call(
       out_type<Array<Orderable<T1>>>& out,
-      const arg_type<Map<Orderable<T1>, Orderable<T2>>>& inputMap,
+      const arg_type<Map<Orderable<T1>, Generic<T2>>>& inputMap,
       int64_t n) {
     VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0");
 

--- a/velox/functions/prestosql/MapTopNKeys.h
+++ b/velox/functions/prestosql/MapTopNKeys.h
@@ -25,7 +25,7 @@ template <typename TExec>
 struct CompareKeys {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-  using It = typename arg_type<Map<Orderable<T1>, Orderable<T2>>>::Iterator;
+  using It = typename arg_type<Map<Orderable<T1>, Generic<T2>>>::Iterator;
 
   bool operator()(const It& l, const It& r) const {
     static const CompareFlags flags{

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -118,7 +118,7 @@ void registerMapFunctions(const std::string& prefix) {
   registerFunction<
       MapTopNKeysFunction,
       Array<Orderable<T1>>,
-      Map<Orderable<T1>, Orderable<T2>>,
+      Map<Orderable<T1>, Generic<T2>>,
       int64_t>({prefix + "map_top_n_keys"});
 
   registerFunction<


### PR DESCRIPTION
Summary:
map_top_n_keys returns the top N keys of the given map by sorting the keys in descending order according to the natural ordering of its keys. The values are unnecessarily orderable

partial function support https://fb.prod.workplace.com/groups/presto.users/permalink/28036948789260370/

Scalar function presto.default.map_top_n_keys not registered with arguments: (MAP<VARCHAR,MAP<VARCHAR,VARCHAR>>, BIGINT)

Differential Revision: D71176927


