### PR TITLE
velox/functions/prestosql/aggregates/BitwiseAggregates.cpp: suppress llvm-19-exposed -Wmissing-template-arg-list-after-template-kw warning

### DIFF
--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -88,7 +88,7 @@ class BitwiseAndAggregate : public BitwiseAggregateBase<T> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    SimpleNumericAggregate<T, T, T>::template updateOneGroup(
+    SimpleNumericAggregate<T, T, T>::updateOneGroup(
         group,
         rows,
         args[0],


### PR DESCRIPTION
Summary:
This avoids the following errors:

  velox/functions/prestosql/aggregates/BitwiseAggregates.cpp:91:47: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]

Reviewed By: dtolnay

Differential Revision: D71579788


