### PR TITLE
feat(json): Expand support for non alphanumeric characters after dot in json path

### DIFF
--- a/velox/functions/prestosql/json/JsonPathTokenizer.h
+++ b/velox/functions/prestosql/json/JsonPathTokenizer.h
@@ -106,7 +106,8 @@ namespace facebook::velox::functions {
 ///   "[0][1]"
 ///   "$['store'][book][1]"
 ///
-/// TODO: Add support for unicode charaters after dot notation.
+/// TODO: Add support for optional dot after closing square bracket, eg.
+/// $.[0]key should be valid.
 class JsonPathTokenizer {
  public:
   enum class Selector { KEY, WILDCARD, KEY_OR_INDEX, RECURSIVE };

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -188,9 +188,9 @@ TEST_F(JsonExtractScalarTest, invalidPath) {
   VELOX_ASSERT_THROW(
       jsonExtractScalar(R"({"k1":"v1"})", "$.k1."), "Invalid JSON path");
   VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"({"k1":"v1"})", "$.k1]"), "Invalid JSON path");
+      jsonExtractScalar(R"({"k1":"v1"})", "$.k1["), "Invalid JSON path");
   VELOX_ASSERT_THROW(
-      jsonExtractScalar(R"({"k1":"v1)", "$.k1]"), "Invalid JSON path");
+      jsonExtractScalar(R"({"k1":"v1)", "$.k1["), "Invalid JSON path");
 }
 
 // simdjson, like Presto java, returns the large number as-is as a string,

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -952,8 +952,8 @@ TEST_F(JsonFunctionsTest, invalidPath) {
   VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$-1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$k1"), "Invalid JSON path");
   VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1."), "Invalid JSON path");
-  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1]"), "Invalid JSON path");
-  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1)", "$.k1]"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1["), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1)", "$.k1["), "Invalid JSON path");
 }
 
 TEST_F(JsonFunctionsTest, jsonExtract) {
@@ -1058,6 +1058,12 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
       "[[123, 456]]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a..b"));
   EXPECT_EQ("[]", jsonExtract(R"({"a": {"b": [123, 456]}})", "$.a..c"));
   EXPECT_EQ(std::nullopt, jsonExtract(R"({"a": {"b": [123, 456]}})", "$.c..b"));
+
+  // Unicode keys
+  EXPECT_EQ(R"({"á": 1, "â": 2})", jsonExtract(R"({"á": 1, "â": 2})", "$"));
+  EXPECT_EQ("1", jsonExtract(R"({"á": 1, "â": 2})", "$.á"));
+  EXPECT_EQ("1", jsonExtract(R"({"á": 1, "â": 2})", "$.[\"á\"]"));
+  EXPECT_EQ("1", jsonExtract(R"({"á": 1, "â": 2})", "$.[\"\u00E1\"]"));
 
   // TODO The following paths are supported by Presto via Jayway, but do not
   // work in Velox yet. Figure out how to add support for these.


### PR DESCRIPTION
Summary: Currently json path implementation in velox only accepts a very limited set of symbols for a key defined after the dot notation. This change expands the coverage to include all of UTF-8 character set apart from some special symbols in json path like dot or left squre brackets. This would make it conform to jayways implementation.

Differential Revision: D71373178


