### PR TITLE
refactor: Capitalize types consistently in toTypeSql

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -102,6 +102,13 @@ class ConstantTypedExpr : public ITypedExpr {
     return valueVector_;
   }
 
+  bool isNull() const {
+    if (hasValueVector()) {
+      return valueVector_->isNullAt(0);
+    }
+    return value_.isNull();
+  }
+
   VectorPtr toConstantVector(memory::MemoryPool* pool) const {
     if (valueVector_) {
       return valueVector_;

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -30,32 +30,29 @@ void appendComma(int32_t i, std::stringstream& sql) {
 std::string toTypeSql(const TypePtr& type) {
   switch (type->kind()) {
     case TypeKind::ARRAY:
-      return fmt::format("array({})", toTypeSql(type->childAt(0)));
+      return fmt::format("ARRAY({})", toTypeSql(type->childAt(0)));
     case TypeKind::MAP:
       return fmt::format(
-          "map({}, {})",
+          "MAP({}, {})",
           toTypeSql(type->childAt(0)),
           toTypeSql(type->childAt(1)));
     case TypeKind::ROW: {
       const auto& rowType = type->asRow();
       std::stringstream sql;
-      sql << "row(";
+      sql << "ROW(";
       for (auto i = 0; i < type->size(); ++i) {
         appendComma(i, sql);
+        // TODO Field names may need to be quoted.
         sql << rowType.nameOf(i) << " " << toTypeSql(type->childAt(i));
       }
       sql << ")";
       return sql.str();
     }
     case TypeKind::VARCHAR:
-      if (isJsonType(type)) {
-        return "json";
-      } else {
-        return "varchar";
-      }
+      return isJsonType(type) ? "JSON" : "VARCHAR";
     default:
       if (type->isPrimitiveType()) {
-        return type->toString();
+        return mapTypeKindToName(type->kind());
       }
       VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
   }

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -259,7 +259,7 @@ std::string toConstantSql(const core::ConstantTypedExprPtr& constant) {
   const auto typeSql = toTypeSql(type);
 
   std::stringstream sql;
-  if (constant->toString() == "null") {
+  if (constant->isNull()) {
     // Syntax like BIGINT 'null' for typed null is not supported, so use cast
     // instead.
     sql << fmt::format("cast(null as {})", typeSql);

--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -45,6 +45,9 @@ std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
 std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
 
 /// Convert a constant expression into a SQL string.
+///
+/// Constant expressions of complex types, timestamp with timezone, interval,
+/// and decimal types are not supported yet.
 std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
 
 // Converts aggregate call expression into a SQL string.


### PR DESCRIPTION
Summary:
Before this change some types were all-caps, while other types were lowercase.

Use all-caps for types consistently.

DOUBLE '1.0' vs. varchar 'foo'

Differential Revision: D72166471


