### PR TITLE
feat: Add memory order to breeze atomics

### DIFF
--- a/velox/experimental/breeze/breeze/utils/types.h
+++ b/velox/experimental/breeze/breeze/utils/types.h
@@ -186,6 +186,12 @@ enum DataArrangement {
   WARP_STRIPED,
 };
 
+enum MemoryOrder {
+  RELAXED,
+  ACQUIRE,
+  RELEASE,
+};
+
 class NullType {};
 
 class EmptySlice {


### PR DESCRIPTION
Currently limited to CUDA platform and load/store/cas operations but can be extended to support more atomic operations and platforms as needed.

No PTX specializations are currently used but can be added if neccessary for optimal performance.