### PR TITLE
fix: Correct argument order in setupMemory in MemoryPoolTest.cpp

### DIFF
--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -954,8 +954,8 @@ TEST_P(MemoryPoolTest, customizedGetPreferredSize) {
       checkedPlus<size_t>(size, AlignedBuffer::kPaddedSize);
   {
     setupMemory({
-        .getPreferredSize = [](int64_t size) { return size; },
         .allocatorCapacity = kMemoryCapBytes,
+        .getPreferredSize = [](int64_t size) { return size; },
     });
     MemoryManager& manager = *getMemoryManager();
     auto root = manager.addRootPool("same size");
@@ -980,8 +980,8 @@ TEST_P(MemoryPoolTest, customizedGetPreferredSize) {
 
   {
     setupMemory({
-        .getPreferredSize = [](int64_t size) { return size * 2; },
         .allocatorCapacity = kMemoryCapBytes,
+        .getPreferredSize = [](int64_t size) { return size * 2; },
     });
     MemoryManager& manager = *getMemoryManager();
     auto root = manager.addRootPool("double size");
@@ -1009,8 +1009,8 @@ TEST_P(MemoryPoolTest, customizedGetPreferredSize) {
   // Invalid preferred size callback.
   {
     setupMemory({
-        .getPreferredSize = [](int64_t size) { return size - 1; },
         .allocatorCapacity = kMemoryCapBytes,
+        .getPreferredSize = [](int64_t size) { return size - 1; },
     });
     MemoryManager& manager = *getMemoryManager();
     auto root = manager.addRootPool("bad sizer");


### PR DESCRIPTION
Summary
This PR fixes the issue below when running github CI
https://github.com/facebookincubator/velox/actions/runs/13928041466/job/38977688524?pr=12274
```
/__w/velox/velox/velox/velox/common/memory/tests/MemoryPoolTest.cpp:956:16: error: designator order for field ‘facebook::velox::memory::MemoryManagerOptions::allocatorCapacity’ does not match declaration order in ‘facebook::velox::memory::MemoryManagerOptions’
  956 |     setupMemory({
      |     ~~~~~~~~~~~^~
  957 |         .getPreferredSize = [](int64_t size) { return size; },
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  958 |         .allocatorCapacity = kMemoryCapBytes,
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  959 |     });
      |     ~~          
```