### PR TITLE
feat: Adding StripeFooter Wrapper to for accessing orc and dwrf StripeFooter

### DIFF
--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -828,6 +828,123 @@ class FooterWrapper : public ProtoWrapperBase {
   }
 };
 
+class StripeFooterWrapper : public ProtoWrapperBase {
+  // Supporting the two following proto definitions:
+  //  kOrc
+  //  message StripeFooter {
+  //    repeated Stream streams = 1;
+  //    repeated ColumnEncoding columns = 2;
+  //    optional string writerTimezone = 3;
+  //    repeated StripeEncryptionVariant encryption = 4;
+  //  }
+  //
+  //  kDwrf
+  //  message StripeFooter {
+  //    repeated Stream streams = 1;
+  //    repeated ColumnEncoding encoding = 2;
+  //    repeated bytes encryptionGroups = 3;
+  //  }
+
+ public:
+  explicit StripeFooterWrapper(
+      std::shared_ptr<const proto::StripeFooter> stripeFooter)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, stripeFooter.get()),
+        dwrfStripeFooter_(std::move(stripeFooter)) {}
+
+  explicit StripeFooterWrapper(
+      std::shared_ptr<const proto::orc::StripeFooter> stripeFooter)
+      : ProtoWrapperBase(DwrfFormat::kOrc, stripeFooter.get()),
+        orcStripeFooter_(std::move(stripeFooter)) {}
+
+  const proto::StripeFooter& getStripeFooterDwrf() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    VELOX_CHECK_NOT_NULL(rawProtoPtr());
+    return *reinterpret_cast<const proto::StripeFooter*>(rawProtoPtr());
+  }
+
+  const proto::orc::StripeFooter& getStripeFooterOrc() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    VELOX_CHECK_NOT_NULL(rawProtoPtr());
+    return *reinterpret_cast<const proto::orc::StripeFooter*>(rawProtoPtr());
+  }
+
+  int streamsSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->streams_size()
+                                        : orcPtr()->streams_size();
+  }
+
+  const proto::Stream& streamDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->streams(index);
+  }
+
+  const proto::orc::Stream& streamOrc(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->streams(index);
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::Stream>& streamsDwrf()
+      const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->streams();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::orc::Stream>& streamsOrc()
+      const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->streams();
+  }
+
+  int columnEncodingSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->encoding_size()
+                                        : orcPtr()->columns_size();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::ColumnEncoding>&
+  columnEncodingsDwrf() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encoding();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::orc::ColumnEncoding>&
+  columnEncodingsOrc() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->columns();
+  }
+
+  const proto::ColumnEncoding& columnEncodingDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encoding(index);
+  }
+
+  const proto::orc::ColumnEncoding& columnEncodingOrc(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->columns(index);
+  }
+
+  int encryptiongroupsSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->encryptiongroups_size()
+                                        : 0;
+  }
+
+  const std::string& encryptiongroupsDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encryptiongroups(index);
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::StripeFooter* dwrfPtr() const {
+    return reinterpret_cast<const proto::StripeFooter*>(rawProtoPtr());
+  }
+  inline const proto::orc::StripeFooter* orcPtr() const {
+    return reinterpret_cast<const proto::orc::StripeFooter*>(rawProtoPtr());
+  }
+
+  std::shared_ptr<const proto::StripeFooter> dwrfStripeFooter_ = nullptr;
+  std::shared_ptr<const proto::orc::StripeFooter> orcStripeFooter_ = nullptr;
+};
+
 } // namespace facebook::velox::dwrf
 
 template <>

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -25,13 +25,36 @@ namespace facebook::velox::dwrf {
 
 struct StripeMetadata {
   dwio::common::BufferedInput* stripeInput;
-  std::shared_ptr<const proto::StripeFooter> footer;
+  std::shared_ptr<const StripeFooterWrapper> footer;
   std::unique_ptr<encryption::DecryptionHandler> decryptionHandler;
   StripeInformationWrapper stripeInfo;
 
   StripeMetadata(
       std::shared_ptr<dwio::common::BufferedInput> _stripeInput,
       std::shared_ptr<const proto::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            std::move(_stripeInput),
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
+  StripeMetadata(
+      dwio::common::BufferedInput* _stripeInput,
+      std::shared_ptr<const proto::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            _stripeInput,
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
+ private:
+  StripeMetadata(
+      std::shared_ptr<dwio::common::BufferedInput> _stripeInput,
+      std::shared_ptr<const StripeFooterWrapper> _footer,
       std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
       StripeInformationWrapper _stripeInfo)
       : stripeInput{_stripeInput.get()},
@@ -42,15 +65,13 @@ struct StripeMetadata {
 
   StripeMetadata(
       dwio::common::BufferedInput* _stripeInput,
-      std::shared_ptr<const proto::StripeFooter> _footer,
+      std::shared_ptr<const StripeFooterWrapper> _footer,
       std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
       StripeInformationWrapper _stripeInfo)
       : stripeInput{_stripeInput},
         footer{std::move(_footer)},
         decryptionHandler{std::move(_decryptionHandler)},
         stripeInfo{std::move(_stripeInfo)} {}
-
- private:
   const std::shared_ptr<dwio::common::BufferedInput> stripeInputOwned_;
 };
 

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -257,7 +257,8 @@ class StripeStreamsImpl : public StripeStreamsBase {
       const EncodingKey& encodingKey) const override {
     auto index = encodings_.find(encodingKey);
     if (index != encodings_.end()) {
-      return readState_->stripeMetadata->footer->encoding(index->second);
+      return readState_->stripeMetadata->footer->columnEncodingDwrf(
+          index->second);
     }
     auto encodingKeyIt = decryptedEncodings_.find(encodingKey);
     VELOX_CHECK(

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -257,6 +257,12 @@ target_link_libraries(
   velox_dwio_dwrf_encryption_test velox_link_libs Folly::folly
   ${TEST_LINK_LIBS})
 
+add_executable(velox_filemetadata_test FileMetadataTest.cpp)
+add_test(velox_filemetadata_test velox_filemetadata_test)
+
+target_link_libraries(
+  velox_filemetadata_test velox_link_libs ${TEST_LINK_LIBS})
+
 add_executable(velox_dwio_dwrf_stripe_reader_base_test
                StripeReaderBaseTests.cpp)
 add_test(velox_dwio_dwrf_stripe_reader_base_test

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -84,7 +84,7 @@ void verifyStats(
   // Compute Node Size and verify the File Footer Node Size matches.
   auto& stripeFooter = *stripeMetadata->footer;
   std::unordered_map<uint32_t, uint64_t> nodeSizes;
-  for (auto&& ss : stripeFooter.streams()) {
+  for (auto&& ss : stripeFooter.streamsDwrf()) {
     nodeSizes[ss.node()] += ss.length();
   }
 

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -113,8 +113,8 @@ class E2EWriterTest : public testing::Test {
     for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
       auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
       auto& footer = *stripeMetadata->footer;
-      for (int32_t j = 0; j < footer.encoding_size(); ++j) {
-        auto encoding = footer.encoding(j);
+      for (int32_t j = 0; j < footer.columnEncodingSize(); ++j) {
+        auto encoding = footer.columnEncodingDwrf(j);
         if (encoding.kind() ==
             dwrf::proto::ColumnEncoding_Kind::ColumnEncoding_Kind_MAP_FLAT) {
           actualNodeIds.insert(encoding.node());
@@ -575,8 +575,8 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
   for (int i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& footer = *stripeMetadata->footer;
-    for (int j = 0; j < footer.streams_size(); ++j) {
-      auto stream = footer.streams(j);
+    for (int j = 0; j < footer.streamsSize(); ++j) {
+      auto stream = footer.streamDwrf(j);
       ASSERT_NE(stream.kind(), dwrf::proto::Stream_Kind::Stream_Kind_PRESENT);
     }
   }
@@ -1227,9 +1227,9 @@ TEST_F(E2EEncryptionTest, EncryptRoot) {
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& sf = *stripeMetadata->footer;
-    ASSERT_EQ(sf.encoding_size(), 0);
-    ASSERT_EQ(sf.streams_size(), 0);
-    ASSERT_EQ(sf.encryptiongroups_size(), 1);
+    ASSERT_EQ(sf.columnEncodingSize(), 0);
+    ASSERT_EQ(sf.streamsSize(), 0);
+    ASSERT_EQ(sf.encryptiongroupsSize(), 1);
   }
 
   validateFileContent(*reader);
@@ -1308,10 +1308,10 @@ TEST_F(E2EEncryptionTest, EncryptSelectedFields) {
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& sf = *stripeMetadata->footer;
-    for (auto& enc : sf.encoding()) {
+    for (const auto& enc : sf.columnEncodingsDwrf()) {
       ASSERT_TRUE(encryptedNodes.find(enc.node()) == encryptedNodes.end());
     }
-    for (auto& stream : sf.streams()) {
+    for (const auto& stream : sf.streamsDwrf()) {
       ASSERT_TRUE(encryptedNodes.find(stream.node()) == encryptedNodes.end());
     }
   }

--- a/velox/dwio/dwrf/test/FileMetadataTest.cpp
+++ b/velox/dwio/dwrf/test/FileMetadataTest.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include "velox/dwio/dwrf/common/FileMetadata.h"
+
+using namespace ::testing;
+namespace facebook::velox::dwrf {
+
+class FileMetadataTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<proto::StripeFooter> dwrfStripeFooter_ =
+      std::make_shared<proto::StripeFooter>();
+  StripeFooterWrapper dwrfStripeFooterWrapper_ =
+      StripeFooterWrapper(dwrfStripeFooter_);
+
+  std::shared_ptr<proto::orc::StripeFooter> orcStripeFooter_ =
+      std::make_shared<proto::orc::StripeFooter>();
+
+  StripeFooterWrapper orcStripeFooterWrapper_ =
+      StripeFooterWrapper(orcStripeFooter_);
+};
+
+TEST_F(FileMetadataTest, StripeFooterWrapper_GetFormat_CorrectFormat) {
+  EXPECT_EQ(dwrfStripeFooterWrapper_.format(), DwrfFormat::kDwrf);
+  EXPECT_EQ(orcStripeFooterWrapper_.format(), DwrfFormat::kOrc);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetStripeFooter_ReturnsProtoTypes) {
+  EXPECT_EQ(
+      &dwrfStripeFooterWrapper_.getStripeFooterDwrf(), dwrfStripeFooter_.get());
+  EXPECT_ANY_THROW(dwrfStripeFooterWrapper_.getStripeFooterOrc());
+
+  EXPECT_EQ(
+      &orcStripeFooterWrapper_.getStripeFooterOrc(), orcStripeFooter_.get());
+  EXPECT_ANY_THROW(orcStripeFooterWrapper_.getStripeFooterDwrf());
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetStreamData_ReturnsCorrispondingProtoInfo) {
+  // 2 streams with incrementing length for validation
+  dwrfStripeFooter_->add_streams()->set_length(1);
+  dwrfStripeFooter_->add_streams()->set_length(2);
+
+  // 3 streams with incrementing length for validation
+  orcStripeFooter_->add_streams()->set_length(3);
+  orcStripeFooter_->add_streams()->set_length(4);
+  orcStripeFooter_->add_streams()->set_length(5);
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamsSize(), 2);
+
+  // all streams
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamsDwrf().size(), 2);
+
+  // access stream by index
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamDwrf(0).length(), 1);
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamDwrf(1).length(), 2);
+
+  // ORC
+  // get size
+  EXPECT_EQ(orcStripeFooterWrapper_.streamsSize(), 3);
+
+  // all streams
+  EXPECT_EQ(orcStripeFooterWrapper_.streamsOrc().size(), 3);
+
+  // access stream by index
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(0).length(), 3);
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(1).length(), 4);
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(2).length(), 5);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetEncodings_ReturnsCorrispondingProtoInfo) {
+  // 2 encoding with incrementing node for validation
+  dwrfStripeFooter_->add_encoding()->set_kind(
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+  dwrfStripeFooter_->add_encoding()->set_kind(
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+
+  // 3 encoding with incrementing node for validation
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT);
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.columnEncodingSize(), 2);
+
+  // all encoding
+  EXPECT_EQ(dwrfStripeFooterWrapper_.columnEncodingsDwrf().size(), 2);
+
+  // access encoding by index
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.columnEncodingDwrf(0).kind(),
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.columnEncodingDwrf(1).kind(),
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+
+  // ORC
+  // get size
+  EXPECT_EQ(orcStripeFooterWrapper_.columnEncodingSize(), 3);
+
+  // all encoding
+  EXPECT_EQ(orcStripeFooterWrapper_.columnEncodingsOrc().size(), 3);
+
+  // access encoding by index
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(0).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT);
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(1).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(2).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetEncryptionGroups_ReturnsCorrispondingProtoInfo) {
+  // 2 encryption groups with incrementing group for validation
+  dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_1");
+  dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_2");
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.encryptiongroupsSize(), 2);
+
+  // access encryption groups by index
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.encryptiongroupsDwrf(0),
+      "test_encryption_group_1");
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.encryptiongroupsDwrf(1),
+      "test_encryption_group_2");
+
+  // ORC
+  // orc encryption groups are not supported
+  // get size always zero
+  EXPECT_EQ(orcStripeFooterWrapper_.encryptiongroupsSize(), 0);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -67,14 +67,14 @@ namespace {
 void enqueueReads(
     BufferedInput& input,
     facebook::velox::dwrf::ReaderBase& readerBase,
-    const proto::StripeFooter& footer,
+    const StripeFooterWrapper& footer,
     const ColumnSelector& selector,
     uint64_t stripeStart,
     uint32_t stripeIndex) {
   auto& metadataCache = readerBase.metadataCache();
   uint64_t offset = stripeStart;
   uint64_t length = 0;
-  for (const auto& stream : footer.streams()) {
+  for (const auto& stream : footer.streamsDwrf()) {
     length = stream.length();
     // If index cache is available, there is no need to read it
     auto inMetaCache = metadataCache &&

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -129,8 +129,8 @@ namespace facebook::velox::dwrf {
     bool preload{false};
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     const auto& stripeFooter = *stripeMetadata->footer;
-    totalEncodingCount += stripeFooter.encoding_size();
-    for (const auto& encoding : stripeFooter.encoding()) {
+    totalEncodingCount += stripeFooter.columnEncodingSize();
+    for (const auto& encoding : stripeFooter.columnEncodingsDwrf()) {
       if (encoding.kind() == proto::ColumnEncoding_Kind_DICTIONARY) {
         ++dictEncodingCount;
       }


### PR DESCRIPTION
Summary:
Some internal service in Meta is intending to migrate to Velox and we need to support our existing ORC format.  Long term we can investigate migrating to DWRF formate however to unblock the near term efforts we need to have backward compatibility with our existing ORC format.

For this change set we are updating Velox to support reading ORC format

Core Changes
- Added StripeFooterWrapper to handle proto::StriperFooter and proto::orc::StripeFooter
- Added added StreamKind to indepentantly identify proto::Stream_Kind vs proto::orc::Stream_Kind
- Added overloads and helper to correctly get the DwrfStreamIdentifier depending dwrf vs orc EncoderKey
- Updated all readers to use the correct EncoderKey to get StreamId (dwrf vs orc)

# diff
Non functional change

Adding a wrapper for Stipe footer that will be used throughout the internal implementation to handling orc vs drwf reader functioanlity

Differential Revision: D71331178


