### PR TITLE
fix(fuzzer): Wrap is null call to remove query ambiguity

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -170,7 +170,8 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     sql << "(";
     VELOX_CHECK_EQ(call->inputs().size(), 1);
     toCallInputsSql({call->inputs()[0]}, sql);
-    sql << fmt::format(" is{} null)", call->name() == "not_null" ? " not" : "");
+    sql << fmt::format(" is{} null", call->name() == "not_null" ? " not" : "");
+    sql << ")";
   } else if (call->name() == "in") {
     VELOX_CHECK_GE(call->inputs().size(), 2);
     toCallInputsSql({call->inputs()[0]}, sql);

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -167,9 +167,10 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql({call->inputs()[1]}, sql);
     sql << ")";
   } else if (call->name() == "is_null" || call->name() == "not_null") {
+    sql << "(";
     VELOX_CHECK_EQ(call->inputs().size(), 1);
     toCallInputsSql({call->inputs()[0]}, sql);
-    sql << fmt::format(" is{} null", call->name() == "not_null" ? " not" : "");
+    sql << fmt::format(" is{} null)", call->name() == "not_null" ? " not" : "");
   } else if (call->name() == "in") {
     VELOX_CHECK_GE(call->inputs().size(), 2);
     toCallInputsSql({call->inputs()[0]}, sql);


### PR DESCRIPTION
Summary: A previous change updated `is_null` SQL converstion to `is null` since the prior is not registered with Presto. This solved the issue, but also created a rare case where the SQL executor may be confused by the order of operations (see Test Plan). This change will wrap this conversion in parantheses to avoid any ambiguity.

Differential Revision: D71906852


