### PR TITLE
fix(util): Generate SQL for function subscript

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -161,3 +161,7 @@ target_link_libraries(
 target_link_libraries(
   velox_cache_fuzzer_lib velox_dwio_common velox_temp_path
   velox_vector_test_lib)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -266,6 +266,12 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     sql << "row(";
     toCallInputsSql(call->inputs(), sql);
     sql << ")";
+  } else if (call->name() == "subscript") {
+    VELOX_CHECK_EQ(call->inputs().size(), 2);
+    toCallInputsSql({call->inputs()[0]}, sql);
+    sql << "[";
+    toCallInputsSql({call->inputs()[1]}, sql);
+    sql << "]";
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -253,6 +253,7 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql(call->inputs(), sql);
     sql << "]";
   } else if (call->name() == "between") {
+    sql << "(";
     const auto& inputs = call->inputs();
     VELOX_CHECK_EQ(inputs.size(), 3);
     toCallInputsSql({inputs[0]}, sql);
@@ -260,6 +261,7 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     toCallInputsSql({inputs[1]}, sql);
     sql << " and ";
     toCallInputsSql({inputs[2]}, sql);
+    sql << ")";
   } else if (call->name() == "row_constructor") {
     sql << "row(";
     toCallInputsSql(call->inputs(), sql);

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(presto_sql_test PrestoSqlTest.cpp)
+add_test(presto_sql_test presto_sql_test)
+
+target_link_libraries(
+  presto_sql_test velox_fuzzer_util velox_presto_types)

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/fuzzer/PrestoSql.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+TEST(PrestoSqlTest, toTypeSql) {
+  EXPECT_EQ(toTypeSql(BOOLEAN()), "BOOLEAN");
+  EXPECT_EQ(toTypeSql(TINYINT()), "TINYINT");
+  EXPECT_EQ(toTypeSql(SMALLINT()), "SMALLINT");
+  EXPECT_EQ(toTypeSql(INTEGER()), "INTEGER");
+  EXPECT_EQ(toTypeSql(BIGINT()), "BIGINT");
+  EXPECT_EQ(toTypeSql(REAL()), "REAL");
+  EXPECT_EQ(toTypeSql(DOUBLE()), "DOUBLE");
+  EXPECT_EQ(toTypeSql(VARCHAR()), "VARCHAR");
+  EXPECT_EQ(toTypeSql(VARBINARY()), "VARBINARY");
+  EXPECT_EQ(toTypeSql(TIMESTAMP()), "TIMESTAMP");
+  EXPECT_EQ(toTypeSql(DATE()), "DATE");
+  EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");
+  EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");
+  EXPECT_EQ(toTypeSql(MAP(BOOLEAN(), INTEGER())), "MAP(BOOLEAN, INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(ROW({{"a", BOOLEAN()}, {"b", INTEGER()}})),
+      "ROW(a BOOLEAN, b INTEGER)");
+  EXPECT_EQ(
+      toTypeSql(
+          ROW({{"a_", BOOLEAN()}, {"b$", INTEGER()}, {"c d", INTEGER()}})),
+      "ROW(a_ BOOLEAN, b$ INTEGER, c d INTEGER)");
+  EXPECT_EQ(toTypeSql(JSON()), "JSON");
+  EXPECT_EQ(toTypeSql(UNKNOWN()), "UNKNOWN");
+  VELOX_ASSERT_THROW(
+      toTypeSql(FUNCTION({INTEGER()}, INTEGER())),
+      "Type is not supported: FUNCTION");
+}
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -61,7 +61,7 @@ TEST(PrestoSqlTest, toCallSql) {
   auto nullConstant = std::make_shared<core::ConstantTypedExpr>(
       INTEGER(), variant::null(TypeKind::INTEGER));
   auto expression = std::make_shared<core::CallTypedExpr>(
-      INTEGER(),
+      BOOLEAN(),
       std::vector<core::TypedExprPtr>{
           std::make_shared<core::CallTypedExpr>(
               BOOLEAN(),
@@ -73,6 +73,16 @@ TEST(PrestoSqlTest, toCallSql) {
   EXPECT_EQ(
       toCallSql(expression),
       "((c0 between c0 and cast(null as INTEGER)) < c0)");
+
+  // Builds susbscript SQL expression
+  expression = std::make_shared<core::CallTypedExpr>(
+      INTEGER(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(INTEGER()), "array"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
+      "subscript");
+  EXPECT_EQ(toCallSql(expression), "array[c0]");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Generate SQL for function `subscript`.

As part of Presto 0.291, Presto now supports subscripting arrays (https://prestodb.io/docs/current/functions/array.html):
```
SELECT my_array[1] AS first_element
```

Because we have not yet created a special case for subscript, and treat it like any other function, we generate as the following, which causes fuzzer failures:
```
Executing expression 0 : subscript("c0",2059751923) # Velox expression eval
Execute presto sql: SELECT subscript(c0, INTEGER '2059751923') as p0, row_number as p1 FROM (t_values) # SQL executed in Presto
Presto query failed: 1 line 1:8: Function subscript not registered
```
This review adds proper SQL generation for subscripts

Differential Revision: D72651898


