### PR TITLE
feat: Add isSupportedCompression

### DIFF
--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -82,21 +82,29 @@ std::string compressionKindToString(CompressionKind kind) {
   return folly::to<std::string>("unknown - ", kind);
 }
 
+static const std::unordered_map<std::string, CompressionKind>
+    stringToCompressionKindMap = {
+        {"none", CompressionKind_NONE},
+        {"zlib", CompressionKind_ZLIB},
+        {"snappy", CompressionKind_SNAPPY},
+        {"lzo", CompressionKind_LZO},
+        {"zstd", CompressionKind_ZSTD},
+        {"lz4", CompressionKind_LZ4},
+        {"gzip", CompressionKind_GZIP}};
+
 CompressionKind stringToCompressionKind(const std::string& kind) {
-  static const std::unordered_map<std::string, CompressionKind>
-      stringToCompressionKindMap = {
-          {"none", CompressionKind_NONE},
-          {"zlib", CompressionKind_ZLIB},
-          {"snappy", CompressionKind_SNAPPY},
-          {"lzo", CompressionKind_LZO},
-          {"zstd", CompressionKind_ZSTD},
-          {"lz4", CompressionKind_LZ4},
-          {"gzip", CompressionKind_GZIP}};
-  auto iter = stringToCompressionKindMap.find(kind);
-  if (iter != stringToCompressionKindMap.end()) {
+  if (const auto iter = stringToCompressionKindMap.find(kind);
+      iter != stringToCompressionKindMap.end()) {
     return iter->second;
-  } else {
-    VELOX_UNSUPPORTED("Not support compression kind {}", kind);
   }
+  VELOX_UNSUPPORTED("Not support compression kind {}", kind);
+}
+
+bool isSupportedCompression(const std::string& kind) {
+  if (const auto iter = stringToCompressionKindMap.find(kind);
+      iter != stringToCompressionKindMap.end()) {
+    return true;
+  }
+  return false;
 }
 } // namespace facebook::velox::common

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -43,6 +43,8 @@ std::string compressionKindToString(CompressionKind kind);
 
 CompressionKind stringToCompressionKind(const std::string& kind);
 
+bool isSupportedCompression(const std::string& kind);
+
 constexpr uint64_t DEFAULT_COMPRESSION_BLOCK_SIZE = 256 * 1024;
 
 } // namespace facebook::velox::common

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -59,4 +59,15 @@ TEST_F(CompressionTest, stringToCompressionKind) {
   VELOX_ASSERT_THROW(
       stringToCompressionKind("bz2"), "Not support compression kind bz2");
 }
+
+TEST_F(CompressionTest, isSupportedCompression) {
+  EXPECT_EQ(isSupportedCompression("none"), true);
+  EXPECT_EQ(isSupportedCompression("zlib"), true);
+  EXPECT_EQ(isSupportedCompression("snappy"), true);
+  EXPECT_EQ(isSupportedCompression("lzo"), true);
+  EXPECT_EQ(isSupportedCompression("lz4"), true);
+  EXPECT_EQ(isSupportedCompression("zstd"), true);
+  EXPECT_EQ(isSupportedCompression("gzip"), true);
+  EXPECT_EQ(isSupportedCompression("bz2"), false);
+}
 } // namespace facebook::velox::common


### PR DESCRIPTION
We’re introducing support for mutiple compression codecs for Presto exchange in prestodb/presto#24670.
It is unnessary to cast the codec session property string to CompressionKind when creating the query context, but we do need to validate whether it is supported by Velox. To address this, I added the isSupportedCompression function in this PR.
A discussion is in https://github.com/prestodb/presto/pull/24670#discussion_r2015273633.