### PR TITLE
misc: Remove duplicate index lookup runtime stats

### DIFF
--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -142,10 +142,6 @@ These stats are reported only by IndexLookupJoin operator
    * - Stats
      - Unit
      - Description
-   * - lookupWaitWallNanos
-     - nanos
-     - The walltime in nanoseconds the lookup operator blocked waiting for the lookup
-       result from the index source.
    * - lookupWallNanos
      - nanos
      - The walltime in nanoseconds that the index connector do the lookup.

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -376,7 +376,6 @@ bool IndexLookupJoin::needsInput() const {
 BlockingReason IndexLookupJoin::isBlocked(ContinueFuture* future) {
   auto& batch = currentInputBatch();
   if (!batch.lookupFuture.valid()) {
-    endLookupBlockWait();
     return BlockingReason::kNotBlocked;
   }
   if (lookupPrefetchEnabled() && (numInputBatches() < maxNumInputBatches_) &&
@@ -385,28 +384,7 @@ BlockingReason IndexLookupJoin::isBlocked(ContinueFuture* future) {
   }
   *future = std::move(batch.lookupFuture);
   VELOX_CHECK(!batch.lookupFuture.valid());
-  startLookupBlockWait();
   return BlockingReason::kWaitForIndexLookup;
-}
-
-void IndexLookupJoin::startLookupBlockWait() {
-  VELOX_CHECK(!blockWaitStartNs_.has_value());
-  blockWaitStartNs_ = getCurrentTimeNano();
-}
-
-void IndexLookupJoin::endLookupBlockWait() {
-  if (!blockWaitStartNs_.has_value()) {
-    return;
-  }
-  SCOPE_EXIT {
-    blockWaitStartNs_ = std::nullopt;
-  };
-  const auto blockWaitEndNs = getCurrentTimeNano();
-  VELOX_CHECK_GE(blockWaitEndNs, blockWaitStartNs_.value());
-  const auto blockWaitNs = blockWaitEndNs - blockWaitStartNs_.value();
-  stats_.wlock()->addRuntimeStat(
-      kLookupBlockWaitTime,
-      RuntimeCounter(blockWaitNs, RuntimeCounter::Unit::kNanos));
 }
 
 void IndexLookupJoin::addInput(RowVectorPtr input) {

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -42,9 +42,6 @@ class IndexLookupJoin : public Operator {
   void close() override;
 
   /// Defines lookup runtime stats.
-  /// The walltime the lookup operator blocked waiting for the lookup result
-  /// from the index source.
-  static inline const std::string kLookupBlockWaitTime{"lookupWaitWallNanos"};
   /// The walltime time that the index connector do the lookup.
   static inline const std::string kConnectorLookupWallTime{"lookupWallNanos"};
   /// The cpu time that the index connector do the lookup.
@@ -122,9 +119,6 @@ class IndexLookupJoin : public Operator {
   void prepareOutputRowMappings(size_t outputBatchSize);
   // Prepare 'output_' for the next output batch with size of 'numOutputRows'.
   void prepareOutput(vector_size_t numOutputRows);
-
-  void startLookupBlockWait();
-  void endLookupBlockWait();
 
   // Invoked at operator close to record the lookup stats.
   void recordConnectorStats();
@@ -227,9 +221,5 @@ class IndexLookupJoin : public Operator {
 
   // The reusable output vector for the join output.
   RowVectorPtr output_;
-
-  // The start time of the current lookup driver block wait, and reset after the
-  // driver wait completes.
-  std::optional<size_t> blockWaitStartNs_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -1820,16 +1820,6 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
       runtimeStats.at(IndexLookupJoin::kConnectorLookupCpuTime).count,
       numProbeBatches);
   ASSERT_GT(runtimeStats.at(IndexLookupJoin::kConnectorLookupCpuTime).sum, 0);
-  if (GetParam().asyncLookup) {
-    ASSERT_GE(
-        runtimeStats.at(IndexLookupJoin::kLookupBlockWaitTime).count,
-        numProbeBatches);
-    ASSERT_GE(runtimeStats.at(IndexLookupJoin::kLookupBlockWaitTime).sum, 0);
-  } else {
-    ASSERT_TRUE(
-        runtimeStats.find(IndexLookupJoin::kLookupBlockWaitTime) ==
-        runtimeStats.end());
-  }
   ASSERT_THAT(
       operatorStats.toString(true, true),
       testing::MatchesRegex(


### PR DESCRIPTION
Summary:
Lookup wait walltime is already collected operator stats and we have added the stats tracking in sequential task
execution mode

Reviewed By: zacw7

Differential Revision: D71356588


