### PR TITLE
feat: Register spark map_from_entries function

### DIFF
--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -46,6 +46,12 @@ Map Functions
 
         SELECT map_from_arrays(array(1.0, 3.0), array('2', '4')); -- {1.0 -> 2, 3.0 -> 4}
 
+.. spark:function:: map_from_entries(array(row(K, V))) -> map(K, V)
+
+    Returns a map created from the given array of entries. Keys are not allowed to be null or to contain nulls. ::
+
+        SELECT map_from_entries(ARRAY(ROW(1, 'a'), ROW(2, 'b')));; -- {1 -> 'x', 2 -> 'y'}
+
 .. spark:function:: map_keys(x(K,V)) -> array(K)
 
     Returns all the keys in the map ``x``.

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -29,6 +29,8 @@ void registerSparkMapFunctions(const std::string& prefix) {
   //   function expression corresponds to body, arguments to signature
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_filter, prefix + "map_filter");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_entries, prefix + "map_entries");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_from_entries, prefix + "map_from_entries");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, prefix + "map_keys");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, prefix + "map_values");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, prefix + "map_zip_with");


### PR DESCRIPTION
This PR aims to register spark `map_from_entries` function with presto function.  

Spark implement: https://github.com/apache/spark/blob/9dc5e94deb1496a4acf97816b10fd03a922b257b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L808-L897