### PR TITLE
refactor(util): Consolidate handling of primitive types in toTypeSql

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -161,3 +161,7 @@ target_link_libraries(
 target_link_libraries(
   velox_cache_fuzzer_lib velox_dwio_common velox_temp_path
   velox_vector_test_lib)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -28,12 +28,6 @@ void appendComma(int32_t i, std::stringstream& sql) {
 
 // Returns the SQL string of the given type.
 std::string toTypeSql(const TypePtr& type) {
-  // Date needs special handling because it is not supported by TypeKind. We
-  // will need to explicitly specify or we are at risk of a date being casted to
-  // an integer and failing.
-  if (type->isDate()) {
-    return "DATE";
-  }
   switch (type->kind()) {
     case TypeKind::ARRAY:
       return fmt::format("ARRAY({})", toTypeSql(type->childAt(0)));
@@ -54,11 +48,9 @@ std::string toTypeSql(const TypePtr& type) {
       sql << ")";
       return sql.str();
     }
-    case TypeKind::VARCHAR:
-      return isJsonType(type) ? "JSON" : "VARCHAR";
     default:
       if (type->isPrimitiveType()) {
-        return mapTypeKindToName(type->kind());
+        return type->name();
       }
       VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
   }

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_fuzzer_util_test PrestoSqlTest.cpp)
+add_test(velox_fuzzer_util_test velox_fuzzer_util_test)
+
+target_link_libraries(
+  velox_fuzzer_util_test velox_fuzzer_util velox_presto_types)

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/fuzzer/PrestoSql.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+TEST(PrestoSqlTest, toTypeSql) {
+  EXPECT_EQ(toTypeSql(BOOLEAN()), "BOOLEAN");
+  EXPECT_EQ(toTypeSql(TINYINT()), "TINYINT");
+  EXPECT_EQ(toTypeSql(SMALLINT()), "SMALLINT");
+  EXPECT_EQ(toTypeSql(INTEGER()), "INTEGER");
+  EXPECT_EQ(toTypeSql(BIGINT()), "BIGINT");
+  EXPECT_EQ(toTypeSql(REAL()), "REAL");
+  EXPECT_EQ(toTypeSql(DOUBLE()), "DOUBLE");
+  EXPECT_EQ(toTypeSql(VARCHAR()), "VARCHAR");
+  EXPECT_EQ(toTypeSql(VARBINARY()), "VARBINARY");
+  EXPECT_EQ(toTypeSql(TIMESTAMP()), "TIMESTAMP");
+  EXPECT_EQ(toTypeSql(DATE()), "DATE");
+  EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");
+  EXPECT_EQ(toTypeSql(MAP(BOOLEAN(), INTEGER())), "MAP(BOOLEAN, INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(ROW({{"a", BOOLEAN()}, {"b", INTEGER()}})),
+      "ROW(a BOOLEAN, b INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(
+          ROW({{"a_", BOOLEAN()}, {"b$", INTEGER()}, {"c d", INTEGER()}})),
+      "ROW(a_ BOOLEAN, b$ INTEGER, c d INTEGER)");
+  EXPECT_EQ(toTypeSql(JSON()), "JSON");
+  EXPECT_EQ(toTypeSql(UNKNOWN()), "UNKNOWN");
+  VELOX_ASSERT_THROW(
+      toTypeSql(FUNCTION({INTEGER()}, INTEGER())),
+      "Type is not supported: FUNCTION");
+}
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::exec::test {
 namespace {
@@ -35,6 +36,7 @@ TEST(PrestoSqlTest, toTypeSql) {
   EXPECT_EQ(toTypeSql(VARBINARY()), "VARBINARY");
   EXPECT_EQ(toTypeSql(TIMESTAMP()), "TIMESTAMP");
   EXPECT_EQ(toTypeSql(DATE()), "DATE");
+  EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");
   EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");
   EXPECT_EQ(toTypeSql(MAP(BOOLEAN(), INTEGER())), "MAP(BOOLEAN, INTEGER)");
   EXPECT_EQ(


### PR DESCRIPTION
Update and consolidate function toTypeSQL of PrestoSql file to compress logic and eliminate unnecessary if and switch cases. This change was originally necessary to avoid missing particular logical types unsupported by type() that are missed by the switch block and lead to fuzzer failures and inaccurate SQL generation.

Differential Revision: D72411897


