### PR TITLE
Mark TDigest Value at Quantile as non-deterministic

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -85,13 +85,6 @@ int main(int argc, char** argv) {
       "cardinality",
       "element_at",
       "width_bucket",
-      // Fuzzer and the underlying engine are confused about TDigest functions
-      // (since TDigest is a user defined type), and tries to pass a
-      // VARBINARY (since TDigest's implementation uses an
-      // alias to VARBINARY).
-      "value_at_quantile",
-      "values_at_quantiles",
-      "merge_tdigest",
       // Fuzzer cannot generate valid 'comparator' lambda.
       "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
       "split_to_map(varchar,varchar,varchar,function(varchar,varchar,varchar,varchar)) -> map(varchar,varchar)",

--- a/velox/functions/prestosql/TDigestFunctions.h
+++ b/velox/functions/prestosql/TDigestFunctions.h
@@ -25,6 +25,8 @@ namespace facebook::velox::functions {
 template <typename T>
 struct ValueAtQuantileFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr bool is_deterministic = false;
+
   FOLLY_ALWAYS_INLINE void call(
       out_type<double>& result,
       const arg_type<SimpleTDigest<double>>& input,
@@ -40,6 +42,7 @@ struct ValueAtQuantileFunction {
 template <typename T>
 struct ValuesAtQuantilesFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr bool is_deterministic = false;
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Array<double>>& result,
@@ -59,6 +62,8 @@ struct ValuesAtQuantilesFunction {
 template <typename T>
 struct MergeTDigestFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr bool is_deterministic = false;
+
   FOLLY_ALWAYS_INLINE bool call(
       out_type<SimpleTDigest<double>>& result,
       const arg_type<Array<SimpleTDigest<double>>>& input) {


### PR DESCRIPTION
Summary:
- Value at Quantile, Values at Quantiles, Merge T-Digest are scalar functions that are not deterministic 
- Add determinism flag to functions, and remove from skip list

- Test Suite - Determinism = No
https://www.internalfb.com/intern/presto/verifier/results/?test_id=214605
https://www.internalfb.com/intern/presto/verifier/results/?test_id=214605
 
- Mark it as non-deterministic and remove from Fuzzer skip function list

Differential Revision: D72011902


