### PR TITLE
feat(parquet): Add config for enabling dictionary and dictionary page size

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -681,6 +681,16 @@ Each query can override the config by setting corresponding query session proper
      - Type
      - Default Value
      - Description
+   * - hive.parquet.writer.enable-dictionary
+     - hive.parquet.writer.enable_dictionary
+     - bool
+     - true
+     - Whether to enable dictionary encoding when writing into Parquet through the Arrow bridge.
+   * - hive.parquet.writer.dictionary-page-size-limit
+     - hive.parquet.writer.dictionary_page_size_limit
+     - string
+     - 1MB
+     - Dictionary Page size used when writing into Parquet through Arrow bridge. This setting is applicable only when dictionary encoding is enabled.
    * - hive.parquet.writer.timestamp-unit
      - hive.parquet.writer.timestamp_unit
      - tinyint

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -214,43 +214,50 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
 
   // Test incorrect enable dictionary config
 
+  const std::string invalidEnableDictionaryValue{"NaB"};
   const std::unordered_map<std::string, std::string>
       incorrectEnableDictionaryConfigFromFile = {
           {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary,
-           "NaB"},
+           invalidEnableDictionaryValue},
       };
   const std::unordered_map<std::string, std::string>
       incorrectEnableDictionarySessionProperties = {
-          {parquet::WriterOptions::kParquetSessionEnableDictionary, "NaB"},
+          {parquet::WriterOptions::kParquetSessionEnableDictionary,
+           invalidEnableDictionaryValue},
       };
 
   // Values cannot be parsed so that the exception is thrown
-  EXPECT_THROW(
+  VELOX_ASSERT_THROW(
       testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
           incorrectEnableDictionaryConfigFromFile,
           incorrectEnableDictionarySessionProperties,
           true),
-      folly::ConversionError);
+      fmt::format(
+          "Invalid parquet writer enable dictionary option: Non-whitespace character found after end of conversion: \"{}\"",
+          invalidEnableDictionaryValue.substr(1)));
 
   // Test incorrect dictionary page size config
+
+  const std::string invalidDictionaryPageSizeValue{"NaN"};
   const std::unordered_map<std::string, std::string>
       incorrectDictionaryPageSizeConfigFromFile = {
           {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit,
-           "NaN"},
+           invalidDictionaryPageSizeValue},
       };
   const std::unordered_map<std::string, std::string>
       incorrectDictionaryPageSizeSessionProperties = {
           {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit,
-           "NaN"},
+           invalidDictionaryPageSizeValue},
       };
 
   // Values cannot be parsed so that the exception is thrown
-  EXPECT_THROW(
+  VELOX_ASSERT_THROW(
       testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
           incorrectDictionaryPageSizeConfigFromFile,
           incorrectDictionaryPageSizeSessionProperties,
           true),
-      VeloxUserError);
+      fmt::format(
+          "Invalid capacity string '{}'", invalidDictionaryPageSizeValue));
 }
 
 TEST_F(ParquetWriterTest, dictionaryEncodingOff) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -91,141 +91,255 @@ std::vector<CompressionKind> params = {
 };
 
 TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
-  // Create an in-memory writer.
-  auto sink = std::make_unique<MemorySink>(
-      200 * 1024 * 1024,
-      dwio::common::FileSink::Options{.pool = leafPool_.get()});
-  auto sinkPtr = sink.get();
-  parquet::WriterOptions writerOptions;
-  writerOptions.memoryPool = leafPool_.get();
+  const auto schema = ROW({"c0"}, {SMALLINT()});
+  constexpr int64_t kRows = 10'000;
+  const auto data = makeRowVector({
+      makeFlatVector<int16_t>(kRows, [](auto row) { return row + 1; }),
+  });
+
+  // Write Parquet test data, then read and return the DataPage
+  // (thrift::PageType::type) used.
+  const auto testEnableDictionaryAndDictionaryPageSizeToGetPageHeader =
+      [&](std::unordered_map<std::string, std::string> configFromFile,
+          std::unordered_map<std::string, std::string> sessionProperties,
+          bool isFirstPageOrSecondPage) {
+        // Create an in-memory writer.
+        auto sink = std::make_unique<MemorySink>(
+            200 * 1024 * 1024,
+            dwio::common::FileSink::Options{.pool = leafPool_.get()});
+        auto sinkPtr = sink.get();
+        parquet::WriterOptions writerOptions;
+        writerOptions.memoryPool = leafPool_.get();
+
+        auto connectorConfig = config::ConfigBase(std::move(configFromFile));
+        auto connectorSessionProperties =
+            config::ConfigBase(std::move(sessionProperties));
+
+        writerOptions.processConfigs(
+            connectorConfig, connectorSessionProperties);
+        auto writer = std::make_unique<parquet::Writer>(
+            std::move(sink), writerOptions, rootPool_, schema);
+        writer->write(data);
+        writer->close();
+
+        // Read to identify DataPage used.
+        dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+        auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+
+        auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
+        std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
+
+        auto readFile = std::make_shared<InMemoryReadFile>(sinkData);
+        auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
+
+        if (isFirstPageOrSecondPage) {
+          auto inputStream = std::make_unique<SeekableFileInputStream>(
+              std::move(file),
+              colChunkPtr.dataPageOffset(),
+              150,
+              *leafPool_,
+              LogType::TEST);
+          auto pageReader = std::make_unique<PageReader>(
+              std::move(inputStream),
+              *leafPool_,
+              colChunkPtr.compression(),
+              colChunkPtr.totalCompressedSize());
+          return pageReader->readPageHeader();
+        } else {
+          constexpr int64_t kFirstDataPageCompressedSize = 1291;
+          constexpr int64_t kFirstDataPageHeaderSize = 48;
+          auto inputStream = std::make_unique<SeekableFileInputStream>(
+              std::move(file),
+              colChunkPtr.dataPageOffset() + kFirstDataPageCompressedSize +
+                  kFirstDataPageHeaderSize,
+              150,
+              *leafPool_,
+              LogType::TEST);
+          auto pageReader = std::make_unique<PageReader>(
+              std::move(inputStream),
+              *leafPool_,
+              colChunkPtr.compression(),
+              colChunkPtr.totalCompressedSize());
+          return pageReader->readPageHeader();
+        }
+      };
+
+  // Test default config (i.e., no explicit config)
+
+  const std::unordered_map<std::string, std::string> defaultConfigFromFile;
+  const std::unordered_map<std::string, std::string>
+      defaultSessionPropertiesFromFile;
+
+  const auto defaultHeader =
+      testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
+          defaultConfigFromFile, defaultSessionPropertiesFromFile, true);
+  // We use the default version of data page (V1)
+  EXPECT_EQ(defaultHeader.type, thrift::PageType::type::DATA_PAGE);
+  // Dictionary encoding is enabled as default
+  EXPECT_EQ(
+      defaultHeader.data_page_header.encoding,
+      thrift::Encoding::RLE_DICTIONARY);
+  // Default dictionary page size is 1MB (same as data page size), so it can
+  // contain a dictionary for all values. So all data will be in the first
+  // data page
+  EXPECT_EQ(defaultHeader.data_page_header.num_values, kRows);
+
+  // Test normal config
 
   // Set the dictionary page size limit to 1B so that the first data page will
   // only contain one batch of data encoded with dictionary, and from the
   // second batch it falls back to PLAIN encoding. If not set the dictionary
   // page size limit, the default is 1MB (same as data page default size) then
   // there will be only one data page contains all data encoded with dictionary
-  std::unordered_map<std::string, std::string> configFromFile = {
+  const std::unordered_map<std::string, std::string> normalConfigFromFile = {
       {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "true"},
       {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit,
        "1B"},
   };
-  std::unordered_map<std::string, std::string> sessionProperties = {
+  const std::unordered_map<std::string, std::string> normalSessionProperties = {
       {parquet::WriterOptions::kParquetSessionEnableDictionary, "true"},
       {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit, "1B"},
   };
-  auto connectorConfig = config::ConfigBase(std::move(configFromFile));
-  auto connectorSessionProperties =
-      config::ConfigBase(std::move(sessionProperties));
 
-  auto schema = ROW({"c0"}, {SMALLINT()});
-  constexpr int64_t kRows = 10'000;
-  const auto data = makeRowVector({
-      makeFlatVector<int16_t>(kRows, [](auto row) { return row + 1; }),
-  });
-
-  writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
-  auto writer = std::make_unique<parquet::Writer>(
-      std::move(sink), writerOptions, rootPool_, schema);
-  writer->write(data);
-  writer->close();
-
-  // Read to identify DataPage used.
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
-
-  auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
-  std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
-
-  auto readFile = std::make_shared<InMemoryReadFile>(sinkData);
-  auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
-
-  constexpr int64_t kFirstDataPageCompressedSize = 1291;
-  constexpr int64_t kFirstDataPageHeaderSize = 48;
   // Here we are reading the second data page. If we don't set the dictionary
   // page size, then there will be only one data page (See the comments above
   // the declaration of configFromFile)
-  auto inputStream = std::make_unique<SeekableFileInputStream>(
-      std::move(file),
-      colChunkPtr.dataPageOffset() + kFirstDataPageCompressedSize +
-          kFirstDataPageHeaderSize,
-      150,
-      *leafPool_,
-      LogType::TEST);
-  auto pageReader = std::make_unique<PageReader>(
-      std::move(inputStream),
-      *leafPool_,
-      colChunkPtr.compression(),
-      colChunkPtr.totalCompressedSize());
-  auto header = pageReader->readPageHeader();
+  const auto normalHeader =
+      testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
+          normalConfigFromFile, normalSessionProperties, false);
 
   // We use the default version of data page (V1)
-  EXPECT_EQ(header.type, thrift::PageType::type::DATA_PAGE);
+  EXPECT_EQ(normalHeader.type, thrift::PageType::type::DATA_PAGE);
   // The second data page will fall back to PLAIN encoding
-  EXPECT_EQ(header.data_page_header.encoding, thrift::Encoding::PLAIN);
+  EXPECT_EQ(normalHeader.data_page_header.encoding, thrift::Encoding::PLAIN);
+
+  // Test incorrect config
+
+  const std::unordered_map<std::string, std::string> incorrectConfigFromFile = {
+      {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "NaB"},
+      {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit,
+       "NaN"},
+  };
+  const std::unordered_map<std::string, std::string>
+      incorrectSessionProperties = {
+          {parquet::WriterOptions::kParquetSessionEnableDictionary, "NaB"},
+          {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit,
+           "NaN"},
+      };
+
+  EXPECT_THROW(
+      testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
+          incorrectConfigFromFile, incorrectSessionProperties, true),
+      folly::ConversionError);
 }
 
 TEST_F(ParquetWriterTest, dictionaryEncodingOff) {
-  // Create an in-memory writer.
-  auto sink = std::make_unique<MemorySink>(
-      200 * 1024 * 1024,
-      dwio::common::FileSink::Options{.pool = leafPool_.get()});
-  auto sinkPtr = sink.get();
-  parquet::WriterOptions writerOptions;
-  writerOptions.memoryPool = leafPool_.get();
-
-  std::unordered_map<std::string, std::string> configFromFile = {
-      {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "false"},
-  };
-  std::unordered_map<std::string, std::string> sessionProperties = {
-      {parquet::WriterOptions::kParquetSessionEnableDictionary, "false"},
-  };
-  auto connectorConfig = config::ConfigBase(std::move(configFromFile));
-  auto connectorSessionProperties =
-      config::ConfigBase(std::move(sessionProperties));
-
-  auto schema = ROW({"c0"}, {SMALLINT()});
+  const auto schema = ROW({"c0"}, {SMALLINT()});
   constexpr int64_t kRows = 10'000;
   const auto data = makeRowVector({
       makeFlatVector<int16_t>(kRows, [](auto row) { return row + 1; }),
   });
 
-  writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
-  auto writer = std::make_unique<parquet::Writer>(
-      std::move(sink), writerOptions, rootPool_, schema);
-  writer->write(data);
-  writer->close();
+  // Write Parquet test data, then read and return the DataPage
+  // (thrift::PageType::type) used.
+  const auto testEnableDictionaryAndDictionaryPageSizeToGetPageHeader =
+      [&](std::unordered_map<std::string, std::string> configFromFile,
+          std::unordered_map<std::string, std::string> sessionProperties) {
+        // Create an in-memory writer.
+        auto sink = std::make_unique<MemorySink>(
+            200 * 1024 * 1024,
+            dwio::common::FileSink::Options{.pool = leafPool_.get()});
+        auto sinkPtr = sink.get();
+        parquet::WriterOptions writerOptions;
+        writerOptions.memoryPool = leafPool_.get();
 
-  // Read to identify DataPage used.
-  dwio::common::ReaderOptions readerOptions{leafPool_.get()};
-  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+        auto connectorConfig = config::ConfigBase(std::move(configFromFile));
+        auto connectorSessionProperties =
+            config::ConfigBase(std::move(sessionProperties));
 
-  auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
-  std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
+        writerOptions.processConfigs(
+            connectorConfig, connectorSessionProperties);
+        auto writer = std::make_unique<parquet::Writer>(
+            std::move(sink), writerOptions, rootPool_, schema);
+        writer->write(data);
+        writer->close();
 
-  auto readFile = std::make_shared<InMemoryReadFile>(sinkData);
-  auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
+        // Read to identify DataPage used.
+        dwio::common::ReaderOptions readerOptions{leafPool_.get()};
+        auto reader = createReaderInMemory(*sinkPtr, readerOptions);
 
-  auto inputStream = std::make_unique<SeekableFileInputStream>(
-      std::move(file),
-      colChunkPtr.dataPageOffset(),
-      150,
-      *leafPool_,
-      LogType::TEST);
-  auto pageReader = std::make_unique<PageReader>(
-      std::move(inputStream),
-      *leafPool_,
-      colChunkPtr.compression(),
-      colChunkPtr.totalCompressedSize());
-  auto header = pageReader->readPageHeader();
+        auto colChunkPtr = reader->fileMetaData().rowGroup(0).columnChunk(0);
+        std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
+
+        auto readFile = std::make_shared<InMemoryReadFile>(sinkData);
+        auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
+
+        auto inputStream = std::make_unique<SeekableFileInputStream>(
+            std::move(file),
+            colChunkPtr.dataPageOffset(),
+            150,
+            *leafPool_,
+            LogType::TEST);
+        auto pageReader = std::make_unique<PageReader>(
+            std::move(inputStream),
+            *leafPool_,
+            colChunkPtr.compression(),
+            colChunkPtr.totalCompressedSize());
+        return pageReader->readPageHeader();
+      };
+
+  // Test only dictionary off without dictionary page size configured
+
+  const std::unordered_map<std::string, std::string>
+      withoutPageSizeConfigFromFile = {
+          {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary,
+           "false"},
+      };
+  const std::unordered_map<std::string, std::string>
+      withoutPageSizeSessionProperties = {
+          {parquet::WriterOptions::kParquetSessionEnableDictionary, "false"},
+      };
+
+  const auto withoutPageSizeHeader =
+      testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
+          withoutPageSizeConfigFromFile, withoutPageSizeSessionProperties);
 
   // We use the default version of data page (V1)
-  EXPECT_EQ(header.type, thrift::PageType::type::DATA_PAGE);
+  EXPECT_EQ(withoutPageSizeHeader.type, thrift::PageType::type::DATA_PAGE);
   // Since we turn off the dictionary encoding, and the default data page size
   // is 1MB, there is only one page, and its encoding should be PLAIN, which
   // means the configuration is applied
-  EXPECT_EQ(header.data_page_header.encoding, thrift::Encoding::PLAIN);
+  EXPECT_EQ(
+      withoutPageSizeHeader.data_page_header.encoding, thrift::Encoding::PLAIN);
   // All rows will be on the only data page, this is a sanity check
-  EXPECT_EQ(header.data_page_header.num_values, kRows);
+  EXPECT_EQ(withoutPageSizeHeader.data_page_header.num_values, kRows);
+
+  // Test dictionary off but with dictionary page size configured
+
+  const std::unordered_map<std::string, std::string>
+      withPageSizeConfigFromFile = {
+          {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary,
+           "false"},
+          {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit,
+           "1B"},
+      };
+  const std::unordered_map<std::string, std::string>
+      withPageSizeSessionProperties = {
+          {parquet::WriterOptions::kParquetSessionEnableDictionary, "false"},
+          {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit,
+           "1B"},
+      };
+
+  const auto withPageSizeHeader =
+      testEnableDictionaryAndDictionaryPageSizeToGetPageHeader(
+          withPageSizeConfigFromFile, withPageSizeSessionProperties);
+
+  // Should be the same as without dictionary page size configured, because
+  // when the dictionary is disabled, the dictionary page silze is meaningless
+  EXPECT_EQ(withPageSizeHeader.type, thrift::PageType::type::DATA_PAGE);
+  EXPECT_EQ(
+      withPageSizeHeader.data_page_header.encoding, thrift::Encoding::PLAIN);
+  EXPECT_EQ(withPageSizeHeader.data_page_header.num_values, kRows);
 }
 
 TEST_F(ParquetWriterTest, compression) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -105,12 +105,13 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
   // page size limit, the default is 1MB (same as data page default size) then
   // there will be only one data page contains all data encoded with dictionary
   std::unordered_map<std::string, std::string> configFromFile = {
-    {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "true"},
-    {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit, "1B"},
+      {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "true"},
+      {parquet::WriterOptions::kParquetHiveConnectorDictionaryPageSizeLimit,
+       "1B"},
   };
   std::unordered_map<std::string, std::string> sessionProperties = {
-    {parquet::WriterOptions::kParquetSessionEnableDictionary, "true"},
-    {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit, "1B"},
+      {parquet::WriterOptions::kParquetSessionEnableDictionary, "true"},
+      {parquet::WriterOptions::kParquetSessionDictionaryPageSizeLimit, "1B"},
   };
   auto connectorConfig = config::ConfigBase(std::move(configFromFile));
   auto connectorSessionProperties =
@@ -122,8 +123,7 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
       makeFlatVector<int16_t>(kRows, [](auto row) { return row + 1; }),
   });
 
-  writerOptions.processConfigs(
-            connectorConfig, connectorSessionProperties);
+  writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
   auto writer = std::make_unique<parquet::Writer>(
       std::move(sink), writerOptions, rootPool_, schema);
   writer->write(data);
@@ -146,9 +146,8 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
   // the declaration of configFromFile)
   auto inputStream = std::make_unique<SeekableFileInputStream>(
       std::move(file),
-      colChunkPtr.dataPageOffset()
-      + kFirstDataPageCompressedSize
-      + kFirstDataPageHeaderSize,
+      colChunkPtr.dataPageOffset() + kFirstDataPageCompressedSize +
+          kFirstDataPageHeaderSize,
       150,
       *leafPool_,
       LogType::TEST);
@@ -175,10 +174,10 @@ TEST_F(ParquetWriterTest, dictionaryEncodingOff) {
   writerOptions.memoryPool = leafPool_.get();
 
   std::unordered_map<std::string, std::string> configFromFile = {
-    {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "false"},
+      {parquet::WriterOptions::kParquetHiveConnectorEnableDictionary, "false"},
   };
   std::unordered_map<std::string, std::string> sessionProperties = {
-    {parquet::WriterOptions::kParquetSessionEnableDictionary, "false"},
+      {parquet::WriterOptions::kParquetSessionEnableDictionary, "false"},
   };
   auto connectorConfig = config::ConfigBase(std::move(configFromFile));
   auto connectorSessionProperties =
@@ -190,8 +189,7 @@ TEST_F(ParquetWriterTest, dictionaryEncodingOff) {
       makeFlatVector<int16_t>(kRows, [](auto row) { return row + 1; }),
   });
 
-  writerOptions.processConfigs(
-            connectorConfig, connectorSessionProperties);
+  writerOptions.processConfigs(connectorConfig, connectorSessionProperties);
   auto writer = std::make_unique<parquet::Writer>(
       std::move(sink), writerOptions, rootPool_, schema);
   writer->write(data);

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -268,15 +268,6 @@ std::optional<bool> isParquetEnableDictionary(
   return std::nullopt;
 }
 
-std::optional<int64_t> getParquetPageSize(
-    const config::ConfigBase& config,
-    const char* configKey) {
-  if (const auto pageSize = config.get<std::string>(configKey)) {
-    return config::toCapacity(pageSize.value(), config::CapacityUnit::BYTE);
-  }
-  return std::nullopt;
-}
-
 std::optional<bool> getParquetDataPageVersion(
     const config::ConfigBase& config,
     const char* configKey) {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -131,15 +131,15 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
     const std::unique_ptr<DefaultFlushPolicy>& flushPolicy) {
   auto builder = WriterProperties::Builder();
   WriterProperties::Builder* properties = &builder;
-  if (options.enableDictionary.value_or(facebook::velox::parquet::arrow::DEFAULT_IS_DICTIONARY_ENABLED)) {
+  if (options.enableDictionary.value_or(
+          facebook::velox::parquet::arrow::DEFAULT_IS_DICTIONARY_ENABLED)) {
     properties = properties->enable_dictionary();
   } else {
     properties = properties->disable_dictionary();
   }
-  properties =
-      properties->dictionary_pagesize_limit(
-        options.dictionaryPageSizeLimit.value_or(
-            facebook::velox::parquet::arrow::DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT));
+  properties = properties->dictionary_pagesize_limit(
+      options.dictionaryPageSizeLimit.value_or(
+          facebook::velox::parquet::arrow::DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT));
   properties = properties->compression(getArrowParquetCompression(
       options.compressionKind.value_or(common::CompressionKind_NONE)));
   for (const auto& columnCompressionValues : options.columnCompressionsMap) {
@@ -263,7 +263,9 @@ std::optional<bool> isParquetEnableDictionary(
     } else if ("false" == enableDictionary) {
       return false;
     } else {
-      VELOX_FAIL("Unsupported enable dictionary flag (true/false): {}", enableDictionary.value());
+      VELOX_FAIL(
+          "Unsupported enable dictionary flag (true/false): {}",
+          enableDictionary.value());
     }
   }
   return std::nullopt;
@@ -275,9 +277,14 @@ std::optional<int64_t> getParquetPageSize(
   if (const auto pageSize = config.get<std::string>(configKey)) {
     std::string trimmed;
     // Remove spaces if any
-    std::remove_copy_if(pageSize->begin(), pageSize->end(), std::back_inserter(trimmed), ::isspace);
+    std::remove_copy_if(
+        pageSize->begin(),
+        pageSize->end(),
+        std::back_inserter(trimmed),
+        ::isspace);
     size_t firstNonDigitPos{0};
-    while (firstNonDigitPos < trimmed.size() && std::isdigit(trimmed[firstNonDigitPos])) {
+    while (firstNonDigitPos < trimmed.size() &&
+           std::isdigit(trimmed[firstNonDigitPos])) {
       firstNonDigitPos++;
     }
     int64_t value = std::stoll(trimmed.substr(0, firstNonDigitPos));

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -263,7 +263,7 @@ std::optional<bool> isParquetEnableDictionary(
     } else if ("false" == enableDictionary) {
       return false;
     } else {
-      VELOX_FAIL("Unsupported enable dictionary flag (true/false): {}", enableDictionary);
+      VELOX_FAIL("Unsupported enable dictionary flag (true/false): {}", enableDictionary.value());
     }
   }
   return std::nullopt;
@@ -579,7 +579,7 @@ void WriterOptions::processConfigs(
             .has_value()
         ? getParquetPageSize(session, kParquetSessionDictionaryPageSizeLimit)
         : getParquetPageSize(
-              connectorConfig, kParquetSessionDictionaryPageSizeLimit);
+              connectorConfig, kParquetHiveConnectorDictionaryPageSizeLimit);
   }
 
   if (!useParquetDataPageV2) {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -134,12 +134,13 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   if (options.enableDictionary.value_or(
           facebook::velox::parquet::arrow::DEFAULT_IS_DICTIONARY_ENABLED)) {
     properties = properties->enable_dictionary();
+    properties = properties->dictionary_pagesize_limit(
+        options.dictionaryPageSizeLimit.value_or(
+            facebook::velox::parquet::arrow::
+                DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT));
   } else {
     properties = properties->disable_dictionary();
   }
-  properties = properties->dictionary_pagesize_limit(
-      options.dictionaryPageSizeLimit.value_or(
-          facebook::velox::parquet::arrow::DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT));
   properties = properties->compression(getArrowParquetCompression(
       options.compressionKind.value_or(common::CompressionKind_NONE)));
   for (const auto& columnCompressionValues : options.columnCompressionsMap) {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -257,8 +257,13 @@ std::optional<std::string> getTimestampTimeZone(
 std::optional<bool> isParquetEnableDictionary(
     const config::ConfigBase& config,
     const char* configKey) {
-  if (const auto enableDictionary = config.get<bool>(configKey)) {
-    return enableDictionary.value();
+  try {
+    if (const auto enableDictionary = config.get<bool>(configKey)) {
+      return enableDictionary.value();
+    }
+  } catch (const folly::ConversionError& e) {
+    VELOX_USER_FAIL(
+        "Invalid parquet writer enable dictionary option: {}", e.what());
   }
   return std::nullopt;
 }

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -131,9 +131,15 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
     const std::unique_ptr<DefaultFlushPolicy>& flushPolicy) {
   auto builder = WriterProperties::Builder();
   WriterProperties::Builder* properties = &builder;
-  if (!options.enableDictionary) {
+  if (options.enableDictionary.value_or(facebook::velox::parquet::arrow::DEFAULT_IS_DICTIONARY_ENABLED)) {
+    properties = properties->enable_dictionary();
+  } else {
     properties = properties->disable_dictionary();
   }
+  properties =
+      properties->dictionary_pagesize_limit(
+        options.dictionaryPageSizeLimit.value_or(
+            facebook::velox::parquet::arrow::DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT));
   properties = properties->compression(getArrowParquetCompression(
       options.compressionKind.value_or(common::CompressionKind_NONE)));
   for (const auto& columnCompressionValues : options.columnCompressionsMap) {
@@ -244,6 +250,49 @@ std::optional<std::string> getTimestampTimeZone(
     const char* configKey) {
   if (const auto timezone = config.get<std::string>(configKey)) {
     return timezone.value();
+  }
+  return std::nullopt;
+}
+
+std::optional<bool> isParquetEnableDictionary(
+    const config::ConfigBase& config,
+    const char* configKey) {
+  if (const auto enableDictionary = config.get<std::string>(configKey)) {
+    if ("true" == enableDictionary) {
+      return true;
+    } else if ("false" == enableDictionary) {
+      return false;
+    } else {
+      VELOX_FAIL("Unsupported enable dictionary flag (true/false): {}", enableDictionary);
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<int64_t> getParquetPageSize(
+    const config::ConfigBase& config,
+    const char* configKey) {
+  if (const auto pageSize = config.get<std::string>(configKey)) {
+    std::string trimmed;
+    // Remove spaces if any
+    std::remove_copy_if(pageSize->begin(), pageSize->end(), std::back_inserter(trimmed), ::isspace);
+    size_t firstNonDigitPos{0};
+    while (firstNonDigitPos < trimmed.size() && std::isdigit(trimmed[firstNonDigitPos])) {
+      firstNonDigitPos++;
+    }
+    int64_t value = std::stoll(trimmed.substr(0, firstNonDigitPos));
+    std::string unit = trimmed.substr(firstNonDigitPos);
+    if (unit.empty() || "B" == unit) {
+      return value;
+    } else if ("KB" == unit) {
+      return value * 1'024;
+    } else if ("MB" == unit) {
+      return value * 1'024 * 1'024;
+    } else if ("GB" == unit) {
+      return value * 1'024 * 1'024 * 1'024;
+    } else {
+      VELOX_FAIL("Unsupported parquet page size unit {}", unit);
+    }
   }
   return std::nullopt;
 }
@@ -513,6 +562,24 @@ void WriterOptions::processConfigs(
   }
   if (!parquetWriteTimestampTimeZone) {
     parquetWriteTimestampTimeZone = parquetWriterOptions->sessionTimezoneName;
+  }
+
+  if (!enableDictionary) {
+    enableDictionary =
+        isParquetEnableDictionary(session, kParquetSessionEnableDictionary)
+            .has_value()
+        ? isParquetEnableDictionary(session, kParquetSessionEnableDictionary)
+        : isParquetEnableDictionary(
+              connectorConfig, kParquetHiveConnectorEnableDictionary);
+  }
+
+  if (!dictionaryPageSizeLimit) {
+    dictionaryPageSizeLimit =
+        getParquetPageSize(session, kParquetSessionDictionaryPageSizeLimit)
+            .has_value()
+        ? getParquetPageSize(session, kParquetSessionDictionaryPageSizeLimit)
+        : getParquetPageSize(
+              connectorConfig, kParquetSessionDictionaryPageSizeLimit);
   }
 
   if (!useParquetDataPageV2) {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -125,7 +125,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   static constexpr const char* kParquetHiveConnectorEnableDictionary =
       "hive.parquet.writer.enable-dictionary";
   static constexpr const char* kParquetSessionDictionaryPageSizeLimit =
-    "hive.parquet.writer.dictionary_page_size_limit";
+      "hive.parquet.writer.dictionary_page_size_limit";
   static constexpr const char* kParquetHiveConnectorDictionaryPageSizeLimit =
       "hive.parquet.writer.dictionary-page-size-limit";
   static constexpr const char* kParquetSessionDataPageVersion =

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -88,8 +88,6 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
 };
 
 struct WriterOptions : public dwio::common::WriterOptions {
-  bool enableDictionary = true;
-  int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from
   // folly/FBVector(https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md#memory-handling).
@@ -107,9 +105,12 @@ struct WriterOptions : public dwio::common::WriterOptions {
   /// Timestamp time zone for Parquet write through Arrow bridge.
   std::optional<std::string> parquetWriteTimestampTimeZone;
   bool writeInt96AsTimestamp = false;
-  std::optional<bool> useParquetDataPageV2;
-  std::optional<int64_t> dataPageSize;
+
   std::optional<int64_t> batchSize;
+  std::optional<int64_t> dataPageSize;
+  std::optional<int64_t> dictionaryPageSizeLimit;
+  std::optional<bool> enableDictionary;
+  std::optional<bool> useParquetDataPageV2;
 
   // Parsing session and hive configs.
 
@@ -119,6 +120,14 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.timestamp_unit";
   static constexpr const char* kParquetHiveConnectorWriteTimestampUnit =
       "hive.parquet.writer.timestamp-unit";
+  static constexpr const char* kParquetSessionEnableDictionary =
+      "hive.parquet.writer.enable_dictionary";
+  static constexpr const char* kParquetHiveConnectorEnableDictionary =
+      "hive.parquet.writer.enable-dictionary";
+  static constexpr const char* kParquetSessionDictionaryPageSizeLimit =
+    "hive.parquet.writer.dictionary_page_size_limit";
+  static constexpr const char* kParquetHiveConnectorDictionaryPageSizeLimit =
+      "hive.parquet.writer.dictionary-page-size-limit";
   static constexpr const char* kParquetSessionDataPageVersion =
       "hive.parquet.writer.datapage_version";
   static constexpr const char* kParquetHiveConnectorDataPageVersion =


### PR DESCRIPTION
In this PR, I mainly made enabling dictionary and dictionary page size. There are completed handlers for non-dictionary case in the [encoder](https://github.com/facebookincubator/velox/blob/main/velox/dwio/parquet/writer/arrow/Encoding.cpp#L4155-L4227), so it should make sense that this is a configurable option.

This PR also makes the dictionary page size configurable, similar to #12755 , they share the exactly same function `getParquetPageSize` to read from the config file. So that user can customize the dictionary page size threshold to fall back to plain encoding if dictionary page size grows too big.

But the dictionary page size is a soft restriction, because the data is written in batch. If a batch contains too many values to write once, the actual dictionary page size might be far bigger than the preset threshold. So the batch size should also be configurable, which is implemented in #12755  

Fixes: #12734 