### PR TITLE
fix: Make type check reflect the corresponding logical type

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -389,7 +389,7 @@ struct TypeFactory;
   const typename TypeTraits<TypeKind::KIND>::ImplType& as##NAME() const { \
     return this->as<TypeKind::KIND>();                                    \
   }                                                                       \
-  bool is##NAME() const {                                                 \
+  virtual bool is##NAME() const {                                         \
     return this->kind() == TypeKind::KIND;                                \
   }
 
@@ -745,6 +745,14 @@ class DecimalType : public ScalarType<KIND> {
   static_assert(KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT);
   static constexpr uint8_t kMaxPrecision = KIND == TypeKind::BIGINT ? 18 : 38;
   static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 1 : 19;
+
+  bool isBigint() const override {
+    return false;
+  }
+
+  bool isHugeint() const override {
+    return false;
+  }
 
   inline bool equivalent(const Type& other) const override {
     if (!Type::hasSameTypeId(other)) {
@@ -1276,6 +1284,10 @@ class IntervalDayTimeType : public BigintType {
     return this == &other;
   }
 
+  bool isBigint() const override {
+    return false;
+  }
+
   std::string toString() const override {
     return name();
   }
@@ -1334,6 +1346,10 @@ class IntervalYearMonthType : public IntegerType {
     return name();
   }
 
+  bool isInteger() const override {
+    return false;
+  }
+
   /// Returns the interval 'value' (months) formatted as YEARS MONTHS.
   /// For example, 14 months (INTERVAL '1-2' YEAR TO MONTH) would be
   /// represented as 1-2; -14 months would be represents as -1-2.
@@ -1378,6 +1394,10 @@ class DateType : public IntegerType {
 
   bool equivalent(const Type& other) const override {
     return this == &other;
+  }
+
+  bool isInteger() const override {
+    return false;
   }
 
   std::string toString() const override {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -1148,3 +1148,31 @@ TEST(TypeTest, toSummaryString) {
       "ROW(BOOLEAN, INTEGER, VARCHAR, ARRAY, MAP, ROW)",
       rowType->toSummaryString({.maxChildren = 10}));
 }
+
+TEST(TypeTest, typeCheck) {
+  EXPECT_TRUE(INTEGER()->isInteger());
+  EXPECT_TRUE(BIGINT()->isBigint());
+  EXPECT_TRUE(HUGEINT()->isHugeint());
+
+  EXPECT_TRUE(DATE()->isDate());
+  EXPECT_FALSE(DATE()->isInteger());
+
+  // Short decimal.
+  const auto shortDecimal = DECIMAL(10, 5);
+  EXPECT_TRUE(shortDecimal->isDecimal());
+  EXPECT_TRUE(shortDecimal->isShortDecimal());
+  EXPECT_FALSE(shortDecimal->isLongDecimal());
+  EXPECT_FALSE(shortDecimal->isBigint());
+  // Long decimal.
+  const auto longDecimal = DECIMAL(30, 5);
+  EXPECT_TRUE(longDecimal->isDecimal());
+  EXPECT_TRUE(longDecimal->isLongDecimal());
+  EXPECT_FALSE(longDecimal->isShortDecimal());
+  EXPECT_FALSE(longDecimal->isHugeint());
+
+  EXPECT_TRUE(INTERVAL_YEAR_MONTH()->isIntervalYearMonth());
+  EXPECT_FALSE(INTERVAL_YEAR_MONTH()->isInteger());
+
+  EXPECT_TRUE(INTERVAL_DAY_TIME()->isIntervalDayTime());
+  EXPECT_FALSE(INTERVAL_DAY_TIME()->isBigint());
+}


### PR DESCRIPTION
In Type.h, `is##NAME()` was defined to handily check data type based on `TypeKind` used in its
implementation. It may not reflect the logical type. For example, `isBigint()` returns true for
ShortDecimalType, IntervalDayTimeType and BigintType. It can potentially cause bugs if developers
don't notice this. In this pr, we make this type check function reflect the logical type instead of its
implementation type (when using this check function, developers generally don't care about its
implementation type). Thus, `isBigint()` will return true only for BigintType.