### PR TITLE
fix: Fix the bug related to sorting of boolean in array_sort_desc

### DIFF
--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -171,7 +171,7 @@ void applyScalarType(
         bits::fillBits(rawBits, endZeroRow, endRow, true);
       } else {
         bits::fillBits(rawBits, startRow, startRow + numOneBits, true);
-        bits::fillBits(rawBits, endZeroRow, endRow, false);
+        bits::fillBits(rawBits, startRow + numOneBits, endRow, false);
       }
     } else if constexpr (kind == TypeKind::REAL || kind == TypeKind::DOUBLE) {
       T* resultRawValues = flatResults->mutableRawValues();

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -873,6 +873,35 @@ TEST_F(ArraySortTest, floatingPointExtremes) {
   testFloatingPoint<double>();
 }
 
+TEST_F(ArraySortTest, constant_desc_boolean) {
+  auto data = makeRowVector({makeNullableArrayVector<bool>({
+      {false, true, std::nullopt, false, true, false, false},
+      {true, false, true, false, false, std::nullopt},
+      {false, std::nullopt, false, false, true, true, true, std::nullopt},
+      {false, std::nullopt, false, false, true, true, false, std::nullopt},
+      {true, std::nullopt},
+      {false, std::nullopt},
+      {true, std::nullopt, true},
+      {std::nullopt, false, false},
+      {std::nullopt, std::nullopt},
+  })});
+
+  auto expected = makeRowVector({makeNullableArrayVector<bool>({
+      {true, true, false, false, false, false, std::nullopt},
+      {true, true, false, false, false, std::nullopt},
+      {true, true, true, false, false, false, std::nullopt, std::nullopt},
+      {true, true, false, false, false, false, std::nullopt, std::nullopt},
+      {true, std::nullopt},
+      {false, std::nullopt},
+      {true, true, std::nullopt},
+      {false, false, std::nullopt},
+      {std::nullopt, std::nullopt},
+  })});
+
+  auto result = evaluate("array_sort_desc(c0)", data);
+  assertEqualVectors(expected, makeRowVector({result}));
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ArraySortTest,
     ArraySortTest,


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/issues/12614. 

It looks we have minor bug in sort desc of boolean type. Fixed the issue

Differential Revision: D71689192


