### PR TITLE
fix(util): Wrap between and in parantheses

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -201,13 +201,17 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
   const auto& unaryOperators = unaryOperatorMap();
   const auto& binaryOperators = binaryOperatorMap();
   if (unaryOperators.count(call->name()) > 0) {
-    VELOX_CHECK_EQ(call->inputs().size(), 1);
+    VELOX_CHECK_EQ(
+        call->inputs().size(), 1, "Expected one argument to a unary operator");
     sql << "(";
     sql << fmt::format("{} ", unaryOperators.at(call->name()));
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << ")";
   } else if (binaryOperators.count(call->name()) > 0) {
-    VELOX_CHECK_EQ(call->inputs().size(), 2);
+    VELOX_CHECK_EQ(
+        call->inputs().size(),
+        2,
+        "Expected two arguments to a binary operator");
     sql << "(";
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << fmt::format(" {} ", binaryOperators.at(call->name()));
@@ -215,12 +219,18 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     sql << ")";
   } else if (call->name() == "is_null" || call->name() == "not_null") {
     sql << "(";
-    VELOX_CHECK_EQ(call->inputs().size(), 1);
+    VELOX_CHECK_EQ(
+        call->inputs().size(),
+        1,
+        "Expected one argument to function 'is_null' or 'not_null'");
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << fmt::format(" is{} null", call->name() == "not_null" ? " not" : "");
     sql << ")";
   } else if (call->name() == "in") {
-    VELOX_CHECK_GE(call->inputs().size(), 2);
+    VELOX_CHECK_GE(
+        call->inputs().size(),
+        2,
+        "Expected at least two arguments to function 'in'");
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << " in (";
     for (auto i = 1; i < call->inputs().size(); ++i) {
@@ -229,6 +239,14 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     }
     sql << ")";
   } else if (call->name() == "like") {
+    VELOX_CHECK_GE(
+        call->inputs().size(),
+        2,
+        "Expected at least two arguments to function 'like'");
+    VELOX_CHECK_LE(
+        call->inputs().size(),
+        3,
+        "Expected at most three arguments to function 'like'");
     sql << "(";
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << " like ";
@@ -239,6 +257,10 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     }
     sql << ")";
   } else if (call->name() == "or" || call->name() == "and") {
+    VELOX_CHECK_GE(
+        call->inputs().size(),
+        2,
+        "Expected at least two arguments to function 'or' or 'and'");
     sql << "(";
     const auto& inputs = call->inputs();
     for (auto i = 0; i < inputs.size(); ++i) {
@@ -253,19 +275,29 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql(call->inputs(), sql);
     sql << "]";
   } else if (call->name() == "between") {
+    VELOX_CHECK_EQ(
+        call->inputs().size(),
+        3,
+        "Expected three arguments to function 'between'");
     const auto& inputs = call->inputs();
-    VELOX_CHECK_EQ(inputs.size(), 3);
     toCallInputsSql({inputs[0]}, sql);
     sql << " between ";
     toCallInputsSql({inputs[1]}, sql);
     sql << " and ";
     toCallInputsSql({inputs[2]}, sql);
   } else if (call->name() == "row_constructor") {
+    VELOX_CHECK_GE(
+        call->inputs().size(),
+        1,
+        "Expected at least one argument to function 'row_constructor'");
     sql << "row(";
     toCallInputsSql(call->inputs(), sql);
     sql << ")";
   } else if (call->name() == "subscript") {
-    VELOX_CHECK_EQ(call->inputs().size(), 2);
+    VELOX_CHECK_EQ(
+        call->inputs().size(),
+        2,
+        "Expected two arguments to function 'subscript'");
     toCallInputsSql({call->inputs()[0]}, sql);
     sql << "[";
     toCallInputsSql({call->inputs()[1]}, sql);

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -52,5 +52,276 @@ TEST(PrestoSqlTest, toTypeSql) {
       toTypeSql(FUNCTION({INTEGER()}, INTEGER())),
       "Type is not supported: FUNCTION");
 }
+
+void toUnaryOperator(
+    const std::string& operatorName,
+    const std::string& expectedSql) {
+  auto expression = std::make_shared<core::CallTypedExpr>(
+      INTEGER(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0")},
+      operatorName);
+  EXPECT_EQ(toCallSql(expression), expectedSql);
+}
+
+void toBinaryOperator(
+    const std::string& operatorName,
+    const std::string& expectedSql) {
+  auto expression = std::make_shared<core::CallTypedExpr>(
+      INTEGER(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
+      operatorName);
+  EXPECT_EQ(toCallSql(expression), expectedSql);
+}
+
+void toIsNullOrIsNotNull(
+    const std::string& operatorName,
+    const std::string& expectedSql) {
+  auto expression = std::make_shared<core::CallTypedExpr>(
+      BOOLEAN(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
+      operatorName);
+  EXPECT_EQ(toCallSql(expression), expectedSql);
+}
+
+TEST(PrestoSqlTest, toCallSql) {
+  // Unary operators
+  toUnaryOperator("negate", "(- c0)");
+  toUnaryOperator("not", "(not c0)");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1")},
+          "not")),
+      "Expected one argument to a unary operator");
+
+  // Binary operators
+  toBinaryOperator("plus", "(c0 + c1)");
+  toBinaryOperator("subtract", "(c0 - c1)");
+  toBinaryOperator("minus", "(c0 - c1)");
+  toBinaryOperator("multiply", "(c0 * c1)");
+  toBinaryOperator("divide", "(c0 / c1)");
+  toBinaryOperator("eq", "(c0 = c1)");
+  toBinaryOperator("neq", "(c0 <> c1)");
+  toBinaryOperator("lt", "(c0 < c1)");
+  toBinaryOperator("gt", "(c0 > c1)");
+  toBinaryOperator("lte", "(c0 <= c1)");
+  toBinaryOperator("gte", "(c0 >= c1)");
+  toBinaryOperator("distinct_from", "(c0 is distinct from c1)");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3")},
+          "plus")),
+      "Expected two arguments to a binary operator");
+
+  // Functions IS NULL and NOT NULL
+  toIsNullOrIsNotNull("is_null", "(c0 is null)");
+  toIsNullOrIsNotNull("not_null", "(c0 is not null)");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
+          "is_null")),
+      "Expected one argument to function 'is_null' or 'not_null'");
+
+  // Function IN
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b")},
+          "in")),
+      "'a' in ('b')");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
+          "in")),
+      "'a' in ('b', 'c', 'd')");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
+          "in")),
+      "Expected at least two arguments to function 'in'");
+
+  // Function LIKE
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
+          "like")),
+      "(c0 like 'a')");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b")},
+          "like")),
+      "(c0 like 'a' escape 'b')");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
+          "like")),
+      "Expected at least two arguments to function 'like'");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
+          "like")),
+      "Expected at most three arguments to function 'like'");
+
+  // Functions OR and AND
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
+          "or")),
+      "(BOOLEAN 'true' or BOOLEAN 'false')");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
+          "and")),
+      "(BOOLEAN 'true' and BOOLEAN 'false')");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
+          "or")),
+      "(BOOLEAN 'true' or BOOLEAN 'false' or BOOLEAN 'true' or BOOLEAN 'false')");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
+          "and")),
+      "(BOOLEAN 'true' and BOOLEAN 'false' and BOOLEAN 'true' and BOOLEAN 'false')");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "or")),
+      "Expected at least two arguments to function 'or' or 'and'");
+
+  // Functions ARRAY_CONSTRUCTOR and ROW_CONSTRUCTOR
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          ARRAY(INTEGER()),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c")},
+          "array_constructor")),
+      "ARRAY['a', 'b', 'c']");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          ARRAY(INTEGER()),
+          std::vector<core::TypedExprPtr>{},
+          "array_constructor")),
+      "ARRAY[]");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
+          "row_constructor")),
+      "row('a', 'b', 'c', 'd')");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "row_constructor")),
+      "Expected at least one argument to function 'row_constructor'");
+
+  // Function BETWEEN
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c2")},
+          "between")),
+      "c0 between c1 and c2");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "between")),
+      "Expected three arguments to function 'between'");
+
+  // Function SUBSCRIPT, builds '[]' SQL
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  ARRAY(INTEGER()), "array"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
+          "subscript")),
+      "array[c0]");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  ARRAY(INTEGER()), "array"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
+          "subscript")),
+      "Expected two arguments to function 'subscript'");
+
+  // Generic functions
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  ARRAY(INTEGER()), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
+          "array_top_n")),
+      "array_top_n(c0, c1)");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          REAL(), std::vector<core::TypedExprPtr>{}, "infinity")),
+      "infinity()");
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary: Wraps `between ... and` in paranthesis due to ambiguous SQL processing.

Differential Revision: D72420747


