### PR TITLE
fix: PrestoSerde should be using chain length during serialization

### DIFF
--- a/velox/serializers/PrestoSerializerSerializationUtils.h
+++ b/velox/serializers/PrestoSerializerSerializationUtils.h
@@ -310,7 +310,7 @@ inline FlushSizes flushCompressed(
       "UncompressedSize exceeds limit");
   auto iobuf = out.getIOBuf();
   const auto compressedBuffer = codec.compress(iobuf.get());
-  const int32_t compressedSize = compressedBuffer->length();
+  const int32_t compressedSize = compressedBuffer->computeChainDataLength();
   if (compressedSize > uncompressedSize * minCompressionRatio) {
     flushSerialization(
         numRows,

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -841,12 +841,12 @@ TEST_P(PrestoSerializerTest, basic) {
 }
 
 TEST_P(PrestoSerializerTest, basicLarge) {
-  const vector_size_t numRows = 80'000;
+  const vector_size_t numRows = 800'000;
   auto rowVector = makeRowVector(
       {makeFlatVector<int64_t>(numRows, [](vector_size_t row) { return row; }),
        makeFlatVector<std::string>(
-           numRows, [](vector_size_t row) { return std::string(1024, 'x'); })});
-  testRoundTrip(rowVector);
+           numRows, [](vector_size_t) { return std::string(2048, 'x'); })});
+  testRoundTrip(std::move(rowVector));
 }
 
 /// Test serialization of a dictionary vector that adds nulls to the base


### PR DESCRIPTION
Summary:
Compression does not guarantee a single buffer. This caused a silent corruption (see in test plan) because we were passing in the length of the single iobuf length for the compressed data instead of the whole data chain size. This caused issues on the decompression path with fail to decompress or worse, silent errors (but I havn't seen this).

Fix is to simply pass the whole chain length.

Reviewed By: xiaoxmeng, singcha

Differential Revision: D71761561


