### PR TITLE
fix(fuzzer): Add SQL generation support for type DATE

### DIFF
--- a/velox/exec/fuzzer/ToSQLUtil.cpp
+++ b/velox/exec/fuzzer/ToSQLUtil.cpp
@@ -28,6 +28,12 @@ void appendComma(int32_t i, std::stringstream& sql) {
 
 // Returns the SQL string of the given type.
 std::string toTypeSql(const TypePtr& type) {
+  // Date needs special handling because it is not supported by TypeKind. We
+  // will need to explicitly specify or we are at risk of a date being casted to
+  // an integer and failing.
+  if (type->isDate()) {
+    return "DATE";
+  }
   switch (type->kind()) {
     case TypeKind::ARRAY:
       return fmt::format("ARRAY({})", toTypeSql(type->childAt(0)));


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebookincubator/velox/pull/12888

Allow for SQL generation of input types using DATE to be explicitly specified as DATE rather than INTEGER. Without this time functions using DATE as input generated by their signature will fail.

A regression was identified by the continuous fuzzer run that broke the teset: https://www.internalfb.com/chronos/job/silver/1125908496757416
This was a result of changing `type->toString()` to `mapTypeKindToName(type->kind())` that omits `DATE`.
https://github.com/facebookincubator/velox/issues/12891