### PR TITLE
feat(type): Implement hash function for opaque variant

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -800,7 +800,11 @@ uint64_t variant::hash<TypeKind::MAP>() const {
 
 template <>
 uint64_t variant::hash<TypeKind::OPAQUE>() const {
-  VELOX_NYI();
+  const detail::OpaqueCapsule& capsule = value<TypeKind::OPAQUE>();
+  auto serializeFunction = capsule.type->getSerializeFunc();
+
+  return folly::Hash{}(
+      capsule.type->toString(), serializeFunction(capsule.obj));
 }
 
 uint64_t variant::hash() const {


### PR DESCRIPTION
Hashing some expressions can throw because opaque variant hash function throws NYI. This PR implements the hash function in a similar fashion to the opaque variant's toString() implementation