### PR TITLE
fix(expression): Remove unused compare function in ITypedExpr

### DIFF
--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -81,7 +81,7 @@ class ITypedExpr : public ISerializable {
       return false;
     }
     for (int32_t i = 0; i < inputs_.size(); ++i) {
-      if (*inputs_[i] == *other.inputs_[i]) {
+      if (!(*inputs_[i] == *other.inputs_[i])) {
         return false;
       }
     }

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -70,24 +70,6 @@ class ITypedExpr : public ISerializable {
     return hash;
   }
 
-  /// Returns true if other is recursively equal to 'this'. We do not
-  /// overload == because this is overloaded in a subclass for a
-  /// different purpose.
-  bool equals(const ITypedExpr& other) const {
-    if (type_ != other.type_ || inputs_.size() != other.inputs_.size()) {
-      return false;
-    }
-    if (!equalsNonRecursive(other)) {
-      return false;
-    }
-    for (int32_t i = 0; i < inputs_.size(); ++i) {
-      if (!(*inputs_[i] == *other.inputs_[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   virtual bool operator==(const ITypedExpr& other) const = 0;
 
   static void registerSerDe();
@@ -106,10 +88,6 @@ class ITypedExpr : public ISerializable {
   }
 
  private:
-  virtual bool equalsNonRecursive(const ITypedExpr& other) const {
-    return false;
-  }
-
   TypePtr type_;
   std::vector<TypedExprPtr> inputs_;
 };


### PR DESCRIPTION
It seems that the `equals()` comparison function is wrong when dealing with `inputs_` expressions, and this PR tries to fix it.