### PR TITLE
feat: Make page size and batch size configurable for velox parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -109,6 +109,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   bool writeInt96AsTimestamp = false;
   std::optional<bool> useParquetDataPageV2;
   std::optional<int64_t> dataPageSize;
+  std::optional<int64_t> batchSize;
 
   // Parsing session and hive configs.
 
@@ -123,9 +124,13 @@ struct WriterOptions : public dwio::common::WriterOptions {
   static constexpr const char* kParquetHiveConnectorDataPageVersion =
       "hive.parquet.writer.datapage-version";
   static constexpr const char* kParquetSessionWritePageSize =
-      "hive.parquet.writer.page-size";
-  static constexpr const char* kParquetHiveConnectorWritePageSize =
       "hive.parquet.writer.page_size";
+  static constexpr const char* kParquetHiveConnectorWritePageSize =
+      "hive.parquet.writer.page-size";
+  static constexpr const char* kParquetSessionWriteBatchSize =
+      "hive.parquet.writer.batch_size";
+  static constexpr const char* kParquetHiveConnectorWriteBatchSize =
+      "hive.parquet.writer.batch-size";
 
   // Process hive connector and session configs.
   void processConfigs(

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -89,7 +89,6 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
 
 struct WriterOptions : public dwio::common::WriterOptions {
   bool enableDictionary = true;
-  int64_t dataPageSize = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from
@@ -109,6 +108,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<std::string> parquetWriteTimestampTimeZone;
   bool writeInt96AsTimestamp = false;
   std::optional<bool> useParquetDataPageV2;
+  std::optional<int64_t> dataPageSize;
 
   // Parsing session and hive configs.
 
@@ -122,6 +122,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.datapage_version";
   static constexpr const char* kParquetHiveConnectorDataPageVersion =
       "hive.parquet.writer.datapage-version";
+  static constexpr const char* kParquetSessionWritePageSize =
+      "hive.parquet.writer.page-size";
+  static constexpr const char* kParquetHiveConnectorWritePageSize =
+      "hive.parquet.writer.page_size";
 
   // Process hive connector and session configs.
   void processConfigs(


### PR DESCRIPTION
#12734 
In this issue, I found that some options in the `WriterOptions` are hardcoded but there are setters for them so it does not make sense that they are not configurable. **In this PR, I mainly made the page size and the batch size configurable.** The page size is configurable in Presto [here](https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/ParquetFileWriterConfig.java#L49-L59), so we could make it configurable in velox as well.

However I think it is not enough to just make the page size configurable, because batch size could also affect the page size since velox parquet writer writes the data in batch, and each batch at most take one page. So if the batch size is too big, the actual page size could be far larger than the page size set by user. So user might also want to set the batch size. 