### PR TITLE
feat(hive): Support decimal as partition key type in Hive write and read

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -32,7 +32,6 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
   uint64_t absValue =
       isNegative ? -static_cast<uint64_t>(value) : static_cast<uint64_t>(value);
 
-  // Split into 32-bit words (big-endian)
   int32_t high = static_cast<int32_t>(absValue >> 32);
   int32_t low = static_cast<int32_t>(absValue & 0xFFFFFFFF);
 
@@ -57,7 +56,7 @@ inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
   words[2] = static_cast<int32_t>(absValue >> 32);
   words[3] = static_cast<int32_t>(absValue);
 
-  int hash = 0;
+  int32_t hash = 0;
   for (auto i = 0; i < 4; i++) {
     hash = 31 * hash + words[i];
   }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -172,7 +172,7 @@ void hashPrimitive(
         const uint32_t hash = values.isNullAt(row)
             ? 0
             : hashDecimal(
-                  values.valueAt<typename TypeTraits<kind>::NativeType>(i),
+                  values.valueAt<typename TypeTraits<kind>::NativeType>(row),
                   scale);
         mergeHash(mix, hash, hashes[row]);
       });
@@ -199,7 +199,7 @@ void hashPrimitive(
       const uint32_t hash = values.isNullAt(row)
           ? 0
           : hashOne<kind>(
-                values.valueAt<typename TypeTraits<kind>::NativeType>(i));
+                values.valueAt<typename TypeTraits<kind>::NativeType>(row));
       mergeHash(mix, hash, hashes[row]);
     });
   }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -35,7 +35,7 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
   int32_t high = static_cast<int32_t>(absValue >> 32);
   int32_t low = static_cast<int32_t>(absValue & 0xFFFFFFFF);
 
-  unt32_t hash = 31 * high + low;
+  uint32_t hash = 31 * high + low;
   if (isNegative) {
     hash = -hash;
   }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -32,8 +32,8 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
   uint64_t absValue =
       isNegative ? -static_cast<uint64_t>(value) : static_cast<uint64_t>(value);
 
-  int32_t high = static_cast<int32_t>(absValue >> 32);
-  int32_t low = static_cast<int32_t>(absValue & 0xFFFFFFFF);
+  uint32_t high = absValue >> 32;
+  uint32_t low = absValue & 0xFFFFFFFF;
 
   uint32_t hash = 31 * high + low;
   if (isNegative) {

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -169,7 +169,7 @@ void hashPrimitive(
       }
     } else {
       rows.applyToSelected([&](auto row) INLINE_LAMBDA {
-        const uint32_t hash = values.isNullAt(i)
+        const uint32_t hash = values.isNullAt(row)
             ? 0
             : hashDecimal(
                   values.valueAt<typename TypeTraits<kind>::NativeType>(i),
@@ -196,7 +196,7 @@ void hashPrimitive(
     }
   } else {
     rows.applyToSelected([&](auto row) INLINE_LAMBDA {
-      const uint32_t hash = values.isNullAt(i)
+      const uint32_t hash = values.isNullAt(row)
           ? 0
           : hashOne<kind>(
                 values.valueAt<typename TypeTraits<kind>::NativeType>(i));

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -63,7 +63,8 @@ inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
   if (isNegative) {
     hash = -hash;
   }
-  return hash * 31 + scale;
+  __builtin_mul_overflow(hash, 31, &hash);
+  return hash + scale;
 }
 
 #if defined(__has_feature)

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -63,6 +63,8 @@ inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
   if (isNegative) {
     hash = -hash;
   }
+  // Ignore the overflow to align with java implementation, only for lint error
+  // fix.
   __builtin_mul_overflow(hash, 31, &hash);
   return hash + scale;
 }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -56,17 +56,14 @@ inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
   words[2] = static_cast<int32_t>(absValue >> 32);
   words[3] = static_cast<int32_t>(absValue);
 
-  int32_t hash = 0;
+  uint32_t hash = 0;
   for (auto i = 0; i < 4; i++) {
     hash = 31 * hash + words[i];
   }
   if (isNegative) {
     hash = -hash;
   }
-  // Ignore the overflow to align with java implementation, only for lint error
-  // fix.
-  __builtin_mul_overflow(hash, 31, &hash);
-  return hash + scale;
+  return hash * 31 + scale;
 }
 
 #if defined(__has_feature)

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -33,7 +33,7 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
       isNegative ? -static_cast<uint64_t>(value) : static_cast<uint64_t>(value);
 
   uint32_t high = absValue >> 32;
-  uint32_t low = absValue & 0xFFFFFFFF;
+  uint32_t low = absValue;
 
   uint32_t hash = 31 * high + low;
   if (isNegative) {
@@ -48,13 +48,13 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
 // Returns java BigDecimal#hashCode()
 template <>
 inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
-  int32_t words[4];
+  uint32_t words[4];
   bool isNegative = value < 0;
   uint128_t absValue = isNegative ? -value : value;
-  words[0] = static_cast<int32_t>(absValue >> 96);
-  words[1] = static_cast<int32_t>(absValue >> 64);
-  words[2] = static_cast<int32_t>(absValue >> 32);
-  words[3] = static_cast<int32_t>(absValue);
+  words[0] = absValue >> 96;
+  words[1] = absValue >> 64;
+  words[2] = absValue >> 32;
+  words[3] = absValue;
 
   uint32_t hash = 0;
   for (auto i = 0; i < 4; i++) {

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -35,7 +35,7 @@ inline int32_t hashDecimal(T value, uint8_t scale) {
   int32_t high = static_cast<int32_t>(absValue >> 32);
   int32_t low = static_cast<int32_t>(absValue & 0xFFFFFFFF);
 
-  int32_t hash = 31 * high + low;
+  unt32_t hash = 31 * high + low;
   if (isNegative) {
     hash = -hash;
   }

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -155,7 +155,8 @@ void hashPrimitive(
     bool mix,
     std::vector<uint32_t>& hashes) {
   const auto& type = values.base()->type();
-  const auto scale = type->isDecimal() ? getDecimalPrecisionScale(*type).second : 0;
+  const auto scale =
+      type->isDecimal() ? getDecimalPrecisionScale(*type).second : 0;
   if (rows.isAllSelected()) {
     // The compiler seems to be a little fickle with optimizations.
     // Although rows.applyToSelected should do roughly the same thing, doing

--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -27,6 +27,7 @@ namespace facebook::velox::connector::hive {
       case TypeKind::SMALLINT:                                              \
       case TypeKind::INTEGER:                                               \
       case TypeKind::BIGINT:                                                \
+      case TypeKind::HUGEINT:                                               \
       case TypeKind::VARCHAR:                                               \
       case TypeKind::VARBINARY:                                             \
       case TypeKind::TIMESTAMP:                                             \
@@ -89,6 +90,22 @@ std::pair<std::string, std::string> makePartitionKeyValueString(
         DATE()->toString(
             partitionVector->as<SimpleVector<int32_t>>()->valueAt(row)));
   }
+  if constexpr (Kind == TypeKind::BIGINT || Kind == TypeKind::HUGEINT) {
+    if (partitionVector->type()->isDecimal()) {
+      auto [precision, scale] =
+          getDecimalPrecisionScale(*partitionVector->type());
+      const auto maxStringSize =
+          DecimalUtil::maxStringViewSize(precision, scale);
+      std::vector<char> maxString(maxStringSize);
+      const auto size = DecimalUtil::castToString(
+          partitionVector->as<SimpleVector<T>>()->valueAt(row),
+          scale,
+          maxStringSize,
+          maxString.data());
+      return std::make_pair(name, std::string(maxString.data(), size));
+    }
+  }
+
   return std::make_pair(
       name,
       makePartitionValueString(

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -54,6 +54,18 @@ VectorPtr newConstantFromString(
         pool, size, false, type, std::move(days));
   }
 
+  if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
+    if (type->isDecimal()) {
+      auto [precision, scale] = getDecimalPrecisionScale(*type);
+      T result;
+      const auto status = DecimalUtil::castFromString<T>(
+          StringView(value.value()), precision, scale, result);
+      VELOX_USER_CHECK(status.ok(), status.message());
+      return std::make_shared<ConstantVector<T>>(
+          pool, size, false, type, std::move(result));
+    }
+  }
+
   if constexpr (std::is_same_v<T, StringView>) {
     return std::make_shared<ConstantVector<StringView>>(
         pool, size, false, type, StringView(value.value()));

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -635,10 +635,9 @@ TEST_F(HiveDataSinkTest, decimalPartition) {
   auto partitionPath = [&](std::string value) {
     partitionKeys["c2"] = value;
     auto path = listFiles(rootPath + "/c2=" + value)[0];
-    splits.push_back(
-        makeHiveConnectorSplits(
-            path, 1, dwio::common::FileFormat::DWRF, partitionKeys)
-            .back());
+    splits.push_back(makeHiveConnectorSplits(
+                         path, 1, dwio::common::FileFormat::DWRF, partitionKeys)
+                         .back());
   };
   partitionPath("0.0001");
   partitionPath("0.0340");

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -598,6 +598,68 @@ TEST_F(HiveDataSinkTest, basicBucket) {
   verifyWrittenData(outputDirectory->getPath(), numBuckets);
 }
 
+TEST_F(HiveDataSinkTest, decimalPartition) {
+  const auto outputDirectory = TempDirectoryPath::create();
+
+  connectorSessionProperties_->set(
+      HiveConfig::kSortWriterFinishTimeSliceLimitMsSession, "1");
+  const auto rowType =
+      ROW({"c0", "c1", "c2"}, {BIGINT(), DECIMAL(14, 3), DECIMAL(20, 4)});
+  auto dataSink = createDataSink(
+      rowType,
+      outputDirectory->getPath(),
+      dwio::common::FileFormat::PARQUET,
+      {"c2"});
+  auto stats = dataSink->stats();
+  ASSERT_TRUE(stats.empty()) << stats.toString();
+
+  const auto vector = makeRowVector(
+      {makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 345}),
+       makeNullableFlatVector<int64_t>(
+           {1, 2, std::nullopt, 345}, DECIMAL(14, 3)),
+       makeFlatVector<int128_t>({1, 340, 234567, -345}, DECIMAL(20, 4))});
+
+  dataSink->appendData(vector);
+  while (!dataSink->finish()) {
+  }
+  const auto partitions = dataSink->close();
+  stats = dataSink->stats();
+  ASSERT_FALSE(stats.empty());
+  ASSERT_EQ(partitions.size(), vector->size());
+
+  createDuckDbTable({vector});
+
+  const auto rootPath = outputDirectory->getPath();
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+  auto partitionPath = [&](std::string value) {
+    partitionKeys["c2"] = value;
+    auto path = listFiles(rootPath + "/c2=" + value)[0];
+    splits.push_back(
+        makeHiveConnectorSplits(
+            path, 1, dwio::common::FileFormat::PARQUET, partitionKeys)
+            .back());
+  };
+  partitionPath("0.0001");
+  partitionPath("0.0340");
+  partitionPath("23.4567");
+  partitionPath("-0.0345");
+
+  ColumnHandleMap assignments = {
+      {"c0", regularColumn("c0", BIGINT())},
+      {"c1", regularColumn("c1", DECIMAL(14, 3))},
+      {"c2", partitionKey("c2", DECIMAL(20, 4))}};
+
+  auto op = PlanBuilder()
+                .startTableScan()
+                .outputType(rowType)
+                .assignments(assignments)
+                .endTableScan()
+                .planNode();
+
+  assertQuery(op, splits, fmt::format("SELECT * FROM tmp"));
+}
+
 TEST_F(HiveDataSinkTest, close) {
   for (bool empty : {true, false}) {
     SCOPED_TRACE(fmt::format("Data sink is empty: {}", empty));

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -608,7 +608,7 @@ TEST_F(HiveDataSinkTest, decimalPartition) {
   auto dataSink = createDataSink(
       rowType,
       outputDirectory->getPath(),
-      dwio::common::FileFormat::PARQUET,
+      dwio::common::FileFormat::DWRF,
       {"c2"});
   auto stats = dataSink->stats();
   ASSERT_TRUE(stats.empty()) << stats.toString();
@@ -637,7 +637,7 @@ TEST_F(HiveDataSinkTest, decimalPartition) {
     auto path = listFiles(rootPath + "/c2=" + value)[0];
     splits.push_back(
         makeHiveConnectorSplits(
-            path, 1, dwio::common::FileFormat::PARQUET, partitionKeys)
+            path, 1, dwio::common::FileFormat::DWRF, partitionKeys)
             .back());
   };
   partitionPath("0.0001");

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -884,11 +884,10 @@ TEST_F(HivePartitionFunctionTest, skew) {
   }
   std::vector<VectorPtr> partitionedInputs;
   for (int partition = 0; partition < numRemotePartitions; ++partition) {
-    partitionedInputs.push_back(
-        exec::wrap(
-            partitionSizeVectors[partition],
-            partitionIndicesVector[partition],
-            input));
+    partitionedInputs.push_back(exec::wrap(
+        partitionSizeVectors[partition],
+        partitionIndicesVector[partition],
+        input));
   }
 
   // Checks that the bad hive partition function (using round-robin map from

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -124,6 +124,58 @@ TEST_F(HivePartitionFunctionTest, bigint) {
   assertPartitionsWithConstChannel(values, 997);
 }
 
+TEST_F(HivePartitionFunctionTest, shortDecimal) {
+  auto values = makeNullableFlatVector<int64_t>(
+      {std::nullopt,
+       300'000'000'000,
+       123456789,
+       DecimalUtil::kShortDecimalMin / 100,
+       DecimalUtil::kShortDecimalMax / 100},
+      DECIMAL(18, 2));
+
+  assertPartitions(values, 1, {0, 0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 1, 1, 1, 1});
+  assertPartitions(values, 500, {0, 471, 313, 115, 37});
+  assertPartitions(values, 997, {0, 681, 6, 982, 502});
+
+  assertPartitionsWithConstChannel(values, 1);
+  assertPartitionsWithConstChannel(values, 2);
+  assertPartitionsWithConstChannel(values, 500);
+  assertPartitionsWithConstChannel(values, 997);
+
+  values = makeFlatVector<int64_t>(
+      {123456789, DecimalUtil::kShortDecimalMin, DecimalUtil::kShortDecimalMax},
+      DECIMAL(18, 0));
+  assertPartitions(values, 500, {311, 236, 412});
+}
+
+TEST_F(HivePartitionFunctionTest, longDecimal) {
+  auto values = makeNullableFlatVector<int128_t>(
+      {std::nullopt,
+       300'000'000'000,
+       HugeInt::parse("12345678901234567891"),
+       DecimalUtil::kLongDecimalMin / 100,
+       DecimalUtil::kLongDecimalMax / 100},
+      DECIMAL(38, 2));
+
+  assertPartitions(values, 1, {0, 0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 1, 1, 1, 1});
+  assertPartitions(values, 500, {0, 471, 99, 49, 103});
+  assertPartitions(values, 997, {0, 681, 982, 481, 6});
+
+  assertPartitionsWithConstChannel(values, 1);
+  assertPartitionsWithConstChannel(values, 2);
+  assertPartitionsWithConstChannel(values, 500);
+  assertPartitionsWithConstChannel(values, 997);
+
+  values = makeNullableFlatVector<int128_t>(
+      {HugeInt::parse("1234567890123456789112345678"),
+       DecimalUtil::kLongDecimalMin,
+       DecimalUtil::kLongDecimalMax},
+      DECIMAL(38, 0));
+  assertPartitions(values, 997, {51, 835, 645});
+}
+
 TEST_F(HivePartitionFunctionTest, varchar) {
   auto values = makeNullableFlatVector<std::string>(
       {std::nullopt,
@@ -832,10 +884,11 @@ TEST_F(HivePartitionFunctionTest, skew) {
   }
   std::vector<VectorPtr> partitionedInputs;
   for (int partition = 0; partition < numRemotePartitions; ++partition) {
-    partitionedInputs.push_back(exec::wrap(
-        partitionSizeVectors[partition],
-        partitionIndicesVector[partition],
-        input));
+    partitionedInputs.push_back(
+        exec::wrap(
+            partitionSizeVectors[partition],
+            partitionIndicesVector[partition],
+            input));
   }
 
   // Checks that the bad hive partition function (using round-robin map from

--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -74,7 +74,9 @@ TEST_F(HivePartitionUtilTest, partitionName) {
          "flat_bigint_col",
          "dict_string_col",
          "const_date_col",
-         "flat_timestamp_col"},
+         "flat_timestamp_col",
+         "short_decimal_col",
+         "long_decimal_col"},
         {makeFlatVector<bool>(std::vector<bool>{false}),
          makeFlatVector<int8_t>(std::vector<int8_t>{10}),
          makeFlatVector<int16_t>(std::vector<int16_t>{100}),
@@ -83,7 +85,10 @@ TEST_F(HivePartitionUtilTest, partitionName) {
          makeDictionary<StringView>(std::vector<StringView>{"str1000"}),
          makeConstant<int32_t>(10000, 1, DATE()),
          makeFlatVector<Timestamp>(
-             std::vector<Timestamp>{Timestamp::fromMillis(1577836800000)})});
+             std::vector<Timestamp>{Timestamp::fromMillis(1577836800000)}),
+         makeConstant<int64_t>(10000, 1, DECIMAL(12, 2)),
+         makeConstant<int128_t>(
+             DecimalUtil::kLongDecimalMin / 100, 1, DECIMAL(38, 2))});
 
     std::vector<std::string> expectedPartitionKeyValues{
         "flat_bool_col=false",
@@ -93,7 +98,9 @@ TEST_F(HivePartitionUtilTest, partitionName) {
         "flat_bigint_col=10000",
         "dict_string_col=str1000",
         "const_date_col=1997-05-19",
-        "flat_timestamp_col=2019-12-31 16%3A00%3A00.0"};
+        "flat_timestamp_col=2019-12-31 16%3A00%3A00.0",
+        "short_decimal_col=100.00",
+        "long_decimal_col=-" + std::string(34, '9') + ".99"};
 
     std::vector<column_index_t> partitionChannels;
     for (auto i = 1; i <= expectedPartitionKeyValues.size(); i++) {
@@ -140,7 +147,9 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
       "flat_bigint_col",
       "flat_string_col",
       "const_date_col",
-      "flat_timestamp_col"};
+      "flat_timestamp_col",
+      "short_decimal_col",
+      "long_decimal_col"};
 
   RowVectorPtr input = makeRowVector(
       partitionColumnNames,
@@ -151,7 +160,9 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
        makeNullableFlatVector<int64_t>({std::nullopt}),
        makeNullableFlatVector<StringView>({std::nullopt}),
        makeConstant<int32_t>(std::nullopt, 1, DATE()),
-       makeNullableFlatVector<Timestamp>({std::nullopt})});
+       makeNullableFlatVector<Timestamp>({std::nullopt}),
+       makeConstant<int64_t>(std::nullopt, 1, DECIMAL(12, 2)),
+       makeConstant<int128_t>(std::nullopt, 1, DECIMAL(38, 2))});
 
   for (auto i = 0; i < partitionColumnNames.size(); i++) {
     std::vector<column_index_t> partitionChannels = {(column_index_t)i};

--- a/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
@@ -322,8 +322,9 @@ TEST_F(PartitionIdGeneratorTest, supportedPartitionKeyTypes) {
             INTEGER(),
             BIGINT(),
             TIMESTAMP(),
+            DECIMAL(20, 2),
         }),
-        {0, 1, 2, 3, 4, 5, 6, 7},
+        {0, 1, 2, 3, 4, 5, 6, 7, 8},
         100,
         pool(),
         true);
@@ -341,7 +342,9 @@ TEST_F(PartitionIdGeneratorTest, supportedPartitionKeyTypes) {
          makeNullableFlatVector<Timestamp>(
              {std::nullopt,
               Timestamp::fromMillis(1639426440001),
-              Timestamp::fromMillis(1639426440002)})});
+              Timestamp::fromMillis(1639426440002)}),
+         makeNullableFlatVector<int128_t>(
+             {std::nullopt, 1, DecimalUtil::kLongDecimalMin})});
 
     raw_vector<uint64_t> ids;
     idGenerator.run(input, ids);

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -41,6 +41,9 @@ namespace facebook::velox::exec {
       case TypeKind::BIGINT: {                                           \
         return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);             \
       }                                                                  \
+      case TypeKind::HUGEINT: {                                          \
+        return TEMPLATE_FUNC<TypeKind::HUGEINT>(__VA_ARGS__);            \
+      }                                                                  \
       case TypeKind::VARCHAR:                                            \
       case TypeKind::VARBINARY: {                                        \
         return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);            \
@@ -736,6 +739,7 @@ void extendRange(
       extendRange<int32_t>(reserve, min, max);
       break;
     case TypeKind::BIGINT:
+    case TypeKind::HUGEINT:
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
     case TypeKind::TIMESTAMP:

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -291,6 +291,7 @@ class VectorHasher {
       case TypeKind::SMALLINT:
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
+      case TypeKind::HUGEINT:
       case TypeKind::VARCHAR:
       case TypeKind::VARBINARY:
       case TypeKind::TIMESTAMP:

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1870,6 +1870,15 @@ TEST_F(TableScanTest, partitionedTableDoubleKey) {
   testPartitionedTable(filePath->getPath(), DOUBLE(), "3.5");
 }
 
+TEST_F(TableScanTest, partitionedTableDecimalKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->getPath(), DECIMAL(20, 4), "3.5123");
+}
+
 TEST_F(TableScanTest, partitionedTableDateKey) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -720,6 +720,11 @@ TEST_F(VectorHasherTest, merge) {
   EXPECT_EQ(numDistinct - 1, ids.size());
 }
 
+TEST_F(VectorHasherTest, computeValueIdsHugeInt) {
+  testComputeValueIds<int128_t>(false);
+  testComputeValueIds<int128_t>(true);
+}
+
 TEST_F(VectorHasherTest, computeValueIdsBigint) {
   testComputeValueIds<int64_t>(false);
   testComputeValueIds<int64_t>(true);

--- a/velox/exec/tests/utils/TableScanTestBase.cpp
+++ b/velox/exec/tests/utils/TableScanTestBase.cpp
@@ -173,6 +173,11 @@ void TableScanTestBase::testPartitionedTableImpl(
   std::string partitionValueStr;
   partitionValueStr =
       partitionValue.has_value() ? "'" + *partitionValue + "'" : "null";
+  if (partitionValue.has_value() && partitionType->isDecimal()) {
+    auto [p, s] = getDecimalPrecisionScale(*partitionType);
+    partitionValueStr =
+        fmt::format("CAST({} AS DECIMAL({}, {}))", partitionValueStr, p, s);
+  }
   assertQuery(
       op, split, fmt::format("SELECT {}, * FROM tmp", partitionValueStr));
 


### PR DESCRIPTION
Presto does not support decimal as partition key, https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/HiveBucketing.java
For Hive, it supports decimal, https://github.com/apache/hive/blob/master/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java#L754, construct BigDecimal, and use the java function BigDecimal.hashCode() to get the hashValue, https://github.com/apache/hive/blob/master/storage-api/src/java/org/apache/hadoop/hive/common/type/FastHiveDecimalImpl.java#L4106
For Spark, it aligns with hive implementation https://github.com/apache/spark/blob/master/common/unsafe/src/main/java/org/apache/spark/sql/catalyst/expressions/HiveHasher.java