### PR TITLE
fix(escape): Update escape to accept empty string as a valid character

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1015,7 +1015,7 @@ class LikeGeneric final : public exec::VectorFunction {
       context.applyToSelectedNoThrow(rows, [&](auto row) {
         vectorWriter.setOffset(row);
         auto escapeChar = escapeReader[row];
-        VELOX_USER_CHECK_EQ(
+        VELOX_USER_CHECK_LE(
             escapeChar.size(), 1, "Escape string must be a single character");
         vectorWriter.current() = applyRow(
             inputReader[row], patternReader[row], escapeChar.data()[0]);
@@ -2237,7 +2237,7 @@ std::shared_ptr<exec::VectorFunction> makeLike(
     //
     // [1].https://github.com/facebookincubator/velox/issues/8363
     try {
-      VELOX_USER_CHECK_EQ(
+      VELOX_USER_CHECK_LE(
           constantEscape->valueAt(0).size(),
           1,
           "Escape string must be a single character");

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1456,13 +1456,12 @@ TEST_F(Re2FunctionsTest, invalidEscapeChar) {
       evaluate("like(c0 ,'AA', 'AA')", rowVector),
       "Escape string must be a single character");
 
-  VELOX_ASSERT_THROW(
-      evaluate("like(c0 ,'AA', '')", rowVector),
-      "Escape string must be a single character");
+  // Can pass, empty escape char is allowed.
+  evaluate("like(c0 ,'AA', '')", rowVector);
+
   {
     auto result = evaluate("try(like(c0 , c1, c2))", rowVector);
-    auto expected =
-        makeNullableFlatVector<bool>({std::nullopt, std::nullopt, false});
+    auto expected = makeNullableFlatVector<bool>({std::nullopt, true, false});
     assertEqualVectors(expected, result);
   }
 


### PR DESCRIPTION
Summary:
Update behavior of function `escape` to accept empty string as a valid input character. This change should increase function parity with Presto identified by: https://github.com/facebookincubator/velox/issues/12558

Currently Presto's behavior is identified by the following:
```
presto> SELECT c0 like c1 escape c2 from (values (varchar 'N#w&{~>|.v^''%Ed{H^v6/\k::<,pf5-p?g;1MsE$!Y0&9[hks,eHvrTv>H', varchar 'oEP}kS-lLtMzK_9-|Q&p0zA17[]6-"ZeKB&d(3B!I0Wp7Xu%\0xg&dH', varchar '') ) t(c0, c1, c2);
 _col0 
-------
 false 
```
Velox, on the other hand:
```
presto:di> SELECT c0 like c1 escape c2 from (values (varchar 'N#w&{~>|.v^''%Ed{H^v6/\k::<,pf5-p?g;1MsE$!Y0&9[hks,eHvrTv>H', varchar 'oEP}kS-lLtMzK_9-|Q&p0zA17[]6-"ZeKB&d(3B!I0Wp7Xu%\0xg&dH', varchar '') ) t(c0, c1, c2);
Query 20250305_225027_43941_nqej6 failed: escapeChar.size() == 1 (0 vs. 1) Escape string must be a single character Top-level Expression: presto.default.like(field, field_0, field_1)
```

Differential Revision: D71139264


