### PR TITLE
build: Remove redundant `CACHE` for `FetchContent`

### DIFF
--- a/CMake/resolve_dependency_modules/grpc.cmake
+++ b/CMake/resolve_dependency_modules/grpc.cmake
@@ -34,6 +34,9 @@ FetchContent_Declare(
   URL_HASH ${VELOX_GRPC_BUILD_SHA256_CHECKSUM}
   OVERRIDE_FIND_PACKAGE EXCLUDE_FROM_ALL)
 
+# We need to specify CACHE explicitly even when we have
+# set(CMAKE_POLICY_DEFAULT_CMP0077 NEW). Because gRPC doesn't use option(). gRPC
+# uses set(... CACHE). So CMP0077 isn't affected.
 set(gRPC_ABSL_PROVIDER
     "package"
     CACHE STRING "Provider of absl library")

--- a/CMake/resolve_dependency_modules/protobuf.cmake
+++ b/CMake/resolve_dependency_modules/protobuf.cmake
@@ -43,8 +43,6 @@ FetchContent_Declare(
   OVERRIDE_FIND_PACKAGE EXCLUDE_FROM_ALL SYSTEM)
 
 set(protobuf_BUILD_TESTS OFF)
-set(protobuf_ABSL_PROVIDER
-    "package"
-    CACHE STRING "Provider of absl library")
+set(protobuf_ABSL_PROVIDER "package")
 FetchContent_MakeAvailable(protobuf)
 set(Protobuf_INCLUDE_DIRS ${protobuf_SOURCE_DIR}/src)


### PR DESCRIPTION
We have `set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)` in the top-level `CMakeLists.txt`. So we don't need to specify `CACHE` for `FetchContent`.

Fixes #12750