### PR TITLE
misc: Allow to set plan stats output fields

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2735,7 +2735,7 @@ std::string summarizeOutputType(
   out << type->size() << " fields";
 
   // Include names and types for the first few fields.
-  const auto cnt = std::min<size_t>(options.maxOutputFileds, type->size());
+  const auto cnt = std::min<size_t>(options.maxOutputFields, type->size());
   if (cnt > 0) {
     out << ": ";
     for (auto i = 0; i < cnt; ++i) {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -128,7 +128,7 @@ struct PlanSummaryOptions {
   /// summary. Each field has a name and a type. The amount of type information
   /// is controlled by 'maxChildTypes' option. Use 0 to include only the number
   /// of output fields.
-  size_t maxOutputFileds = 5;
+  size_t maxOutputFields = 5;
 
   /// For a given output type, maximum number of child types to include in the
   /// summary. By default, only top-level type is included: BIGINT, ARRAY, MAP,

--- a/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
@@ -92,7 +92,7 @@ TEST_F(PlanNodeToSummaryStringTest, basic) {
       "          table: hive_table\n",
       plan->toSummaryString({
           .project = {.maxProjections = 2},
-          .maxOutputFileds = 3,
+          .maxOutputFields = 3,
           .maxChildTypes = 2,
       }));
 }


### PR DESCRIPTION
Summary: Configure to print out the the complete list of fields in the plan.

Reviewed By: wenqiwooo

Differential Revision: D71295791


