### PR TITLE
Remove unused exception parameter from velox/common/memory/SharedArbitrator.cpp

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -52,7 +52,7 @@ namespace {
 #define CHECKED_GROW(pool, growBytes, reservationBytes) \
   try {                                                 \
     checkedGrow(pool, growBytes, reservationBytes);     \
-  } catch (const VeloxRuntimeError& e) {                \
+  } catch (const VeloxRuntimeError&) {                  \
     freeCapacity(growBytes);                            \
     throw;                                              \
   }


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D71290942


