### PR TITLE
feat: Add decimal support in histogram aggregate

### DIFF
--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -624,6 +624,11 @@ void registerHistogramAggregate(
           case TypeKind::ROW:
             return std::make_unique<HistogramAggregate<ComplexType>>(
                 resultType);
+          case TypeKind::HUGEINT:
+            if (inputType->isLongDecimal()) {
+              return std::make_unique<HistogramAggregate<int128_t>>(resultType);
+            }
+            [[fallthrough]];
           case TypeKind::UNKNOWN:
             return std::make_unique<HistogramAggregate<int8_t>>(resultType);
           default:


### PR DESCRIPTION
Summary: Add decimal support in histogram aggregate. This is top contributor to Sapphire query failing in PROD

Differential Revision: D71860678


