### PR TITLE
fix(velox): Resolve runtime error when using ARRAY<UNKNOWN> as checksum argument

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -423,4 +423,12 @@ TEST_F(ChecksumAggregateTest, complexVectorWithNulls) {
   assertChecksum(row, "i5mk/hSs+AQ=");
 }
 
+TEST_F(ChecksumAggregateTest, nullArray) {
+  auto emptyArrayVector = makeArrayVector<UnknownValue>({{}});
+  assertChecksum(emptyArrayVector, "AAAAAAAAAAA=");
+
+  emptyArrayVector = makeArrayVector<UnknownValue>({{}, {}});
+  assertChecksum(emptyArrayVector, "AAAAAAAAAAA=");
+}
+
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
We encountered numerous GENERIC_INTERNAL_ERROR issues originating from the error "not a known type kind: UNKNOWN Operator: Aggregation[10] 1." 
You can find more details at this link: https://fburl.com/scuba/presto_queries/zqwioxmt.

This problem arises because an UNKNOWN(aka null) is passed into the checksum hash function from ARRAY<>. To resolve this, we need to ensure that ARRAY[] defaults to returning 0(the behavior can be found in [java]( https://www.internalfb.com/code/fbsource/[1b646bfae4ec]/fbcode/github/presto-deprecated/presto-common/src/main/java/com/facebook/presto/common/type/UnknownType.java?lines=95)) before the hash function is called.

Differential Revision: D72474507


