### PR TITLE
fix: Expand the range of supported years

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -579,6 +579,10 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "1970-01-02 00:00:00.001 +01:01:01.002",
       // No optional separators
       "1970-01-01 00:00:00 -010101001",
+      // Maximum timestamp.
+      "73326-09-11 20:14:45.247",
+      // Minimum timestamp.
+      "-69387-12-31 23:59:59.999",
       std::nullopt,
   };
 
@@ -610,6 +614,8 @@ TEST_F(CastExprTest, stringToTimestamp) {
       Timestamp(3662, 1000000),
       Timestamp(82738, 999000000),
       Timestamp(3661, 1000000),
+      Timestamp(2251799813685, 247000000),
+      Timestamp(-2251777881601, 999000000),
       std::nullopt,
   };
   testCast<std::string, Timestamp>("timestamp", input, expected);
@@ -624,6 +630,10 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "2000-01-01 12:21:56Z",
       "2000-01-01 12:21:56+01:01:01",
       "2045-12-31 18:00:00",
+      // Maximum timestamp.
+      "73326-09-11 13:14:45.247",
+      // Minimum timestamp.
+      "-69387-12-31 16:07:01.999",
       // Test going back and forth across DST boundaries.
       "2024-03-10 09:59:59 -00:00:02",
       "2024-03-10 10:00:01 +00:00:02",
@@ -662,26 +672,48 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "2007-11-04 01:59:00",
       "2007-11-04 02:00:00",
       "2007-11-04 02:01:00"};
-  expected = {Timestamp(28800, 0),        Timestamp(0, 0),
-              Timestamp(-3600, 0),        Timestamp(10800, 0),
-              Timestamp(946729316, 0),    Timestamp(946725655, 0),
-              Timestamp(2398384800, 0),   Timestamp(1710064801, 0),
-              Timestamp(1710064799, 0),   Timestamp(1730624401, 0),
-              Timestamp(1730624399, 0),   Timestamp(4108701601, 0),
-              Timestamp(4108701599, 0),   Timestamp(4129264801, 0),
-              Timestamp(4129264799, 0),   Timestamp(971865511140, 0),
-              Timestamp(971865511200, 0), Timestamp(971865511260, 0),
-              Timestamp(971886070740, 0), Timestamp(971886074400, 0),
-              Timestamp(971886074460, 0), Timestamp(1236506340, 0),
-              Timestamp(1236506400, 0),   Timestamp(1236506460, 0),
-              Timestamp(1257065940, 0),   Timestamp(1257069600, 0),
-              Timestamp(1257069660, 0),   Timestamp(1205056740, 0),
-              Timestamp(1205056800, 0),   Timestamp(1205056860, 0),
-              Timestamp(1225616340, 0),   Timestamp(1225620000, 0),
-              Timestamp(1225620060, 0),   Timestamp(1173607140, 0),
-              Timestamp(1173607200, 0),   Timestamp(1173607260, 0),
-              Timestamp(1194166740, 0),   Timestamp(1194170400, 0),
-              Timestamp(1194170460, 0)};
+  expected = {
+      Timestamp(28800, 0),
+      Timestamp(0, 0),
+      Timestamp(-3600, 0),
+      Timestamp(10800, 0),
+      Timestamp(946729316, 0),
+      Timestamp(946725655, 0),
+      Timestamp(2398384800, 0),
+      Timestamp(2251799813685, 247000000),
+      Timestamp(-2251777881601, 999000000),
+      Timestamp(1710064801, 0),
+      Timestamp(1710064799, 0),
+      Timestamp(1730624401, 0),
+      Timestamp(1730624399, 0),
+      Timestamp(4108701601, 0),
+      Timestamp(4108701599, 0),
+      Timestamp(4129264801, 0),
+      Timestamp(4129264799, 0),
+      Timestamp(971865511140, 0),
+      Timestamp(971865511200, 0),
+      Timestamp(971865511260, 0),
+      Timestamp(971886070740, 0),
+      Timestamp(971886074400, 0),
+      Timestamp(971886074460, 0),
+      Timestamp(1236506340, 0),
+      Timestamp(1236506400, 0),
+      Timestamp(1236506460, 0),
+      Timestamp(1257065940, 0),
+      Timestamp(1257069600, 0),
+      Timestamp(1257069660, 0),
+      Timestamp(1205056740, 0),
+      Timestamp(1205056800, 0),
+      Timestamp(1205056860, 0),
+      Timestamp(1225616340, 0),
+      Timestamp(1225620000, 0),
+      Timestamp(1225620060, 0),
+      Timestamp(1173607140, 0),
+      Timestamp(1173607200, 0),
+      Timestamp(1173607260, 0),
+      Timestamp(1194166740, 0),
+      Timestamp(1194170400, 0),
+      Timestamp(1194170460, 0)};
   testCast<std::string, Timestamp>("timestamp", input, expected);
 
   // Test invalid inputs.
@@ -691,13 +723,10 @@ TEST_F(CastExprTest, stringToTimestamp) {
       "Cannot cast VARCHAR '1970-01-01T00:00' to TIMESTAMP. Unknown timezone value: \"T00:00\"");
   VELOX_ASSERT_THROW(
       (evaluateOnce<Timestamp, std::string>(
-          "cast(c0 as timestamp)", "201915-04-23 11:46:00.000")),
+          "cast(c0 as timestamp)", "292278994-04-23 11:46:00.000")),
       "Timepoint is outside of supported year range");
-  VELOX_ASSERT_THROW(
-      (evaluateOnce<Timestamp, std::string>(
-          "try_cast(c0 as timestamp)", "201915-04-23 11:46:00.000")),
-      "Timepoint is outside of supported year range");
-  // Only one white space is allowed before the offset string.
+  //   Only one white space is allowed before the offset
+  //   string.
   VELOX_ASSERT_THROW(
       (evaluateOnce<Timestamp, std::string>(
           "cast(c0 as timestamp)", "2000-01-01 00:00:00  +01:01:01")),

--- a/velox/external/date/date.h
+++ b/velox/external/date/date.h
@@ -180,16 +180,16 @@ using ratio_divide = decltype(std::ratio_divide<R1, R2>{});
 // durations
 
 using days = std::chrono::duration
-    <int, detail::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
+    <int64_t, detail::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
 
 using weeks = std::chrono::duration
-    <int, detail::ratio_multiply<std::ratio<7>, days::period>>;
+    <int64_t, detail::ratio_multiply<std::ratio<7>, days::period>>;
 
 using years = std::chrono::duration
-    <int, detail::ratio_multiply<std::ratio<146097, 400>, days::period>>;
+    <int64_t, detail::ratio_multiply<std::ratio<146097, 400>, days::period>>;
 
 using months = std::chrono::duration
-    <int, detail::ratio_divide<years::period, std::ratio<12>>>;
+    <int64_t, detail::ratio_divide<years::period, std::ratio<12>>>;
 
 // time_point
 
@@ -263,20 +263,20 @@ CONSTCD11 month_weekday_last operator/(const weekday_last& wdl, int          m) 
 CONSTCD11 year_month_day operator/(const year_month& ym, const day& d) NOEXCEPT;
 CONSTCD11 year_month_day operator/(const year_month& ym, int        d) NOEXCEPT;
 CONSTCD11 year_month_day operator/(const year& y, const month_day& md) NOEXCEPT;
-CONSTCD11 year_month_day operator/(int         y, const month_day& md) NOEXCEPT;
+CONSTCD11 year_month_day operator/(int64_t         y, const month_day& md) NOEXCEPT;
 CONSTCD11 year_month_day operator/(const month_day& md, const year& y) NOEXCEPT;
-CONSTCD11 year_month_day operator/(const month_day& md, int         y) NOEXCEPT;
+CONSTCD11 year_month_day operator/(const month_day& md, int64_t         y) NOEXCEPT;
 
 CONSTCD11
     year_month_day_last operator/(const year_month& ym,   last_spec) NOEXCEPT;
 CONSTCD11
     year_month_day_last operator/(const year& y, const month_day_last& mdl) NOEXCEPT;
 CONSTCD11
-    year_month_day_last operator/(int         y, const month_day_last& mdl) NOEXCEPT;
+    year_month_day_last operator/(int64_t         y, const month_day_last& mdl) NOEXCEPT;
 CONSTCD11
     year_month_day_last operator/(const month_day_last& mdl, const year& y) NOEXCEPT;
 CONSTCD11
-    year_month_day_last operator/(const month_day_last& mdl, int         y) NOEXCEPT;
+    year_month_day_last operator/(const month_day_last& mdl,int64_t         y) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday
@@ -288,7 +288,7 @@ operator/(const year&        y, const month_weekday&   mwd) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday
-operator/(int                y, const month_weekday&   mwd) NOEXCEPT;
+operator/(int64_t                y, const month_weekday&   mwd) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday
@@ -296,7 +296,7 @@ operator/(const month_weekday& mwd, const year&          y) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday
-operator/(const month_weekday& mwd, int                  y) NOEXCEPT;
+operator/(const month_weekday& mwd, int64_t                  y) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday_last
@@ -308,7 +308,7 @@ operator/(const year& y, const month_weekday_last& mwdl) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday_last
-operator/(int         y, const month_weekday_last& mwdl) NOEXCEPT;
+operator/(int64_t         y, const month_weekday_last& mwdl) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday_last
@@ -316,7 +316,7 @@ operator/(const month_weekday_last& mwdl, const year& y) NOEXCEPT;
 
 CONSTCD11
 year_month_weekday_last
-operator/(const month_weekday_last& mwdl, int         y) NOEXCEPT;
+operator/(const month_weekday_last& mwdl, int64_t         y) NOEXCEPT;
 
 // Detailed interface
 
@@ -400,11 +400,11 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const month& m);
 
 class year
 {
-    int y_;
+    int64_t y_;
 
 public:
     year() = default;
-    explicit CONSTCD11 year(int y) NOEXCEPT;
+    explicit CONSTCD11 year(int64_t y) NOEXCEPT;
 
     CONSTCD14 year& operator++()    NOEXCEPT;
     CONSTCD14 year  operator++(int) NOEXCEPT;
@@ -419,11 +419,13 @@ public:
 
     CONSTCD11 bool is_leap() const NOEXCEPT;
 
-    CONSTCD11 explicit operator int() const NOEXCEPT;
+    CONSTCD11 explicit operator int64_t() const NOEXCEPT;
     CONSTCD11 bool ok() const NOEXCEPT;
 
-    static CONSTCD11 year min() NOEXCEPT { return year{-32767}; }
-    static CONSTCD11 year max() NOEXCEPT { return year{32767}; }
+    // Years outside this range will see overflows when converting to
+    // millis since epoch.
+    static CONSTCD11 year min() NOEXCEPT { return year{-292275054}; }
+    static CONSTCD11 year max() NOEXCEPT { return year{292278993}; }
 };
 
 CONSTCD11 bool operator==(const year& x, const year& y) NOEXCEPT;
@@ -461,6 +463,8 @@ public:
     CONSTCD14 weekday& operator+=(const days& d) NOEXCEPT;
     CONSTCD14 weekday& operator-=(const days& d) NOEXCEPT;
 
+    CONSTCD11 explicit operator unsigned() const NOEXCEPT;
+
     CONSTCD11 bool ok() const NOEXCEPT;
 
     CONSTCD11 unsigned c_encoding() const NOEXCEPT;
@@ -470,7 +474,7 @@ public:
     CONSTCD11 weekday_last    operator[](last_spec)      const NOEXCEPT;
 
 private:
-    static CONSTCD14 unsigned char weekday_from_days(int z) NOEXCEPT;
+    static CONSTCD14 unsigned char weekday_from_days(int64_t z) NOEXCEPT;
 
     friend CONSTCD11 bool operator==(const weekday& x, const weekday& y) NOEXCEPT;
     friend CONSTCD14 days operator-(const weekday& x, const weekday& y) NOEXCEPT;
@@ -1606,7 +1610,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const month& m)
 
 // year
 
-CONSTCD11 inline year::year(int y) NOEXCEPT : y_(static_cast<decltype(y_)>(y)) {}
+CONSTCD11 inline year::year(int64_t y) NOEXCEPT : y_(static_cast<decltype(y_)>(y)) {}
 CONSTCD14 inline year& year::operator++() NOEXCEPT {++y_; return *this;}
 CONSTCD14 inline year year::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
 CONSTCD14 inline year& year::operator--() NOEXCEPT {--y_; return *this;}
@@ -1624,14 +1628,14 @@ year::is_leap() const NOEXCEPT
     return y_ % 4 == 0 && (y_ % 100 != 0 || y_ % 400 == 0);
 }
 
-CONSTCD11 inline year::operator int() const NOEXCEPT {return y_;}
+CONSTCD11 inline year::operator int64_t() const NOEXCEPT {return y_;}
 
 CONSTCD11
 inline
 bool
 year::ok() const NOEXCEPT
 {
-    return y_ != std::numeric_limits<short>::min();
+    return y_ >= year::min().y_ && y_ <= year::max().y_;
 }
 
 CONSTCD11
@@ -1639,7 +1643,7 @@ inline
 bool
 operator==(const year& x, const year& y) NOEXCEPT
 {
-    return static_cast<int>(x) == static_cast<int>(y);
+    return static_cast<int64_t>(x) == static_cast<int64_t>(y);
 }
 
 CONSTCD11
@@ -1655,7 +1659,7 @@ inline
 bool
 operator<(const year& x, const year& y) NOEXCEPT
 {
-    return static_cast<int>(x) < static_cast<int>(y);
+    return static_cast<int64_t>(x) < static_cast<int64_t>(y);
 }
 
 CONSTCD11
@@ -1687,7 +1691,7 @@ inline
 years
 operator-(const year& x, const year& y) NOEXCEPT
 {
-    return years{static_cast<int>(x) - static_cast<int>(y)};
+    return years{static_cast<int64_t>(x) - static_cast<int64_t>(y)};
 }
 
 CONSTCD11
@@ -1695,7 +1699,7 @@ inline
 year
 operator+(const year& x, const years& y) NOEXCEPT
 {
-    return year{static_cast<int>(x) + y.count()};
+    return year{static_cast<int64_t>(x) + y.count()};
 }
 
 CONSTCD11
@@ -1711,7 +1715,7 @@ inline
 year
 operator-(const year& x, const years& y) NOEXCEPT
 {
-    return year{static_cast<int>(x) - y.count()};
+    return year{static_cast<int64_t>(x) - y.count()};
 }
 
 template<class CharT, class Traits>
@@ -1724,7 +1728,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
     os.flags(std::ios::dec | std::ios::internal);
     os.width(4 + (y < year{0}));
     os.imbue(std::locale::classic());
-    os << static_cast<int>(y);
+    os << static_cast<int64_t>(y);
     if (!y.ok())
         os << " is not a valid year";
     return os;
@@ -1735,7 +1739,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
 CONSTCD14
 inline
 unsigned char
-weekday::weekday_from_days(int z) NOEXCEPT
+weekday::weekday_from_days(int64_t z) NOEXCEPT
 {
     auto u = static_cast<unsigned>(z);
     return static_cast<unsigned char>(z >= -4 ? (u+4) % 7 : u % 7);
@@ -1780,6 +1784,13 @@ weekday::operator-=(const days& d) NOEXCEPT
 {
     *this = *this - d;
     return *this;
+}
+
+CONSTCD11
+inline
+weekday::operator unsigned() const NOEXCEPT
+{
+    return wd_;
 }
 
 CONSTCD11 inline bool weekday::ok() const NOEXCEPT {return wd_ <= 6;}
@@ -2755,7 +2766,7 @@ year_month_day::to_days() const NOEXCEPT
              "This algorithm has not been ported to a 16 bit unsigned integer");
     static_assert(std::numeric_limits<int>::digits >= 20,
              "This algorithm has not been ported to a 16 bit signed integer");
-    auto const y = static_cast<int>(y_) - (m_ <= February);
+    auto const y = static_cast<int64_t>(y_) - (m_ <= February);
     auto const m = static_cast<unsigned>(m_);
     auto const d = static_cast<unsigned>(d_);
     auto const era = (y >= 0 ? y : y-399) / 400;
@@ -2868,11 +2879,11 @@ year_month_day::from_days(days dp) NOEXCEPT
              "This algorithm has not been ported to a 16 bit unsigned integer");
     static_assert(std::numeric_limits<int>::digits >= 20,
              "This algorithm has not been ported to a 16 bit signed integer");
-    auto const z = dp.count() + 719468L; // For velox, use long to avoid overflow.
+    auto const z =  dp.count() + 719468L; // For velox, use long to avoid overflow.
     auto const era = (z >= 0 ? z : z - 146096) / 146097;
     auto const doe = static_cast<unsigned>(z - era * 146097);          // [0, 146096]
     auto const yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;  // [0, 399]
-    auto const y = static_cast<days::rep>(yoe + era * 400);
+    auto const y = static_cast<int>(yoe + era * 400);
     auto const doy = doe - (365*yoe + yoe/4 - yoe/100);                // [0, 365]
     auto const mp = (5*doy + 2)/153;                                   // [0, 11]
     auto const d = doy - (153*mp+2)/5 + 1;                             // [1, 31]
@@ -4921,7 +4932,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     }
                     tm.tm_mday = static_cast<int>(static_cast<unsigned>(ymd.day()));
                     tm.tm_mon = static_cast<int>(extract_month(os, fds) - 1);
-                    tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                    tm.tm_year = static_cast<int64_t>(ymd.year()) - 1900;
                     tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
                     if (os.fail())
                         return os;
@@ -4977,7 +4988,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                 {
                     if (!fds.ymd.year().ok())
                         os.setstate(std::ios::failbit);
-                    auto y = static_cast<int>(fds.ymd.year());
+                    auto y = static_cast<int64_t>(fds.ymd.year());
 #if !ONLY_C_LOCALE
                     if (modified == CharT{})
 #endif
@@ -5067,7 +5078,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     os.width(2);
                     os << static_cast<unsigned>(ymd.day()) << CharT{'/'};
                     os.width(2);
-                    os << static_cast<int>(ymd.year()) % 100;
+                    os << static_cast<int64_t>(ymd.year()) % 100;
                 }
                 else
                 {
@@ -5092,7 +5103,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     os.fill('0');
                     os.flags(std::ios::dec | std::ios::right);
                     os.width(4);
-                    os << static_cast<int>(ymd.year()) << CharT{'-'};
+                    os << static_cast<int64_t>(ymd.year()) << CharT{'-'};
                     os.width(2);
                     os << static_cast<unsigned>(ymd.month()) << CharT{'-'};
                     os.width(2);
@@ -5130,7 +5141,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                         os.fill('0');
                         os.flags(std::ios::dec | std::ios::right);
                         os.width(2);
-                        os << std::abs(static_cast<int>(y)) % 100;
+                        os << std::abs(static_cast<int64_t>(y)) % 100;
                     }
                 }
                 else
@@ -5550,7 +5561,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         const CharT f[] = {'%', modified, *fmt};
-                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_year = static_cast<int64_t>(ymd.year()) - 1900;
                         tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
                         if (os.fail())
                             return os;
@@ -5598,7 +5609,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     {
                         const CharT f[] = {'%', modified, *fmt};
                         auto const& ymd = fds.ymd;
-                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_year = static_cast<int64_t>(ymd.year()) - 1900;
                         tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
                         if (os.fail())
                             return os;
@@ -5675,7 +5686,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     else if (modified == CharT{'O'})
                     {
                         const CharT f[] = {'%', modified, *fmt};
-                        tm.tm_year = static_cast<int>(ymd.year()) - 1900;
+                        tm.tm_year = static_cast<int64_t>(ymd.year()) - 1900;
                         tm.tm_wday = static_cast<int>(extract_weekday(os, fds));
                         if (os.fail())
                             return os;
@@ -5725,7 +5736,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
             {
                 if (!fds.ymd.year().ok())
                     os.setstate(std::ios::failbit);
-                auto y = static_cast<int>(fds.ymd.year());
+                auto y = static_cast<int64_t>(fds.ymd.year());
 #if !ONLY_C_LOCALE
                 if (modified == CharT{})
                 {
@@ -5771,7 +5782,7 @@ to_stream(std::basic_ostream<CharT, Traits>& os, const CharT* fmt,
                     else if (modified == CharT{'E'})
                     {
                         const CharT f[] = {'%', modified, *fmt};
-                        tm.tm_year = static_cast<int>(y) - 1900;
+                        tm.tm_year = static_cast<int64_t>(y) - 1900;
                         facet.put(os, os, os.fill(), &tm, std::begin(f), std::end(f));
                     }
 #endif
@@ -7454,7 +7465,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                     goto broken;
                 G = tG;
             }
-            if (Y < static_cast<int>(year::min()) || Y > static_cast<int>(year::max()))
+            if (Y < static_cast<int64_t>(year::min()) || Y > static_cast<int64_t>(year::max()))
                 Y = not_a_year;
             bool computed = false;
             if (G != not_a_year && V != not_a_week_num && wd != not_a_weekday)
@@ -7463,7 +7474,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                                            (Monday-Thursday) + weeks{V-1} +
                                            (weekday{static_cast<unsigned>(wd)}-Monday);
                 if (Y == not_a_year)
-                    Y = static_cast<int>(ymd_trial.year());
+                    Y = static_cast<int64_t>(ymd_trial.year());
                 else if (year{Y} != ymd_trial.year())
                     goto broken;
                 if (m == not_a_month)
@@ -7482,7 +7493,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                                            weeks{U-1} +
                                            (weekday{static_cast<unsigned>(wd)} - Sunday);
                 if (Y == not_a_year)
-                    Y = static_cast<int>(ymd_trial.year());
+                    Y = static_cast<int64_t>(ymd_trial.year());
                 else if (year{Y} != ymd_trial.year())
                     goto broken;
                 if (m == not_a_month)
@@ -7501,7 +7512,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                                            weeks{W-1} +
                                            (weekday{static_cast<unsigned>(wd)} - Monday);
                 if (Y == not_a_year)
-                    Y = static_cast<int>(ymd_trial.year());
+                    Y = static_cast<int64_t>(ymd_trial.year());
                 else if (year{Y} != ymd_trial.year())
                     goto broken;
                 if (m == not_a_month)
@@ -7549,7 +7560,7 @@ from_stream(std::basic_istream<CharT, Traits>& is, const CharT* fmt,
                                 start = sys_days((G_trial - years{1})/December/Thursday[last])
                                         + (Monday - Thursday);
                         }
-                        if (G != not_a_year && G != static_cast<int>(G_trial))
+                        if (G != not_a_year && G != static_cast<int64_t>(G_trial))
                             goto broken;
                         if (V != not_a_week_num)
                         {

--- a/velox/external/date/iso_week.h
+++ b/velox/external/date/iso_week.h
@@ -56,9 +56,7 @@ struct last_week
     explicit last_week() = default;
 };
 
-class weekday;
 class weeknum;
-class year;
 
 class year_weeknum;
 class year_lastweek;
@@ -94,90 +92,6 @@ CONSTCD11 year_lastweek_weekday operator/(const year_lastweek& ylw, int         
 
 CONSTCD11 year_lastweek_weekday operator/(const lastweek_weekday& lwwd, const year& y) NOEXCEPT;
 CONSTCD11 year_lastweek_weekday operator/(const lastweek_weekday& lwwd, int         y) NOEXCEPT;
-
-// weekday
-
-class weekday
-{
-    unsigned char wd_;
-public:
-    explicit CONSTCD11 weekday(unsigned wd) NOEXCEPT;
-    CONSTCD11 weekday(date::weekday wd) NOEXCEPT;
-    explicit weekday(int) = delete;
-    CONSTCD11 weekday(const sys_days& dp) NOEXCEPT;
-    CONSTCD11 explicit weekday(const local_days& dp) NOEXCEPT;
-
-    weekday& operator++()    NOEXCEPT;
-    weekday  operator++(int) NOEXCEPT;
-    weekday& operator--()    NOEXCEPT;
-    weekday  operator--(int) NOEXCEPT;
-
-    weekday& operator+=(const days& d) NOEXCEPT;
-    weekday& operator-=(const days& d) NOEXCEPT;
-
-    CONSTCD11 explicit operator unsigned() const NOEXCEPT;
-    CONSTCD11 operator date::weekday() const NOEXCEPT;
-    CONSTCD11 bool ok() const NOEXCEPT;
-
-private:
-    static CONSTCD11 unsigned char weekday_from_days(int z) NOEXCEPT;
-    static CONSTCD11 unsigned char to_iso_encoding(unsigned char) NOEXCEPT;
-    static CONSTCD11 unsigned from_iso_encoding(unsigned) NOEXCEPT;
-};
-
-CONSTCD11 bool operator==(const weekday& x, const weekday& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const weekday& x, const weekday& y) NOEXCEPT;
-
-CONSTCD14 weekday operator+(const weekday& x, const days&    y) NOEXCEPT;
-CONSTCD14 weekday operator+(const days&    x, const weekday& y) NOEXCEPT;
-CONSTCD14 weekday operator-(const weekday& x, const days&    y) NOEXCEPT;
-CONSTCD14 days    operator-(const weekday& x, const weekday& y) NOEXCEPT;
-
-template<class CharT, class Traits>
-std::basic_ostream<CharT, Traits>&
-operator<<(std::basic_ostream<CharT, Traits>& os, const weekday& wd);
-
-// year
-
-class year
-{
-    short y_;
-
-public:
-    explicit CONSTCD11 year(int y) NOEXCEPT;
-
-    year& operator++()    NOEXCEPT;
-    year  operator++(int) NOEXCEPT;
-    year& operator--()    NOEXCEPT;
-    year  operator--(int) NOEXCEPT;
-
-    year& operator+=(const years& y) NOEXCEPT;
-    year& operator-=(const years& y) NOEXCEPT;
-
-    CONSTCD14 bool is_leap() const NOEXCEPT;
-
-    CONSTCD11 explicit operator int() const NOEXCEPT;
-    CONSTCD11 bool ok() const NOEXCEPT;
-
-    static CONSTCD11 year min() NOEXCEPT;
-    static CONSTCD11 year max() NOEXCEPT;
-};
-
-CONSTCD11 bool operator==(const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator!=(const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator< (const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator> (const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator<=(const year& x, const year& y) NOEXCEPT;
-CONSTCD11 bool operator>=(const year& x, const year& y) NOEXCEPT;
-
-CONSTCD11 year  operator+(const year&  x, const years& y) NOEXCEPT;
-CONSTCD11 year  operator+(const years& x, const year&  y) NOEXCEPT;
-CONSTCD11 year  operator-(const year&  x, const years& y) NOEXCEPT;
-CONSTCD11 years operator-(const year&  x, const year&  y) NOEXCEPT;
-
-template<class CharT, class Traits>
-std::basic_ostream<CharT, Traits>&
-operator<<(std::basic_ostream<CharT, Traits>& os, const year& y);
 
 // weeknum
 
@@ -220,13 +134,13 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const weeknum& wn);
 
 class year_weeknum
 {
-    iso_week::year    y_;
+    date::year    y_;
     iso_week::weeknum wn_;
 
 public:
-    CONSTCD11 year_weeknum(const iso_week::year& y, const iso_week::weeknum& wn) NOEXCEPT;
+    CONSTCD11 year_weeknum(const date::year& y, const iso_week::weeknum& wn) NOEXCEPT;
 
-    CONSTCD11 iso_week::year    year()    const NOEXCEPT;
+    CONSTCD11 date::year    year()    const NOEXCEPT;
     CONSTCD11 iso_week::weeknum weeknum() const NOEXCEPT;
 
     year_weeknum& operator+=(const years& dy) NOEXCEPT;
@@ -254,12 +168,12 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_weeknum& ym);
 
 class year_lastweek
 {
-    iso_week::year    y_;
+    date::year    y_;
 
 public:
-    CONSTCD11 explicit year_lastweek(const iso_week::year& y) NOEXCEPT;
+    CONSTCD11 explicit year_lastweek(const date::year& y) NOEXCEPT;
 
-    CONSTCD11 iso_week::year    year()    const NOEXCEPT;
+    CONSTCD11 date::year    year()    const NOEXCEPT;
     CONSTCD14 iso_week::weeknum weeknum() const NOEXCEPT;
 
     year_lastweek& operator+=(const years& dy) NOEXCEPT;
@@ -288,14 +202,14 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_lastweek& ym);
 class weeknum_weekday
 {
     iso_week::weeknum wn_;
-    iso_week::weekday wd_;
+    date::weekday wd_;
 
 public:
     CONSTCD11 weeknum_weekday(const iso_week::weeknum& wn,
-                              const iso_week::weekday& wd) NOEXCEPT;
+                              const date::weekday& wd) NOEXCEPT;
 
     CONSTCD11 iso_week::weeknum weeknum() const NOEXCEPT;
-    CONSTCD11 iso_week::weekday weekday() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
 
     CONSTCD14 bool ok() const NOEXCEPT;
 };
@@ -315,12 +229,12 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const weeknum_weekday& md);
 
 class lastweek_weekday
 {
-    iso_week::weekday wd_;
+    date::weekday wd_;
 
 public:
-    CONSTCD11 explicit lastweek_weekday(const iso_week::weekday& wd) NOEXCEPT;
+    CONSTCD11 explicit lastweek_weekday(const date::weekday& wd) NOEXCEPT;
 
-    CONSTCD11 iso_week::weekday weekday() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
 
     CONSTCD14 bool ok() const NOEXCEPT;
 };
@@ -340,19 +254,19 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const lastweek_weekday& md);
 
 class year_lastweek_weekday
 {
-    iso_week::year    y_;
-    iso_week::weekday wd_;
+    date::year    y_;
+    date::weekday wd_;
 
 public:
-    CONSTCD11 year_lastweek_weekday(const iso_week::year& y,
-                                    const iso_week::weekday& wd) NOEXCEPT;
+    CONSTCD11 year_lastweek_weekday(const date::year& y,
+                                    const date::weekday& wd) NOEXCEPT;
 
     year_lastweek_weekday& operator+=(const years& y) NOEXCEPT;
     year_lastweek_weekday& operator-=(const years& y) NOEXCEPT;
 
-    CONSTCD11 iso_week::year    year()    const NOEXCEPT;
+    CONSTCD11 date::year    year()    const NOEXCEPT;
     CONSTCD14 iso_week::weeknum weeknum() const NOEXCEPT;
-    CONSTCD11 iso_week::weekday weekday() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
 
     CONSTCD14 operator sys_days() const NOEXCEPT;
     CONSTCD14 explicit operator local_days() const NOEXCEPT;
@@ -378,13 +292,13 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_lastweek_weekday& y
 
 class year_weeknum_weekday
 {
-    iso_week::year    y_;
+    date::year    y_;
     iso_week::weeknum wn_;
-    iso_week::weekday wd_;
+    date::weekday wd_;
 
 public:
-    CONSTCD11 year_weeknum_weekday(const iso_week::year& y, const iso_week::weeknum& wn,
-                                   const iso_week::weekday& wd) NOEXCEPT;
+    CONSTCD11 year_weeknum_weekday(const date::year& y, const iso_week::weeknum& wn,
+                                   const date::weekday& wd) NOEXCEPT;
     CONSTCD14 year_weeknum_weekday(const year_lastweek_weekday& ylwwd) NOEXCEPT;
     CONSTCD14 year_weeknum_weekday(const sys_days& dp) NOEXCEPT;
     CONSTCD14 explicit year_weeknum_weekday(const local_days& dp) NOEXCEPT;
@@ -392,9 +306,9 @@ public:
     year_weeknum_weekday& operator+=(const years& y) NOEXCEPT;
     year_weeknum_weekday& operator-=(const years& y) NOEXCEPT;
 
-    CONSTCD11 iso_week::year    year()    const NOEXCEPT;
+    CONSTCD11 date::year    year()    const NOEXCEPT;
     CONSTCD11 iso_week::weeknum weeknum() const NOEXCEPT;
-    CONSTCD11 iso_week::weekday weekday() const NOEXCEPT;
+    CONSTCD11 date::weekday weekday() const NOEXCEPT;
 
     CONSTCD14 operator sys_days() const NOEXCEPT;
     CONSTCD14 explicit operator local_days() const NOEXCEPT;
@@ -422,340 +336,16 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_weeknum_weekday& yw
 //----------------+
 // Implementation |
 //----------------+
-
-// weekday
-
-CONSTCD11
-inline
-unsigned char
-weekday::to_iso_encoding(unsigned char z) NOEXCEPT
-{
-    return z != 0 ? z : (unsigned char)7;
-}
-
-CONSTCD11
-inline
-unsigned
-weekday::from_iso_encoding(unsigned z) NOEXCEPT
-{
-    return z != 7 ? z : 0u;
-}
-
-CONSTCD11
-inline
-unsigned char
-weekday::weekday_from_days(int z) NOEXCEPT
-{
-    return to_iso_encoding(static_cast<unsigned char>(static_cast<unsigned>(
-        z >= -4 ? (z+4) % 7 : (z+5) % 7 + 6)));
-}
-
-CONSTCD11
-inline
-weekday::weekday(unsigned wd) NOEXCEPT
-    : wd_(static_cast<decltype(wd_)>(wd))
-    {}
-
-CONSTCD11
-inline
-weekday::weekday(date::weekday wd) NOEXCEPT
-    : wd_(wd.iso_encoding())
-    {}
-
-CONSTCD11
-inline
-weekday::weekday(const sys_days& dp) NOEXCEPT
-    : wd_(weekday_from_days(dp.time_since_epoch().count()))
-    {}
-
-CONSTCD11
-inline
-weekday::weekday(const local_days& dp) NOEXCEPT
-    : wd_(weekday_from_days(dp.time_since_epoch().count()))
-    {}
-
-inline weekday& weekday::operator++() NOEXCEPT {if (++wd_ == 8) wd_ = 1; return *this;}
-inline weekday weekday::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
-inline weekday& weekday::operator--() NOEXCEPT {if (wd_-- == 1) wd_ = 7; return *this;}
-inline weekday weekday::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
-
-inline
-weekday&
-weekday::operator+=(const days& d) NOEXCEPT
-{
-    *this = *this + d;
-    return *this;
-}
-
-inline
-weekday&
-weekday::operator-=(const days& d) NOEXCEPT
-{
-    *this = *this - d;
-    return *this;
-}
-
-CONSTCD11
-inline
-weekday::operator unsigned() const NOEXCEPT
-{
-    return wd_;
-}
-
-CONSTCD11
-inline
-weekday::operator date::weekday() const NOEXCEPT
-{
-    return date::weekday{from_iso_encoding(unsigned{wd_})};
-}
-
-CONSTCD11 inline bool weekday::ok() const NOEXCEPT {return 1 <= wd_ && wd_ <= 7;}
-
-CONSTCD11
-inline
-bool
-operator==(const weekday& x, const weekday& y) NOEXCEPT
-{
-    return static_cast<unsigned>(x) == static_cast<unsigned>(y);
-}
-
-CONSTCD11
-inline
-bool
-operator!=(const weekday& x, const weekday& y) NOEXCEPT
-{
-    return !(x == y);
-}
-
-CONSTCD14
-inline
-days
-operator-(const weekday& x, const weekday& y) NOEXCEPT
-{
-    auto const diff = static_cast<unsigned>(x) - static_cast<unsigned>(y);
-    return days{diff <= 6 ? diff : diff + 7};
-}
-
-CONSTCD14
-inline
-weekday
-operator+(const weekday& x, const days& y) NOEXCEPT
-{
-    auto const wdu = static_cast<long long>(static_cast<unsigned>(x) - 1u) + y.count();
-    auto const wk = (wdu >= 0 ? wdu : wdu-6) / 7;
-    return weekday{static_cast<unsigned>(wdu - wk * 7) + 1u};
-}
-
-CONSTCD14
-inline
-weekday
-operator+(const days& x, const weekday& y) NOEXCEPT
-{
-    return y + x;
-}
-
-CONSTCD14
-inline
-weekday
-operator-(const weekday& x, const days& y) NOEXCEPT
-{
-    return x + -y;
-}
-
-template<class CharT, class Traits>
-inline
-std::basic_ostream<CharT, Traits>&
-operator<<(std::basic_ostream<CharT, Traits>& os, const weekday& wd)
-{
-    switch (static_cast<unsigned>(wd))
-    {
-    case 7:
-        os << "Sun";
-        break;
-    case 1:
-        os << "Mon";
-        break;
-    case 2:
-        os << "Tue";
-        break;
-    case 3:
-        os << "Wed";
-        break;
-    case 4:
-        os << "Thu";
-        break;
-    case 5:
-        os << "Fri";
-        break;
-    case 6:
-        os << "Sat";
-        break;
-    default:
-        os << static_cast<unsigned>(wd) << " is not a valid weekday";
-        break;
-    }
-    return os;
-}
-
-// year
-
-CONSTCD11 inline year::year(int y) NOEXCEPT : y_(static_cast<decltype(y_)>(y)) {}
-inline year& year::operator++() NOEXCEPT {++y_; return *this;}
-inline year year::operator++(int) NOEXCEPT {auto tmp(*this); ++(*this); return tmp;}
-inline year& year::operator--() NOEXCEPT {--y_; return *this;}
-inline year year::operator--(int) NOEXCEPT {auto tmp(*this); --(*this); return tmp;}
-inline year& year::operator+=(const years& y) NOEXCEPT {*this = *this + y; return *this;}
-inline year& year::operator-=(const years& y) NOEXCEPT {*this = *this - y; return *this;}
-
-CONSTCD14
-inline
-bool
-year::is_leap() const NOEXCEPT
-{
-    const auto y = date::year{static_cast<int>(y_)};
-    const auto s0 = sys_days((y-years{1})/12/date::thu[date::last]);
-    const auto s1 = sys_days(y/12/date::thu[date::last]);
-    return s1-s0 != days{7*52};
-}
-
-CONSTCD11 inline year::operator int() const NOEXCEPT {return y_;}
-CONSTCD11 inline bool year::ok() const NOEXCEPT {return min() <= *this && *this <= max();}
-
-CONSTCD11
-inline
-year
-year::min() NOEXCEPT
-{
-    using std::chrono::seconds;
-    using std::chrono::minutes;
-    using std::chrono::hours;
-    using std::chrono::duration_cast;
-    static_assert(sizeof(seconds)*CHAR_BIT >= 41, "seconds may overflow");
-    static_assert(sizeof(hours)*CHAR_BIT >= 30, "hours may overflow");
-    return sizeof(minutes)*CHAR_BIT < 34 ?
-        year{1970} + duration_cast<years>(minutes::min()) :
-        year{std::numeric_limits<short>::min()};
-}
-
-CONSTCD11
-inline
-year
-year::max() NOEXCEPT
-{
-    using std::chrono::seconds;
-    using std::chrono::minutes;
-    using std::chrono::hours;
-    using std::chrono::duration_cast;
-    static_assert(sizeof(seconds)*CHAR_BIT >= 41, "seconds may overflow");
-    static_assert(sizeof(hours)*CHAR_BIT >= 30, "hours may overflow");
-    return sizeof(minutes)*CHAR_BIT < 34 ?
-        year{1969} + duration_cast<years>(minutes::max()) :
-        year{std::numeric_limits<short>::max()};
-}
-
-CONSTCD11
-inline
-bool
-operator==(const year& x, const year& y) NOEXCEPT
-{
-    return static_cast<int>(x) == static_cast<int>(y);
-}
-
-CONSTCD11
-inline
-bool
-operator!=(const year& x, const year& y) NOEXCEPT
-{
-    return !(x == y);
-}
-
-CONSTCD11
-inline
-bool
-operator<(const year& x, const year& y) NOEXCEPT
-{
-    return static_cast<int>(x) < static_cast<int>(y);
-}
-
-CONSTCD11
-inline
-bool
-operator>(const year& x, const year& y) NOEXCEPT
-{
-    return y < x;
-}
-
-CONSTCD11
-inline
-bool
-operator<=(const year& x, const year& y) NOEXCEPT
-{
-    return !(y < x);
-}
-
-CONSTCD11
-inline
-bool
-operator>=(const year& x, const year& y) NOEXCEPT
-{
-    return !(x < y);
-}
-
-CONSTCD11
-inline
-years
-operator-(const year& x, const year& y) NOEXCEPT
-{
-    return years{static_cast<int>(x) - static_cast<int>(y)};
-}
-
-CONSTCD11
-inline
-year
-operator+(const year& x, const years& y) NOEXCEPT
-{
-    return year{static_cast<int>(x) + y.count()};
-}
-
-CONSTCD11
-inline
-year
-operator+(const years& x, const year& y) NOEXCEPT
-{
-    return y + x;
-}
-
-CONSTCD11
-inline
-year
-operator-(const year& x, const years& y) NOEXCEPT
-{
-    return year{static_cast<int>(x) - y.count()};
-}
-
-template<class CharT, class Traits>
-inline
-std::basic_ostream<CharT, Traits>&
-operator<<(std::basic_ostream<CharT, Traits>& os, const year& y)
-{
-    date::detail::save_ostream<CharT, Traits> _(os);
-    os.fill('0');
-    os.flags(std::ios::dec | std::ios::internal);
-    os.width(4 + (y < year{0}));
-    os << static_cast<int>(y);
-    return os;
-}
-
 #if !defined(_MSC_VER) || (_MSC_VER >= 1900)
 inline namespace literals
 {
 
 CONSTCD11
 inline
-iso_week::year
+date::year
 operator "" _y(unsigned long long y) NOEXCEPT
 {
-    return iso_week::year(static_cast<int>(y));
+    return date::year(static_cast<int64_t>(y));
 }
 
 CONSTCD11
@@ -770,13 +360,13 @@ operator "" _w(unsigned long long wn) NOEXCEPT
 
 CONSTDATA iso_week::last_week last{};
 
-CONSTDATA iso_week::weekday sun{7u};
-CONSTDATA iso_week::weekday mon{1u};
-CONSTDATA iso_week::weekday tue{2u};
-CONSTDATA iso_week::weekday wed{3u};
-CONSTDATA iso_week::weekday thu{4u};
-CONSTDATA iso_week::weekday fri{5u};
-CONSTDATA iso_week::weekday sat{6u};
+CONSTDATA date::weekday sun{7u};
+CONSTDATA date::weekday mon{1u};
+CONSTDATA date::weekday tue{2u};
+CONSTDATA date::weekday wed{3u};
+CONSTDATA date::weekday thu{4u};
+CONSTDATA date::weekday fri{5u};
+CONSTDATA date::weekday sat{6u};
 
 #if !defined(_MSC_VER) || (_MSC_VER >= 1900)
 }  // inline namespace literals
@@ -913,7 +503,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const weeknum& wn)
 
 CONSTCD11
 inline
-year_weeknum::year_weeknum(const iso_week::year& y, const iso_week::weeknum& wn) NOEXCEPT
+year_weeknum::year_weeknum(const date::year& y, const iso_week::weeknum& wn) NOEXCEPT
     : y_(y)
     , wn_(wn)
     {}
@@ -1028,7 +618,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_weeknum& ywn)
 
 CONSTCD11
 inline
-year_lastweek::year_lastweek(const iso_week::year& y) NOEXCEPT
+year_lastweek::year_lastweek(const date::year& y) NOEXCEPT
     : y_(y)
     {}
 
@@ -1145,7 +735,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_lastweek& ywn)
 CONSTCD11
 inline
 weeknum_weekday::weeknum_weekday(const iso_week::weeknum& wn,
-                                 const iso_week::weekday& wd) NOEXCEPT
+                                 const date::weekday& wd) NOEXCEPT
     : wn_(wn)
     , wd_(wd)
     {}
@@ -1223,7 +813,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const weeknum_weekday& md)
 
 CONSTCD11
 inline
-lastweek_weekday::lastweek_weekday(const iso_week::weekday& wd) NOEXCEPT
+lastweek_weekday::lastweek_weekday(const date::weekday& wd) NOEXCEPT
     : wd_(wd)
     {}
 
@@ -1297,8 +887,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const lastweek_weekday& md)
 
 CONSTCD11
 inline
-year_lastweek_weekday::year_lastweek_weekday(const iso_week::year& y,
-                                             const iso_week::weekday& wd) NOEXCEPT
+year_lastweek_weekday::year_lastweek_weekday(const date::year& y,
+                                             const date::weekday& wd) NOEXCEPT
     : y_(y)
     , wd_(wd)
     {}
@@ -1335,7 +925,7 @@ CONSTCD14
 inline
 year_lastweek_weekday::operator sys_days() const NOEXCEPT
 {
-    return sys_days(date::year{static_cast<int>(y_)}/date::dec/date::thu[date::last])
+    return sys_days(date::year{static_cast<int64_t>(y_)}/date::dec/date::thu[date::last])
          + (sun - thu) - (sun - wd_);
 }
 
@@ -1343,7 +933,7 @@ CONSTCD14
 inline
 year_lastweek_weekday::operator local_days() const NOEXCEPT
 {
-    return local_days(date::year{static_cast<int>(y_)}/date::dec/date::thu[date::last])
+    return local_days(date::year{static_cast<int64_t>(y_)}/date::dec/date::thu[date::last])
          + (sun - thu) - (sun - wd_);
 }
 
@@ -1441,9 +1031,9 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_lastweek_weekday& y
 
 CONSTCD11
 inline
-year_weeknum_weekday::year_weeknum_weekday(const iso_week::year& y,
+year_weeknum_weekday::year_weeknum_weekday(const date::year& y,
                                            const iso_week::weeknum& wn,
-                                           const iso_week::weekday& wd) NOEXCEPT
+                                           const date::weekday& wd) NOEXCEPT
     : y_(y)
     , wn_(wn)
     , wd_(wd)
@@ -1493,7 +1083,7 @@ CONSTCD14
 inline
 year_weeknum_weekday::operator sys_days() const NOEXCEPT
 {
-    return sys_days(date::year{static_cast<int>(y_)-1}/date::dec/date::thu[date::last])
+    return sys_days(date::year{static_cast<int64_t>(y_)-1}/date::dec/date::thu[date::last])
          + (date::mon - date::thu) + weeks{static_cast<unsigned>(wn_)-1} + (wd_ - mon);
 }
 
@@ -1501,7 +1091,7 @@ CONSTCD14
 inline
 year_weeknum_weekday::operator local_days() const NOEXCEPT
 {
-    return local_days(date::year{static_cast<int>(y_)-1}/date::dec/date::thu[date::last])
+    return local_days(date::year{static_cast<int64_t>(y_)-1}/date::dec/date::thu[date::last])
          + (date::mon - date::thu) + weeks{static_cast<unsigned>(wn_)-1} + (wd_ - mon);
 }
 
@@ -1519,7 +1109,7 @@ year_weeknum_weekday
 year_weeknum_weekday::from_days(days d) NOEXCEPT
 {
     const auto dp = sys_days{d};
-    const auto wd = iso_week::weekday{dp};
+    const auto wd = date::weekday{dp};
     auto y = date::year_month_day{dp + days{3}}.year();
     auto start = sys_days((y - date::years{1})/date::dec/date::thu[date::last]) + (mon-thu);
     if (dp < start)
@@ -1529,7 +1119,7 @@ year_weeknum_weekday::from_days(days d) NOEXCEPT
     }
     const auto wn = iso_week::weeknum(
                        static_cast<unsigned>(date::trunc<weeks>(dp - start).count() + 1));
-    return {iso_week::year(static_cast<int>(y)), wn, wd};
+    return {date::year(static_cast<int64_t>(y)), wn, wd};
 }
 
 CONSTCD11

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -343,7 +343,7 @@ static void __matches(std::istream& __input, std::string_view __expected) {
     __input.get();
 
   int64_t __result = __parse_integral(__input, true);
-  if (__result > static_cast<int>(date::year::max())) {
+  if (__result > static_cast<int64_t>(date::year::max())) {
     if (__negative)
       std::__throw_runtime_error(
           "corrupt tzdb year: year is less than the minimum");

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1178,8 +1178,8 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         size += 2;
         break;
       case DateTimeFormatSpecifier::YEAR_OF_ERA:
-        // Timestamp is in [-32767-01-01, 32767-12-31] range.
-        size += std::max((int)token.pattern.minRepresentDigits, 6);
+        // Timestamp is in [-292275054-01-01, 292278993-12-31] range.
+        size += std::max((int)token.pattern.minRepresentDigits, 9);
         break;
       case DateTimeFormatSpecifier::DAY_OF_WEEK_0_BASED:
       case DateTimeFormatSpecifier::DAY_OF_WEEK_1_BASED:
@@ -1193,12 +1193,14 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         break;
       case DateTimeFormatSpecifier::WEEK_YEAR:
       case DateTimeFormatSpecifier::YEAR:
-        // Timestamp is in [-32767-01-01, 32767-12-31] range.
+        // Timestamp is in [-292275054-01-01, 292278993-12-31] range.
         size += token.pattern.minRepresentDigits == 2
             ? 2
-            : std::max((int)token.pattern.minRepresentDigits, 6);
+            : std::max((int)token.pattern.minRepresentDigits, 10);
         break;
       case DateTimeFormatSpecifier::CENTURY_OF_ERA:
+        size += std::max((int)token.pattern.minRepresentDigits, 8);
+        break;
       case DateTimeFormatSpecifier::DAY_OF_YEAR:
         size += std::max((int)token.pattern.minRepresentDigits, 3);
         break;
@@ -1239,11 +1241,6 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
           // 'ZZ' means output the time zone offset with a colon.
           size += 9;
         } else {
-          // 'ZZZ' (or more) means otuput the time zone ID.
-          if (timezone == nullptr) {
-            VELOX_USER_FAIL("Timezone unknown");
-          }
-
           // The longest time zone ID is 32, America/Argentina/ComodRivadavia.
           size += 32;
         }
@@ -1289,12 +1286,12 @@ int32_t DateTimeFormatter::format(
       switch (token.pattern.specifier) {
         case DateTimeFormatSpecifier::ERA: {
           const std::string_view piece =
-              static_cast<signed>(calDate.year()) > 0 ? "AD" : "BC";
+              static_cast<int64_t>(calDate.year()) > 0 ? "AD" : "BC";
           std::memcpy(result, piece.data(), piece.length());
           result += piece.length();
         } break;
         case DateTimeFormatSpecifier::CENTURY_OF_ERA: {
-          auto year = static_cast<signed>(calDate.year());
+          auto year = static_cast<int64_t>(calDate.year());
           year = (year < 0 ? -year : year);
           auto century = year / 100;
           result += padContent(
@@ -1306,7 +1303,7 @@ int32_t DateTimeFormatter::format(
         } break;
 
         case DateTimeFormatSpecifier::YEAR_OF_ERA: {
-          auto year = static_cast<signed>(calDate.year());
+          auto year = static_cast<int64_t>(calDate.year());
           if (token.pattern.minRepresentDigits == 2) {
             result +=
                 padContent(std::abs(year) % 100, '0', 2, maxResultEnd, result);
@@ -1351,10 +1348,10 @@ int32_t DateTimeFormatter::format(
 
         case DateTimeFormatSpecifier::WEEK_YEAR:
         case DateTimeFormatSpecifier::YEAR: {
-          auto year = static_cast<signed>(calDate.year());
+          auto year = static_cast<int64_t>(calDate.year());
           if (token.pattern.specifier == DateTimeFormatSpecifier::WEEK_YEAR) {
             const auto isoWeek = date::iso_week::year_weeknum_weekday{calDate};
-            year = isoWeek.year().ok() ? static_cast<signed>(isoWeek.year())
+            year = isoWeek.year().ok() ? static_cast<int64_t>(isoWeek.year())
                                        : year;
           }
           if (token.pattern.minRepresentDigits == 2) {
@@ -1504,6 +1501,10 @@ int32_t DateTimeFormatter::format(
             std::memcpy(result, zeroOffsetText->data(), zeroOffsetText->size());
             result += zeroOffsetText->size();
             break;
+          }
+
+          if (timezone == nullptr) {
+            VELOX_USER_FAIL("Timezone unknown");
           }
 
           if (token.pattern.minRepresentDigits >= 3) {

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1331,20 +1331,20 @@ TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
   auto* timezone = tz::locateZone("GMT");
 
   EXPECT_EQ(
-      getJodaDateTimeFormatter("yyyy-MM-dd")->maxResultSize(timezone), 12);
-  EXPECT_EQ(getJodaDateTimeFormatter("yyyy-MM")->maxResultSize(timezone), 9);
-  EXPECT_EQ(getJodaDateTimeFormatter("y")->maxResultSize(timezone), 6);
+      getJodaDateTimeFormatter("yyyy-MM-dd")->maxResultSize(timezone), 16);
+  EXPECT_EQ(getJodaDateTimeFormatter("yyyy-MM")->maxResultSize(timezone), 13);
+  EXPECT_EQ(getJodaDateTimeFormatter("y")->maxResultSize(timezone), 10);
   EXPECT_EQ(
       getJodaDateTimeFormatter("yyyy////MM////dd")->maxResultSize(timezone),
-      18);
+      22);
   EXPECT_EQ(
       getJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS")
           ->maxResultSize(timezone),
-      31);
-  // No padding. CENTURY_OF_ERA can be at most 3 digits.
-  EXPECT_EQ(getJodaDateTimeFormatter("C")->maxResultSize(timezone), 3);
-  // Needs to pad to make result contain 4 digits.
-  EXPECT_EQ(getJodaDateTimeFormatter("CCCC")->maxResultSize(timezone), 4);
+      35);
+  // No padding. CENTURY_OF_ERA can be at most 8 digits.
+  EXPECT_EQ(getJodaDateTimeFormatter("C")->maxResultSize(timezone), 8);
+  // Needs to pad to make result contain 9 digits.
+  EXPECT_EQ(getJodaDateTimeFormatter("CCCCCCCCC")->maxResultSize(timezone), 9);
 }
 
 TEST_F(JodaDateTimeFormatterTest, betterErrorMessaging) {
@@ -1460,11 +1460,13 @@ TEST_F(MysqlDateTimeTest, formatYear) {
       formatMysqlDateTime("%Y", fromTimestampString("-1-01-01"), timezone),
       "-0001");
   EXPECT_THROW(
-      formatMysqlDateTime("%Y", fromTimestampString("-99999-01-01"), timezone),
-      VeloxRuntimeError);
+      formatMysqlDateTime(
+          "%Y", fromTimestampString("-292275056-01-01"), timezone),
+      VeloxUserError);
   EXPECT_THROW(
-      formatMysqlDateTime("%Y", fromTimestampString("99999-01-01"), timezone),
-      VeloxRuntimeError);
+      formatMysqlDateTime(
+          "%Y", fromTimestampString("292278995-01-01"), timezone),
+      VeloxUserError);
 }
 
 TEST_F(MysqlDateTimeTest, formatMonthDay) {

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -389,7 +389,8 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
       static_cast<unsigned>(toCalLastYearMonthDay.day());
 
   if (unit == DateTimeUnit::kMonth || unit == DateTimeUnit::kQuarter) {
-    int64_t diff = (int(toCalDate.year()) - int(fromCalDate.year())) * 12 +
+    int64_t diff =
+        (int64_t(toCalDate.year()) - int64_t(fromCalDate.year())) * 12 +
         int(toMonth) - int(fromMonth);
 
     if ((toDay != toLastYearMonthDay && fromDay > toDay) ||

--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -389,12 +389,8 @@ TEST_F(ArrayDistinctTest, timestampWithTimezone) {
   testArrayDistinct({}, {});
   testArrayDistinct({pack(0, 0)}, {pack(0, 0)});
   testArrayDistinct({pack(1, 0)}, {pack(1, 0)});
-  testArrayDistinct(
-      {pack(std::numeric_limits<int64_t>::min(), 0)},
-      {pack(std::numeric_limits<int64_t>::min(), 0)});
-  testArrayDistinct(
-      {pack(std::numeric_limits<int64_t>::max(), 0)},
-      {pack(std::numeric_limits<int64_t>::max(), 0)});
+  testArrayDistinct({pack(kMinMillisUtc, 0)}, {pack(kMinMillisUtc, 0)});
+  testArrayDistinct({pack(kMaxMillisUtc, 0)}, {pack(kMaxMillisUtc, 0)});
   testArrayDistinct({std::nullopt}, {std::nullopt});
   testArrayDistinct({pack(-1, 0)}, {pack(-1, 0)});
   testArrayDistinct(

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
@@ -40,6 +40,6 @@ variant TimestampWithTimeZoneInputGenerator::generate() {
   int16_t timeZoneId =
       timeZoneIds_[rand<size_t>(rng_, 0, timeZoneIds_.size() - 1)];
 
-  return pack(rand<int64_t>(rng_), timeZoneId);
+  return pack(rand<int64_t>(rng_, kMinMillisUtc, kMaxMillisUtc), timeZoneId);
 }
 } // namespace facebook::velox::fuzzer

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -337,12 +337,10 @@ TEST_F(DateTimeFunctionsTest, unixTimestampDateInput) {
   EXPECT_EQ(1727766000, unixTimestamp(parseDate("2024-10-01")));
   EXPECT_EQ(-126065866022, unixTimestamp(parseDate("-2025-02-18")));
   EXPECT_EQ(2398320000, unixTimestamp(parseDate("2045-12-31")));
-
-  // Test invalid inputs.
-  VELOX_ASSERT_THROW(
-      unixTimestamp(kMax), "Timepoint is outside of supported year range");
-  VELOX_ASSERT_THROW(
-      unixTimestamp(kMin), "Timepoint is outside of supported year range");
+  EXPECT_EQ(
+      185542587126000, unixTimestamp(std::numeric_limits<int32_t>::max()));
+  EXPECT_EQ(
+      -185542587158822, unixTimestamp(std::numeric_limits<int32_t>::min()));
 }
 
 // unix_timestamp and to_unix_timestamp are aliases.

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -382,20 +382,6 @@ TEST(TimestampTest, decreaseOperator) {
   VELOX_ASSERT_THROW(--kMin, "Timestamp nanos out of range");
 }
 
-TEST(TimestampTest, outOfRange) {
-  // external/date cannot handle years larger than 32k (date::year::max()).
-  // Any conversions exceeding that threshold will fail right away.
-  auto* timezone = tz::locateZone("GMT");
-  Timestamp t1(-3217830796800, 0);
-
-  std::string expected = "Timepoint is outside of supported year range";
-  VELOX_ASSERT_THROW(t1.toTimePointMs(), expected);
-  VELOX_ASSERT_THROW(t1.toTimezone(*timezone), expected);
-
-  timezone = tz::locateZone("America/Los_Angeles");
-  VELOX_ASSERT_THROW(t1.toGMT(*timezone), expected);
-}
-
 // In debug mode, Timestamp constructor will throw exception if range check
 // fails.
 #ifdef NDEBUG

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -244,6 +244,18 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
   static constexpr auto kMinYear = year::min();
   static constexpr auto kMaxYear = year::max();
 
+  if (timePoint.time_since_epoch() <
+          std::chrono::seconds(std::numeric_limits<int64_t>::min() / 1000) ||
+      timePoint.time_since_epoch() >
+          std::chrono::seconds(std::numeric_limits<int64_t>::max() / 1000)) {
+    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
+        "Timepoint is outside of supported timestamp seconds since epoch range: [{}, {}], got {}",
+        std::chrono::seconds(std::numeric_limits<int64_t>::min() / 1000)
+            .count(),
+        std::chrono::seconds(std::numeric_limits<int64_t>::max() / 1000)
+            .count(),
+        static_cast<int64_t>(timePoint.time_since_epoch().count()));
+  }
   auto year = year_month_day(floor<days>(timePoint)).year();
 
   if (year < kMinYear || year > kMaxYear) {
@@ -251,9 +263,9 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
     // VeloxRuntimeError to avoid it being suppressed by TRY().
     VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
         "Timepoint is outside of supported year range: [{}, {}], got {}",
-        static_cast<int>(kMinYear),
-        static_cast<int>(kMaxYear),
-        static_cast<int>(year));
+        static_cast<int64_t>(kMinYear),
+        static_cast<int64_t>(kMaxYear),
+        static_cast<int64_t>(year));
   }
 }
 

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -140,16 +140,23 @@ TEST(TimeZoneMapTest, timePointBoundary) {
   EXPECT_NO_THROW(tryLocalYear(year::max()));
   EXPECT_NO_THROW(tryLocalYear(year::min()));
 
-  std::string expected = "Timepoint is outside of supported year range";
-  VELOX_ASSERT_THROW(trySysYear(year(int(year::max()) + 1)), expected);
-  VELOX_ASSERT_THROW(trySysYear(year(int(year::min()) - 1)), expected);
+  std::string expected =
+      "Timepoint is outside of supported timestamp seconds since epoch range:";
+  VELOX_ASSERT_THROW(
+      trySysYear(year(int64_t(year::max()) + 1)),
+      "Timepoint is outside of supported year range");
+  VELOX_ASSERT_THROW(trySysYear(year(int64_t(year::min()) - 1)), expected);
 
-  VELOX_ASSERT_THROW(tryLocalYear(year(int(year::max()) + 1)), expected);
-  VELOX_ASSERT_THROW(tryLocalYear(year(int(year::min()) - 1)), expected);
+  VELOX_ASSERT_THROW(
+      tryLocalYear(year(int64_t(year::max()) + 1)),
+      "Timepoint is outside of supported year range");
+  VELOX_ASSERT_THROW(tryLocalYear(year(int64_t(year::min()) - 1)), expected);
 
   // This time point triggers an assertion failure in external/date. Make sure
   // we catch and throw before getting to that point.
-  VELOX_ASSERT_THROW(tz->to_sys(seconds{-1096193779200l - 86400l}), expected);
+  VELOX_ASSERT_THROW(
+      tz->to_sys(seconds{std::numeric_limits<int64_t>::max()}),
+      "Timepoint is outside of supported timestamp seconds since epoch range:");
 }
 
 TEST(TimeZoneMapTest, getTimeZoneName) {


### PR DESCRIPTION
Summary:
Presto Java supports any timestamp that can fit in the 52 bits well allocate for millis UTC in
the TimestampWithTimeZone type.  Likewise the Timestamp type can support dates with
years past 200 million.

In Velox currently we limit the year to what can be represented with 16 bits (this is what
std::chrono applies in C++20).

This change adds support for years up to +/-2^22. This is well beyond what is needed to
support the full range of timestamps Presto Java supports in TimestampWithTimeZone.
This falls short of what Presto Java supports for the Timestamp type (this only supports
years a little past 4 million) but the algorithms we use to convert between year_month_day
and days since epoch fall apart beyond that point.

Differential Revision: D71349259


