### PR TITLE
fix: Account for sorted array structs memory in aggregation unspill

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -251,6 +251,9 @@ class GroupingSet {
       int32_t maxOutputRows,
       const RowVectorPtr& result);
 
+  // Returns the currently accummulated bytes of the unspill merge rows.
+  uint64_t mergeRowBytes() const;
+
   // Initializes a new row in 'mergeRows' with the keys from the
   // current element from 'stream'. Accumulators are left in the initial
   // state with no data accumulated. This is called each time a new
@@ -274,6 +277,10 @@ class GroupingSet {
   // 'mergeRows'. Used for producing a batch of results when aggregating spilled
   // groups.
   void extractSpillResult(const RowVectorPtr& result);
+
+  // Clears the merge results, including 'mergeRows_' and 'sortedAggregations_'
+  // if applicable.
+  void clearMergeRows();
 
   // Returns a list of accumulators for 'aggregates_', plus one more accumulator
   // for 'sortedAggregations_', and one for each 'distinctAggregations_'.  When

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -82,6 +82,10 @@ class SortedAggregations {
   /// results in the specified 'result' vector.
   void extractValues(folly::Range<char**> groups, const RowVectorPtr& result);
 
+  uint64_t inputRowBytes() const {
+    return inputData_->allocatedBytes();
+  }
+
   /// Clears all data accumulated so far. Used to release memory after spilling.
   void clear();
 


### PR DESCRIPTION
Summary:
Currently in hash aggregation unspill path, when there is sorted aggregations case (sort within each group), the following behaviors are wrong, and in turn caused various QME(Query Memory Exceeds) scenarios:
1. For each unspill iteration, the memory used by sorted aggregations is not cleared, causing the accumulation of unused memory.
2. For each batch size assessment, the memory used by sorted aggregations is not counted, causing a batch size underestimated.
This PR fixes the above issues.

Differential Revision: D72322863


