### PR TITLE
test: Add support for TimestampWithTimeZone in Expression Fuzzer

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -300,7 +300,8 @@ bool PrestoQueryRunner::isConstantExprSupported(
     auto& type = expr->type();
     return type->isPrimitiveType() && !type->isTimestamp() &&
         !isJsonType(type) && !type->isIntervalDayTime() &&
-        !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type);
+        !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
+        !isTimestampWithTimeZoneType(type);
   }
   return true;
 }

--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -342,6 +342,11 @@ class ExpressionFuzzer {
 
   std::vector<std::string> supportedFunctions_;
 
+  // The set of scalar types to be used when fuzzing types, used when fuzzing
+  // argument/return types. Defaults to whatever VectorFuzzer supports, but may
+  // be augmented/restricted by the ReferenceQueryRunner.
+  std::vector<TypePtr> supportedScalarTypes_;
+
   State state_;
 
   // Maps from function name to a specific generator of argument types.

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -29,6 +29,7 @@
 #include "velox/expression/FunctionSignature.h"
 #include "velox/expression/ReverseSignatureBinder.h"
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
+#include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::fuzzer {
 
@@ -83,6 +84,7 @@ ExpressionFuzzerVerifier::ExpressionFuzzerVerifier(
           argValuesGenerators),
       referenceQueryRunner_{
           options_.expressionFuzzerOptions.referenceQueryRunner} {
+  parse::registerTypeResolver();
   filesystems::registerLocalFileSystem();
   connector::registerConnectorFactory(
       std::make_shared<connector::hive::HiveConnectorFactory>());

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -225,6 +225,19 @@ bool hasNestedDictionaryLayers(const VectorPtr& baseVector) {
       VectorEncoding::isDictionary(baseVector->valueVector()->encoding());
 }
 
+// Returns an AbstractInputGeneratorPtr for the given type if it's a custom
+// type, otherwise returns null.
+AbstractInputGeneratorPtr maybeGetCustomTypeInputGenerator(
+    const TypePtr& type,
+    const double nullRatio,
+    FuzzerGenerator& rng) {
+  if (customTypeExists(type->name())) {
+    InputGeneratorConfig config{rand<uint32_t>(rng), nullRatio};
+    return getCustomTypeInputGenerator(type->name(), config);
+  }
+
+  return nullptr;
+}
 } // namespace
 
 VectorPtr VectorFuzzer::fuzzNotNull(
@@ -254,18 +267,15 @@ VectorPtr VectorFuzzer::fuzz(
     const AbstractInputGeneratorPtr& customGenerator) {
   VectorPtr vector;
   vector_size_t vectorSize = size;
-  auto inputGenerator = customGenerator;
+  const auto inputGenerator = customGenerator
+      ? customGenerator
+      : maybeGetCustomTypeInputGenerator(type, opts_.nullRatio, rng_);
 
   bool usingLazyVector = opts_.allowLazyVector && coinToss(0.1);
   // Lazy Vectors cannot be sliced, so we skip this if using lazy wrapping.
   if (opts_.allowSlice && !usingLazyVector && coinToss(0.1)) {
     // Extend the underlying vector to allow slicing later.
     vectorSize += rand<uint32_t>(rng_) % 8;
-  }
-
-  if (!inputGenerator && customTypeExists(type->name())) {
-    InputGeneratorConfig config{rand<uint32_t>(rng_), opts_.nullRatio};
-    inputGenerator = getCustomTypeInputGenerator(type->name(), config);
   }
 
   // 20% chance of adding a constant vector.
@@ -320,6 +330,10 @@ VectorPtr VectorFuzzer::fuzzConstant(
     const TypePtr& type,
     vector_size_t size,
     const AbstractInputGeneratorPtr& customGenerator) {
+  const auto inputGenerator = customGenerator
+      ? customGenerator
+      : maybeGetCustomTypeInputGenerator(type, opts_.nullRatio, rng_);
+
   // For constants, there are two possible cases:
   // - generate a regular constant vector (only for primitive types).
   // - generate a random vector and wrap it using a constant vector.
@@ -367,7 +381,7 @@ VectorPtr VectorFuzzer::fuzzConstant(
         opts_.maxConstantContainerSize.value(), opts_.complexElementsMaxSize);
   }
   return BaseVector::wrapInConstant(
-      size, constantIndex, fuzz(type, innerVectorSize, customGenerator));
+      size, constantIndex, fuzz(type, innerVectorSize, inputGenerator));
 }
 
 VectorPtr VectorFuzzer::fuzzFlat(


### PR DESCRIPTION
Summary:
This change adds support for TimestampWithTimeZone in ExpressionFuzzer with
PrestoQueryRunner.

This change primarily just integrations the inputProjections function from
ReferenceQueryRunner into the ExpressionFuzzer and plumbs the resulting updated input
Vectors and projections through to verification.

The only other change was to VectorFuzzer, this exposed some code paths that were not
respecting the input generators for custom types.

Differential Revision: D71849125
