### PR TITLE
fix(util): Update default case for SQL type generation

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -71,12 +71,6 @@ void appendComma(int32_t i, std::stringstream& sql) {
 
 // Returns the SQL string of the given type.
 std::string toTypeSql(const TypePtr& type) {
-  // Date needs special handling because it is not supported by TypeKind. We
-  // will need to explicitly specify or we are at risk of a date being casted to
-  // an integer and failing.
-  if (type->isDate()) {
-    return "DATE";
-  }
   switch (type->kind()) {
     case TypeKind::ARRAY:
       return fmt::format("ARRAY({})", toTypeSql(type->childAt(0)));
@@ -97,11 +91,9 @@ std::string toTypeSql(const TypePtr& type) {
       sql << ")";
       return sql.str();
     }
-    case TypeKind::VARCHAR:
-      return isJsonType(type) ? "JSON" : "VARCHAR";
     default:
       if (type->isPrimitiveType()) {
-        return mapTypeKindToName(type->kind());
+        return type->name();
       }
       VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
   }


### PR DESCRIPTION
Summary: Fix bug introduced by https://github.com/facebookincubator/velox/pull/12858 that doesn't allow for SQL generation of logical types (for example, DATE and JSON). It would be best to not special case these and minimize the switch-block logic.

Differential Revision: D72597782


