### PR TITLE
feat: Index join constant filter condition support

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -34,7 +34,8 @@ void duplicateJoinKeyCheck(
 
 std::string getColumnName(const core::TypedExprPtr& typeExpr) {
   const auto field = core::TypedExprs::asFieldAccess(typeExpr);
-  VELOX_USER_CHECK(field->isInputColumn());
+  VELOX_CHECK_NOT_NULL(field);
+  VELOX_CHECK(field->isInputColumn());
   return field->name();
 }
 

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -33,9 +33,11 @@ class IndexLookupJoinTestBase
     std::vector<int64_t> maxKeys;
   };
 
-  facebook::velox::RowTypePtr concat(
+  static facebook::velox::RowTypePtr concat(
       const facebook::velox::RowTypePtr& a,
       const facebook::velox::RowTypePtr& b);
+
+  bool isFilter(const std::string& conditionSql) const;
 
   int getNumRows(const std::vector<int>& cardinalities);
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -29,6 +29,7 @@
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SignatureBinder.h"
+#include "velox/expression/VectorReaders.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/TypeResolver.h"
 
@@ -64,46 +65,6 @@ std::shared_ptr<HiveBucketProperty> buildHiveBucketProperty(
       bucketColumns,
       bucketTypes,
       sortBy);
-}
-
-core::IndexLookupConditionPtr parseJoinCondition(
-    const std::string& joinCondition,
-    const RowTypePtr& rowType,
-    const parse::ParseOptions& options,
-    memory::MemoryPool* pool) {
-  const auto joinConditionExpr =
-      parseExpr(joinCondition, rowType, options, pool);
-  const auto typedCallExpr =
-      std::dynamic_pointer_cast<const core::CallTypedExpr>(joinConditionExpr);
-  VELOX_CHECK_NOT_NULL(typedCallExpr);
-  if (typedCallExpr->name() == "contains") {
-    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 2);
-    auto keyColumnExpr =
-        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-            typedCallExpr->inputs()[1]);
-    VELOX_CHECK_NOT_NULL(keyColumnExpr);
-    auto conditionColumnExpr =
-        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-            typedCallExpr->inputs()[0]);
-    VELOX_CHECK_NOT_NULL(conditionColumnExpr);
-    return std::make_shared<core::InIndexLookupCondition>(
-        std::move(keyColumnExpr), std::move(conditionColumnExpr));
-  }
-
-  if (typedCallExpr->name() == "between") {
-    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 3);
-    auto keyColumnExpr =
-        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-            typedCallExpr->inputs()[0]);
-    VELOX_CHECK_NOT_NULL(keyColumnExpr);
-    const auto& lowerExpr = typedCallExpr->inputs()[1];
-    const auto& upperExpr = typedCallExpr->inputs()[2];
-    return std::make_shared<core::BetweenIndexLookupCondition>(
-        std::move(keyColumnExpr), lowerExpr, upperExpr);
-  }
-  VELOX_USER_FAIL(
-      "Invalid index join condition: {}, and we only support in and between conditions",
-      joinCondition);
 }
 } // namespace
 
@@ -1618,6 +1579,191 @@ PlanBuilder& PlanBuilder::nestedLoopJoin(
   return *this;
 }
 
+namespace {
+core::TypedExprPtr removeCastTypedExpr(const core::TypedExprPtr& expr) {
+  core::TypedExprPtr convertedTypedExpr = expr;
+  while (auto castTypedExpr =
+             std::dynamic_pointer_cast<const core::CastTypedExpr>(
+                 convertedTypedExpr)) {
+    VELOX_CHECK_EQ(castTypedExpr->inputs().size(), 1);
+    convertedTypedExpr = castTypedExpr->inputs()[0];
+  }
+  return convertedTypedExpr;
+}
+
+template <TypeKind SrcKind, TypeKind DstKind>
+core::TypedExprPtr castConstantArrayConditionInput(
+    const core::ConstantTypedExprPtr& constantExpr) {
+  if (SrcKind == DstKind) {
+    return constantExpr;
+  }
+
+  auto srcVector = constantExpr->valueVector();
+  BaseVector::flattenVector(srcVector);
+  auto* srcArrayVector = srcVector->asChecked<velox::ArrayVector>();
+  VELOX_CHECK_EQ(srcArrayVector->size(), 1);
+  using SrcCppType = typename velox::TypeTraits<SrcKind>::NativeType;
+  auto* srcValueVector = srcArrayVector->elements()->asFlatVector<SrcCppType>();
+
+  const auto dstType = createScalarType(DstKind);
+  auto dstValueVector = BaseVector::create(
+      dstType, srcValueVector->size(), srcArrayVector->pool());
+  using DstCppType = typename velox::TypeTraits<DstKind>::NativeType;
+  auto* dstFlatValueVector =
+      dstValueVector->template asFlatVector<DstCppType>();
+
+  velox::DecodedVector decodedSrcValueVector{*srcValueVector};
+  velox::exec::VectorReader<SrcCppType> srcValueReader{&decodedSrcValueVector};
+  for (auto row = 0; row < srcValueVector->size(); ++row) {
+    const auto value = srcValueReader[row];
+    dstFlatValueVector->set(row, static_cast<DstCppType>(value));
+  }
+  auto dstArrayVector = std::make_shared<ArrayVector>(
+      srcArrayVector->pool(),
+      ARRAY(dstType),
+      nullptr,
+      1,
+      srcArrayVector->offsets(),
+      srcArrayVector->sizes(),
+      dstValueVector);
+  return std::make_shared<core::ConstantTypedExpr>(dstArrayVector);
+}
+
+template <TypeKind SrcKind, TypeKind DstKind>
+core::TypedExprPtr castConstantConditionInput(
+    const core::ConstantTypedExprPtr& constantExpr) {
+  if (SrcKind == DstKind) {
+    return constantExpr;
+  }
+  const auto dstType = createScalarType(DstKind);
+  return std::make_shared<core::ConstantTypedExpr>(
+      dstType,
+      static_cast<typename TypeTraits<DstKind>::NativeType>(
+          constantExpr->value().value<SrcKind>()));
+}
+
+template <TypeKind Kind>
+core::TypedExprPtr castIndexConditionInputExpr(const core::TypedExprPtr& expr) {
+  core::TypedExprPtr convertedTypedExpr = removeCastTypedExpr(expr);
+  if (std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+          convertedTypedExpr)) {
+    VELOX_CHECK(
+        convertedTypedExpr->type()->kind() == Kind ||
+        std::dynamic_pointer_cast<const ArrayType>(convertedTypedExpr->type())
+                ->elementType()
+                ->kind() == Kind);
+    return convertedTypedExpr;
+  }
+
+  const auto constantTypedExpr =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+          convertedTypedExpr);
+  VELOX_CHECK_NOT_NULL(constantTypedExpr, "{}", expr->toString());
+
+  if (constantTypedExpr->type()->isArray()) {
+    const auto arrayType =
+        std::dynamic_pointer_cast<const ArrayType>(constantTypedExpr->type());
+    if (arrayType->elementType()->kind() == Kind) {
+      return constantTypedExpr;
+    }
+    switch (arrayType->elementType()->kind()) {
+      case TypeKind::INTEGER:
+        return castConstantArrayConditionInput<TypeKind::INTEGER, Kind>(
+            constantTypedExpr);
+      case TypeKind::BIGINT:
+        return castConstantArrayConditionInput<TypeKind::BIGINT, Kind>(
+            constantTypedExpr);
+      case TypeKind::SMALLINT:
+        return castConstantArrayConditionInput<TypeKind::SMALLINT, Kind>(
+            constantTypedExpr);
+      default:
+        VELOX_UNSUPPORTED(
+            "Incompatible condition input type: {}, index column kind: {}",
+            constantTypedExpr->type()->toString(),
+            Kind);
+    }
+  }
+
+  if (constantTypedExpr->type()->kind() == Kind) {
+    return convertedTypedExpr;
+  }
+
+  switch (constantTypedExpr->type()->kind()) {
+    case TypeKind::INTEGER:
+      return castConstantConditionInput<TypeKind::INTEGER, Kind>(
+          constantTypedExpr);
+    case TypeKind::BIGINT:
+      return castConstantConditionInput<TypeKind::BIGINT, Kind>(
+          constantTypedExpr);
+    case TypeKind::SMALLINT:
+      return castConstantConditionInput<TypeKind::SMALLINT, Kind>(
+          constantTypedExpr);
+    default:
+      VELOX_UNSUPPORTED(
+          "Incompatible condition input type: {}, index column kind: {}",
+          constantTypedExpr->type()->toString(),
+          Kind);
+  }
+}
+
+core::TypedExprPtr castIndexConditionInputExpr(
+    const core::TypedExprPtr& expr,
+    const TypePtr& indexType) {
+  switch (indexType->kind()) {
+    case TypeKind::INTEGER:
+      return castIndexConditionInputExpr<TypeKind::INTEGER>(expr);
+    case TypeKind::BIGINT:
+      return castIndexConditionInputExpr<TypeKind::BIGINT>(expr);
+    case TypeKind::SMALLINT:
+      return castIndexConditionInputExpr<TypeKind::SMALLINT>(expr);
+    default:
+      VELOX_UNSUPPORTED("Unsupported index column kind: {}", expr->toString());
+  }
+}
+} // namespace
+
+// static
+core::IndexLookupConditionPtr PlanBuilder::parseIndexJoinCondition(
+    const std::string& joinCondition,
+    const RowTypePtr& rowType,
+    memory::MemoryPool* pool) {
+  const auto joinConditionExpr =
+      parseExpr(joinCondition, rowType, parse::ParseOptions{}, pool);
+  const auto typedCallExpr =
+      std::dynamic_pointer_cast<const core::CallTypedExpr>(joinConditionExpr);
+  VELOX_CHECK_NOT_NULL(typedCallExpr);
+  if (typedCallExpr->name() == "contains") {
+    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 2);
+    const auto keyColumnExpr =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            removeCastTypedExpr(typedCallExpr->inputs()[1]));
+    VELOX_CHECK_NOT_NULL(
+        keyColumnExpr, "{}", typedCallExpr->inputs()[1]->toString());
+    return std::make_shared<core::InIndexLookupCondition>(
+        keyColumnExpr,
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[0], keyColumnExpr->type()));
+  }
+
+  if (typedCallExpr->name() == "between") {
+    VELOX_CHECK_EQ(typedCallExpr->inputs().size(), 3);
+    const auto keyColumnExpr =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+            removeCastTypedExpr(typedCallExpr->inputs()[0]));
+    VELOX_CHECK_NOT_NULL(
+        keyColumnExpr, "{}", typedCallExpr->inputs()[0]->toString());
+    return std::make_shared<core::BetweenIndexLookupCondition>(
+        keyColumnExpr,
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[1], keyColumnExpr->type()),
+        castIndexConditionInputExpr(
+            typedCallExpr->inputs()[2], keyColumnExpr->type()));
+  }
+  VELOX_USER_FAIL(
+      "Invalid index join condition: {}, and we only support in and between conditions",
+      joinCondition);
+}
+
 PlanBuilder& PlanBuilder::indexLookupJoin(
     const std::vector<std::string>& leftKeys,
     const std::vector<std::string>& rightKeys,
@@ -1636,7 +1782,7 @@ PlanBuilder& PlanBuilder::indexLookupJoin(
   joinConditionPtrs.reserve(joinConditions.size());
   for (const auto& joinCondition : joinConditions) {
     joinConditionPtrs.push_back(
-        parseJoinCondition(joinCondition, inputType, options_, pool_));
+        parseIndexJoinCondition(joinCondition, inputType, pool_));
   }
 
   planNode_ = std::make_shared<core::IndexLookupJoinNode>(

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1124,13 +1124,18 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 
+  static core::IndexLookupConditionPtr parseIndexJoinCondition(
+      const std::string& joinCondition,
+      const RowTypePtr& rowType,
+      memory::MemoryPool* pool);
+
   /// Add an IndexLoopJoinNode to join two inputs using one or more join keys
   /// plus optional join conditions. First input comes from the preceding plan
   /// node. Second input is specified in 'right' parameter and must be a
   /// table source with the connector table handle with index lookup support.
   ///
   /// @param right The right input source with index lookup support.
-  /// @param joinCondition SQL expressions as the join conditions. Each join
+  /// @param joinConditions SQL expressions as the join conditions. Each join
   /// condition must use columns from both sides. For the right side, it can
   /// only use one index column. Currently we support "in" and "between" join
   /// conditions:
@@ -1148,7 +1153,7 @@ class PlanBuilder {
       const std::vector<std::string>& leftKeys,
       const std::vector<std::string>& rightKeys,
       const core::TableScanNodePtr& right,
-      const std::vector<std::string>& joinCondition,
+      const std::vector<std::string>& joinConditions,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 


### PR DESCRIPTION
Summary:
Add constant filter support in ss connector. Also improve the plan builder utility that generate a join/filter condition
from sql text using duckdb parser which actually generate expression with unnecessary data type casting.

Differential Revision: D71954999


