### PR TITLE
fix(json): Fix casting of NaN's in json

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -1034,6 +1034,18 @@ TEST_F(JsonCastTest, toDouble) {
       DOUBLE(),
       {"NaN"_sv},
       "The JSON document has an improper structure");
+
+  testThrow<JsonNativeType>(
+      JSON(),
+      REAL(),
+      {"\"nan\""_sv},
+      "The JSON element does not have the requested type");
+
+  testThrow<JsonNativeType>(
+      JSON(),
+      DOUBLE(),
+      {"\"nan\""_sv},
+      "The JSON element does not have the requested type");
 }
 
 TEST_F(JsonCastTest, toBoolean) {

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -593,6 +593,16 @@ simdjson::simdjson_result<T> fromString(const std::string_view& s) {
   if (result.hasError()) {
     return simdjson::INCORRECT_TYPE;
   }
+
+  if constexpr (std::is_floating_point_v<T>) {
+    // Only "NaN" is allowed to be converted to NaN.  "nan" is not allowed.
+    if (FOLLY_UNLIKELY(std::isnan(*result))) {
+      if (s != "NaN" && s != "-NaN") {
+        return simdjson::INCORRECT_TYPE;
+      }
+    }
+  }
+
   return std::move(*result);
 }
 


### PR DESCRIPTION
Summary: We use folly::tryTo to cast json strings . This is quite permissive for certain strings such as "nan"'s etc which are allowed in folly but not in presto java.

Differential Revision: D71936263


