### PR TITLE
fix: Fix crashes caused by ClassificationAggregation

### DIFF
--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
@@ -334,7 +334,7 @@ struct Accumulator {
     double runningFalseWeight = 0;
     double runningTrueWeight = 0;
     int64_t trueWeightIndex = 0;
-    while (trueWeightIndex < trueWeights_.bucketCount() &&
+    while (trueWeightIndex < trueWeights_.size() &&
            totalTrueWeight > runningTrueWeight) {
       auto trueBucketResult = trueWeights_.getBucket(trueWeightIndex);
       auto falseBucketResult = falseWeights_.getBucket(trueWeightIndex);


### PR DESCRIPTION
Summary:
We got two different ASAN stacktraces: P1774941545 P1774941264

This query causes crashes in prod: [20250401_091330_01869_b6mfs](https://www.internalfb.com/intern/presto/query/?query_id=20250401_091330_01869_b6mfs#sql)
Trimmed query: [20250404_000136_00001_gxr7s](https://www.internalfb.com/intern/presto/query/?query_id=20250404_000136_00001_gxr7s#sql)

## What happened?
In both stack traces we see the process was crashed with SEGV signal. If we look into the stack and code around it, we see that it's Velox read path. After some investigation it started to be clear, that the memory was corrupted some time ago and later we failed to interpret that memory during the read. So the stacktraces don't help much in this case.

## How did I found the corruption?
I wrote small mem validation function that validates certain type of corruption and added it to suspicious call stacks.

## What was the stack trace when we corrupted memory?
We corrupted the memory on this line (the remaining stack is not hard to figure out):
https://www.internalfb.com/code/fbsource/[29b8221201c9]/fbcode/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp?lines=350-351
Basically `(offset + trueWeightIndex)` points to the memory outside the vector's range.

**How much we allocate?**
The allocation happens here:
https://www.internalfb.com/code/fbsource/[29b8221201c9]/fbcode/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp?lines=503-504
where the `numValues = SUM(Accumulator::size())` for all the groups.

**How do we write into the allocated memory?**
We write it by offsets and that part works correct, but while loop in `extractValues(...)` doesn't work as expected:
https://www.internalfb.com/code/fbsource/[29b8221201c93ac6d6f26050a330f161d3738993]/fbcode/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp?lines=337-338
It contains 2 clauses, both should be satisfied:
1. `trueWeightIndex < trueWeights_.bucketCount()`
2. `totalTrueWeight > runningTrueWeight`

The interesting thing is that they basically aiming the same, they stop iteration over  `trueWeights_` container and they almost always either both true or false. But there is some difference between them:
(1) The first one checks that we don't access the memory outside the vector's range.
(2) The second one checks, that the current sum of weights isn't higher than the total sum.

**Why the second one is needed?**
That's a good question. It's needed, because below in the code we assume that `totalTrueWeight - runningTrueWeight` is always greater than 0:
https://www.internalfb.com/code/fbsource/[29b8221201c9]/fbcode/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp?lines=348
The (1) isn't enough, because for double numbers the order of summing matters, as example:
`(0.1 + 0.2) + 0.3 != 0.1 + (0.2 + 0.3)`.
So (2) is needed as protection against `totalTrueWeight - runningTrueWeight` being negative.

Unfortunately (1) has a bug.
And the (2) clause helped us to avoid memory corruptions for the most of the inputs, but not for all of them.

## The fix
The bug and fix are actually simple. `bucketCount()` is not the right way to get the size of the container, because we allocate memory in FlatVector for `size()` elements, not for `bucketCount()` elements.

## What I've learnt from it.
- The debugging process would be much more quicker if I had just enabled the debug mode, because the check is in the code:
https://www.internalfb.com/code/fbsource/[29b8221201c9]/fbcode/velox/vector/FlatVector.h?lines=234-235
- I've went through the entire velox stack from vector reads to the driver and from the driver to writes. This investigation gave me a lot of knowledge about Velox internals.

Reviewed By: yuandagits

Differential Revision: D72598606


