### PR TITLE
refactor: Make tests composable

### DIFF
--- a/velox/exec/tests/utils/LocalRunnerTestBase.h
+++ b/velox/exec/tests/utils/LocalRunnerTestBase.h
@@ -47,6 +47,7 @@ class LocalRunnerTestBase : public HiveConnectorTestBase {
   }
 
   static void TearDownTestCase() {
+    initialized_ = false;
     files_.reset();
     HiveConnectorTestBase::TearDownTestCase();
   }
@@ -84,6 +85,8 @@ class LocalRunnerTestBase : public HiveConnectorTestBase {
   inline static std::vector<TableSpec> testTables_;
 
   // The top level directory with the test data.
+  inline static bool initialized_;
+  inline static std::string testDataPath_;
   inline static std::shared_ptr<TempDirectoryPath> files_;
   /// Map from table name to list of file system paths.
   inline static std::unordered_map<std::string, std::vector<std::string>>

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -28,7 +28,7 @@
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::exec::test {
-class OperatorTestBase : public testing::Test,
+class OperatorTestBase : public virtual testing::Test,
                          public velox::test::VectorTestBase {
  public:
   /// The following methods are used by google unit test framework to do


### PR DESCRIPTION
Inherits the gtest test virtually to llow combining test base classes. Allows specifying an extrermal path for LocalRunnerTestBase.