### PR TITLE
Remove unused private from velox/dwio/common/DirectBufferedInput.h +12

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -52,13 +52,12 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
   DirectCoalescedLoad(
       std::shared_ptr<ReadFileInputStream> input,
       std::shared_ptr<IoStatistics> ioStats,
-      uint64_t groupId,
+      uint64_t /* groupId */,
       const std::vector<LoadRequest*>& requests,
       memory::MemoryPool& pool,
       int32_t loadQuantum)
       : CoalescedLoad({}, {}),
         ioStats_(ioStats),
-        groupId_(groupId),
         input_(std::move(input)),
         loadQuantum_(loadQuantum),
         pool_(pool) {
@@ -95,7 +94,6 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
 
  private:
   const std::shared_ptr<IoStatistics> ioStats_;
-  const uint64_t groupId_;
   const std::shared_ptr<ReadFileInputStream> input_;
   const int32_t loadQuantum_;
   memory::MemoryPool& pool_;

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -197,7 +197,6 @@ SeekableFileInputStream::SeekableFileInputStream(
       start_(offset),
       length_(byteCount),
       blockSize_(computeBlock(blockSize, length_)),
-      pool_(&pool),
       buffer_{pool} {
   position_ = 0;
   pushback_ = 0;

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -131,7 +131,6 @@ class SeekableFileInputStream : public SeekableInputStream {
   const uint64_t start_;
   const uint64_t length_;
   const uint64_t blockSize_;
-  memory::MemoryPool* const pool_;
 
   DataBuffer<char> buffer_;
   uint64_t position_;

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1753,7 +1753,6 @@ class StructColumnReader : public ColumnReader {
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<ColumnReader>> children_;
-  folly::Executor* executor_;
   std::unique_ptr<dwio::common::ParallelFor> parallelForOnChildren_;
 
  public:
@@ -1796,8 +1795,7 @@ StructColumnReader::StructColumnReader(
     FlatMapContext flatMapContext,
     ColumnReaderFactory& factory)
     : ColumnReader(fileType, stripe, streamLabels, std::move(flatMapContext)),
-      requestedType_{requestedType},
-      executor_{executor} {
+      requestedType_{requestedType} {
   DWIO_ENSURE_EQ(
       fileType_->id(),
       fileType->id(),

--- a/velox/exec/OperatorTraceReader.cpp
+++ b/velox/exec/OperatorTraceReader.cpp
@@ -65,10 +65,9 @@ OperatorTraceInputReader::getInputStream() const {
 
 OperatorTraceSummaryReader::OperatorTraceSummaryReader(
     std::string traceDir,
-    memory::MemoryPool* pool)
+    memory::MemoryPool* /* pool */)
     : traceDir_(std::move(traceDir)),
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
-      pool_(pool),
       summaryFile_(fs_->openFileForRead(getOpTraceSummaryFilePath(traceDir_))) {
 }
 

--- a/velox/exec/OperatorTraceReader.h
+++ b/velox/exec/OperatorTraceReader.h
@@ -65,7 +65,6 @@ class OperatorTraceSummaryReader {
  private:
   const std::string traceDir_;
   const std::shared_ptr<filesystems::FileSystem> fs_;
-  memory::MemoryPool* const pool_;
   const std::unique_ptr<ReadFile> summaryFile_;
 };
 

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -67,7 +67,6 @@ class OperatorTraceInputWriter {
 
   std::unique_ptr<WriteFile> traceFile_;
   std::unique_ptr<VectorStreamGroup> batch_;
-  bool limitExceeded_{false};
   bool finished_{false};
 };
 

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -27,7 +27,7 @@ class OutputBufferManager {
   /// agree.
   struct Options {};
 
-  explicit OutputBufferManager(Options options) : options_(options) {}
+  explicit OutputBufferManager(Options) {}
 
   void initializeTask(
       std::shared_ptr<Task> task,
@@ -154,7 +154,5 @@ class OutputBufferManager {
 
   std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory_{
       nullptr};
-
-  Options options_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/TaskTraceWriter.cpp
+++ b/velox/exec/TaskTraceWriter.cpp
@@ -25,11 +25,10 @@ namespace facebook::velox::exec::trace {
 
 TaskTraceMetadataWriter::TaskTraceMetadataWriter(
     std::string traceDir,
-    memory::MemoryPool* pool)
+    memory::MemoryPool* /* pool */)
     : traceDir_(std::move(traceDir)),
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
-      traceFilePath_(getTaskTraceMetaFilePath(traceDir_)),
-      pool_(pool) {
+      traceFilePath_(getTaskTraceMetaFilePath(traceDir_)) {
   VELOX_CHECK_NOT_NULL(fs_);
   VELOX_CHECK(!fs_->exists(traceFilePath_));
 }

--- a/velox/exec/TaskTraceWriter.h
+++ b/velox/exec/TaskTraceWriter.h
@@ -33,7 +33,6 @@ class TaskTraceMetadataWriter {
   const std::string traceDir_;
   const std::shared_ptr<filesystems::FileSystem> fs_;
   const std::string traceFilePath_;
-  memory::MemoryPool* const pool_;
   bool finished_{false};
 };
 } // namespace facebook::velox::exec::trace

--- a/velox/serializers/VectorStream.cpp
+++ b/velox/serializers/VectorStream.cpp
@@ -66,8 +66,6 @@ VectorStream::VectorStream(
     const PrestoVectorSerde::PrestoOptions& opts)
     : type_(type),
       streamArena_(streamArena),
-      useLosslessTimestamp_(opts.useLosslessTimestamp),
-      nullsFirst_(opts.nullsFirst),
       isLongDecimal_(type_->isLongDecimal()),
       isUuid_(isUuidType(type_)),
       isIpAddress_(isIPAddressType(type_)),

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -206,11 +206,6 @@ class VectorStream {
 
   const TypePtr type_;
   StreamArena* const streamArena_;
-  /// Indicates whether to serialize timestamps with nanosecond precision.
-  /// If false, they are serialized with millisecond precision which is
-  /// compatible with presto.
-  const bool useLosslessTimestamp_;
-  const bool nullsFirst_;
   const bool isLongDecimal_;
   const bool isUuid_;
   const bool isIpAddress_;


### PR DESCRIPTION
Summary:
`-Wunused-private-field` has identified an unused private field. This diff removes it.

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D71291948


