### PR TITLE
refactor: Do not require shared_ptr in toConstantSql

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -348,16 +348,16 @@ std::optional<std::string> PrestoQueryRunner::toSql(
     } else if (
         auto cast =
             std::dynamic_pointer_cast<const core::CastTypedExpr>(projection)) {
-      sql << toCastSql(cast);
+      sql << toCastSql(*cast);
     } else if (
         auto concat = std::dynamic_pointer_cast<const core::ConcatTypedExpr>(
             projection)) {
-      sql << toConcatSql(concat);
+      sql << toConcatSql(*concat);
     } else if (
         auto constant =
             std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
                 projection)) {
-      sql << toConstantSql(constant);
+      sql << toConstantSql(*constant);
     } else {
       VELOX_NYI();
     }

--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -261,9 +261,18 @@ std::string toConstantSql(const core::ConstantTypedExprPtr& constant) {
     // instead.
     sql << fmt::format("cast(null as {})", typeSql);
   } else if (type->isVarchar() || type->isVarbinary()) {
+    std::string value;
+    if (constant->hasValueVector()) {
+      value = constant->valueVector()
+                  ->as<SimpleVector<StringView>>()
+                  ->valueAt(0)
+                  .getString();
+    } else {
+      value = constant->value().value<std::string>();
+    }
+
     // Escape single quote in string literals used in SQL texts.
-    sql << typeSql << " "
-        << std::quoted(constant->valueVector()->toString(0), '\'', '\'');
+    sql << typeSql << " " << std::quoted(value, '\'', '\'');
   } else if (type->isPrimitiveType()) {
     sql << fmt::format("{} '{}'", typeSql, constant->toString());
   } else {

--- a/velox/exec/fuzzer/ToSQLUtil.h
+++ b/velox/exec/fuzzer/ToSQLUtil.h
@@ -36,19 +36,16 @@ void toCallInputsSql(
 std::string toCallSql(const core::CallTypedExprPtr& call);
 
 /// Convert a cast expression into a SQL string.
-std::string toCastSql(const core::CastTypedExprPtr& cast);
+std::string toCastSql(const core::CastTypedExpr& cast);
 
 /// Convert a concat expression into a SQL string.
-std::string toConcatSql(const core::ConcatTypedExprPtr& concat);
-
-/// Convert a dereference expression into a SQL string.
-std::string toDereferenceSql(const core::DereferenceTypedExprPtr& dereference);
+std::string toConcatSql(const core::ConcatTypedExpr& concat);
 
 /// Convert a constant expression into a SQL string.
 ///
 /// Constant expressions of complex types, timestamp with timezone, interval,
 /// and decimal types are not supported yet.
-std::string toConstantSql(const core::ConstantTypedExprPtr& constant);
+std::string toConstantSql(const core::ConstantTypedExpr& constant);
 
 // Converts aggregate call expression into a SQL string.
 std::string toAggregateCallSql(


### PR DESCRIPTION
Summary:
toConstantSql and similar APIs do not need to require the caller to provide a shared_ptr. A reference is sufficient.

toDereferenceSql is not used outside of ToSQLUtil.cpp. Remove it from the header file to reduce (untested) API surface.

Differential Revision: D72191041


