### PR TITLE
fix: Impl ends_with Null Args

### DIFF
--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -348,6 +348,13 @@ struct EndsWithFunction {
     result =
         (memcmp(x.data() + (x.size() - y.size()), y.data(), y.size()) == 0);
   }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& x,
+      const arg_type<UnknownValue>& y) {
+    return;
+  }
 };
 
 /// Pad functions

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -54,6 +54,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "starts_with"});
   registerFunction<EndsWithFunction, bool, Varchar, Varchar>(
       {prefix + "ends_with"});
+  registerFunction<EndsWithFunction, bool, Varchar, UnknownValue>(
+      {prefix + "ends_with"});
 
   registerFunction<TrailFunction, Varchar, Varchar, int32_t>(
       {prefix + "trail"});

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1047,6 +1047,21 @@ TEST_F(StringFunctionsTest, endsWith) {
   ASSERT_FALSE(endsWith("", " "));
 }
 
+TEST_F(StringFunctionsTest, endsWithHasNull) {
+  auto data =
+      makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})});
+  auto rest = evaluate(fmt::format("ends_with(c0, '{}')", ""), data);
+  ASSERT_TRUE(rest->isNullAt(0));
+
+  data = makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})});
+  rest = evaluate(fmt::format("ends_with(c0, null)"), data);
+  ASSERT_TRUE(rest->isNullAt(0));
+
+  data = makeRowVector({makeNullableFlatVector<std::string>({"hello"})});
+  rest = evaluate(fmt::format("ends_with(c0, null)"), data);
+  ASSERT_TRUE(rest->isNullAt(0));
+}
+
 // Test strpos function
 template <typename TInstance>
 void StringFunctionsTest::testStringPositionAllFlatVector(


### PR DESCRIPTION
Summary:
Presto  `ends_with` supports NULL as `X` and `Y`, we should make the behavior consistent in prestissimo 

{F1976608403}

Differential Revision: D72192579


