### PR TITLE
fix: Prevent null-deref in complex vector during estimateFlatSize and prepareForReuse

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1198,13 +1198,13 @@ void ArrayVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
   if (!offsets_->isMutable()) {
-    offsets_ = nullptr;
+    offsets_ = allocateOffsets(BaseVector::length_, pool_);
   } else {
     zeroOutBuffer(offsets_);
   }
 
   if (!sizes_->isMutable()) {
-    sizes_ = nullptr;
+    sizes_ = allocateSizes(BaseVector::length_, pool_);
   } else {
     zeroOutBuffer(sizes_);
   }
@@ -1497,13 +1497,13 @@ void MapVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
   if (!offsets_->isMutable()) {
-    offsets_ = nullptr;
+    offsets_ = allocateOffsets(BaseVector::length_, pool_);
   } else {
     zeroOutBuffer(offsets_);
   }
 
   if (!sizes_->isMutable()) {
-    sizes_ = nullptr;
+    sizes_ = allocateSizes(BaseVector::length_, pool_);
   } else {
     zeroOutBuffer(sizes_);
   }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -681,9 +681,10 @@ class MapVector : public ArrayVectorBase {
   bool isWritable() const override;
 
   /// Calls BaseVector::prepareForReuse() to check and reset nulls buffer if
-  /// needed, checks and resets offsets and sizes buffers, zeros out offsets and
-  /// sizes if reusable, calls BaseVector::prepareForReuse(keys|values, 0) for
-  /// the keys and values vectors.
+  /// needed. Checks and re-allocate offsets and sizes buffers to have
+  /// BaseVector::length_, or zeros out offsets and sizes if reusable, calls
+  /// BaseVector::prepareForReuse(keys|values, 0) for the keys and values
+  /// vectors.
   void prepareForReuse() override;
 
   bool mayHaveNullsRecursive() const override {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3960,7 +3960,7 @@ TEST_F(VectorTest, arrayCopyTargetNullOffsets) {
   auto offsetsRef = target->asUnchecked<ArrayVector>()->offsets();
   ASSERT_TRUE(offsetsRef);
   BaseVector::prepareForReuse(target, target->size());
-  ASSERT_FALSE(target->asUnchecked<ArrayVector>()->offsets());
+  ASSERT_TRUE(target->asUnchecked<ArrayVector>()->offsets());
   auto source = makeArrayVector<int64_t>(
       11, [](auto) { return 1; }, [](auto i, auto) { return i; });
   target->copy(source.get(), 0, 0, source->size());
@@ -4065,6 +4065,17 @@ TEST_F(VectorTest, hasOverlappingRanges) {
   test(3, {false, false, false}, {2, 1, 0}, {1, 2, 1}, true);
   test(2, {false, false}, {0, 1}, {3, 1}, true);
   test(2, {false, false}, {1, 0}, {1, 3}, true);
+}
+
+TEST_F(VectorTest, estimateFlatSize) {
+  auto arrayVector = makeArrayVector<int64_t>(
+      10, [](auto) { return 1; }, [](auto i, auto) { return i; });
+  auto originalSize = arrayVector->estimateFlatSize();
+  arrayVector->prepareForReuse();
+  auto flatSize = arrayVector->estimateFlatSize();
+  EXPECT_NE(originalSize, flatSize);
+  // Test that the second call to prepareForReuse will not cause crash
+  arrayVector->prepareForReuse();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
size_ and offset_ can be nullptr in ComplexVectors. For estimateFlatSize(), we use 0 instead of the buffer capacity if these pointers are null.

For prepareForReuse, we only assign these pointers to nullptr if the exist + i!sMutuable, and zero out the pointer if the pointer exists.

Differential Revision: D71689808


