### PR TITLE
fix(tableScan): Convert remainingFilterSubfields to member variable

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -142,7 +142,6 @@ HiveDataSource::HiveDataSource(
     randomSkip_ = std::make_shared<random::RandomSkipTracker>(sampleRate);
   }
 
-  std::vector<common::Subfield> remainingFilterSubfields;
   if (remainingFilter) {
     remainingFilterExprSet_ = expressionEvaluator_->compile(remainingFilter);
     auto& remainingFilterExpr = remainingFilterExprSet_->expr(0);
@@ -164,13 +163,13 @@ HiveDataSource::HiveDataSource(
       readColumnNames.push_back(input->field());
       readColumnTypes.push_back(input->type());
     }
-    remainingFilterSubfields = remainingFilterExpr->extractSubfields();
+    remainingFilterSubfields_ = remainingFilterExpr->extractSubfields();
     if (VLOG_IS_ON(1)) {
       VLOG(1) << fmt::format(
           "Extracted subfields from remaining filter: [{}]",
-          fmt::join(remainingFilterSubfields, ", "));
+          fmt::join(remainingFilterSubfields_, ", "));
     }
-    for (auto& subfield : remainingFilterSubfields) {
+    for (auto& subfield : remainingFilterSubfields_) {
       const auto& name = getColumnName(subfield);
       auto it = subfields_.find(name);
       if (it != subfields_.end()) {

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -159,6 +159,7 @@ class HiveDataSource : public DataSource {
   std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
       infoColumns_;
   SpecialColumnNames specialColumns_{};
+  std::vector<common::Subfield> remainingFilterSubfields_;
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields_;
   common::SubfieldFilters filters_;


### PR DESCRIPTION
Summary:
remainingFilterSubfields is a local variable in the HiveDataSource constructor, and its memory will be freed after the constructor finishes executing. However, we are storing a reference to it in the member variable subfields_, which will become invalid once the constructor finishes.

This causes a problem in the setupBucketConversion() function, where we try to access the content of subfields_. Since the memory for remainingFilterSubfields has already been freed, this results in undefined behavior and ultimately leads to a crash.


Crashed Query ASAN log: P1778761122

Differential Revision: D72578859


