### PR TITLE
fix(build): Arrow bundled dependency build may fail on macOS

### DIFF
--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -14,7 +14,6 @@
 project(Arrow)
 
 if(VELOX_ENABLE_ARROW)
-  find_package(Thrift)
   if(Thrift_FOUND)
     set(THRIFT_SOURCE "SYSTEM")
   else()


### PR DESCRIPTION
An issue occurs if thrift is installed to the system. On macOS we don’t install arrow and it is always bundled. If thrift was installed in the system (e.g. via brew) PR 12599 changed the flow such that FindThrift is called twice. thrift::thrift is first added via FindThrift in FindArrow line 20. Then again FindThrift is called when the Cmakefile for Arrow is called line 13. This is removed because we now always call FindThrift. Prior to PR 12599 it would not have called FindThrift if Arrow was not present.