### PR TITLE
Pass key_indices and value indices to RowReaderOptions

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -627,6 +627,7 @@ void configureRowReaderOptions(
     rowReaderOptions.setTimestampPrecision(static_cast<TimestampPrecision>(
         hiveConfig->readTimestampUnit(sessionProperties)));
   }
+  rowReaderOptions.setStorageParameters(hiveSplit->storageParameters);
 }
 
 namespace {

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -348,4 +348,26 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptions) {
       ->setFilter(common::createBigintValues({1, 3}, false));
   float_features->setFlatMapFeatureSelection({"1", "3"});
 }
+
+TEST_F(HiveConnectorUtilTest, configureStoragePamatersRowReaderOptions) {
+  dwio::common::RowReaderOptions rowReaderOpts;
+  auto hiveSplit =
+      std::make_shared<hive::HiveConnectorSplit>("", "", FileFormat::SST);
+  hiveSplit->storageParameters = {
+      {"key_col_indices", "0,1,2"},
+      {"value_col_indices", "4,5"},
+  };
+  configureRowReaderOptions(
+      /*tableParameters=*/{},
+      /*scanSpec=*/nullptr,
+      /*metadataFilter=*/nullptr,
+      /*rowType=*/nullptr,
+      /*hiveSplit=*/hiveSplit,
+      /*hiveConfig=*/nullptr,
+      /*sessionProperties=*/nullptr,
+      /*rowReaderOptions=*/rowReaderOpts);
+
+  EXPECT_EQ(rowReaderOpts.storageParameters(), hiveSplit->storageParameters);
+}
+
 } // namespace facebook::velox::connector

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -382,6 +382,16 @@ class RowReaderOptions {
     formatSpecificOptions_ = std::move(options);
   }
 
+  const std::unordered_map<std::string, std::string>& storageParameters()
+      const {
+    return storageParameters_;
+  }
+
+  void setStorageParameters(
+      std::unordered_map<std::string, std::string> storageParameters) {
+    storageParameters_ = std::move(storageParameters);
+  }
+
  private:
   uint64_t dataStart_;
   uint64_t dataLength_;
@@ -402,6 +412,8 @@ class RowReaderOptions {
   std::shared_ptr<folly::Executor> decodingExecutor_;
   size_t decodingParallelismFactor_{0};
   std::optional<RowNumberColumnInfo> rowNumberColumnInfo_{std::nullopt};
+  // Parameters that are provided as the physical storage properties.
+  std::unordered_map<std::string, std::string> storageParameters_ = {};
 
   // Function to populate metrics related to feature projection stats
   // in Koski. This gets fired in FlatMapColumnReader.


### PR DESCRIPTION
Summary: Added && Passed down storage parameters to sst reader's RowReaderOptions to keep hive connector agnostic to SST reader implementation details. Will decode this information in SST Row Reader instead in Presto code

Reviewed By: harsharastogi

Differential Revision: D71953610


