### PR TITLE
fix: Impl split_to_map Null Args

### DIFF
--- a/velox/functions/prestosql/SplitToMap.h
+++ b/velox/functions/prestosql/SplitToMap.h
@@ -41,6 +41,19 @@ struct SplitToMapFunction {
         OnDuplicateKey::kFail);
   }
 
+  // Overloaded call function to handle UnknownValue cases
+  template <typename TEntryDelimiter, typename TKeyValueDelimiter>
+  Status call(
+      out_type<Map<Varchar, Array<Varchar>>>& out,
+      const arg_type<Varchar>& input,
+      const TEntryDelimiter& entryDelimiter,
+      const TKeyValueDelimiter& keyValueDelimiter) {
+    static_assert(
+        std::is_same_v<TEntryDelimiter, arg_type<UnknownValue>> ||
+        std::is_same_v<TKeyValueDelimiter, arg_type<UnknownValue>>);
+    return Status::OK();
+  }
+
   Status call(
       out_type<Map<Varchar, Varchar>>& out,
       const arg_type<Varchar>& input,

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -148,6 +148,25 @@ void registerSplitToMap(const std::string& prefix) {
       Varchar,
       Varchar>({prefix + "split_to_map"});
 
+  registerFunction<
+      SplitToMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      UnknownValue,
+      Varchar>({prefix + "split_to_map"});
+  registerFunction<
+      SplitToMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      Varchar,
+      UnknownValue>({prefix + "split_to_map"});
+  registerFunction<
+      SplitToMapFunction,
+      Map<Varchar, Array<Varchar>>,
+      Varchar,
+      UnknownValue,
+      UnknownValue>({prefix + "split_to_map"});
+
   exec::registerVectorFunction(
       prefix + "split_to_map",
       {

--- a/velox/functions/prestosql/tests/SplitToMapTest.cpp
+++ b/velox/functions/prestosql/tests/SplitToMapTest.cpp
@@ -268,5 +268,24 @@ TEST_F(SplitToMapTest, lambda) {
       "split_to_map with arbitrary lambda is not supported");
 }
 
+TEST_F(SplitToMapTest, testNullArg) {
+  const auto nullMapVector = makeMapVector(
+      {0}, makeFlatVector<std::string>({}), makeArrayVector<std::string>({}));
+  nullMapVector->setNull(0, true);
+
+  auto data = makeRowVector({
+      makeNullableFlatVector<std::string>({"1:10,2:20,4:30"}),
+  });
+
+  auto result =
+      evaluate(fmt::format("split_to_map(c0, '{}', null)", ':'), data);
+  velox::test::assertEqualVectors(nullMapVector, result);
+
+  result = evaluate(fmt::format("split_to_map(c0, null, '{}')", ','), data);
+  velox::test::assertEqualVectors(nullMapVector, result);
+
+  result = evaluate(fmt::format("split_to_map(c0, null, null)"), data);
+  velox::test::assertEqualVectors(nullMapVector, result);
+}
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Presto  `split_to_map` supports `NULL` as EntryDelimiter and KeyValueDelimiter, we should make the behavior consistent in prestissimo 
 {F1976601386}

Differential Revision: D71905670


