### PR TITLE
Replaces 2x string.find(..) with custom one using optimized folly:memchr

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -674,7 +674,7 @@ bool matchSuffixPattern(
 bool matchSubstringPattern(
     const StringView& input,
     const std::string& fixedPattern) {
-    std::size_t found = facebook::velox::functions::stringCore::long_string_find(
+    std::size_t found = facebook::velox::functions::stringCore::longStringFind(
                             std::string_view(input), std::string_view(fixedPattern), (size_t)0);
   return found != std::string::npos;
 }

--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -312,7 +312,7 @@ cappedByteLengthUnicode(const char* input, size_t size, int64_t maxChars) {
   return utf8Position;
 }
 
-constexpr size_t long_string_find(
+constexpr size_t longStringFind(
     std::string_view str, const std::string_view substr, size_t start_pos
 ) noexcept
 {
@@ -362,7 +362,7 @@ static inline int64_t findNthInstanceByteIndexFromStart(
     return -1;
   }
 
-  auto byteIndex = long_string_find(string, subString, startPosition);
+  auto byteIndex = longStringFind(string, subString, startPosition);
   // Not found
   if (byteIndex == std::string_view::npos) {
     return -1;


### PR DESCRIPTION
This provides performance boost to two Like sub-benchmarks.
Depends on Folly PR: https://github.com/facebook/folly/pull/2409