### PR TITLE
fix(parquet): SkippedStrides runtime stats

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1002,11 +1002,16 @@ class ParquetRowReader::Impl {
       if (rowGroupInRange && !isExcluded && !isEmpty) {
         rowGroupIds_.push_back(i);
         firstRowOfRowGroup_.push_back(rowNumber);
-      } else if (i != 0) {
-        // Clear the metadata of row groups that are not read. This helps reduce
-        // the memory consumption. ColumnChunks consume the most memory.
-        // Skip the 0th RowGroup as it is used by estimatedRowSize().
-        rowGroups_[i].columns.clear();
+      } else {
+        if (i != 0) {
+          // Clear the metadata of row groups that are not read. This helps
+          // reduce the memory consumption. ColumnChunks consume the most
+          // memory. Skip the 0th RowGroup as it is used by estimatedRowSize().
+          rowGroups_[i].columns.clear();
+        }
+        if (rowGroupInRange) {
+          skippedStrides_++;
+        }
       }
 
       rowNumber += rowGroups_[i].num_rows;
@@ -1064,7 +1069,7 @@ class ParquetRowReader::Impl {
   }
 
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
-    stats.skippedStrides += rowGroups_.size() - rowGroupIds_.size();
+    stats.skippedStrides += skippedStrides_;
   }
 
   void resetFilterCaches() {
@@ -1107,6 +1112,7 @@ class ParquetRowReader::Impl {
   const thrift::RowGroup* currentRowGroupPtr_{nullptr};
   uint64_t rowsInCurrentRowGroup_;
   uint64_t currentRowInGroup_;
+  uint32_t skippedStrides_{0};
 
   std::unique_ptr<dwio::common::SelectiveColumnReader> columnReader_;
 


### PR DESCRIPTION
skippedStrides must only count the RowGroups that were skipped in the split range.
Currently, this value is calculated using the RowGroup count in the entire file.