### PR TITLE
misc: Fix a comment for kUnsupportedInputUncatchable error code

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -125,8 +125,8 @@ inline constexpr auto kFileNotFound = "FILE_NOT_FOUND"_fs;
 inline constexpr auto kUnknown = "UNKNOWN"_fs;
 
 /// VeloxRuntimeErrors due to unsupported input values such as unicode input to
-/// cast-varchar-to-integer and timestamps beyond the year 2037 to datetime
-/// functions. This kind of errors is allowed in expression fuzzer.
+/// cast-varchar-to-integer. This kind of errors is allowed in expression
+/// fuzzer.
 inline constexpr auto kUnsupportedInputUncatchable =
     "UNSUPPORTED_INPUT_UNCATCHABLE"_fs;
 } // namespace error_code


### PR DESCRIPTION
Summary: Timestamp beyond 2037 is supported now. Fixing a comment.

Differential Revision: D71689375


