### PR TITLE
fix(json): Special case certain unicode characters to escape when casting from json

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.cpp
+++ b/velox/functions/prestosql/json/JsonStringUtil.cpp
@@ -530,9 +530,13 @@ size_t unescapeSizeForJsonCast(const char* input, size_t length) {
             start += 6;
             continue;
           } else {
-            unsigned char buf[4];
-            auto increment = utf8proc_encode_char(codePoint, buf);
-            outSize += increment;
+            if (!isSpecialCode(codePoint)) {
+              unsigned char buf[4];
+              auto increment = utf8proc_encode_char(codePoint, buf);
+              outSize += increment;
+            } else {
+              outSize += 6;
+            }
           }
           start += 6;
           continue;
@@ -608,9 +612,21 @@ void unescapeForJsonCast(const char* input, size_t length, char* output) {
             start += 6;
             continue;
           } else {
-            auto increment = utf8proc_encode_char(
-                codePoint, reinterpret_cast<unsigned char*>(pos));
-            pos += increment;
+            if (!isSpecialCode(codePoint)) {
+              auto increment = utf8proc_encode_char(
+                  codePoint, reinterpret_cast<unsigned char*>(pos));
+              pos += increment;
+            } else {
+              *pos++ = '\\';
+              *pos++ = 'u';
+              start += 2;
+              // java upper cases the code points
+              for (auto k = 0; k < 4; k++) {
+                *pos++ = std::toupper(start[k]);
+              }
+              start += 4;
+              continue;
+            }
           }
           start += 6;
           continue;


### PR DESCRIPTION
Summary:
When casting from a json to another json complex type , json -> array(json) etc, we by default unescape unicode. However certain unicode sequences in the basic latin (https://www.compart.com/en/unicode/block/U+0000) are not unescaped. This is not a problem generally but if subsequently this json is again casted to another complex type json (i.e you go from json-> array(json) -> Row(x : json)) then simdjson throws requiring certain characters in this sequence to be escaped.

Note we previously added a fix to unescape json's here : D71078371 but it did not cover this edge case.

Differential Revision: D71834496


