### PR TITLE
fix(tpch): Concurrency issues in dbgen

### DIFF
--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -39,6 +39,9 @@ class DBGenBackend {
     load_dists(
         300 * 1024 * 1024,
         &dbgenCtx); // 300 MB buffer size for text generation.
+
+    // Initialize global dbgen buffers required to generate data.
+    init_build_buffers();
   }
   ~DBGenBackend() {
     cleanup_dists();

--- a/velox/tpch/gen/dbgen/include/dbgen/dsstypes.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dsstypes.h
@@ -17,6 +17,10 @@
 
 namespace facebook::velox::tpch::dbgen {
 
+// Clients must call this function before calling any of the data generation
+// functions below.
+void init_build_buffers PROTO(());
+
 /*
  * typedefs
  */


### PR DESCRIPTION
Summary:
Moving the intialization of buffers out of the mk_* functions
themselves (since they can be called concurrently) to a separate initialization
function called once when the Velox dbgen singleton gets constructed. This
concurrency issue was caught by TSAN.

Differential Revision: D71902408


