### PR TITLE
refactor: Harden is-null check in toConstantSql

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -102,6 +102,13 @@ class ConstantTypedExpr : public ITypedExpr {
     return valueVector_;
   }
 
+  bool isNull() const {
+    if (hasValueVector()) {
+      return valueVector_->isNullAt(0);
+    }
+    return value_.isNull();
+  }
+
   VectorPtr toConstantVector(memory::MemoryPool* pool) const {
     if (valueVector_) {
       return valueVector_;

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -259,7 +259,7 @@ std::string toConstantSql(const core::ConstantTypedExprPtr& constant) {
   const auto typeSql = toTypeSql(type);
 
   std::stringstream sql;
-  if (constant->toString() == "null") {
+  if (constant->isNull()) {
     // Syntax like BIGINT 'null' for typed null is not supported, so use cast
     // instead.
     sql << fmt::format("cast(null as {})", typeSql);

--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -45,6 +45,9 @@ std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
 std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
 
 /// Convert a constant expression into a SQL string.
+///
+/// Constant expressions of complex types, timestamp with timezone, interval,
+/// and decimal types are not supported yet.
 std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
 
 // Converts aggregate call expression into a SQL string.


### PR DESCRIPTION
Summary:
> constant->toString() == "null"

toString() API is not designed to return stable value and should not be used for anything other than logging and debugging.

Replace with constant->isNull().

Differential Revision: D72166016


