### PR TITLE
feat: Add is_private_ip to check if ipaddress is private

### DIFF
--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -59,7 +59,7 @@ IP Functions
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.1.0/24']); -- [{192.168.0.0/23}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '2620:10d:c090::/48', IPPREFIX '2620:10d:c091::/48']); -- [{2620:10d:c090::/47}]
         SELECT IP_PREFIX_COLLAPSE(ARRAY[IPPREFIX '192.168.1.0/24', IPPREFIX '192.168.0.0/24', IPPREFIX '192.168.2.0/24', IPPREFIX '192.168.9.0/24']); -- [{192.168.0.0/23}, {192.168.2.0/24}, {192.168.9.0/24}]
-        
+
 .. function:: ip_prefix_subnets(ip_prefix, prefix_length) -> array(ip_prefix)
 
     Returns the subnets of ``ip_prefix`` of size ``prefix_length``. ``prefix_length`` must be valid ([0, 32] for IPv4
@@ -68,3 +68,13 @@ IP Functions
 
         SELECT IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 25); -- [{192.168.1.0/25}, {192.168.1.128/25}]
         SELECT IP_PREFIX_SUBNETS(IPPREFIX '2a03:2880:c000::/34', 36); -- [{2a03:2880:c000::/36}, {2a03:2880:d000::/36}, {2a03:2880:e000::/36}, {2a03:2880:f000::/36}]
+
+.. function:: is_private_ip(ip_address) -> boolean
+
+    Returns whether ``ip_address`` of type ``IPADDRESS`` is a private or reserved IP address
+    that is not considered globally reachable by IANA. For more information, see `IANA IPv4 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml>`_ and `IANA IPv6 Special-Purpose Address Registry <https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml>`_. `Null` inputs return `null`. ::
+
+        SELECT is_private_ip(IPADDRESS '10.0.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '192.168.0.1'); -- true
+        SELECT is_private_ip(IPADDRESS '157.240.200.99'); -- false
+        SELECT is_private_ip(IPADDRESS '2a03:2880:f031:12:face:b00c:0:2'); -- false

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -77,6 +77,10 @@ class IPAddressFunctionsTest : public functions::test::FunctionBaseTest {
         prefix,
         prefix2);
   }
+
+  std::optional<bool> isPrivateIP(const std::optional<std::string>& input) {
+    return evaluateOnce<bool>("is_private_ip(cast(c0 as ipaddress))", input);
+  }
 };
 
 TEST_F(IPAddressFunctionsTest, ipPrefixFromIpAddress) {
@@ -624,6 +628,97 @@ TEST_F(IPAddressFunctionsTest, IPPrefixSubnetsTest) {
                 {makeConstantRow(IPPREFIX(), ipprefix("192.168.0.0/24"), 1)})),
         "Invalid prefix length for IPv4: -1");
   }
+}
+
+TEST_F(IPAddressFunctionsTest, IsPrivateIPTest) {
+  const static std::vector<std::string> privateIpAddresses = {
+      // The first and last IP address in each private range
+      {"0.0.0.0"},
+      {"0.255.255.255"}, // 0.0.0.0/8 RFC1122: "This host on this network"
+      {"10.0.0.0"},
+      {"10.255.255.255"}, // 10.0.0.0/8 RFC1918: Private-Use
+      {"100.64.0.0"},
+      {"100.127.255.255"}, // 100.64.0.0/10 RFC6598: Shared Address Space
+      {"127.0.0.0"},
+      {"127.255.255.255"}, // 127.0.0.0/8 RFC1122: Loopback
+      {"169.254.0.0"},
+      {"169.254.255.255"}, // 169.254.0.0/16 RFC3927: Link Local
+      {"172.16.0.0"},
+      {"172.31.255.255"}, // 172.16.0.0/12 RFC1918: Private-Use
+      {"192.0.0.0"},
+      {"192.0.0.255"}, // 192.0.0.0/24 RFC6890: IETF Protocol Assignments
+      {"192.0.2.0"},
+      {"192.0.2.255"}, // 192.0.2.0/24 RFC5737: Documentation (TEST-NET-1)
+      {"192.88.99.0"},
+      {"192.88.99.255"}, // 192.88.99.0/24 RFC3068: 6to4 Relay anycast
+      {"192.168.0.0"},
+      {"192.168.255.255"}, // 192.168.0.0/16 RFC1918: Private-Use
+      {"198.18.0.0"},
+      {"198.19.255.255"}, // 198.18.0.0/15 RFC2544: Benchmarking
+      {"198.51.100.0"},
+      {"198.51.100.255"}, // 198.51.100.0/24 RFC5737: Documentation (TEST-NET-2)
+      {"203.0.113.0"},
+      {"203.0.113.255"}, // 203.0.113.0/24 RFC5737: Documentation (TEST-NET-3)
+      {"240.0.0.0"},
+      {"255.255.255.255"}, // 240.0.0.0/4 RFC1112: Reserved
+      {"::"},
+      {"::"}, // ::/128 RFC4291: Unspecified address
+      {"::1"},
+      {"::1"}, // ::1/128 RFC4291: Loopback address
+      {"100::"},
+      {"100::ffff:ffff:ffff:ffff"}, // 100::/64 RFC6666: Discard-Only Address
+      // Block
+      {"64:ff9b:1::"},
+      {"64:ff9b:1:ffff:ffff:ffff:ffff:ffff"}, // 64:ff9b:1::/48 RFC8215:
+      // IPv4-IPv6 Translation
+      {"2001:2::"},
+      {"2001:2:0:ffff:ffff:ffff:ffff:ffff"}, // 2001:2::/48 RFC5180,RFC Errata
+      // 1752: Benchmarking
+      {"2001:db8::"},
+      {"2001:db8:ffff:ffff:ffff:ffff:ffff:ffff"}, // 2001:db8::/32 RFC3849:
+      // Documentation
+      {"2001::"},
+      {"2001:1ff:ffff:ffff:ffff:ffff:ffff:ffff"}, // 2001::/23 RFC2928: IETF
+      // Protocol Assignments
+      {"5f00::"},
+      {"5f00:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}, // 5f00::/16
+      // RFC-ietf-6man-sids-06:
+      // Segment Routing (SRv6)
+      {"fe80::"},
+      {"febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}, // fe80::/10 RFC4291:
+      // Link-Local Unicast
+      {"fc00::"},
+      {"fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"}, // fc00::/7 RFC4193, RFC8190:
+      // Unique Local
+      // some IPs in the middle of ranges
+      {"10.1.2.3"},
+      {"100.64.3.2"},
+      {"192.168.55.99"},
+      {"2001:0DB8:0000:0000:face:b00c:0000:0000"},
+      {"0100:0000:0000:0000:ffff:ffff:0000:0000"}};
+  for (const auto& ip : privateIpAddresses) {
+    EXPECT_EQ(isPrivateIP(ip), true);
+  }
+
+  const static std::vector<std::string> publicIpAddresses{
+      "6.7.8.9",
+      "157.240.200.99",
+      "8.8.8.8",
+      "128.1.2.8",
+      "2a03:2880:f031:12:face:b00c:0:2",
+      "2600:1406:6c00::173c:ad43",
+      "2607:f8b0:4007:818::2004"};
+  for (const auto& ip : publicIpAddresses) {
+    EXPECT_EQ(isPrivateIP(ip), false);
+  }
+
+  // Test private ips from presto docs
+  EXPECT_EQ(isPrivateIP("10.0.0.1"), true);
+  EXPECT_EQ(isPrivateIP("192.168.0.1"), true);
+  EXPECT_EQ(isPrivateIP("157.240.200.99"), false);
+  EXPECT_EQ(isPrivateIP("2a03:2880:f031:12:face:b00c:0:2"), false);
+
+  EXPECT_EQ(std::nullopt, isPrivateIP(std::nullopt));
 }
 
 } // namespace facebook::velox::functions::prestosql


### PR DESCRIPTION
Summary:
Add function to see if ip address is private or not. This is based off of presto implementation:
https://github.com/prestodb/presto/blob/33ff9521dbd25e2b7b1181cf01391cb899857d65/presto-main/src/main/java/com/facebook/presto/operator/scalar/IpPrefixFunctions.java#L267

Differential Revision: D71838646


