### PR TITLE
fix(function): Fix Spark `json_object_keys` function to return NULL for invalid json

### DIFF
--- a/velox/functions/sparksql/JsonObjectKeys.h
+++ b/velox/functions/sparksql/JsonObjectKeys.h
@@ -51,9 +51,24 @@ struct JsonObjectKeysFunction {
     }
 
     for (auto field : jsonObject) {
+      if (isFatal(field.error())) {
+        // On-Demand only fully validates the values used and the structure
+        // leading to it.
+        return false;
+      }
       out.add_item().copy_from(std::string_view(field.unescaped_key()));
     }
     return true;
+  }
+
+ private:
+  // TODO: After upgrade simdjson v3.12.3, we could replace with simdjson
+  // function relevant simdjson function:
+  // https://github.com/simdjson/simdjson/blob/master/include/simdjson/error-inl.h#L10-L12
+  bool isFatal(simdjson::error_code error) noexcept {
+    // Indicates the document is not valid JSON.
+    return error == simdjson::error_code::TAPE_ERROR ||
+        error == simdjson::error_code::INCOMPLETE_ARRAY_OR_OBJECT;
   }
 };
 

--- a/velox/functions/sparksql/tests/JsonObjectKeysTest.cpp
+++ b/velox/functions/sparksql/tests/JsonObjectKeysTest.cpp
@@ -41,6 +41,14 @@ TEST_F(JsonObjectKeysTest, basic) {
   assertEqualVectors(jsonObjectKeys(R"(1)"), expected);
   assertEqualVectors(jsonObjectKeys(R"("hello")"), expected);
   assertEqualVectors(jsonObjectKeys(R"("")"), expected);
+  assertEqualVectors(
+      jsonObjectKeys(R"({"key": 45, "random_string"})"), expected);
+  assertEqualVectors(jsonObjectKeys(R"([{1, 2, 3}])"), expected);
+  // Test with UNCLOSED_STRING error of simdjson.
+  assertEqualVectors(jsonObjectKeys(R"({"key: 45})"), expected);
+  assertEqualVectors(
+      jsonObjectKeys(R"({ "pie": true, "cherry": [1, 2, 3 })"), expected);
+  assertEqualVectors(jsonObjectKeys(R"([*.{cs,vb}])"), expected);
 }
 
 } // namespace


### PR DESCRIPTION
This PR supports Spark json_object_keys function returning NULL when on-demand 
validates in simdjson[1][2].

Fixes #12671.

[1] https://github.com/simdjson/simdjson/blob/master/doc/basics.md?plain=1#L379-L382  
[2] https://github.com/simdjson/simdjson/blob/master/doc/basics.md?plain=1#L1534-L1536