### PR TITLE
misc: Decrease row count for presto serializer large buffer test

### DIFF
--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -841,11 +841,12 @@ TEST_P(PrestoSerializerTest, basic) {
 }
 
 TEST_P(PrestoSerializerTest, basicLarge) {
-  const vector_size_t numRows = 800'000;
-  auto rowVector = makeRowVector(
-      {makeFlatVector<int64_t>(numRows, [](vector_size_t row) { return row; }),
-       makeFlatVector<std::string>(
-           numRows, [](vector_size_t) { return std::string(2048, 'x'); })});
+  const vector_size_t numRows = 200'000;
+  auto rowVector = makeRowVector({
+      makeFlatVector<int64_t>(numRows, [](vector_size_t row) { return row; }),
+      makeFlatVector<std::string>(
+          numRows, [](vector_size_t) { return std::string(2048, 'x'); }),
+  });
   testRoundTrip(std::move(rowVector));
 }
 


### PR DESCRIPTION
We need a buffer that is large enough to have the zstd codec return a chained iobuf; however, this was causing a time out in our parameterized tests.

Decrease the from 800k -> 200k rows

