### PR TITLE
feat(vector): Add SVE (Scalable Vector Extension) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,13 @@ GENERATOR += -DVELOX_FORCE_COLORED_OUTPUT=ON
 endif
 endif
 
+SVE_ENABLED := $(shell lscpu | grep -q "sve" && echo 1 || echo 0)
+
+ifeq ($(SVE_ENABLED),1)
+    export CC  := /usr/bin/gcc-12
+    export CXX := /usr/bin/g++-12
+endif
+
 NUM_THREADS ?= $(shell getconf _NPROCESSORS_CONF 2>/dev/null || echo 1)
 CPU_TARGET ?= "avx"
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -53,6 +53,10 @@ if [[ ${VERSION} =~ "20.04" ]]; then
   export CXX=/usr/bin/g++-11
 fi
 
+if lscpu | grep -q "sve"; then
+  $SUDO apt install -y gcc-12 g++-12
+fi
+
 function install_clang15 {
   if [[ ! ${VERSION} =~ "22.04" && ! ${VERSION} =~ "24.04" ]]; then
     echo "Warning: using the Clang configuration is for Ubuntu 22.04 and 24.04. Errors might occur."

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -25,6 +25,16 @@ XSIMD_DECLARE_SIMD_REGISTER(
 } // namespace xsimd::types
 #endif
 
+#if XSIMD_WITH_SVE
+#include <arm_sve.h>
+namespace xsimd::types {
+XSIMD_DECLARE_SIMD_REGISTER(
+    bool,
+    sve,
+    detail::sve_vector_type<unsigned char>);
+} 
+#endif
+
 namespace facebook::velox::simd {
 
 namespace detail {
@@ -82,7 +92,7 @@ struct BitMask<T, A, 1> {
   }
 #endif
 
-#if XSIMD_WITH_NEON
+#if XSIMD_WITH_NEON 
   static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::neon&) {
     alignas(A::alignment()) static const int8_t kShift[] = {
         -7, -6, -5, -4, -3, -2, -1, 0, -7, -6, -5, -4, -3, -2, -1, 0};
@@ -91,6 +101,10 @@ struct BitMask<T, A, 1> {
     return (vaddv_u8(vget_high_u8(vmask)) << 8) | vaddv_u8(vget_low_u8(vmask));
   }
 #endif
+
+static int toBitMask(xsimd::batch_bool<T, A> mask, const xsimd::generic&) {
+    return genericToBitMask(mask);   
+  }
 };
 
 template <typename T, typename A>
@@ -290,9 +304,21 @@ template <>
 inline xsimd::batch_bool<float, xsimd::default_arch> leadingMask(
     int i,
     const xsimd::default_arch&) {
-  return reinterpret_cast<
-      xsimd::batch_bool<float, xsimd::default_arch>::register_type>(
-      leadingMask32[i].data);
+/*
+With GCC builds, compiler throws an error "invalid cast" on reintepreting to the same data type, in SVE 256's case, svbool_t __attribute__((arm_sve_vector_bits(256))).
+With clang++ build, there are no isses.
+So this is a workaround for now.
+Can be updated once the bug in GCC is resolved in future GCC versions.
+*/
+
+#if XSIMD_WITH_SVE && defined(__GNUC__) && !defined(__clang__)
+        return xsimd::batch_bool<float, xsimd::default_arch>(
+        leadingMask32[i].data);
+#else
+        return reinterpret_cast<
+        xsimd::batch_bool<float, xsimd::default_arch>::register_type>(
+        leadingMask32[i].data);
+#endif
 }
 
 template <>
@@ -306,9 +332,21 @@ template <>
 inline xsimd::batch_bool<double, xsimd::default_arch> leadingMask(
     int i,
     const xsimd::default_arch&) {
-  return reinterpret_cast<
-      xsimd::batch_bool<double, xsimd::default_arch>::register_type>(
+/*
+With GCC builds, compiler throws an error "invalid cast" on reintepreting to the same data type, in SVE 256's case, svbool_t __attribute__((arm_sve_vector_bits(256))).
+With clang++ build, there are no isses.
+So this is a workaround for now.
+Can be updated once the bug in GCC is resolved in future GCC versions.
+*/
+
+#if XSIMD_WITH_SVE && defined(__GNUC__) && !defined(__clang__)
+      return xsimd::batch_bool<double, xsimd::default_arch>(
       leadingMask64[i].data);
+#else
+        return reinterpret_cast<
+        xsimd::batch_bool<double, xsimd::default_arch>::register_type>(
+      leadingMask64[i].data);
+#endif
 }
 
 } // namespace detail
@@ -525,6 +563,18 @@ struct Gather<T, int32_t, A, 4> {
     return maskApply<kScale>(src, mask, base, loadIndices(indices, arch), arch);
   }
 
+#if XSIMD_WITH_SVE
+    template <int kScale>
+    static xsimd::batch<T, A> maskApply(
+      xsimd::batch<T, A> src,
+      xsimd::batch_bool<T, A> mask,
+      const T* base,
+      const int32_t* indices,
+      const xsimd::sve& arch) {
+    return genericMaskGather<T, A, kScale>(src, mask, base, indices);
+  }
+#endif
+
   template <int kScale>
   static xsimd::batch<T, A> maskApply(
       xsimd::batch<T, A> src,
@@ -582,6 +632,20 @@ struct Gather<T, int32_t, A, 8> {
     return Batch64<int32_t>::load_unaligned(indices);
   }
 
+#if (XSIMD_WITH_SVE && SVE_BITS==128)
+
+  static Batch64<int32_t> loadIndices(
+      const int32_t* indices,
+      const xsimd::sve&) {
+    return Batch64<int32_t>::load_unaligned(indices);
+  }
+#endif
+#if (XSIMD_WITH_SVE && SVE_BITS==256)
+static Batch128<int32_t> loadIndices(const int32_t* indices, const xsimd::sve&) {
+    return Batch128<int32_t>::load_unaligned(indices);
+}
+#endif
+
   static Batch64<int32_t> loadIndices(
       const int32_t* indices,
       const xsimd::neon&) {
@@ -601,6 +665,38 @@ struct Gather<T, int32_t, A, 8> {
   apply(const T* base, const int32_t* indices, const xsimd::generic&) {
     return genericGather<T, A, kScale>(base, indices);
   }
+
+#if (XSIMD_WITH_SVE && SVE_BITS==256)
+template <int kScale>
+static xsimd::batch<T, A> apply(
+    const T* base,
+    Batch128<int32_t> vindex, 
+    const xsimd::sve&) {
+  constexpr int N = xsimd::batch<T, A>::size;
+  alignas(A::alignment()) T dst[N];
+  auto bytes = reinterpret_cast<const char*>(base);
+  for (int i = 0; i < N; ++i) {
+    dst[i] = *reinterpret_cast<const T*>(bytes + vindex.data[i] * kScale);
+  }
+  return xsimd::load_aligned(dst);
+}
+#endif
+
+#if (XSIMD_WITH_SVE && SVE_BITS==128)
+template <int kScale>
+static xsimd::batch<T, A> apply(
+    const T* base,
+    Batch64<int32_t> vindex, 
+    const xsimd::sve&) {
+  constexpr int N = xsimd::batch<T, A>::size;
+  alignas(A::alignment()) T dst[N];
+  auto bytes = reinterpret_cast<const char*>(base);
+  for (int i = 0; i < N; ++i) {
+    dst[i] = *reinterpret_cast<const T*>(bytes + vindex.data[i] * kScale);
+  }
+  return xsimd::load_aligned(dst);
+}
+#endif
 
 #if XSIMD_WITH_AVX2
   template <int kScale>
@@ -623,6 +719,48 @@ struct Gather<T, int32_t, A, 8> {
       const xsimd::generic&) {
     return genericMaskGather<T, A, kScale>(src, mask, base, indices);
   }
+
+#if XSIMD_WITH_SVE
+  template <int kScale>
+  static xsimd::batch<T, A> maskApply(
+      xsimd::batch<T, A> src,
+      xsimd::batch_bool<T, A> mask,
+      const T* base,
+      const int32_t* indices,
+      const xsimd::sve& arch) {
+    return genericMaskGather<T, A, kScale>(src, mask, base, indices);
+  }
+#endif
+
+#if (XSIMD_WITH_SVE && SVE_BITS==128)
+template <int kScale>
+static xsimd::batch<T, A> maskApply(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    Batch64<int32_t> vindex,
+    const xsimd::sve& arch) {
+    constexpr int N = Batch64<int32_t>::size;
+    alignas(A::alignment()) int32_t indices[N];
+    vindex.store_unaligned(indices);
+    return maskApply<kScale>(src, mask, base, indices, arch);
+}
+#endif
+
+#if (XSIMD_WITH_SVE && SVE_BITS==256)
+template <int kScale>
+static xsimd::batch<T, A> maskApply(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    Batch128<int32_t> vindex,
+    const xsimd::sve& arch) {
+    constexpr int N = Batch128<int32_t>::size;
+    alignas(A::alignment()) int32_t indices[N];
+    vindex.store_unaligned(indices);
+    return maskApply<kScale>(src, mask, base, indices, arch);
+}
+#endif
 
 #if XSIMD_WITH_AVX2
   template <int kScale>
@@ -697,6 +835,18 @@ struct Gather<T, int64_t, A, 8> {
     return maskApply<kScale>(src, mask, base, loadIndices(indices, arch), arch);
   }
 
+#if XSIMD_WITH_SVE
+  template <int kScale>
+  static xsimd::batch<T, A> maskApply(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    const int64_t* indices,
+    const xsimd::sve& arch) {
+    return genericMaskGather<T, A, kScale>(src, mask, base, indices);
+}
+#endif
+
 #if XSIMD_WITH_AVX2
   template <int kScale>
   static xsimd::batch<T, A> maskApply(
@@ -714,6 +864,7 @@ struct Gather<T, int64_t, A, 8> {
             kScale));
   }
 #endif
+
 
   template <int kScale>
   static xsimd::batch<T, A> maskApply(
@@ -756,6 +907,26 @@ xsimd::batch<int16_t, A> pack32(
 }
 #endif
 
+template <typename A>
+xsimd::batch<int16_t, A> pack32(
+    xsimd::batch<int32_t, A> x,
+    xsimd::batch<int32_t, A> y,
+    const xsimd::generic&) {
+  constexpr std::size_t size = xsimd::batch<int32_t, A>::size;
+  alignas(A) int32_t xArr[size];
+  alignas(A) int32_t yArr[size];
+  alignas(A) int16_t resultArr[2 * size];
+
+  x.store_unaligned(xArr);
+  y.store_unaligned(yArr);  
+
+  for (std::size_t i = 0; i < size; ++i) {
+    resultArr[i] = static_cast<int16_t>(xArr[i]);
+    resultArr[i + size] = static_cast<int16_t>(yArr[i]);
+  }
+  return xsimd::batch<int16_t, A>::load_unaligned(resultArr);
+}
+
 #if XSIMD_WITH_AVX2
 template <typename A>
 xsimd::batch<int16_t, A> pack32(
@@ -795,6 +966,16 @@ template <typename T>
 Batch64<T> genericPermute(Batch64<T> data, Batch64<int32_t> idx) {
   static_assert(data.size >= idx.size);
   Batch64<T> ans;
+  for (int i = 0; i < idx.size; ++i) {
+    ans.data[i] = data.data[idx.data[i]];
+  }
+  return ans;
+}
+
+template <typename T>
+Batch128<T> genericPermute(Batch128<T> data, Batch128<int32_t> idx) {
+  static_assert(data.size >= idx.size);
+  Batch128<T> ans;
   for (int i = 0; i < idx.size; ++i) {
     ans.data[i] = data.data[idx.data[i]];
   }
@@ -865,8 +1046,10 @@ xsimd::batch<int16_t, A> gather(
   } else {
     second = xsimd::batch<int32_t, A>::broadcast(0);
   }
-  return detail::pack32(first, second, arch);
+  auto packed = detail::pack32(first, second, arch);
+  return packed;
 }
+
 
 namespace detail {
 
@@ -988,6 +1171,25 @@ struct GetHalf<int64_t, int32_t, A> {
   }
 #endif
 
+template <bool kSecond>
+static xsimd::batch<int64_t, A> apply(
+    xsimd::batch<int32_t, A> data,
+    const xsimd::generic&) {
+  constexpr std::size_t input_size = xsimd::batch<int32_t, A>::size;
+  constexpr std::size_t half_size = input_size / 2;
+  
+  std::array<int32_t, input_size> input_buffer;
+  data.store_aligned(input_buffer.data());
+  
+  std::array<int64_t, half_size> output_buffer;
+  for (std::size_t i = 0; i < half_size; ++i) {
+    output_buffer[i] = static_cast<int64_t>(
+        kSecond ? input_buffer[i + half_size] : input_buffer[i]);
+  }
+  
+  return xsimd::load_aligned(output_buffer.data());
+}
+
 #if XSIMD_WITH_NEON
   template <bool kSecond>
   static xsimd::batch<int64_t, A> apply(
@@ -1039,6 +1241,25 @@ struct GetHalf<uint64_t, int32_t, A> {
     return vmovl_u32(vreinterpret_u32_s32(half));
   }
 #endif
+
+template <bool kSecond>
+static xsimd::batch<uint64_t, A> apply(
+  xsimd::batch<int32_t, A> data, 
+  const xsimd::generic&){
+    constexpr std::size_t input_size = xsimd::batch<int32_t, A>::size;
+    constexpr std::size_t half_size = input_size / 2;
+    std::array<int32_t, input_size> input_buffer;
+    data.store_aligned(input_buffer.data());
+    std::array<uint64_t, half_size> output_buffer;
+    for (std::size_t i = 0; i < half_size; ++i)
+    {
+        output_buffer[i] = static_cast<uint64_t>(
+            kSecond ? static_cast<uint32_t>(input_buffer[i + half_size])
+            : static_cast<uint32_t>(input_buffer[i]));
+    }
+    return xsimd::load_aligned(output_buffer.data());
+}
+
 };
 
 } // namespace detail
@@ -1081,6 +1302,20 @@ struct Filter<T, A, 2> {
         detail::filterHalf<A, 1>(data, mask >> 8, arch);
     return ans;
   }
+#endif
+
+#if XSIMD_WITH_SVE
+static xsimd::batch<T, A> apply(xsimd::batch<T, A> data, int mask, const xsimd::sve& arch) {
+    int lane_count = svcntb() / sizeof(T);  
+    T compressed[lane_count];  
+    int idx = 0;
+    for (int i = 0; i < lane_count; i++) {
+        if (mask & (1 << i)) {
+            compressed[idx++] = data.get(i);  
+        }
+    }
+    return xsimd::load_unaligned(compressed); 
+}
 #endif
 };
 
@@ -1132,6 +1367,15 @@ struct Crc32<uint64_t, A> {
   }
 #endif
 
+#if XSIMD_WITH_SVE
+  static uint32_t apply(uint32_t checksum, uint64_t value, const xsimd::sve&) {
+    __asm__("crc32cx %w[c], %w[c], %x[v]"
+            : [c] "+r"(checksum)
+            : [v] "r"(value));
+    return checksum;
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static uint32_t apply(uint32_t checksum, uint64_t value, const xsimd::neon&) {
     __asm__("crc32cx %w[c], %w[c], %x[v]"
@@ -1156,6 +1400,20 @@ xsimd::batch<T, A> iota(const A&) {
 }
 
 namespace detail {
+
+#if (XSIMD_WITH_SVE && SVE_BITS==256)
+template <typename T, typename A>
+struct HalfBatchImpl<T, A, std::enable_if_t<std::is_base_of_v<xsimd::sve, A>>> {
+  using Type = Batch128<T>;
+};
+#endif
+
+#if (XSIMD_WITH_SVE && SVE_BITS==128)
+template <typename T, typename A>
+struct HalfBatchImpl<T, A, std::enable_if_t<std::is_base_of_v<xsimd::sve, A>>> {
+  using Type = Batch64<T>;
+};
+#endif
 
 template <typename T, typename A>
 struct HalfBatchImpl<T, A, std::enable_if_t<std::is_base_of_v<xsimd::avx, A>>> {
@@ -1194,10 +1452,18 @@ struct ReinterpretBatch<T, T, A> {
   }
 };
 
-#if XSIMD_WITH_NEON || XSIMD_WITH_NEON64
+#if XSIMD_WITH_NEON || XSIMD_WITH_NEON64 || XSIMD_WITH_SVE
 
 template <typename A>
 struct ReinterpretBatch<uint8_t, int8_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint8_t, A> apply(
+      xsimd::batch<int8_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u8_s8(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint8_t, A> apply(
       xsimd::batch<int8_t, A> data,
@@ -1217,6 +1483,14 @@ struct ReinterpretBatch<uint8_t, int8_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<int8_t, uint8_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<int8_t, A> apply(
+      xsimd::batch<uint8_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_s8_u8(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<int8_t, A> apply(
       xsimd::batch<uint8_t, A> data,
@@ -1236,6 +1510,14 @@ struct ReinterpretBatch<int8_t, uint8_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint16_t, int16_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint16_t, A> apply(
+      xsimd::batch<int16_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u16_s16(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint16_t, A> apply(
       xsimd::batch<int16_t, A> data,
@@ -1255,6 +1537,14 @@ struct ReinterpretBatch<uint16_t, int16_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<int16_t, uint16_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<int16_t, A> apply(
+      xsimd::batch<uint16_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_s16_u16(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<int16_t, A> apply(
       xsimd::batch<uint16_t, A> data,
@@ -1274,6 +1564,14 @@ struct ReinterpretBatch<int16_t, uint16_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint32_t, int32_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint32_t, A> apply(
+      xsimd::batch<int32_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u32_s32(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint32_t, A> apply(
       xsimd::batch<int32_t, A> data,
@@ -1293,6 +1591,14 @@ struct ReinterpretBatch<uint32_t, int32_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<int32_t, uint32_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<int32_t, A> apply(
+      xsimd::batch<uint32_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_s32_u32(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<int32_t, A> apply(
       xsimd::batch<uint32_t, A> data,
@@ -1312,6 +1618,14 @@ struct ReinterpretBatch<int32_t, uint32_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint64_t, uint32_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint64_t, A> apply(
+      xsimd::batch<uint32_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u64_u32(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint64_t, A> apply(
       xsimd::batch<uint32_t, A> data,
@@ -1331,6 +1645,14 @@ struct ReinterpretBatch<uint64_t, uint32_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint64_t, int64_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint64_t, A> apply(
+      xsimd::batch<int64_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u64_s64(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint64_t, A> apply(
       xsimd::batch<int64_t, A> data,
@@ -1350,6 +1672,14 @@ struct ReinterpretBatch<uint64_t, int64_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint32_t, int64_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint32_t, A> apply(
+      xsimd::batch<int64_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u32_s64(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint32_t, A> apply(
       xsimd::batch<int64_t, A> data,
@@ -1369,6 +1699,14 @@ struct ReinterpretBatch<uint32_t, int64_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<int64_t, uint64_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<int64_t, A> apply(
+      xsimd::batch<uint64_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_s64_u64(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<int64_t, A> apply(
       xsimd::batch<uint64_t, A> data,
@@ -1388,6 +1726,14 @@ struct ReinterpretBatch<int64_t, uint64_t, A> {
 
 template <typename A>
 struct ReinterpretBatch<uint32_t, uint64_t, A> {
+#if XSIMD_WITH_SVE
+  static xsimd::batch<uint32_t, A> apply(
+      xsimd::batch<uint64_t, A> data,
+      const xsimd::sve&) {
+    return svreinterpret_u32_u64(data.data);
+  }
+#endif
+
 #if XSIMD_WITH_NEON
   static xsimd::batch<uint32_t, A> apply(
       xsimd::batch<uint64_t, A> data,
@@ -1443,6 +1789,9 @@ namespace detail {
 /// performance will be better than std::find in that case.
 #if XSIMD_WITH_AVX2
 using CharVector = xsimd::batch<uint8_t, xsimd::avx2>;
+#define VELOX_SIMD_STRSTR 1
+#elif XSIMD_WITH_SVE
+using CharVector = xsimd::batch<uint8_t, xsimd::sve>;
 #define VELOX_SIMD_STRSTR 1
 #elif XSIMD_WITH_NEON
 using CharVector = xsimd::batch<uint8_t, xsimd::neon>;

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -131,6 +131,51 @@ struct Batch64 {
   }
 };
 
+template <typename T>
+struct Batch128 {
+  static constexpr size_t size = [] {
+    static_assert(16 % sizeof(T) == 0);
+    return 16 / sizeof(T);
+  }();
+
+  T data[size];
+
+  static Batch128 from(std::initializer_list<T> values) {
+    VELOX_DCHECK_EQ(values.size(), size);
+    Batch128 ans;
+    for (int i = 0; i < size; ++i) {
+      ans.data[i] = *(values.begin() + i);
+    }
+    return ans;
+  }
+
+  void store_unaligned(T* out) const {
+    std::copy(std::begin(data), std::end(data), out);
+  }
+
+  static Batch128 load_aligned(const T* mem) {
+    return load_unaligned(mem);
+  }
+
+  static Batch128 load_unaligned(const T* mem) {
+    Batch128 ans;
+    std::copy(mem, mem + size, ans.data);
+    return ans;
+  }
+
+  friend Batch128 operator+(Batch128 x, T y) {
+    for (int i = 0; i < size; ++i) {
+      x.data[i] += y;
+    }
+    return x;
+  }
+
+  friend Batch128 operator-(Batch128 x, T y) {
+    return x + (-y);
+  }
+};
+
+
 namespace detail {
 template <typename T, typename IndexType, typename A, int kSizeT = sizeof(T)>
 struct Gather;
@@ -178,6 +223,18 @@ gather(const T* base, Batch64<IndexType> vindex, const A& arch = {}) {
   return Impl::template apply<kScale>(base, vindex.data, arch);
 }
 
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A>
+gather(const T* base, Batch128<IndexType> vindex, const A& arch = {}) {
+  using Impl = detail::Gather<T, IndexType, A>;
+  return Impl::template apply<kScale>(base, vindex.data, arch);
+}
+
+
 // Same as 'gather' above except the indices are read from memory.
 template <
     typename T,
@@ -218,6 +275,21 @@ xsimd::batch<T, A> maskGather(
     xsimd::batch_bool<T, A> mask,
     const T* base,
     Batch64<IndexType> vindex,
+    const A& arch = {}) {
+  using Impl = detail::Gather<T, IndexType, A>;
+  return Impl::template maskApply<kScale>(src, mask, base, vindex.data, arch);
+}
+
+template <
+    typename T,
+    typename IndexType,
+    int kScale = sizeof(T),
+    typename A = xsimd::default_arch>
+xsimd::batch<T, A> maskGather(
+    xsimd::batch<T, A> src,
+    xsimd::batch_bool<T, A> mask,
+    const T* base,
+    Batch128<IndexType> vindex,
     const A& arch = {}) {
   using Impl = detail::Gather<T, IndexType, A>;
   return Impl::template maskApply<kScale>(src, mask, base, vindex.data, arch);

--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -703,7 +703,15 @@ inline xsimd::batch<int64_t> cvtU32toI64(
     xsimd::batch<int32_t, xsimd::sse2> values) {
   return _mm256_cvtepu32_epi64(values);
 }
-#elif XSIMD_WITH_SSE2 || XSIMD_WITH_NEON
+#elif (XSIMD_WITH_SVE && SVE_BITS == 256)
+inline xsimd::batch<int64_t> cvtU32toI64(simd::Batch128<int32_t> values) {
+  int64_t element_1 = static_cast<uint32_t>(values.data[0]);
+  int64_t element_2 = static_cast<uint32_t>(values.data[1]);
+  int64_t element_3 = static_cast<uint32_t>(values.data[2]);
+  int64_t element_4 = static_cast<uint32_t>(values.data[3]);
+  return xsimd::batch<int64_t>(element_1,element_2,element_3,element_4);
+}
+#elif XSIMD_WITH_SSE2 || XSIMD_WITH_NEON || (XSIMD_WITH_SVE && SVE_BITS == 128)
 inline xsimd::batch<int64_t> cvtU32toI64(simd::Batch64<int32_t> values) {
   int64_t lo = static_cast<uint32_t>(values.data[0]);
   int64_t hi = static_cast<uint32_t>(values.data[1]);
@@ -892,10 +900,10 @@ class DictionaryColumnVisitor
           dictMask,
           reinterpret_cast<const int32_t*>(filterCache() - 3),
           indices);
-      auto unknowns = simd::toBitMask(xsimd::batch_bool<int32_t>(
-          simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1)));
-      auto passed = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
+      auto cache_bits = xsimd::batch_bool<int32_t>(cache != 0);
+      auto shifted_bits = xsimd::batch_bool<int32_t>(((cache & (kUnknown << 24)) << 1) != 0);
+      auto passed = simd::toBitMask(cache_bits);
+      auto unknowns = simd::toBitMask(shifted_bits);
       if (UNLIKELY(unknowns)) {
         uint16_t bits = unknowns;
         // Ranges only over inputs that are in dictionary, the not in dictionary
@@ -1263,10 +1271,10 @@ class StringDictionaryColumnVisitor
       } else {
         cache = simd::gather<int32_t, int32_t, 1>(base, indices);
       }
-      auto unknowns = simd::toBitMask(xsimd::batch_bool<int32_t>(
-          simd::reinterpretBatch<uint32_t>((cache & (kUnknown << 24)) << 1)));
-      auto passed = simd::toBitMask(
-          xsimd::batch_bool<int32_t>(simd::reinterpretBatch<uint32_t>(cache)));
+      auto cache_bits = xsimd::batch_bool<int32_t>(cache != 0);
+      auto shifted_bits = xsimd::batch_bool<int32_t>(((cache & (kUnknown << 24)) << 1) != 0);
+      auto passed = simd::toBitMask(cache_bits);
+      auto unknowns = simd::toBitMask(shifted_bits);
       if (UNLIKELY(unknowns)) {
         uint16_t bits = unknowns;
         while (bits) {

--- a/velox/functions/lib/SIMDComparisonUtil.h
+++ b/velox/functions/lib/SIMDComparisonUtil.h
@@ -40,27 +40,27 @@ inline uint64_t to64Bits(const int8_t* resultData) {
   uint64_t res = 0UL;
   if constexpr (numScalarElements == 64) {
     res = simd::toBitMask(xsimd::batch_bool<int8_t>(
-        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))));
+        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))!=0));
   } else if constexpr (numScalarElements == 32) {
     auto* addr = reinterpret_cast<uint32_t*>(&res);
     *(addr) = simd::toBitMask(xsimd::batch_bool<int8_t>(
-        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))));
+        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))!=0));
     *(addr + 1) = simd::toBitMask(
         xsimd::batch_bool<int8_t>(simd::reinterpretBatch<uint8_t>(
-            d_type::load_unaligned(resultData + 32))));
+            d_type::load_unaligned(resultData + 32))!=0));
   } else if constexpr (numScalarElements == 16) {
     auto* addr = reinterpret_cast<uint16_t*>(&res);
     *(addr) = simd::toBitMask(xsimd::batch_bool<int8_t>(
-        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))));
+        simd::reinterpretBatch<uint8_t>(d_type::load_unaligned(resultData))!=0));
     *(addr + 1) = simd::toBitMask(
         xsimd::batch_bool<int8_t>(simd::reinterpretBatch<uint8_t>(
-            d_type::load_unaligned(resultData + 16))));
+            d_type::load_unaligned(resultData + 16))!=0));
     *(addr + 2) = simd::toBitMask(
         xsimd::batch_bool<int8_t>(simd::reinterpretBatch<uint8_t>(
-            d_type::load_unaligned(resultData + 32))));
+            d_type::load_unaligned(resultData + 32))!=0));
     *(addr + 3) = simd::toBitMask(
         xsimd::batch_bool<int8_t>(simd::reinterpretBatch<uint8_t>(
-            d_type::load_unaligned(resultData + 48))));
+            d_type::load_unaligned(resultData + 48))!=0));
   }
   return res;
 }


### PR DESCRIPTION
### Overview
This commit introduces support for the Scalable Vector Extension (SVE) in Velox. Previously, enabling SVE during the build process resulted in compilation errors due to missing architecture-specific handling. This update resolves those issues and enables SVE-based additions for 128 bit and 256 bit architectures.

### Key Changes
- SVE Detection in Build System: Added proper detection of SVE support to ensure compatibility, and introduced necessary compiler flags
- SVE-Specific Implementations: Added SVE-based functions to complement existing NEON and AVX2 implementations in the SIMD utility file.
- Code Refactoring & Fixes: Made necessary adjustments in related utility files to resolve build issues and ensure smooth integration of SVE.

### Impact
- Ensures Velox successfully compiles with SVE enabled, eliminating previous build failures.
- This build is an initial commit that unlocks SVE-based vectorization, that will eventually lead to better performance on supported ARM platforms.


We inspected the results of the benchmarks comparing the underlying architectures of NEON and SVE. There is no degradation of any benchmark seen.

### Breaking API Changes
N/A

### Related Issues
Fixes #12718 