### PR TITLE
feat(parquet): Add created by config in parquet writer

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -725,6 +725,11 @@ Each query can override the config by setting corresponding query session proper
      - integer
      - 1024
      - Batch size used when writing into Parquet through Arrow bridge.
+   * - hive.parquet.writer.created-by
+     -
+     - string
+     - parquet-cpp-velox version 0.0.0
+     - Created-by value used when writing to Parquet.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -359,4 +359,8 @@ std::string FileMetaDataPtr::keyValueMetadataValue(
   VELOX_FAIL(fmt::format("Input key {} is not in the key value metadata", key));
 }
 
+std::string FileMetaDataPtr::createdBy() const {
+  return thriftFileMetaDataPtr(ptr_)->created_by;
+}
+
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -153,6 +153,9 @@ class FileMetaDataPtr {
   /// Returns the value inside the key/value metadata if the key is present.
   std::string keyValueMetadataValue(const std::string_view key) const;
 
+  /// Return the Parquet writer created_by string.
+  std::string createdBy() const;
+
  private:
   const void* ptr_;
 };

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -111,6 +111,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<int64_t> dictionaryPageSizeLimit;
   std::optional<bool> enableDictionary;
   std::optional<bool> useParquetDataPageV2;
+  std::optional<std::string> createdBy;
 
   // Parsing session and hive configs.
 
@@ -140,6 +141,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.batch_size";
   static constexpr const char* kParquetHiveConnectorWriteBatchSize =
       "hive.parquet.writer.batch-size";
+  static constexpr const char* kParquetHiveConnectorCreatedBy =
+      "hive.parquet.writer.created-by";
 
   // Process hive connector and session configs.
   void processConfigs(

--- a/velox/dwio/parquet/writer/arrow/Properties.h
+++ b/velox/dwio/parquet/writer/arrow/Properties.h
@@ -36,6 +36,8 @@
 
 // Define the parquet created by version.
 #define CREATED_BY_VERSION "parquet-cpp-velox"
+// Velox has no versioning yet. Set default 0.0.0.
+#define VELOX_VERSION "0.0.0"
 
 namespace facebook::velox::parquet::arrow {
 
@@ -326,8 +328,7 @@ class PARQUET_EXPORT WriterProperties {
           version_(ParquetVersion::PARQUET_2_6),
           data_page_version_(ParquetDataPageVersion::V1),
           created_by_(
-              std::string("parquet-mr version 2.6.0 (build ") +
-              DEFAULT_CREATED_BY + ")"),
+              DEFAULT_CREATED_BY + std::string(" version ") + VELOX_VERSION),
           store_decimal_as_integer_(false),
           page_checksum_enabled_(false) {}
     virtual ~Builder() {}

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -428,6 +428,9 @@ TEST(Metadata, TestAddKeyValueMetadata) {
   }
   // Verify keys that were added after file writer was closed are not present.
   EXPECT_FALSE(reader->fileMetaData().keyValueMetadataContains("test_key_4"));
+  ASSERT_EQ(
+      CREATED_BY_VERSION + std::string(" version ") + VELOX_VERSION,
+      reader->fileMetaData().createdBy());
 }
 
 // TODO: disabled as they require Arrow parquet data dir.
@@ -502,10 +505,12 @@ TEST(Metadata, TestSortingColumns) {
     sortingColumns.push_back(sortingColumn);
   }
 
+  auto createdBy = CREATED_BY_VERSION + std::string(" version 1.0");
   auto sink = CreateOutputStream();
   auto writerProps = WriterProperties::Builder()
                          .disable_dictionary()
                          ->set_sorting_columns(sortingColumns)
+                         ->created_by(createdBy)
                          ->build();
 
   EXPECT_EQ(sortingColumns, writerProps->sorting_columns());
@@ -537,6 +542,7 @@ TEST(Metadata, TestSortingColumns) {
   EXPECT_EQ(sortingColumns[0].column_idx, rowGroup.sortingColumnIdx(0));
   EXPECT_EQ(sortingColumns[0].descending, rowGroup.sortingColumnDescending(0));
   EXPECT_EQ(sortingColumns[0].nulls_first, rowGroup.sortingColumnNullsFirst(0));
+  ASSERT_EQ(createdBy, reader->fileMetaData().createdBy());
 }
 
 TEST(ApplicationVersion, Basics) {


### PR DESCRIPTION
Need to change presto velox parquet-tools inspect output on parquet tools created by to contain the velox version. Also adding in a config for created by similar to arrow.