### PR TITLE
fix(function): Fix Spark json_object_keys function to return NULL for invalid json

### DIFF
--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -84,3 +84,4 @@ JSON Functions
         SELECT json_object_keys(''); -- NULL
         SELECT json_object_keys(1); -- NULL
         SELECT json_object_keys('"hello"'); -- NULL
+        SELECT json_object_keys("invalid json"); -- NULL

--- a/velox/functions/sparksql/JsonObjectKeys.h
+++ b/velox/functions/sparksql/JsonObjectKeys.h
@@ -40,7 +40,6 @@ struct JsonObjectKeysFunction {
     }
 
     // The result is NULL if the given string is not a valid JSON string.
-    // such as "invalid json"
     if (isFatal(jsonDoc.type().error())) {
       return false;
     }

--- a/velox/functions/sparksql/JsonObjectKeys.h
+++ b/velox/functions/sparksql/JsonObjectKeys.h
@@ -39,6 +39,12 @@ struct JsonObjectKeysFunction {
       return false;
     }
 
+    // The result is NULL if the given string is not a valid JSON string.
+    // such as "invalid json"
+    if (isFatal(jsonDoc.type().error())) {
+      return false;
+    }
+
     // The result is NULL if the given string is not a JSON object string.
     if (jsonDoc.type() != simdjson::ondemand::json_type::object) {
       return false;

--- a/velox/functions/sparksql/tests/JsonObjectKeysTest.cpp
+++ b/velox/functions/sparksql/tests/JsonObjectKeysTest.cpp
@@ -40,6 +40,7 @@ TEST_F(JsonObjectKeysTest, basic) {
   expected = makeNullableArrayVector<std::string>({std::nullopt});
   assertEqualVectors(jsonObjectKeys(R"(1)"), expected);
   assertEqualVectors(jsonObjectKeys(R"("hello")"), expected);
+  assertEqualVectors(jsonObjectKeys(R"(invalid json)"), expected);
   assertEqualVectors(jsonObjectKeys(R"("")"), expected);
   assertEqualVectors(
       jsonObjectKeys(R"({"key": 45, "random_string"})"), expected);


### PR DESCRIPTION
This PR aims to fix Spark `json_object_keys` function to return NULL for invalid json.  

Relative test: https://github.com/apache/spark/blob/v3.5.0/sql/core/src/test/scala/org/apache/spark/sql/JsonFunctionsSuite.scala#L1390-L1399


Follow up #12671