### PR TITLE
fix: Move only one region to prefetch if the regions overlap

### DIFF
--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -199,8 +199,13 @@ class BufferedInput {
         }
         while (i < noPrefetch.size() &&
                getRegionEnd(noPrefetch[i]) <= coalesceEnd) {
-          prefetch[k++] = noPrefetch[i++];
-          ++numMoved;
+          if (getRegionOffset(noPrefetch[i]) >= coalesceStart) {
+            coalesceStart = getRegionEnd(noPrefetch[i]);
+            prefetch[k++] = noPrefetch[i++];
+            ++numMoved;
+          } else {
+            noPrefetch[l++] = noPrefetch[i++];
+          }
         }
         prefetch[k++] = oldPrefetch[j++];
       }

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -151,13 +151,11 @@ uint64_t getOffset(const CacheRequest& request) {
 }
 
 template <bool kSsd>
-std::pair<uint64_t, uint64_t> toRegion(const CacheRequest& request) {
-  return std::make_pair(getOffset<kSsd>(request), request.size);
-}
-
-template <bool kSsd>
 bool lessThan(const CacheRequest* left, const CacheRequest* right) {
-  return toRegion<kSsd>(*left) < toRegion<kSsd>(*right);
+  auto leftOffset = getOffset<kSsd>(*left);
+  auto rightOffset = getOffset<kSsd>(*right);
+  return leftOffset < rightOffset ||
+      (leftOffset == rightOffset && left->size > right->size);
 }
 
 } // namespace

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -84,7 +84,7 @@ bool isPrefetchablePct(int32_t pct) {
 }
 
 bool lessThan(const LoadRequest* left, const LoadRequest* right) {
-  return left->region < right->region;
+  return *left < *right;
 }
 
 } // namespace

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -34,6 +34,12 @@ struct LoadRequest {
   LoadRequest(velox::common::Region& _region, cache::TrackingId _trackingId)
       : region(_region), trackingId(_trackingId) {}
 
+  bool operator<(const LoadRequest& other) const {
+    return region.offset < other.region.offset ||
+        (region.offset == other.region.offset &&
+         region.length > other.region.length);
+  }
+
   velox::common::Region region;
   cache::TrackingId trackingId;
 

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -204,6 +204,13 @@ TEST_F(DirectBufferedInputTest, noRedownloadCoalescedPrefetch) {
   testLoads({{100, 100}, {201, 1, true}, {202, 100}}, 1, fsStats_);
 }
 
+TEST_F(DirectBufferedInputTest, coalesedPrefetchOverlap) {
+  testLoads(
+      {{100, 100}, {201, 1, false}, {201, 2, false}, {203, 100}}, 2, fsStats_);
+  testLoads(
+      {{100, 100}, {201, 1, true}, {201, 2, true}, {203, 100}}, 2, fsStats_);
+}
+
 TEST_F(DirectBufferedInputTest, ioStatsLifeTimeTest) {
   for (size_t i = 0; i < 10; i++) {
     auto stats =


### PR DESCRIPTION
Summary:
When same stream is fetched multiple times (e.g. shared dictionary),
currently if it falls in the coalesce gap, we move all of them to prefetch, but
only one of them can be read without issue, others would get EOF error.  Fix
this by moving only one of them.  We also pick the largest one if the sizes are
different, although such case probably would not show up in real world data.

Differential Revision: D71711902


