### PR TITLE
fix: Fix potential hanging issue in case of a right/full join and empty build table

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -236,7 +236,7 @@ class NestedLoopJoinProbe : public Operator {
     return (buildIndex_ >= buildVectors_.value().size());
   }
 
-  /// Cross joins are translated into NLJ's without a join conditition.
+  // Cross joins are translated into NLJ's without a join conditition.
   bool isCrossJoin() const {
     return joinCondition_ == nullptr;
   }
@@ -276,7 +276,8 @@ class NestedLoopJoinProbe : public Operator {
     state_ = state;
   }
 
- private:
+  const core::JoinType joinType_;
+
   // Output buffer members.
 
   // Maximum number of rows in the output batch.
@@ -314,7 +315,6 @@ class NestedLoopJoinProbe : public Operator {
 
   // Join metadata and state.
   std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
-  const core::JoinType joinType_;
 
   ProbeOperatorState state_{ProbeOperatorState::kWaitForBuild};
   ContinueFuture future_{ContinueFuture::makeEmpty()};


### PR DESCRIPTION
Currently NLJ start mismatch build processing when receives no more input signal in noMoreInput()
or when advance the last probe input. We don't need mismatch build processing for right/full
join if the build side is empty. However, currently we only check that in advance probe input site
but not in noMoreInput(), this might cause potential hanging as the last probe wait expect all the probe
peers participate in the mismatch build processing wait

Differential Revision: D72147392


