### PR TITLE
feat: Add API DataSource::cancel() to allow implementation run cleanup logic while TableScan::close() is called

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -297,6 +297,13 @@ class DataSource {
   virtual std::shared_ptr<wave::WaveDataSource> toWaveDataSource() {
     VELOX_UNSUPPORTED();
   }
+
+
+  /// Invoked by table scan close to cancel any inflight async operations
+  /// running inside the data source. This is the best effort and the actual
+  /// connector implementation decides how to support the cancellation if
+  /// needed.
+  virtual void cancel() {}
 };
 
 class IndexSource {

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -298,7 +298,6 @@ class DataSource {
     VELOX_UNSUPPORTED();
   }
 
-
   /// Invoked by table scan close to cancel any inflight async operations
   /// running inside the data source. This is the best effort and the actual
   /// connector implementation decides how to support the cancellation if

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -436,6 +436,10 @@ void TableScan::addDynamicFilter(
 void TableScan::close() {
   Operator::close();
 
+  if (dataSource_ != nullptr) {
+    dataSource_->cancel();
+  }
+
   if (scaledController_ == nullptr) {
     return;
   }


### PR DESCRIPTION
This is another simpler approach to allow downstream project deal with the memory leak issue mentioned in https://github.com/facebookincubator/velox/pull/12609.

See also [comment](https://github.com/facebookincubator/velox/pull/12609#issuecomment-2726568760).