### PR TITLE
feat: Implement murmur3_x64_128 hash function in velox

### DIFF
--- a/velox/common/hyperloglog/Murmur3Hash128.cpp
+++ b/velox/common/hyperloglog/Murmur3Hash128.cpp
@@ -142,4 +142,107 @@ int64_t Murmur3Hash128::hash64(const void* data, int32_t length, int64_t seed) {
   return static_cast<int64_t>(h1 + h2);
 }
 
+void Murmur3Hash128::hash(
+    const void* key,
+    const int32_t len,
+    const uint32_t seed,
+    void* out) {
+  VELOX_DCHECK_NOT_NULL(key);
+  VELOX_DCHECK_NOT_NULL(out);
+  const uint8_t* data = static_cast<const uint8_t*>(key);
+  const int32_t nblocks = len / 16;
+  uint64_t h1 = seed;
+  uint64_t h2 = seed;
+  // Body
+  for (int32_t i = 0; i < nblocks; ++i) {
+    uint64_t k1 = getLong(data, i * 16);
+    uint64_t k2 = getLong(data, i * 16 + 8);
+    k1 *= C1;
+    k1 = bits::rotateLeft64(k1, 31);
+    k1 *= C2;
+    h1 ^= k1;
+    h1 = bits::rotateLeft64(h1, 27);
+    h1 += h2;
+    h1 = h1 * 5 + 0x52dce729;
+    k2 *= C2;
+    k2 = bits::rotateLeft64(k2, 33);
+    k2 *= C1;
+    h2 ^= k2;
+    h2 = bits::rotateLeft64(h2, 31);
+    h2 += h1;
+    h2 = h2 * 5 + 0x38495ab5;
+  }
+  // Tail
+  const uint8_t* tail = data + nblocks * 16;
+  uint64_t k1 = 0;
+  uint64_t k2 = 0;
+  switch (len & 15) {
+    case 15:
+      k2 ^= uint64_t(tail[14]) << 48;
+      [[fallthrough]];
+    case 14:
+      k2 ^= uint64_t(tail[13]) << 40;
+      [[fallthrough]];
+    case 13:
+      k2 ^= uint64_t(tail[12]) << 32;
+      [[fallthrough]];
+    case 12:
+      k2 ^= uint64_t(tail[11]) << 24;
+      [[fallthrough]];
+    case 11:
+      k2 ^= uint64_t(tail[10]) << 16;
+      [[fallthrough]];
+    case 10:
+      k2 ^= uint64_t(tail[9]) << 8;
+      [[fallthrough]];
+    case 9:
+      k2 ^= uint64_t(tail[8]) << 0;
+      k2 *= C2;
+      k2 = bits::rotateLeft64(k2, 33);
+      k2 *= C1;
+      h2 ^= k2;
+      [[fallthrough]];
+    case 8:
+      k1 ^= uint64_t(tail[7]) << 56;
+      [[fallthrough]];
+    case 7:
+      k1 ^= uint64_t(tail[6]) << 48;
+      [[fallthrough]];
+    case 6:
+      k1 ^= uint64_t(tail[5]) << 40;
+      [[fallthrough]];
+    case 5:
+      k1 ^= uint64_t(tail[4]) << 32;
+      [[fallthrough]];
+    case 4:
+      k1 ^= uint64_t(tail[3]) << 24;
+      [[fallthrough]];
+    case 3:
+      k1 ^= uint64_t(tail[2]) << 16;
+      [[fallthrough]];
+    case 2:
+      k1 ^= uint64_t(tail[1]) << 8;
+      [[fallthrough]];
+    case 1:
+      k1 ^= uint64_t(tail[0]) << 0;
+      k1 *= C1;
+      k1 = bits::rotateLeft64(k1, 31);
+      k1 *= C2;
+      h1 ^= k1;
+  }
+  // Finalization
+  h1 ^= len;
+  h2 ^= len;
+  h1 += h2;
+  h2 += h1;
+  h1 = mix64(h1);
+  h2 = mix64(h2);
+  h1 += h2;
+  h2 += h1;
+  // Store the result in the output buffer
+  uint64_t* out64 = static_cast<uint64_t*>(out);
+  out64[0] = h1;
+  out64[1] = h2;
+}
+
 } // namespace facebook::velox::common::hll

--- a/velox/common/hyperloglog/Murmur3Hash128.h
+++ b/velox/common/hyperloglog/Murmur3Hash128.h
@@ -38,6 +38,9 @@ class Murmur3Hash128 {
     return static_cast<int64_t>(mix64(h1) + mix64(h1 + h2));
   }
 
+  static void
+  hash(const void* key, const int32_t len, const uint32_t seed, void* out);
+
  private:
   static constexpr uint64_t C1 = 0x87c37b91114253d5L;
   static constexpr uint64_t C2 = 0x4cf5ad432745937fL;

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -25,6 +25,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<XxHash64Function, Varbinary, Varbinary>(
       {prefix + "xxhash64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({prefix + "md5"});
+  registerFunction<Murmur3X64_128Function, Varbinary, Varbinary>(
+      {prefix + "murmur3_x64_128"});
   registerFunction<Sha1Function, Varbinary, Varbinary>({prefix + "sha1"});
   registerFunction<Sha256Function, Varbinary, Varbinary>({prefix + "sha256"});
   registerFunction<Sha512Function, Varbinary, Varbinary>({prefix + "sha512"});

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -833,4 +833,17 @@ TEST_F(BinaryFunctionsTest, lpad) {
   VELOX_ASSERT_USER_THROW(lpad("2312", 1, ""), "padString must not be empty");
 }
 
+TEST_F(BinaryFunctionsTest, murmur3_x64_128) {
+  const auto murmur3_x64_128 = [&](std::optional<std::string> arg) {
+    return evaluateOnce<std::string>(
+        "murmur3_x64_128(c0)", VARBINARY(), std::move(arg));
+  };
+
+  EXPECT_EQ(murmur3_x64_128(""), hexToDec("00000000000000000000000000000000"));
+  EXPECT_EQ(
+      murmur3_x64_128("hashme"), hexToDec("93192FE805BE23041C8318F67EC4F2BC"));
+
+  EXPECT_EQ(murmur3_x64_128(std::nullopt), std::nullopt);
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
implement murmur3_x64_128 hash function.
Java method  here - https://www.internalfb.com/code/fbsource/[56450e673a0e7fa39512b3877b55f35943e7d046]/fbcode/github/presto-trunk/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java?lines=302

Differential Revision: D72272422


