### PR TITLE
build: Add xxd hex dump util to dependencies

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -80,7 +80,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel
+    libsodium-devel zlib-devel vim-common
 
   # install sphinx for doc gen
   pip install sphinx sphinx-tabs breathe sphinx_rtd_theme

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -150,7 +150,8 @@ function install_velox_deps_from_apt {
     bison \
     flex \
     libfl-dev \
-    tzdata
+    tzdata \
+    xxd
 }
 
 function install_fmt {


### PR DESCRIPTION
Adds dependencies `vim-common` to `setup-centos` and `xxd` to `setup-ubuntu`.
This lets us use the `xxd` command to create hex dump from file 
`velox/tpcds/gen/include/tpcds.idx` in https://github.com/facebookincubator/velox/pull/12714.
Required for https://github.com/facebookincubator/velox/pull/12714.