### PR TITLE
feat: Add ColumnReaderOptions

### DIFF
--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -70,4 +70,11 @@ std::string_view toString(FileFormat fmt) {
   }
 }
 
+ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options) {
+  ColumnReaderOptions columnReaderOptions;
+  columnReaderOptions.useColumnNamesForColumnMapping_ =
+      options.useColumnNamesForColumnMapping();
+  return columnReaderOptions;
+}
+
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -681,6 +681,15 @@ struct WriterOptions {
   virtual ~WriterOptions() = default;
 };
 
+// Options for creating a column reader.
+struct ColumnReaderOptions {
+  // Whether to map table field names to file field names using names, not
+  // indices.
+  bool useColumnNamesForColumnMapping_{false};
+};
+
+ColumnReaderOptions makeColumnReaderOptions(const ReaderOptions& options);
+
 } // namespace facebook::velox::dwio::common
 
 template <>

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -176,6 +176,8 @@ class DwrfRowReader : public StrideIndexProvider,
   std::unique_ptr<dwio::common::UnitLoader> getUnitLoader();
 
   const dwio::common::RowReaderOptions options_;
+  dwio::common::ColumnReaderOptions columnReaderOptions_;
+
   // column selector
   const std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;
   const std::function<void(std::chrono::high_resolution_clock::duration)>

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -60,6 +60,7 @@ std::unique_ptr<SelectiveColumnReader> buildIntegerReader(
 
 // static
 std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
@@ -90,16 +91,16 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
           requestedType, fileType, params, SHORT_BYTE_SIZE, scanSpec);
     case TypeKind::ARRAY:
       return std::make_unique<SelectiveListColumnReader>(
-          requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec);
     case TypeKind::MAP:
       if (stripe.format() == DwrfFormat::kDwrf &&
           stripe.getEncoding(ek).kind() ==
               proto::ColumnEncoding_Kind_MAP_FLAT) {
         return createSelectiveFlatMapColumnReader(
-            requestedType, fileType, params, scanSpec);
+            columnReaderOptions, requestedType, fileType, params, scanSpec);
       }
       return std::make_unique<SelectiveMapColumnReader>(
-          requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec);
     case TypeKind::REAL:
       if (requestedType->kind() == TypeKind::REAL) {
         return std::make_unique<
@@ -116,7 +117,12 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
           requestedType, fileType, params, scanSpec);
     case TypeKind::ROW:
       return std::make_unique<SelectiveStructColumnReader>(
-          requestedType, fileType, params, scanSpec, isRoot);
+          columnReaderOptions,
+          requestedType,
+          fileType,
+          params,
+          scanSpec,
+          isRoot);
     case TypeKind::BOOLEAN:
       return std::make_unique<SelectiveByteRleColumnReader>(
           requestedType, fileType, params, scanSpec, true);

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -26,6 +26,7 @@ namespace facebook::velox::dwrf {
 class SelectiveDwrfReader {
  public:
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
@@ -35,6 +36,7 @@ class SelectiveDwrfReader {
   /// Compatibility wrapper for tests. Takes the components of DwrfParams as
   /// separate.
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
@@ -44,7 +46,13 @@ class SelectiveDwrfReader {
       FlatMapContext flatMapContext = {},
       bool isRoot = false) {
     auto params = DwrfParams(stripe, streamLabels, stats, flatMapContext);
-    return build(requestedType, fileType, params, *scanSpec, isRoot);
+    return build(
+        columnReaderOptions,
+        requestedType,
+        fileType,
+        params,
+        *scanSpec,
+        isRoot);
   }
 };
 

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.h
@@ -23,6 +23,7 @@ namespace facebook::velox::dwrf {
 
 std::unique_ptr<dwio::common::SelectiveColumnReader>
 createSelectiveFlatMapColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams&,

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -49,6 +49,7 @@ FlatMapContext flatMapContextFromEncodingKey(const EncodingKey& encodingKey) {
 }
 
 SelectiveListColumnReader::SelectiveListColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
@@ -75,11 +76,16 @@ SelectiveListColumnReader::SelectiveListColumnReader(
       params.runtimeStatistics(),
       flatMapContextFromEncodingKey(encodingKey));
   child_ = SelectiveDwrfReader::build(
-      childType, fileType_->childAt(0), childParams, *scanSpec_->children()[0]);
+      columnReaderOptions,
+      childType,
+      fileType_->childAt(0),
+      childParams,
+      *scanSpec_->children()[0]);
   children_ = {child_.get()};
 }
 
 SelectiveMapColumnReader::SelectiveMapColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
@@ -108,6 +114,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       params.runtimeStatistics(),
       flatMapContextFromEncodingKey(encodingKey));
   keyReader_ = SelectiveDwrfReader::build(
+      columnReaderOptions,
       keyType,
       fileType_->childAt(0),
       keyParams,
@@ -120,6 +127,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       params.runtimeStatistics(),
       flatMapContextFromEncodingKey(encodingKey));
   elementReader_ = SelectiveDwrfReader::build(
+      columnReaderOptions,
       valueType,
       fileType_->childAt(1),
       elementParams,

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -28,6 +28,7 @@ class SelectiveListColumnReader
     : public dwio::common::SelectiveListColumnReader {
  public:
   SelectiveListColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
@@ -61,6 +62,7 @@ class SelectiveListColumnReader
 class SelectiveMapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   SelectiveMapColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -24,6 +24,7 @@ namespace facebook::velox::dwrf {
 using namespace dwio::common;
 
 SelectiveStructColumnReader::SelectiveStructColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const TypeWithId>& fileType,
     DwrfParams& params,
@@ -86,7 +87,11 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
             .inMapDecoder = nullptr,
             .keySelectionCallback = nullptr});
     addChild(SelectiveDwrfReader::build(
-        childRequestedType, childFileType, childParams, *childSpec));
+        columnReaderOptions,
+        childRequestedType,
+        childFileType,
+        childParams,
+        *childSpec));
     childSpec->setSubscript(children_.size() - 1);
   }
 }

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -81,6 +81,7 @@ class SelectiveStructColumnReaderBase
 class SelectiveStructColumnReader : public SelectiveStructColumnReaderBase {
  public:
   SelectiveStructColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -144,7 +144,9 @@ class ColumnReaderTestBase {
         scanSpec = scanSpec_.get();
       }
       makeFieldSpecs("", 0, rowType, scanSpec);
+      dwio::common::ColumnReaderOptions columnReaderOptions;
       selectiveColumnReader_ = SelectiveDwrfReader::build(
+          columnReaderOptions,
           cs.getSchema(),
           fileTypeWithId,
           streams_,

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -34,6 +34,7 @@ namespace facebook::velox::parquet {
 
 // static
 std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
@@ -58,7 +59,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(
-          requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec);
 
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
@@ -66,11 +67,11 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::ARRAY:
       return std::make_unique<ListColumnReader>(
-          requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec);
 
     case TypeKind::MAP:
       return std::make_unique<MapColumnReader>(
-          requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec);
 
     case TypeKind::BOOLEAN:
       return std::make_unique<BooleanColumnReader>(

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/parquet/reader/ParquetData.h"
 
 namespace facebook::velox::parquet {
@@ -42,6 +43,7 @@ class ParquetColumnReader {
   /// Builds a reader tree producing 'fileType'. The metadata is in 'params'.
   /// The filters and pruning are in 'scanSpec'.
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -67,6 +67,10 @@ class ReaderBase {
     return FileMetaDataPtr(reinterpret_cast<const void*>(fileMetaData_.get()));
   }
 
+  const dwio::common::ReaderOptions& options() const {
+    return options_;
+  }
+
   const std::shared_ptr<const RowType>& schema() const {
     return schema_;
   }
@@ -1062,6 +1066,7 @@ class ParquetRowReader::Impl {
     requestedType_ = options_.requestedType() ? options_.requestedType()
                                               : readerBase_->schema();
     columnReader_ = ParquetColumnReader::build(
+        columnReaderOptions_,
         requestedType_,
         readerBase_->schemaWithId(), // Id is schema id
         params,
@@ -1075,6 +1080,9 @@ class ParquetRowReader::Impl {
       // table scan.
       advanceToNextRowGroup();
     }
+
+    columnReaderOptions_ =
+        dwio::common::makeColumnReaderOptions(readerBase_->options());
   }
 
   void filterRowGroups() {
@@ -1209,6 +1217,7 @@ class ParquetRowReader::Impl {
   memory::MemoryPool& pool_;
   const std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::RowReaderOptions options_;
+  dwio::common::ColumnReaderOptions columnReaderOptions_;
 
   // All row groups from file metadata.
   std::vector<thrift::RowGroup>& rowGroups_;

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -110,6 +110,7 @@ void ensureRepDefs(
 }
 
 MapColumnReader::MapColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
@@ -123,9 +124,17 @@ MapColumnReader::MapColumnReader(
   auto& keyChildType = requestedType->childAt(0);
   auto& elementChildType = requestedType->childAt(1);
   keyReader_ = ParquetColumnReader::build(
-      keyChildType, fileType_->childAt(0), params, *scanSpec.children()[0]);
+      columnReaderOptions,
+      keyChildType,
+      fileType_->childAt(0),
+      params,
+      *scanSpec.children()[0]);
   elementReader_ = ParquetColumnReader::build(
-      elementChildType, fileType_->childAt(1), params, *scanSpec.children()[1]);
+      columnReaderOptions,
+      elementChildType,
+      fileType_->childAt(1),
+      params,
+      *scanSpec.children()[1]);
   reinterpret_cast<const ParquetTypeWithId*>(fileType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {keyReader_.get(), elementReader_.get()};
@@ -219,6 +228,7 @@ void MapColumnReader::filterRowGroups(
 }
 
 ListColumnReader::ListColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
@@ -230,7 +240,11 @@ ListColumnReader::ListColumnReader(
           scanSpec) {
   auto& childType = requestedType->childAt(0);
   child_ = ParquetColumnReader::build(
-      childType, fileType_->childAt(0), params, *scanSpec.children()[0]);
+      columnReaderOptions,
+      childType,
+      fileType_->childAt(0),
+      params,
+      *scanSpec.children()[0]);
   reinterpret_cast<const ParquetTypeWithId*>(fileType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {child_.get()};

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SelectiveRepeatedColumnReader.h"
 #include "velox/dwio/parquet/reader/ParquetData.h"
 
@@ -56,6 +57,7 @@ class RepeatedLengths {
 class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   MapColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
@@ -112,6 +114,7 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
 class ListColumnReader : public dwio::common::SelectiveListColumnReader {
  public:
   ListColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -27,6 +27,7 @@ class ScanSpec;
 namespace facebook::velox::parquet {
 
 StructColumnReader::StructColumnReader(
+    const dwio::common::ColumnReaderOptions& columnReaderOptions,
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
@@ -46,7 +47,11 @@ StructColumnReader::StructColumnReader(
     auto childRequestedType =
         requestedType_->asRow().findChild(childSpec->fieldName());
     addChild(ParquetColumnReader::build(
-        childRequestedType, childFileType, params, *childSpec));
+        columnReaderOptions,
+        childRequestedType,
+        childFileType,
+        params,
+        *childSpec));
 
     childSpecs[i]->setSubscript(children_.size() - 1);
   }

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/dwio/parquet/common/LevelConversion.h"
 
@@ -32,6 +33,7 @@ class ParquetParams;
 class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
  public:
   StructColumnReader(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,


### PR DESCRIPTION
This PR adds column reader options created from reader options, and pass it to 
the Parquet and Dwrf column readers. This allows customization of the column 
readers based on the options.