### PR TITLE
misc(fuzzer): Log input test cases in expression fuzzer

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -463,6 +463,7 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "hugeint") ||
       usesTypeName(signature, "hyperloglog") ||
       usesTypeName(signature, "tdigest") ||
+      usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -408,6 +408,10 @@ void ExpressionFuzzerVerifier::go() {
     auto [inputTestCases, inputRowMetadata] =
         generateInput(inputType, *vectorFuzzer_, inputGenerators);
     totalTestCases += inputTestCases.size();
+    for (auto j = 0; j < inputTestCases.size(); ++j) {
+      VLOG(1) << "Input test case " << j << ": ";
+      exec::test::logVectors({inputTestCases[j].inputVector});
+    }
 
     auto resultVectors = generateResultVectors(plans);
     std::vector<fuzzer::ResultOrError> results;


### PR DESCRIPTION
Summary:
This diff makes the expression fuzzer log values in the input vectors when `-v=1` is 
specified. This diff also makes PrestoQueryRunner function signatures that has JSON 
argument type because JSON cannot be written directly to HIVE.

Differential Revision: D71333637


