### PR TITLE
fix(fuzzer): Update ConcatTypedExpr SQL generation to use ROW instead of CONCAT

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -239,7 +239,7 @@ std::string toCastSql(const core::CastTypedExprPtr& cast) {
 
 std::string toConcatSql(const core::ConcatTypedExprPtr& concat) {
   std::stringstream sql;
-  sql << "concat(";
+  sql << "row(";
   toCallInputsSql(concat->inputs(), sql);
   sql << ")";
   return sql.str();


### PR DESCRIPTION
Summary: Update SQL generation for ConcatTypedExpr to use `row` instead of `concat` for SQL building. This is because the `concat` that Presto and Velox are referring to is different. Velox interprets `concat` as the combining of primitive elements into a singular data structure, a `ROW`, while Presto interprets it as invoking the `concat` SQL function, which has a more restricted allowed input (see example below) and a different behavior. This diff fixes the SQL generation to match Presto's with Velox's, which ultimately stabalizes fuzzer runs using `enable_dereference`.

Differential Revision: D71989324


