### PR TITLE
feat(re2): Upgrade bundled RE2 to 2024-07-02

### DIFF
--- a/CMake/resolve_dependency_modules/re2.cmake
+++ b/CMake/resolve_dependency_modules/re2.cmake
@@ -16,12 +16,12 @@ include_guard(GLOBAL)
 if(DEFINED ENV{VELOX_RE2_URL})
   set(VELOX_RE2_SOURCE_URL "$ENV{VELOX_RE2_URL}")
 else()
-  set(VELOX_RE2_VERSION 2022-02-01)
+  set(VELOX_RE2_VERSION 2024-07-02)
   set(VELOX_RE2_SOURCE_URL
       "https://github.com/google/re2/archive/refs/tags/${VELOX_RE2_VERSION}.tar.gz"
   )
   set(VELOX_RE2_BUILD_SHA256_CHECKSUM
-      9c1e6acfd0fed71f40b025a7a1dabaf3ee2ebb74d64ced1f9ee1b0b01d22fd27)
+      eb2df807c781601c14a260a507a5bb4509be1ee626024cb45acbd57cb9d4032b)
 endif()
 
 message(STATUS "Building re2 from source")
@@ -33,13 +33,24 @@ FetchContent_Declare(
 set(RE2_USE_ICU ON)
 set(RE2_BUILD_TESTING OFF)
 
+# RE2 needs Abseil.
+velox_set_source(absl)
+velox_resolve_dependency(absl)
+
 FetchContent_MakeAvailable(re2)
-if(ICU_SOURCE)
-  # empty var will cause a syntax error
-  if(${ICU_SOURCE} STREQUAL "BUNDLED")
-    # build re2 after icu so the files are available
-    add_dependencies(re2 ICU ICU::uc)
+if("${absl_SOURCE}" STREQUAL "SYSTEM")
+  if(DEFINED absl_VERSION AND "${absl_VERSION}" VERSION_LESS "20240116")
+    message(
+      FATAL_ERROR
+        "Abseil 20240116 or later is required for bundled RE2: ${absl_VERSION}")
   endif()
+elseif("${absl_SOURCE}" STREQUAL "BUNDLED")
+  # Build RE2 after Abseil so the files are available
+  add_dependencies(re2 absl::base)
+endif()
+if("${ICU_SOURCE}" STREQUAL "BUNDLED")
+  # Build RE2 after ICU so the files are available
+  add_dependencies(re2 ICU ICU::uc)
 endif()
 
 set(re2_LIBRARIES ${re2_BINARY_DIR}/libre2.a)


### PR DESCRIPTION
We need Abseil 20240116 or later for RE2 2024-07-02. Because RE2 uses `ABSL_LOG(DFATAL)` and it needs this commit:
https://github.com/abseil/abseil-cpp/commit/70172ada858b8739ce07e8c2f1ecd8c11c8768c7

Fixes #12674