### PR TITLE
feat: Add unknown to map union sum

### DIFF
--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -290,6 +290,11 @@ struct AccumulatorTypeTraits<ComplexType, V> {
   using AccumulatorType = ComplexTypeAccumulator<V>;
 };
 
+template <typename S>
+struct AccumulatorTypeTraits<UnknownValue, S> {
+  using AccumulatorType = Accumulator<int32_t, S>;
+};
+
 // Defines common aggregator.
 template <typename K, typename S>
 class MapUnionSumAggregate : public exec::Aggregate {
@@ -487,20 +492,14 @@ void registerMapUnionSumAggregate(
     bool withCompanionFunctions,
     bool overwrite) {
   const std::vector<std::string> valueTypes = {
-      "tinyint",
-      "smallint",
-      "integer",
-      "bigint",
-      "double",
-      "real",
-  };
+      "tinyint", "smallint", "integer", "bigint", "double", "real"};
 
   // Add all allowed signatures.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (auto valueType : valueTypes) {
     signatures.push_back(
         exec::AggregateFunctionSignatureBuilder()
-            .comparableTypeVariable("K")
+            .typeVariable("K")
             .returnType(fmt::format("map(K,{})", valueType))
             .intermediateType(fmt::format("map(K,{})", valueType))
             .argumentType(fmt::format("map(K,{})", valueType))
@@ -554,6 +553,9 @@ void registerMapUnionSumAggregate(
           case TypeKind::MAP:
           case TypeKind::ROW:
             return createMapUnionSumAggregate<ComplexType>(
+                valueTypeKind, resultType);
+          case TypeKind::UNKNOWN:
+            return createMapUnionSumAggregate<UnknownValue>(
                 valueTypeKind, resultType);
           default:
             VELOX_UNREACHABLE(

--- a/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
@@ -552,4 +552,8 @@ TEST_F(MapUnionSumTest, complexType) {
       {data}, {"c1"}, {"map_union_sum(c0)"}, {"a0", "c1"}, {expectedResult});
 }
 
+TEST_F(MapUnionSumTest, unknownKey) {
+  auto data = makeRowVector({makeAllNullMapVector(3, UNKNOWN(), BIGINT())});
+  testAggregations({data}, {}, {"map_union_sum(c0)"}, {"VALUES (NULL)"});
+}
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Add Unknown key support to Map Union Sum
Process Unknown key as int32_t similar to other Map aggregate function - https://www.internalfb.com/code/fbsource/[3373263d5d0a4cd2c7dee8a9a7c22d3c588aea90]/fbcode/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp?lines=666  (Unknown type doesn't work with aggregate logic like hash(), keys() etc)