### PR TITLE
fix(parquet): Fix INT64 timestamp precision conversion

### DIFF
--- a/velox/dwio/parquet/reader/TimestampColumnReader.h
+++ b/velox/dwio/parquet/reader/TimestampColumnReader.h
@@ -119,6 +119,9 @@ class TimestampColumnReader : public IntegerColumnReader {
       } else {
         VELOX_NYI("Logical type and converted type are not provided.");
       }
+      if (filePrecision_ != requestedPrecision_) {
+        needsConversion_ = true;
+      }
     }
   }
 
@@ -144,6 +147,9 @@ class TimestampColumnReader : public IntegerColumnReader {
       const int128_t encoded = reinterpret_cast<int128_t&>(rawValues[i]);
       if constexpr (std::is_same_v<T, int64_t>) {
         rawValues[i] = toInt64Timestamp(encoded, filePrecision_);
+        if (needsConversion_) {
+          rawValues[i] = rawValues[i].toPrecision(requestedPrecision_);
+        }
       } else if constexpr (std::is_same_v<T, int128_t>) {
         rawValues[i] =
             toInt96Timestamp(encoded).toPrecision(requestedPrecision_);
@@ -199,6 +205,9 @@ class TimestampColumnReader : public IntegerColumnReader {
 
   // The precision of int64_t timestamp in Parquet. Only set when T is int64_t.
   TimestampPrecision filePrecision_;
+
+  // Whether Int64 Timestamp needs to be converted to the requested precision.
+  bool needsConversion_ = false;
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/TimestampColumnReader.h
+++ b/velox/dwio/parquet/reader/TimestampColumnReader.h
@@ -144,9 +144,6 @@ class TimestampColumnReader : public IntegerColumnReader {
       const int128_t encoded = reinterpret_cast<int128_t&>(rawValues[i]);
       if constexpr (std::is_same_v<T, int64_t>) {
         rawValues[i] = toInt64Timestamp(encoded, filePrecision_);
-        if (needsConversion_) {
-          rawValues[i] = rawValues[i].toPrecision(requestedPrecision_);
-        }
       } else if constexpr (std::is_same_v<T, int128_t>) {
         rawValues[i] =
             toInt96Timestamp(encoded).toPrecision(requestedPrecision_);
@@ -202,9 +199,6 @@ class TimestampColumnReader : public IntegerColumnReader {
 
   // The precision of int64_t timestamp in Parquet. Only set when T is int64_t.
   TimestampPrecision filePrecision_;
-
-  // Whether Int64 Timestamp needs to be converted to the requested precision.
-  bool needsConversion_ = false;
 };
 
 } // namespace facebook::velox::parquet


### PR DESCRIPTION
In #11964, the assignment of `needsConversion_` in `TimestampColumnReader.h` has
been removed, causing `needsConversion_` to always be false. We need to update
the `needsConversion_` if `filePrecision_` is different with
`requestedPrecision_`.