### PR TITLE
feat: Allow user to customize the get prefered size for memory efficiency

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -409,6 +409,7 @@ class TestMemoryPool : public memory::MemoryPool {
       const std::string& /* unused */,
       Kind /* unused */,
       bool /* unused */,
+      const std::function<size_t(size_t)>& /* unused */,
       std::unique_ptr<memory::MemoryReclaimer> /* unused */) override {
     return nullptr;
   }

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -97,6 +97,7 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       debugEnabled_(options.debugEnabled),
       coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled),
       disableMemoryPoolTracking_(options.disableMemoryPoolTracking),
+      getPreferredSize_(options.getPreferredSize),
       poolDestructionCb_([&](MemoryPool* pool) { dropPool(pool); }),
       sysRoot_{std::make_shared<MemoryPoolImpl>(
           this,
@@ -112,7 +113,8 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .trackUsage = options.trackDefaultUsage,
               .debugEnabled = options.debugEnabled,
               .coreOnAllocationFailureEnabled =
-                  options.coreOnAllocationFailureEnabled})},
+                  options.coreOnAllocationFailureEnabled,
+              .getPreferredSize = getPreferredSize_})},
       spillPool_{addLeafPool("__sys_spilling__")},
       cachePool_{addLeafPool("__sys_caching__")},
       tracePool_{addLeafPool("__sys_tracing__")},
@@ -247,6 +249,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   options.trackUsage = true;
   options.debugEnabled = debugEnabled_;
   options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
+  options.getPreferredSize = getPreferredSize_;
 
   auto pool = createRootPool(poolName, reclaimer, options);
   if (!disableMemoryPoolTracking_) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -168,6 +168,11 @@ struct MemoryManagerOptions {
 
   /// Additional configs that are arbitrator implementation specific.
   std::unordered_map<std::string, std::string> extraArbitratorConfigs{};
+
+  /// Provides the customized get preferred size function for memory pool
+  /// allocation. It returns the actual allocation size for a given input size.
+  /// If not set, uses the memory pool's default get preferred size function.
+  std::function<size_t(size_t)> getPreferredSize{nullptr};
 };
 
 /// 'MemoryManager' is responsible for creating allocator, arbitrator and
@@ -308,6 +313,7 @@ class MemoryManager {
   const bool debugEnabled_;
   const bool coreOnAllocationFailureEnabled_;
   const bool disableMemoryPoolTracking_;
+  const std::function<size_t(size_t)> getPreferredSize_;
 
   // The destruction callback set for the allocated root memory pools which are
   // tracked by 'pools_'. It is invoked on the root pool destruction and removes

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -166,6 +166,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       const std::string& name,
       MemoryPool::Kind kind,
       bool /*unused*/,
+      const std::function<size_t(size_t)>& /*unused*/,
       std::unique_ptr<memory::MemoryReclaimer> /*unused*/) override {
     return std::make_shared<MockMemoryPool>(
         name, kind, parent, parent->capacity());


### PR DESCRIPTION
Summary:
The memory manager provides get preferred size callback option to customize get preferred size for memory
pool allocation to allow application to customize the preferred size for memory efficiency

Differential Revision: D71347152


