### PR TITLE
fix(parquet): Multi range filter in timestamp reader

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -293,6 +293,11 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         {},
         "t == TIMESTAMP '2022-12-23 03:56:01'",
         "SELECT t from tmp where t == TIMESTAMP '2022-12-23 03:56:01'");
+    assertSelectWithFilter(
+        {"t"},
+        {},
+        "not(eq(t, TIMESTAMP '2000-09-12 22:36:29'))",
+        "SELECT t from tmp where t != TIMESTAMP '2000-09-12 22:36:29'");
   }
 
  private:

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1489,6 +1489,15 @@ bool MultiRange::testFloat(float value) const {
   return false;
 }
 
+bool MultiRange::testInt128(const int128_t& value) const {
+  for (const auto& filter : filters_) {
+    if (filter->testInt128(value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool MultiRange::testBytes(const char* value, int32_t length) const {
   for (const auto& filter : filters_) {
     if (filter->testBytes(value, length)) {

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -89,6 +89,10 @@ class Filter : public velox::ISerializable {
     return kind_;
   }
 
+  bool nullAllowed() const {
+    return nullAllowed_;
+  }
+
   /// Return a copy of this filter. If nullAllowed is set, modified the
   /// nullAllowed flag in the copy to match.
   virtual std::unique_ptr<Filter> clone(
@@ -1955,10 +1959,6 @@ class TimestampRange : public Filter {
     return upper_;
   }
 
-  bool nullAllowed() const {
-    return nullAllowed_;
-  }
-
   bool testingEquals(const Filter& other) const final;
 
  private:
@@ -2164,6 +2164,8 @@ class MultiRange final : public Filter {
   bool testDouble(double value) const final;
 
   bool testFloat(float value) const final;
+
+  bool testInt128(const int128_t& value) const final;
 
   bool testBytes(const char* value, int32_t length) const final;
 


### PR DESCRIPTION
Adds `MultiRange::testInt128` and converts `TimestampRange` filters in multi range 
as `ParquetTimestampRange`.