### PR TITLE
build(cmake): Remove Profiler from core Velox library

### DIFF
--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -15,7 +15,6 @@
 velox_add_library(
   velox_process
   ProcessBase.cpp
-  Profiler.cpp
   StackTrace.cpp
   ThreadDebugInfo.cpp
   TraceContext.cpp

--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -24,6 +24,13 @@ velox_add_library(
 velox_link_libraries(
   velox_process
   PUBLIC velox_file velox_flag_definitions Folly::folly
+  PRIVATE fmt::fmt gflags::gflags)
+
+# Profiler need not be part of the core Velox library
+add_library(velox_profiler OBJECT Profiler.cpp)
+target_link_libraries(
+  velox_profiler
+  PUBLIC velox_flag_definitions Folly::folly
   PRIVATE fmt::fmt gflags::gflags glog::glog)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   velox_process_test
   PRIVATE
     velox_process
+    velox_profiler
     fmt::fmt
     velox_time
     GTest::gtest

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
   velox_hash_benchmark
   velox_exec
   velox_exec_test_lib
+  velox_profiler
   velox_vector_test_lib
   Folly::follybenchmark)
 


### PR DESCRIPTION
Profiler need not be part of the core Velox library.
This also excludes it from the GlobalConfig change.