### PR TITLE
Properly fix the chronos formatting

### DIFF
--- a/velox/external/date/date.h
+++ b/velox/external/date/date.h
@@ -3970,7 +3970,7 @@ make_time(const std::chrono::duration<Rep, Period>& d)
     return hh_mm_ss<std::chrono::duration<Rep, Period>>(d);
 }
 
-#if defined(__cpp_lib_format)
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 170004
 
 // already have operator<<
 
@@ -3997,6 +3997,7 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const sys_days& dp)
 {
     return os << year_month_day(dp);
 }
+#endif
 
 template <class CharT, class Traits, class Duration>
 inline
@@ -4005,8 +4006,6 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const local_time<Duration>& ut
 {
     return (os << sys_time<Duration>{ut.time_since_epoch()});
 }
-
-#endif
 
 namespace detail
 {

--- a/velox/external/date/tz.h
+++ b/velox/external/date/tz.h
@@ -70,7 +70,7 @@ struct transition
     std::ostream&
     operator<<(std::ostream& os, const transition& t)
     {
-        date::operator<<(os, t.timepoint) << "Z ";
+        os << t.timepoint << "Z ";
         if (t.info->offset >= std::chrono::seconds{0}) {
             os << '+';
         }


### PR DESCRIPTION
Summary:
We made some mistakes here. 

1. `__cpp_lib_format` is not the feature test macro for the `operator<<(`. We can just check if we are using libc++.
2. There doesn't seem to be an implementation for `local_time`, so keep this one.
3. Don't call the qualified version.

Differential Revision: D71582606


