### PR TITLE
fix: Fix float precision in rescaleFloatingPoint

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -233,7 +233,7 @@ class DecimalUtil {
 
     uint8_t digits;
     if constexpr (std::is_same_v<TInput, float>) {
-      // A float provides at least 7 digits are precise.
+      // A float provides nearly 7 precise digits.
       digits = 7;
     } else {
       // A double provides from 15 to 17 decimal digits, so at least 15 digits

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -233,9 +233,8 @@ class DecimalUtil {
 
     uint8_t digits;
     if constexpr (std::is_same_v<TInput, float>) {
-      // A float provides between 6 and 7 decimal digits, so at least 6 digits
-      // are precise.
-      digits = 6;
+      // A float provides at least 7 digits are precise.
+      digits = 7;
     } else {
       // A double provides from 15 to 17 decimal digits, so at least 15 digits
       // are precise.

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -486,6 +486,10 @@ TEST(DecimalTest, rescaleReal) {
 
   assertRescaleReal(std::numeric_limits<float>::min(), DECIMAL(38, 2), 0);
 
+  assertRescaleReal(27867.64, DECIMAL(18, 2), 2786764);
+  assertRescaleReal(27867.644, DECIMAL(18, 2), 2786764);
+  assertRescaleReal(27867.645, DECIMAL(18, 2), 2786765);
+
   // Test for overflows.
   std::vector<float> invalidInputs = {
       std::numeric_limits<float>::max(),

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -488,7 +488,7 @@ TEST(DecimalTest, rescaleReal) {
 
   assertRescaleReal(27867.64, DECIMAL(18, 2), 2786764);
   assertRescaleReal(27867.644, DECIMAL(18, 2), 2786764);
-  assertRescaleReal(27867.645, DECIMAL(18, 2), 2786765);
+  assertRescaleReal(27867.645, DECIMAL(18, 2), 2786764);
 
   // Test for overflows.
   std::vector<float> invalidInputs = {


### PR DESCRIPTION
This PR fixes float precision issue in rescaleFloatingPoint. 