### PR TITLE
feat: Impl split_to_multimap Null Args

### DIFF
--- a/velox/functions/prestosql/SplitToMultiMap.h
+++ b/velox/functions/prestosql/SplitToMultiMap.h
@@ -47,6 +47,19 @@ struct SplitToMultiMapFunction {
         toStringView(keyValueDelimiter));
   }
 
+  // Overloaded call function to handle UnknownValue cases
+  template <typename TEntryDelimiter, typename TKeyValueDelimiter>
+  void call(
+      out_type<Map<Varchar, Array<Varchar>>>& out,
+      const arg_type<Varchar>& input,
+      const TEntryDelimiter& entryDelimiter,
+      const TKeyValueDelimiter& keyValueDelimiter) {
+    static_assert(
+        std::is_same_v<TEntryDelimiter, arg_type<UnknownValue>> ||
+        std::is_same_v<TKeyValueDelimiter, arg_type<UnknownValue>>);
+    return;
+  }
+
  private:
   static std::string_view toStringView(const arg_type<Varchar>& input) {
     return std::string_view(input.data(), input.size());

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -111,13 +111,33 @@ void registerSimpleFunctions(const std::string& prefix) {
 
   registerFunction<Re2RegexpSplit, Array<Varchar>, Varchar, Varchar>(
       {prefix + "regexp_split"});
+}
 
+void registerSplitToMultiMap(const std::string& prefix) {
   registerFunction<
       SplitToMultiMapFunction,
       Map<Varchar, Array<Varchar>>,
       Varchar,
       Varchar,
       Varchar>({prefix + "split_to_multimap"});
+  registerFunction<
+      SplitToMultiMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      UnknownValue,
+      Varchar>({prefix + "split_to_multimap"});
+  registerFunction<
+      SplitToMultiMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      Varchar,
+      UnknownValue>({prefix + "split_to_multimap"});
+  registerFunction<
+      SplitToMultiMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      UnknownValue,
+      UnknownValue>({prefix + "split_to_multimap"});
 }
 
 void registerSplitToMap(const std::string& prefix) {
@@ -161,6 +181,7 @@ void registerStringFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_split, prefix + "split");
 
   registerSplitToMap(prefix);
+  registerSplitToMultiMap(prefix);
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replaceFirst, prefix + "replace_first");


### PR DESCRIPTION
Summary:
In Presto, when either entryDelimiter or keyValueDelimiter is null, the SPLIT_TO_MULTIMAP function returns null instead of throwing an exception. 
We should maintain the consistency between presto and prestissimo

{F1976364311}

Differential Revision: D71688028


