### PR TITLE
feat(fuzzer): Add comman eval execution logging

### DIFF
--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -253,7 +253,9 @@ ExpressionVerifier::verify(
             "Input after common",
             rows);
       }
+      LOG(INFO) << "Common eval succeeded.";
     } catch (const VeloxException& e) {
+      LOG(INFO) << "Common eval failed.";
       if (e.errorCode() == error_code::kUnsupportedInputUncatchable) {
         unsupportedInputUncatchableError = true;
       } else if (!(canThrow && e.isUserError())) {
@@ -315,9 +317,9 @@ ExpressionVerifier::verify(
               if (!(defaultNull &&
                     referenceQueryRunner_->runnerType() ==
                         ReferenceQueryRunner::RunnerType::kPrestoQueryRunner)) {
-                LOG(ERROR) << "Only "
-                           << (exceptionCommonPtr ? "common" : "reference")
-                           << " path threw exception:";
+                LOG(ERROR) << fmt::format(
+                    "Only {} path threw exception",
+                    exceptionCommonPtr ? "common" : "reference");
                 if (exceptionCommonPtr) {
                   std::rethrow_exception(exceptionCommonPtr);
                 } else {


### PR DESCRIPTION
Summary: Minor update to ExpressionVerifier to add logging during the common eval try/catch block. I've noticed on my local runs, it really helps to quickly identify whether the value/behavior mismatch occurred because Velox failed and was caught or outputted successfully and failed on Presto.

Differential Revision: D71404365


