### PR TITLE
feat: Implement BingTile(quadkey) function

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -30,6 +30,10 @@ for more details.
     Zoom levels from 0 to 23 are supported, with valid `x` and `y` coordinates
     described above.  Invalid parameters will return a User Error.
 
+.. function:: bing_tile(quadKey: varchar) -> tile: BingTile
+
+    Creates a Bing tile object from a quadkey. An invalid quadkey will return a User Error.
+
 .. function:: bing_tile_coordinates(tile: BingTile) -> coords: row(integer,integer)
 
     Returns the `x`, `y` coordinates of a given Bing tile as `row(x, y)`.

--- a/velox/functions/prestosql/BingTileFunctions.h
+++ b/velox/functions/prestosql/BingTileFunctions.h
@@ -63,6 +63,17 @@ struct BingTileFunction {
     result = tile;
     return Status::OK();
   }
+
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<BingTile>& result, const arg_type<Varchar>& quadKey) {
+    folly::Expected<uint64_t, std::string> tile =
+        BingTileType::bingTileFromQuadKey(std::string_view(quadKey));
+    if (tile.hasError()) {
+      return Status::UserError(tile.error());
+    }
+    result = tile.value();
+    return Status::OK();
+  }
 };
 
 template <typename T>

--- a/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
@@ -30,6 +30,7 @@ void registerSimpleBingTileFunctions(const std::string& prefix) {
   // BingTile constructors
   registerFunction<BingTileFunction, BingTile, int32_t, int32_t, int8_t>(
       {prefix + "bing_tile"});
+  registerFunction<BingTileFunction, BingTile, Varchar>({prefix + "bing_tile"});
 
   // BingTile accessors
   registerFunction<BingTileZoomLevelFunction, int8_t, BingTile>(

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -139,6 +139,9 @@ class BingTileType : public BigintType {
   static folly::Expected<std::vector<uint64_t>, std::string> bingTileChildren(
       uint64_t tile,
       uint8_t childZoom);
+
+  static folly::Expected<uint64_t, std::string> bingTileFromQuadKey(
+      const std::string_view& quadKey);
 };
 
 inline bool isBingTileType(const TypePtr& type) {


### PR DESCRIPTION
Summary: Adds `quadkey: varchar` constructor for `BingTile`.

Differential Revision: D71856961


