### PR TITLE
refactor: Refactor ArrayRemoveNullFunction and register it for Spark array_compact function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -24,6 +24,17 @@ Array Functions
         SELECT array_append(array(1, 2, 3), 2); -- [1, 2, 3, 2]
         SELECT array_append(array(1, 2, 3), NULL); -- [1, 2, 3, NULL]
 
+.. spark:function:: array_compact(array(E) x) -> array(E)
+
+    Removes all NULL elements from array ``x``. Returns NULL if array ``x`` is NULL.
+    Returns empty array if array ``x`` is empty or all elements in it are NULL. ::
+
+        SELECT array_compact(array(1, 2, NULL, 3)); -- [1, 2, 3]
+        SELECT array_compact(array()); -- []
+        SELECT array_compact(array(NULL)); -- []
+        SELECT array_compact(NULL); -- NULL
+        SELECT array_compact(array(array(1, 2), NULL, array(NULL, 3, 4))); -- [[1, 2], [NULL, 3, 4]]
+
 .. spark:function:: array_contains(array(E), value) -> boolean
 
     Returns true if the array contains the value. ::

--- a/velox/functions/lib/ArrayRemoveNullFunction.h
+++ b/velox/functions/lib/ArrayRemoveNullFunction.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions {
+
+/// DEFINITION:
+/// Presto: remove_nulls(array(E)) -> array(E)
+/// Spark: array_compact(array(E)) -> array(E)
+///
+/// Removes all NULL elements from the input array. Returns empty array if the
+/// input array is empty or all elements in it are NULL.
+template <typename T>
+struct ArrayRemoveNullFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Fast path for primitives.
+  template <typename Out, typename In>
+  FOLLY_ALWAYS_INLINE void call(Out& out, const In& inputArray) {
+    if (inputArray.mayHaveNulls()) {
+      for (const auto& value : inputArray.skipNulls()) {
+        out.push_back(value);
+      }
+      return;
+    }
+
+    // No nulls, skip reading nullity.
+    for (const auto& value : inputArray) {
+      out.push_back(value);
+    }
+  }
+
+  // Generic implementation.
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Array<Generic<T1>>>& out,
+      const arg_type<Array<Generic<T1>>>& inputArray) {
+    if (inputArray.mayHaveNulls()) {
+      for (const auto& value : inputArray.skipNulls()) {
+        out.push_back(value);
+      }
+      return;
+    }
+
+    // No nulls, skip reading nullity.
+    for (const auto& value : inputArray) {
+      out.push_back(value);
+    }
+  }
+};
+
+/// Removes all NULL elements from the input string array. Returns empty string
+/// array if the input string array is empty or all elements in it are NULL.
+/// Optimised by avoiding copy of strings.
+template <typename T>
+struct ArrayRemoveNullFunctionString {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // String version that avoids copy of strings.
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Array<Varchar>>& out,
+      const arg_type<Array<Varchar>>& inputArray) {
+    if (inputArray.mayHaveNulls()) {
+      for (const auto& element : inputArray.skipNulls()) {
+        auto& newItem = out.add_item();
+        newItem.setNoCopy(element);
+      }
+      return;
+    }
+
+    // No nulls, skip reading nullity.
+    for (const auto& element : inputArray) {
+      auto& newItem = out.add_item();
+      newItem.setNoCopy(element.value());
+    }
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/ArrayRemoveNullsTest.cpp
+++ b/velox/functions/lib/tests/ArrayRemoveNullsTest.cpp
@@ -71,4 +71,11 @@ TEST_F(ArrayRemoveNullsTest, complexType) {
   testArrayRemoveNull(expected, input);
 }
 
+TEST_F(ArrayRemoveNullsTest, nullArray) {
+  const auto input = makeArrayVectorFromJson<int64_t>({"[null]", "[]", "null"});
+
+  auto expected = makeArrayVectorFromJson<int64_t>({"[]", "[]", "null"});
+  testArrayRemoveNull(expected, input);
+}
+
 } // namespace

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_executable(
   velox_functions_lib_test
   ApproxMostFrequentStreamSummaryTest.cpp
+  ArrayRemoveNullsTest.cpp
   CheckNestedNullsTest.cpp
   DateTimeFormatterTest.cpp
   IsNullTest.cpp

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -934,51 +934,6 @@ struct ArrayTrimFunctionString {
 };
 
 template <typename T>
-struct ArrayRemoveNullFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  // Fast path for primitives.
-  template <typename Out, typename In>
-  FOLLY_ALWAYS_INLINE void call(Out& out, const In& inputArray) {
-    for (int i = 0; i < inputArray.size(); ++i) {
-      if (inputArray[i].has_value()) {
-        out.push_back(inputArray[i].value());
-      }
-    }
-  }
-
-  // Generic implementation.
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Array<Generic<T1>>>& out,
-      const arg_type<Array<Generic<T1>>>& inputArray) {
-    for (int i = 0; i < inputArray.size(); ++i) {
-      if (inputArray[i].has_value()) {
-        out.push_back(inputArray[i].value());
-      }
-    }
-  }
-};
-
-template <typename T>
-struct ArrayRemoveNullFunctionString {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  static constexpr int32_t reuse_strings_from_arg = 0;
-
-  // String version that avoids copy of strings.
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Array<Varchar>>& out,
-      const arg_type<Array<Varchar>>& inputArray) {
-    for (int i = 0; i < inputArray.size(); ++i) {
-      if (inputArray[i].has_value()) {
-        auto& newItem = out.add_item();
-        newItem.setNoCopy(inputArray[i].value());
-      }
-    }
-  }
-};
-
-template <typename T>
 struct ArrayNGramsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T)
 

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "velox/functions/Registerer.h"
+#include "velox/functions/lib/ArrayRemoveNullFunction.h"
 #include "velox/functions/lib/ArrayShuffle.h"
 #include "velox/functions/lib/Repeat.h"
 #include "velox/functions/lib/Slice.h"

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -41,7 +41,6 @@ add_executable(
   ArrayNoneMatchTest.cpp
   ArrayNormalizeTest.cpp
   ArrayPositionTest.cpp
-  ArrayRemoveNullsTest.cpp
   ArrayRemoveTest.cpp
   ArrayShuffleTest.cpp
   ArraySortTest.cpp

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/lib/ArrayRemoveNullFunction.h"
 #include "velox/functions/lib/ArrayShuffle.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
 #include "velox/functions/lib/Repeat.h"
@@ -158,6 +159,31 @@ inline void registerArrayUnionFunctions(const std::string& prefix) {
   registerArrayUnionFunction<Generic<T1>>(prefix);
 }
 
+template <typename T>
+inline void registerArrayCompactFunction(const std::string& prefix) {
+  registerFunction<ArrayRemoveNullFunction, Array<T>, Array<T>>(
+      {prefix + "array_compact"});
+}
+
+inline void registerArrayCompactFunctions(const std::string& prefix) {
+  registerArrayCompactFunction<int8_t>(prefix);
+  registerArrayCompactFunction<int16_t>(prefix);
+  registerArrayCompactFunction<int32_t>(prefix);
+  registerArrayCompactFunction<int64_t>(prefix);
+  registerArrayCompactFunction<int128_t>(prefix);
+  registerArrayCompactFunction<float>(prefix);
+  registerArrayCompactFunction<double>(prefix);
+  registerArrayCompactFunction<bool>(prefix);
+  registerArrayCompactFunction<Timestamp>(prefix);
+  registerArrayCompactFunction<Date>(prefix);
+  registerArrayCompactFunction<Varbinary>(prefix);
+  registerArrayCompactFunction<Generic<T1>>(prefix);
+  registerFunction<
+      ArrayRemoveNullFunctionString,
+      Array<Varchar>,
+      Array<Varchar>>({prefix + "array_compact"});
+}
+
 void registerArrayFunctions(const std::string& prefix) {
   registerArrayConcatFunctions(prefix);
   registerArrayJoinFunctions(prefix);
@@ -198,6 +224,7 @@ void registerArrayFunctions(const std::string& prefix) {
       Array<Generic<T1>>,
       Generic<T1>>({prefix + "array_append"});
   registerArrayUnionFunctions(prefix);
+  registerArrayCompactFunctions(prefix);
 }
 
 } // namespace sparksql


### PR DESCRIPTION
This PR aims to refactor `ArrayRemoveNullFunction` and register it for Spark
`array_compact` function.

Spark implement: https://github.com/apache/spark/blob/0670e4f7945ae4935261ed1f45db7ede79aca127/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L5308-L5335

Fixes #12699.