### PR TITLE
refactor: Remove unused bufferEnd_ field from parquet decoders

### DIFF
--- a/velox/dwio/parquet/reader/BooleanDecoder.h
+++ b/velox/dwio/parquet/reader/BooleanDecoder.h
@@ -20,8 +20,8 @@ namespace facebook::velox::parquet {
 
 class BooleanDecoder {
  public:
-  BooleanDecoder(const char* start, const char* end)
-      : bufferStart_(start), bufferEnd_(end) {}
+  BooleanDecoder(const char* start, const char* /*end*/)
+      : bufferStart_(start) {}
 
   void skip(uint64_t numValues) {
     skip<false>(numValues, 0, nullptr);
@@ -100,7 +100,6 @@ class BooleanDecoder {
   size_t remainingBits_{0};
   uint8_t reversedLastByte_{0};
   const char* bufferStart_{nullptr};
-  const char* bufferEnd_{nullptr};
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -22,7 +22,6 @@ class StringDecoder {
  public:
   StringDecoder(const char* start, const char* end, int fixedLength = -1)
       : bufferStart_(start),
-        bufferEnd_(end),
         lastSafeWord_(end - simd::kPadding),
         fixedLength_(fixedLength) {}
 
@@ -103,7 +102,6 @@ class StringDecoder {
   }
 
   const char* bufferStart_;
-  const char* bufferEnd_;
   const char* const lastSafeWord_;
   const int fixedLength_;
 };


### PR DESCRIPTION
Summary: We keep it in the constructor just in case we need it someday.

Differential Revision: D71554837


