### PR TITLE
velox/exec/tests/utils/PlanBuilder.cpp: fix llvm-19-exposed -Wunused-but-set-variable warnings

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2110,12 +2110,11 @@ std::vector<core::TypedExprPtr> PlanBuilder::exprs(
     auto typedExpression = core::Expressions::inferTypes(
         parse::parseExpr(expr, options_), inputType, pool_);
 
-    if (auto field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+    if (dynamic_cast<const core::FieldAccessTypedExpr*>(
             typedExpression.get())) {
       typedExpressions.push_back(typedExpression);
-    } else if (
-        auto constant = dynamic_cast<const core::ConstantTypedExpr*>(
-            typedExpression.get())) {
+    } else if (dynamic_cast<const core::ConstantTypedExpr*>(
+                   typedExpression.get())) {
       typedExpressions.push_back(typedExpression);
     } else {
       VELOX_FAIL("Expected field name or constant: {}", expr);


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/exec/tests/utils/PlanBuilder.cpp:2117:14: error: variable 'constant' set but not used [-Werror,-Wunused-but-set-variable]
  velox/exec/tests/utils/PlanBuilder.cpp:2113:14: error: variable 'field' set but not used [-Werror,-Wunused-but-set-variable]

Reviewed By: dtolnay

Differential Revision: D71579752


