### PR TITLE
misc: Support tracking blocked waiting time for sequential task execution

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -260,7 +260,7 @@ class BlockingState {
   ContinueFuture future_;
   Operator* operator_;
   BlockingReason reason_;
-  uint64_t sinceMicros_;
+  uint64_t sinceUs_;
 
   static std::atomic_uint64_t numBlockedDrivers_;
 };
@@ -370,14 +370,18 @@ class Driver : public std::enable_shared_from_this<Driver> {
   /// Run the pipeline until it produces a batch of data or gets blocked.
   /// Return the data produced or nullptr if pipeline finished processing and
   /// will not produce more data. Return nullptr and set 'future' if
-  /// pipeline got blocked.
+  /// pipeline got blocked. 'blockingOp' and 'blockingReason' are set if the
+  /// driver is blocked by an operator.
   ///
   /// This API supports execution of a Task synchronously in the caller's
   /// thread. The caller must use either this API or 'enqueue', but not both.
   /// When using 'enqueue', the last operator in the pipeline (sink) must not
   /// return any data from Operator::getOutput(). When using 'next', the last
   /// operator must produce data that will be returned to caller.
-  RowVectorPtr next(ContinueFuture* future);
+  RowVectorPtr next(
+      ContinueFuture* future,
+      Operator*& blockingOp,
+      BlockingReason& blockingReason);
 
   /// Invoked to initialize the operators from this driver once on its first
   /// execution.

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -737,14 +737,19 @@ RowVectorPtr Task::next(ContinueFuture* future) {
       ++runnableDrivers;
 
       ContinueFuture driverFuture = ContinueFuture::makeEmpty();
-      auto result = driver->next(&driverFuture);
+      Operator* driverOp{nullptr};
+      BlockingReason blockReason{BlockingReason::kNotBlocked};
+      auto result = driver->next(&driverFuture, driverOp, blockReason);
       if (result != nullptr) {
         VELOX_CHECK(!driverFuture.valid());
+        VELOX_CHECK_NULL(driverOp);
+        VELOX_CHECK_EQ(blockReason, BlockingReason::kNotBlocked);
         return result;
       }
 
       if (driverFuture.valid()) {
-        driverBlockingStates_[i]->setDriverFuture(driverFuture);
+        driverBlockingStates_[i]->setDriverFuture(
+            driverFuture, driverOp, blockReason);
       }
 
       if (error()) {
@@ -3229,13 +3234,21 @@ void Task::MemoryReclaimer::abort(
   }
 }
 
-void Task::DriverBlockingState::setDriverFuture(ContinueFuture& driverFuture) {
+void Task::DriverBlockingState::setDriverFuture(
+    ContinueFuture& driverFuture,
+    Operator* driverOp,
+    BlockingReason blockingReason) {
   VELOX_CHECK(!blocked_);
+  VELOX_CHECK_NULL(op_);
+  VELOX_CHECK_EQ(blockingReason_, BlockingReason::kNotBlocked);
   {
     std::lock_guard<std::mutex> l(mutex_);
     VELOX_CHECK(promises_.empty());
     VELOX_CHECK_NULL(error_);
     blocked_ = true;
+    op_ = driverOp;
+    blockingReason_ = blockingReason;
+    blockStartUs_ = getCurrentTimeMicro();
   }
   std::move(driverFuture)
       .via(&folly::InlineExecutor::instance())
@@ -3247,7 +3260,11 @@ void Task::DriverBlockingState::setDriverFuture(ContinueFuture& driverFuture) {
               VELOX_CHECK(blocked_);
               VELOX_CHECK_NULL(error_);
               promises = std::move(promises_);
-              blocked_ = false;
+              if ((op_ != nullptr) && !driver_->state().isTerminated) {
+                VELOX_CHECK_NE(blockingReason_, BlockingReason::kNotBlocked);
+                op_->recordBlockingTime(blockStartUs_, blockingReason_);
+              }
+              clearLocked();
             }
             for (auto& promise : promises) {
               promise->setValue();
@@ -3257,19 +3274,34 @@ void Task::DriverBlockingState::setDriverFuture(ContinueFuture& driverFuture) {
           folly::tag_t<std::exception>{},
           [&, driverHolder = driver_->shared_from_this()](
               std::exception const& e) {
-            std::lock_guard<std::mutex> l(mutex_);
-            VELOX_CHECK(blocked_);
-            VELOX_CHECK_NULL(error_);
-            try {
-              VELOX_FAIL(
-                  "A driver future from task {} was realized with error: {}",
-                  driver_->task()->taskId(),
-                  e.what());
-            } catch (const VeloxException&) {
-              error_ = std::current_exception();
+            std::vector<std::unique_ptr<ContinuePromise>> promises;
+            {
+              std::lock_guard<std::mutex> l(mutex_);
+              VELOX_CHECK(blocked_);
+              VELOX_CHECK_NULL(error_);
+              promises = std::move(promises_);
+              try {
+                VELOX_FAIL(
+                    "A driver future from task {} was realized with error: {}",
+                    driver_->task()->taskId(),
+                    e.what());
+              } catch (const VeloxException&) {
+                error_ = std::current_exception();
+              }
+              clearLocked();
             }
-            blocked_ = false;
+            for (auto& promise : promises) {
+              promise->setValue();
+            }
           });
+}
+
+void Task::DriverBlockingState::clearLocked() {
+  VELOX_CHECK(promises_.empty());
+  op_ = nullptr;
+  blockingReason_ = BlockingReason::kNotBlocked;
+  blockStartUs_ = 0;
+  blocked_ = false;
 }
 
 bool Task::DriverBlockingState::blocked(ContinueFuture* future) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1123,13 +1123,17 @@ class Task : public std::enable_shared_from_this<Task> {
   // Tracks the blocking state for each driver under serialized execution mode.
   class DriverBlockingState {
    public:
-    explicit DriverBlockingState(const Driver* driver) : driver_(driver) {
+    explicit DriverBlockingState(Driver* driver) : driver_(driver) {
       VELOX_CHECK_NOT_NULL(driver_);
     }
 
     /// Sets driver future by setting the continuation callback via inline
-    /// executor.
-    void setDriverFuture(ContinueFuture& diverFuture);
+    /// executor. 'driverOp' and 'blockingReason' are set if the driver is
+    /// blocked by an operator.
+    void setDriverFuture(
+        ContinueFuture& diverFuture,
+        Operator* driverOp,
+        BlockingReason blockingReason);
 
     /// Indicates if the associated driver is blocked or not. If blocked,
     /// 'future' is set which becomes realized when the driver is unblocked.
@@ -1138,13 +1142,23 @@ class Task : public std::enable_shared_from_this<Task> {
     bool blocked(ContinueFuture* future);
 
    private:
-    const Driver* const driver_;
+    void clearLocked();
+
+    Driver* const driver_;
 
     mutable std::mutex mutex_;
     // Indicates if the associated driver is blocked or not.
     bool blocked_{false};
     // Sets the driver future error if not null.
     std::exception_ptr error_{nullptr};
+    // If not null, set to the current blocking operator which should only be
+    // set if 'blocked_' is true.
+    Operator* op_{nullptr};
+    // Sets to blocking reason 'op_', and cleared when the driver is resumed.
+    BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+    // Sets to the time that driver was blocked, and cleared when the driver is
+    // resumed.
+    uint64_t blockStartUs_{0};
     // Promises to fulfill when the driver is unblocked.
     std::vector<std::unique_ptr<ContinuePromise>> promises_;
   };


### PR DESCRIPTION
Summary:
Current operator's blocked wait time is not set under sequential task execution mode. This PR fixes this by
set it DriverBlockingState which is similar to Driver::setResume. This PR also fixes a bug in operator future
error case to clear pending promises. This help blocked time analysis when operator is executed in
asynchronous mode like index join operator.

Differential Revision: D71249423


