### PR TITLE
fix: Fix Expr to allow peeling on inputs of deterministic functions in non-deterministic expression

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -210,6 +210,15 @@ void Expr::computeDistinctFields() {
   }
 }
 
+bool Expr::isCurrentFunctionDeterministic() const {
+  if (vectorFunction_) {
+    return vectorFunctionMetadata_.deterministic;
+  } else {
+    VELOX_CHECK(isSpecialForm());
+    return true;
+  }
+}
+
 void Expr::computeMetadata() {
   if (metaDataComputed_) {
     return;
@@ -223,13 +232,7 @@ void Expr::computeMetadata() {
   // (1) Compute deterministic_.
   // An expression is deterministic if it is a deterministic function call or
   // a special form, and all its inputs are also deterministic.
-  if (vectorFunction_) {
-    deterministic_ = vectorFunctionMetadata_.deterministic;
-  } else {
-    VELOX_CHECK(isSpecialForm());
-    deterministic_ = true;
-  }
-
+  deterministic_ = isCurrentFunctionDeterministic();
   for (auto& input : inputs_) {
     deterministic_ &= input->deterministic_;
   }
@@ -1405,7 +1408,7 @@ void Expr::evalAllImpl(
     evalSpecialFormWithStats(rows, context, result);
     return;
   }
-  bool tryPeelArgs = deterministic_ ? true : false;
+  bool tryPeelArgs = isCurrentFunctionDeterministic();
   bool defaultNulls = vectorFunctionMetadata_.defaultNullBehavior;
 
   // Tracks what subset of rows shall un-evaluated inputs and current

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -227,6 +227,12 @@ class Expr {
     evalSpecialForm(rows, context, result);
   }
 
+  // Return true if the current function is deterministic, regardless of the
+  // determinism of its inputs. Return false otherwise. Note that this is
+  // different from deterministic_ that represents the determinism of the
+  // current expression including its inputs.
+  bool isCurrentFunctionDeterministic() const;
+
   // Compute the following properties: deterministic_, propagatesNulls_,
   // distinctFields_, multiplyReferencedFields_, hasConditionals_ and
   // sameAsParentDistinctFields_.


### PR DESCRIPTION
Summary: Peeling on inputs of non-deterministic functions is not allowed, but peeling on inputs of deterministic functions should be even if the inputs themselves are non-determinstic. Expr::evalAllImpl() currently disallow peeling if inputs are non-determistic. This diff fixes this issue.

Differential Revision: D72662169


