### PR TITLE
feat(s3): Add config to support registering custom AWSCredentialsProvider

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -151,4 +151,12 @@ void registerS3Metrics() {
 #endif
 }
 
+void registerAWSCredentialsProvider(
+    const std::string& providerName,
+    const AWSCredentialsProviderFactory& provider) {
+#ifdef VELOX_ENABLE_S3
+  registerCredentialsProvider(providerName, provider);
+#endif
+}
+
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -20,6 +20,11 @@
 #include <memory>
 #include <string>
 
+namespace Aws::Auth {
+// Forward-declare the AWSCredentialsProvider class from the AWS SDK.
+class AWSCredentialsProvider;
+} // namespace Aws::Auth
+
 namespace facebook::velox::config {
 class ConfigBase;
 }
@@ -43,5 +48,15 @@ void registerS3Metrics();
 /// This could lead to a segmentation fault during the program exit.
 /// Ref https://github.com/aws/aws-sdk-cpp/issues/1550#issuecomment-1412601061
 void finalizeS3FileSystem();
+
+class S3Config;
+
+using AWSCredentialsProviderFactory =
+    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
+        const S3Config& config)>;
+
+void registerAWSCredentialsProvider(
+    const std::string& providerName,
+    const AWSCredentialsProviderFactory& provider);
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -20,6 +20,11 @@
 #include <memory>
 #include <string>
 
+#ifdef VELOX_ENABLE_S3
+#include <aws/core/auth/AWSCredentialsProvider.h>
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
+#endif
+
 namespace facebook::velox::config {
 class ConfigBase;
 }
@@ -43,5 +48,15 @@ void registerS3Metrics();
 /// This could lead to a segmentation fault during the program exit.
 /// Ref https://github.com/aws/aws-sdk-cpp/issues/1550#issuecomment-1412601061
 void finalizeS3FileSystem();
+
+#ifdef VELOX_ENABLE_S3
+using AWSCredentialsProviderFactory =
+    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
+        const S3Config& config)>;
+
+void registerAWSCredentialsProvider(
+    std::string providerName,
+    AWSCredentialsProviderFactory provider);
+#endif
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -20,11 +20,6 @@
 #include <memory>
 #include <string>
 
-#ifdef VELOX_ENABLE_S3
-#include <aws/core/auth/AWSCredentialsProvider.h>
-#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
-#endif
-
 namespace facebook::velox::config {
 class ConfigBase;
 }
@@ -48,15 +43,5 @@ void registerS3Metrics();
 /// This could lead to a segmentation fault during the program exit.
 /// Ref https://github.com/aws/aws-sdk-cpp/issues/1550#issuecomment-1412601061
 void finalizeS3FileSystem();
-
-#ifdef VELOX_ENABLE_S3
-using AWSCredentialsProviderFactory =
-    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
-        const S3Config& config)>;
-
-void registerAWSCredentialsProvider(
-    std::string providerName,
-    AWSCredentialsProviderFactory provider);
-#endif
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -39,7 +39,8 @@ std::string S3Config::cacheKey(
 
 S3Config::S3Config(
     std::string_view bucket,
-    const std::shared_ptr<const config::ConfigBase> properties) {
+    const std::shared_ptr<const config::ConfigBase> properties)
+    : bucket_(bucket) {
   for (int key = static_cast<int>(Keys::kBegin);
        key < static_cast<int>(Keys::kEnd);
        key++) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -75,6 +75,7 @@ class S3Config {
     kMaxAttempts,
     kRetryMode,
     kUseProxyFromEnv,
+    kCredentialsProvider,
     kEnd
   };
 
@@ -110,7 +111,10 @@ class S3Config {
             {Keys::kMaxAttempts, std::make_pair("max-attempts", std::nullopt)},
             {Keys::kRetryMode, std::make_pair("retry-mode", std::nullopt)},
             {Keys::kUseProxyFromEnv,
-             std::make_pair("use-proxy-from-env", "false")}};
+             std::make_pair("use-proxy-from-env", "false")},
+            {Keys::kCredentialsProvider,
+             std::make_pair("credentials-provider", std::nullopt)},
+        };
     return config;
   }
 
@@ -231,9 +235,18 @@ class S3Config {
     return payloadSigningPolicy_;
   }
 
+  std::string bucket() const {
+    return bucket_;
+  }
+
+  std::optional<std::string> credentialsProvider() const {
+    return config_.find(Keys::kCredentialsProvider)->second;
+  }
+
  private:
   std::unordered_map<Keys, std::optional<std::string>> config_;
   std::string payloadSigningPolicy_;
+  std::string bucket_;
 };
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -113,7 +113,7 @@ class S3Config {
             {Keys::kUseProxyFromEnv,
              std::make_pair("use-proxy-from-env", "false")},
             {Keys::kCredentialsProvider,
-             std::make_pair("credentials-provider", std::nullopt)},
+             std::make_pair("aws-credentials-provider", std::nullopt)},
         };
     return config;
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -86,14 +86,16 @@ std::optional<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>>
 getCredentialsProviderByName(
     const std::string& providerName,
     const S3Config& s3Config) {
-  return credentialsProviderFactories().withRLock([&](const auto& factories) {
-    const auto it = factories->find(providerName);
-    if (it == factories->end()) {
-      return std::nullopt;
-    }
-    const auto& factory = it->second;
-    return factory(s3Config);
-  });
+  return credentialsProviderFactories().withRLock(
+      [&](const auto& factories)
+          -> std::optional<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>> {
+        const auto it = factories.find(providerName);
+        if (it == factories.end()) {
+          return std::nullopt;
+        }
+        const auto& factory = it->second;
+        return factory(s3Config);
+      });
 }
 
 class S3ReadFile final : public ReadFile {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -612,8 +612,13 @@ void registerCredentialsProvider(
     const AWSCredentialsProviderFactory& factory) {
   VELOX_CHECK(
       !providerName.empty(), "CredentialsProviderFactory name cannot be empty");
-  credentialsProviderFactories().withWLock(
-      [&](auto& factories) { factories.insert({providerName, factory}); });
+  credentialsProviderFactories().withWLock([&](auto& factories) {
+    VELOX_CHECK(
+        factories.find(providerName) == factories.end(),
+        "CredentialsProviderFactory {} already registered",
+        providerName);
+    factories.insert({providerName, factory});
+  });
 }
 
 class S3FileSystem::Impl {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -73,10 +73,6 @@ Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
   return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
 
-using AWSCredentialsProviderFactory =
-    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
-        const S3Config& config)>;
-
 folly::Synchronized<
     std::unordered_map<std::string, AWSCredentialsProviderFactory>>&
 credentialsProviderFactories() {
@@ -89,7 +85,7 @@ credentialsProviderFactories() {
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> getCredentialsProviderByName(
     const std::string& providerName,
     const S3Config& s3Config) {
-  const auto it = credentialsProviderFactories()->find(providerName);
+  auto it = credentialsProviderFactories()->find(providerName);
   VELOX_CHECK(
       it != credentialsProviderFactories()->end(),
       "CredentialsProviderFactory for '{}' not registered",

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -86,12 +86,14 @@ std::optional<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>>
 getCredentialsProviderByName(
     const std::string& providerName,
     const S3Config& s3Config) {
-  const auto it = credentialsProviderFactories()->find(providerName);
-  if (it == credentialsProviderFactories()->end()) {
-    return std::nullopt;
-  }
-  const auto& factory = it->second;
-  return factory(s3Config);
+  return credentialsProviderFactories().withRLock([&](const auto& factories) {
+    const auto it = factories->find(providerName);
+    if (it == factories->end()) {
+      return std::nullopt;
+    }
+    const auto& factory = it->second;
+    return factory(s3Config);
+  });
 }
 
 class S3ReadFile final : public ReadFile {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -73,6 +73,10 @@ Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
   return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
 
+using AWSCredentialsProviderFactory =
+    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
+        const S3Config& config)>;
+
 folly::Synchronized<
     std::unordered_map<std::string, AWSCredentialsProviderFactory>>&
 credentialsProviderFactories() {
@@ -85,7 +89,7 @@ credentialsProviderFactories() {
 std::shared_ptr<Aws::Auth::AWSCredentialsProvider> getCredentialsProviderByName(
     const std::string& providerName,
     const S3Config& s3Config) {
-  auto it = credentialsProviderFactories()->find(providerName);
+  const auto it = credentialsProviderFactories()->find(providerName);
   VELOX_CHECK(
       it != credentialsProviderFactories()->end(),
       "CredentialsProviderFactory for '{}' not registered",

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -17,9 +17,11 @@
 #pragma once
 
 #include "velox/common/file/FileSystems.h"
-#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
-#include <aws/core/auth/AWSCredentialsProvider.h>
+namespace Aws::Auth {
+// Forward-declare the AWSCredentialsProvider class from the AWS SDK.
+class AWSCredentialsProvider;
+} // namespace Aws::Auth
 
 namespace facebook::velox::filesystems {
 
@@ -29,13 +31,15 @@ bool initializeS3(
 
 void finalizeS3();
 
+class S3Config;
+
 using AWSCredentialsProviderFactory =
     std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
         const S3Config& config)>;
 
-void registerAWSCredentialsProvider(
-    std::string providerName,
-    AWSCredentialsProviderFactory provider);
+void registerCredentialsProvider(
+    const std::string& providerName,
+    const AWSCredentialsProviderFactory& factory);
 
 /// Implementation of S3 filesystem and file interface.
 /// We provide a registration method for read and write files so the appropriate

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -19,6 +19,8 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
+#include <aws/core/auth/AWSCredentialsProvider.h>
+
 namespace facebook::velox::filesystems {
 
 bool initializeS3(
@@ -26,6 +28,14 @@ bool initializeS3(
     std::optional<std::string_view> logLocation = std::nullopt);
 
 void finalizeS3();
+
+using AWSCredentialsProviderFactory =
+    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
+        const S3Config& config)>;
+
+void registerAWSCredentialsProvider(
+    std::string providerName,
+    AWSCredentialsProviderFactory provider);
 
 /// Implementation of S3 filesystem and file interface.
 /// We provide a registration method for read and write files so the appropriate

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -19,8 +19,6 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
-#include <aws/core/auth/AWSCredentialsProvider.h>
-
 namespace facebook::velox::filesystems {
 
 bool initializeS3(
@@ -28,14 +26,6 @@ bool initializeS3(
     std::optional<std::string_view> logLocation = std::nullopt);
 
 void finalizeS3();
-
-using AWSCredentialsProviderFactory =
-    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
-        const S3Config& config)>;
-
-void registerAWSCredentialsProvider(
-    std::string providerName,
-    AWSCredentialsProviderFactory provider);
 
 /// Implementation of S3 filesystem and file interface.
 /// We provide a registration method for read and write files so the appropriate

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
+
+#include <aws/core/auth/AWSCredentialsProvider.h>
 
 namespace facebook::velox::filesystems {
 
@@ -25,6 +28,14 @@ bool initializeS3(
     std::optional<std::string_view> logLocation = std::nullopt);
 
 void finalizeS3();
+
+using AWSCredentialsProviderFactory =
+    std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
+        const S3Config& config)>;
+
+void registerAWSCredentialsProvider(
+    std::string providerName,
+    AWSCredentialsProviderFactory provider);
 
 /// Implementation of S3 filesystem and file interface.
 /// We provide a registration method for read and write files so the appropriate

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
@@ -36,6 +36,7 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.iamRoleSessionName(), "velox-session");
   ASSERT_EQ(s3Config.payloadSigningPolicy(), "Never");
   ASSERT_EQ(s3Config.cacheKey("foo", config), "foo");
+  ASSERT_EQ(s3Config.bucket(), "");
 }
 
 TEST(S3ConfigTest, overrideConfig) {
@@ -50,10 +51,12 @@ TEST(S3ConfigTest, overrideConfig) {
       {S3Config::baseConfigKey(S3Config::Keys::kAccessKey), "access"},
       {S3Config::baseConfigKey(S3Config::Keys::kSecretKey), "secret"},
       {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "iam"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"}};
+      {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"},
+      {S3Config::baseConfigKey(S3Config::Keys::kCredentialsProvider),
+       "my-credentials-provider"}};
   auto configBase =
       std::make_shared<config::ConfigBase>(std::move(configFromFile));
-  auto s3Config = S3Config("", configBase);
+  auto s3Config = S3Config("bucket", configBase);
   ASSERT_EQ(s3Config.useVirtualAddressing(), false);
   ASSERT_EQ(s3Config.useSSL(), false);
   ASSERT_EQ(s3Config.useInstanceCredentials(), true);
@@ -66,6 +69,8 @@ TEST(S3ConfigTest, overrideConfig) {
   ASSERT_EQ(s3Config.payloadSigningPolicy(), "RequestDependent");
   ASSERT_EQ(s3Config.cacheKey("foo", configBase), "endpoint-foo");
   ASSERT_EQ(s3Config.cacheKey("bar", configBase), "endpoint-bar");
+  ASSERT_EQ(s3Config.bucket(), "bucket");
+  ASSERT_EQ(s3Config.credentialsProvider(), "my-credentials-provider");
 }
 
 TEST(S3ConfigTest, overrideBucketConfig) {
@@ -86,7 +91,11 @@ TEST(S3ConfigTest, overrideBucketConfig) {
       {S3Config::bucketConfigKey(S3Config::Keys::kSecretKey, bucket),
        "bucket-secret"},
       {S3Config::baseConfigKey(S3Config::Keys::kIamRole), "iam"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"}};
+      {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"},
+      {S3Config::baseConfigKey(S3Config::Keys::kCredentialsProvider),
+       "my-credentials-provider"},
+      {S3Config::bucketConfigKey(S3Config::Keys::kCredentialsProvider, bucket),
+       "override-credentials-provider"}};
   auto configBase =
       std::make_shared<config::ConfigBase>(std::move(bucketConfigFromFile));
   auto s3Config = S3Config(bucket, configBase);
@@ -105,6 +114,7 @@ TEST(S3ConfigTest, overrideBucketConfig) {
       s3Config.cacheKey(bucket, configBase),
       "bucket.s3-region.amazonaws.com-bucket");
   ASSERT_EQ(s3Config.cacheKey("foo", configBase), "endpoint-foo");
+  ASSERT_EQ(s3Config.credentialsProvider(), "override-credentials-provider");
 }
 
 } // namespace

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -315,11 +315,12 @@ TEST_F(S3FileSystemTest, registerCredentialProviderFactories) {
       {{"hive.s3.aws-credentials-provider", credentialsProvider}});
   ASSERT_NO_THROW(filesystems::S3FileSystem("", hiveConfig));
 
-  // Configure with unregistered credential provider will use the default code
-  // path to create the credentials provider based on the configuration.
+  // Configure with unregistered credential provider.
   hiveConfig = minioServer_->hiveConfig(
       {{"hive.s3.aws-credentials-provider", invalidCredentialsProvider}});
-  ASSERT_NO_THROW(filesystems::S3FileSystem("", hiveConfig));
+  VELOX_ASSERT_THROW(
+      filesystems::S3FileSystem({"", hiveConfig}),
+      "CredentialsProviderFactory for 'invalid-credentials-provider' not registered");
 
   // Register invalid credentials provider name.
   VELOX_ASSERT_THROW(
@@ -337,8 +338,6 @@ TEST_F(S3FileSystemTest, registerCredentialProviderFactories) {
           [](const S3Config& config) {
             return std::make_shared<MyCredentialsProvider>();
           }),
-      fmt::format(
-          "CredentialsProviderFactory {} already registered",
-          credentialsProvider));
+      "CredentialsProviderFactory 'my-credentials-provider' already registered");
 }
 } // namespace facebook::velox::filesystems

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -765,6 +765,11 @@ Each query can override the config by setting corresponding query session proper
        Legacy mode only enables throttled retry for transient errors.
        Standard mode is built on top of legacy mode and has throttled retry enabled for throttling errors apart from transient errors.
        Adaptive retry mode dynamically limits the rate of AWS requests to maximize success rate.
+   * - hive.s3.aws-credentials-provider
+     - string
+     -
+     - Specifies the user-defined AWSCredentialsProvider. The provider must be registered using "registerAWSCredentialsProvider" before it
+       can be used.
 
 Bucket Level Configuration
 """"""""""""""""""""""""""


### PR DESCRIPTION
Add config entry `kCredentialsProvider` in `S3Config` to use user-specific AWSCredentialsProvider.
Add API `registerAWSCredentialsProvider` to support registering custom AWSCredentialsProviderFactory.