### PR TITLE
refactor: Clean up some error messages and file structure

### DIFF
--- a/velox/functions/prestosql/GeospatialFunctions.h
+++ b/velox/functions/prestosql/GeospatialFunctions.h
@@ -30,6 +30,19 @@ struct BingTileFunction {
       const arg_type<int32_t>& x,
       const arg_type<int32_t>& y,
       const arg_type<int8_t>& zoom) {
+    if (FOLLY_UNLIKELY(x < 0)) {
+      return Status::UserError(
+          fmt::format("Bing tile X coordinate {} cannot be negative", x));
+    }
+    if (FOLLY_UNLIKELY(y < 0)) {
+      return Status::UserError(
+          fmt::format("Bing tile Y coordinate {} cannot be negative", y));
+    }
+    if (FOLLY_UNLIKELY(zoom < 0)) {
+      return Status::UserError(
+          fmt::format("Bing tile zoom {} cannot be negative", zoom));
+    }
+
     uint64_t tile = BingTileType::bingTileCoordsToInt(
         static_cast<uint32_t>(x),
         static_cast<uint32_t>(y),

--- a/velox/functions/prestosql/tests/GeospatialFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeospatialFunctionsTest.cpp
@@ -54,25 +54,22 @@ TEST_F(GeospatialFunctionsTest, toBingTileCoordinates) {
   testToBingTile(std::nullopt, 1, 1);
   testToBingTile(1, std::nullopt, 1);
   testToBingTile(1, 1, std::nullopt);
-}
 
-TEST_F(GeospatialFunctionsTest, toBingTileCoordinatesErrors) {
-  const auto testToBingTileError = [&](std::optional<int32_t> x,
-                                       std::optional<int32_t> y,
-                                       std::optional<int8_t> zoom,
-                                       const std::string& errorMsg) {
-    VELOX_ASSERT_USER_THROW(
-        evaluateOnce<int64_t>("bing_tile(c0, c1, c2)", x, y, zoom), errorMsg);
-  };
-
-  testToBingTileError(
-      0, 1, 0, "Y coordinate 1 is greater than max coordinate 0 at zoom 0");
-  testToBingTileError(
-      256,
-      1,
-      8,
-      "X coordinate 256 is greater than max coordinate 255 at zoom 8");
-  testToBingTileError(0, 0, 24, "Zoom 24 is greater than max zoom 23");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(0, 1, 0),
+      "Bing tile Y coordinate 1 is greater than max coordinate 0 at zoom 0");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(256, 1, 8),
+      "Bing tile X coordinate 256 is greater than max coordinate 255 at zoom 8");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(0, 0, 24),
+      "Bing tile zoom 24 is greater than max zoom 23");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(-1, 1, 2), "Bing tile X coordinate -1 cannot be negative");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(1, -1, 2), "Bing tile Y coordinate -1 cannot be negative");
+  VELOX_ASSERT_USER_THROW(
+      testToBingTile(1, 1, -1), "Bing tile zoom -1 cannot be negative");
 }
 
 TEST_F(GeospatialFunctionsTest, bingTileZoomLevelSignatures) {

--- a/velox/functions/prestosql/types/BingTileType.cpp
+++ b/velox/functions/prestosql/types/BingTileType.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/BingTileType.h"
+#include <folly/Expected.h>
+#include <optional>
+#include <string>
+
+namespace facebook::velox {
+
+std::optional<std::string> BingTileType::bingTileInvalidReason(uint64_t tile) {
+  // TODO?: We are duplicating some logic in isBingTileIntValid; maybe we
+  // should extract?
+
+  uint8_t version = BingTileType::bingTileVersion(tile);
+  if (version != BingTileType::kBingTileVersion) {
+    return fmt::format("Version {} not supported", version);
+  }
+
+  uint8_t zoom = BingTileType::bingTileZoom(tile);
+  if (zoom > BingTileType::kBingTileMaxZoomLevel) {
+    return fmt::format(
+        "Bing tile zoom {} is greater than max zoom {}",
+        zoom,
+        BingTileType::kBingTileMaxZoomLevel);
+  }
+
+  uint64_t coordinateBound = 1 << zoom;
+
+  if (BingTileType::bingTileX(tile) >= coordinateBound) {
+    return fmt::format(
+        "Bing tile X coordinate {} is greater than max coordinate {} at zoom {}",
+        BingTileType::bingTileX(tile),
+        coordinateBound - 1,
+        zoom);
+  }
+  if (BingTileType::bingTileY(tile) >= coordinateBound) {
+    return fmt::format(
+        "Bing tile Y coordinate {} is greater than max coordinate {} at zoom {}",
+        BingTileType::bingTileY(tile),
+        coordinateBound - 1,
+        zoom);
+  }
+
+  return std::nullopt;
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -129,42 +129,7 @@ class BingTileType : public BigintType {
         (uint8_t)(bingTileY(tile) < coordinateBound);
   }
 
-  static std::optional<std::string> bingTileInvalidReason(uint64_t tile) {
-    // TODO?: We are duplicating some logic in isBingTileIntValid; maybe we
-    // should extract?
-
-    uint8_t version = BingTileType::bingTileVersion(tile);
-    if (version != BingTileType::kBingTileVersion) {
-      return fmt::format("Version {} not supported", version);
-    }
-
-    uint8_t zoom = BingTileType::bingTileZoom(tile);
-    if (zoom > BingTileType::kBingTileMaxZoomLevel) {
-      return fmt::format(
-          "Zoom {} is greater than max zoom {}",
-          zoom,
-          BingTileType::kBingTileMaxZoomLevel);
-    }
-
-    uint64_t coordinateBound = 1 << zoom;
-
-    if (BingTileType::bingTileX(tile) >= coordinateBound) {
-      return fmt::format(
-          "X coordinate {} is greater than max coordinate {} at zoom {}",
-          BingTileType::bingTileX(tile),
-          coordinateBound - 1,
-          zoom);
-    }
-    if (BingTileType::bingTileY(tile) >= coordinateBound) {
-      return fmt::format(
-          "Y coordinate {} is greater than max coordinate {} at zoom {}",
-          BingTileType::bingTileY(tile),
-          coordinateBound - 1,
-          zoom);
-    }
-
-    return std::nullopt;
-  }
+  static std::optional<std::string> bingTileInvalidReason(uint64_t tile);
 };
 
 inline bool isBingTileType(const TypePtr& type) {

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -14,6 +14,7 @@
 velox_add_library(
   velox_presto_types
   BingTileRegistration.cpp
+  BingTileType.cpp
   HyperLogLogRegistration.cpp
   IPAddressRegistration.cpp
   IPPrefixRegistration.cpp

--- a/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
@@ -65,19 +65,34 @@ TEST_F(BingTileTypeTest, packing) {
   ASSERT_FALSE(BingTileType::isBingTileIntValid(tileZ24));
   ASSERT_EQ(
       BingTileType::bingTileInvalidReason(tileZ24),
-      "Zoom 24 is greater than max zoom 23");
+      "Bing tile zoom 24 is greater than max zoom 23");
 
   uint64_t tileX0Y1Z0 = BingTileType::bingTileCoordsToInt(0, 1, 0);
   ASSERT_FALSE(BingTileType::isBingTileIntValid(tileX0Y1Z0));
   ASSERT_EQ(
       BingTileType::bingTileInvalidReason(tileX0Y1Z0),
-      "Y coordinate 1 is greater than max coordinate 0 at zoom 0");
+      "Bing tile Y coordinate 1 is greater than max coordinate 0 at zoom 0");
 
   uint64_t tileX256Y1Z8 = BingTileType::bingTileCoordsToInt(256, 1, 8);
   ASSERT_FALSE(BingTileType::isBingTileIntValid(tileX256Y1Z8));
   ASSERT_EQ(
       BingTileType::bingTileInvalidReason(tileX256Y1Z8),
-      "X coordinate 256 is greater than max coordinate 255 at zoom 8");
+      "Bing tile X coordinate 256 is greater than max coordinate 255 at zoom 8");
+}
+
+TEST_F(BingTileTypeTest, coordinateRoundtrip) {
+  const auto testBingTileCoordinates =
+      [&](uint32_t x, uint32_t y, uint8_t zoom) {
+        uint64_t tile = BingTileType::bingTileCoordsToInt(x, y, zoom);
+        ASSERT_EQ(x, BingTileType::bingTileX(tile));
+        ASSERT_EQ(y, BingTileType::bingTileY(tile));
+        ASSERT_EQ(zoom, BingTileType::bingTileZoom(tile));
+      };
+
+  testBingTileCoordinates(0, 0, 0);
+  testBingTileCoordinates(1, 1, 1);
+  testBingTileCoordinates(127, 11, 8);
+  testBingTileCoordinates(0, 3000, 20);
 }
 
 } // namespace facebook::velox::test

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -622,7 +622,7 @@ class TypeBase : public Type {
     if (providesCustomComparison) {
       VELOX_CHECK(
           kindCanProvideCustomComparison<KIND>::value,
-          "Custom comparisons are only supported for primite types that are fixed width.");
+          "Custom comparisons are only supported for primitive types that are fixed width.");
     }
   }
 


### PR DESCRIPTION
Summary:
In addition to some text changes and extra invariant checks, BingTileType will soon
get a bunch more logic.  So I've extracted the non-inline `bingTileInvalidReason`
from BingTileType.h to BingTileType.cpp.  This is the only type in prestosql that
has a cpp file, so I'd like to check that's the right direction to go.

Differential Revision: D71222628


