### PR TITLE
build: Fix usage of declareNamed

### DIFF
--- a/velox/experimental/wave/exec/WaveGen.cpp
+++ b/velox/experimental/wave/exec/WaveGen.cpp
@@ -397,8 +397,9 @@ std::string CompileState::generateIsTrue(const AbstractOperand& op) {
       declareNamed(fmt::format("bool flag{};\n", ord));
       generated_ << fmt::format("flag{} = r{}", ord, ord);
     } else {
+      declareNamed(fmt::format("bool flag{};\n", ord));
       generated_ << fmt::format(
-          "bool flag{} = r{} && !isRegisterNull(nulls{}, {});\n",
+          "flag{} = r{} && !isRegisterNull(nulls{}, {});\n",
           ord,
           ord,
           ord / 32,
@@ -410,12 +411,12 @@ std::string CompileState::generateIsTrue(const AbstractOperand& op) {
     if (op.notNull || insideNullPropagating_) {
       declareNamed(fmt::format("bool flag{};\n", ord));
       generated_ << fmt::format(
-          "bool flag{} = nonNullOperand<bool, {}>(operands, {}, blockBase)",
+          "flag{} = nonNullOperand<bool, {}>(operands, {}, blockBase)",
           ord,
           mayWrap,
           ord);
     } else {
-      generated_ << fmt::format("bool flag{};\n", ord);
+      declareNamed(fmt::format("bool flag{};\n", ord));
       generated_ << fmt::format(
           "if (!valueOrNull<{}, bool>(operands, {}, blockBase, flags{})) {{ flags{} = false; }};\n",
           mayWrap ? "true" : "false",


### PR DESCRIPTION
Missing or incorrect usage of declareNamed causes compile failures with clang.