### PR TITLE
build: Add missing include for uint64_t type

### DIFF
--- a/velox/common/file/Region.h
+++ b/velox/common/file/Region.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string_view>
 
 namespace facebook::velox::common {


### PR DESCRIPTION
The cstdint file should be included when using this type.