### PR TITLE
test(util): Create unit tests for function toTypeSql of PrestoSql

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -161,3 +161,7 @@ target_link_libraries(
 target_link_libraries(
   velox_cache_fuzzer_lib velox_dwio_common velox_temp_path
   velox_vector_test_lib)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(presto_sql_test PrestoSqlTest.cpp)
+add_test(presto_sql_test presto_sql_test)
+
+target_link_libraries(
+  presto_sql_test velox_fuzzer_util velox_presto_types)

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/fuzzer/PrestoSql.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+TEST(PrestoSqlTest, toTypeSql) {
+  EXPECT_EQ(toTypeSql(BOOLEAN()), "BOOLEAN");
+  EXPECT_EQ(toTypeSql(TINYINT()), "TINYINT");
+  EXPECT_EQ(toTypeSql(SMALLINT()), "SMALLINT");
+  EXPECT_EQ(toTypeSql(INTEGER()), "INTEGER");
+  EXPECT_EQ(toTypeSql(BIGINT()), "BIGINT");
+  EXPECT_EQ(toTypeSql(REAL()), "REAL");
+  EXPECT_EQ(toTypeSql(DOUBLE()), "DOUBLE");
+  EXPECT_EQ(toTypeSql(VARCHAR()), "VARCHAR");
+  EXPECT_EQ(toTypeSql(VARBINARY()), "VARBINARY");
+  EXPECT_EQ(toTypeSql(TIMESTAMP()), "TIMESTAMP");
+  EXPECT_EQ(toTypeSql(DATE()), "DATE");
+  EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");
+  EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");
+  EXPECT_EQ(toTypeSql(MAP(BOOLEAN(), INTEGER())), "MAP(BOOLEAN, INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(ROW({{"a", BOOLEAN()}, {"b", INTEGER()}})),
+      "ROW(a BOOLEAN, b INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(
+          ROW({{"a_", BOOLEAN()}, {"b$", INTEGER()}, {"c d", INTEGER()}})),
+      "ROW(a_ BOOLEAN, b$ INTEGER, c d INTEGER)");
+  EXPECT_EQ(toTypeSql(JSON()), "JSON");
+  EXPECT_EQ(toTypeSql(UNKNOWN()), "UNKNOWN");
+  VELOX_ASSERT_THROW(
+      toTypeSql(FUNCTION({INTEGER()}, INTEGER())),
+      "Type is not supported: FUNCTION");
+}
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary: Create unit tests for function toTypeSql of PrestoSql. This class generates Sql for our query runners during fuzzer runs

Differential Revision: D72428441


