### PR TITLE
fix: Deadlock/Stuckness during exchange

### DIFF
--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -49,8 +49,10 @@ class LocalExchangeSource : public exec::ExchangeSource {
 
     auto promise = VeloxPromise<Response>("LocalExchangeSource::request");
     auto future = promise.getSemiFuture();
-
-    promise_ = std::move(promise);
+    {
+      std::lock_guard<std::mutex> l(queue_->mutex());
+      promise_ = std::move(promise);
+    }
 
     auto buffers = OutputBufferManager::getInstanceRef();
     VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");


### PR DESCRIPTION
Summary:
Exchange supports batching as of late January, meaning that consumers will only pull from the `ExchangeQueue` if the data in `ExchangeQueue` >= `minOutputBatchBytes_`.

ExchangeClient will only request data from producing sources if there is enough availableSpace.

Deadlock happens if the following are true
1. We have data in `ExchangeQueue` < `minOutputBatchBytes_`, so consumers do not pull from the queue
2. `availableSpace = maxQueuedBytes_ - queue_->totalBytes() - totalPendingBytes_` s.t. availableSpace is not enough to request from producers because `producingSources_.front().remainingBytes` + availableSpace < 0. And we have `queue_->totalBytes() > 0 ` (condition 1).

If both are true, consumer cannot pull from queue because data is too small, and at the same time we cannot ask for more data because the data in the queue is big enough s.t. we do not have enough queue space to request for more data because the producer's size is too large. 

This causes the driver thread to wait on a futex that never gets woken up. 

The fix here is to account for `minOutputBatchBytes_` in ExchangeClient so that we request a page if we do not have enough buffer to to fill up at least `minOutputBatchBytes_` in the queue.

Differential Revision: D72250518


