### PR TITLE
fix(json): Ensure json_array_get always canonicalizes the output

### DIFF
--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -54,11 +54,6 @@ void registerJsonFunctions(const std::string& prefix) {
   registerFunction<JsonArrayContainsFunction, bool, Varchar, Varchar>(
       {prefix + "json_array_contains"});
 
-  registerFunction<JsonArrayGetFunction, Json, Json, int64_t>(
-      {prefix + "json_array_get"});
-  registerFunction<JsonArrayGetFunction, Json, Varchar, int64_t>(
-      {prefix + "json_array_get"});
-
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
       {prefix + "json_size"});
   registerFunction<JsonSizeFunction, int64_t, Varchar, Varchar>(
@@ -69,6 +64,8 @@ void registerJsonFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, prefix + "json_parse");
+
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_array_get, prefix + "json_array_get");
 
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_$internal$_json_string_to_array,


### PR DESCRIPTION
Summary:
This introduces a vector function version of json_array_get which leverages
the existing json_parse implementation to parse the output before returning.

Differential Revision: D71880585


