### PR TITLE
fix(util): Generate SQL for function subscript (#12957)

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -264,6 +264,12 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     sql << "row(";
     toCallInputsSql(call->inputs(), sql);
     sql << ")";
+  } else if (call->name() == "subscript") {
+    VELOX_CHECK_EQ(call->inputs().size(), 2);
+    toCallInputsSql({call->inputs()[0]}, sql);
+    sql << "[";
+    toCallInputsSql({call->inputs()[1]}, sql);
+    sql << "]";
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";


### PR DESCRIPTION
Summary:

Generate SQL for function `subscript`.
As part of Presto 0.291, Presto now supports subscripting arrays (https://prestodb.io/docs/current/functions/array.html):
```
SELECT my_array[1] AS first_element
```

Because we have not yet created a special case for subscript, and treat it like any other function, we generate as the following, which causes fuzzer failures:
```
Executing expression 0 : subscript("c0",2059751923) # Velox expression eval
Execute presto sql: SELECT subscript(c0, INTEGER '2059751923') as p0, row_number as p1 FROM (t_values) # SQL executed in Presto
Presto query failed: 1 line 1:8: Function subscript not registered
```
This review adds proper SQL generation for subscripts

Differential Revision: D72670134


