### PR TITLE
fix: Exclude CLion-generated CMake build directories correctly in `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,8 +293,7 @@ distribute/*
 *.bin
 cmake_build
 .cmake_build
-cmake-build-debug
-cmake-build-release
+cmake-build-*
 
 # tests
 test/test.sql


### PR DESCRIPTION
CLion generates CMake build directories with name `cmake-build-<profile-name>`. Which means it can be `cmake-build-release`, `cmake-build-debug`, also `cmake-build-relwithdebinfo` or so.

The patch fixes `.gitignore` to maximize the exclusion for CLion.