### PR TITLE
feat: Adding missing support for reading orc files

### DIFF
--- a/velox/dwio/dwrf/common/Common.cpp
+++ b/velox/dwio/dwrf/common/Common.cpp
@@ -61,6 +61,32 @@ std::string streamKindToString(StreamKind kind) {
       return "stride dictionary length";
     case StreamKind_BLOOM_FILTER_UTF8:
       return "bloom";
+    case StreamKindOrc_PRESENT:
+      return "orc present";
+    case StreamKindOrc_DATA:
+      return "orc data";
+    case StreamKindOrc_LENGTH:
+      return "orc length";
+    case StreamKindOrc_DICTIONARY_DATA:
+      return "orc dictionary";
+    case StreamKindOrc_DICTIONARY_COUNT:
+      return "orc dictionary count";
+    case StreamKindOrc_SECONDARY:
+      return "orc secondary";
+    case StreamKindOrc_ROW_INDEX:
+      return "orc index";
+    case StreamKindOrc_BLOOM_FILTER:
+      return "orc bloom";
+    case StreamKindOrc_BLOOM_FILTER_UTF8:
+      return "orc bloom utf8";
+    case StreamKindOrc_ENCRYPTED_INDEX:
+      return "orc encrypted index";
+    case StreamKindOrc_ENCRYPTED_DATA:
+      return "orc encrypted data";
+    case StreamKindOrc_STRIPE_STATISTICS:
+      return "orc stripe statistics";
+    case StreamKindOrc_FILE_STATISTICS:
+      return "orc file statistics";
   }
   return folly::to<std::string>("unknown - ", kind);
 }
@@ -80,6 +106,11 @@ std::string columnEncodingKindToString(ColumnEncodingKind kind) {
 }
 
 DwrfStreamIdentifier EncodingKey::forKind(const proto::Stream_Kind kind) const {
+  return DwrfStreamIdentifier(node_, sequence_, 0, kind);
+}
+
+DwrfStreamIdentifier EncodingKey::forKind(
+    const proto::orc::Stream_Kind kind) const {
   return DwrfStreamIdentifier(node_, sequence_, 0, kind);
 }
 

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -25,11 +25,6 @@
 
 namespace facebook::velox::dwrf {
 
-enum class DwrfFormat : uint8_t {
-  kDwrf = 0,
-  kOrc = 1,
-};
-
 class ProtoWrapperBase {
  public:
   DwrfFormat format() const {

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -828,6 +828,123 @@ class FooterWrapper : public ProtoWrapperBase {
   }
 };
 
+class StripeFooterWrapper : public ProtoWrapperBase {
+  // Supporting the two following proto definitions:
+  //  kOrc
+  //  message StripeFooter {
+  //    repeated Stream streams = 1;
+  //    repeated ColumnEncoding columns = 2;
+  //    optional string writerTimezone = 3;
+  //    repeated StripeEncryptionVariant encryption = 4;
+  //  }
+  //
+  //  kDwrf
+  //  message StripeFooter {
+  //    repeated Stream streams = 1;
+  //    repeated ColumnEncoding encoding = 2;
+  //    repeated bytes encryptionGroups = 3;
+  //  }
+
+ public:
+  explicit StripeFooterWrapper(
+      std::shared_ptr<const proto::StripeFooter> stripeFooter)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, stripeFooter.get()),
+        dwrfStripeFooter_(std::move(stripeFooter)) {}
+
+  explicit StripeFooterWrapper(
+      std::shared_ptr<const proto::orc::StripeFooter> stripeFooter)
+      : ProtoWrapperBase(DwrfFormat::kOrc, stripeFooter.get()),
+        orcStripeFooter_(std::move(stripeFooter)) {}
+
+  const proto::StripeFooter& getStripeFooterDwrf() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    VELOX_CHECK_NOT_NULL(rawProtoPtr());
+    return *reinterpret_cast<const proto::StripeFooter*>(rawProtoPtr());
+  }
+
+  const proto::orc::StripeFooter& getStripeFooterOrc() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    VELOX_CHECK_NOT_NULL(rawProtoPtr());
+    return *reinterpret_cast<const proto::orc::StripeFooter*>(rawProtoPtr());
+  }
+
+  int streamsSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->streams_size()
+                                        : orcPtr()->streams_size();
+  }
+
+  const proto::Stream& streamDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->streams(index);
+  }
+
+  const proto::orc::Stream& streamOrc(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->streams(index);
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::Stream>& streamsDwrf()
+      const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->streams();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::orc::Stream>& streamsOrc()
+      const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->streams();
+  }
+
+  int columnEncodingSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->encoding_size()
+                                        : orcPtr()->columns_size();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::ColumnEncoding>&
+  columnEncodingsDwrf() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encoding();
+  }
+
+  const ::google::protobuf::RepeatedPtrField<proto::orc::ColumnEncoding>&
+  columnEncodingsOrc() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->columns();
+  }
+
+  const proto::ColumnEncoding& columnEncodingDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encoding(index);
+  }
+
+  const proto::orc::ColumnEncoding& columnEncodingOrc(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kOrc);
+    return orcPtr()->columns(index);
+  }
+
+  int encryptiongroupsSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->encryptiongroups_size()
+                                        : 0;
+  }
+
+  const std::string& encryptiongroupsDwrf(int index) const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->encryptiongroups(index);
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::StripeFooter* dwrfPtr() const {
+    return reinterpret_cast<const proto::StripeFooter*>(rawProtoPtr());
+  }
+  inline const proto::orc::StripeFooter* orcPtr() const {
+    return reinterpret_cast<const proto::orc::StripeFooter*>(rawProtoPtr());
+  }
+
+  std::shared_ptr<const proto::StripeFooter> dwrfStripeFooter_ = nullptr;
+  std::shared_ptr<const proto::orc::StripeFooter> orcStripeFooter_ = nullptr;
+};
+
 } // namespace facebook::velox::dwrf
 
 template <>

--- a/velox/dwio/dwrf/reader/BinaryStreamReader.h
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.h
@@ -38,7 +38,11 @@ class BinaryStripeStreams {
       const EncodingKey ek,
       std::string_view label) const {
     return ProtoUtils::readProto<proto::RowIndex>(stripeStreams_.getStream(
-        ek.forKind(proto::Stream_Kind_ROW_INDEX), label, false));
+        stripeStreams_.format() == DwrfFormat::kDwrf
+            ? ek.forKind(proto::Stream_Kind_ROW_INDEX)
+            : ek.forKind(proto::orc::Stream_Kind_ROW_INDEX),
+        label,
+        false));
   }
 
   std::unique_ptr<dwio::common::SeekableInputStream> getStream(

--- a/velox/dwio/dwrf/reader/DwrfData.cpp
+++ b/velox/dwio/dwrf/reader/DwrfData.cpp
@@ -32,7 +32,11 @@ DwrfData::DwrfData(
       rowsPerRowGroup_{stripe.rowsPerRowGroup()} {
   EncodingKey encodingKey{fileType_->id(), flatMapContext_.sequence};
   std::unique_ptr<dwio::common::SeekableInputStream> stream = stripe.getStream(
-      encodingKey.forKind(proto::Stream_Kind_PRESENT),
+      StripeStreamsUtil::getStreamForKind(
+          stripe,
+          encodingKey,
+          proto::Stream_Kind_PRESENT,
+          proto::orc::Stream_Kind_PRESENT),
       streamLabels.label(),
       false);
   if (stream) {
@@ -44,7 +48,11 @@ DwrfData::DwrfData(
   // reader tree. This is not known at construct time because the first filter
   // can come from a hash join or other run time push-down.
   indexStream_ = stripe.getStream(
-      encodingKey.forKind(proto::Stream_Kind_ROW_INDEX),
+      StripeStreamsUtil::getStreamForKind(
+          stripe,
+          encodingKey,
+          proto::Stream_Kind_ROW_INDEX,
+          proto::orc::Stream_Kind_ROW_INDEX),
       streamLabels.label(),
       false);
 }

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -178,4 +178,29 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
   }
 }
 
+inline RleVersion convertRleVersion(proto::orc::ColumnEncoding_Kind kind) {
+  switch (kind) {
+    case proto::orc::ColumnEncoding_Kind_DIRECT:
+    case proto::orc::ColumnEncoding_Kind_DICTIONARY:
+      return RleVersion_1;
+    case proto::orc::ColumnEncoding_Kind_DIRECT_V2:
+    case proto::orc::ColumnEncoding_Kind_DICTIONARY_V2:
+      return RleVersion_2;
+    default:
+      VELOX_FAIL(
+          "Unknown encoding in convertRleVersion: {}",
+          static_cast<int64_t>(kind));
+  }
+}
+
+inline RleVersion convertRleVersion(
+    const StripeStreams& stripe,
+    const EncodingKey& encodingKey) {
+  if (stripe.format() == DwrfFormat::kDwrf) {
+    return convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  } else {
+    return convertRleVersion(stripe.getEncodingOrc(encodingKey).kind());
+  }
+}
+
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -42,14 +42,22 @@ class SelectiveByteRleColumnReader
     if (isBool) {
       boolRle_ = createBooleanRleDecoder(
           stripe.getStream(
-              encodingKey.forKind(proto::Stream_Kind_DATA),
+              StripeStreamsUtil::getStreamForKind(
+                  stripe,
+                  encodingKey,
+                  proto::Stream_Kind_DATA,
+                  proto::orc::Stream_Kind_DATA),
               params.streamLabels().label(),
               true),
           encodingKey);
     } else {
       byteRle_ = createByteRleDecoder(
           stripe.getStream(
-              encodingKey.forKind(proto::Stream_Kind_DATA),
+              StripeStreamsUtil::getStreamForKind(
+                  stripe,
+                  encodingKey,
+                  proto::Stream_Kind_DATA,
+                  proto::orc::Stream_Kind_DATA),
               params.streamLabels().label(),
               true),
           encodingKey);

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -31,15 +31,23 @@ SelectiveDecimalColumnReader<DataT>::SelectiveDecimalColumnReader(
   } else {
     scale_ = requestedType_->asLongDecimal().scale();
   }
-  version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
-  auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
+  version_ = convertRleVersion(stripe, encodingKey);
+  auto data = StripeStreamsUtil::getStreamForKind(
+      stripe,
+      encodingKey,
+      proto::Stream_Kind_DATA,
+      proto::orc::Stream_Kind_DATA);
   valueDecoder_ = createDirectDecoder</*isSigned*/ true>(
       stripe.getStream(data, params.streamLabels().label(), true),
       stripe.getUseVInts(data),
       sizeof(DataT));
 
   // [NOTICE] DWRF's NANO_DATA has the same enum value as ORC's SECONDARY
-  auto secondary = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
+  auto secondary = StripeStreamsUtil::getStreamForKind(
+      stripe,
+      encodingKey,
+      proto::Stream_Kind_NANO_DATA,
+      proto::orc::Stream_Kind_SECONDARY);
   scaleDecoder_ = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(secondary, params.streamLabels().label(), true),
       version_,

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -72,8 +72,13 @@ SelectiveFloatingPointColumnReader<TFile, TRequested>::
           params,
           scanSpec),
       decoder_(params.stripeStreams().getStream(
-          EncodingKey{this->fileType_->id(), params.flatMapContext().sequence}
-              .forKind(proto::Stream_Kind_DATA),
+          StripeStreamsUtil::getStreamForKind(
+              params.stripeStreams(),
+              EncodingKey{
+                  this->fileType_->id(),
+                  params.flatMapContext().sequence},
+              proto::Stream_Kind_DATA,
+              proto::orc::Stream_Kind_DATA),
           params.streamLabels().label(),
           true)) {}
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -35,6 +35,8 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
   const EncodingKey encodingKey{
       fileType_->id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
+  VELOX_CHECK_EQ(stripe.format(), DwrfFormat::kDwrf);
+
   const auto encoding = stripe.getEncoding(encodingKey);
   scanState_.dictionary.numValues = encoding.dictionarysize();
   rleVersion_ = convertRleVersion(encoding.kind());

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -25,9 +25,12 @@ std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> makeLengthDecoder(
     memory::MemoryPool& pool) {
   EncodingKey encodingKey{fileType.id(), params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  const auto rleVersion =
-      convertRleVersion(stripe.getEncoding(encodingKey).kind());
-  const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
+  const auto rleVersion = convertRleVersion(stripe, encodingKey);
+  const auto lenId = StripeStreamsUtil::getStreamForKind(
+      stripe,
+      encodingKey,
+      proto::Stream_Kind_LENGTH,
+      proto::orc::Stream_Kind_LENGTH);
   const bool lenVints = stripe.getUseVInts(lenId);
   return createRleDecoder</*isSigned=*/false>(
       stripe.getStream(lenId, params.streamLabels().label(), true),

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -51,6 +51,28 @@ struct StripeMetadata {
             std::move(_decryptionHandler),
             _stripeInfo) {}
 
+  StripeMetadata(
+      std::shared_ptr<dwio::common::BufferedInput> _stripeInput,
+      std::shared_ptr<const proto::orc::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            std::move(_stripeInput),
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
+  StripeMetadata(
+      dwio::common::BufferedInput* _stripeInput,
+      std::shared_ptr<const proto::orc::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            _stripeInput,
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
  private:
   StripeMetadata(
       std::shared_ptr<dwio::common::BufferedInput> _stripeInput,

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -25,13 +25,36 @@ namespace facebook::velox::dwrf {
 
 struct StripeMetadata {
   dwio::common::BufferedInput* stripeInput;
-  std::shared_ptr<const proto::StripeFooter> footer;
+  std::shared_ptr<const StripeFooterWrapper> footer;
   std::unique_ptr<encryption::DecryptionHandler> decryptionHandler;
   StripeInformationWrapper stripeInfo;
 
   StripeMetadata(
       std::shared_ptr<dwio::common::BufferedInput> _stripeInput,
       std::shared_ptr<const proto::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            std::move(_stripeInput),
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
+  StripeMetadata(
+      dwio::common::BufferedInput* _stripeInput,
+      std::shared_ptr<const proto::StripeFooter> _footer,
+      std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
+      StripeInformationWrapper _stripeInfo)
+      : StripeMetadata(
+            _stripeInput,
+            std::make_shared<StripeFooterWrapper>(_footer),
+            std::move(_decryptionHandler),
+            _stripeInfo) {}
+
+ private:
+  StripeMetadata(
+      std::shared_ptr<dwio::common::BufferedInput> _stripeInput,
+      std::shared_ptr<const StripeFooterWrapper> _footer,
       std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
       StripeInformationWrapper _stripeInfo)
       : stripeInput{_stripeInput.get()},
@@ -42,15 +65,13 @@ struct StripeMetadata {
 
   StripeMetadata(
       dwio::common::BufferedInput* _stripeInput,
-      std::shared_ptr<const proto::StripeFooter> _footer,
+      std::shared_ptr<const StripeFooterWrapper> _footer,
       std::unique_ptr<encryption::DecryptionHandler> _decryptionHandler,
       StripeInformationWrapper _stripeInfo)
       : stripeInput{_stripeInput},
         footer{std::move(_footer)},
         decryptionHandler{std::move(_decryptionHandler)},
         stripeInfo{std::move(_stripeInfo)} {}
-
- private:
   const std::shared_ptr<dwio::common::BufferedInput> stripeInputOwned_;
 };
 

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -257,7 +257,8 @@ class StripeStreamsImpl : public StripeStreamsBase {
       const EncodingKey& encodingKey) const override {
     auto index = encodings_.find(encodingKey);
     if (index != encodings_.end()) {
-      return readState_->stripeMetadata->footer->encoding(index->second);
+      return readState_->stripeMetadata->footer->columnEncodingDwrf(
+          index->second);
     }
     auto encodingKeyIt = decryptedEncodings_.find(encodingKey);
     VELOX_CHECK(

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -257,6 +257,12 @@ target_link_libraries(
   velox_dwio_dwrf_encryption_test velox_link_libs Folly::folly
   ${TEST_LINK_LIBS})
 
+add_executable(velox_filemetadata_test FileMetadataTest.cpp)
+add_test(velox_filemetadata_test velox_filemetadata_test)
+
+target_link_libraries(
+  velox_filemetadata_test velox_link_libs ${TEST_LINK_LIBS})
+
 add_executable(velox_dwio_dwrf_stripe_reader_base_test
                StripeReaderBaseTests.cpp)
 add_test(velox_dwio_dwrf_stripe_reader_base_test

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -263,6 +263,12 @@ add_test(velox_filemetadata_test velox_filemetadata_test)
 target_link_libraries(
   velox_filemetadata_test velox_link_libs ${TEST_LINK_LIBS})
 
+add_executable(velox_common_test CommonTests.cpp)
+add_test(velox_common_test velox_common_test)
+
+target_link_libraries(
+  velox_common_test velox_link_libs ${TEST_LINK_LIBS})
+
 add_executable(velox_dwio_dwrf_stripe_reader_base_test
                StripeReaderBaseTests.cpp)
 add_test(velox_dwio_dwrf_stripe_reader_base_test

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -84,7 +84,7 @@ void verifyStats(
   // Compute Node Size and verify the File Footer Node Size matches.
   auto& stripeFooter = *stripeMetadata->footer;
   std::unordered_map<uint32_t, uint64_t> nodeSizes;
-  for (auto&& ss : stripeFooter.streams()) {
+  for (auto&& ss : stripeFooter.streamsDwrf()) {
     nodeSizes[ss.node()] += ss.length();
   }
 

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -136,6 +136,11 @@ class TestStripeStreams : public StripeStreamsBase {
     DWIO_RAISE("encoding not found");
   }
 
+  const proto::orc::ColumnEncoding& getEncodingOrc(
+      const EncodingKey& ek) const override {
+    DWIO_RAISE("encoding not found");
+  }
+
   uint32_t visitStreamsOfNode(
       uint32_t node,
       std::function<void(const StreamInformation&)> visitor) const override {

--- a/velox/dwio/dwrf/test/CommonTests.cpp
+++ b/velox/dwio/dwrf/test/CommonTests.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/dwrf/common/Common.h"
+
+using namespace ::testing;
+
+namespace facebook::velox::dwrf {
+
+class CommonTest : public ::testing::Test {
+ protected:
+  proto::Stream createDwrfStream(
+      proto::Stream::Kind kind,
+      uint32_t node,
+      uint32_t sequence,
+      uint32_t column) {
+    proto::Stream stream;
+    stream.set_kind(kind);
+    stream.set_node(node);
+    stream.set_sequence(sequence);
+    stream.set_column(column);
+    return stream;
+  }
+
+  proto::orc::Stream createOrcStream(
+      proto::orc::Stream::Kind kind,
+      uint32_t column) {
+    proto::orc::Stream stream;
+    stream.set_kind(kind);
+    stream.set_column(column);
+    return stream;
+  }
+};
+
+TEST_F(
+    CommonTest,
+    DwrfStreamIdentifierGetFormat_WithStreamTypes_GetCorrectFormat) {
+  EXPECT_EQ(
+      DwrfStreamIdentifier(createDwrfStream({}, {}, {}, {})).format(),
+      DwrfFormat::kDwrf);
+
+  EXPECT_EQ(
+      DwrfStreamIdentifier(createOrcStream({}, {})).format(), DwrfFormat::kOrc);
+}
+
+TEST_F(CommonTest, DwrfStreamIdentifier_WithDwrfStream_GetCorrectInfo) {
+  auto streamId = DwrfStreamIdentifier(
+      createDwrfStream(proto::Stream::Kind::Stream_Kind_DATA, 1, 2, 3));
+
+  EXPECT_EQ(streamId.format(), DwrfFormat::kDwrf);
+  EXPECT_EQ(streamId.kind(), StreamKind::StreamKind_DATA);
+  EXPECT_EQ(streamId.encodingKey().node(), 1);
+  EXPECT_EQ(streamId.encodingKey().sequence(), 2);
+  EXPECT_EQ(streamId.column(), 3);
+}
+
+TEST_F(CommonTest, DwrfStreamIdentifier_WithOrcStream_GetCorrectInfo) {
+  auto streamId = DwrfStreamIdentifier(
+      createOrcStream(proto::orc::Stream::Kind::Stream_Kind_DATA, 1));
+
+  // ORC doesn't use node directly, column is used as node
+  EXPECT_EQ(streamId.format(), DwrfFormat::kOrc);
+  EXPECT_EQ(streamId.kind(), StreamKind::StreamKindOrc_DATA);
+  EXPECT_EQ(streamId.encodingKey().node(), 1);
+  EXPECT_EQ(streamId.encodingKey().sequence(), 0);
+  EXPECT_EQ(streamId.column(), dwio::common::MAX_UINT32);
+}
+
+TEST_F(
+    CommonTest,
+    DwrfStreamIdentifierGetKind_WithAllStreamKinds_GetCorrectConversion) {
+  // DWRF
+  for (auto [dwrfStreamKind, veloxStreamKind] :
+       std::vector<std::tuple<proto::Stream_Kind, StreamKind>>{
+           // clang-format off
+           {proto::Stream_Kind_PRESENT, StreamKind::StreamKind_PRESENT},
+           {proto::Stream_Kind_DATA, StreamKind::StreamKind_DATA},
+           {proto::Stream_Kind_LENGTH, StreamKind::StreamKind_LENGTH},
+           {proto::Stream_Kind_DICTIONARY_DATA, StreamKind::StreamKind_DICTIONARY_DATA},
+           {proto::Stream_Kind_DICTIONARY_COUNT, StreamKind::StreamKind_DICTIONARY_COUNT},
+           {proto::Stream_Kind_NANO_DATA, StreamKind::StreamKind_NANO_DATA},
+           {proto::Stream_Kind_ROW_INDEX, StreamKind::StreamKind_ROW_INDEX},
+           {proto::Stream_Kind_IN_DICTIONARY, StreamKind::StreamKind_IN_DICTIONARY}, {proto::Stream_Kind_STRIDE_DICTIONARY, StreamKind::StreamKind_STRIDE_DICTIONARY}, 
+           {proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, StreamKind::StreamKind_STRIDE_DICTIONARY_LENGTH},
+           {proto::Stream_Kind_BLOOM_FILTER_UTF8, StreamKind::StreamKind_BLOOM_FILTER_UTF8},
+           {proto::Stream_Kind_IN_MAP, StreamKind::StreamKind_IN_MAP},
+           // clang-format on
+       }) {
+    EXPECT_EQ(
+        DwrfStreamIdentifier(createDwrfStream(dwrfStreamKind, {}, {}, {}))
+            .kind(),
+        veloxStreamKind);
+  }
+
+  for (auto [orcStreamKind, veloxStreamKind] :
+       std::vector<std::tuple<proto::orc::Stream_Kind, StreamKind>>{
+           // clang-format off
+           {proto::orc::Stream_Kind_PRESENT, StreamKind::StreamKindOrc_PRESENT},
+           {proto::orc::Stream_Kind_DATA, StreamKind::StreamKindOrc_DATA},
+           {proto::orc::Stream_Kind_LENGTH, StreamKind::StreamKindOrc_LENGTH},
+           {proto::orc::Stream_Kind_DICTIONARY_DATA, StreamKind::StreamKindOrc_DICTIONARY_DATA},
+           {proto::orc::Stream_Kind_DICTIONARY_COUNT, StreamKind::StreamKindOrc_DICTIONARY_COUNT},
+           {proto::orc::Stream_Kind_SECONDARY, StreamKind::StreamKindOrc_SECONDARY},
+           {proto::orc::Stream_Kind_ROW_INDEX, StreamKind::StreamKindOrc_ROW_INDEX},
+           {proto::orc::Stream_Kind_BLOOM_FILTER, StreamKind::StreamKindOrc_BLOOM_FILTER},
+           {proto::orc::Stream_Kind_BLOOM_FILTER_UTF8, StreamKind::StreamKindOrc_BLOOM_FILTER_UTF8},
+           {proto::orc::Stream_Kind_ENCRYPTED_INDEX, StreamKind::StreamKindOrc_ENCRYPTED_INDEX},
+           {proto::orc::Stream_Kind_ENCRYPTED_DATA, StreamKind::StreamKindOrc_ENCRYPTED_DATA},
+           {proto::orc::Stream_Kind_STRIPE_STATISTICS, StreamKind::StreamKindOrc_STRIPE_STATISTICS},
+           {proto::orc::Stream_Kind_FILE_STATISTICS, StreamKind::StreamKindOrc_FILE_STATISTICS},
+           // clang-format on
+       }) {
+    EXPECT_EQ(
+        DwrfStreamIdentifier(createOrcStream(orcStreamKind, {})).kind(),
+        veloxStreamKind);
+  }
+}
+
+TEST_F(
+    CommonTest,
+    EncodingKeyGetKindFor_WithAllStreamKinds_GetCorrectConversion) {
+  // DWRF
+  for (auto [dwrfStreamKind, veloxStreamKind] :
+       std::vector<std::tuple<proto::Stream_Kind, StreamKind>>{
+           // clang-format off
+           {proto::Stream_Kind_PRESENT, StreamKind::StreamKind_PRESENT},
+           {proto::Stream_Kind_DATA, StreamKind::StreamKind_DATA},
+           {proto::Stream_Kind_LENGTH, StreamKind::StreamKind_LENGTH},
+           {proto::Stream_Kind_DICTIONARY_DATA, StreamKind::StreamKind_DICTIONARY_DATA},
+           {proto::Stream_Kind_DICTIONARY_COUNT, StreamKind::StreamKind_DICTIONARY_COUNT},
+           {proto::Stream_Kind_NANO_DATA, StreamKind::StreamKind_NANO_DATA},
+           {proto::Stream_Kind_ROW_INDEX, StreamKind::StreamKind_ROW_INDEX},
+           {proto::Stream_Kind_IN_DICTIONARY, StreamKind::StreamKind_IN_DICTIONARY}, {proto::Stream_Kind_STRIDE_DICTIONARY, StreamKind::StreamKind_STRIDE_DICTIONARY}, 
+           {proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH, StreamKind::StreamKind_STRIDE_DICTIONARY_LENGTH},
+           {proto::Stream_Kind_BLOOM_FILTER_UTF8, StreamKind::StreamKind_BLOOM_FILTER_UTF8},
+           {proto::Stream_Kind_IN_MAP, StreamKind::StreamKind_IN_MAP},
+           // clang-format on
+       }) {
+    EncodingKey encodingKey;
+    auto stream = encodingKey.forKind(dwrfStreamKind);
+
+    EXPECT_EQ(stream.kind(), veloxStreamKind);
+  }
+
+  for (auto [orcStreamKind, veloxStreamKind] :
+       std::vector<std::tuple<proto::orc::Stream_Kind, StreamKind>>{
+           // clang-format off
+           {proto::orc::Stream_Kind_PRESENT, StreamKind::StreamKindOrc_PRESENT},
+           {proto::orc::Stream_Kind_DATA, StreamKind::StreamKindOrc_DATA},
+           {proto::orc::Stream_Kind_LENGTH, StreamKind::StreamKindOrc_LENGTH},
+           {proto::orc::Stream_Kind_DICTIONARY_DATA, StreamKind::StreamKindOrc_DICTIONARY_DATA},
+           {proto::orc::Stream_Kind_DICTIONARY_COUNT, StreamKind::StreamKindOrc_DICTIONARY_COUNT},
+           {proto::orc::Stream_Kind_SECONDARY, StreamKind::StreamKindOrc_SECONDARY},
+           {proto::orc::Stream_Kind_ROW_INDEX, StreamKind::StreamKindOrc_ROW_INDEX},
+           {proto::orc::Stream_Kind_BLOOM_FILTER, StreamKind::StreamKindOrc_BLOOM_FILTER},
+           {proto::orc::Stream_Kind_BLOOM_FILTER_UTF8, StreamKind::StreamKindOrc_BLOOM_FILTER_UTF8},
+           {proto::orc::Stream_Kind_ENCRYPTED_INDEX, StreamKind::StreamKindOrc_ENCRYPTED_INDEX},
+           {proto::orc::Stream_Kind_ENCRYPTED_DATA, StreamKind::StreamKindOrc_ENCRYPTED_DATA},
+           {proto::orc::Stream_Kind_STRIPE_STATISTICS, StreamKind::StreamKindOrc_STRIPE_STATISTICS},
+           {proto::orc::Stream_Kind_FILE_STATISTICS, StreamKind::StreamKindOrc_FILE_STATISTICS},
+           // clang-format on
+       }) {
+    EncodingKey encodingKey;
+    auto stream = encodingKey.forKind(orcStreamKind);
+
+    EXPECT_EQ(stream.kind(), veloxStreamKind);
+  }
+}
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -113,8 +113,8 @@ class E2EWriterTest : public testing::Test {
     for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
       auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
       auto& footer = *stripeMetadata->footer;
-      for (int32_t j = 0; j < footer.encoding_size(); ++j) {
-        auto encoding = footer.encoding(j);
+      for (int32_t j = 0; j < footer.columnEncodingSize(); ++j) {
+        auto encoding = footer.columnEncodingDwrf(j);
         if (encoding.kind() ==
             dwrf::proto::ColumnEncoding_Kind::ColumnEncoding_Kind_MAP_FLAT) {
           actualNodeIds.insert(encoding.node());
@@ -575,8 +575,8 @@ TEST_F(E2EWriterTest, PresentStreamIsSuppressedOnFlatMap) {
   for (int i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& footer = *stripeMetadata->footer;
-    for (int j = 0; j < footer.streams_size(); ++j) {
-      auto stream = footer.streams(j);
+    for (int j = 0; j < footer.streamsSize(); ++j) {
+      auto stream = footer.streamDwrf(j);
       ASSERT_NE(stream.kind(), dwrf::proto::Stream_Kind::Stream_Kind_PRESENT);
     }
   }
@@ -1227,9 +1227,9 @@ TEST_F(E2EEncryptionTest, EncryptRoot) {
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& sf = *stripeMetadata->footer;
-    ASSERT_EQ(sf.encoding_size(), 0);
-    ASSERT_EQ(sf.streams_size(), 0);
-    ASSERT_EQ(sf.encryptiongroups_size(), 1);
+    ASSERT_EQ(sf.columnEncodingSize(), 0);
+    ASSERT_EQ(sf.streamsSize(), 0);
+    ASSERT_EQ(sf.encryptiongroupsSize(), 1);
   }
 
   validateFileContent(*reader);
@@ -1308,10 +1308,10 @@ TEST_F(E2EEncryptionTest, EncryptSelectedFields) {
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     auto& sf = *stripeMetadata->footer;
-    for (auto& enc : sf.encoding()) {
+    for (const auto& enc : sf.columnEncodingsDwrf()) {
       ASSERT_TRUE(encryptedNodes.find(enc.node()) == encryptedNodes.end());
     }
-    for (auto& stream : sf.streams()) {
+    for (const auto& stream : sf.streamsDwrf()) {
       ASSERT_TRUE(encryptedNodes.find(stream.node()) == encryptedNodes.end());
     }
   }

--- a/velox/dwio/dwrf/test/FileMetadataTest.cpp
+++ b/velox/dwio/dwrf/test/FileMetadataTest.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include "velox/dwio/dwrf/common/FileMetadata.h"
+
+using namespace ::testing;
+namespace facebook::velox::dwrf {
+
+class FileMetadataTest : public ::testing::Test {
+ protected:
+  std::shared_ptr<proto::StripeFooter> dwrfStripeFooter_ =
+      std::make_shared<proto::StripeFooter>();
+  StripeFooterWrapper dwrfStripeFooterWrapper_ =
+      StripeFooterWrapper(dwrfStripeFooter_);
+
+  std::shared_ptr<proto::orc::StripeFooter> orcStripeFooter_ =
+      std::make_shared<proto::orc::StripeFooter>();
+
+  StripeFooterWrapper orcStripeFooterWrapper_ =
+      StripeFooterWrapper(orcStripeFooter_);
+};
+
+TEST_F(FileMetadataTest, StripeFooterWrapper_GetFormat_CorrectFormat) {
+  EXPECT_EQ(dwrfStripeFooterWrapper_.format(), DwrfFormat::kDwrf);
+  EXPECT_EQ(orcStripeFooterWrapper_.format(), DwrfFormat::kOrc);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetStripeFooter_ReturnsProtoTypes) {
+  EXPECT_EQ(
+      &dwrfStripeFooterWrapper_.getStripeFooterDwrf(), dwrfStripeFooter_.get());
+  EXPECT_ANY_THROW(dwrfStripeFooterWrapper_.getStripeFooterOrc());
+
+  EXPECT_EQ(
+      &orcStripeFooterWrapper_.getStripeFooterOrc(), orcStripeFooter_.get());
+  EXPECT_ANY_THROW(orcStripeFooterWrapper_.getStripeFooterDwrf());
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetStreamData_ReturnsCorrispondingProtoInfo) {
+  // 2 streams with incrementing length for validation
+  dwrfStripeFooter_->add_streams()->set_length(1);
+  dwrfStripeFooter_->add_streams()->set_length(2);
+
+  // 3 streams with incrementing length for validation
+  orcStripeFooter_->add_streams()->set_length(3);
+  orcStripeFooter_->add_streams()->set_length(4);
+  orcStripeFooter_->add_streams()->set_length(5);
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamsSize(), 2);
+
+  // all streams
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamsDwrf().size(), 2);
+
+  // access stream by index
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamDwrf(0).length(), 1);
+  EXPECT_EQ(dwrfStripeFooterWrapper_.streamDwrf(1).length(), 2);
+
+  // ORC
+  // get size
+  EXPECT_EQ(orcStripeFooterWrapper_.streamsSize(), 3);
+
+  // all streams
+  EXPECT_EQ(orcStripeFooterWrapper_.streamsOrc().size(), 3);
+
+  // access stream by index
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(0).length(), 3);
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(1).length(), 4);
+  EXPECT_EQ(orcStripeFooterWrapper_.streamOrc(2).length(), 5);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetEncodings_ReturnsCorrispondingProtoInfo) {
+  // 2 encoding with incrementing node for validation
+  dwrfStripeFooter_->add_encoding()->set_kind(
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+  dwrfStripeFooter_->add_encoding()->set_kind(
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+
+  // 3 encoding with incrementing node for validation
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT);
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+  orcStripeFooter_->add_columns()->set_kind(
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.columnEncodingSize(), 2);
+
+  // all encoding
+  EXPECT_EQ(dwrfStripeFooterWrapper_.columnEncodingsDwrf().size(), 2);
+
+  // access encoding by index
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.columnEncodingDwrf(0).kind(),
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.columnEncodingDwrf(1).kind(),
+      proto::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+
+  // ORC
+  // get size
+  EXPECT_EQ(orcStripeFooterWrapper_.columnEncodingSize(), 3);
+
+  // all encoding
+  EXPECT_EQ(orcStripeFooterWrapper_.columnEncodingsOrc().size(), 3);
+
+  // access encoding by index
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(0).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT);
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(1).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DIRECT_V2);
+  EXPECT_EQ(
+      orcStripeFooterWrapper_.columnEncodingOrc(2).kind(),
+      proto::orc::ColumnEncoding_Kind::ColumnEncoding_Kind_DICTIONARY);
+}
+
+TEST_F(
+    FileMetadataTest,
+    StripeFooterWrapper_GetEncryptionGroups_ReturnsCorrispondingProtoInfo) {
+  // 2 encryption groups with incrementing group for validation
+  dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_1");
+  dwrfStripeFooter_->add_encryptiongroups()->append("test_encryption_group_2");
+
+  // DWRF
+  // get size
+  EXPECT_EQ(dwrfStripeFooterWrapper_.encryptiongroupsSize(), 2);
+
+  // access encryption groups by index
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.encryptiongroupsDwrf(0),
+      "test_encryption_group_1");
+  EXPECT_EQ(
+      dwrfStripeFooterWrapper_.encryptiongroupsDwrf(1),
+      "test_encryption_group_2");
+
+  // ORC
+  // orc encryption groups are not supported
+  // get size always zero
+  EXPECT_EQ(orcStripeFooterWrapper_.encryptiongroupsSize(), 0);
+}
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -859,26 +859,29 @@ TEST_P(TestColumnReader, testIntegerRLEv2) {
   // set format
   streams_.setFormat(DwrfFormat::kOrc);
   // set getEncoding
-  proto::ColumnEncoding directEncoding;
-  proto::ColumnEncoding directv2Encoding;
-  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
-  directv2Encoding.set_kind(proto::ColumnEncoding_Kind_DIRECT_V2);
-  EXPECT_CALL(streams_, getEncodingProxy(0))
+  proto::orc::ColumnEncoding directEncoding;
+  proto::orc::ColumnEncoding directv2Encoding;
+  directEncoding.set_kind(proto::orc::ColumnEncoding_Kind_DIRECT);
+  directv2Encoding.set_kind(proto::orc::ColumnEncoding_Kind_DIRECT_V2);
+  EXPECT_CALL(streams_, getEncodingOrcProxy(0))
       .WillRepeatedly(Return(&directEncoding)); // row type use direct only
-  EXPECT_CALL(streams_, getEncodingProxy(1))
+  EXPECT_CALL(streams_, getEncodingOrcProxy(1))
       .WillRepeatedly(Return(&directv2Encoding)); // col_0 use RLEv2
-  EXPECT_CALL(streams_, getEncodingProxy(2))
+  EXPECT_CALL(streams_, getEncodingOrcProxy(2))
       .WillRepeatedly(Return(&directEncoding)); // col_1 use RLEv1
-  EXPECT_CALL(streams_, getEncodingProxy(3))
+  EXPECT_CALL(streams_, getEncodingOrcProxy(3))
       .WillRepeatedly(Return(&directv2Encoding)); // col_2 use RLEv2
 
   // set getStream
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(_, proto::orc::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
-  EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(_, proto::orc::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
   // col_0's DATA stream
-  EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(1, proto::orc::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer0, VELOX_ARRAY_SIZE(buffer0))));
   // col_1's DATA stream
@@ -889,13 +892,15 @@ TEST_P(TestColumnReader, testIntegerRLEv2) {
     v.push_back(i);
   }
   auto count = writeVsLongs(data.data() + 1, v);
-  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(2, proto::orc::Stream_Kind_DATA, true))
       .WillRepeatedly(
           Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
             return new SeekableArrayInputStream(data.data(), count + 1);
           }));
   // col_2's DATA stream
-  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+  EXPECT_CALL(
+      streams_, getStreamOrcProxy(3, proto::orc::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
           new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -67,14 +67,14 @@ namespace {
 void enqueueReads(
     BufferedInput& input,
     facebook::velox::dwrf::ReaderBase& readerBase,
-    const proto::StripeFooter& footer,
+    const StripeFooterWrapper& footer,
     const ColumnSelector& selector,
     uint64_t stripeStart,
     uint32_t stripeIndex) {
   auto& metadataCache = readerBase.metadataCache();
   uint64_t offset = stripeStart;
   uint64_t length = 0;
-  for (const auto& stream : footer.streams()) {
+  for (const auto& stream : footer.streamsDwrf()) {
     length = stream.length();
     // If index cache is available, there is no need to read it
     auto inMetaCache = metadataCache &&

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -129,8 +129,8 @@ namespace facebook::velox::dwrf {
     bool preload{false};
     auto stripeMetadata = dwrfRowReader->fetchStripe(i, preload);
     const auto& stripeFooter = *stripeMetadata->footer;
-    totalEncodingCount += stripeFooter.encoding_size();
-    for (const auto& encoding : stripeFooter.encoding()) {
+    totalEncodingCount += stripeFooter.columnEncodingSize();
+    for (const auto& encoding : stripeFooter.columnEncodingsDwrf()) {
       if (encoding.kind() == proto::ColumnEncoding_Kind_DICTIONARY) {
         ++dictEncodingCount;
       }

--- a/velox/dwio/orc/test/CMakeLists.txt
+++ b/velox/dwio/orc/test/CMakeLists.txt
@@ -26,5 +26,19 @@ target_link_libraries(
   GTest::gtest_main
   GTest::gmock)
 
+add_executable(velox_dwio_orc_reader_filter_test ReaderFilterTest.cpp)
+add_test(
+  NAME velox_dwio_orc_reader_filter_test
+  COMMAND velox_dwio_orc_reader_filter_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(
+  velox_dwio_orc_reader_filter_test
+  velox_dwrf_test_utils
+  velox_dwio_common_test_utils
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock)
+
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/dwio/orc/test/ReaderFilterTest.cpp
+++ b/velox/dwio/orc/test/ReaderFilterTest.cpp
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/testutil/TestValue.h"
+#include "velox/dwio/common/tests/utils/E2EFilterTestBase.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/dwrf/test/OrcTest.h"
+#include "velox/dwio/dwrf/writer/FlushPolicy.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox;
+using namespace facebook::velox::dwrf;
+using namespace facebook::velox::test;
+
+class OrcReaderFilterBase : public VectorTestBase {
+ protected:
+  std::string getExamplesFilePath(const std::string& fileName) {
+    return test::getDataFilePath("velox/dwio/orc/test", "examples/" + fileName);
+  }
+};
+
+struct OrcReaderFilterParam {
+  std::string columnName;
+  std::shared_ptr<Filter> filter;
+  int resultsExpected;
+};
+
+class OrcReaderFilterTestP
+    : public ::testing::TestWithParam<OrcReaderFilterParam>,
+      public OrcReaderFilterBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    OrcReaderFilterTestsP,
+    OrcReaderFilterTestP,
+    testing::Values(
+        // "a": 111, int
+        OrcReaderFilterParam{
+            "a",
+            std::make_shared<common::BigintRange>(100, 200, false),
+            1},
+        OrcReaderFilterParam{
+            "a",
+            std::make_shared<common::BigintRange>(200, 300, false),
+            0},
+        // "b": 1111, bigint
+        OrcReaderFilterParam{
+            "b",
+            std::make_shared<common::BigintRange>(1000, 2000, false),
+            1},
+        OrcReaderFilterParam{
+            "b",
+            std::make_shared<common::BigintRange>(2000, 3000, false),
+            0},
+        // "c": 127, tinyint
+        OrcReaderFilterParam{
+            "c",
+            std::make_shared<common::BigintRange>(100, 200, false),
+            1},
+        OrcReaderFilterParam{
+            "c",
+            std::make_shared<common::BigintRange>(200, 300, false),
+            0},
+        // "d": 11, smallint
+        OrcReaderFilterParam{
+            "d",
+            std::make_shared<common::BigintRange>(10, 20, false),
+            1},
+        OrcReaderFilterParam{
+            "d",
+            std::make_shared<common::BigintRange>(20, 30, false),
+            0},
+        // "e": 1.1, float
+        OrcReaderFilterParam{
+            "e",
+            std::make_shared<common::FloatingPointRange<
+                float>>(1.0, false, false, 2.0, false, false, false),
+            1},
+        OrcReaderFilterParam{
+            "e",
+            std::make_shared<common::FloatingPointRange<
+                float>>(2.0, false, false, 3.0, false, false, false),
+            0},
+        // "f": 1.12, double
+        OrcReaderFilterParam{
+            "f",
+            std::make_shared<common::FloatingPointRange<
+                double>>(1.0, false, false, 2.0, false, false, false),
+            1},
+        OrcReaderFilterParam{
+            "f",
+            std::make_shared<common::FloatingPointRange<
+                double>>(2.0, false, false, 3.0, false, false, false),
+            0},
+        // "g": "velox", varchar
+        OrcReaderFilterParam{
+            "g",
+            std::make_shared<common::BytesRange>(
+                "velox",
+                false,
+                false,
+                "velox",
+                false,
+                false,
+                false),
+            1},
+        OrcReaderFilterParam{
+            "g",
+            std::make_shared<common::BytesRange>(
+                "velox_bad",
+                false,
+                false,
+                "velox_bad",
+                false,
+                false,
+                false),
+            0},
+        // "h": false, boolean
+        OrcReaderFilterParam{
+            "h",
+            std::make_shared<common::BoolValue>(false, false),
+            1},
+        OrcReaderFilterParam{
+            "h",
+            std::make_shared<common::BoolValue>(true, false),
+            0},
+        // "i": 1242141234.123456, decimal(38, 6)
+        // "j": 321423.21, decimal(9, 2)
+        // "k": "2023-08-18", days as date
+        OrcReaderFilterParam{
+            "k",
+            std::make_shared<common::BigintRange>(19587, 19587, false),
+            1},
+        OrcReaderFilterParam{
+            "k",
+            std::make_shared<common::BigintRange>(19588, 19588, false),
+            0},
+        // "l": "2023-08-18 01:12:23.0", timestamp
+        OrcReaderFilterParam{
+            "l",
+            std::make_shared<common::TimestampRange>(
+                Timestamp(1692342000, 0),
+                Timestamp(1692428400, 0),
+                false),
+            1},
+        OrcReaderFilterParam{
+            "l",
+            std::make_shared<common::TimestampRange>(
+                Timestamp(1692428400, 0),
+                Timestamp(1692514800, 0),
+                false),
+            0} // "m": ["aaaa", "BBBB", "velox"], array<string>
+               // "n": [{"key": "foo", "value": 1}, {"key": "bar", "value": 2}],
+               // map<string, "o": {"x": 1, "y": 2} struct<int, double>
+        ));
+// DATA
+// {
+// "a": 111,
+// "b": 1111,
+// "c": 127,
+// "d": 11,
+// "e": 1.1,
+// "f": 1.12,
+// "g": "velox",
+// // "h": false,
+// "i": 1242141234.123456,
+// "j": 321423.21,
+// "k": "2023-08-18",
+// "l": "2023-08-18 01:12:23.0",
+// "m": ["aaaa", "BBBB", "velox"],
+// "n": [{"key": "foo", "value": 1}, {"key": "bar", "value": 2}],
+// "o": {"x": 1, "y": 2}
+// }
+TEST_P(OrcReaderFilterTestP, tests) {
+  // Define Schema
+  auto schema = ROW({
+      {"a", INTEGER()},
+      {"b", BIGINT()},
+      {"c", TINYINT()},
+      {"d", SMALLINT()},
+      {"e", REAL()},
+      {"f", DOUBLE()},
+      {"g", VARCHAR()},
+      {"h", BOOLEAN()},
+      {"i", DECIMAL(38, 6)},
+      {"j", DECIMAL(9, 2)},
+      {"k", INTEGER()},
+      {"l", TIMESTAMP()},
+      {"m", ARRAY(VARCHAR())},
+      {"n", MAP(VARCHAR(), BIGINT())},
+      {"o", ROW({{"x", BIGINT()}, {"y", DOUBLE()}})},
+  });
+
+  // auto rowType = DataSetBuilder::makeRowType(schema, true);
+  // auto filterGenerator = std::make_unique<FilterGenerator>(rowType);
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addAllChildFields(*schema);
+
+  std::string fileName = "orc_all_type.orc";
+
+  dwio::common::ReaderOptions readerOpts{pool()};
+
+  // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
+  readerOpts.setFileFormat(dwio::common::FileFormat::ORC);
+  readerOpts.setScanSpec(scanSpec);
+
+  // Read orc file
+  auto orcFilePath = getExamplesFilePath(fileName);
+  auto reader = DwrfReader::create(
+      createFileBufferedInput(orcFilePath, readerOpts.memoryPool()),
+      readerOpts);
+
+  // Apply Filter
+  scanSpec->childByName(GetParam().columnName)
+      ->setFilter(GetParam().filter->clone());
+
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(scanSpec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto batch = BaseVector::create(schema, 0, &readerOpts.memoryPool());
+
+  rowReader->next(10, batch);
+  auto rowVector = batch->as<RowVector>();
+
+  EXPECT_EQ(GetParam().resultsExpected, rowVector->size());
+}


### PR DESCRIPTION
Summary:
Logarithm is intending to migrate to Velox and we need to support our existing ORC format.  Long term we can investigate migrating to DWRF formate however to unblock the near term efforts we need to have backward compatibility with our existing ORC format.

For this change set we are updating Velox to support reading ORC format

Core Changes
- Added StripeFooterWrapper to handle proto::StriperFooter and proto::orc::StripeFooter
- Added added StreamKind to indepentantly identify proto::Stream_Kind vs proto::orc::Stream_Kind
- Added overloads and helper to correctly get the DwrfStreamIdentifier depending dwrf vs orc EncoderKey
- Updated all readers to use the correct EncoderKey to get StreamId (dwrf vs orc)

# diff
This should be a no functional changes for reading DWRF format.

This diff add support for exposing ORC encodings to all of the reader functionality and enables the orc::StripeFooter to be parsed into a StripeFooterWrapper

Differential Revision: D71048852
