### PR TITLE
misc: Include runtime stats in planNodeStats and log in dpp and ss load tests

### DIFF
--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -150,7 +150,9 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
   spilledFiles += stats.spilledFiles;
 }
 
-std::string PlanNodeStats::toString(bool includeInputStats) const {
+std::string PlanNodeStats::toString(
+    bool includeInputStats,
+    bool includeRuntimeStats) const {
   std::stringstream out;
   if (includeInputStats) {
     out << "Input: " << inputRows << " rows (" << succinctBytes(inputBytes)
@@ -197,6 +199,13 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
              succinctNanos(getOutputTiming.cpuNanos),
              succinctNanos(finishTiming.cpuNanos));
 
+  if (includeRuntimeStats) {
+    out << ", Runtime stats: (";
+    for (const auto& [name, metric] : customStats) {
+      out << name << ": " << metric.toString() << ", ";
+    }
+    out << ")";
+  }
   return out.str();
 }
 

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -145,7 +145,9 @@ struct PlanNodeStats {
   /// Add stats for a single operator instance.
   void add(const OperatorStats& stats);
 
-  std::string toString(bool includeInputStats = false) const;
+  std::string toString(
+      bool includeInputStats = false,
+      bool includeRuntimeStats = false) const;
 
   bool isMultiOperatorTypeNode() const {
     return operatorStats.size() > 1;

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/exec/IndexLookupJoin.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest-matchers.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/Connector.h"
@@ -1714,6 +1716,10 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
         runtimeStats.find(IndexLookupJoin::kLookupBlockWaitTime) ==
         runtimeStats.end());
   }
+  ASSERT_THAT(
+      operatorStats.toString(true, true),
+      testing::MatchesRegex(
+          ".*Runtime stats.*lookupWallNanos.*lookupCpuNanos.*"));
 }
 
 TEST_P(IndexLookupJoinTest, joinFuzzer) {


### PR DESCRIPTION
Summary: Add to provide option to log runtime stats in plan stats for analysis

Reviewed By: wenqiwooo

Differential Revision: D71267048


