### PR TITLE
build: Fix template-id-cdtor compile warning on gcc 14

### DIFF
--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -115,7 +115,7 @@ struct ConstantVectorReader {
 
   std::optional<exec_in_t> value;
 
-  explicit ConstantVectorReader<T>(ConstantVector<exec_in_t>& vector) {
+  explicit ConstantVectorReader(ConstantVector<exec_in_t>& vector) {
     if (!vector.isNullAt(0)) {
       value = *vector.rawValues();
     }
@@ -160,7 +160,7 @@ struct FlatVectorReader {
   const exec_in_t* values;
   FlatVector<exec_in_t>* vector;
 
-  explicit FlatVectorReader<T>(FlatVector<exec_in_t>& baseVector)
+  explicit FlatVectorReader(FlatVector<exec_in_t>& baseVector)
       : values(baseVector.rawValues()), vector(&baseVector) {}
 
   exec_in_t operator[](vector_size_t offset) const {
@@ -733,8 +733,9 @@ struct VectorReader<DynamicRow> {
         vector_(detail::getDecoded<in_vector_t>(decoded_)),
         childrenDecoders_{vector_.childrenSize()} {
     for (int i = 0; i < vector_.childrenSize(); i++) {
-      childReaders_.push_back(std::make_unique<VectorReader<Any>>(
-          detail::decode(childrenDecoders_[i], *vector_.childAt(i))));
+      childReaders_.push_back(
+          std::make_unique<VectorReader<Any>>(
+              detail::decode(childrenDecoders_[i], *vector_.childAt(i))));
     }
   }
 

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -733,9 +733,8 @@ struct VectorReader<DynamicRow> {
         vector_(detail::getDecoded<in_vector_t>(decoded_)),
         childrenDecoders_{vector_.childrenSize()} {
     for (int i = 0; i < vector_.childrenSize(); i++) {
-      childReaders_.push_back(
-          std::make_unique<VectorReader<Any>>(
-              detail::decode(childrenDecoders_[i], *vector_.childAt(i))));
+      childReaders_.push_back(std::make_unique<VectorReader<Any>>(
+          detail::decode(childrenDecoders_[i], *vector_.childAt(i))));
     }
   }
 


### PR DESCRIPTION
When compiling with newer gcc versions, it gives the following compiling warnings:
```
../projects/velox-dev/./velox/expression/VectorReaders.h:163:32: note: remove the ‘< >’
In file included from ../projects/velox-dev/./velox/expression/SimpleFunctionAdapter.h:30,
                 from ../projects/velox-dev/./velox/expression/SimpleFunctionRegistry.h:21,
                 from ../projects/velox-dev/./velox/functions/Registerer.h:19,
                 from ../projects/velox-dev/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp:16:
../projects/velox-dev/./velox/expression/VectorReaders.h:118:36: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  118 |   explicit ConstantVectorReader<T>(ConstantVector<exec_in_t>& vector) {
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
../projects/velox-dev/./velox/expression/VectorReaders.h:118:36: note: remove the ‘< >’
../projects/velox-dev/./velox/expression/VectorReaders.h:163:32: warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
  163 |   explicit FlatVectorReader<T>(FlatVector<exec_in_t>& baseVector)
      |                                ^~~~~~~~~~~~~~~~~~~~~
../projects/velox-dev/./velox/expression/VectorReaders.h:163:32: note: remove the ‘< >’
```
Constructor like `ConstantVectorReader<T>()` is not valid any more in C++20, and gcc emits a warning although it is compiled with C++17.

This PR helps fix this warning, and not affected by the C++ versions.