### PR TITLE
fix: The new LLVM library for time zones is slow with transitions after 2037

### DIFF
--- a/velox/external/date/tz.cpp
+++ b/velox/external/date/tz.cpp
@@ -308,7 +308,7 @@ load_data(std::istream& inf,
                             info.tt_isdst != 0});
     }
     auto i = 0u;
-    transitions.emplace(transitions.begin(), min_seconds - std::chrono::seconds(1));
+    transitions.emplace(transitions.begin(), min_seconds);
     auto tf = std::find_if(ttinfos.begin(), ttinfos.end(),
                             [](const expanded_ttinfo& ti)
                                 {return ti.is_dst == 0;});

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -52,6 +52,8 @@ struct expanded_ttinfo
     std::chrono::seconds offset;
     std::string          abbrev;
     bool                 is_dst;
+
+    expanded_ttinfo(std::chrono::seconds offset, const std::string& abbrev, bool is_dst) : offset(offset), abbrev(abbrev), is_dst(is_dst) {}
 };
 
 struct transition

--- a/velox/external/tzdb/time_zone.h
+++ b/velox/external/tzdb/time_zone.h
@@ -167,6 +167,8 @@ class time_zone {
 
   [[nodiscard]] std::string_view __name() const noexcept;
 
+
+  [[nodiscard]] sys_info __get_info_to_populate_transition(date::sys_seconds __time) const;
   [[nodiscard]] sys_info __get_info(date::sys_seconds __time) const;
   [[nodiscard]] local_info __get_info(date::local_seconds __time) const;
 

--- a/velox/external/tzdb/types_private.h
+++ b/velox/external/tzdb/types_private.h
@@ -107,6 +107,8 @@ struct __continuation {
       std::string /*, size_t*/>;
 
   __rules_t __rules;
+  bool __has_forever_rules = false;
+  std::pair<std::vector<__rule>::const_iterator, std::vector<__rule>::const_iterator> __forever_rules{};
 
   std::string __format;
   // TODO TZDB the until field can contain more than just a year.


### PR DESCRIPTION
Summary:
The new LLVM library has logic to apply rules dynamically to figure out which rule applies to a
particular time point. We recently updated the logic to use precomputed transition times to
speed up the calculations.

Doing this works great, but we can't store those precomputed transition times into the distant
future. In particular there are rules I call "forever rules" where transitions alternate every year
deep into the future (like daylight savings time).

We can speed these up by taking advantage of the fact there are only two rules. If we figure it
which one applies first in the year prior to the target timestamp (to make sure we pick a time
before the target timestamp) we can quickly jump forward to figure out which rule applied in
at target timestamp and when that rule began.  (Note that if there are not "forever rules" then
we can just use whatever the last rule was).

To do this, I had to make a few changes:
1) When loading a continuity into the time zone database, check if it has "forever rules" and
store them (mainly for ease of use).
2) When constructing a time zone, make sure we have the transitions loaded to at least 2
years past the end of the second to last continuation (the start of the last continuation) and 2 
years past the start of any "forever rules"
3) When looking up system_info check if it's within the range of the precomputed transitions,
use those (like before), otherwise use the "forever rules" to figure out the current rule and
when it started.

I also fixed some discrepancies between the min/max time used by the date library and LLVM.

Differential Revision: D71329726


