### PR TITLE
refactor: Update ReferenceQueryRunners to use PlanNodeVisitor to generate SQL

### DIFF
--- a/velox/exec/fuzzer/DuckQueryRunner.h
+++ b/velox/exec/fuzzer/DuckQueryRunner.h
@@ -60,23 +60,6 @@ class DuckQueryRunner : public ReferenceQueryRunner {
   execute(const core::PlanNodePtr& plan) override;
 
  private:
-  using ReferenceQueryRunner::toSql;
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::AggregationNode>& aggregationNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::WindowNode>& windowNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::ProjectNode>& projectNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::RowNumberNode>& rowNumberNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::TopNRowNumberNode>& topNRowNumberNode);
-
   std::unordered_set<std::string> aggregateFunctionNames_;
 };
 

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -107,25 +107,6 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
     return pool_.get();
   }
 
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const velox::core::AggregationNode>&
-          aggregationNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const velox::core::WindowNode>& windowNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const velox::core::ProjectNode>& projectNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const velox::core::RowNumberNode>& rowNumberNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::TopNRowNumberNode>& rowNumberNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
-
   std::string startQuery(
       const std::string& sql,
       const std::string& sessionProperty = "");

--- a/velox/exec/fuzzer/ReferenceQueryRunner.cpp
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.cpp
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <optional>
-#include <set>
 #include <unordered_map>
 
 #include "velox/core/PlanNode.h"
@@ -22,44 +20,6 @@
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 
 namespace facebook::velox::exec::test {
-
-namespace {
-
-std::string joinKeysToSql(
-    const std::vector<core::FieldAccessTypedExprPtr>& keys) {
-  std::vector<std::string> keyNames;
-  keyNames.reserve(keys.size());
-  for (const core::FieldAccessTypedExprPtr& key : keys) {
-    keyNames.push_back(key->name());
-  }
-  return folly::join(", ", keyNames);
-}
-
-std::string filterToSql(const core::TypedExprPtr& filter) {
-  auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(filter);
-  return toCallSql(call);
-}
-
-std::string joinConditionAsSql(const core::AbstractJoinNode& joinNode) {
-  std::stringstream out;
-  for (auto i = 0; i < joinNode.leftKeys().size(); ++i) {
-    if (i > 0) {
-      out << " AND ";
-    }
-    out << joinNode.leftKeys()[i]->name() << " = "
-        << joinNode.rightKeys()[i]->name();
-  }
-  if (joinNode.filter()) {
-    if (!joinNode.leftKeys().empty()) {
-      out << " AND ";
-    }
-    out << filterToSql(joinNode.filter());
-  }
-  return out.str();
-}
-
-} // namespace
-
 bool ReferenceQueryRunner::isSupportedDwrfType(const TypePtr& type) {
   if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
     return false;
@@ -79,7 +39,7 @@ ReferenceQueryRunner::getAllTables(const core::PlanNodePtr& plan) {
   std::unordered_map<std::string, std::vector<velox::RowVectorPtr>> result;
   if (const auto valuesNode =
           std::dynamic_pointer_cast<const core::ValuesNode>(plan)) {
-    result.insert({getTableName(valuesNode), valuesNode->values()});
+    result.insert({getTableName(*valuesNode), valuesNode->values()});
   } else {
     for (const auto& source : plan->sources()) {
       auto tablesAndNames = getAllTables(source);
@@ -88,160 +48,4 @@ ReferenceQueryRunner::getAllTables(const core::PlanNodePtr& plan) {
   }
   return result;
 }
-
-std::optional<std::string> ReferenceQueryRunner::joinSourceToSql(
-    const core::PlanNodePtr& planNode) {
-  const std::optional<std::string> subQuery = toSql(planNode);
-  if (subQuery) {
-    return subQuery->find(" ") != std::string::npos
-        ? fmt::format("({})", *subQuery)
-        : *subQuery;
-  }
-  return std::nullopt;
-}
-
-std::optional<std::string> ReferenceQueryRunner::toSql(
-    const core::ValuesNodePtr& valuesNode) {
-  if (!isSupportedDwrfType(valuesNode->outputType())) {
-    return std::nullopt;
-  }
-  return getTableName(valuesNode);
-}
-
-std::optional<std::string> ReferenceQueryRunner::toSql(
-    const core::TableScanNodePtr& tableScanNode) {
-  return tableScanNode->tableHandle()->name();
-}
-
-std::optional<std::string> ReferenceQueryRunner::toSql(
-    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
-  if (!isSupportedDwrfType(joinNode->sources()[0]->outputType()) ||
-      !isSupportedDwrfType(joinNode->sources()[1]->outputType())) {
-    return std::nullopt;
-  }
-
-  std::optional<std::string> probeTableName =
-      joinSourceToSql(joinNode->sources()[0]);
-  std::optional<std::string> buildTableName =
-      joinSourceToSql(joinNode->sources()[1]);
-  if (!probeTableName || !buildTableName) {
-    return std::nullopt;
-  }
-
-  const auto& outputNames = joinNode->outputType()->names();
-
-  std::stringstream sql;
-  if (joinNode->isLeftSemiProjectJoin()) {
-    sql << "SELECT "
-        << folly::join(", ", outputNames.begin(), --outputNames.end());
-  } else {
-    sql << "SELECT " << folly::join(", ", outputNames);
-  }
-
-  switch (joinNode->joinType()) {
-    case core::JoinType::kInner:
-      sql << " FROM " << *probeTableName << " INNER JOIN " << *buildTableName
-          << " ON " << joinConditionAsSql(*joinNode);
-      break;
-    case core::JoinType::kLeft:
-      sql << " FROM " << *probeTableName << " LEFT JOIN " << *buildTableName
-          << " ON " << joinConditionAsSql(*joinNode);
-      break;
-    case core::JoinType::kFull:
-      sql << " FROM " << *probeTableName << " FULL OUTER JOIN "
-          << *buildTableName << " ON " << joinConditionAsSql(*joinNode);
-      break;
-    case core::JoinType::kLeftSemiFilter:
-      // Multiple columns returned by a scalar subquery is not supported. A
-      // scalar subquery expression is a subquery that returns one result row
-      // from exactly one column for every input row.
-      if (joinNode->leftKeys().size() > 1) {
-        return std::nullopt;
-      }
-      sql << " FROM " << *probeTableName << " WHERE "
-          << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
-          << joinKeysToSql(joinNode->rightKeys()) << " FROM "
-          << *buildTableName;
-      if (joinNode->filter()) {
-        sql << " WHERE " << filterToSql(joinNode->filter());
-      }
-      sql << ")";
-      break;
-    case core::JoinType::kLeftSemiProject:
-      if (joinNode->isNullAware()) {
-        sql << ", " << joinKeysToSql(joinNode->leftKeys()) << " IN (SELECT "
-            << joinKeysToSql(joinNode->rightKeys()) << " FROM "
-            << *buildTableName;
-        if (joinNode->filter()) {
-          sql << " WHERE " << filterToSql(joinNode->filter());
-        }
-        sql << ") FROM " << *probeTableName;
-      } else {
-        sql << ", EXISTS (SELECT * FROM " << *buildTableName << " WHERE "
-            << joinConditionAsSql(*joinNode);
-        sql << ") FROM " << *probeTableName;
-      }
-      break;
-    case core::JoinType::kAnti:
-      if (joinNode->isNullAware()) {
-        sql << " FROM " << *probeTableName << " WHERE "
-            << joinKeysToSql(joinNode->leftKeys()) << " NOT IN (SELECT "
-            << joinKeysToSql(joinNode->rightKeys()) << " FROM "
-            << *buildTableName;
-        if (joinNode->filter()) {
-          sql << " WHERE " << filterToSql(joinNode->filter());
-        }
-        sql << ")";
-      } else {
-        sql << " FROM " << *probeTableName
-            << " WHERE NOT EXISTS (SELECT * FROM " << *buildTableName
-            << " WHERE " << joinConditionAsSql(*joinNode);
-        sql << ")";
-      }
-      break;
-    default:
-      VELOX_UNREACHABLE(
-          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
-  }
-  return sql.str();
-}
-
-std::optional<std::string> ReferenceQueryRunner::toSql(
-    const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode) {
-  std::optional<std::string> probeTableName =
-      joinSourceToSql(joinNode->sources()[0]);
-  std::optional<std::string> buildTableName =
-      joinSourceToSql(joinNode->sources()[1]);
-  if (!probeTableName || !buildTableName) {
-    return std::nullopt;
-  }
-
-  std::stringstream sql;
-  sql << "SELECT " << folly::join(", ", joinNode->outputType()->names());
-
-  // Nested loop join without filter.
-  VELOX_CHECK_NULL(
-      joinNode->joinCondition(),
-      "This code path should be called only for nested loop join without filter");
-  const std::string joinCondition{"(1 = 1)"};
-  switch (joinNode->joinType()) {
-    case core::JoinType::kInner:
-      sql << " FROM " << *probeTableName << " INNER JOIN " << *buildTableName
-          << " ON " << joinCondition;
-      break;
-    case core::JoinType::kLeft:
-      sql << " FROM " << *probeTableName << " LEFT JOIN " << *buildTableName
-          << " ON " << joinCondition;
-      break;
-    case core::JoinType::kFull:
-      sql << " FROM " << *probeTableName << " FULL OUTER JOIN "
-          << *buildTableName << " ON " << joinCondition;
-      break;
-    default:
-      VELOX_UNREACHABLE(
-          "Unknown join type: {}", static_cast<int>(joinNode->joinType()));
-  }
-  return sql.str();
-}
-
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/ReferenceQueryRunner.h
+++ b/velox/exec/fuzzer/ReferenceQueryRunner.h
@@ -79,22 +79,6 @@ class ReferenceQueryRunner {
   /// reference database.
   virtual std::optional<std::string> toSql(const core::PlanNodePtr& plan) = 0;
 
-  /// Same as the above toSql but for values nodes.
-  virtual std::optional<std::string> toSql(
-      const core::ValuesNodePtr& valuesNode);
-
-  /// Same as the above toSql but for table scan nodes.
-  virtual std::optional<std::string> toSql(
-      const core::TableScanNodePtr& tableScanNode);
-
-  /// Same as the above toSql but for hash join nodes.
-  virtual std::optional<std::string> toSql(
-      const std::shared_ptr<const core::HashJoinNode>& joinNode);
-
-  /// Same as the above toSql but for nested loop join nodes.
-  virtual std::optional<std::string> toSql(
-      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
-
   /// Returns whether a constant expression is supported by the reference
   /// database.
   virtual bool isConstantExprSupported(const core::TypedExprPtr& /*expr*/) {
@@ -172,16 +156,16 @@ class ReferenceQueryRunner {
     VELOX_UNSUPPORTED();
   }
 
- protected:
-  memory::MemoryPool* aggregatePool() {
-    return aggregatePool_;
-  }
-
   bool isSupportedDwrfType(const TypePtr& type);
 
   /// Returns the name of the values node table in the form t_<id>.
-  std::string getTableName(const core::ValuesNodePtr& valuesNode) {
-    return fmt::format("t_{}", valuesNode->id());
+  std::string getTableName(const core::ValuesNode& valuesNode) {
+    return fmt::format("t_{}", valuesNode.id());
+  }
+
+ protected:
+  memory::MemoryPool* aggregatePool() {
+    return aggregatePool_;
   }
 
   // Traverses all nodes in the plan and returns all tables and their names.
@@ -190,7 +174,5 @@ class ReferenceQueryRunner {
 
  private:
   memory::MemoryPool* aggregatePool_;
-
-  std::optional<std::string> joinSourceToSql(const core::PlanNodePtr& planNode);
 };
 } // namespace facebook::velox::exec::test

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunner.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunner.h
@@ -15,10 +15,10 @@
  */
 #pragma once
 
-#include "grpc++/channel.h"
-#include "grpc++/client_context.h"
-#include "grpc++/create_channel.h"
-#include "grpc++/security/credentials.h"
+#include "grpc++/channel.h" // @manual
+#include "grpc++/client_context.h" // @manual
+#include "grpc++/create_channel.h" // @manual
+#include "grpc++/security/credentials.h" // @manual
 #include "spark/connect/base.grpc.pb.h"
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/common/memory/Memory.h"
@@ -104,13 +104,6 @@ class SparkQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   // Reads the arrow IPC-format string data with arrow IPC reader and convert
   // them into Velox RowVectors.
   std::vector<velox::RowVectorPtr> readArrowData(const std::string& data);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const velox::core::AggregationNode>&
-          aggregationNode);
-
-  std::optional<std::string> toSql(
-      const std::shared_ptr<const core::ProjectNode>& projectNode);
 
   google::protobuf::Arena arena_;
   const std::string userId_;


### PR DESCRIPTION
Summary:
This diff changes the ReferenceQueryRunner and its implementations to use a 
ToSqlPlanNodeVisitor implementation of the PlanNodeVisitor interface to convert a tree of
PlanNodes to SQL.

This simply moves the implementations of the various overloads of the toSql methods into
implementations of the PlanNodeVisitor interface and the various overloads of its visit 
methods.

It also removes the large series of if/else statements to try to dynamic cast PlanNodes to
their appropriate derived classes.

Differential Revision: D72272735


