### PR TITLE
misc: Add index lookup operator async blocked time metrics

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -616,6 +616,11 @@ void registerVeloxMetrics() {
   DEFINE_HISTOGRAM_METRIC(
       kMetricIndexLookupWaitTimeMs, 32, 0, 16L << 10, 50, 90, 99, 100);
 
+  // The time distribution of index lookup operator blocked wait time in range
+  // of [0, 16s] with 512 buckets and reports P50, P90, P99, and P100.
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricIndexLookupBlockedWaitTimeMs, 32, 0, 16L << 10, 50, 90, 99, 100);
+
   /// ================== Table Scan Counters =================
   // The time distribution of table scan batch processing time in range of [0,
   // 16s] with 512 buckets and reports P50, P90, P99, and P100.

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -373,6 +373,9 @@ constexpr folly::StringPiece kMetricIndexLookupTimeMs{
 constexpr folly::StringPiece kMetricIndexLookupWaitTimeMs{
     "velox.index_lookup_wait_time_ms"};
 
+constexpr folly::StringPiece kMetricIndexLookupBlockedWaitTimeMs{
+    "velox.index_lookup_blocked_wait_time_ms"};
+
 constexpr folly::StringPiece kMetricTableScanBatchProcessTimeMs{
     "velox.table_scan_batch_process_time_ms"};
 } // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -579,6 +579,10 @@ Index Join
      - Histogram
      - The time distribution of index lookup time in range of [0, 16s] with 512
        buckets and reports P50, P90, P99, and P100.
+   * - index_lookup_blocked_wait_time_ms
+     - Histogram
+     - The time distribution of index lookup operator blocked wait time in range
+       of [0, 16s] with 512 buckets and reports P50, P90, P99, and P100.
    * - index_lookup_result_raw_bytes
      - Histogram
      - The distribution of index lookup result raw bytes in range of [0, 128MB]

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -121,6 +121,9 @@ class IndexLookupJoin : public Operator {
   void prepareLookup(InputBatchState& batch);
   void startLookup(InputBatchState& batch);
 
+  void startLookupBlockWait();
+  void endLookupBlockWait();
+
   RowVectorPtr getOutputFromLookupResult(InputBatchState& batch);
   RowVectorPtr produceOutputForInnerJoin(const InputBatchState& batch);
   RowVectorPtr produceOutputForLeftJoin(const InputBatchState& batch);
@@ -250,5 +253,9 @@ class IndexLookupJoin : public Operator {
 
   // The reusable output vector for the join output.
   RowVectorPtr output_;
+
+  // The start time of the current lookup driver block wait, and reset after the
+  // driver wait completes.
+  std::optional<size_t> blockWaitStartNs_;
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary: Add metrics to observe async wait time distribution for index lookup in running server

Differential Revision: D72331816


