### PR TITLE
fix: ExpressionFuzzer never selects function signatures that return a type variable

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -417,19 +417,18 @@ ExpressionFuzzer::ExpressionFuzzer(
   sortSignatureTemplates(signatureTemplates_);
 
   for (const auto& it : signatureTemplates_) {
-    const auto returnType =
-        exec::sanitizeName(it.signature->returnType().baseName());
-    const auto* returnTypeKey = &returnType;
+    const auto returnType = it.signature->returnType().baseName();
+    std::string returnTypeKey = exec::sanitizeName(returnType);
 
     if (it.typeVariables.find(returnType) != it.typeVariables.end()) {
       // Return type is a template variable.
-      returnTypeKey = &kTypeParameterName;
+      returnTypeKey = kTypeParameterName;
     }
-    if (typeToExpressionList_[*returnTypeKey].empty() ||
-        typeToExpressionList_[*returnTypeKey].back() != it.name) {
-      addToTypeToExpressionListByTicketTimes(*returnTypeKey, it.name);
+    if (typeToExpressionList_[returnTypeKey].empty() ||
+        typeToExpressionList_[returnTypeKey].back() != it.name) {
+      addToTypeToExpressionListByTicketTimes(returnTypeKey, it.name);
     }
-    expressionToTemplatedSignature_[it.name][*returnTypeKey].push_back(&it);
+    expressionToTemplatedSignature_[it.name][returnTypeKey].push_back(&it);
   }
 
   if (options_.enableDereference) {
@@ -771,7 +770,9 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
   }
   auto baseType = typeToBaseName(returnType);
   VELOX_CHECK_NE(
-      baseType, "T", "returnType should have all concrete types defined");
+      baseType,
+      kTypeParameterName,
+      "returnType should have all concrete types defined");
   // Randomly pick among all functions that support this return type. Also,
   // consider all functions that have return type "T" as they can
   // support any concrete return type.

--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -299,23 +299,24 @@ class ExpressionFuzzer {
   // Returns random integer between min and max inclusive.
   int32_t rand32(int32_t min, int32_t max);
 
-  static const inline std::string kTypeParameterName = "T";
-
   const Options options_;
 
   std::vector<CallableSignature> signatures_;
   std::vector<SignatureTemplate> signatureTemplates_;
 
+  // IMPORTANT: this needs to be sanitized because ExpressionFuzzer sanitizes
+  // type names before adding them to the maps below.
+  static const inline std::string kTypeParameterName = exec::sanitizeName("T");
+
   /// Maps the base name of a return type signature to the function names that
-  /// support that return type. Base name could be "T" if the return type is a
-  /// type variable.
+  /// support that return type. Base name could be `kTypeParameterName` if the
+  /// return type is a type variable.
   std::unordered_map<std::string, std::vector<std::string>>
       typeToExpressionList_;
 
   /// Maps the base name of a *concrete* return type signature to the function
   /// names that support that return type. Those names then each further map
-  /// to a list of CallableSignature objects that they support. Base name
-  /// could be "T" if the return type is a type variable.
+  /// to a list of CallableSignature objects that they support.
   std::unordered_map<
       std::string,
       std::unordered_map<std::string, std::vector<const CallableSignature*>>>
@@ -324,7 +325,8 @@ class ExpressionFuzzer {
   /// Maps the base name of a *templated* return type signature to the
   /// function names that support that return type. Those names then each
   /// further map to a list of SignatureTemplate objects that they support.
-  /// Base name could be "T" if the return type is a type variable.
+  /// Base name could be `kTypeParameterName` if the return type is a type
+  /// variable.
   std::unordered_map<
       std::string,
       std::unordered_map<std::string, std::vector<const SignatureTemplate*>>>

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -123,6 +123,8 @@ int main(int argc, char** argv) {
       "bing_tile_parent",
       "bing_tile_children",
       "bing_tile_quadkey",
+      "array_min_by", // https://github.com/facebookincubator/velox/issues/12934
+      "array_max_by", // https://github.com/facebookincubator/velox/issues/12934
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 


### PR DESCRIPTION
Summary:
I was trying to run the expression fuzzer on the newly added array_min_by/array_max_by
functions and discovered it would never select either of these functions when generating an 
expression.

I discovered that when we look up function templates as candidates, we use
`typeToExpressionList_[kTypeParameterName]`
Likewise we use kTypeParameterName when looking up a signature in 
expressionToTemplatedSignature_ with chooseRandomSignatureTemplate.

However, when we add entries to these two maps, we first sanitize the type name, which just
converts it to lower case. kTypeParameterName is "T" which will clearly never match an all
lower case string. So in practice we never recognize functions that return a type variable as a
viable candidate.

This diff update kTypeParameterName to sanitize the string we choose for it, to ensure it's
consistent with the keys in the maps we use it for lookups in.

I also noticed that when we iterate over the list of signatureTemplates_, we check if the return
type is a type variable, but again we sanitize it before doing this check.  Since simple 
functions use strings like __user_T1 for type variable names, and it's common practice to use
capital letters like T and U in Vector functions, this likewise never matches.

I updated this logic to do the check against the unsanitized type name as well.

These bugs were preventing ExpressionFuzzer from ever covering array_min_by, 
array_max_by, subscript, find_first at all, among other functions that are only being partially
covered.

Differential Revision: D72474230


