### PR TITLE
refactor: Cleanup toConstantSql

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -45,6 +45,9 @@ std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
 std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
 
 /// Convert a constant expression into a SQL string.
+///
+/// Constant expressions of complex types, timestamp with timezone, interval,
+/// and decimal types are not supported yet.
 std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
 
 // Converts aggregate call expression into a SQL string.


### PR DESCRIPTION
Summary:
- Use std::quoted instead of custom code: https://en.cppreference.com/w/cpp/io/manip/quoted
- Reduce copy-paste.

Differential Revision: D72165464


