### PR TITLE
feat: Makes sequence storage connector configurable

### DIFF
--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -168,6 +168,12 @@ These stats are reported only by IndexLookupJoin operator
      - nanos
      - The cpu time in nanoseconds that the index connector process response from storages
        client for followup processing by index join operator.
+   * - clientlookupWaitWallNanos
+     - nanos
+     - The walltime in nanoseconds that the storage client wait for the lookup from remote storage.
+   * - clientNumStorageRequests
+     - nanos
+     - The number of split requests sent to remote storage for a client lookup request.
    * - clientRequestProcessCpuNanos
      - nanos
      - The cpu time in nanoseconds that the storage client process request for remote

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -59,6 +59,10 @@ class IndexLookupJoin : public Operator {
   /// from remote storage.
   static inline const std::string kClientLookupWaitWallTime{
       "clientlookupWaitWallNanos"};
+  /// The number of split requests sent to remote storage for a client lookup
+  /// request.
+  static inline const std::string kClientNumStorageRequests{
+      "clientNumStorageRequests"};
   /// The cpu time in nanoseconds that the storage client process response from
   /// remote storage lookup such as decoding the response data into velox
   /// vectors.

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -343,4 +343,18 @@ bool IndexLookupJoinTestBase::isFilter(const std::string& conditionSql) const {
              conditionSql, inputType, pool_.get())
       ->isFilter();
 }
+
+std::shared_ptr<facebook::velox::exec::Task>
+IndexLookupJoinTestBase::runLookupQuery(
+    const facebook::velox::core::PlanNodePtr& plan,
+    int numPrefetchBatches,
+    const std::string& duckDbVefifySql) {
+  return facebook::velox::exec::test::AssertQueryBuilder(duckDbQueryRunner_)
+      .plan(plan)
+      .config(
+          facebook::velox::core::QueryConfig::
+              kIndexLookupJoinMaxPrefetchBatches,
+          std::to_string(numPrefetchBatches))
+      .assertResults(duckDbVefifySql);
+}
 } // namespace fecebook::velox::exec::test

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/core/PlanNode.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 
@@ -129,6 +130,11 @@ class IndexLookupJoinTestBase
   // column names.
   facebook::velox::RowTypePtr makeScanOutputType(
       std::vector<std::string> outputNames);
+
+  std::shared_ptr<facebook::velox::exec::Task> runLookupQuery(
+      const facebook::velox::core::PlanNodePtr& plan,
+      int numPrefetchBatches,
+      const std::string& duckDbVefifySql);
 
   facebook::velox::RowTypePtr keyType_;
   facebook::velox::RowTypePtr valueType_;


### PR DESCRIPTION
Summary:
Make sequence storage connector configurable through connector config.
And apply this to request key deduplication and add runtime stats for monitoring.

The followup is to set this in result adapter for fast path processing if request dedup is not
configured

Differential Revision: D72123739


