### PR TITLE
feat: Add Spark array_prepend function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -122,6 +122,17 @@ Array Functions
         SELECT array_position(array(1, 2, 3), 4); -- 0
         SELECT array_position(array(1, 2, 3, 2), 2); -- 2
 
+.. spark:function:: array_prepend(x, element) -> array
+
+    Add the ``element`` at the beginning of the input array ``x``.
+    Type of ``element`` should be the same to the type of elements in the array ``x``.
+    NULL element is also prepended into the array ``x``. Returns NULL when the input array ``x`` is NULL. ::
+
+        SELECT array_prepend(array(1, 2, 3), 2); -- [2, 1, 2, 3]
+        SELECT array_prepend(array(1, 2, 3), NULL); -- [NULL, 1, 2, 3]
+        SELECT array_prepend(NULL, 1); -- NULL
+        SELECT array_prepend(array(NULL, 2, 3), 1); -- [1, NULL, 2, 3]
+
 .. spark:function:: array_remove(x, element) -> array
 
     Remove all elements that equal ``element`` from array ``x``. Returns NULL as result if ``element`` is NULL.

--- a/velox/functions/sparksql/ArrayPrepend.h
+++ b/velox/functions/sparksql/ArrayPrepend.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// array_prepend(array(E), element) -> array(E)
+/// Given an array and another element, append the element at the front of the
+/// array.
+template <typename TExec>
+struct ArrayPrependFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  // Results refer to the first input strings parameter buffer.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // Fast path for primitives.
+  template <typename Out, typename In, typename E>
+  FOLLY_ALWAYS_INLINE bool callNullable(Out& out, const In* array, E* element) {
+    if (array == nullptr) {
+      return false;
+    }
+    out.reserve(array->size() + 1);
+    element ? out.push_back(*element) : out.add_null();
+    out.add_items(*array);
+    return true;
+  }
+
+  // Generic implementation.
+  FOLLY_ALWAYS_INLINE bool callNullable(
+      out_type<Array<Generic<T1>>>& out,
+      const arg_type<Array<Generic<T1>>>* array,
+      const arg_type<Generic<T1>>* element) {
+    if (array == nullptr) {
+      return false;
+    }
+    out.reserve(array->size() + 1);
+    element ? out.push_back(*element) : out.add_null();
+    out.add_items(*array);
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/sparksql/ArrayFlattenFunction.h"
 #include "velox/functions/sparksql/ArrayInsert.h"
 #include "velox/functions/sparksql/ArrayMinMaxFunction.h"
+#include "velox/functions/sparksql/ArrayPrepend.h"
 #include "velox/functions/sparksql/ArraySort.h"
 
 namespace facebook::velox::functions {
@@ -137,6 +138,28 @@ inline void registerArrayRemoveFunctions(const std::string& prefix) {
 }
 
 template <typename T>
+inline void registerArrayPrependFunctions(const std::string& prefix) {
+  registerFunction<ArrayPrependFunction, Array<T>, Array<T>, T>(
+      {prefix + "array_prepend"});
+}
+
+inline void registerArrayPrependFunctions(const std::string& prefix) {
+  registerArrayPrependFunctions<int8_t>(prefix);
+  registerArrayPrependFunctions<int16_t>(prefix);
+  registerArrayPrependFunctions<int32_t>(prefix);
+  registerArrayPrependFunctions<int64_t>(prefix);
+  registerArrayPrependFunctions<int128_t>(prefix);
+  registerArrayPrependFunctions<float>(prefix);
+  registerArrayPrependFunctions<double>(prefix);
+  registerArrayPrependFunctions<bool>(prefix);
+  registerArrayPrependFunctions<Timestamp>(prefix);
+  registerArrayPrependFunctions<Date>(prefix);
+  registerArrayPrependFunctions<Varbinary>(prefix);
+  registerArrayPrependFunctions<Varchar>(prefix);
+  registerArrayPrependFunctions<Generic<T1>>(prefix);
+}
+
+template <typename T>
 inline void registerArrayUnionFunction(const std::string& prefix) {
   registerFunction<ArrayUnionFunction, Array<T>, Array<T>, Array<T>>(
       {prefix + "array_union"});
@@ -163,6 +186,7 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayJoinFunctions(prefix);
   registerArrayMinMaxFunctions(prefix);
   registerArrayRemoveFunctions(prefix);
+  registerArrayPrependFunctions(prefix);
   registerSparkArrayFunctions(prefix);
   // Register array sort functions.
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/ArrayPrependTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayPrependTest.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayPrependTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename T>
+  void testFloats() {
+    static const T kNaN = std::numeric_limits<T>::quiet_NaN();
+    static const T kSNaN = std::numeric_limits<T>::signaling_NaN();
+    {
+      const auto arrayVector = makeNullableArrayVector<T>(
+          {{std::nullopt, 2, 3, std::nullopt, 4},
+           {3, 4, 5, kNaN, 3, 4, kNaN},
+           {kSNaN, 8, 9}});
+      const auto elementVector = makeFlatVector<T>({1, kNaN, kNaN});
+      const auto expected = makeNullableArrayVector<T>({
+          {1, std::nullopt, 2, 3, std::nullopt, 4},
+          {kNaN, 3, 4, 5, kNaN, 3, 4, kNaN},
+          {kNaN, kSNaN, 8, 9},
+      });
+      testExpression(
+          "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+    }
+    // Test array_prepend with complex-type elements.
+    {
+      RowTypePtr rowType;
+      if constexpr (std::is_same_v<T, float>) {
+        rowType = ROW({REAL(), VARCHAR()});
+      } else {
+        static_assert(std::is_same_v<T, double>);
+        rowType = ROW({DOUBLE(), VARCHAR()});
+      }
+      using ArrayOfRow = std::vector<std::optional<std::tuple<T, std::string>>>;
+      std::vector<ArrayOfRow> data = {
+          {{{1, "red"}}, {{2, "black"}}, {{3, "green"}}},
+          {{{1, "red"}}, {{2, "black"}}, {{3, "green"}}}};
+      auto arrayVector = makeArrayOfRowVector(data, rowType);
+
+      const auto elementVector =
+          makeConstantRow(rowType, variant::row({kNaN, "blue"}), 2);
+
+      std::vector<ArrayOfRow> expectedData = {
+          {{{kNaN, "blue"}}, {{1, "red"}}, {{2, "black"}}, {{3, "green"}}},
+          {{{kNaN, "blue"}}, {{1, "red"}}, {{2, "black"}}, {{3, "green"}}}};
+      const auto expected = makeArrayOfRowVector(expectedData, rowType);
+      testExpression(
+          "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+    }
+  }
+};
+
+// Prepend simple-type elements to array.
+TEST_F(ArrayPrependTest, intArrays) {
+  const auto arrayVector = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
+  const auto elementVector = makeFlatVector<int64_t>({11, 22, 33, 44});
+
+  VectorPtr expected = makeArrayVector<int64_t>({
+      {11, 1, 2, 3, 4},
+      {22, 3, 4, 5},
+      {33, 7, 8, 9},
+      {44, 10, 20, 30},
+  });
+  testExpression(
+      "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+// Prepend simple-type elements to array.
+TEST_F(ArrayPrependTest, floatArrays) {
+  testFloats<float>();
+  testFloats<double>();
+}
+
+// Prepend simple-type elements to array.
+TEST_F(ArrayPrependTest, stringArrays) {
+  const auto arrayVector = makeNullableArrayVector<std::string>(
+      {{"foo", std::nullopt, "bar"}, {"bar", "baz"}});
+  const auto elementVector =
+      makeNullableFlatVector<std::string>({std::nullopt, "foo"});
+
+  VectorPtr expected = makeNullableArrayVector<std::string>(
+      {{std::nullopt, "foo", std::nullopt, "bar"}, {"foo", "bar", "baz"}});
+  testExpression(
+      "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+// Prepend simple-type elements to array.
+TEST_F(ArrayPrependTest, boolArrays) {
+  auto arrayVector = makeNullableArrayVector<bool>(
+      {{true, false, true}, {true, false, std::nullopt}});
+  const auto elementVector =
+      makeNullableFlatVector<bool>({std::nullopt, false});
+
+  VectorPtr expected = makeNullableArrayVector<bool>(
+      {{std::nullopt, true, false, true}, {false, true, false, std::nullopt}});
+  testExpression(
+      "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+// Prepend null element to array or null array.
+TEST_F(ArrayPrependTest, nullArrays) {
+  const auto arrayVector = makeArrayVectorFromJson<int64_t>(
+      {"[1, 2, 3, null]", "[3, 4, 5]", "null", "[10, 20, null]"});
+
+  const auto elementVector = makeNullableFlatVector<int64_t>(
+      {11, std::nullopt, std::nullopt, std::nullopt});
+
+  VectorPtr expected = makeArrayVectorFromJson<int64_t>(
+      {"[11, 1, 2, 3, null]",
+       "[null, 3, 4, 5]",
+       "null",
+       "[null, 10, 20, null]"});
+  testExpression(
+      "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+// Prepend complex-type elements to array.
+TEST_F(ArrayPrependTest, complexArray) {
+  const auto arrayVector = makeNestedArrayVectorFromJson<int32_t>(
+      {"[[1, 2, null], [null], [3, null, 4, null]]",
+       "[[1, null, 2], null, [3, null, 4, null]]",
+       "[[1, 2], [], [null, 3, 4]]",
+       "null",
+       "[[], [1, 2]]",
+       "[[1, 2], null]",
+       "[[1, 2], []]"});
+
+  VectorPtr elementVector = makeArrayVectorFromJson<int32_t>(
+      {"[1, 2, 3]",
+       "[5]",
+       "null",
+       "[10, 20]",
+       "[6]",
+       "[7, null, 8]",
+       "[null]"});
+
+  const auto expected = makeNestedArrayVectorFromJson<int32_t>(
+      {"[[1, 2, 3], [1, 2, null], [null], [3, null, 4, null]]",
+       "[[5], [1, null, 2], null, [3, null, 4, null]]",
+       "[null, [1, 2], [], [null, 3, 4]]",
+       "null",
+       "[[6], [], [1, 2]]",
+       "[[7, null, 8], [1, 2], null]",
+       "[[null], [1, 2], []]"});
+  testExpression(
+      "array_prepend(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ArrayInsertTest.cpp
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
+  ArrayPrependTest.cpp
   ArraySortTest.cpp
   ArrayShuffleTest.cpp
   ArrayUnionTest.cpp


### PR DESCRIPTION
This PR aims to add Spark `array_prepend` function. 

Spark implement: https://github.com/apache/spark/blob/aaa94c4e40dfe3dd4f7d05c2388903bad93a2907/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L1694-L1721

Fixes #12726.