### PR TITLE
feat(fuzzer): Add input generation for varchar and json cast to generic type

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -461,6 +461,25 @@ class JsonPathGenerator : public AbstractInputGenerator {
   bool makeRandomVariation_;
 };
 
+// Input generator to cast a Varchar or Json to a given type T.
+class CastVarcharInputGenerator : public AbstractInputGenerator {
+ public:
+  CastVarcharInputGenerator(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      const TypePtr& castToType);
+
+  ~CastVarcharInputGenerator() override;
+
+  variant generate() override;
+
+ private:
+  TypePtr castToType_;
+
+  std::string generateValidPrimitiveAsString();
+};
+
 class TDigestInputGenerator : public AbstractInputGenerator {
  public:
   TDigestInputGenerator(size_t seed, const TypePtr& type, double nullRatio);
@@ -469,4 +488,5 @@ class TDigestInputGenerator : public AbstractInputGenerator {
 
   variant generate() override;
 };
+
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ArgValuesGenerators.cpp
+++ b/velox/expression/fuzzer/ArgValuesGenerators.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/core/Expressions.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::fuzzer {
@@ -263,6 +264,53 @@ std::vector<core::TypedExprPtr> JsonExtractArgValuesGenerator::generate(
   return inputExpressions;
 }
 
+std::vector<core::TypedExprPtr> CastVarcharAndJsonArgValuesGenerator::generate(
+    const CallableSignature& signature,
+    const VectorFuzzer::Options& options,
+    FuzzerGenerator& rng,
+    ExpressionFuzzerState& state) {
+  VELOX_CHECK_EQ(signature.args.size(), 1);
+  populateInputTypesAndNames(signature, state);
+  std::vector<core::TypedExprPtr> inputExpressions;
+
+  // Use default input generation for non-varchar inputs.
+  if (signature.args[0]->kind() != TypeKind::VARCHAR) {
+    state.customInputGenerators_.emplace_back(nullptr);
+    inputExpressions.emplace_back(nullptr);
+  }
+  // Use custom input generation for varchar.
+  // This will be used to test casting to primitive and complex types.
+  else {
+    const auto seed = rand<uint32_t>(rng);
+    const auto nullRatio = options.nullRatio;
+
+    // Populate state.customInputGenerators_ and inputExpressions for inputs
+    // that require custom input generators. Casting to complex type should
+    // require JSON as input.
+    if (isJsonType(signature.args[0])) {
+      state.customInputGenerators_.emplace_back(
+          std::make_shared<fuzzer::JsonInputGenerator>(
+              seed,
+              signature.args[0],
+              nullRatio,
+              fuzzer::getRandomInputGenerator(
+                  seed, signature.returnType, nullRatio),
+              true));
+    } else {
+      VELOX_CHECK(signature.args[0]->isPrimitiveType());
+      state.customInputGenerators_.emplace_back(
+          std::make_shared<fuzzer::CastVarcharInputGenerator>(
+              seed, signature.args[0], nullRatio, signature.returnType));
+    }
+
+    VELOX_CHECK_GE(signature.args.size(), 1);
+    inputExpressions.emplace_back(std::make_shared<core::FieldAccessTypedExpr>(
+        signature.args[0], state.inputRowNames_.back()));
+  }
+
+  return inputExpressions;
+}
+
 std::vector<core::TypedExprPtr> TDigestArgValuesGenerator::generate(
     const CallableSignature& signature,
     const VectorFuzzer::Options& options,
@@ -289,5 +337,4 @@ std::vector<core::TypedExprPtr> TDigestArgValuesGenerator::generate(
   }
   return inputExpressions;
 }
-
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ArgValuesGenerators.h
+++ b/velox/expression/fuzzer/ArgValuesGenerators.h
@@ -82,6 +82,17 @@ class JsonExtractArgValuesGenerator : public ArgValuesGenerator {
       ExpressionFuzzerState& state) override;
 };
 
+class CastVarcharAndJsonArgValuesGenerator : public ArgValuesGenerator {
+ public:
+  ~CastVarcharAndJsonArgValuesGenerator() override = default;
+
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
+};
+
 class TDigestArgValuesGenerator : public ArgValuesGenerator {
  public:
   explicit TDigestArgValuesGenerator(std::string functionName) {

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -55,6 +55,7 @@ using namespace facebook::velox::exec::test;
 using facebook::velox::exec::test::PrestoQueryRunner;
 using facebook::velox::fuzzer::ArgTypesGenerator;
 using facebook::velox::fuzzer::ArgValuesGenerator;
+using facebook::velox::fuzzer::CastVarcharAndJsonArgValuesGenerator;
 using facebook::velox::fuzzer::ExpressionFuzzer;
 using facebook::velox::fuzzer::FuzzerRunner;
 using facebook::velox::fuzzer::JsonExtractArgValuesGenerator;
@@ -156,6 +157,7 @@ int main(int argc, char** argv) {
 
   std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
       argValuesGenerators = {
+          {"cast", std::make_shared<CastVarcharAndJsonArgValuesGenerator>()},
           {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()},
           {"json_extract", std::make_shared<JsonExtractArgValuesGenerator>()},
           {"value_at_quantile",


### PR DESCRIPTION
Summary:
Generate valid input for `cast(V as T)` where `V` is either varchar or json and T can be any other type such as boolean, int, real, timestamp, complex, etc.

We can accomplish so by implementing a new class `CastVarcharAndJsonInputGenerator` that generates the aforementioned valid input and invoking it from Expression Fuzzer.

This will increase our test coverage to allow for json and varchar casting.

Differential Revision: D71510669


