### PR TITLE
misc: Throw spill limit error in validateSpillBytesSize

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -34,6 +34,15 @@ namespace facebook::velox::common {
       "{}",                                                         \
       errorMessage);
 
+#define VELOX_GENERIC_SPILL_FAILURE(errorMessage)                   \
+  _VELOX_THROW(                                                     \
+      ::facebook::velox::VeloxRuntimeError,                         \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
+      ::facebook::velox::error_code::kGenericSpillFailure.c_str(),  \
+      /* isRetriable */ true,                                       \
+      "{}",                                                         \
+      errorMessage);
+
 /// Defining type for a callback function that returns the spill directory path.
 /// Implementations can use it to ensure the path exists before returning.
 using GetSpillDirectoryPathCB = std::function<std::string_view()>;

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -109,6 +109,9 @@ inline constexpr auto kNoCacheSpace = "NO_CACHE_SPACE"_fs;
 /// An error raised when spill bytes exceeds limits.
 inline constexpr auto kSpillLimitExceeded = "SPILL_LIMIT_EXCEEDED"_fs;
 
+/// An error raised to indicate any general failure happened during spilling.
+inline constexpr auto kGenericSpillFailure = "GENERIC_SPILL_FAILURE"_fs;
+
 /// An error raised when trace bytes exceeds limits.
 inline constexpr auto kTraceLimitExceeded = "TRACE_LIMIT_EXCEEDED"_fs;
 

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -133,7 +133,12 @@ void SpillState::setPartitionSpilled(uint32_t partition) {
 void SpillState::validateSpillBytesSize(uint64_t bytes) {
   static constexpr uint64_t kMaxSpillBytesPerWrite =
       std::numeric_limits<int32_t>::max();
-  VELOX_CHECK_LT(bytes, kMaxSpillBytesPerWrite, "Spill bytes will overflow.");
+  if (bytes >= kMaxSpillBytesPerWrite) {
+    VELOX_GENERIC_SPILL_FAILURE(fmt::format(
+        "Spill bytes will overflow. Bytes {}, kMaxSpillBytesPerWrite: {}",
+        bytes,
+        kMaxSpillBytesPerWrite));
+  }
 }
 
 void SpillState::updateSpilledInputBytes(uint64_t bytes) {


### PR DESCRIPTION
Summary: Throwing spilling exception to properly catagorize spilling issues.

Differential Revision: D71249799


