### PR TITLE
feat: Add ip_prefix_subnets function for ipprefix

### DIFF
--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -59,3 +59,12 @@ IP Functions
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.1.0/24']); -- [{192.168.0.0/23}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '2620:10d:c090::/48', IPPREFIX '2620:10d:c091::/48']); -- [{2620:10d:c090::/47}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.1.0/24', IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.2.0/24', IPPREFIX '192.168.9.0/24']); -- [{192.168.0.0/23}, {192.168.2.0/24}, {192.168.9.0/24}]
+        
+.. function:: ip_prefix_subnets(ip_prefix, prefix_length) -> array(ip_prefix)
+
+    Returns the subnets of ``ip_prefix`` of size ``prefix_length``. ``prefix_length`` must be valid ([0, 32] for IPv4
+    and [0, 128] for IPv6) or the query will fail and raise an error. An empty array is returned if ``prefix_length``
+    is shorter (that is, less specific) than ``ip_prefix``. ::
+
+        SELECT IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 25); -- [{192.168.1.0/25}, {192.168.1.128/25}]
+        SELECT IP_PREFIX_SUBNETS(IPPREFIX '2a03:2880:c000::/34', 36); -- [{2a03:2880:c000::/36}, {2a03:2880:d000::/36}, {2a03:2880:e000::/36}, {2a03:2880:f000::/36}]


### PR DESCRIPTION
Summary:
Implement ip_prefix_subnets similar to Java function https://github.com/prestodb/presto/blob/33ff9521dbd25e2b7b1181cf01391cb899857d65/presto-main/src/main/java/com/facebook/presto/operator/scalar/IpPrefixFunctions.java#L303.

This is done by first ensurin the ipprefix and the new length are valid. 

We find the number of new prefix ip counts and new prefix counts, this is used to compute the array of new ipaddresses/prefix based on the new prefix length.

The implementation is the same as Java.

Differential Revision: D71826712


