### PR TITLE
feat: Make kRequestDataSizesMaxWait in ExchangeClient configurable

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -516,6 +516,10 @@ class QueryConfig {
   static constexpr const char* kIndexLookupJoinMaxPrefetchBatches =
       "index_lookup_join_max_prefetch_batches";
 
+  // Max wait time for exchange request in seconds.
+  static constexpr const char* kRequestDataSizesMaxWaitSec =
+      "request_data_sizes_max_wait_sec";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -943,6 +947,10 @@ class QueryConfig {
 
   std::string shuffleCompressionKind() const {
     return get<std::string>(kShuffleCompressionKind, "none");
+  }
+
+  int32_t requestDataSizesMaxWaitSec() const {
+    return get<int32_t>(kRequestDataSizesMaxWaitSec, 10);
   }
 
   bool throwExceptionOnDuplicateMapKeys() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -38,11 +38,13 @@ TEST_F(QueryConfigTest, emptyConfig) {
 TEST_F(QueryConfigTest, setConfig) {
   std::string path = "/tmp/setConfig";
   std::unordered_map<std::string, std::string> configData(
-      {{QueryConfig::kLegacyCast, "true"}});
+      {{QueryConfig::kLegacyCast, "true"},
+       {QueryConfig::kRequestDataSizesMaxWaitSec, "12"}});
   auto queryCtx = QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_TRUE(config.isLegacyCast());
+  EXPECT_EQ(config.requestDataSizesMaxWaitSec(), 12);
 }
 
 TEST_F(QueryConfigTest, invalidConfig) {

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -161,7 +161,7 @@ void ExchangeClient::request(std::vector<RequestSpec>&& requestSpecs) {
   for (auto& spec : requestSpecs) {
     auto future = folly::SemiFuture<ExchangeSource::Response>::makeEmpty();
     if (spec.maxBytes == 0) {
-      future = spec.source->requestDataSizes(kRequestDataSizesMaxWait);
+      future = spec.source->requestDataSizes(kRequestDataSizesMaxWaitSec_);
     } else {
       future = spec.source->request(spec.maxBytes, kRequestDataMaxWait);
     }

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3012,7 +3012,8 @@ void Task::createExchangeClientLocked(
       numberOfConsumers,
       queryCtx()->queryConfig().minExchangeOutputBatchBytes(),
       addExchangeClientPool(planNodeId, pipelineId),
-      queryCtx()->executor());
+      queryCtx()->executor(),
+      queryCtx()->queryConfig().requestDataSizesMaxWaitSec());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -418,7 +418,7 @@ TEST_P(ExchangeClientTest, sourceTimeout) {
   // Wait until all sources have timed out at least once.
   auto deadline = std::chrono::system_clock::now() +
       3 * kNumSources *
-          std::chrono::seconds(ExchangeClient::kRequestDataSizesMaxWait);
+          std::chrono::seconds(client->requestDataSizesMaxWaitSec());
   while (std::chrono::system_clock::now() < deadline) {
     {
       std::lock_guard<std::mutex> l(mutex);


### PR DESCRIPTION
Summary: Added kRequestDataSizesMaxWait to query config and pass it to ExchangeClient to set the value

Differential Revision: D71191632


