### PR TITLE
feat: Add function prefix flags in TraceReplayRunner

### DIFF
--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -99,6 +99,10 @@ DEFINE_uint64(
     0,
     "Specify the query memory capacity limit in GB. If it is zero, then there is no limit.");
 DEFINE_bool(copy_results, false, "Copy the replaying results.");
+DEFINE_string(
+    function_prefix,
+    "",
+    "Prefix for the scalar and aggregate functions.");
 
 namespace facebook::velox::tool::trace {
 namespace {
@@ -287,8 +291,8 @@ void TraceReplayRunner::init() {
   connector::hive::registerHivePartitionFunctionSerDe();
   connector::hive::HiveBucketProperty::registerSerDe();
 
-  functions::prestosql::registerAllScalarFunctions();
-  aggregate::prestosql::registerAllAggregateFunctions();
+  functions::prestosql::registerAllScalarFunctions(FLAGS_function_prefix);
+  aggregate::prestosql::registerAllAggregateFunctions(FLAGS_function_prefix);
   parse::registerTypeResolver();
 
   if (!facebook::velox::connector::hasConnectorFactory("hive")) {

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -38,6 +38,7 @@ DECLARE_uint64(query_memory_capacity_mb);
 DECLARE_double(driver_cpu_executor_hw_multiplier);
 DECLARE_string(memory_arbitrator_type);
 DECLARE_bool(copy_results);
+DECLARE_string(function_prefix);
 
 namespace facebook::velox::tool::trace {
 

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -328,13 +328,6 @@ TEST_F(HashJoinReplayerTest, partialDriverIds) {
 }
 
 TEST_F(HashJoinReplayerTest, runner) {
-  const auto planWithSplits = createPlan(
-      tableDir_,
-      core::JoinType::kInner,
-      probeKeys_,
-      buildKeys_,
-      probeInput_,
-      buildInput_);
   const auto testDir = TempDirectoryPath::create();
   const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
   std::shared_ptr<Task> task;


### PR DESCRIPTION
Add function prefix flags in `TraceReplayRunner` to support
adding function prefix for trace replay.

Resolve #12815 