### PR TITLE
fix: Attribute cardinality change in FilterProject to Filter, not Project node

### DIFF
--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -209,20 +209,33 @@ std::string PlanNodeStats::toString(
   return out.str();
 }
 
+void appendOperatorStats(
+    const OperatorStats& stats,
+    std::unordered_map<core::PlanNodeId, PlanNodeStats>& planStats) {
+  const auto& planNodeId = stats.planNodeId;
+  auto it = planStats.find(planNodeId);
+  if (it != planStats.end()) {
+    it->second.add(stats);
+  } else {
+    PlanNodeStats nodeStats;
+    nodeStats.add(stats);
+    planStats.emplace(planNodeId, std::move(nodeStats));
+  }
+}
+
 std::unordered_map<core::PlanNodeId, PlanNodeStats> toPlanStats(
     const TaskStats& taskStats) {
   std::unordered_map<core::PlanNodeId, PlanNodeStats> planStats;
 
   for (const auto& pipelineStats : taskStats.pipelineStats) {
     for (const auto& opStats : pipelineStats.operatorStats) {
-      const auto& planNodeId = opStats.planNodeId;
-      auto it = planStats.find(planNodeId);
-      if (it != planStats.end()) {
-        it->second.add(opStats);
+      if (opStats.statsSplitter.has_value()) {
+        const auto& multiNodeStats = opStats.statsSplitter.value()(opStats);
+        for (const auto& stats : multiNodeStats) {
+          appendOperatorStats(stats, planStats);
+        }
       } else {
-        PlanNodeStats nodeStats;
-        nodeStats.add(opStats);
-        planStats.emplace(planNodeId, std::move(nodeStats));
+        appendOperatorStats(opStats, planStats);
       }
     }
   }


### PR DESCRIPTION
Summary:
Partial fix for https://github.com/facebookincubator/velox/issues/12893

FilterProject operator implements the logic describe by 2 plan nodes: Filter followed by Project. It reports runtime stats on Project node ID. Thus, Filter node ID has no stats.

This change introduces an option for an operator to provide a function to split stats among multiple plan nodes. FilterProject uses that mechanism to attribute cardinality change to Filter node. CPU and memory stats are kept on the Project node.

Differential Revision: D72317735


