### PR TITLE
fix(fuzzer): Make less ambiguous function not execution by adding to unary operator map

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -123,6 +123,7 @@ void toCallInputsSql(
 const std::unordered_map<std::string, std::string>& unaryOperatorMap() {
   static std::unordered_map<std::string, std::string> unaryOperatorMap{
       {"negate", "-"},
+      {"not", "not"},
   };
   return unaryOperatorMap;
 }


### PR DESCRIPTION
Summary:
Update query generation for function `not` to treat it as an operator and not a function. Currently it is being used as the following which is leading to errors:
```
SELECT (BOOLEAN 'false' >= not(BOOLEAN 'true'));

Presto query failed: 1 line 1:28: mismatched input 'not'.
```
We can wrap the function to "unambiguize" the call:
```
presto:tpch> SELECT (BOOLEAN 'false' >= (not BOOLEAN 'true'));
 _col0 
-------
 true  
(1 row)
```

Reviewed By: kagamiori

Differential Revision: D71767079


