### PR TITLE
fix: Fully qualify which operator we are using

### DIFF
--- a/velox/external/date/date.h
+++ b/velox/external/date/date.h
@@ -3981,12 +3981,6 @@ make_time(const std::chrono::duration<Rep, Period>& d)
     return hh_mm_ss<std::chrono::duration<Rep, Period>>(d);
 }
 
-#if defined(__cpp_lib_format)
-
-// already have operator<<
-
-#else
-
 template <class CharT, class Traits, class Duration>
 inline
 typename std::enable_if
@@ -4014,10 +4008,8 @@ inline
 std::basic_ostream<CharT, Traits>&
 operator<<(std::basic_ostream<CharT, Traits>& os, const local_time<Duration>& ut)
 {
-    return (os << sys_time<Duration>{ut.time_since_epoch()});
+    return ::facebook::velox::date::operator<<(os, sys_time<Duration>{ut.time_since_epoch()});
 }
-
-#endif
 
 namespace detail
 {

--- a/velox/external/tzdb/exception.h
+++ b/velox/external/tzdb/exception.h
@@ -57,8 +57,9 @@ class nonexistent_local_time : public std::runtime_error {
        << ' ' << __info.first.abbrev << " and\n"
        << date::local_seconds{__info.second.begin.time_since_epoch()} +
             __info.second.offset
-       << ' ' << __info.second.abbrev << " which are both equivalent to\n"
-       << __info.first.end << " UTC";
+       << ' ' << __info.second.abbrev << " which are both equivalent to\n";
+    
+    ::facebook::velox::date::operator<<(os, __info.first.end) << " UTC";
     return os.str();
   }
 };
@@ -97,6 +98,7 @@ class ambiguous_local_time : public std::runtime_error {
       const date::local_time<_Duration>& __time,
       const local_info& __info) {
     std::ostringstream os;
+    using ::facebook::velox::date::operator<<;
     os << __time << " is ambiguous.  It could be\n"
        << __time << ' ' << __info.first.abbrev
        << " == " << __time - __info.first.offset << " UTC or\n"


### PR DESCRIPTION
Summary: libc++ introduced these operator<< for some chrono types. velox defined them as well in the `facebook::velox::date` namespace, which could lead to ambiguous lookup. Fully qualify the name when such lookup can be ambiguous.

Differential Revision: D71929677
