### PR TITLE
feat: Expose memory pool alloc tracking to external API

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -94,7 +94,6 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       arbitrator_(createArbitrator(options)),
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
       checkUsageLeak_(options.checkUsageLeak),
-      debugEnabled_(options.debugEnabled),
       coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled),
       disableMemoryPoolTracking_(options.disableMemoryPoolTracking),
       getPreferredSize_(options.getPreferredSize),
@@ -111,7 +110,6 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .alignment = alignment_,
               .maxCapacity = kMaxMemory,
               .trackUsage = options.trackDefaultUsage,
-              .debugEnabled = options.debugEnabled,
               .coreOnAllocationFailureEnabled =
                   options.coreOnAllocationFailureEnabled,
               .getPreferredSize = getPreferredSize_})},
@@ -236,7 +234,8 @@ std::shared_ptr<MemoryPoolImpl> MemoryManager::createRootPool(
 std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
     const std::string& name,
     int64_t maxCapacity,
-    std::unique_ptr<MemoryReclaimer> reclaimer) {
+    std::unique_ptr<MemoryReclaimer> reclaimer,
+    const std::optional<MemoryPool::DebugOptions>& poolDebugOpts) {
   std::string poolName = name;
   if (poolName.empty()) {
     static std::atomic<int64_t> poolId{0};
@@ -247,9 +246,9 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   options.alignment = alignment_;
   options.maxCapacity = maxCapacity;
   options.trackUsage = true;
-  options.debugEnabled = debugEnabled_;
   options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
   options.getPreferredSize = getPreferredSize_;
+  options.debugOptions = poolDebugOpts;
 
   auto pool = createRootPool(poolName, reclaimer, options);
   if (!disableMemoryPoolTracking_) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -73,11 +73,6 @@ struct MemoryManagerOptions {
   /// have been fixed.
   bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
 
-  /// If true, the memory pool will be running in debug mode to track the
-  /// allocation and free call stacks to detect the source of memory leak for
-  /// testing purpose.
-  bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
-
   /// Terminates the process and generates a core file on an allocation failure
   bool coreOnAllocationFailureEnabled{false};
 
@@ -217,7 +212,9 @@ class MemoryManager {
   std::shared_ptr<MemoryPool> addRootPool(
       const std::string& name = "",
       int64_t maxCapacity = kMaxMemory,
-      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr);
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr,
+      const std::optional<MemoryPool::DebugOptions>& poolDebugOpts =
+          std::nullopt);
 
   /// Creates a leaf memory pool for direct memory allocation use with specified
   /// 'name'. If 'name' is missing, the memory manager generates a default name
@@ -310,7 +307,6 @@ class MemoryManager {
   const std::unique_ptr<MemoryArbitrator> arbitrator_;
   const uint16_t alignment_;
   const bool checkUsageLeak_;
-  const bool debugEnabled_;
   const bool coreOnAllocationFailureEnabled_;
   const bool disableMemoryPoolTracking_;
   const std::function<size_t(size_t)> getPreferredSize_;

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -104,9 +104,20 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   };
   static std::string kindString(Kind kind);
 
+  /// 'DebugOptions' is used to configure the per memory pool wise debug options
+  /// for memory pool when adding root memory pools.
+  struct DebugOptions {
+    /// Regex for filtering on memory pool name when 'debugEnabled' is true.
+    /// This allows us to only track the callsites of memory allocations for
+    /// memory pools whose name matches the specified regular expression. Empty
+    /// string means no match for all.
+    std::string debugPoolNameRegex;
+  };
+
   struct Options {
     /// Specifies the memory allocation alignment through this memory pool.
     uint16_t alignment{MemoryAllocator::kMaxAlignment};
+
     /// Specifies the max memory capacity of this memory pool.
     int64_t maxCapacity{kMaxMemory};
 
@@ -131,10 +142,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// memory pools from the same root memory pool independently.
     bool threadSafe{true};
 
-    /// If true, tracks the allocation and free call stacks to detect the source
-    /// of memory leak for testing purpose.
-    bool debugEnabled{FLAGS_velox_memory_pool_debug_enabled};
-
     /// Terminates the process and generates a core file on an allocation
     /// failure
     bool coreOnAllocationFailureEnabled{false};
@@ -142,6 +149,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// Provides the customized get preferred size function. If not set, uses
     /// the memory pool's default function.
     std::function<size_t(size_t)> getPreferredSize{nullptr};
+
+    /// If non-empty, enables debug mode for the created memory pool.
+    std::optional<DebugOptions> debugOptions{std::nullopt};
   };
 
   /// Constructs a named memory pool with specified 'name', 'parent' and 'kind'.
@@ -524,6 +534,10 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// child memory pool tracking.
   virtual void dropChild(const MemoryPool* child);
 
+  virtual inline bool debugEnabled() const {
+    return debugOptions_.has_value();
+  }
+
   const std::string name_;
   const Kind kind_;
   const uint16_t alignment_;
@@ -531,7 +545,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const int64_t maxCapacity_;
   const bool trackUsage_;
   const bool threadSafe_;
-  const bool debugEnabled_;
+  const std::optional<DebugOptions> debugOptions_;
   const bool coreOnAllocationFailureEnabled_;
   std::function<size_t(size_t)> getPreferredSize_;
 
@@ -722,10 +736,6 @@ class MemoryPoolImpl : public MemoryPool {
     return debugAllocRecords_;
   }
 
-  static void setDebugPoolNameRegex(const std::string& regex) {
-    debugPoolNameRegex() = regex;
-  }
-
  private:
   void enterArbitration() override;
 
@@ -742,11 +752,6 @@ class MemoryPoolImpl : public MemoryPool {
   FOLLY_ALWAYS_INLINE static MemoryPoolImpl* toImpl(
       const std::shared_ptr<MemoryPool>& pool) {
     return static_cast<MemoryPoolImpl*>(pool.get());
-  }
-
-  static folly::Synchronized<std::string>& debugPoolNameRegex() {
-    static folly::Synchronized<std::string> debugPoolNameRegex_;
-    return debugPoolNameRegex_;
   }
 
   std::shared_ptr<MemoryPool> genChild(
@@ -955,7 +960,6 @@ class MemoryPoolImpl : public MemoryPool {
   // of times that the allocations are recorded. 'isAlloc' will be true at
   // allocation sites, false at free sites. A good example of this filter would
   // be based on the 'name_' of the MemoryPool.
-  //  TODO(jtan6): Add support for dynamic condition change.
   bool needRecordDbg(bool isAlloc);
 
   // Invoked to record the call stack of a buffer allocation if debug mode of
@@ -998,11 +1002,6 @@ class MemoryPoolImpl : public MemoryPool {
   MemoryManager* const manager_;
   MemoryAllocator* const allocator_;
   MemoryArbitrator* const arbitrator_;
-
-  // Regex for filtering on 'name_' when debug mode is enabled. This allows us
-  // to only track the callsites of memory allocations for memory pools whose
-  // name matches the specified regular expression 'debugPoolNameRegex_'.
-  const std::string debugPoolNameRegex_;
 
   // Serializes updates on 'reservationBytes_', 'usedReservationBytes_'
   // and 'minReservationBytes_' to make reservation decision on a consistent

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -98,7 +98,6 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
 
   void setupMemory(
       MemoryManagerOptions options = {
-          .debugEnabled = true,
           .allocatorCapacity = kDefaultCapacity,
           .arbitratorCapacity = kDefaultCapacity,
           .extraArbitratorConfigs = {
@@ -2692,9 +2691,9 @@ TEST(MemoryPoolTest, debugMode) {
 
   MemoryManagerOptions options;
   options.allocatorCapacity = kMaxMemory;
-  options.debugEnabled = true;
   MemoryManager manager{options};
-  auto pool = manager.addRootPool("root")->addLeafChild("child");
+  auto pool = manager.addRootPool("root", kMaxMemory, nullptr, {{".*"}})
+                  ->addLeafChild("child");
   const auto& allocRecords = std::dynamic_pointer_cast<MemoryPoolImpl>(pool)
                                  ->testingDebugAllocRecords();
   std::vector<void*> smallAllocs;
@@ -2741,111 +2740,117 @@ TEST(MemoryPoolTest, debugModeWithFilter) {
   const std::vector<int64_t> kAllocSizes = {128, 8 * KB, 2 * MB};
   const std::vector<bool> debugEnabledSet{true, false};
   for (const auto& debugEnabled : debugEnabledSet) {
-    MemoryManager manager{
-        {.debugEnabled = debugEnabled, .allocatorCapacity = kMaxMemory}};
+    MemoryManager manager{{.allocatorCapacity = kMaxMemory}};
 
     // leaf child created from MemoryPool, not match filter
-    MemoryPoolImpl::setDebugPoolNameRegex("NO-MATCH");
-    auto root0 = manager.addRootPool("root0");
-    auto pool0 = root0->addLeafChild("PartialAggregation.0.0");
-    auto* buffer0 = pool0->allocate(1 * KB);
-    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(pool0)
+    auto root0 = manager.addRootPool(
+        "root0",
+        kMaxMemory,
+        nullptr,
+        debugEnabled ? std::optional(MemoryPool::DebugOptions{
+                           .debugPoolNameRegex = "NO-MATCH"})
+                     : std::nullopt);
+    auto pool0_0 = root0->addLeafChild("PartialAggregation.0.0");
+    auto* buffer0 = pool0_0->allocate(1 * KB);
+    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(pool0_0)
                     ->testingDebugAllocRecords()
                     .empty());
-    pool0->free(buffer0, 1 * KB);
+    pool0_0->free(buffer0, 1 * KB);
 
     // leaf child created from MemoryPool, match filter
-    MemoryPoolImpl::setDebugPoolNameRegex(".*PartialAggregation.*");
-    auto root1 = manager.addRootPool("root1");
-    auto pool1 = root1->addLeafChild("PartialAggregation.0.1");
-    auto* buffer1 = pool1->allocate(1 * KB);
+    auto root1 = manager.addRootPool(
+        "root1",
+        kMaxMemory,
+        nullptr,
+        debugEnabled ? std::optional(MemoryPool::DebugOptions{
+                           .debugPoolNameRegex = ".*PartialAggregation.*"})
+                     : std::nullopt);
+    auto pool1_0 = root1->addLeafChild("PartialAggregation.0.1");
+    auto* buffer1 = pool1_0->allocate(1 * KB);
     if (!debugEnabled) {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool1)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool1_0)
               ->testingDebugAllocRecords()
               .size(),
           0);
     } else {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool1)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool1_0)
               ->testingDebugAllocRecords()
               .size(),
           1);
     }
-    pool1->free(buffer1, 1 * KB);
+    pool1_0->free(buffer1, 1 * KB);
 
-    // old pool should not be affected by updated filter
-    buffer0 = pool0->allocate(1 * KB);
-    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(pool0)
+    // old pool from root0 should not be affected by root1
+    buffer0 = pool0_0->allocate(1 * KB);
+    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(pool0_0)
                     ->testingDebugAllocRecords()
                     .empty());
-    pool0->free(buffer0, 1 * KB);
+    pool0_0->free(buffer0, 1 * KB);
 
     // leaf child created from MemoryPool, match filter
-    MemoryPoolImpl::setDebugPoolNameRegex(".*OrderBy.*");
-    auto root2 = manager.addRootPool("root2");
-    auto pool2 = root2->addLeafChild("OrderBy.0.0");
-    auto* buffer2 = pool2->allocate(1 * KB);
+    auto root2 = manager.addRootPool(
+        "root2",
+        kMaxMemory,
+        nullptr,
+        debugEnabled ? std::optional(MemoryPool::DebugOptions{
+                           .debugPoolNameRegex = ".*OrderBy.*"})
+                     : std::nullopt);
+    auto pool2_0 = root2->addLeafChild("OrderBy.0.0");
+    auto* buffer2 = pool2_0->allocate(1 * KB);
     if (!debugEnabled) {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2_0)
               ->testingDebugAllocRecords()
               .size(),
           0);
     } else {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2_0)
               ->testingDebugAllocRecords()
               .size(),
           1);
     }
-    pool2->free(buffer2, 1 * KB);
+    pool2_0->free(buffer2, 1 * KB);
 
     // leaf child created from aggr MemoryPool, match filter
     auto intPool = root2->addAggregateChild("AGG-Pool");
-    auto pool3 = intPool->addLeafChild("OrderBy.0.1");
-    auto* buffer3 = pool3->allocate(1 * KB);
+    auto pool2_1 = intPool->addLeafChild("OrderBy.0.1");
+    auto* buffer3 = pool2_1->allocate(1 * KB);
     if (!debugEnabled) {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool3)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2_1)
               ->testingDebugAllocRecords()
               .size(),
           0);
     } else {
       EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool3)
+          std::dynamic_pointer_cast<MemoryPoolImpl>(pool2_1)
               ->testingDebugAllocRecords()
               .size(),
           1);
     }
-    pool3->free(buffer3, 1 * KB);
+    pool2_1->free(buffer3, 1 * KB);
+
+    // leaf child with default regex filter should not record.
+    auto root3 = manager.addRootPool("root3");
+    auto pool3_0 = root3->addLeafChild("OrderBy.0.0");
+    auto* buffer4 = pool3_0->allocate(1 * KB);
+    EXPECT_EQ(
+        std::dynamic_pointer_cast<MemoryPoolImpl>(pool3_0)
+            ->testingDebugAllocRecords()
+            .size(),
+        0);
+    pool3_0->free(buffer4, 1 * KB);
 
     // leaf child created from MemoryManager, not match filter
-    auto pool4 = manager.addLeafPool("Arbitrator.0.0");
-    auto* buffer4 = pool4->allocate(1 * KB);
-    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(pool4)
+    auto sysLeaf = manager.addLeafPool("Arbitrator.0.0");
+    auto* buffer5 = sysLeaf->allocate(1 * KB);
+    EXPECT_TRUE(std::dynamic_pointer_cast<MemoryPoolImpl>(sysLeaf)
                     ->testingDebugAllocRecords()
                     .empty());
-    pool4->free(buffer4, 1 * KB);
-
-    // leaf child created from MemoryManager, match filter
-    MemoryPoolImpl::setDebugPoolNameRegex(".*Arbitrator.*");
-    auto pool5 = manager.addLeafPool("Arbitrator.0.1");
-    auto* buffer5 = pool5->allocate(1 * KB);
-    if (!debugEnabled) {
-      EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool5)
-              ->testingDebugAllocRecords()
-              .size(),
-          0);
-    } else {
-      EXPECT_EQ(
-          std::dynamic_pointer_cast<MemoryPoolImpl>(pool5)
-              ->testingDebugAllocRecords()
-              .size(),
-          1);
-    }
-    pool5->free(buffer5, 1 * KB);
+    sysLeaf->free(buffer5, 1 * KB);
   }
 }
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -451,6 +451,11 @@ class QueryConfig {
       kDebugAggregationApproxPercentileFixedRandomSeed =
           "debug_aggregation_approx_percentile_fixed_random_seed";
 
+  /// When debug is enabled for memory manager, this is used to match the memory
+  /// pools that need allocation callsites tracking. Default to track nothing.
+  static constexpr const char* kDebugMemoryPoolNameRegex =
+      "debug_memory_pool_name_regex";
+
   /// Temporary flag to control whether selective Nimble reader should be used
   /// in this query or not.  Will be removed after the selective Nimble reader
   /// is fully rolled out.
@@ -538,6 +543,10 @@ class QueryConfig {
 
   bool debugDisableExpressionsWithLazyInputs() const {
     return get<bool>(kDebugDisableExpressionWithLazyInputs, false);
+  }
+
+  std::string debugMemoryPoolNameRegex() const {
+    return get<std::string>(kDebugMemoryPoolNameRegex, "");
   }
 
   std::optional<uint32_t> debugAggregationApproxPercentileFixedRandomSeed()


### PR DESCRIPTION
Summary:
Expose the debug allocation tracking flag to external API.
Now the memory leak debugging facility could be dynamically used for debugging, without the need to change and build a custom debug binary.

Differential Revision: D71646743


