### PR TITLE
fix: Make hash batch size configurable

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -25,6 +25,8 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/vector/VectorTypeUtils.h"
 
+DECLARE_int32(velox_hash_batch_size);
+
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
@@ -1031,7 +1033,7 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::partitionRows(
     HashTable<ignoreNullKeys>& subtable,
     RowPartitions& rowPartitions) {
-  constexpr int32_t kBatch = 1024;
+  int32_t kBatch = FLAGS_velox_hash_batch_size;
   raw_vector<char*> rows(kBatch);
   raw_vector<uint64_t> hashes(kBatch);
   raw_vector<uint8_t> partitions(kBatch);
@@ -1059,7 +1061,7 @@ void HashTable<ignoreNullKeys>::buildJoinPartition(
     uint8_t partition,
     const std::vector<std::unique_ptr<RowPartitions>>& rowPartitions,
     std::vector<char*>& overflow) {
-  constexpr int32_t kBatch = 1024;
+  int32_t kBatch = FLAGS_velox_hash_batch_size;
   raw_vector<char*> rows(kBatch);
   raw_vector<uint64_t> hashes(kBatch);
   const int32_t numPartitions = 1 + otherTables_.size();
@@ -1329,7 +1331,7 @@ void HashTable<ignoreNullKeys>::rehash(
     bool initNormalizedKeys,
     int8_t spillInputStartPartitionBit) {
   ++numRehashes_;
-  constexpr int32_t kHashBatchSize = 1024;
+  int32_t kHashBatchSize = FLAGS_velox_hash_batch_size;
   if (canApplyParallelJoinBuild()) {
     parallelJoinBuild();
     return;
@@ -1391,7 +1393,7 @@ void HashTable<ignoreNullKeys>::setHashMode(
 
 template <bool ignoreNullKeys>
 bool HashTable<ignoreNullKeys>::analyze() {
-  constexpr int32_t kHashBatchSize = 1024;
+  int32_t kHashBatchSize = FLAGS_velox_hash_batch_size;
   // @lint-ignore CLANGTIDY
   char* groups[kHashBatchSize];
   RowContainerIterator iterator;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -131,3 +131,8 @@ DEFINE_bool(
     velox_ssd_verify_write,
     false,
     "Read back data after writing to SSD");
+
+DEFINE_int32(
+    velox_hash_batch_size,
+    1024,
+    "Number of rows per batch used in preparing hash join table");


### PR DESCRIPTION
The hash batch size used in hash table building is hard-coded as `1024`. This patch make this parameter configurable so users can tune this for better performance. 
on my local env, "2048" is better on the micro benchmark

-1024
![image](https://github.com/user-attachments/assets/483ae66a-b277-438d-bc6c-fb26902d65af)

-2048
![image](https://github.com/user-attachments/assets/6ced4aee-0f2a-4c02-993f-b24e139f1802)
