### PR TITLE
misc: Remove deprecated OutputBufferManager initialization functions

### DIFF
--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -94,18 +94,6 @@ class OutputBufferManager {
 
   void removeTask(const std::string& taskId);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  /// Initializes singleton with 'options'. May be called once before
-  /// getInstance().
-  static void initialize(const Options& options) {
-    getInstanceRef(options);
-  }
-
-  static std::weak_ptr<OutputBufferManager> getInstance() {
-    return getInstanceRef(Options());
-  }
-#endif
-
   static const std::shared_ptr<OutputBufferManager>& getInstanceRef();
 
   static const std::shared_ptr<OutputBufferManager>& getInstanceRef(


### PR DESCRIPTION
Prestissimo code using these APIs was advanced in https://github.com/prestodb/presto/pull/24730