### PR TITLE
MockSharedArbitrationTest.configToString bug: config string is dependent on unordered_map, which may behavior from different platform

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -97,7 +97,8 @@ class MemoryArbitrator {
 
     std::string toString() const {
       std::stringstream ss;
-      for (const auto& extraConfig : extraConfigs) {
+      auto orderedConfig = std::map(extraConfigs.begin(), extraConfigs.end());
+      for (const auto& extraConfig : orderedConfig) {
         ss << extraConfig.first << "=" << extraConfig.second << ";";
       }
       return fmt::format(
@@ -404,7 +405,7 @@ class MemoryReclaimer {
   virtual void abort(MemoryPool* pool, const std::exception_ptr& error);
 
  protected:
-  explicit MemoryReclaimer(int32_t priority) : priority_(priority){};
+  explicit MemoryReclaimer(int32_t priority) : priority_(priority) {};
 
  private:
   const int32_t priority_;

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -604,17 +604,17 @@ TEST_F(MockSharedArbitrationTest, configToString) {
       arbitratorConfig.toString(),
       "kind=SHARED;capacity=1.00KB;"
       "arbitrationStateCheckCb=(unset);"
-      "global-arbitration-without-spill=true;"
-      "memory-reclaim-threads-hw-multiplier=1.0;"
       "check-usage-leak=false;"
+      "global-arbitration-abort-time-ratio=0.8;"
       "global-arbitration-enabled=true;"
-      "max-memory-arbitration-time=5000ms;"
       "global-arbitration-memory-reclaim-pct=30;"
+      "global-arbitration-without-spill=true;"
+      "max-memory-arbitration-time=5000ms;"
       "memory-pool-abort-capacity-limit=256mb;"
+      "memory-pool-initial-capacity=512MB;"
       "memory-pool-min-reclaim-bytes=64mb;"
       "memory-pool-reserved-capacity=200B;"
-      "memory-pool-initial-capacity=512MB;"
-      "global-arbitration-abort-time-ratio=0.8;"
+      "memory-reclaim-threads-hw-multiplier=1.0;"
       "reserved-capacity=100B;");
 }
 


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/12732