### PR TITLE
build: Use breeze prefetch API instead of PTX

### DIFF
--- a/velox/experimental/breeze/breeze/platforms/cuda.cuh
+++ b/velox/experimental/breeze/breeze/platforms/cuda.cuh
@@ -146,6 +146,8 @@ struct CudaSpecialization {
                                                    int num_bits);
   template <bool HIGH_PRIORITY>
   static __device__ __forceinline__ void scheduling_hint() {}
+  template <typename SliceT>
+  static __device__ __forceinline__ void prefetch(SliceT) {}
 };
 
 template <int CUDA_BLOCK_THREADS, int CUDA_WARP_THREADS>
@@ -264,6 +266,10 @@ struct CudaPlatform {
   template <bool HIGH_PRIORITY>
   __device__ __forceinline__ void scheduling_hint() {
     CudaSpecialization::scheduling_hint<HIGH_PRIORITY>();
+  }
+  template <typename SliceT>
+  __device__ __forceinline__ void prefetch(SliceT address) {
+    CudaSpecialization::prefetch(address);
   }
 };
 

--- a/velox/experimental/breeze/breeze/platforms/hip.hpp
+++ b/velox/experimental/breeze/breeze/platforms/hip.hpp
@@ -161,6 +161,8 @@ struct HipPlatform {
   }
   template <bool HIGH_PRIORITY>
   __device__ __forceinline__ void scheduling_hint() {}
+  template <typename SliceT>
+  __device__ __forceinline__ void prefetch(SliceT) {}
 };
 
 // specialization for T=unsigned

--- a/velox/experimental/breeze/breeze/platforms/metal.h
+++ b/velox/experimental/breeze/breeze/platforms/metal.h
@@ -282,6 +282,8 @@ struct MetalPlatform {
   }
   template <bool HIGH_PRIORITY>
   inline void scheduling_hint() {}
+  template <typename SliceT>
+  inline void prefetch(SliceT) {}
 
   uint thread_idx_;
   uint block_idx_;

--- a/velox/experimental/breeze/breeze/platforms/opencl.h
+++ b/velox/experimental/breeze/breeze/platforms/opencl.h
@@ -130,4 +130,6 @@ struct OpenCLPlatform {
   }
   template <bool HIGH_PRIORITY>
   inline void scheduling_hint() {}
+  template <typename SliceT>
+  inline void prefetch(SliceT) {}
 };

--- a/velox/experimental/breeze/breeze/platforms/openmp.h
+++ b/velox/experimental/breeze/breeze/platforms/openmp.h
@@ -417,6 +417,8 @@ struct OpenMPPlatform {
   }
   template <bool HIGH_PRIORITY>
   inline void scheduling_hint() {}
+  template <typename SliceT>
+  inline void prefetch(SliceT) {}
   int block_idx_;
   void *shared_scratch_;
 };

--- a/velox/experimental/breeze/breeze/platforms/specialization/cuda-ptx.cuh
+++ b/velox/experimental/breeze/breeze/platforms/specialization/cuda-ptx.cuh
@@ -68,3 +68,18 @@ __device__ __forceinline__ unsigned CudaSpecialization::extract_bits(
     unsigned value, int start_bit, int num_bits) {
   return BFE(value, start_bit, num_bits);
 }
+
+__device__ __forceinline__ void PREFETCH(void *ptr) {
+  asm("prefetch.global.L1 [%0];" ::"l"(ptr));
+}
+
+// specialization for T=Slice<GLOBAL, BLOCKED, unsigned long long>
+template <>
+__device__ __forceinline__ void
+CudaSpecialization::prefetch<breeze::utils::Slice<
+    breeze::utils::GLOBAL, breeze::utils::BLOCKED, unsigned long long>>(
+    breeze::utils::Slice<breeze::utils::GLOBAL, breeze::utils::BLOCKED,
+                         unsigned long long>
+        address) {
+  PREFETCH(address.data());
+}

--- a/velox/experimental/breeze/breeze/platforms/sycl.hpp
+++ b/velox/experimental/breeze/breeze/platforms/sycl.hpp
@@ -199,5 +199,7 @@ struct SyCLPlatform {
   }
   template <bool HIGH_PRIORITY>
   inline void scheduling_hint() {}
+  template <typename SliceT>
+  inline void prefetch(SliceT) {}
   cl::sycl::nd_item<1> work_item;
 };

--- a/velox/experimental/wave/CMakeLists.txt
+++ b/velox/experimental/wave/CMakeLists.txt
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use breeze PTX specialization by default for CUDA.
+if(NOT DEFINED CUDA_PLATFORM_SPECIALIZATION_HEADER)
+  set(CUDA_PLATFORM_SPECIALIZATION_HEADER
+      breeze/platforms/specialization/cuda-ptx.cuh
+      CACHE STRING "CUDA platform specialization header")
+endif()
+
+# Add header only library for breeze and CUDA platform.
+add_library(breeze_cuda INTERFACE)
+target_include_directories(breeze_cuda INTERFACE ../breeze)
+target_compile_definitions(
+  breeze_cuda
+  INTERFACE
+    PLATFORM_CUDA
+    CUDA_PLATFORM_SPECIALIZATION_HEADER=${CUDA_PLATFORM_SPECIALIZATION_HEADER})
+
 add_subdirectory(common)
 add_subdirectory(exec)
 add_subdirectory(vector)

--- a/velox/experimental/wave/common/tests/BreezeCudaTest.cu
+++ b/velox/experimental/wave/common/tests/BreezeCudaTest.cu
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-#define PLATFORM_CUDA
-
-// clang-format off
-#define CUDA_PLATFORM_SPECIALIZATION_HEADER \
-  breeze/platforms/specialization/cuda-ptx.cuh
-// clang-format on
-
 #include <breeze/functions/reduce.h>
 #include <breeze/platforms/platform.h>
 #include <breeze/utils/device_vector.h>

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -27,7 +27,6 @@ add_executable(
 add_test(velox_wave_common_test velox_wave_common_test)
 set_tests_properties(velox_wave_common_test PROPERTIES LABELS cuda_driver)
 
-target_include_directories(velox_wave_common_test PRIVATE ../../../breeze)
 if(VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST)
   target_compile_definitions(velox_wave_common_test
                              PRIVATE VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST=1)
@@ -38,4 +37,5 @@ target_link_libraries(
   xsimd
   GTest::gtest
   GTest::gtest_main
-  CUDA::cudart)
+  CUDA::cudart
+  breeze_cuda)

--- a/velox/experimental/wave/dwio/decode/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/CMakeLists.txt
@@ -17,4 +17,4 @@ add_subdirectory(tests)
 add_library(velox_wave_decode GpuDecoder.cu)
 
 target_link_libraries(
-  velox_wave_decode velox_wave_common CUDA::cudart)
+  velox_wave_decode velox_wave_common CUDA::cudart breeze_cuda)


### PR DESCRIPTION
No change in behavior. Just uses the same PTX code but behind the breeze platform API where it can be specialized to something else as needed.