### PR TITLE
fix: Use memory pool to track raw_vector in selective column readers

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -747,7 +747,7 @@ inline uint64_t nextPowerOfTwo(uint64_t size) {
 }
 
 inline bool isPowerOfTwo(uint64_t size) {
-  return bits::countBits(&size, 0, sizeof(uint64_t) * 8) <= 1;
+  return (size & (size - 1)) == 0;
 }
 
 // This is the Hash128to64 function from Google's cityhash (available

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -135,10 +135,13 @@ MemoryAllocator::SizeMix MemoryAllocator::allocationSize(
 bool MemoryAllocator::isAlignmentValid(
     uint64_t allocateBytes,
     uint16_t alignmentBytes) {
+  // Check if the allocateBytes is conforming to the alignmentBytes.
+  // alignmentBytes must be a power of two, so we can replace the expensive
+  // modulo operation with bitwise and.
   return (alignmentBytes == kMinAlignment) ||
       (alignmentBytes >= kMinAlignment && alignmentBytes <= kMaxAlignment &&
-       allocateBytes % alignmentBytes == 0 &&
-       (alignmentBytes & (alignmentBytes - 1)) == 0);
+       bits::isPowerOfTwo(alignmentBytes) &&
+       (allocateBytes & (alignmentBytes - 1)) == 0);
 }
 
 void MemoryAllocator::alignmentCheck(

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -491,7 +491,9 @@ void* MemoryPoolImpl::allocate(
     std::optional<uint32_t> alignment) {
   if (alignment.has_value()) {
     const auto alignmentValue = alignment.value();
-    if (FOLLY_UNLIKELY(alignment_ % alignmentValue != 0)) {
+    if (FOLLY_UNLIKELY(
+            !(bits::isPowerOfTwo(alignmentValue) &&
+              alignmentValue <= alignment_))) {
       VELOX_UNSUPPORTED(
           "Memory pool only supports fixed alignment allocations. Requested "
           "alignment {} must already be aligned with this memory pool's fixed "

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -278,7 +278,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual size_t preferredSize(size_t size);
 
   /// Returns the memory allocation alignment size applied internally by this
-  /// memory pool object.
+  /// memory pool object.  Must be a power of two.
   virtual uint16_t alignment() const {
     return alignment_;
   }
@@ -755,8 +755,8 @@ class MemoryPoolImpl : public MemoryPool {
         : std::max<int64_t>(0, reservationBytes_ - usedReservationBytes_);
   }
 
-  FOLLY_ALWAYS_INLINE int64_t sizeAlign(int64_t size) {
-    const auto remainder = size % alignment_;
+  FOLLY_ALWAYS_INLINE int64_t sizeAlign(int64_t size) const {
+    const auto remainder = size & (alignment_ - 1);
     return (remainder == 0) ? size : (size + alignment_ - remainder);
   }
 

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -50,7 +50,14 @@ SelectiveColumnReader::SelectiveColumnReader(
       requestedType_(requestedType),
       fileType_(fileType),
       formatData_(params.toFormatData(fileType, scanSpec)),
-      scanSpec_(&scanSpec) {}
+      scanSpec_(&scanSpec),
+      outputRows_(memoryPool_),
+      valueRows_(memoryPool_),
+      outerNonNullRows_(memoryPool_),
+      innerNonNullRows_(memoryPool_) {
+  scanState_.rowsCopy = raw_vector<vector_size_t>(memoryPool_);
+  scanState_.filterCache = raw_vector<uint8_t>(memoryPool_);
+}
 
 void SelectiveColumnReader::filterRowGroups(
     uint64_t rowGroupSize,

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -41,11 +41,8 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
       FormatParams& params,
       velox::common::ScanSpec& scanSpec,
       std::shared_ptr<const dwio::common::TypeWithId> type)
-      : SelectiveColumnReader(
-            requestedType,
-            std::move(type),
-            params,
-            scanSpec) {}
+      : SelectiveColumnReader(requestedType, std::move(type), params, scanSpec),
+        nestedRowsHolder_(memoryPool_) {}
 
   /// Reads 'numLengths' next lengths into 'result'. If 'nulls' is
   /// non-null, each kNull bit signifies a null with a length of 0 to

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -119,7 +119,8 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       : SelectiveColumnReader(requestedType, fileType, params, scanSpec),
         debugString_(
             getExceptionContext().message(VeloxException::Type::kSystem)),
-        isRoot_(isRoot) {}
+        isRoot_(isRoot),
+        rows_(memoryPool_) {}
 
   bool hasDeletion() const final {
     return hasDeletion_;


### PR DESCRIPTION
Differential Revision: D71318586


