### PR TITLE
misc: improve tzdb to be compatible with old tzdata

### DIFF
--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -708,6 +708,10 @@ static void __parse_zone(
   } while (std::isdigit(__input.peek()) || __input.peek() == '-');
 
   std::filesystem::path __root = __libcpp_tzdb_directory();
+  if (!std::filesystem::exists(__root/ __p->__name())) {
+    // in case the zonefile does not exists
+    return;
+  }
   std::ifstream zone_file{__root / __p->__name()};
   date::populate_transitions(__p->transitions(), __p->ttinfos(), zone_file);
 


### PR DESCRIPTION
On some legacy system the tzdata is not updated, it's better to skip on non-exits zones rather than throw exception.
This patch add the logic to ignore the missing zonefile

fixes: https://github.com/facebookincubator/velox/issues/12721