### PR TITLE
test: Add IntermediateTypeTransforms for supporting intermediate types in PrestoQueryRunner

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(
   ReferenceQueryRunner.cpp
   DuckQueryRunner.cpp
   PrestoQueryRunner.cpp
+  PrestoQueryRunnerIntermediateTypeTransforms.cpp
+  PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
   FuzzerUtil.cpp
   ToSQLUtil.cpp)
 

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -1,0 +1,444 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
+#include "velox/expression/VectorWriters.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/parse/Expressions.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/fuzzer/Utils.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+class ArrayTransform {
+ public:
+  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
+      const;
+
+  core::ExprPtr projectionExpr(
+      const TypePtr& type,
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const;
+};
+
+class MapTransform {
+ public:
+  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
+      const;
+
+  core::ExprPtr projectionExpr(
+      const TypePtr& type,
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const;
+};
+
+class RowTransform {
+ public:
+  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
+      const;
+
+  core::ExprPtr projectionExpr(
+      const TypePtr& type,
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const;
+};
+
+const ArrayTransform kArrayTransform;
+const MapTransform kMapTransform;
+const RowTransform kRowTransform;
+
+const std::unordered_map<TypePtr, std::shared_ptr<IntermediateTypeTransform>>&
+intermediateTypeTransforms() {
+  static std::unordered_map<TypePtr, std::shared_ptr<IntermediateTypeTransform>>
+      intermediateTypeTransforms{
+          {TIMESTAMP_WITH_TIME_ZONE(),
+           std::make_shared<TimestampWithTimeZoneTransform>()}};
+  return intermediateTypeTransforms;
+}
+
+const std::shared_ptr<IntermediateTypeTransform>& getIntermediateTypeTransform(
+    const TypePtr& type) {
+  auto it = intermediateTypeTransforms().find(type);
+
+  if (it == intermediateTypeTransforms().end()) {
+    VELOX_FAIL(
+        "Attempting to transform unsupported intermediate only type: {}",
+        type->toString());
+  }
+
+  return it->second;
+}
+
+VectorPtr transformIntermediateOnlyType(
+    const VectorPtr& vector,
+    const SelectivityVector& rows) {
+  const auto& type = vector->type();
+  if (type->isArray()) {
+    return kArrayTransform.transform(vector, rows);
+  } else if (type->isMap()) {
+    return kMapTransform.transform(vector, rows);
+  } else if (type->isRow()) {
+    return kRowTransform.transform(vector, rows);
+  } else {
+    const auto& transform = getIntermediateTypeTransform(type);
+    DecodedVector decoded(*vector);
+    const auto* base = decoded.base();
+
+    VectorPtr result;
+    const auto& transformedType = transform->transformedType();
+    BaseVector::ensureWritable(
+        SelectivityVector(base->size()), transformedType, base->pool(), result);
+    VectorWriter<Any> writer;
+    writer.init(*result);
+
+    if (base->isConstantEncoding()) {
+      if (rows.countSelected() > 0) {
+        if (base->isNullAt(0)) {
+          result = BaseVector::createNullConstant(
+              transformedType, base->size(), base->pool());
+        } else {
+          const auto value = transform->transform(base, 0);
+
+          if (value.isNull()) {
+            result = BaseVector::createNullConstant(
+                transformedType, base->size(), base->pool());
+          } else {
+            writer.setOffset(0);
+            VELOX_DYNAMIC_TYPE_DISPATCH(
+                fuzzer::writeOne,
+                transformedType->kind(),
+                value,
+                writer.current());
+            writer.commit(true);
+            result = BaseVector::wrapInConstant(base->size(), 0, result);
+          }
+        }
+      }
+    } else {
+      rows.applyToSelected([&](vector_size_t row) {
+        auto index = decoded.index(row);
+        writer.setOffset(index);
+
+        if (base->isNullAt(index)) {
+          writer.commitNull();
+        } else {
+          const auto value = transform->transform(base, index);
+
+          if (value.isNull()) {
+            writer.commitNull();
+          } else {
+            VELOX_DYNAMIC_TYPE_DISPATCH(
+                fuzzer::writeOne,
+                transformedType->kind(),
+                value,
+                writer.current());
+            writer.commit(true);
+          }
+        }
+      });
+    }
+
+    if (!decoded.isIdentityMapping()) {
+      result = decoded.wrap(result, *vector, vector->size());
+    }
+
+    return result;
+  }
+}
+
+// Converts an ArrayVector so that any intermediate only types in the elements
+// are transformed.
+VectorPtr ArrayTransform::transform(
+    const VectorPtr& vector,
+    const SelectivityVector& rows) const {
+  VELOX_CHECK(vector->type()->isArray());
+  DecodedVector decoded(*vector);
+  const auto* base = decoded.base()->as<ArrayVector>();
+
+  SelectivityVector elementRows(base->elements()->size(), false);
+  rows.applyToSelected([&](vector_size_t row) {
+    if (!decoded.isNullAt(row)) {
+      auto index = decoded.index(row);
+      elementRows.setValidRange(
+          base->offsetAt(index),
+          base->offsetAt(index) + base->sizeAt(index),
+          true);
+    }
+  });
+  elementRows.updateBounds();
+
+  VectorPtr elementsVector =
+      transformIntermediateOnlyType(base->elements(), elementRows);
+
+  VectorPtr array = std::make_shared<ArrayVector>(
+      base->pool(),
+      ARRAY(elementsVector->type()),
+      base->nulls(),
+      base->size(),
+      base->offsets(),
+      base->sizes(),
+      elementsVector);
+
+  if (!decoded.isIdentityMapping()) {
+    array = decoded.wrap(array, *vector, vector->size());
+  }
+
+  return array;
+}
+
+// Applies a lambda transform to the elements of an array to convert input
+// types to intermediate only types where necessary.
+core::ExprPtr ArrayTransform::projectionExpr(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  VELOX_CHECK(type->isArray());
+
+  return std::make_shared<core::CallExpr>(
+      "transform",
+      std::vector<core::ExprPtr>{
+          inputExpr,
+          std::make_shared<core::LambdaExpr>(
+              std::vector<std::string>{"x"},
+              getIntermediateOnlyTypeProjectionExpr(
+                  type->asArray().elementType(),
+                  std::make_shared<core::FieldAccessExpr>("x", "x"),
+                  "x"))},
+      columnAlias);
+}
+
+// Converts an MapVector so that any intermediate only types in the keys and
+// values are transformed.
+VectorPtr MapTransform::transform(
+    const VectorPtr& vector,
+    const SelectivityVector& rows) const {
+  VELOX_CHECK(vector->type()->isMap());
+  DecodedVector decoded(*vector);
+  const auto* base = decoded.base()->as<MapVector>();
+
+  VectorPtr keysVector = base->mapKeys();
+  VectorPtr valuesVector = base->mapValues();
+  const auto& keysType = keysVector->type();
+  const auto& valuesType = valuesVector->type();
+
+  SelectivityVector elementRows(keysVector->size(), false);
+  rows.applyToSelected([&](vector_size_t row) {
+    if (!decoded.isNullAt(row)) {
+      auto index = decoded.index(row);
+      elementRows.setValidRange(
+          base->offsetAt(index),
+          base->offsetAt(index) + base->sizeAt(index),
+          true);
+    }
+  });
+  elementRows.updateBounds();
+
+  if (isIntermediateOnlyType(keysType)) {
+    keysVector = transformIntermediateOnlyType(keysVector, elementRows);
+  }
+
+  if (isIntermediateOnlyType(valuesType)) {
+    valuesVector = transformIntermediateOnlyType(valuesVector, elementRows);
+  }
+
+  VectorPtr map = std::make_shared<MapVector>(
+      base->pool(),
+      MAP(keysVector->type(), valuesVector->type()),
+      base->nulls(),
+      base->size(),
+      base->offsets(),
+      base->sizes(),
+      keysVector,
+      valuesVector);
+
+  if (!decoded.isIdentityMapping()) {
+    map = decoded.wrap(map, *vector, vector->size());
+  }
+
+  return map;
+}
+
+// Applies a lambda transform to the keys and values of a map to convert input
+// types to intermediate only types where necessary.
+core::ExprPtr MapTransform::projectionExpr(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  VELOX_CHECK(type->isMap());
+  const auto& mapType = type->asMap();
+  const auto& keysType = mapType.keyType();
+  const auto& valuesType = mapType.valueType();
+
+  core::ExprPtr expr = inputExpr;
+
+  if (isIntermediateOnlyType(keysType)) {
+    expr = std::make_shared<core::CallExpr>(
+        "transform_keys",
+        std::vector<core::ExprPtr>{
+            expr,
+            std::make_shared<core::LambdaExpr>(
+                std::vector<std::string>{"k", "v"},
+                getIntermediateOnlyTypeProjectionExpr(
+                    keysType,
+                    std::make_shared<core::FieldAccessExpr>("k", "k"),
+                    "k"))},
+        columnAlias);
+  }
+
+  if (isIntermediateOnlyType(valuesType)) {
+    expr = std::make_shared<core::CallExpr>(
+        "transform_values",
+        std::vector<core::ExprPtr>{
+            expr,
+            std::make_shared<core::LambdaExpr>(
+                std::vector<std::string>{"k", "v"},
+                getIntermediateOnlyTypeProjectionExpr(
+                    valuesType,
+                    std::make_shared<core::FieldAccessExpr>("v", "v"),
+                    "v"))},
+        columnAlias);
+  }
+
+  return expr;
+}
+
+// Converts an RowVector so that any intermediate only types in the children
+// are transformed.
+VectorPtr RowTransform::transform(
+    const VectorPtr& vector,
+    const SelectivityVector& rows) const {
+  VELOX_CHECK(vector->type()->isRow());
+  DecodedVector decoded(*vector);
+  const auto* base = decoded.base()->as<RowVector>();
+
+  SelectivityVector childRows(base->size(), false);
+  rows.applyToSelected([&](vector_size_t row) {
+    if (!decoded.isNullAt(row)) {
+      childRows.setValid(decoded.index(row), true);
+    }
+  });
+  childRows.updateBounds();
+
+  std::vector<VectorPtr> children;
+  std::vector<TypePtr> childrenTypes;
+  std::vector<std::string> childrenNames = base->type()->asRow().names();
+  for (const auto& child : base->children()) {
+    if (isIntermediateOnlyType(child->type())) {
+      children.push_back(transformIntermediateOnlyType(child, childRows));
+      childrenTypes.push_back(children.back()->type());
+    } else {
+      children.push_back(child);
+      childrenTypes.push_back(child->type());
+    }
+  }
+
+  VectorPtr row = std::make_shared<RowVector>(
+      base->pool(),
+      ROW(std::move(childrenNames), std::move(childrenTypes)),
+      base->nulls(),
+      base->size(),
+      std::move(children));
+
+  if (!decoded.isIdentityMapping()) {
+    row = decoded.wrap(row, *vector, vector->size());
+  }
+
+  return row;
+}
+
+// Applies transforms to the children of a row to convert input types to
+// intermediate only types where necessary, and reconstructs the row via
+// row_constructor.
+core::ExprPtr RowTransform::projectionExpr(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  VELOX_CHECK(type->isRow());
+  const auto& rowType = type->asRow();
+
+  std::vector<core::ExprPtr> children;
+  for (int i = 0; i < rowType.size(); i++) {
+    if (isIntermediateOnlyType(rowType.childAt(i))) {
+      children.push_back(getIntermediateOnlyTypeProjectionExpr(
+          rowType.childAt(i),
+          std::make_shared<core::FieldAccessExpr>(
+              rowType.nameOf(i),
+              rowType.nameOf(i),
+              std::vector<core::ExprPtr>{inputExpr}),
+          rowType.nameOf(i)));
+    } else {
+      children.push_back(std::make_shared<core::FieldAccessExpr>(
+          rowType.nameOf(i),
+          rowType.nameOf(i),
+          std::vector<core::ExprPtr>{inputExpr}));
+    }
+  }
+
+  return std::make_shared<core::CallExpr>(
+      "switch",
+      std::vector<core::ExprPtr>{
+          std::make_shared<core::CallExpr>(
+              "is_null", std::vector<core::ExprPtr>{inputExpr}, std::nullopt),
+          std::make_shared<core::ConstantExpr>(
+              type, variant::null(TypeKind::ROW), std::nullopt),
+          std::make_shared<core::CastExpr>(
+              type,
+              std::make_shared<core::CallExpr>(
+                  "row_constructor", std::move(children), std::nullopt),
+              false,
+              std::nullopt)},
+      columnAlias);
+}
+} // namespace
+
+bool isIntermediateOnlyType(const TypePtr& type) {
+  if (intermediateTypeTransforms().find(type) !=
+      intermediateTypeTransforms().end()) {
+    return true;
+  }
+
+  for (auto i = 0; i < type->size(); ++i) {
+    if (isIntermediateOnlyType(type->childAt(i))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+VectorPtr transformIntermediateOnlyType(const VectorPtr& vector) {
+  return transformIntermediateOnlyType(
+      vector, SelectivityVector(vector->size(), true));
+}
+
+core::ExprPtr getIntermediateOnlyTypeProjectionExpr(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) {
+  if (type->isArray()) {
+    return kArrayTransform.projectionExpr(type, inputExpr, columnAlias);
+  } else if (type->isMap()) {
+    return kMapTransform.projectionExpr(type, inputExpr, columnAlias);
+  } else if (type->isRow()) {
+    return kRowTransform.projectionExpr(type, inputExpr, columnAlias);
+  } else {
+    return getIntermediateTypeTransform(type)->projectionExpr(
+        inputExpr, columnAlias);
+  }
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/parse/IExpr.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec::test {
+/// Defines a transform for an intermediate type.
+class IntermediateTypeTransform {
+ public:
+  virtual ~IntermediateTypeTransform() = default;
+
+  /// The type of the value returned by transform().
+  virtual TypePtr transformedType() const = 0;
+
+  /// Converts the value in vector at position row into a value that can be
+  /// converted back to the original type by the result of projectExpr. Will
+  /// only be called with a ConstantVector or a flat-like Vector (depending on
+  /// the intermediate type's parent type) where the value is non-null.
+  virtual variant transform(const BaseVector* const vector, vector_size_t row)
+      const = 0;
+
+  /// An expression tree that can convert the value returned by transform() back
+  /// into its original value. It is assumed this has default-null behavior,
+  /// i.e. a null input produces a null output.
+  virtual core::ExprPtr projectionExpr(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const = 0;
+};
+
+/// Returns true if this types is an intermediate only type or contains an
+/// intermediate only type.
+bool isIntermediateOnlyType(const TypePtr& type);
+
+/// Converts a Vector of an intermediate only type, or containing one, to a
+/// Vector of value(s) that can be input to a projection to produce those values
+/// of that type but are of types supported as input. Preserves nulls and
+/// encodings.
+VectorPtr transformIntermediateOnlyType(const VectorPtr& vector);
+
+/// Converts an expression that takes in a value of an intermediate only type so
+/// that it applies a transformation to convert valid input types into values
+/// of the intermediate only type.
+/// @param type The expected output type of the expression, either an
+/// intermediate only type, or a complex type containing one.
+/// @param inputExpr The expression that will be the input to the returned
+/// expression, the output of this expression will be of a type not containing
+/// intermediate only types.
+/// @param columnAlias The alias to give the returned expression.
+core::ExprPtr getIntermediateOnlyTypeProjectionExpr(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias);
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/parse/Expressions.h"
+#include "velox/type/tz/TimeZoneMap.h"
+#include "velox/vector/SimpleVector.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+const std::string kFormat = "yyyy-MM-dd HH:mm:ss.SSS ZZZ";
+const std::string kBackupFormat = "yyyy-MM-dd HH:mm:ss.SSS ZZ";
+
+std::string format(const int64_t timestampWithTimeZone) {
+  static const std::shared_ptr<functions::DateTimeFormatter> kJodaDateTime =
+      functions::buildJodaDateTimeFormatter(kFormat).value();
+
+  const auto timestamp = unpackTimestampUtc(timestampWithTimeZone);
+  const auto timeZoneId = unpackZoneKeyId(timestampWithTimeZone);
+  auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
+
+  const auto maxResultSize = kJodaDateTime->maxResultSize(timezonePtr);
+  std::string str;
+  str.resize(maxResultSize);
+  const auto resultSize =
+      kJodaDateTime->format(timestamp, timezonePtr, maxResultSize, str.data());
+  str.resize(resultSize);
+
+  return str;
+}
+} // namespace
+
+// Convert a TimestampWithTimeZone into a Varchar using DatetimeFormatter, so
+// that we can get the TimestampWithTimeZone back by calling parse_datetime.
+variant TimestampWithTimeZoneTransform::transform(
+    const BaseVector* const vector,
+    vector_size_t row) const {
+  VELOX_CHECK(isTimestampWithTimeZoneType(vector->type()));
+  VELOX_CHECK(!vector->isNullAt(row));
+
+  return variant::create<TypeKind::VARCHAR>(
+      format(vector->asChecked<SimpleVector<int64_t>>()->valueAt(row)));
+}
+
+// Applies parse_datetime to a Vector of VARCHAR (formatted timestamps with time
+// zone) to produce values of type TimestampWithTimeZone.
+core::ExprPtr TimestampWithTimeZoneTransform::projectionExpr(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  // format_datetime with the ZZZ pattern produces time zones that need to be
+  // parsed with either the ZZZ or ZZ pattern, to handle this we try parsing
+  // with the ZZZ pattern first, and then the ZZ pattern if that fails.
+  // coalesce(try(parse_datetime(..., '... ZZZ')), parse_datetime(..., '...
+  // ZZ'))
+  return std::make_shared<core::CallExpr>(
+      "coalesce",
+      std::vector<core::ExprPtr>{
+          std::make_shared<core::CallExpr>(
+              "try",
+              std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+                  "parse_datetime",
+                  std::vector<core::ExprPtr>{
+                      inputExpr,
+                      std::make_shared<core::ConstantExpr>(
+                          VARCHAR(),
+                          variant::create<TypeKind::VARCHAR>(kFormat),
+                          std::nullopt)},
+                  std::nullopt)},
+              std::nullopt),
+          std::make_shared<core::CallExpr>(
+              "parse_datetime",
+              std::vector<core::ExprPtr>{
+                  inputExpr,
+                  std::make_shared<core::ConstantExpr>(
+                      VARCHAR(),
+                      variant::create<TypeKind::VARCHAR>(kBackupFormat),
+                      std::nullopt)},
+              std::nullopt)},
+      columnAlias);
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h
@@ -16,23 +16,20 @@
 
 #pragma once
 
-#include "velox/vector/BaseVector.h"
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
 
-namespace facebook::velox::fuzzer {
-
-class ConstrainedVectorGenerator {
+namespace facebook::velox::exec::test {
+class TimestampWithTimeZoneTransform : public IntermediateTypeTransform {
  public:
-  ConstrainedVectorGenerator() = delete;
+  TypePtr transformedType() const override {
+    return VARCHAR();
+  }
 
-  static VectorPtr generateConstant(
-      const AbstractInputGeneratorPtr& customGenerator,
-      vector_size_t size,
-      memory::MemoryPool* pool);
+  variant transform(const BaseVector* const vector, vector_size_t row)
+      const override;
 
-  static VectorPtr generateFlat(
-      const AbstractInputGeneratorPtr& customGenerator,
-      vector_size_t size,
-      memory::MemoryPool* pool);
+  core::ExprPtr projectionExpr(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
 };
-
-} // namespace facebook::velox::fuzzer
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(
   PlanNodeToStringTest.cpp
   PlanNodeToSummaryStringTest.cpp
   PrefixSortTest.cpp
+  PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
   PrintPlanWithStatsTest.cpp
   ProbeOperatorStateTest.cpp
   TraceUtilTest.cpp

--- a/velox/exec/tests/PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+class PrestoQueryRunnerTimestampWithTimeZoneTransformTest
+    : public functions::test::FunctionBaseTest {
+ public:
+  VectorPtr fuzzTimestampWithTimeZone(
+      const size_t seed,
+      const double nullRatio,
+      const vector_size_t size) {
+    auto generator =
+        fuzzer::TimestampWithTimeZoneInputGenerator(seed, nullRatio);
+    std::vector<std::optional<int64_t>> values;
+    for (int i = 0; i < size; i++) {
+      auto value = generator.generate();
+      if (value.hasValue()) {
+        values.emplace_back(value.value<TypeKind::BIGINT>());
+      } else {
+        values.emplace_back(std::nullopt);
+      }
+    }
+
+    return makeNullableFlatVector(values, TIMESTAMP_WITH_TIME_ZONE());
+  }
+
+  void test(const VectorPtr& vector) {
+    const auto colName = "col";
+    const auto input =
+        makeRowVector({colName}, {transformIntermediateOnlyType(vector)});
+
+    auto expr = getIntermediateOnlyTypeProjectionExpr(
+        vector->type(),
+        std::make_shared<core::FieldAccessExpr>(
+            colName,
+            std::nullopt,
+            std::vector<core::ExprPtr>{std::make_shared<core::InputExpr>()}),
+        colName);
+
+    core::PlanNodePtr plan =
+        PlanBuilder().values({input}).projectExpressions({expr}).planNode();
+
+    AssertQueryBuilder(plan).assertResults(makeRowVector({colName}, {vector}));
+  }
+
+  void testDictionary(const VectorPtr& base) {
+    // Wrap in a dictionary without nulls.
+    test(BaseVector::wrapInDictionary(
+        nullptr, makeIndicesInReverse(100), 100, base));
+    // Wrap in a dictionary with some nulls.
+    test(BaseVector::wrapInDictionary(
+        makeNulls(100, [](vector_size_t row) { return row % 10 == 0; }),
+        makeIndicesInReverse(100),
+        100,
+        base));
+    // Wrap in a dictionary with all nulls.
+    test(BaseVector::wrapInDictionary(
+        makeNulls(100, [](vector_size_t) { return true; }),
+        makeIndicesInReverse(100),
+        100,
+        base));
+  }
+
+  void testConstant(const VectorPtr& base) {
+    // Test a non-null constant.
+    test(BaseVector::wrapInConstant(100, 0, base));
+    // Test a null constant.
+    test(BaseVector::createNullConstant(
+        ARRAY(TIMESTAMP_WITH_TIME_ZONE()), 100, pool_.get()));
+  }
+};
+
+TEST_F(
+    PrestoQueryRunnerTimestampWithTimeZoneTransformTest,
+    isIntermediateOnlyType) {
+  ASSERT_FALSE(isIntermediateOnlyType(BOOLEAN()));
+  ASSERT_FALSE(isIntermediateOnlyType(BIGINT()));
+  ASSERT_FALSE(isIntermediateOnlyType(VARCHAR()));
+  ASSERT_TRUE(isIntermediateOnlyType(TIMESTAMP_WITH_TIME_ZONE()));
+
+  ASSERT_FALSE(isIntermediateOnlyType(ARRAY(BOOLEAN())));
+  ASSERT_FALSE(isIntermediateOnlyType(ARRAY(BIGINT())));
+  ASSERT_FALSE(isIntermediateOnlyType(ARRAY(VARCHAR())));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(TIMESTAMP_WITH_TIME_ZONE())));
+
+  ASSERT_FALSE(isIntermediateOnlyType(MAP(BOOLEAN(), BIGINT())));
+  ASSERT_FALSE(isIntermediateOnlyType(MAP(TIMESTAMP(), VARCHAR())));
+  ASSERT_TRUE(
+      isIntermediateOnlyType(MAP(TIMESTAMP_WITH_TIME_ZONE(), SMALLINT())));
+  ASSERT_TRUE(
+      isIntermediateOnlyType(MAP(VARBINARY(), TIMESTAMP_WITH_TIME_ZONE())));
+
+  ASSERT_FALSE(isIntermediateOnlyType(ROW({BOOLEAN(), BIGINT()})));
+  ASSERT_FALSE(
+      isIntermediateOnlyType(ROW({TINYINT(), VARCHAR(), ARRAY(VARBINARY())})));
+  ASSERT_TRUE(
+      isIntermediateOnlyType(ROW({TIMESTAMP_WITH_TIME_ZONE(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(
+      ROW({BOOLEAN(), ARRAY(TIMESTAMP_WITH_TIME_ZONE())})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(),
+       TIMESTAMP(),
+       ARRAY(ROW({MAP(VARCHAR(), TIMESTAMP_WITH_TIME_ZONE())}))})));
+}
+
+TEST_F(
+    PrestoQueryRunnerTimestampWithTimeZoneTransformTest,
+    transformIntermediateOnlyTypeTimestampWithTimeZone) {
+  auto seed = 0;
+  // No nulls.
+  test(fuzzTimestampWithTimeZone(seed++, 0, 100));
+  // Some nulls.
+  test(fuzzTimestampWithTimeZone(seed++, 0.1, 100));
+  // All nulls.
+  test(fuzzTimestampWithTimeZone(seed++, 1, 100));
+
+  auto base = fuzzTimestampWithTimeZone(seed++, 0, 100);
+  testDictionary(base);
+  testConstant(base);
+}
+
+TEST_F(
+    PrestoQueryRunnerTimestampWithTimeZoneTransformTest,
+    transformIntermediateOnlyTypeTimestampWithTimeZoneArray) {
+  auto elements = fuzzTimestampWithTimeZone(0, 0.1, 1000);
+  auto size = 100;
+  std::vector<vector_size_t> offsets(size + 1);
+  for (int i = 0; i < size + 1; i++) {
+    offsets.push_back(i * 10);
+  }
+  // Test array vector no nulls.
+  test(vectorMaker_.arrayVector(offsets, elements));
+
+  std::vector<vector_size_t> nulls(size / 10);
+  for (int i = 0; i < size / 10; i++) {
+    nulls[i] = i * 10;
+  }
+  // Test array vector some nulls.
+  test(vectorMaker_.arrayVector(offsets, elements, nulls));
+
+  nulls.clear();
+  for (int i = 0; i < size; i++) {
+    nulls.push_back(i);
+  }
+  // Test array vector all nulls.
+  test(vectorMaker_.arrayVector(offsets, elements, nulls));
+
+  const auto base = vectorMaker_.arrayVector(offsets, elements);
+  testDictionary(base);
+  testConstant(base);
+}
+
+TEST_F(
+    PrestoQueryRunnerTimestampWithTimeZoneTransformTest,
+    transformIntermediateOnlyTypeTimestampWithTimeZoneMap) {
+  auto keys = fuzzTimestampWithTimeZone(0, 0, 1000);
+  auto values = fuzzTimestampWithTimeZone(1, 0.1, 1000);
+  auto size = 100;
+  std::vector<vector_size_t> offsets(size + 1);
+  for (int i = 0; i < size + 1; i++) {
+    offsets.push_back(i * 10);
+  }
+  // Test map vector no nulls.
+  test(vectorMaker_.mapVector(offsets, keys, values));
+
+  std::vector<vector_size_t> nulls(size / 10);
+  for (int i = 0; i < size / 10; i++) {
+    nulls[i] = i * 10;
+  }
+  // Test map vector some nulls.
+  test(vectorMaker_.mapVector(offsets, keys, values, nulls));
+
+  nulls.clear();
+  for (int i = 0; i < size; i++) {
+    nulls.push_back(i);
+  }
+  // Test map vector all nulls.
+  test(vectorMaker_.mapVector(offsets, keys, values, nulls));
+
+  const auto base = vectorMaker_.mapVector(offsets, keys, values);
+  testDictionary(base);
+  testConstant(base);
+}
+
+TEST_F(
+    PrestoQueryRunnerTimestampWithTimeZoneTransformTest,
+    transformIntermediateOnlyTypeTimestampWithTimeZoneRow) {
+  const auto size = 100;
+  auto field1 = fuzzTimestampWithTimeZone(0, 0, size);
+  auto field2 = fuzzTimestampWithTimeZone(1, 0.1, size);
+  auto field3 = fuzzTimestampWithTimeZone(2, 1, size);
+  const auto rowType =
+      ROW({"c1", "c2", "c3"}, {field1->type(), field2->type(), field3->type()});
+  // Test map vector no nulls.
+  test(vectorMaker_.rowVector({field1, field2, field3}));
+
+  // Test row vector some nulls.
+  test(std::make_shared<RowVector>(
+      pool_.get(),
+      rowType,
+      makeNulls(size, [](vector_size_t row) { return row % 10 == 0; }),
+      size,
+      std::vector<VectorPtr>{field1, field2, field3}));
+
+  // Test row vector all nulls.
+  test(std::make_shared<RowVector>(
+      pool_.get(),
+      rowType,
+      makeNulls(size, [](vector_size_t) { return true; }),
+      size,
+      std::vector<VectorPtr>{field1, field2, field3}));
+
+  const auto base = vectorMaker_.rowVector({field1, field2, field3});
+  testDictionary(base);
+  testConstant(base);
+}
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -36,8 +36,11 @@ endif()
 add_library(velox_constrained_vector_generator ConstrainedVectorGenerator.cpp)
 
 target_link_libraries(
-  velox_constrained_vector_generator velox_vector velox_expression
-  velox_constrained_input_generators)
+  velox_constrained_vector_generator
+  velox_vector
+  velox_expression
+  velox_constrained_input_generators
+  velox_vector_fuzzer_util)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
+++ b/velox/vector/fuzzer/ConstrainedVectorGenerator.cpp
@@ -17,6 +17,7 @@
 #include "velox/vector/fuzzer/ConstrainedVectorGenerator.h"
 
 #include "velox/expression/VectorWriters.h"
+#include "velox/vector/fuzzer/Utils.h"
 
 namespace facebook::velox::fuzzer {
 
@@ -35,86 +36,6 @@ VectorPtr ConstrainedVectorGenerator::generateConstant(
   const auto variant = customGenerator->generate();
 
   return BaseVector::createConstant(type, variant, size, pool);
-}
-
-template <TypeKind KIND>
-void writeOne(const variant& v, GenericWriter& writer);
-template <>
-void writeOne<TypeKind::VARCHAR>(const variant& v, GenericWriter& writer);
-template <>
-void writeOne<TypeKind::VARBINARY>(const variant& v, GenericWriter& writer);
-template <>
-void writeOne<TypeKind::ARRAY>(const variant& v, GenericWriter& writer);
-template <>
-void writeOne<TypeKind::MAP>(const variant& v, GenericWriter& writer);
-template <>
-void writeOne<TypeKind::ROW>(const variant& v, GenericWriter& writer);
-
-template <TypeKind KIND>
-void writeOne(const variant& v, GenericWriter& writer) {
-  using T = typename TypeTraits<KIND>::NativeType;
-  writer.template castTo<T>() = v.value<KIND>();
-}
-
-template <>
-void writeOne<TypeKind::VARCHAR>(const variant& v, GenericWriter& writer) {
-  writer.template castTo<Varchar>() = v.value<TypeKind::VARCHAR>();
-}
-
-template <>
-void writeOne<TypeKind::VARBINARY>(const variant& v, GenericWriter& writer) {
-  writer.template castTo<Varbinary>() = v.value<TypeKind::VARBINARY>();
-}
-
-template <>
-void writeOne<TypeKind::ARRAY>(const variant& v, GenericWriter& writer) {
-  auto& writerTyped = writer.template castTo<Array<Any>>();
-  const auto& elements = v.array();
-  for (const auto& element : elements) {
-    if (element.isNull()) {
-      writerTyped.add_null();
-    } else {
-      VELOX_DYNAMIC_TYPE_DISPATCH(
-          writeOne, element.kind(), element, writerTyped.add_item());
-    }
-  }
-}
-
-template <>
-void writeOne<TypeKind::MAP>(const variant& v, GenericWriter& writer) {
-  auto& writerTyped = writer.template castTo<Map<Any, Any>>();
-  const auto& map = v.map();
-  for (const auto& pair : map) {
-    const auto& key = pair.first;
-    const auto& value = pair.second;
-    VELOX_CHECK(!key.isNull());
-    if (value.isNull()) {
-      VELOX_DYNAMIC_TYPE_DISPATCH(
-          writeOne, key.kind(), key, writerTyped.add_null());
-    } else {
-      auto writers = writerTyped.add_item();
-      VELOX_DYNAMIC_TYPE_DISPATCH(
-          writeOne, key.kind(), key, std::get<0>(writers));
-      VELOX_DYNAMIC_TYPE_DISPATCH(
-          writeOne, value.kind(), value, std::get<1>(writers));
-    }
-  }
-}
-
-template <>
-void writeOne<TypeKind::ROW>(const variant& v, GenericWriter& writer) {
-  auto& writerTyped = writer.template castTo<DynamicRow>();
-  const auto& elements = v.row();
-  column_index_t i = 0;
-  for (const auto& element : elements) {
-    if (element.isNull()) {
-      writerTyped.set_null_at(i);
-    } else {
-      VELOX_DYNAMIC_TYPE_DISPATCH(
-          writeOne, element.kind(), element, writerTyped.get_writer_at(i));
-    }
-    i++;
-  }
 }
 
 // static

--- a/velox/vector/fuzzer/tests/ConstrainedVectorGeneratorTest.cpp
+++ b/velox/vector/fuzzer/tests/ConstrainedVectorGeneratorTest.cpp
@@ -18,6 +18,7 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::fuzzer::test {


### PR DESCRIPTION
Summary:
Presto supports a number of what I call "intermediate types" that are supported in the query
engine but not in the file formats.  This means we can't currently use fuzzers with the 
PrestoQueryRunner with these types because there's no way to ensure we don't generate
plans with these types as inputs (which have to be written to a DWRF file), and if we did
exclude them, that would prevent us from e.g. testing them in keys/aggregates in the 
AggregationFuzzer which doesn't do any projections.

To solve this, I add IntermediateTypeTransforms which provides functions transform and 
projectionExpr. Transform converts values of an "intermediate type" to values of a type that
is supported in the file format. projectionExpr generates an expression tree that can convert
the types output by transform back into the "intermediate type".

In a follow up diff I integrate this into the fuzzers that support PrestoQueryRunner so that
they can begin fuzzing "intermediate types".

In this diff I provide implementations for Array, Map, and Row in cases where they contain an
"intermediate type", as well as an implementation for TimestampWithTimeZone as the
inaugural "intermediate type".

Differential Revision: D71585451


