### PR TITLE
feat: Refactor TaskTraceReader

### DIFF
--- a/velox/exec/TaskTraceReader.h
+++ b/velox/exec/TaskTraceReader.h
@@ -24,17 +24,28 @@ class TaskTraceMetadataReader {
  public:
   TaskTraceMetadataReader(std::string traceDir, memory::MemoryPool* pool);
 
-  void read(
-      std::unordered_map<std::string, std::string>& queryConfigs,
-      std::unordered_map<
-          std::string,
-          std::unordered_map<std::string, std::string>>& connectorProperties,
-      core::PlanNodePtr& queryPlan) const;
+  /// Returns trace query config;
+  std::unordered_map<std::string, std::string> queryConfigs() const;
+
+  /// Returns trace query connector properties;
+  std::unordered_map<std::string, std::unordered_map<std::string, std::string>>
+  connectorProperties() const;
+
+  /// Returns trace query plan;
+  core::PlanNodePtr queryPlan() const;
+
+  /// Returns node name in the trace query plan by ID.
+  std::string nodeName(const std::string& nodeId) const;
+
+  /// Returns connector ID in the TableScanNode.
+  std::string connectorId(const std::string& nodeId) const;
 
  private:
   const std::string traceDir_;
   const std::shared_ptr<filesystems::FileSystem> fs_;
   const std::string traceFilePath_;
   memory::MemoryPool* const pool_;
+  const folly::dynamic metadataObj_;
+  const core::PlanNodePtr tracePlanNode_;
 };
 } // namespace facebook::velox::exec::trace

--- a/velox/exec/TraceUtil.h
+++ b/velox/exec/TraceUtil.h
@@ -81,21 +81,6 @@ std::string getOpTraceSplitFilePath(const std::string& opTraceDir);
 /// Returns the file path for a given operator's traced input file.
 std::string getOpTraceSummaryFilePath(const std::string& opTraceDir);
 
-/// Extracts the trace node name from the trace metadata file.
-std::string getNodeName(
-    const std::string& nodeId,
-    const std::string& taskMetaFilePath,
-    const std::shared_ptr<filesystems::FileSystem>& fs,
-    memory::MemoryPool* pool);
-
-/// Extracts the hive connector from the trace metadata file, return empty if
-/// it does not exist.
-std::string getHiveConnectorId(
-    const std::string& nodeId,
-    const std::string& taskMetaFilePath,
-    const std::shared_ptr<filesystems::FileSystem>& fs,
-    memory::MemoryPool* pool);
-
 /// Extracts the input data type for the trace scan operator. The function first
 /// uses the traced node id to find traced operator's plan node from the traced
 /// plan fragment. Then it uses the specified source node index to find the

--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -26,6 +26,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/tool/trace/OperatorReplayerBase.h"
+
 #include "velox/tool/trace/TraceReplayTaskRunner.h"
 
 using namespace facebook::velox;
@@ -66,10 +67,13 @@ OperatorReplayerBase::OperatorReplayerBase(
   } else {
     VELOX_USER_CHECK_EQ(pipelineIds_.size(), 1);
   }
+  VELOX_CHECK_NOT_NULL(executor_);
 
   const auto taskMetaReader = exec::trace::TaskTraceMetadataReader(
       taskTraceDir_, memory::MemoryManager::getInstance()->tracePool());
-  taskMetaReader.read(queryConfigs_, connectorConfigs_, planFragment_);
+  queryConfigs_ = taskMetaReader.queryConfigs();
+  connectorConfigs_ = taskMetaReader.connectorProperties();
+  planFragment_ = taskMetaReader.queryPlan();
   queryConfigs_[core::QueryConfig::kQueryTraceEnabled] = "false";
 }
 

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -21,6 +21,7 @@
 #include "velox/tool/trace/OperatorReplayerBase.h"
 
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include "velox/exec/TaskTraceReader.h"
 
 DECLARE_string(root_dir);
 DECLARE_bool(summary);
@@ -60,6 +61,9 @@ class TraceReplayRunner {
   const std::unique_ptr<folly::CPUThreadPoolExecutor> cpuExecutor_;
   const std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
   std::shared_ptr<filesystems::FileSystem> fs_;
+  std::unique_ptr<exec::trace::TaskTraceMetadataReader>
+      taskTraceMetadataReader_;
+  core::PlanNodePtr tracePlanNode_;
 };
 
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableScanReplayerTest.cpp
@@ -129,11 +129,9 @@ TEST_F(TableScanReplayerTest, runner) {
 
   const auto taskTraceDir =
       exec::trace::getTaskTraceDirectory(traceRoot, *task);
-  const auto connectorId = exec::trace::getHiveConnectorId(
-      traceNodeId_,
-      exec::trace::getTaskTraceMetaFilePath(taskTraceDir),
-      fs,
-      memory::MemoryManager::getInstance()->tracePool());
+  const auto taskTraceReader =
+      exec::trace::TaskTraceMetadataReader(taskTraceDir, pool());
+  const auto connectorId = taskTraceReader.connectorId(traceNodeId_);
   ASSERT_EQ("test-hive", connectorId);
   const auto opTraceDir = exec::trace::getOpTraceDirectory(
       taskTraceDir,


### PR DESCRIPTION
Refactor `TaskTraceReader` and consolidate task metadata parsing,
We need to extract the node name, plan, configs, etc. from it.