### PR TITLE
feat: Add QuantileDigest data structure

### DIFF
--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -25,8 +25,16 @@ inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
 }
 
+inline size_t count_trailing_zeros_32bits(uint32_t x) {
+  return x == 0 ? 32 : __builtin_ctz(x);
+}
+
 inline size_t count_leading_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_clzll(x);
+}
+
+inline size_t count_leading_zeros_32bits(uint32_t x) {
+  return x == 0 ? 32 : __builtin_clz(x);
 }
 
 namespace facebook::velox {

--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -1,0 +1,1193 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Bits.h>
+
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox::functions {
+
+namespace qdigest {
+
+constexpr double kZeroWeightThreshold = 1.0E-5;
+
+/// Implementation of Q-Digest that matches Presto Java behavior. The
+/// serialization format is same as Java. There is one performance improvement:
+/// mergeSerialized(const char* serialized) allows merging another serialized
+/// digest into the current one without having to deserialize it first. This
+/// optimization allows us to perform the merge with one pass instead of two,
+/// and skip memory allocation for storing the deserialized digest. The Java
+/// behavior is the same as testingMerge.
+///
+/// Java implementation can be found at:
+/// https://github.com/airlift/airlift/blob/57a1bb0182f6336cb03a365be018a73490d9b410/stats/src/main/java/io/airlift/stats/QuantileDigest.java
+template <typename T, typename Allocator = StlAllocator<T>>
+class QuantileDigest {
+  static_assert(
+      std::is_same_v<T, int64_t> || std::is_same_v<T, double> ||
+      std::is_same_v<T, float>);
+
+ public:
+  explicit QuantileDigest(const Allocator& allocator, double maxError);
+
+  QuantileDigest(const Allocator& allocator, const char* serialized);
+
+  void add(T value, double weight);
+
+  void mergeSerialized(const char* other);
+
+  double getCount() const;
+
+  void scale(double scaleFactor);
+
+  void compress();
+
+  /// Estimate the values of the given quantiles and write the results in order
+  /// directly into 'result'.
+  void estimateQuantiles(const std::vector<double>& quantiles, T* result);
+
+  T estimateQuantile(double quantile);
+
+  int64_t serializedByteSize() const;
+
+  int64_t serialize(char* out);
+
+  T getMin();
+
+  T getMax();
+
+  // For testing only. Calling this method with 'other' being constructed from
+  // QuantileDigest(const Allocator& allocator, const char* serialized) is
+  // supposed to produce the same result as calling mergeSerialized() directly
+  // on 'serialized'.
+  void testingMerge(const QuantileDigest& other);
+
+ private:
+  using U = std::conditional_t<sizeof(T) == sizeof(int64_t), int64_t, int32_t>;
+
+  template <typename V>
+  using RebindAlloc =
+      typename std::allocator_traits<Allocator>::template rebind_alloc<V>;
+
+  int32_t calculateHeight(int32_t nodeCount);
+
+  int32_t calculateParentLevel(U first, U second);
+
+  int8_t calculateLevel(int8_t nodeStructure);
+
+  int8_t calculateNodeStructure(int8_t level);
+
+  void writeValue(U value, char*& out);
+
+  void insert(U value, double count);
+
+  void setChild(int32_t parent, U branch, int32_t child);
+
+  int32_t makeSiblings(int32_t first, int32_t second);
+
+  int32_t createLeaf(U value, double count);
+
+  int32_t createNode(U value, int8_t level, double count);
+
+  bool inSameSubtree(U bitsA, U bitsB, int32_t level);
+
+  U preprocessByType(T value) const;
+
+  T postprocessByType(U bits) const;
+
+  U longToBits(U value) const;
+
+  U bitsToLong(U bits) const;
+
+  U getBranchMask(int8_t level);
+
+  int32_t calculateCompressionFactor() const;
+
+  int32_t tryRemove(int32_t node);
+
+  void remove(int32_t node);
+
+  void pushFree(int32_t node);
+
+  int32_t popFree();
+
+  template <typename Func>
+  bool postOrderTraverse(
+      int32_t node,
+      Func callback,
+      const std::vector<int32_t, RebindAlloc<int32_t>>& firstChildren,
+      const std::vector<int32_t, RebindAlloc<int32_t>>& secondChildren) {
+    if (node == -1) {
+      return false;
+    } else {
+      auto first = firstChildren[node];
+      auto second = secondChildren[node];
+      if (first != -1 &&
+          !postOrderTraverse(first, callback, firstChildren, secondChildren)) {
+        return false;
+      } else {
+        return second != -1 &&
+                !postOrderTraverse(
+                    second, callback, firstChildren, secondChildren)
+            ? false
+            : callback(node);
+      }
+    }
+  }
+
+  int32_t mergeRecursive(int32_t node, QuantileDigest other, int32_t otherNode);
+
+  int32_t copyRecursive(QuantileDigest other, int32_t otherNode);
+
+  class SerDe {
+   public:
+    static void readNode(
+        const char*& nodeBegin,
+        int8_t& nodeStructure,
+        double& count,
+        U& value);
+
+    static void readMetadata(
+        const char*& metadataBegin,
+        int8_t& version,
+        double& maxError,
+        U& min,
+        U& max,
+        int32_t& nodeCount);
+
+    static void
+    writeNode(int8_t nodeStructure, double count, U value, char*& out);
+
+    static void writeMetadata(
+        int8_t version,
+        double maxError,
+        U min,
+        U max,
+        int32_t nodeCount,
+        char*& out);
+
+   private:
+    static void readValue(const char*& in, U& value);
+
+    static void writeValue(U value, char*& out);
+  };
+
+  // Merge the current subtree at 'node' with the other subtree ending at
+  // 'otherNodeEnd'. This method returns a pair of {newNode, position}.
+  // 'newNode' is the root node of the new subtree after the merge. 'position'
+  // is the position in the serialized 'other' digest right before the nodes
+  // having been read in this call. 'start' is the start position of the entire
+  // serialization to be merged. This method checks that 'otherNodeEnd' must be
+  // after 'start'.
+  std::pair<int32_t, const char*> mergeSerializedRecursive(
+      int32_t node,
+      const char* start,
+      const char* otherNodeEnd);
+
+  // Copy the other subtree ending at 'otherNodeEnd' into the current subtree.
+  // This method returns a pair of {newNode, position}. 'newNode' is the root
+  // node of the copied subtree in the current digest. 'position' is the
+  // position in the serialized 'other' digest right before the nodes having
+  // been read in this call. 'start' is the start position of the entire
+  // serialization to be merged. This method checks that 'otherNodeEnd' must be
+  // after 'start'.
+  std::pair<int32_t, const char*> copySerializedRecursive(
+      const char* start,
+      const char* otherNodeEnd);
+
+  U lowerBound(int32_t node) const;
+
+  U upperBound(int32_t node) const;
+
+  double maxError_;
+  double weightedCount_;
+  U min_;
+  U max_;
+  int32_t root_;
+  int32_t firstFree_;
+  int32_t freeCount_;
+  std::vector<double, RebindAlloc<double>> counts_;
+  std::vector<int8_t, RebindAlloc<int8_t>> levels_;
+  std::vector<U, RebindAlloc<U>> values_;
+  std::vector<int32_t, RebindAlloc<int32_t>> lefts_;
+  std::vector<int32_t, RebindAlloc<int32_t>> rights_;
+};
+
+namespace detail {
+template <typename T>
+void read(const char*& input, T& value) {
+  value = folly::loadUnaligned<T>(input);
+  input += sizeof(T);
+}
+
+template <typename T>
+T read(const char*& input) {
+  T value = folly::loadUnaligned<T>(input);
+  input += sizeof(T);
+  return value;
+}
+
+template <typename T>
+void write(T value, char*& out) {
+  folly::storeUnaligned(out, value);
+  out += sizeof(T);
+}
+} // namespace detail
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::readValue(const char*& in, U& value) {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    detail::read<int64_t>(in, value);
+  } else {
+    int64_t bits;
+    detail::read<int64_t>(in, bits);
+    value = static_cast<U>(
+        (bits ^ std::numeric_limits<int64_t>::min()) ^
+        std::numeric_limits<int32_t>::min());
+  }
+}
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::readNode(
+    const char*& nodeBegin,
+    int8_t& nodeStructure,
+    double& count,
+    U& value) {
+  detail::read<int8_t>(nodeBegin, nodeStructure);
+  detail::read<double>(nodeBegin, count);
+  readValue(nodeBegin, value);
+}
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::readMetadata(
+    const char*& metadataBegin,
+    int8_t& version,
+    double& maxError,
+    U& min,
+    U& max,
+    int32_t& nodeCount) {
+  detail::read<int8_t>(metadataBegin, version);
+
+  detail::read<double>(metadataBegin, maxError);
+
+  auto alpha = detail::read<double>(metadataBegin);
+  VELOX_CHECK_EQ(alpha, 0.0);
+
+  auto landmark = detail::read<int64_t>(metadataBegin);
+  VELOX_CHECK_EQ(landmark, 0);
+
+  int64_t data;
+  detail::read<int64_t>(metadataBegin, data);
+  min = static_cast<U>(data);
+  detail::read<int64_t>(metadataBegin, data);
+  max = static_cast<U>(data);
+
+  nodeCount = detail::read<int32_t>(metadataBegin);
+}
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::writeValue(U value, char*& out) {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    detail::write<int64_t>(value, out);
+  } else {
+    detail::write<int64_t>(
+        (value ^ std::numeric_limits<int32_t>::min()) ^
+            std::numeric_limits<int64_t>::min(),
+        out);
+  }
+}
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::writeNode(
+    int8_t nodeStructure,
+    double count,
+    U value,
+    char*& out) {
+  detail::write<int8_t>(nodeStructure, out);
+  detail::write<double>(count, out);
+  writeValue(value, out);
+}
+
+// static
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::SerDe::writeMetadata(
+    int8_t version,
+    double maxError,
+    U min,
+    U max,
+    int32_t nodeCount,
+    char*& out) {
+  detail::write<int8_t>(version, out); // version
+  detail::write<double>(maxError, out);
+  detail::write<double>(0.0, out); // alpha
+  detail::write<int64_t>(0, out); // landmarkInSeconds
+  detail::write<int64_t>(static_cast<int64_t>(min), out);
+  detail::write<int64_t>(static_cast<int64_t>(max), out);
+  detail::write<int32_t>(nodeCount, out);
+}
+
+template <typename T, typename Allocator>
+QuantileDigest<T, Allocator>::QuantileDigest(
+    const Allocator& allocator,
+    double maxError)
+    : maxError_{maxError},
+      weightedCount_{0},
+      min_{std::numeric_limits<U>::max()},
+      max_{std::numeric_limits<U>::min()},
+      root_{-1},
+      firstFree_{-1},
+      freeCount_{0},
+      counts_{RebindAlloc<double>(allocator)},
+      levels_{RebindAlloc<int8_t>(allocator)},
+      values_{RebindAlloc<U>(allocator)},
+      lefts_{RebindAlloc<int32_t>(allocator)},
+      rights_{RebindAlloc<int32_t>(allocator)} {}
+
+template <typename T, typename Allocator>
+QuantileDigest<T, Allocator>::QuantileDigest(
+    const Allocator& allocator,
+    const char* in)
+    : weightedCount_{0},
+      root_{-1},
+      firstFree_{-1},
+      freeCount_{0},
+      counts_{RebindAlloc<double>(allocator)},
+      levels_{RebindAlloc<int8_t>(allocator)},
+      values_{RebindAlloc<U>(allocator)},
+      lefts_{RebindAlloc<int32_t>(allocator)},
+      rights_{RebindAlloc<int32_t>(allocator)} {
+  int8_t version;
+  int32_t nodeCount;
+  SerDe::readMetadata(in, version, maxError_, min_, max_, nodeCount);
+  VELOX_CHECK_EQ(version, 0);
+  auto height = calculateHeight(nodeCount);
+
+  counts_.resize(nodeCount, 0);
+  levels_.resize(nodeCount, 0);
+  values_.resize(nodeCount, 0);
+  lefts_.resize(nodeCount, -1);
+  rights_.resize(nodeCount, -1);
+
+  std::vector<int32_t, RebindAlloc<int32_t>> stack(
+      height, RebindAlloc<int32_t>(allocator));
+  int32_t top = -1;
+  for (auto i = 0; i < nodeCount; ++i) {
+    int8_t nodeStructure;
+    SerDe::readNode(in, nodeStructure, counts_[i], values_[i]);
+    weightedCount_ += counts_[i];
+
+    bool hasRight = (nodeStructure & 2) != 0;
+    bool hasLeft = (nodeStructure & 1) != 0;
+    levels_[i] = calculateLevel(nodeStructure);
+    if (hasLeft || hasRight) {
+      levels_[i]++;
+    }
+
+    if (hasRight) {
+      rights_[i] = stack[top--];
+    } else {
+      rights_[i] = -1;
+    }
+    if (hasLeft) {
+      lefts_[i] = stack[top--];
+    } else {
+      lefts_[i] = -1;
+    }
+
+    ++top;
+    stack[top] = i;
+  }
+  VELOX_CHECK(
+      nodeCount == 0 || top == 0,
+      "Tree is corrupted. Expected a single root node");
+  root_ = nodeCount - 1;
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::calculateHeight(int32_t nodeCount) {
+  int32_t height;
+  if constexpr (std::is_same_v<U, int64_t>) {
+    height = static_cast<int32_t>(64 - count_leading_zeros(min_ ^ max_) + 1);
+    VELOX_CHECK(
+        height >= 64 || static_cast<int64_t>(nodeCount) <= (1L << height) - 1L,
+        "Too many nodes in deserialized tree. Possible corruption");
+  } else {
+    height =
+        static_cast<int32_t>(32 - count_leading_zeros_32bits(min_ ^ max_) + 1);
+    VELOX_CHECK(
+        height >= 32 || static_cast<int64_t>(nodeCount) <= (1L << height) - 1L,
+        "Too many nodes in deserialized tree. Possible corruption");
+  }
+  return height;
+}
+
+template <typename T, typename Allocator>
+int8_t QuantileDigest<T, Allocator>::calculateLevel(int8_t nodeStructure) {
+  auto level =
+      static_cast<int8_t>(static_cast<uint8_t>(nodeStructure) >> 2 & 63);
+  if constexpr (std::is_same_v<U, int32_t>) {
+    level = (level == 64) ? 32 : level;
+  }
+  return level;
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::calculateParentLevel(U first, U second) {
+  int32_t parentLevel;
+  if constexpr (std::is_same_v<U, int64_t>) {
+    parentLevel =
+        static_cast<int32_t>(64 - count_leading_zeros(first ^ second));
+  } else {
+    parentLevel =
+        static_cast<int32_t>(32 - count_leading_zeros_32bits(first ^ second));
+  }
+  return parentLevel;
+}
+
+template <typename T, typename Allocator>
+int8_t QuantileDigest<T, Allocator>::calculateNodeStructure(int8_t level) {
+  int8_t nodeStructure;
+  if constexpr (std::is_same_v<U, int64_t>) {
+    nodeStructure = static_cast<int8_t>(std::max(level - 1, 0) << 2);
+  } else {
+    nodeStructure =
+        static_cast<int8_t>(std::max((level == 32 ? 64 : level) - 1, 0) << 2);
+  }
+  return nodeStructure;
+}
+
+template <typename T, typename Allocator>
+double QuantileDigest<T, Allocator>::getCount() const {
+  return weightedCount_;
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::scale(double scaleFactor) {
+  VELOX_USER_CHECK(scaleFactor > 0.0, "scale factor must be > 0");
+  for (auto i = 0; i < counts_.size(); ++i) {
+    counts_[i] *= scaleFactor;
+  }
+
+  weightedCount_ *= scaleFactor;
+  compress();
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::preprocessByType(T value) const {
+  if constexpr (std::is_same_v<T, int64_t>) {
+    return value;
+  }
+  if constexpr (std::is_same_v<T, double>) {
+    auto bits = *reinterpret_cast<int64_t*>(&value);
+    return bits ^ ((bits >> 63) & std::numeric_limits<int64_t>::max());
+  } else {
+    auto bits = *reinterpret_cast<int32_t*>(&value);
+    return bits ^ ((bits >> 31) & std::numeric_limits<int32_t>::max());
+  }
+}
+
+template <typename T, typename Allocator>
+T QuantileDigest<T, Allocator>::postprocessByType(U bits) const {
+  if constexpr (std::is_same_v<T, int64_t>) {
+    return bits;
+  } else if constexpr (std::is_same_v<T, double>) {
+    bits = bits ^ ((bits >> 63) & std::numeric_limits<int64_t>::max());
+    return *reinterpret_cast<double*>(&bits);
+  } else {
+    bits = bits ^ ((bits >> 31) & std::numeric_limits<int32_t>::max());
+    return *reinterpret_cast<float*>(&bits);
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::add(T value, double weight) {
+  VELOX_USER_CHECK(weight > 0.0, "weight must be > 0");
+  bool needsCompression{false};
+  auto processedValue = preprocessByType(value);
+  max_ = std::max(max_, processedValue);
+  min_ = std::min(min_, processedValue);
+  auto previousCount = weightedCount_;
+  insert(longToBits(processedValue), weight);
+  auto compressionFactor = calculateCompressionFactor();
+  if (needsCompression ||
+      checkedDivide(
+          static_cast<int64_t>(previousCount),
+          static_cast<int64_t>(compressionFactor)) !=
+          checkedDivide(
+              static_cast<int64_t>(weightedCount_),
+              static_cast<int64_t>(compressionFactor))) {
+    compress();
+  }
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::longToBits(U value) const {
+  return value ^ std::numeric_limits<U>::min();
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::bitsToLong(U bits) const {
+  return bits ^ std::numeric_limits<U>::min();
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::calculateCompressionFactor() const {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    return root_ == -1
+        ? 1
+        : std::max(
+              static_cast<int>(
+                  static_cast<double>(levels_[root_] + 1) / maxError_),
+              1);
+  } else {
+    return root_ == -1
+        ? 1
+        : std::max(
+              static_cast<int>(
+                  static_cast<double>(
+                      (levels_[root_] == 32 ? 64 : levels_[root_]) + 1) /
+                  maxError_),
+              1);
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::insert(U value, double count) {
+  if (count < qdigest::kZeroWeightThreshold) {
+    return;
+  }
+  U lastBranch = 0;
+  int32_t parent = -1;
+  int32_t current = root_;
+  while (current != -1) {
+    auto currentValue = values_[current];
+    auto currentLevel = levels_[current];
+    if (!inSameSubtree(value, currentValue, currentLevel)) {
+      setChild(
+          parent, lastBranch, makeSiblings(current, createLeaf(value, count)));
+      return;
+    }
+
+    if (currentLevel == 0 && currentValue == value) {
+      counts_[current] += count;
+      weightedCount_ += count;
+      return;
+    }
+
+    U branch = value & getBranchMask(currentLevel);
+    parent = current;
+    lastBranch = branch;
+    if (branch == 0) {
+      current = lefts_[current];
+    } else {
+      current = rights_[current];
+    }
+  }
+  setChild(parent, lastBranch, createLeaf(value, count));
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::createLeaf(U value, double count) {
+  return createNode(value, 0, count);
+}
+
+template <typename T, typename Allocator>
+int32_t
+QuantileDigest<T, Allocator>::createNode(U value, int8_t level, double count) {
+  auto node = popFree();
+  weightedCount_ += count;
+  if (node == -1) {
+    node = static_cast<int32_t>(counts_.size());
+    counts_.push_back(count);
+    levels_.push_back(level);
+    values_.push_back(value);
+    lefts_.push_back(-1);
+    rights_.push_back(-1);
+  } else {
+    counts_[node] = count;
+    levels_[node] = level;
+    values_[node] = value;
+    lefts_[node] = -1;
+    rights_[node] = -1;
+  }
+  return node;
+}
+
+template <typename T, typename Allocator>
+bool QuantileDigest<T, Allocator>::inSameSubtree(
+    U bitsA,
+    U bitsB,
+    int32_t level) {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    return (level == 64) ||
+        ((static_cast<uint64_t>(bitsA) >> level) ==
+         (static_cast<uint64_t>(bitsB) >> level));
+  } else {
+    return (level == 32) ||
+        ((static_cast<uint32_t>(bitsA) >> level) ==
+         (static_cast<uint32_t>(bitsB) >> level));
+  }
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::getBranchMask(int8_t level) {
+  return static_cast<U>(1) << (level - 1);
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::makeSiblings(
+    int32_t first,
+    int32_t second) {
+  auto firstValue = values_[first];
+  auto secondValue = values_[second];
+  auto parentLevel = calculateParentLevel(firstValue, secondValue);
+  auto parent = createNode(firstValue, parentLevel, 0.0);
+  auto branch = firstValue & getBranchMask(levels_[parent]);
+  if (branch == 0) {
+    lefts_[parent] = first;
+    rights_[parent] = second;
+  } else {
+    lefts_[parent] = second;
+    rights_[parent] = first;
+  }
+  return parent;
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::setChild(
+    int32_t parent,
+    U branch,
+    int32_t child) {
+  if (parent == -1) {
+    root_ = child;
+  } else if (branch == 0) {
+    lefts_[parent] = child;
+  } else {
+    rights_[parent] = child;
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::compress() {
+  double bound = std::floor(
+      weightedCount_ / static_cast<double>(calculateCompressionFactor()));
+  postOrderTraverse(
+      root_,
+      [this, bound](int32_t node) mutable {
+        auto left = lefts_[node];
+        auto right = rights_[node];
+        if (left == -1 && right == -1) {
+          return true;
+        } else {
+          double leftCount = (left == -1) ? 0.0 : counts_[left];
+          double rightCount = (right == -1) ? 0.0 : counts_[right];
+          bool shouldCompress =
+              (counts_[node] + leftCount + rightCount) < bound;
+          if (left != -1 &&
+              (shouldCompress || leftCount < qdigest::kZeroWeightThreshold)) {
+            lefts_[node] = tryRemove(left);
+            counts_[node] += leftCount;
+          }
+
+          if (right != -1 &&
+              (shouldCompress || rightCount < qdigest::kZeroWeightThreshold)) {
+            rights_[node] = tryRemove(right);
+            counts_[node] += rightCount;
+          }
+
+          return true;
+        }
+      },
+      lefts_,
+      rights_);
+  if (root_ != -1 && counts_[root_] < qdigest::kZeroWeightThreshold) {
+    root_ = tryRemove(root_);
+  }
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::tryRemove(int32_t node) {
+  VELOX_USER_CHECK_NE(node, -1, "node is -1");
+  auto left = lefts_[node];
+  auto right = rights_[node];
+  if (left == -1 && right == -1) {
+    remove(node);
+    return -1;
+  } else if (left != -1 && right != -1) {
+    counts_[node] = 0.0;
+    return node;
+  } else {
+    remove(node);
+    return left != -1 ? left : right;
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::remove(int32_t node) {
+  if (node == counts_.size() - 1) {
+    counts_.pop_back();
+    levels_.pop_back();
+    values_.pop_back();
+    lefts_.pop_back();
+    rights_.pop_back();
+  } else {
+    pushFree(node);
+  }
+  if (node == root_) {
+    root_ = -1;
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::pushFree(int32_t node) {
+  lefts_[node] = firstFree_;
+  firstFree_ = node;
+  ++freeCount_;
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::popFree() {
+  auto node = firstFree_;
+  if (node == -1) {
+    return node;
+  } else {
+    firstFree_ = lefts_[firstFree_];
+    --freeCount_;
+    return node;
+  }
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::testingMerge(
+    const QuantileDigest<T, Allocator>& other) {
+  root_ = mergeRecursive(root_, other, other.root_);
+  max_ = std::max(max_, other.max_);
+  min_ = std::min(min_, other.min_);
+  compress();
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::mergeSerialized(const char* other) {
+  int8_t version;
+  double maxError;
+  U min;
+  U max;
+  int32_t nodeCount;
+  SerDe::readMetadata(other, version, maxError, min, max, nodeCount);
+  VELOX_CHECK_EQ(version, 0);
+  VELOX_CHECK_EQ(maxError, maxError_);
+
+  if (nodeCount == 0) {
+    return;
+  }
+
+  VELOX_CHECK_GT(nodeCount, 0, "nodeCount is negative");
+  auto size = nodeCount * (sizeof(int8_t) + sizeof(double) + sizeof(int64_t));
+
+  const char* pos;
+  std::tie(root_, pos) = mergeSerializedRecursive(root_, other, other + size);
+  max_ = std::max(max_, max);
+  min_ = std::min(min_, min);
+  compress();
+}
+
+template <typename T, typename Allocator>
+std::pair<int32_t, const char*>
+QuantileDigest<T, Allocator>::mergeSerializedRecursive(
+    int32_t node,
+    const char* start,
+    const char* otherNodeEnd) {
+  VELOX_CHECK_GT(
+      otherNodeEnd - start,
+      0,
+      "otherNodeEnd is not after start. Serialization is likely corrupted.");
+  const char* nodeBegin =
+      otherNodeEnd - sizeof(int8_t) - sizeof(double) - sizeof(int64_t);
+  auto lastChild = nodeBegin;
+
+  int8_t nodeStructure;
+  double count;
+  U value;
+  SerDe::readNode(nodeBegin, nodeStructure, count, value);
+
+  bool hasRight = (nodeStructure & 2) != 0;
+  bool hasLeft = (nodeStructure & 1) != 0;
+  int8_t level = calculateLevel(nodeStructure);
+  if (hasLeft || hasRight) {
+    level++;
+  }
+
+  if (node == -1) {
+    return copySerializedRecursive(start, otherNodeEnd);
+  } else if (!inSameSubtree(
+                 values_[node], value, std::max(levels_[node], level))) {
+    auto [newNode, position] = copySerializedRecursive(start, otherNodeEnd);
+    return std::make_pair(makeSiblings(node, newNode), position);
+  } else {
+    if (levels_[node] > level) {
+      auto branch = value & getBranchMask(levels_[node]);
+      if (branch == 0) {
+        auto [left, pos] =
+            mergeSerializedRecursive(lefts_[node], start, otherNodeEnd);
+        lefts_[node] = left;
+        return std::make_pair(node, pos);
+      } else {
+        auto [left, pos] =
+            mergeSerializedRecursive(rights_[node], start, otherNodeEnd);
+        rights_[node] = left;
+        return std::make_pair(node, pos);
+      }
+    } else if (levels_[node] < level) {
+      auto branch = values_[node] & getBranchMask(level);
+      int32_t left = node, right = node;
+      auto position = lastChild;
+      if (branch == 0) {
+        if (hasRight) {
+          std::tie(right, position) = copySerializedRecursive(start, position);
+        }
+        if (hasLeft) {
+          std::tie(left, position) =
+              mergeSerializedRecursive(node, start, position);
+        }
+      } else {
+        if (hasRight) {
+          std::tie(right, position) =
+              mergeSerializedRecursive(node, start, position);
+        }
+        if (hasLeft) {
+          std::tie(left, position) = copySerializedRecursive(start, position);
+        }
+      }
+
+      auto result = createNode(value, level, count);
+      lefts_[result] = left;
+      rights_[result] = right;
+      return std::make_pair(result, position);
+    } else {
+      weightedCount_ += count;
+      counts_[node] += count;
+      auto position = lastChild;
+      int32_t left = lefts_[node];
+      int32_t right = rights_[node];
+      if (hasRight) {
+        std::tie(right, position) =
+            mergeSerializedRecursive(rights_[node], start, position);
+      }
+      if (hasLeft) {
+        std::tie(left, position) =
+            mergeSerializedRecursive(lefts_[node], start, position);
+      }
+
+      lefts_[node] = left;
+      rights_[node] = right;
+      return std::make_pair(node, position);
+    }
+  }
+}
+
+template <typename T, typename Allocator>
+std::pair<int32_t, const char*>
+QuantileDigest<T, Allocator>::copySerializedRecursive(
+    const char* start,
+    const char* otherNodeEnd) {
+  VELOX_CHECK_GT(
+      otherNodeEnd - start,
+      0,
+      "otherNodeEnd is not after start. Serialization is likely corrupted.");
+  const char* nodeBegin =
+      otherNodeEnd - sizeof(int8_t) - sizeof(double) - sizeof(int64_t);
+  auto lastChild = nodeBegin;
+
+  int8_t nodeStructure;
+  double count;
+  U value;
+  SerDe::readNode(nodeBegin, nodeStructure, count, value);
+
+  bool hasRight = (nodeStructure & 2) != 0;
+  bool hasLeft = (nodeStructure & 1) != 0;
+  int8_t level = calculateLevel(nodeStructure);
+  if (hasLeft || hasRight) {
+    level++;
+  }
+
+  auto node = createNode(value, level, count);
+  const char* position = lastChild;
+  rights_[node] = -1;
+  lefts_[node] = -1;
+  if (hasRight) {
+    std::tie(rights_[node], position) =
+        copySerializedRecursive(start, position);
+  }
+  if (hasLeft) {
+    std::tie(lefts_[node], position) = copySerializedRecursive(start, position);
+  }
+  return std::make_pair(node, position);
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::mergeRecursive(
+    int32_t node,
+    QuantileDigest<T, Allocator> other,
+    int32_t otherNode) {
+  if (otherNode == -1) {
+    return node;
+  } else if (node == -1) {
+    return copyRecursive(other, otherNode);
+  } else if (!inSameSubtree(
+                 values_[node],
+                 other.values_[otherNode],
+                 std::max(levels_[node], other.levels_[otherNode]))) {
+    return makeSiblings(node, copyRecursive(other, otherNode));
+  } else {
+    if (levels_[node] > other.levels_[otherNode]) {
+      int32_t left;
+      auto branch = other.values_[otherNode] & getBranchMask(levels_[node]);
+      if (branch == 0) {
+        left = mergeRecursive(lefts_[node], other, otherNode);
+        lefts_[node] = left;
+      } else {
+        left = mergeRecursive(rights_[node], other, otherNode);
+        rights_[node] = left;
+      }
+      return node;
+    } else if (levels_[node] < other.levels_[otherNode]) {
+      auto branch = values_[node] & getBranchMask(other.levels_[otherNode]);
+      int32_t left, right;
+      if (branch == 0) {
+        left = mergeRecursive(node, other, other.lefts_[otherNode]);
+        right = copyRecursive(other, other.rights_[otherNode]);
+      } else {
+        left = copyRecursive(other, other.lefts_[otherNode]);
+        right = mergeRecursive(node, other, other.rights_[otherNode]);
+      }
+
+      auto result = createNode(
+          other.values_[otherNode],
+          other.levels_[otherNode],
+          other.counts_[otherNode]);
+      lefts_[result] = left;
+      rights_[result] = right;
+      return result;
+    } else {
+      weightedCount_ += other.counts_[otherNode];
+      counts_[node] += other.counts_[otherNode];
+      auto left = mergeRecursive(lefts_[node], other, other.lefts_[otherNode]);
+      auto right =
+          mergeRecursive(rights_[node], other, other.rights_[otherNode]);
+      lefts_[node] = left;
+      rights_[node] = right;
+      return node;
+    }
+  }
+}
+
+template <typename T, typename Allocator>
+int32_t QuantileDigest<T, Allocator>::copyRecursive(
+    QuantileDigest other,
+    int32_t otherNode) {
+  if (otherNode == -1) {
+    return otherNode;
+  } else {
+    auto node = createNode(
+        other.values_[otherNode],
+        other.levels_[otherNode],
+        other.counts_[otherNode]);
+    if (other.lefts_[otherNode] != -1) {
+      lefts_[node] = copyRecursive(other, other.lefts_[otherNode]);
+    }
+    if (other.rights_[otherNode] != -1) {
+      rights_[node] = copyRecursive(other, other.rights_[otherNode]);
+    }
+    return node;
+  }
+}
+
+inline bool validateQuantiles(const std::vector<double>& quantiles) {
+  VELOX_CHECK(!quantiles.empty());
+  VELOX_USER_CHECK_GE(quantiles[0], 0.0);
+  VELOX_USER_CHECK_LE(quantiles[0], 1.0);
+  for (auto i = 1; i < quantiles.size(); ++i) {
+    VELOX_USER_CHECK_GE(quantiles[i], quantiles[i - 1]);
+    VELOX_USER_CHECK_GE(quantiles[i], 0.0);
+    VELOX_USER_CHECK_LE(quantiles[i], 1.0);
+  }
+  return true;
+}
+
+template <typename T, typename Allocator>
+void QuantileDigest<T, Allocator>::estimateQuantiles(
+    const std::vector<double>& quantiles,
+    T* result) {
+  VELOX_DCHECK(validateQuantiles(quantiles));
+  int i = -1;
+  double sum = 0.0;
+  postOrderTraverse(
+      root_,
+      [this, &result, &quantiles, &i, &sum](int32_t node) {
+        sum += counts_[node];
+        while (i + 1 < quantiles.size() &&
+               sum > quantiles[i + 1] * weightedCount_) {
+          result[i + 1] = (postprocessByType(std::min(upperBound(node), max_)));
+          i++;
+        }
+        return i < static_cast<int64_t>(quantiles.size());
+      },
+      lefts_,
+      rights_);
+  for (; i + 1 < quantiles.size(); ++i) {
+    result[i + 1] = (postprocessByType(max_));
+  }
+}
+
+template <typename T, typename Allocator>
+T QuantileDigest<T, Allocator>::estimateQuantile(double quantile) {
+  T result;
+  estimateQuantiles({quantile}, &result);
+  return result;
+}
+
+template <typename T, typename Allocator>
+T QuantileDigest<T, Allocator>::getMin() {
+  T result = std::numeric_limits<T>::min();
+  postOrderTraverse(
+      root_,
+      [this, &result](int32_t node) {
+        if (counts_[node] >= qdigest::kZeroWeightThreshold) {
+          result = postprocessByType(lowerBound(node));
+          return false;
+        } else {
+          return true;
+        }
+      },
+      lefts_,
+      rights_);
+  return std::max(postprocessByType(min_), result);
+}
+
+template <typename T, typename Allocator>
+T QuantileDigest<T, Allocator>::getMax() {
+  T result = std::numeric_limits<T>::max();
+  postOrderTraverse(
+      root_,
+      [this, &result](int32_t node) {
+        if (counts_[node] >= qdigest::kZeroWeightThreshold) {
+          result = postprocessByType(upperBound(node));
+          return false;
+        } else {
+          return true;
+        }
+      },
+      rights_,
+      lefts_);
+  return std::min(postprocessByType(max_), result);
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::lowerBound(int32_t node) const {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    uint64_t mask = 0L;
+    if (levels_[node] > 0) {
+      mask = static_cast<uint64_t>(-1L) >> (64 - levels_[node]);
+    }
+    return bitsToLong(values_[node] & ~mask);
+  } else {
+    uint32_t mask = 0;
+    if (levels_[node] > 0) {
+      mask = static_cast<uint32_t>(-1L) >> (32 - levels_[node]);
+    }
+    return bitsToLong(values_[node] & ~mask);
+  }
+}
+
+template <typename T, typename Allocator>
+typename QuantileDigest<T, Allocator>::U
+QuantileDigest<T, Allocator>::upperBound(int32_t node) const {
+  if constexpr (std::is_same_v<U, int64_t>) {
+    uint64_t mask = 0L;
+    if (levels_[node] > 0) {
+      mask = static_cast<uint64_t>(-1L) >> (64 - levels_[node]);
+    }
+    return bitsToLong(values_[node] | mask);
+  } else {
+    uint32_t mask = 0L;
+    if (levels_[node] > 0) {
+      mask = static_cast<uint32_t>(-1) >> (32 - levels_[node]);
+    }
+    return bitsToLong(values_[node] | mask);
+  }
+}
+
+template <typename T, typename Allocator>
+int64_t QuantileDigest<T, Allocator>::serializedByteSize() const {
+  auto nodeCount = counts_.size() - freeCount_;
+  return /*version*/ sizeof(char) + sizeof(maxError_) +
+      /*alpha*/ sizeof(double) + /*landmarkInSeconds*/ sizeof(int64_t) +
+      /*min*/ sizeof(int64_t) + /*max*/ sizeof(int64_t) +
+      /*nodeCount*/ sizeof(int32_t) +
+      (sizeof(typename decltype(counts_)::value_type) * nodeCount) +
+      (sizeof(typename decltype(levels_)::value_type) * nodeCount) +
+      /*values*/ (sizeof(int64_t) * nodeCount);
+}
+
+template <typename T, typename Allocator>
+int64_t QuantileDigest<T, Allocator>::serialize(char* out) {
+  compress();
+  const char* outStart = out;
+  SerDe::writeMetadata(
+      0,
+      maxError_,
+      min_,
+      max_,
+      static_cast<int32_t>(counts_.size() - freeCount_),
+      out);
+  postOrderTraverse(
+      root_,
+      [&](int32_t node) {
+        auto nodeStructure = calculateNodeStructure(levels_[node]);
+        if (lefts_[node] != -1) {
+          nodeStructure = static_cast<int8_t>(nodeStructure | 1);
+        }
+        if (rights_[node] != -1) {
+          nodeStructure = static_cast<int8_t>(nodeStructure | 2);
+        }
+        SerDe::writeNode(nodeStructure, counts_[node], values_[node], out);
+
+        return true;
+      },
+      lefts_,
+      rights_);
+  VELOX_CHECK_EQ(out - outStart, serializedByteSize());
+  return out - outStart;
+}
+
+} // namespace qdigest
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   KllSketchTest.cpp
   LambdaFunctionUtilTest.cpp
   MapConcatTest.cpp
+  QuantileDigestTest.cpp
   Re2FunctionsTest.cpp
   RepeatTest.cpp
   TDigestTest.cpp

--- a/velox/functions/lib/tests/QuantileDigestTest.cpp
+++ b/velox/functions/lib/tests/QuantileDigestTest.cpp
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/QuantileDigest.h"
+
+#include "velox/common/testutil/RandomSeed.h"
+#include "velox/functions/lib/tests/QuantileDigestTestBase.h"
+
+using namespace facebook::velox::functions::qdigest;
+
+namespace facebook::velox::functions {
+
+class QuantileDigestTest : public QuantileDigestTestBase {
+ protected:
+  memory::MemoryPool* pool() {
+    return pool_.get();
+  }
+
+  HashStringAllocator* allocator() {
+    return &allocator_;
+  }
+
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  std::string encodeBase64(std::string_view input) {
+    return folly::base64Encode(input);
+  }
+
+  template <typename T>
+  void testQuantiles(
+      const std::vector<T>& values,
+      const std::vector<double>& quantiles,
+      const std::vector<T>& expected,
+      const std::vector<double>& weight = {}) {
+    ASSERT_EQ(quantiles.size(), expected.size());
+    if (!weight.empty()) {
+      ASSERT_EQ(values.size(), weight.size());
+    }
+
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), 0.99};
+    for (auto i = 0; i < values.size(); ++i) {
+      if (weight.empty()) {
+        digest.add(values[i], 1.0);
+      } else {
+        digest.add(values[i], weight[i]);
+      }
+    }
+
+    std::vector<T> results(quantiles.size());
+    digest.estimateQuantiles(quantiles, results.data());
+    for (auto i = 0; i < quantiles.size(); ++i) {
+      EXPECT_EQ(results[i], expected[i]);
+    }
+  }
+
+  template <typename T>
+  void testLargeInputSize() {
+    constexpr int N = 1e5;
+    constexpr double kAccuracy = 0.8;
+    std::vector<double> values;
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), kAccuracy};
+    std::default_random_engine gen(common::testutil::getRandomSeed(42));
+    std::uniform_real_distribution<T> dist{-10.0, 10.0};
+    for (int i = 0; i < N; ++i) {
+      auto v = dist(gen);
+      digest.add(v, 1.0);
+      values.push_back(v);
+    }
+    std::sort(std::begin(values), std::end(values));
+    checkQuantiles<QuantileDigest<T>, false>(
+        values, digest, 0.0, values.size() * kAccuracy);
+
+    values.clear();
+    QuantileDigest<T> digestWeighted{StlAllocator<T>(allocator()), 0.8};
+    for (int i = 0; i < N; ++i) {
+      auto v = dist(gen);
+      digest.add(v, i % 7 + 1);
+      values.insert(values.end(), i % 7 + 1, v);
+    }
+    std::sort(std::begin(values), std::end(values));
+    checkQuantiles<QuantileDigest<T>, false>(
+        values, digest, 0.0, values.size() * kAccuracy);
+  }
+
+  template <typename T>
+  void testEquivalentMerge() {
+    constexpr double kAccuracy = 0.5;
+    QuantileDigest<T> digest1{allocator(), kAccuracy};
+    // QuantileDigest<T> digest2{allocator(), kAccuracy};
+
+    std::default_random_engine gen(common::testutil::getRandomSeed(42));
+    std::uniform_real_distribution<> dist;
+    for (auto i = 0; i < 100; ++i) {
+      auto v = T(dist(gen));
+      auto w = (i + 2) % 3 + 1;
+      digest1.add(v, w);
+
+      /*v = T(dist(gen));
+      w = (i + 3) % 7 + 1;
+      digest2.add(v, w);*/
+    }
+
+    QuantileDigest<T> mergeResult{allocator(), kAccuracy};
+    digest1.compress();
+    mergeResult.testingMerge(digest1);
+
+    QuantileDigest<T> mergeSerializedResult{allocator(), kAccuracy};
+    std::string buf(digest1.serializedByteSize(), '\0');
+    digest1.serialize(buf.data());
+    mergeSerializedResult.mergeSerialized(buf.data());
+
+    EXPECT_EQ(
+        mergeResult.serializedByteSize(),
+        mergeSerializedResult.serializedByteSize());
+    std::string mergeResultBuf(mergeResult.serializedByteSize(), '\0');
+    mergeResult.serialize(mergeResultBuf.data());
+    std::string mergeSerializedResultBuf(
+        mergeSerializedResult.serializedByteSize(), '\0');
+    mergeSerializedResult.serialize(mergeSerializedResultBuf.data());
+    EXPECT_EQ(mergeResultBuf, mergeSerializedResultBuf);
+  }
+
+  template <typename T>
+  void testMergeEmpty(bool mergeSerialized) {
+    constexpr double kAccuracy = 0.7;
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), kAccuracy};
+    QuantileDigest<T> digestEmpty{StlAllocator<T>(allocator()), kAccuracy};
+
+    std::vector<double> values;
+    std::default_random_engine gen(common::testutil::getRandomSeed(42));
+    std::uniform_real_distribution<> dist;
+    for (auto i = 0; i < 100; ++i) {
+      auto v = T(dist(gen));
+      auto w = (i + 3) % 7 + 1;
+      digest.add(v, w);
+      values.insert(values.end(), w, v);
+    }
+    digest.compress();
+    std::string original(digest.serializedByteSize(), '\0');
+    digest.serialize(original.data());
+
+    if (mergeSerialized) {
+      std::string buf(digestEmpty.serializedByteSize(), '\0');
+      digestEmpty.serialize(buf.data());
+      digest.mergeSerialized(buf.data());
+    } else {
+      digest.testingMerge(digestEmpty);
+    }
+
+    std::string result(digest.serializedByteSize(), '\0');
+    digest.serialize(result.data());
+    EXPECT_EQ(original.size(), result.size());
+    EXPECT_EQ(original, result);
+  }
+
+  template <typename T>
+  void testMerge(bool mergeSerialized) {
+    constexpr double kAccuracy = 0.5;
+    QuantileDigest<T> digest1{StlAllocator<T>(allocator()), kAccuracy};
+    QuantileDigest<T> digest2{StlAllocator<T>(allocator()), kAccuracy};
+    QuantileDigest<T> digestEmpty{StlAllocator<T>(allocator()), kAccuracy};
+
+    std::vector<double> allValues;
+    std::vector<double> digest1Values;
+    std::default_random_engine gen(common::testutil::getRandomSeed(42));
+    std::uniform_real_distribution<> dist;
+    for (auto i = 0; i < 10000; ++i) {
+      auto v = T(dist(gen));
+      auto w = (i + 3) % 7 + 1;
+      digest1.add(v, w);
+      allValues.insert(allValues.end(), w, v);
+      digest1Values.insert(digest1Values.end(), w, v);
+
+      v = T(dist(gen));
+      w = (i + 2) % 3 + 1;
+      digest2.add(v, w);
+      allValues.insert(allValues.end(), w, v);
+    }
+    if (mergeSerialized) {
+      std::string buf(digest1.serializedByteSize(), '\0');
+      digest1.serialize(buf.data());
+      digestEmpty.mergeSerialized(buf.data());
+    } else {
+      digestEmpty.testingMerge(digest1);
+    }
+    std::sort(std::begin(digest1Values), std::end(digest1Values));
+    checkQuantiles<QuantileDigest<T>, false>(
+        digest1Values, digestEmpty, 0.0, digest1Values.size() * kAccuracy);
+
+    if (mergeSerialized) {
+      std::string buf(digest2.serializedByteSize(), '\0');
+      digest2.serialize(buf.data());
+      digest1.mergeSerialized(buf.data());
+    } else {
+      digest1.testingMerge(digest2);
+    }
+    std::sort(std::begin(allValues), std::end(allValues));
+    checkQuantiles<QuantileDigest<T>, false>(
+        allValues, digest1, 0.0, allValues.size() * kAccuracy);
+  }
+
+  template <typename T>
+  void testMergeWithJava(bool mergeSerialized) {
+    constexpr double kAccuracy = 0.99;
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), 0.99};
+    std::vector<double> values;
+    for (auto i = 0; i < 10000; ++i) {
+      digest.add(static_cast<T>(i), 1.0);
+      values.push_back(T(i));
+    }
+
+    std::string data;
+    if constexpr (std::is_same_v<T, double>) {
+      // Presto Query: SELECT QDIGEST_AGG(CAST(c0 AS DOUBLE), 1, 0.99) FROM
+      //               UNNEST(SEQUENCE(5000, 8000, 2)) AS t(c0)
+      data = decodeBase64(
+          "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAAAAAAAAiLNAAAAAAABAv0CSAAAApAAAAAAAADBAAAAAAADAs8CkAAAAAAAAMEAAAAAAAOCzwLcAAAAAAAAAAAAAAAAAwLPAugAAAAAAADBAAAAAAACIs8CkAAAAAAAAMEAAAAAAAAC0wKQAAAAAAAAwQAAAAAAAILTAtwAAAAAAAAAAAAAAAAAAtMCkAAAAAAAAMEAAAAAAAEC0wKQAAAAAAAAwQAAAAAAAYLTAtwAAAAAAAAAAAAAAAABAtMC7AAAAAAAAAAAAAAAAAAC0wKQAAAAAAAAwQAAAAAAAgLTApAAAAAAAADBAAAAAAACgtMC3AAAAAAAAAAAAAAAAAIC0wKQAAAAAAAAwQAAAAAAAwLTApAAAAAAAADBAAAAAAADgtMC3AAAAAAAAAAAAAAAAAMC0wLsAAAAAAAAAAAAAAAAAgLTAvwAAAAAAAAAAAAAAAAAAtMCkAAAAAAAAMEAAAAAAAAC1wKQAAAAAAAAwQAAAAAAAILXAtwAAAAAAAAAAAAAAAAAAtcCkAAAAAAAAMEAAAAAAAEC1wKQAAAAAAAAwQAAAAAAAYLXAtwAAAAAAAAAAAAAAAABAtcC7AAAAAAAAAAAAAAAAAAC1wKQAAAAAAAAwQAAAAAAAgLXApAAAAAAAADBAAAAAAACgtcC3AAAAAAAAAAAAAAAAAIC1wL8AAAAAAAAAAAAAAAAAALXAwwAAAAAAADBAAAAAAAAAtMCkAAAAAAAAMEAAAAAAAAC2wKQAAAAAAAAwQAAAAAAAILbAtwAAAAAAAAAAAAAAAAAAtsCkAAAAAAAAMEAAAAAAAEC2wKQAAAAAAAAwQAAAAAAAYLbAtwAAAAAAAAAAAAAAAABAtsC7AAAAAAAAAAAAAAAAAAC2wKQAAAAAAAAwQAAAAAAAgLbApAAAAAAAADBAAAAAAACgtsC3AAAAAAAAAAAAAAAAAIC2wL8AAAAAAAAwQAAAAAAAALbApAAAAAAAADBAAAAAAABAt8CkAAAAAAAAMEAAAAAAAGC3wLcAAAAAAAAAAAAAAAAAQLfApAAAAAAAADBAAAAAAACAt8CkAAAAAAAAMEAAAAAAAKC3wLcAAAAAAAAAAAAAAAAAgLfApAAAAAAAADBAAAAAAADAt8CkAAAAAAAAMEAAAAAAAOC3wLcAAAAAAAAAAAAAAAAAwLfAuwAAAAAAAAAAAAAAAACAt8C/AAAAAAAAMEAAAAAAAAC3wMMAAAAAAAA0QAAAAAAAALbAxwAAAAAAADRAAAAAAAAAtMDLAAAAAAAAMEAAAAAAAIizwKQAAAAAAAAwQAAAAAAAALjApAAAAAAAADBAAAAAAAAguMC3AAAAAAAAAAAAAAAAAAC4wKQAAAAAAAAwQAAAAAAAQLjApAAAAAAAADBAAAAAAABguMC3AAAAAAAAAAAAAAAAAEC4wLsAAAAAAAAAAAAAAAAAALjApAAAAAAAADBAAAAAAACAuMCkAAAAAAAAMEAAAAAAAKC4wLcAAAAAAAAAAAAAAAAAgLjAvwAAAAAAADtAAAAAAAAAuMCkAAAAAAAAMEAAAAAAAAC5wKQAAAAAAAAwQAAAAAAAILnAtwAAAAAAAAAAAAAAAAAAucC5AAAAAAAAMEAAAAAAAAC5wKQAAAAAAAAwQAAAAAAAgLnApAAAAAAAADBAAAAAAACgucC3AAAAAAAAAAAAAAAAAIC5wKQAAAAAAAAwQAAAAAAAwLnApAAAAAAAADBAAAAAAADgucC3AAAAAAAAAAAAAAAAAMC5wLsAAAAAAAAAAAAAAAAAgLnAvwAAAAAAADBAAAAAAAAAucDDAAAAAAAAAAAAAAAAAAC4wKQAAAAAAAAwQAAAAAAAALrApAAAAAAAAChAAAAAAAAousC3AAAAAAAAAAAAAAAAAAC6wKQAAAAAAAAwQAAAAAAAQLrApAAAAAAAADBAAAAAAABgusC3AAAAAAAAAAAAAAAAAEC6wLsAAAAAAAAAAAAAAAAAALrApAAAAAAAADBAAAAAAADAusCkAAAAAAAAMEAAAAAAAOC6wLcAAAAAAAAAAAAAAAAAwLrAvwAAAAAAAAAAAAAAAAAAusCkAAAAAAAAMEAAAAAAAAC7wKQAAAAAAAAwQAAAAAAAILvAtwAAAAAAAAAAAAAAAAAAu8CkAAAAAAAAMEAAAAAAAEC7wKQAAAAAAAAwQAAAAAAAYLvAtwAAAAAAAAAAAAAAAABAu8C7AAAAAAAAAAAAAAAAAAC7wKQAAAAAAAAwQAAAAAAAgLvApAAAAAAAADBAAAAAAACgu8C3AAAAAAAAAAAAAAAAAIC7wL8AAAAAAAAAAAAAAAAAALvAwwAAAAAAADhAAAAAAAAAusDHAAAAAAAAN0AAAAAAAAC4wKQAAAAAAAAwQAAAAAAAALzApAAAAAAAADBAAAAAAAAgvMC3AAAAAAAAAAAAAAAAAAC8wKQAAAAAAAAwQAAAAAAAQLzApAAAAAAAADBAAAAAAABgvMC3AAAAAAAAAAAAAAAAAEC8wLsAAAAAAAAAAAAAAAAAALzApAAAAAAAADBAAAAAAADAvMCkAAAAAAAAMEAAAAAAAOC8wLcAAAAAAAAAAAAAAAAAwLzAvwAAAAAAACxAAAAAAAAAvMCkAAAAAAAAMEAAAAAAAAC9wKQAAAAAAAAwQAAAAAAAIL3AtwAAAAAAAAAAAAAAAAAAvcCkAAAAAAAAMEAAAAAAAEC9wKQAAAAAAAAwQAAAAAAAYL3AtwAAAAAAAAAAAAAAAABAvcC7AAAAAAAAAAAAAAAAAAC9wKQAAAAAAAAwQAAAAAAAgL3ApAAAAAAAADBAAAAAAACgvcC3AAAAAAAAAAAAAAAAAIC9wLkAAAAAAAAuQAAAAAAAgL3AvwAAAAAAADFAAAAAAAAAvcDDAAAAAAAAAAAAAAAAAAC8wKQAAAAAAAAwQAAAAAAAAL7ApAAAAAAAADBAAAAAAAAgvsC3AAAAAAAAAAAAAAAAAAC+wKQAAAAAAAAwQAAAAAAAgL7ApAAAAAAAADBAAAAAAACgvsC3AAAAAAAAAAAAAAAAAIC+wKQAAAAAAAAwQAAAAAAAwL7ApAAAAAAAADBAAAAAAADgvsC3AAAAAAAAAAAAAAAAAMC+wLsAAAAAAAAAAAAAAAAAgL7AvwAAAAAAAAAAAAAAAAAAvsCkAAAAAAAAMEAAAAAAAAC/wKQAAAAAAAAwQAAAAAAAIL/AtwAAAAAAAAAAAAAAAAAAv8DDAAAAAAAAO0AAAAAAAAC+wMcAAAAAAAA4QAAAAAAAALzAywAAAAAAADFAAAAAAAAAuMDPAAAAAAAAKkAAAAAAAIizwA==");
+    } else {
+      // Presto Query: SELECT QDIGEST_AGG(CAST(c0 AS REAL), 1, 0.99)
+      //               FROM UNNEST(SEQUENCE(5000, 8000, 2)) AS t(c0)
+      data = decodeBase64(
+          "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAABAnEUAAAAAAAD6RQAAAAAwAAAAOAAAAAAAAEhAAECcRQAAAIA4AAAAAAAASEAAAKBFAAAAgDgAAAAAAABGQAAApEUAAACASwAAAAAAAAAAAACgRQAAAIA0AAAAAAAAQEAAAKpFAAAAgDQAAAAAAABAQAAArkUAAACASwAAAAAAAD9AAACoRQAAAIBPAAAAAAAARkAAAKBFAAAAgDgAAAAAAABLQABgsEUAAACANAAAAAAAAD5AACC2RQAAAIBLAAAAAAAAAAAAYLBFAAAAgDQAAAAAAABAQAAAuEUAAACAOAAAAAAAgEVAAAC8RQAAAIBLAAAAAAAAAAAAALhFAAAAgE8AAAAAAABHQABgsEUAAACAUwAAAAAAADxAAACgRQAAAIBXAAAAAACAQUAAQJxFAAAAgDgAAAAAAABOQABAwEUAAACASQAAAAAAADxAAEDARQAAAIA4AAAAAAAATkAAQMxFAAAAgEoAAAAAAABGQAAAyEUAAACATwAAAAAAAEhAAEDARQAAAIA0AAAAAAAAQEAAANRFAAAAgDQAAAAAAABAQAAA1kUAAACARwAAAAAAAAAAAADURQAAAIBKAAAAAAAAPEAAwNBFAAAAgDgAAAAAAABOQABA2EUAAACANAAAAAAAADxAAEDeRQAAAIBLAAAAAAAAQkAAQNhFAAAAgE8AAAAAAAAAAADA0EUAAACAUwAAAAAAADxAAEDARQAAAIA0AAAAAAAAQEAAAORFAAAAgDQAAAAAAABAQAAA5kUAAACARwAAAAAAAAAAAADkRQAAAIA0AAAAAAAAPEAAQOpFAAAAgEYAAAAAAABCQAAA6EUAAACANAAAAAAAADRAAMDuRQAAAIBGAAAAAAAARkAAAOxFAAAAgEsAAAAAAAAAAAAA6EUAAACATwAAAAAAAAAAAEDhRQAAAIA4AAAAAAAATkAAQPBFAAAAgCgAAAAAAAAQQADA90UAAACARgAAAAAAAE5AAAD0RQAAAIBLAAAAAAAAAAAAQPBFAAAAgE0AAAAAAIBAQABA8EUAAACAUwAAAAAAAEhAAEDhRQAAAIBXAAAAAAAARkAAQMBFAAAAgFsAAAAAAAA9QABAnEUAAACA");
+    }
+    for (auto i = 5000; i <= 8000; i += 2) {
+      values.push_back(T(i));
+    }
+
+    if (mergeSerialized) {
+      digest.mergeSerialized(data.data());
+    } else {
+      QuantileDigest<T> digestJava{StlAllocator<T>(allocator()), data.data()};
+      digest.testingMerge(digestJava);
+    }
+    std::sort(std::begin(values), std::end(values));
+    checkQuantiles<QuantileDigest<T>, false>(
+        values, digest, 0.0, values.size() * kAccuracy);
+  }
+
+  template <typename T>
+  void testScale() {
+    constexpr double kAccuracy = 0.75;
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), kAccuracy};
+    std::vector<double> values;
+    for (auto i = 0; i < 10000; ++i) {
+      digest.add(static_cast<T>(i), 1.0);
+      values.push_back(T(i));
+    }
+
+    std::sort(std::begin(values), std::end(values));
+    checkQuantiles<QuantileDigest<T>, false>(
+        values, digest, 0.0, values.size() * kAccuracy);
+
+    digest.scale(10.0);
+    std::vector<double> scaledValues;
+    for (const auto value : values) {
+      scaledValues.insert(scaledValues.end(), 10, value);
+    }
+    checkQuantiles<QuantileDigest<T>, false>(
+        scaledValues, digest, 0.0, scaledValues.size() * kAccuracy);
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::memoryManager()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+TEST_F(QuantileDigestTest, basic) {
+  std::vector<double> quantiles{
+      0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+  testQuantiles<int64_t>(
+      {-5, -4, 4, -3, 3, -2, 2, -1, 1, 0},
+      quantiles,
+      {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 4});
+  testQuantiles<double>(
+      {-5.0, -4.0, 4.0, -3.0, 3.0, -2.0, 2.0, -1.0, 1.0, 0.0},
+      quantiles,
+      {-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0});
+  testQuantiles<float>(
+      {-5.0, -4.0, 4.0, -3.0, 3.0, -2.0, 2.0, -1.0, 1.0, 0.0},
+      quantiles,
+      {-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 4.0});
+}
+
+TEST_F(QuantileDigestTest, weighted) {
+  std::vector<double> quantiles{
+      0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0};
+
+  testQuantiles<int64_t>(
+      {0, 2, 4, 5}, quantiles, {0, 0, 0, 2, 4, 4, 4, 4, 4, 5, 5}, {3, 1, 5, 1});
+  testQuantiles<double>(
+      {0.0, 2.0, 4.0, 5.0},
+      quantiles,
+      {0.0, 0.0, 0.0, 2.0, 4.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0},
+      {3, 1, 5, 1});
+  testQuantiles<float>(
+      {0.0, 2.0, 4.0, 5.0},
+      quantiles,
+      {0.0, 0.0, 0.0, 2.0, 4.0, 4.0, 4.0, 4.0, 4.0, 5.0, 5.0},
+      {3, 1, 5, 1});
+}
+
+TEST_F(QuantileDigestTest, largeInputSize) {
+  testLargeInputSize<double>();
+  testLargeInputSize<float>();
+}
+
+TEST_F(QuantileDigestTest, checkQuantilesAfterSerDe) {
+  QuantileDigest<int64_t> digestBigint{StlAllocator<int64_t>(allocator()), 0.8};
+  QuantileDigest<double> digestDouble{StlAllocator<double>(allocator()), 0.8};
+  for (auto i = 0; i < 100; ++i) {
+    digestBigint.add(static_cast<int64_t>(i), 1.0);
+    digestDouble.add(static_cast<double>(i), 1.0);
+  }
+  // Repeat SerDe three times to match Presto result of a partial ->
+  // intermediate -> intermediate -> final aggregation plan.
+  // Query: SELECT
+  //          VALUES_AT_QUANTILES(
+  //            QDIGEST_AGG(CAST(c0 AS BIGINT/DOUBLE), 1, 0.8),
+  //            ARRAY[0.01, 0.1, 0.15, 0.3, 0.55, 0.7, 0.85, 0.9, 0.99]
+  //        )
+  //        FROM UNNEST(SEQUENCE(0, 99)) AS t(c0)
+  for (auto i = 1; i <= 3; ++i) {
+    std::string buf(1 + digestBigint.serializedByteSize(), '\0');
+    digestBigint.serialize(buf.data());
+    digestBigint =
+        QuantileDigest<int64_t>{StlAllocator<int64_t>(allocator()), buf.data()};
+
+    buf.resize(1 + digestDouble.serializedByteSize(), '\0');
+    digestDouble.serialize(buf.data());
+    digestDouble =
+        QuantileDigest<double>{StlAllocator<double>(allocator()), buf.data()};
+  }
+
+  std::vector<double> quantiles{
+      0.01, 0.1, 0.15, 0.3, 0.55, 0.7, 0.85, 0.9, 0.99};
+  std::vector<int64_t> expectedBigint{0, 8, 8, 40, 63, 80, 95, 96, 99};
+  std::vector<int64_t> resultsBigint(quantiles.size());
+  digestBigint.estimateQuantiles(quantiles, resultsBigint.data());
+  for (auto i = 0; i < quantiles.size(); ++i) {
+    EXPECT_EQ(resultsBigint[i], expectedBigint[i]);
+  }
+
+  std::vector<double> expectedDouble{
+      1.0, 10.0, 15.0, 30.0, 55.0, 70.0, 85.0, 90.0, 99.0};
+  std::vector<double> resultsDouble(quantiles.size());
+  digestDouble.estimateQuantiles(quantiles, resultsDouble.data());
+  for (auto i = 0; i < quantiles.size(); ++i) {
+    EXPECT_EQ(resultsDouble[i], expectedDouble[i]);
+  }
+}
+
+TEST_F(QuantileDigestTest, serializedMatchJava) {
+  // Test small input size.
+  // Query: SELECT QDIGEST_AGG(CAST(c0 AS BIGINT/DOUBLE), 1, 0.99) FROM
+  //        UNNEST(SEQUENCE(-5, 4)) AS t(c0)
+  {
+    QuantileDigest<int64_t> digestBigint{
+        StlAllocator<int64_t>(allocator()), 0.99};
+    QuantileDigest<double> digestDouble{
+        StlAllocator<double>(allocator()), 0.99};
+    QuantileDigest<float> digestReal{StlAllocator<float>(allocator()), 0.99};
+    for (auto i = -5; i < 5; ++i) {
+      digestBigint.add(static_cast<int64_t>(i), 1.0);
+      digestDouble.add(static_cast<double>(i), 1.0);
+      digestReal.add(static_cast<float>(i), 1.0);
+    }
+    std::string buf(1 + digestBigint.serializedByteSize(), '\0');
+    auto length = digestBigint.serialize(buf.data());
+    buf.resize(length);
+    auto encodedBuf = encodeBase64(buf);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAPv/////////BAAAAAAAAAATAAAAAAAAAAAAAPA/+////////38AAAAAAAAA8D/8////////fwAAAAAAAADwP/3///////9/AwAAAAAAAAAA/P///////38AAAAAAAAA8D/+////////fwAAAAAAAADwP/////////9/AwAAAAAAAAAA/v///////38HAAAAAAAAAAD8////////fwsAAAAAAAAAAPv///////9/AAAAAAAAAPA/AAAAAAAAAIAAAAAAAAAA8D8BAAAAAAAAgAMAAAAAAAAAAAAAAAAAAACAAAAAAAAAAPA/AgAAAAAAAIAAAAAAAAAA8D8DAAAAAAAAgAMAAAAAAAAAAAIAAAAAAACABwAAAAAAAAAAAAAAAAAAAIAAAAAAAAAA8D8EAAAAAAAAgAsAAAAAAAAAAAAAAAAAAACA/wAAAAAAAAAA+////////38=");
+
+    buf.clear();
+    buf.resize(1 + digestDouble.serializedByteSize(), '\0');
+    length = digestDouble.serialize(buf.data());
+    buf.resize(length);
+    encodedBuf = encodeBase64(buf);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAP///////+u/AAAAAAAAEEATAAAAAAAAAAAAAPA/////////6z8AAAAAAAAA8D/////////vP8sAAAAAAAAAAP///////+s/AAAAAAAAAPA/////////9z8AAAAAAAAA8D//////////P88AAAAAAAAAAP////////c/0wAAAAAAAAAA////////6z8AAAAAAAAA8D////////8PQPsAAAAAAAAAAP///////+s/AAAAAAAAAPA/AAAAAAAAAIAAAAAAAAAA8D8AAAAAAADwv/cAAAAAAAAAAAAAAAAAAACAAAAAAAAAAPA/AAAAAAAAAMAAAAAAAAAA8D8AAAAAAAAIwM8AAAAAAAAAAAAAAAAAAADAAAAAAAAAAPA/AAAAAAAAEMDTAAAAAAAAAAAAAAAAAAAAwPsAAAAAAAAAAAAAAAAAAACA/wAAAAAAAAAA////////6z8=");
+
+    buf.clear();
+    buf.resize(1 + digestReal.serializedByteSize(), '\0');
+    length = digestReal.serialize(buf.data());
+    buf.resize(length);
+    encodedBuf = encodeBase64(buf);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAP//X7//////AACAQAAAAAATAAAAAAAAAAAAAPA///9fv////38AAAAAAAAA8D///3+/////f1cAAAAAAAAAAP//X7////9/AAAAAAAAAPA///+/v////38AAAAAAAAA8D////+/////f1sAAAAAAAAAAP//v7////9/XwAAAAAAAAAA//9fv////38AAAAAAAAA8D///3/A////f3sAAAAAAAAAAP//X7////9/AAAAAAAAAPA/AAAAAAAAAIAAAAAAAAAA8D8AAIA/AAAAgHcAAAAAAAAAAAAAAAAAAACAAAAAAAAAAPA/AAAAQAAAAIAAAAAAAAAA8D8AAEBAAAAAgFsAAAAAAAAAAAAAAEAAAACAAAAAAAAAAPA/AACAQAAAAIBfAAAAAAAAAAAAAABAAAAAgHsAAAAAAAAAAAAAAAAAAACA/wAAAAAAAAAA//9fv////38=");
+  }
+
+  // Test large input size.
+  // Query: SELECT QDIGEST_AGG(CAST(c0 AS BIGINT), 1, 0.99) FROM
+  //        UNNEST(SEQUENCE(-5000, 4999)) AS t(c0)
+  {
+    QuantileDigest<int64_t> digestBigint{
+        StlAllocator<int64_t>(allocator()), 0.99};
+    QuantileDigest<double> digestDouble{
+        StlAllocator<double>(allocator()), 0.99};
+    QuantileDigest<float> digestReal{StlAllocator<float>(allocator()), 0.99};
+    for (auto i = -5000; i < 5000; ++i) {
+      digestBigint.add(static_cast<int64_t>(i), 1.0);
+      digestDouble.add(static_cast<double>(i), 1.0);
+      digestReal.add(static_cast<float>(i), 1.0);
+    }
+
+    std::string bufBigint(1 + digestBigint.serializedByteSize(), '\0');
+    std::string bufDouble(1 + digestDouble.serializedByteSize(), '\0');
+    std::string bufReal(1 + digestReal.serializedByteSize(), '\0');
+    auto length = digestBigint.serialize(bufBigint.data());
+    bufBigint.resize(length);
+    length = digestDouble.serialize(bufDouble.data());
+    bufDouble.resize(length);
+    length = digestReal.serialize(bufReal.data());
+    bufReal.resize(length);
+    for (auto i = 1; i <= 3; ++i) {
+      digestBigint = QuantileDigest<int64_t>{
+          StlAllocator<int64_t>(allocator()), bufBigint.data()};
+      bufBigint.clear();
+      bufBigint.resize(1 + digestBigint.serializedByteSize(), '\0');
+      length = digestBigint.serialize(bufBigint.data());
+      bufBigint.resize(length);
+
+      digestDouble = QuantileDigest<double>{
+          StlAllocator<double>(allocator()), bufDouble.data()};
+      bufDouble.clear();
+      bufDouble.resize(1 + digestDouble.serializedByteSize(), '\0');
+      length = digestDouble.serialize(bufDouble.data());
+      bufDouble.resize(length);
+
+      digestReal = QuantileDigest<float>{
+          StlAllocator<float>(allocator()), bufReal.data()};
+      bufReal.clear();
+      bufReal.resize(1 + digestReal.serializedByteSize(), '\0');
+      length = digestReal.serialize(bufReal.data());
+      bufReal.resize(length);
+    }
+    auto encodedBuf = encodeBase64(bufBigint);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAHjs////////hxMAAAAAAABUAAAAFAAAAAAA4HJAeOz//////38MAAAAAACAWUAa7v//////fxAAAAAAAABnQAHv//////9/IwAAAAAAwGNAGu7//////38nAAAAAAAAAAB47P//////fxAAAAAAAIBtQBTw//////9/EAAAAAAAAGFADPL//////38QAAAAAAAAb0AI8///////fyMAAAAAAAAAAAzy//////9/JwAAAAAAAHFAFPD//////38UAAAAAABgdEAg9P//////fxQAAAAAAKBzQAr2//////9/JwAAAAAAgGdAIPT//////38rAAAAAACAZEAU8P//////fxAAAAAAAMBvQAL4//////9/EAAAAAAAAHBAAPn//////38jAAAAAAAAAAAC+P//////fyUAAAAAAIBvQAL4//////9/EAAAAAAAgGlANP3//////38AAAAAAAAAAED+////////fx4AAAAAAABlQFb///////9/IgAAAAAAAHVABv7//////38nAAAAAADAckAO/P//////fysAAAAAACBxQAL4//////9/LwAAAAAAAAAAFPD//////38zAAAAAABAdEB47P//////fwgAAAAAAABNQEYAAAAAAACADAAAAAAAQF5AhwAAAAAAAIAfAAAAAAAAAAAAAAAAAAAAgAwAAAAAAABgQAABAAAAAACADAAAAAAAAGBAgAEAAAAAAIAfAAAAAAAAAAAAAQAAAAAAgCMAAAAAAAAAAAAAAAAAAACADAAAAAAAAGBAAAIAAAAAAIAMAAAAAAAAYECAAgAAAAAAgB8AAAAAAAAAAAACAAAAAACAIQAAAAAAQFtAAAIAAAAAAIAnAAAAAABgYkAAAAAAAAAAgAwAAAAAAABgQAAEAAAAAACADAAAAAAAAGBAgAQAAAAAAIAfAAAAAAAAAAAABAAAAAAAgAwAAAAAAEBZQJsFAAAAAACAIwAAAAAAQFBAAAQAAAAAAIAMAAAAAAAAYEAABgAAAAAAgAwAAAAAAABgQIAGAAAAAACAHwAAAAAAAAAAAAYAAAAAAIAMAAAAAABAV0CjBwAAAAAAgB4AAAAAAEBQQGIHAAAAAACAIwAAAAAAgFhAAAYAAAAAAIAnAAAAAACAVkAABAAAAAAAgCsAAAAAAAAAAAAAAAAAAACADAAAAAAAAGBAAAgAAAAAAIAMAAAAAAAAYECACAAAAAAAgB8AAAAAAAAAAAAIAAAAAACAIQAAAAAAwGJAAAgAAAAAAIAMAAAAAAAAYEAACgAAAAAAgAwAAAAAAABgQIAKAAAAAACAHwAAAAAAAAAAAAoAAAAAAIAQAAAAAADAYUByCwAAAAAAgCMAAAAAAIBcQAAKAAAAAACAJwAAAAAAAAAAAAgAAAAAAIAMAAAAAAAAYEAADAAAAAAAgAwAAAAAAABgQIAMAAAAAACAHwAAAAAAAAAAAAwAAAAAAIAhAAAAAADAYEAADAAAAAAAgAwAAAAAAABgQAAOAAAAAACADAAAAAAAAGBAgA4AAAAAAIAfAAAAAAAAAAAADgAAAAAAgAwAAAAAAIBfQIIPAAAAAACAIwAAAAAAQGBAAA4AAAAAAIAnAAAAAAAAAAAADAAAAAAAgCsAAAAAAIBeQAAIAAAAAACALwAAAAAAgFpAAAAAAAAAAIAMAAAAAACAXkCGEAAAAAAAgAwAAAAAAIBdQIoRAAAAAACAHgAAAAAAQGBACBEAAAAAAIAjAAAAAAAAAAAEEAAAAAAAgAwAAAAAAIBcQI4SAAAAAACAHgAAAAAAwGFAABIAAAAAAIAQAAAAAAAAYUAAEwAAAAAAgCMAAAAAAAAAAAASAAAAAACAJwAAAAAAQGFABBAAAAAAAIAzAAAAAABAVEAAAAAAAAAAgP8AAAAAAAAAAHjs//////9/");
+
+    encodedBuf = encodeBase64(bufDouble);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAP//////d0y/AAAAAACHs0B0AAAAsAAAAAAAAGBA//////93TD+sAAAAAABAVkD//////wBNP6wAAAAAAABUQP//////gE0/vwAAAAAAwFRA//////8ATT/DAAAAAAAAAAD//////3dMP6wAAAAAAABUQP//////gE4/sAAAAAAAAGBA//////8ATz/DAAAAAAAAAAD//////wBOP8cAAAAAAABaQP//////d0w/sAAAAAAAAFhA//////8BUD+wAAAAAAAAUED//////wFRP8MAAAAAAAAAAP//////AVA/rAAAAAAAAFBA//////8BUj+wAAAAAAAAWED//////wFTP8MAAAAAAAAAAP//////AVI/xwAAAAAA4GBA//////8BUD+0AAAAAAAAYED//////wFUP7AAAAAAAMBfQP//////A1Y/rAAAAAAAAFBA//////8BVz/DAAAAAAAAAAD//////wNWP8cAAAAAAIBcQP//////AVQ/ywAAAAAAQFVA//////8BUD+0AAAAAAAAYED//////wFYP6wAAAAAAABQQP//////AVo/rAAAAAAAAFBA//////+BWz/DAAAAAAAAWUD//////wFaP8cAAAAAAABVQP//////AVg/tAAAAAAAoGJA//////9XXD+wAAAAAADAVkD//////wFfP8IAAAAAAMBcQP//////B14/xwAAAAAAAFZA//////9XXD/LAAAAAABAV0D//////wFYP88AAAAAAAAAAP//////AVA/0wAAAAAAgGJA//////93TD+0AAAAAAAAV0D//////wNkP7QAAAAAAIBbQP//////S2Y/xwAAAAAAAAAA//////8DZD/KAAAAAAAAYED//////0dgP7QAAAAAAABgQP//////A2g/xQAAAAAAwFZA//////8DaD+0AAAAAADAX0D//////wduP8YAAAAAAIBbQP//////T2w/ywAAAAAAAAAA//////8DaD/PAAAAAACAXUD//////0dgP7gAAAAAAABgQP//////B3A/uAAAAAAAAGBA//////8HeD+4AAAAAABAVkD//////z99P8sAAAAAAAAAAP//////B3g/zwAAAAAAAFdA//////8HcD/TAAAAAABgYED//////0dgP9cAAAAAAIBYQP//////d0w/vAAAAAAAAGBA//////8PiD/AAAAAAAAAYED//////x+QP9MAAAAAAIBcQP//////74A/xAAAAAAAAFhA//////8/oD/XAAAAAAAAAAD//////++AP98AAAAAAABZQP//////d0w/vAAAAAAAAExAAAAAAAAAacC4AAAAAAAAS0AAAAAAAKB0wLwAAAAAAEBdQAAAAAAAsHjAzwAAAAAAAFNAAAAAAACQcMDTAAAAAACAUkAAAAAAAOBgwLQAAAAAAABJQAAAAAAAcILAuAAAAAAAQFxAAAAAAAB4hMDLAAAAAAAAAAAAAAAAAGiAwLgAAAAAAABgQAAAAAAAAIjAuAAAAAAAAGBAAAAAAAAAjMDLAAAAAAAAAAAAAAAAAACIwM8AAAAAAAAAAAAAAAAAaIDAtAAAAAAAAGBAAAAAAAAAkMC0AAAAAAAAYEAAAAAAAACSwMcAAAAAAAAAAAAAAAAAAJDAtAAAAAAAQFlAAAAAAABslsDLAAAAAABAUEAAAAAAAACQwLQAAAAAAABgQAAAAAAAAJjAtAAAAAAAAGBAAAAAAAAAmsDHAAAAAAAAAAAAAAAAAACYwLQAAAAAAEBXQAAAAAAAjJ7AxgAAAAAAQFBAAAAAAACIncDLAAAAAACAWEAAAAAAAACYwM8AAAAAAAAAAAAAAAAAAJDA0wAAAAAAgFZAAAAAAABogMCwAAAAAAAAYEAAAAAAAACgwLAAAAAAAABgQAAAAAAAAKHAwwAAAAAAAAAAAAAAAAAAoMDFAAAAAADAYkAAAAAAAACgwLAAAAAAAABgQAAAAAAAAKTAsAAAAAAAAGBAAAAAAAAApcDDAAAAAAAAAAAAAAAAAACkwLQAAAAAAMBhQAAAAAAA5KbAxwAAAAAAgFxAAAAAAAAApMDLAAAAAAAAAAAAAAAAAACgwLAAAAAAAABgQAAAAAAAAKjAsAAAAAAAAGBAAAAAAAAAqcDDAAAAAAAAAAAAAAAAAACowMUAAAAAAMBgQAAAAAAAAKjAsAAAAAAAAGBAAAAAAAAArMCwAAAAAAAAYEAAAAAAAACtwMMAAAAAAAAAAAAAAAAAAKzAsAAAAAAAgF9AAAAAAAAEr8DHAAAAAABAYEAAAAAAAACswMsAAAAAAAAAAAAAAAAAAKjAzwAAAAAAgF5AAAAAAAAAoMCsAAAAAACAXkAAAAAAAIawwKwAAAAAAIBdQAAAAAAAirHAvgAAAAAAQGBAAAAAAAAIscDDAAAAAAAAAAAAAAAAAASwwKwAAAAAAIBcQAAAAAAAjrLAvgAAAAAAwGFAAAAAAAAAssCwAAAAAAAAYUAAAAAAAACzwMMAAAAAAAAAAAAAAAAAALLAxwAAAAAAQGFAAAAAAAAEsMDTAAAAAACAW0AAAAAAAACgwNcAAAAAAABUQAAAAAAAaIDA3wAAAAAAgFNAAAAAAACAUcD/AAAAAAAgYkD//////3dMPw==");
+
+    encodedBuf = encodeBase64(bufReal);
+    ASSERT_EQ(
+        encodedBuf,
+        "AK5H4XoUru8/AAAAAAAAAAAAAAAAAAAAAP+/Y7r/////ADicRQAAAABuAAAAPAAAAAAA4GJA/wdouv///39OAAAAAAAAZUD/v2O6////fzwAAAAAAEBiQP8fcLr///9/PAAAAAAAIGNA/wd4uv///39PAAAAAACAYkD/H3C6////f1MAAAAAAMBbQP+/Y7r///9/QAAAAAAAwGJA/w+Auv///388AAAAAACAXED/75C6////f1MAAAAAAMBhQP8PgLr///9/PAAAAAAAAGBA/w+guv///388AAAAAACAX0D/L7C6////fzgAAAAAAABLQP+vvLr///9/TwAAAAAAAAAA/y+wuv///39TAAAAAABgYkD/D6C6////f1cAAAAAAMBaQP8PgLr///9/PAAAAAAAwFpA/1/Buv///388AAAAAAAAYED/D8i6////f08AAAAAAAAAAP9fwbr///9/UQAAAAAAwGRA/1/Buv///388AAAAAADAXUD/n+C6////fzwAAAAAAABgQP8P6Lr///9/TwAAAAAAAAAA/5/guv///39AAAAAAAAgY0D/f/a6////f1MAAAAAAMBZQP+f4Lr///9/VwAAAAAAAFVA/1/Buv///39bAAAAAACAVUD/D4C6////f18AAAAAAAAAAP+/Y7r///9/QAAAAAAAQFxA//8hu////39AAAAAAAAAYED/HzC7////f1MAAAAAAAAAAP//Ibv///9/VgAAAAAAQFZA//8Hu////39AAAAAAAAAYED/H0C7////f0AAAAAAAABgQP8fULv///9/UwAAAAAAAAAA/x9Au////39EAAAAAAAgYED//2+7////f1cAAAAAAMBfQP8fQLv///9/WwAAAAAAAAAA//8Hu////39EAAAAAABAUkD//627////f0QAAAAAAMBXQP9/6Lv///9/VgAAAAAAgGNA/3/Bu////39bAAAAAAAAAAD//4a7////f18AAAAAACBkQP//B7v///9/YwAAAAAAQGJA/79juv///39IAAAAAABAWED//0+8////f0wAAAAAAEBcQP//j7z///9/XwAAAAAAYGNA//8JvP///39QAAAAAAAAWED//wG9////f2MAAAAAAAAAAP//Cbz///9/ZQAAAAAAAD5A//8JvP///39rAAAAAAAAAAD/v2O6////f3kAAAAAAEBdQP+/Y7r///9/SAAAAAAAAExAAABIQwAAAIBEAAAAAAAAS0AAAKVDAAAAgEgAAAAAAEBdQACAxUMAAACAWwAAAAAAAFNAAICEQwAAAIBfAAAAAACAUkAAAAdDAAAAgEAAAAAAAABJQACAE0QAAACARAAAAAAAQFxAAMAjRAAAAIBXAAAAAAAAAAAAQANEAAAAgEQAAAAAAABgQAAAQEQAAACARAAAAAAAAGBAAABgRAAAAIBXAAAAAAAAAAAAAEBEAAAAgFsAAAAAAAAAAABAA0QAAACAQAAAAAAAAGBAAACARAAAAIBAAAAAAAAAYEAAAJBEAAAAgFMAAAAAAAAAAAAAgEQAAACAQAAAAAAAQFlAAGCzRAAAAIBXAAAAAABAUEAAAIBEAAAAgEAAAAAAAABgQAAAwEQAAACAQAAAAAAAAGBAAADQRAAAAIBTAAAAAAAAAAAAAMBEAAAAgEAAAAAAAEBXQABg9EQAAACAUgAAAAAAQFBAAEDsRAAAAIBXAAAAAACAWEAAAMBEAAAAgFsAAAAAAAAAAAAAgEQAAACAXwAAAAAAgFZAAEADRAAAAIA8AAAAAAAAYEAAAABFAAAAgDwAAAAAAABgQAAACEUAAACATwAAAAAAAAAAAAAARQAAAIBRAAAAAADAYkAAAABFAAAAgDwAAAAAAABgQAAAIEUAAACAPAAAAAAAAGBAAAAoRQAAAIBPAAAAAAAAAAAAACBFAAAAgEAAAAAAAMBhQAAgN0UAAACAUwAAAAAAgFxAAAAgRQAAAIBXAAAAAAAAAAAAAABFAAAAgDwAAAAAAABgQAAAQEUAAACAPAAAAAAAAGBAAABIRQAAAIBPAAAAAAAAAAAAAEBFAAAAgFEAAAAAAMBgQAAAQEUAAACAPAAAAAAAAGBAAABgRQAAAIA8AAAAAAAAYEAAAGhFAAAAgE8AAAAAAAAAAAAAYEUAAACAPAAAAAAAgF9AACB4RQAAAIBTAAAAAABAYEAAAGBFAAAAgFcAAAAAAAAAAAAAQEUAAACAWwAAAAAAgF5AAAAARQAAAIA4AAAAAACAXkAAMIRFAAAAgDgAAAAAAIBdQABQjEUAAACASgAAAAAAQGBAAECIRQAAAIBPAAAAAAAAAAAAIIBFAAAAgDgAAAAAAIBcQABwlEUAAACASgAAAAAAwGFAAACQRQAAAIA8AAAAAAAAYUAAAJhFAAAAgE8AAAAAAAAAAAAAkEUAAACAUwAAAAAAQGFAACCARQAAAIBfAAAAAACAW0AAAABFAAAAgGMAAAAAAABUQABAA0QAAACAawAAAAAAgFNAAACMQgAAAID/AAAAAACAUUD/v2O6////fw==");
+  }
+}
+
+TEST_F(QuantileDigestTest, merge) {
+  testMerge<double>(true);
+  testMerge<float>(true);
+
+  testMerge<double>(false);
+  testMerge<float>(false);
+}
+
+TEST_F(QuantileDigestTest, mergeWithJava) {
+  testMergeWithJava<double>(true);
+  testMergeWithJava<float>(true);
+
+  testMergeWithJava<double>(false);
+  testMergeWithJava<float>(false);
+}
+
+TEST_F(QuantileDigestTest, mergeWithEmpty) {
+  testMergeEmpty<double>(true);
+  testMergeEmpty<float>(true);
+
+  testMergeEmpty<double>(false);
+  testMergeEmpty<float>(false);
+}
+
+TEST_F(QuantileDigestTest, infinity) {
+  const double kInf = std::numeric_limits<double>::infinity();
+  const float kFInf = std::numeric_limits<float>::infinity();
+  std::vector<double> quantiles{0.0, 0.3, 0.4, 0.5, 0.6, 0.7, 1.0};
+  testQuantiles<double>(
+      {0.0, kInf, -kInf}, quantiles, {-kInf, -kInf, 0.0, 0.0, 0.0, kInf, kInf});
+  testQuantiles<float>(
+      {0.0, kFInf, -kFInf},
+      quantiles,
+      {-kFInf, -kFInf, 0.0, 0.0, 0.0, kFInf, kFInf});
+}
+
+TEST_F(QuantileDigestTest, minMax) {
+  const double kAccuracy = 0.05;
+  QuantileDigest<int64_t> digestBigint{
+      StlAllocator<int64_t>(allocator()), kAccuracy};
+  QuantileDigest<double> digestDouble{
+      StlAllocator<double>(allocator()), kAccuracy};
+  QuantileDigest<float> digestReal{StlAllocator<float>(allocator()), kAccuracy};
+
+  int64_t from = -12345;
+  int64_t to = 54321;
+  for (auto i = from; i <= to; ++i) {
+    digestBigint.add(i, 1);
+    digestDouble.add(static_cast<double>(i), 1);
+    digestReal.add(static_cast<float>(i), 1);
+  }
+
+  auto rankError = (to - from + 1) * kAccuracy;
+  ASSERT_LE(std::abs(from - digestBigint.getMin()), rankError);
+  ASSERT_LE(std::abs(to - digestBigint.getMax()), rankError);
+  ASSERT_LE(std::abs(from - digestDouble.getMin()), rankError);
+  ASSERT_LE(std::abs(to - digestDouble.getMax()), rankError);
+  ASSERT_LE(std::abs(from - digestReal.getMin()), rankError);
+  ASSERT_LE(std::abs(to - digestReal.getMax()), rankError);
+}
+
+TEST_F(QuantileDigestTest, scale) {
+  testScale<int64_t>();
+  testScale<double>();
+  testScale<float>();
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/QuantileDigestTestBase.h
+++ b/velox/functions/lib/tests/QuantileDigestTestBase.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Range.h>
+#include <folly/base64.h>
+#include <gtest/gtest.h>
+#include <numeric>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions {
+
+class QuantileDigestTestBase : public testing::Test {
+ public:
+  static constexpr double kQuantiles[] = {
+      0.0001, 0.0200, 0.0300, 0.04000, 0.0500, 0.1000, 0.2000,
+      0.3000, 0.4000, 0.5000, 0.6000,  0.7000, 0.8000, 0.9000,
+      0.9500, 0.9600, 0.9700, 0.9800,  0.9999,
+  };
+
+  template <typename QuantileDigest, bool testSum = true>
+  static void checkQuantiles(
+      folly::Range<const double*> values,
+      QuantileDigest& digest,
+      double sumError,
+      double rankError) {
+    VELOX_CHECK(std::is_sorted(values.begin(), values.end()));
+    if constexpr (testSum) {
+      auto sum = std::accumulate(values.begin(), values.end(), 0.0);
+      ASSERT_NEAR(digest.sum(), sum, sumError);
+    }
+    for (auto q : kQuantiles) {
+      auto v = digest.estimateQuantile(q);
+      ASSERT_LE(values.front(), v);
+      ASSERT_LE(v, values.back());
+      auto hi = std::lower_bound(values.begin(), values.end(), v);
+      auto lo = hi;
+      while (lo != values.begin() && v > *lo) {
+        --lo;
+      }
+      while (std::next(hi) != values.end() && *hi == *std::next(hi)) {
+        ++hi;
+      }
+      auto l = (lo - values.begin()) / (values.size() - 1.0);
+      auto r = (hi - values.begin()) / (values.size() - 1.0);
+      if (q < l) {
+        ASSERT_NEAR(l, q, rankError);
+      } else if (q > r) {
+        ASSERT_NEAR(r, q, rankError);
+      }
+    }
+  }
+
+  static std::string decodeBase64(std::string_view input) {
+    std::string decoded(folly::base64DecodedSize(input), '\0');
+    folly::base64Decode(input, decoded.data());
+    return decoded;
+  }
+};
+
+#define CHECK_QUANTILES(_values, _digest, _sumError, _rankError) \
+  do {                                                           \
+    SCOPED_TRACE("CHECK_QUANTILES");                             \
+    QuantileDigestTestBase::checkQuantiles(                      \
+        (_values), (_digest), (_sumError), (_rankError));        \
+  } while (false)
+
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary: This diff adds the QuantileDigest data structure to be used for qdigest functions. The serialization and deserialization of this QuantileDigest are compatiable with Presto-Java.

Differential Revision: D71521497


