### PR TITLE
misc: Avoid data copy for duplicate result and simplify the impementation

### DIFF
--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -729,6 +729,7 @@ TEST_P(IndexLookupJoinTest, equalJoin) {
     auto probeVectors = generateProbeInput(
         testData.numProbeBatches,
         testData.numRowsPerProbeBatch,
+        1,
         tableData,
         pool_,
         {"t0", "t1", "t2"},
@@ -1182,6 +1183,7 @@ TEST_P(IndexLookupJoinTest, betweenJoinCondition) {
     auto probeVectors = generateProbeInput(
         testData.numProbeBatches,
         testData.numProbeRowsPerBatch,
+        1,
         tableData,
         pool_,
         {"t0", "t1"},
@@ -1504,6 +1506,7 @@ TEST_P(IndexLookupJoinTest, inJoinCondition) {
     auto probeVectors = generateProbeInput(
         testData.numProbeBatches,
         testData.numProbeRowsPerBatch,
+        1,
         tableData,
         pool_,
         {"t0", "t1"},
@@ -1554,7 +1557,7 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, connectorError) {
   SequenceTableData tableData;
   generateIndexTableData({100, 1, 1}, tableData, pool_);
   const std::vector<RowVectorPtr> probeVectors = generateProbeInput(
-      20, 100, tableData, pool_, {"t0", "t1", "t2"}, {}, {}, 100);
+      20, 100, 1, tableData, pool_, {"t0", "t1", "t2"}, {}, {}, 100);
 
   const std::string errorMsg{"injectedError"};
   std::atomic_int lookupCount{0};
@@ -1607,7 +1610,15 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, prefetch) {
   const int numProbeBatches{20};
   ASSERT_GT(numProbeBatches, GetParam().numPrefetches);
   const std::vector<RowVectorPtr> probeVectors = generateProbeInput(
-      numProbeBatches, 100, tableData, pool_, {"t0", "t1", "t2"}, {}, {}, 100);
+      numProbeBatches,
+      100,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      {},
+      {},
+      100);
   createDuckDbTable("t", probeVectors);
   createDuckDbTable("u", {tableData.tableData});
 
@@ -1704,6 +1715,7 @@ TEST_P(IndexLookupJoinTest, outputBatchSize) {
     const auto probeVectors = generateProbeInput(
         testData.numProbeBatches,
         testData.numRowsPerProbeBatch,
+        1,
         tableData,
         pool_,
         {"t0", "t1", "t2"},
@@ -1765,7 +1777,15 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
   generateIndexTableData({100, 1, 1}, tableData, pool_);
   const int numProbeBatches{2};
   const std::vector<RowVectorPtr> probeVectors = generateProbeInput(
-      numProbeBatches, 100, tableData, pool_, {"t0", "t1", "t2"}, {}, {}, 100);
+      numProbeBatches,
+      100,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      {},
+      {},
+      100);
   createDuckDbTable("t", probeVectors);
   createDuckDbTable("u", {tableData.tableData});
 
@@ -1839,7 +1859,7 @@ TEST_P(IndexLookupJoinTest, joinFuzzer) {
   SequenceTableData tableData;
   generateIndexTableData({1024, 1, 1}, tableData, pool_);
   const auto probeVectors =
-      generateProbeInput(50, 256, tableData, pool_, {"t0", "t1", "t2"});
+      generateProbeInput(50, 256, 1, tableData, pool_, {"t0", "t1", "t2"});
 
   createDuckDbTable("t", probeVectors);
   createDuckDbTable("u", {tableData.tableData});

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -176,7 +176,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"     HashProbe: Input: 2000 rows \\(.+\\), Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        // These lines may or may not appear depending on whether the operator
        // gets blocked during a run.
-       {"        blockedWaitForJoinBuildTimes        sum: 1, count: 1, min: 1, max: 1, avg: 1"},
+       {"        blockedWaitForJoinBuildTimes\\s+sum: 1, count: 1, min: 1, max: 1, avg: 1"},
        {"        blockedWaitForJoinBuildWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        dynamicFiltersProduced\\s+sum: 1, count: 1, min: 1, max: 1, avg: 1"},
        {"        queuedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -42,6 +42,8 @@ class IndexLookupJoinTestBase
   // Generate probe input for lookup join.
   // @param numBatches: number of probe batches.
   // @param batchSize: number of rows in each probe batch.
+  // @param numDuplicateProbeRows: number of duplicates for each probe row so
+  // the actual batch size is batchSize * numDuplicatesProbeRows.
   // @param tableData: contains the sequence table data including key vectors
   // and min/max key values.
   // @param probeJoinKeys: the prefix key colums used for equality joins.
@@ -56,6 +58,7 @@ class IndexLookupJoinTestBase
   std::vector<facebook::velox::RowVectorPtr> generateProbeInput(
       size_t numBatches,
       size_t batchSize,
+      size_t numDuplicateProbeRows,
       SequenceTableData& tableData,
       std::shared_ptr<facebook::velox::memory::MemoryPool>& pool,
       const std::vector<std::string>& probeJoinKeys,


### PR DESCRIPTION
Summary:
We don't need to copy data for duplicate result for inputs with the same key. Extend row serde to support serialize string view.
This optimize cpu/memory and simplify the implementation
Also cover the key-dedup in index join test.

Reviewed By: wenqiwooo

Differential Revision: D71670857


