### PR TITLE
feat: Add std-like wrappers around breeze atomics

### DIFF
--- a/velox/experimental/wave/CMakeLists.txt
+++ b/velox/experimental/wave/CMakeLists.txt
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use breeze PTX specialization by default for CUDA.
+if(NOT DEFINED CUDA_PLATFORM_SPECIALIZATION_HEADER)
+  set(CUDA_PLATFORM_SPECIALIZATION_HEADER
+      breeze/platforms/specialization/cuda-ptx.cuh
+      CACHE STRING "CUDA platform specialization header")
+endif()
+
+# Add header only library for breeze and CUDA platform.
+add_library(breeze_cuda INTERFACE)
+target_include_directories(breeze_cuda INTERFACE ../breeze)
+target_compile_definitions(
+  breeze_cuda
+  INTERFACE
+    PLATFORM_CUDA
+    CUDA_PLATFORM_SPECIALIZATION_HEADER=${CUDA_PLATFORM_SPECIALIZATION_HEADER})
+
 add_subdirectory(common)
 add_subdirectory(exec)
 add_subdirectory(vector)

--- a/velox/experimental/wave/common/Atomic.cuh
+++ b/velox/experimental/wave/common/Atomic.cuh
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <breeze/platforms/platform.h>
+#include <breeze/utils/types.h>
+#include <breeze/platforms/cuda.cuh>
+#include "velox/experimental/wave/common/BitUtil.cuh"
+#include "velox/experimental/wave/common/CompilerDefines.h"
+
+namespace facebook::velox::wave {
+
+enum class MemoryScope { kDevice };
+
+enum class MemoryOrder {
+  kRelaxed,
+  kAcquire,
+  kRelease,
+};
+
+template <MemoryScope>
+struct MemoryScopeTraits;
+
+template <>
+struct MemoryScopeTraits<MemoryScope::kDevice> {
+  WAVE_DEVICE_HOST static constexpr breeze::utils::AddressSpace
+  breeze_address_space() {
+    return breeze::utils::GLOBAL;
+  }
+};
+
+template <MemoryOrder>
+struct MemoryOrderTraits;
+
+template <>
+struct MemoryOrderTraits<MemoryOrder::kRelaxed> {
+  WAVE_DEVICE_HOST static constexpr breeze::utils::MemoryOrder breeze_type() {
+    return breeze::utils::RELAXED;
+  }
+};
+
+template <>
+struct MemoryOrderTraits<MemoryOrder::kAcquire> {
+  WAVE_DEVICE_HOST static constexpr breeze::utils::MemoryOrder breeze_type() {
+    return breeze::utils::ACQUIRE;
+  }
+};
+
+template <>
+struct MemoryOrderTraits<MemoryOrder::kRelease> {
+  WAVE_DEVICE_HOST static constexpr breeze::utils::MemoryOrder breeze_type() {
+    return breeze::utils::RELEASE;
+  }
+};
+
+template <typename T, MemoryScope Scope = MemoryScope::kDevice>
+struct Atomic {
+  // Note: We currently do not require usage of this class to specify
+  // kBlockThreads as that is not technically used by the CUDA platform
+  // implementation of the atomics in breeze and is non-trivial for
+  // existing usage of atomics to provide. We might want to change that
+  // in the future to remove that assumption.
+  using PlatformT = CudaPlatform</*kBlockThreads=*/kWarpThreads, kWarpThreads>;
+
+  alignas(sizeof(T)) T __value;
+
+  Atomic(const Atomic&) = delete;
+  Atomic& operator=(const Atomic&) = delete;
+  Atomic& operator=(const Atomic&) volatile = delete;
+
+  WAVE_DEVICE_HOST explicit constexpr Atomic() noexcept = default;
+  WAVE_DEVICE_HOST constexpr explicit inline Atomic(T value) noexcept
+      : __value(value) {}
+
+  template <MemoryOrder Order = MemoryOrder::kRelaxed>
+  WAVE_DEVICE_HOST T load() noexcept {
+    using namespace breeze::utils;
+    return PlatformT().atomic_load<MemoryOrderTraits<Order>::breeze_type()>(
+        make_slice<MemoryScopeTraits<Scope>::breeze_address_space()>(&__value));
+  }
+
+  template <MemoryOrder Order = MemoryOrder::kRelaxed>
+  WAVE_DEVICE_HOST void store(T value) noexcept {
+    using namespace breeze::utils;
+    PlatformT().atomic_store<MemoryOrderTraits<Order>::breeze_type()>(
+        make_slice<MemoryScopeTraits<Scope>::breeze_address_space()>(&__value),
+        value);
+  }
+
+  template <MemoryOrder Order = MemoryOrder::kRelaxed>
+  WAVE_DEVICE_HOST bool compare_exchange(T& expected, T desired) noexcept {
+    using namespace breeze::utils;
+    T actual = PlatformT().atomic_cas<MemoryOrderTraits<Order>::breeze_type()>(
+        make_slice<MemoryScopeTraits<Scope>::breeze_address_space()>(&__value),
+        expected,
+        desired);
+    bool was_changed = actual == expected;
+    expected = actual;
+    return was_changed;
+  }
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/AtomicTest.cu
+++ b/velox/experimental/wave/common/tests/AtomicTest.cu
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/experimental/wave/common/Atomic.cuh"
+#include "velox/experimental/wave/common/Cuda.h"
+
+namespace facebook::velox::wave {
+namespace {
+
+template <typename T, typename U>
+inline __device__ Atomic<T, MemoryScope::kDevice>* asDeviceAtomic(U* ptr) {
+  return reinterpret_cast<Atomic<T, MemoryScope::kDevice>*>(ptr);
+}
+
+template <MemoryOrder Order>
+__global__ void loadKernel(int* in, int* out) {
+  *out = asDeviceAtomic<int>(in)->template load<Order>();
+}
+
+template <MemoryOrder Order>
+__global__ void storeKernel(int in, int* out) {
+  asDeviceAtomic<int>(out)->template store<Order>(in);
+}
+
+template <MemoryOrder Order>
+__global__ void
+compareExchangeKernel(int* expected, int desired, int* out, bool* was_changed) {
+  int expected_value = *expected;
+  *was_changed = asDeviceAtomic<int>(out)->template compare_exchange<Order>(
+      expected_value, desired);
+  *expected = expected_value;
+}
+
+template <MemoryOrder Order>
+struct AtomicTestType {
+  static const MemoryOrder memory_order = Order;
+};
+
+struct AtomicTestNameGenerator {
+  template <typename T>
+  static std::string GetName(int) {
+    if constexpr (T::memory_order == MemoryOrder::kRelaxed)
+      return "relaxed";
+    if constexpr (T::memory_order == MemoryOrder::kAcquire)
+      return "acquire";
+    if constexpr (T::memory_order == MemoryOrder::kRelease)
+      return "release";
+    return "?";
+  }
+};
+
+template <typename TypeParam>
+class AtomicLoadTest : public testing::Test {};
+
+using AtomicLoadTestTypes = ::testing::Types<
+    AtomicTestType<MemoryOrder::kRelaxed>,
+    AtomicTestType<MemoryOrder::kAcquire>>;
+
+TYPED_TEST_SUITE(AtomicLoadTest, AtomicLoadTestTypes, AtomicTestNameGenerator);
+
+TYPED_TEST(AtomicLoadTest, load) {
+  auto* allocator = getAllocator(getDevice());
+  auto input = allocator->allocate<int>();
+  *input = 1234;
+  auto output = allocator->allocate<int>();
+  loadKernel<TypeParam::memory_order><<<1, 1>>>(input.get(), output.get());
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(*output, 1234);
+}
+
+template <typename TypeParam>
+class AtomicStoreTest : public testing::Test {};
+
+using AtomicStoreTestTypes = ::testing::Types<
+    AtomicTestType<MemoryOrder::kRelaxed>,
+    AtomicTestType<MemoryOrder::kRelease>>;
+
+TYPED_TEST_SUITE(
+    AtomicStoreTest,
+    AtomicStoreTestTypes,
+    AtomicTestNameGenerator);
+
+TYPED_TEST(AtomicStoreTest, store) {
+  auto* allocator = getAllocator(getDevice());
+  auto output = allocator->allocate<int>();
+  storeKernel<TypeParam::memory_order><<<1, 1>>>(4321, output.get());
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(*output, 4321);
+}
+
+template <typename TypeParam>
+class AtomicCompareExchangeTest : public testing::Test {};
+
+using AtomicCompareExchangeTestTypes = ::testing::Types<
+    AtomicTestType<MemoryOrder::kRelaxed>,
+    AtomicTestType<MemoryOrder::kAcquire>,
+    AtomicTestType<MemoryOrder::kRelease>>;
+
+TYPED_TEST_SUITE(
+    AtomicCompareExchangeTest,
+    AtomicCompareExchangeTestTypes,
+    AtomicTestNameGenerator);
+
+TYPED_TEST(AtomicCompareExchangeTest, compare_exchange) {
+  auto* allocator = getAllocator(getDevice());
+  auto expected = allocator->allocate<int>();
+  *expected = 1234;
+  auto output = allocator->allocate<int>();
+  *output = 0;
+  auto was_changed = allocator->allocate<bool>();
+  *was_changed = true;
+  compareExchangeKernel<TypeParam::memory_order>
+      <<<1, 1>>>(expected.get(), 4321, output.get(), was_changed.get());
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(*output, 0);
+  ASSERT_EQ(*expected, 0);
+  ASSERT_EQ(*was_changed, false);
+  *output = 1234;
+  *expected = 1234;
+  compareExchangeKernel<TypeParam::memory_order>
+      <<<1, 1>>>(expected.get(), 4321, output.get(), was_changed.get());
+  ASSERT_EQ(cudaGetLastError(), cudaSuccess);
+  ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+  ASSERT_EQ(*output, 4321);
+  ASSERT_EQ(*expected, 1234);
+  ASSERT_EQ(*was_changed, true);
+}
+
+} // namespace
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/BreezeCudaTest.cu
+++ b/velox/experimental/wave/common/tests/BreezeCudaTest.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-#define PLATFORM_CUDA
-
-// clang-format off
-#define CUDA_PLATFORM_SPECIALIZATION_HEADER \
-  breeze/platforms/specialization/cuda-ptx.cuh
-// clang-format on
-
 #include <breeze/functions/reduce.h>
 #include <breeze/platforms/platform.h>
 #include <breeze/utils/device_vector.h>

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -22,7 +22,8 @@ add_executable(
   BlockTest.cpp
   BlockTest.cu
   HashTableTest.cpp
-  HashTestUtil.cpp)
+  HashTestUtil.cpp
+  AtomicTest.cu)
 
 add_test(velox_wave_common_test velox_wave_common_test)
 set_tests_properties(velox_wave_common_test PROPERTIES LABELS cuda_driver)

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -27,7 +27,6 @@ add_executable(
 add_test(velox_wave_common_test velox_wave_common_test)
 set_tests_properties(velox_wave_common_test PROPERTIES LABELS cuda_driver)
 
-target_include_directories(velox_wave_common_test PRIVATE ../../../breeze)
 if(VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST)
   target_compile_definitions(velox_wave_common_test
                              PRIVATE VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST=1)
@@ -38,4 +37,5 @@ target_link_libraries(
   xsimd
   GTest::gtest
   GTest::gtest_main
-  CUDA::cudart)
+  CUDA::cudart
+  breeze_cuda)


### PR DESCRIPTION
This can be used to replace current libcudacxx usage and as a result make the code more portable and faster to compile.