### PR TITLE
refactor: Allow specializing projectNode description

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -751,7 +751,7 @@ PlanNodePtr ValuesNode::create(const folly::dynamic& obj, void* context) {
       obj["repeatTimes"].asInt());
 }
 
-void ProjectNode::addDetails(std::stringstream& stream) const {
+void AbstractProjectNode::addDetails(std::stringstream& stream) const {
   stream << "expressions: ";
   for (auto i = 0; i < projections_.size(); i++) {
     auto& projection = projections_[i];
@@ -879,7 +879,7 @@ std::string truncate(const std::string& str, size_t maxLen = 50) {
 
 void appendProjections(
     const std::string& indentation,
-    const ProjectNode& op,
+    const AbstractProjectNode& op,
     const std::vector<size_t>& projections,
     size_t cnt,
     std::stringstream& stream) {
@@ -929,7 +929,7 @@ void appendExprSummary(
 
 } // namespace
 
-void ProjectNode::addSummaryDetails(
+void AbstractProjectNode::addSummaryDetails(
     const std::string& indentation,
     const PlanSummaryOptions& options,
     std::stringstream& stream) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -456,9 +456,9 @@ class FilterNode : public PlanNode {
   const TypedExprPtr filter_;
 };
 
-class ProjectNode : public PlanNode {
+class AbstractProjectNode : public PlanNode {
  public:
-  ProjectNode(
+  AbstractProjectNode(
       const PlanNodeId& id,
       std::vector<std::string>&& names,
       std::vector<TypedExprPtr>&& projections,
@@ -469,7 +469,7 @@ class ProjectNode : public PlanNode {
         projections_(std::move(projections)),
         outputType_(makeOutputType(names_, projections_)) {}
 
-  ProjectNode(
+  AbstractProjectNode(
       const PlanNodeId& id,
       const std::vector<std::string>& names,
       const std::vector<TypedExprPtr>& projections,
@@ -502,11 +502,7 @@ class ProjectNode : public PlanNode {
     return "Project";
   }
 
-  folly::dynamic serialize() const override;
-
-  static PlanNodePtr create(const folly::dynamic& obj, void* context);
-
- private:
+ protected:
   void addDetails(std::stringstream& stream) const override;
 
   /// Append a summary of the plan node to 'stream'. Make sure to append full
@@ -535,6 +531,31 @@ class ProjectNode : public PlanNode {
   const std::vector<std::string> names_;
   const std::vector<TypedExprPtr> projections_;
   const RowTypePtr outputType_;
+};
+
+class ProjectNode : public AbstractProjectNode {
+ public:
+  ProjectNode(
+      const PlanNodeId& id,
+      std::vector<std::string>&& names,
+      std::vector<TypedExprPtr>&& projections,
+      PlanNodePtr source)
+      : AbstractProjectNode(
+            id,
+            std::move(names),
+            std::move(projections),
+            source) {}
+
+  ProjectNode(
+      const PlanNodeId& id,
+      const std::vector<std::string>& names,
+      const std::vector<TypedExprPtr>& projections,
+      PlanNodePtr source)
+      : AbstractProjectNode(id, names, projections, source) {}
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 };
 
 class TableScanNode : public PlanNode {


### PR DESCRIPTION
Used in subsequent parallel project node that specializes the ProjectNode summary functions.