### PR TITLE
fix(json): Compute capacity correctly when casting to complex jsons

### DIFF
--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -702,7 +702,6 @@ struct CastFromJsonTypedImpl {
           auto size = unescapeSizeForJsonCast(json.data(), json.size());
           vectorWriter.resize(size);
           unescapeForJsonCast(json.data(), json.size(), vectorWriter.data());
-          vectorWriter.finalize();
         } else {
           vectorWriter.append(json);
         }


### PR DESCRIPTION
Summary: The current JsonCastOperator will incorrectly compute capacity of its json buffer because finalize() gets called twice - once in line 705 and the other when writer->commit() is called. This causes it throw eventually when it gets close to capacity. We fix this by just removing the unnecessary call to finalize in line 705.

Differential Revision: D71322529
