### PR TITLE
fix(json): Round when converting from json double to integral types

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -889,6 +889,30 @@ TEST_F(JsonCastTest, toInteger) {
   testCast<JsonNativeType, int64_t>(
       JSON(),
       BIGINT(),
+      {"1.5"_sv, "2.0001"_sv, "2.59"_sv, "-0.59"_sv, "-1.23"_sv},
+      {2, 2, 3, -1, -1});
+
+  testCast<JsonNativeType, int32_t>(
+      JSON(),
+      INTEGER(),
+      {"1.5"_sv, "2.0001"_sv, "2.59"_sv, "-0.59"_sv, "-1.23"_sv},
+      {2, 2, 3, -1, -1});
+
+  testCast<JsonNativeType, int16_t>(
+      JSON(),
+      SMALLINT(),
+      {"1.5"_sv, "2.0001"_sv, "2.59"_sv, "-0.59"_sv, "-1.23"_sv},
+      {2, 2, 3, -1, -1});
+
+  testCast<JsonNativeType, int8_t>(
+      JSON(),
+      TINYINT(),
+      {"1.5"_sv, "2.0001"_sv, "2.59"_sv, "-0.59"_sv, "-1.23"_sv},
+      {2, 2, 3, -1, -1});
+
+  testCast<JsonNativeType, int64_t>(
+      JSON(),
+      BIGINT(),
       {"1"_sv,
        "-3"_sv,
        "0"_sv,

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -624,7 +624,14 @@ simdjson::error_code convertIfInRange(From x, exec::GenericWriter& writer) {
     if (!(kMin <= x && x <= kMax)) {
       return simdjson::NUMBER_OUT_OF_RANGE;
     }
-    return convertIfInRange<To, int64_t>(x, writer);
+
+    // Need to round to nearest integer to be conformant with Java.
+    simdjson::error_code err{simdjson::NUMBER_OUT_OF_RANGE};
+    folly::tryTo<To>(std::round(x)).then([&err, &writer](To y) {
+      err = convertIfInRange<To, int64_t>(y, writer);
+    });
+
+    return err;
   }
 }
 


### PR DESCRIPTION
Summary:
Currently when given a query like below, velox doesnt round , but rounds down which gives us different results compared to java. 

```
SELECT
    "json_extract"(metrics, '$.eventTimings'),
    CAST("json_extract"(metrics, '$.eventTimings') AS ARRAY(ROW(inputdelay BIGINT))),
    ANY_MATCH(
        CAST(
            "json_extract"(metrics, '$.eventTimings') AS ARRAY(ROW(inputdelay BIGINT))
        ),
        (x) -> (x.inputDelay >= 300)
    )
FROM (
    VALUES
        '{ "eventTimings": [ { "inputDelay": 299.5999999996274} ] }'
) AS t(metrics)
```

Java returns 300 and velox 299. This PR fixes this.

Differential Revision: D71570565


