### PR TITLE
Support Fnv1 hash functions for varbinary

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -8,8 +8,8 @@ Binary Functions
 
 .. function:: from_base64(string) -> varbinary
 
-    Decodes a Base64-encoded ``string`` back into its original binary form. 
-    This function is capable of handling both fully padded and non-padded Base64 encoded strings. 
+    Decodes a Base64-encoded ``string`` back into its original binary form.
+    This function is capable of handling both fully padded and non-padded Base64 encoded strings.
     Partially padded Base64 strings are not supported and will result in an error.
 
     Examples
@@ -77,12 +77,12 @@ Binary Functions
 
 .. function:: lpad(binary, size, padbinary) -> varbinary
     :noindex:
-    
+
     Left pads ``binary`` to ``size`` bytes with ``padbinary``.
     If ``size`` is less than the length of ``binary``, the result is
     truncated to ``size`` characters. ``size`` must not be negative
     and ``padbinary`` must be non-empty. ``size`` has a maximum value of 1 MiB.
-    In the case of ``size`` being smaller than the length of ``binary``, 
+    In the case of ``size`` being smaller than the length of ``binary``,
     ``binary`` will be truncated from the right to fit the ``size``.
 
 .. function:: md5(binary) -> varbinary
@@ -96,9 +96,9 @@ Binary Functions
     If ``size`` is less than the length of ``binary``, the result is
     truncated to ``size`` characters. ``size`` must not be negative
     and ``padbinary`` must be non-empty. ``size`` has a maximum value of 1 MiB.
-    In the case of ``size`` being smaller than the length of ``binary``, 
+    In the case of ``size`` being smaller than the length of ``binary``,
     ``binary`` will be truncated from the right to fit the ``size``.
-    
+
 .. function:: sha1(binary) -> varbinary
 
     Computes the SHA-1 hash of ``binary``.
@@ -150,3 +150,15 @@ Binary Functions
 .. function:: xxhash64(binary) -> varbinary
 
     Computes the xxhash64 hash of ``binary``.
+
+.. function:: fnv1_32(binary) -> integer
+
+    Computes the 4-byte fnv1 hash of ``binary``.
+
+.. function:: fnv1_64(binary) -> bigint
+
+    Computes the 8-byte fnv1 hash of ``binary``.
+
+.. function:: fnv1a_64(binary) -> bigint
+
+    Computes the 8-byte fnv1a hash of ``binary``.

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/hash/Checksum.h>
+#include <folly/hash/Hash.h>
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
@@ -57,6 +58,48 @@ struct XxHash64Function {
     // Resizing output and copy
     result.resize(kLen);
     std::memcpy(result.data(), &hash, kLen);
+  }
+};
+
+/// fnv1_32(varbinary) → integer
+/// Return a 4-byte fnv1 hash of input varbinary.
+template <typename T>
+struct Fnv1_32Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int32_t>& result, const arg_type<Varbinary>& input) {
+    // Use default seed.
+    result = static_cast<int32_t>(
+        folly::hash::fnv32_buf(input.data(), input.size()));
+  }
+};
+
+/// fnv1_64(varbinary) → bigint
+/// Return a 8-byte fnv1 hash of input varbinary.
+template <typename T>
+struct Fnv1_64Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Varbinary>& input) {
+    // Use default seed.
+    result = static_cast<int64_t>(
+        folly::hash::fnv64_buf(input.data(), input.size()));
+  }
+};
+
+/// fnv1a_64(varbinary) → bigint
+/// Return a 8-byte fnv1a hash of input varbinary.
+template <typename T>
+struct Fnv1a_64Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Varbinary>& input) {
+    // Use default seed.
+    result = static_cast<int64_t>(
+        folly::hash::fnva64_buf(input.data(), input.size()));
   }
 };
 

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -24,6 +24,9 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<CRC32Function, int64_t, Varbinary>({prefix + "crc32"});
   registerFunction<XxHash64Function, Varbinary, Varbinary>(
       {prefix + "xxhash64"});
+  registerFunction<Fnv1_32Function, int32_t, Varbinary>({prefix + "fnv1_32"});
+  registerFunction<Fnv1_64Function, int64_t, Varbinary>({prefix + "fnv1_64"});
+  registerFunction<Fnv1a_64Function, int64_t, Varbinary>({prefix + "fnv1a_64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({prefix + "md5"});
   registerFunction<Sha1Function, Varbinary, Varbinary>({prefix + "sha1"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({prefix + "sha256"});

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -315,6 +315,57 @@ TEST_F(BinaryFunctionsTest, xxhash64) {
       hexToDec("D73C92CF24E6EC82"), xxhash64("more_than_12_characters_string"));
 }
 
+TEST_F(BinaryFunctionsTest, fnv1_32) {
+  const auto fnv1_32 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int32_t>("fnv1_32(c0)", VARBINARY(), std::move(value));
+  };
+
+  EXPECT_EQ(-2128831035, fnv1_32(""));
+  EXPECT_EQ(std::nullopt, fnv1_32(std::nullopt));
+
+  EXPECT_EQ(1186288931, fnv1_32("hashme"));
+  EXPECT_EQ(-1225100953, fnv1_32("hello"));
+  EXPECT_EQ(1018752721, fnv1_32("ABC "));
+  EXPECT_EQ(-1175367161, fnv1_32("       "));
+  EXPECT_EQ(495597071, fnv1_32("special_#@,$|%/^~?{}+-"));
+  EXPECT_EQ(-497927534, fnv1_32("1234567890"));
+  EXPECT_EQ(-793433141, fnv1_32("more_than_12_characters_string"));
+}
+
+TEST_F(BinaryFunctionsTest, fnv1_64) {
+  const auto fnv1_64 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t>("fnv1_64(c0)", VARBINARY(), std::move(value));
+  };
+
+  EXPECT_EQ(-3750763034362895579, fnv1_64(""));
+  EXPECT_EQ(std::nullopt, fnv1_64(std::nullopt));
+
+  EXPECT_EQ(-8283365273186809917, fnv1_64("hashme"));
+  EXPECT_EQ(8883723591023973575, fnv1_64("hello"));
+  EXPECT_EQ(1818665342854515697, fnv1_64("ABC "));
+  EXPECT_EQ(-5297705717274092345, fnv1_64("       "));
+  EXPECT_EQ(-4245322807918809073, fnv1_64("special_#@,$|%/^~?{}+-"));
+  EXPECT_EQ(1126012111659584914, fnv1_64("1234567890"));
+  EXPECT_EQ(-8509102626467302869, fnv1_64("more_than_12_characters_string"));
+}
+
+TEST_F(BinaryFunctionsTest, fnv1a_64) {
+  const auto fnv1a_64 = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t>("fnv1a_64(c0)", VARBINARY(), std::move(value));
+  };
+
+  EXPECT_EQ(-3750763034362895579, fnv1a_64(""));
+  EXPECT_EQ(std::nullopt, fnv1a_64(std::nullopt));
+
+  EXPECT_EQ(4520530899586740515, fnv1a_64("hashme"));
+  EXPECT_EQ(-6615550055289275125, fnv1a_64("hello"));
+  EXPECT_EQ(-7809245552128983311, fnv1a_64("ABC "));
+  EXPECT_EQ(-8193175652585562873, fnv1a_64("       "));
+  EXPECT_EQ(-4605116656913079461, fnv1a_64("special_#@,$|%/^~?{}+-"));
+  EXPECT_EQ(7156503584078541220, fnv1a_64("1234567890"));
+  EXPECT_EQ(-1689701394669249229, fnv1a_64("more_than_12_characters_string"));
+}
+
 TEST_F(BinaryFunctionsTest, toHex) {
   const auto toHex = [&](std::optional<std::string> value) {
     return evaluateOnce<std::string>("to_hex(cast(c0 as varbinary))", value);


### PR DESCRIPTION
Summary:
The same way as we support VARBINARY -> BIGINT fnv1 hashing in Java, we want to support it in Velox:
https://www.internalfb.com/code/fbsource/[3c98469a4d248bc88cb7da5802cbfa4394128c5d]/fbcode/github/presto-trunk/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java?lines=396-426

Some notes for reviewers:
1. `fnv1_32` in Java returns `long (BIGINT)`, but in Velox it returns `int32_t`
2. `fnv1a_32` is not supported in folly. I'm going to add  the support to folly and later to Velox, but it will take some time.

Differential Revision: D71220362


