### PR TITLE
Remove unused exception parameter from velox/common/base/Pointers.h

### DIFF
--- a/velox/common/base/Pointers.h
+++ b/velox/common/base/Pointers.h
@@ -36,7 +36,7 @@ inline void castUniquePointer(
     auto* rawDstPtr = dynamic_cast<DestinationType*>(rawSrcPtr);
     VELOX_CHECK_NOT_NULL(rawDstPtr);
     dstPtr.reset(rawDstPtr);
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     srcPtr.reset(rawSrcPtr);
     throw;
   }

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -441,7 +441,7 @@ bool SsdFile::write(
   try {
     writeFile_->write(iovecs, offset, length);
     return true;
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     VELOX_SSD_CACHE_LOG(ERROR)
         << "Failed to write to SSD, file name: " << fileName_
         << ", size: " << iovecs.size() << ", offset: " << offset

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -256,7 +256,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
         VELOX_FAIL("Duplicate root pool name found: {}", poolName);
       }
       pools_.emplace(poolName, pool);
-    } catch (const VeloxRuntimeError& ex) {
+    } catch (const VeloxRuntimeError&) {
       arbitrator_->removePool(pool.get());
       throw;
     }

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1930,11 +1930,11 @@ struct ParseDurationFunction {
       double value = std::stod(match[1].str());
       std::string unit = match[2].str();
       result = valueOfTimeUnitToMillis(value, unit);
-    } catch (std::out_of_range& e) {
+    } catch (std::out_of_range&) {
       VELOX_USER_FAIL(
           "Input duration value is out of range for double: {}",
           match[1].str());
-    } catch (std::invalid_argument& e) {
+    } catch (std::invalid_argument&) {
       VELOX_USER_FAIL(
           "Input duration value is not a valid number: {}", match[1].str());
     }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D71161493


