### PR TITLE
misc: Add 1 to Type::hashKind() to reduce collisions

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -641,7 +641,7 @@ folly::dynamic RowType::serialize() const {
 }
 
 size_t Type::hashKind() const {
-  size_t hash = (int32_t)kind();
+  size_t hash = (int32_t)kind() + 1;
   for (auto& child : *this) {
     hash = hash * 31 + child->hashKind();
   }


### PR DESCRIPTION
Summary:
A users noted they were seeing a lot of collisions in Type::hashKind(). Although we don't
provide any guarantees here, the fact that BOOLEAN maps to 0 definitely increases the chances of collisions.

E.g. ROW({...}) where ... is any number of BOOLEANs will always hash to the same value.

Differential Revision: D72005465


