### PR TITLE
feat(aggregate): Support type DECIMAL for function map_union_sum

### DIFF
--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -558,6 +558,10 @@ void registerMapUnionSumAggregate(
             return createMapUnionSumAggregate<UnknownValue>(
                 valueTypeKind, resultType);
           default:
+            if (mapType.keyType()->isDecimal()) {
+              return createMapUnionSumAggregate<int128_t>(
+                  valueTypeKind, resultType);
+            }
             VELOX_UNREACHABLE(
                 "Unexpected key type {}", mapTypeKindToName(keyTypeKind));
         }


### PR DESCRIPTION
Summary: Add support for key type DECIMAL for function map_union_sum. DECIMAL is not supported by kind() and requires an additional extra check in the default switch block case, otherwise it will be interpretted as a HUGEINT and fail.

Differential Revision: D72430575


