### PR TITLE
feat: Add support for CharVarcharCodegenUtils functions in Sparksql.

### DIFF
--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -147,6 +147,17 @@ void registerStringFunctions(const std::string& prefix) {
   registerFunctionCallToSpecialForm(
       ConcatWsCallToSpecialForm::kConcatWs,
       std::make_unique<ConcatWsCallToSpecialForm>());
+  registerFunction<
+      VarcharTypeWriteSideCheckFunction,
+      Varchar,
+      Varchar,
+      int32_t>({prefix + "varchar_type_write_side_check"});
+
+  registerFunction<CharTypeWriteSideCheckFunction, Varchar, Varchar, int32_t>(
+      {prefix + "char_type_write_side_check"});
+
+  registerFunction<ReadSidePaddingFunction, Varchar, Varchar, int32_t>(
+      {prefix + "read_side_padding"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions


### PR DESCRIPTION
**Description**

To add support for static function callls in Spark's CharVarcharCodegenUtils.java, we add corresponding implementations at Velox side.

(Fixes:  [issue 12772](https://github.com/facebookincubator/velox/issues/12772)

**How was this patch tested?**

1. Unit Tests in StringTest.
2. Built with main branch Gluten(gluten-velox jar) and test with Spark3.4.4 Gluten Velox with simpler test cases.

e.g. for varcharTypeWriteSideCheck:

```sql
create table srcvarchar(id string) stored as parquet;
create table tgt_vanilla(id varchar(3)) stored as parquet;
create table tgt(id varchar(3)) stored as parquet;

create table srcchar(id string) stored as parquet;
create table tgt_vanilla(id char(3)) stored as parquet;
create table tgt(id char(3)) stored as parquet;

insert into srcvarchar values ('a');
insert into srcvarchar values ('ab');
insert into srcvarchar values ('t  '); -- trail space but should retain
insert into srcvarchar values ('tra '); -- trail space but should trim
insert into srcvarchar values ('中  '); -- trailing space but should retain
insert into srcvarchar values ('中   '); -- trailing space but should trim to 3
insert into srcvarchar values ('中文中国'); -- will fail

insert into tgt select id from srcvarchar
```

e.g. for charTypeWriteSideCheck:

```sql
insert into srcchar values ('a');
insert into srcchar values ('ab');
insert into srcchar values ('快');
insert into srcchar values ('捷  ');
insert into tgt_vanilla select id from srcchar where id='abcd';

insert into tgt select id from srcvarchar
```

e.g. for readSidePadding:

```
select id from tgtchar;
```

Some results have been omitted for brevity


3. Test gluten-velox jar on 1G TPC-DS validation set and compare results sets of 99-sqls with vanilla Spark's.

---

