### PR TITLE
fix: Deserializing nulls in Row type in empty Presto Page causes UBSan error

### DIFF
--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -69,7 +69,7 @@ vector_size_t valueCount(
     vector_size_t size,
     Scratch& scratch,
     raw_vector<uint64_t>* copy = nullptr) {
-  if (source->readByte() == 0) {
+  if (source->readByte() == 0 || size == 0) {
     return size;
   }
   ScratchPtr<uint64_t, 16> nullsHolder(scratch);


### PR DESCRIPTION
Summary:
In Aggregation Fuzzer with Presto SOT we've seen that when Presto Java sends an empty
page with a Row type, it will still set the has null flag for that column.  Velox's Presto 
deserializer will therefore try to allocate a buffer for the nulls and copy the flags for it. Since
the page is empty, these buffers are size 0 so we get a nullptr back when we allocate them.
These triggers a UBSan error when we try to copy the null bits into it. In practice, this isn't an
issue because we're copying 0 bytes into the buffer.

This diff adds a check if the size is 0 and skips allocating the buffer and copying if so to avoid
the UBSan error and general code cleanliness.

Differential Revision: D71829523


