### PR TITLE
feat: Create an identity ParitionFunction to allow bucket values to be computed as part of the query

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -64,7 +64,7 @@ class HiveConnector : public Connector {
       RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx,
-      CommitStrategy commitStrategy) override final;
+      CommitStrategy commitStrategy) override;
 
   folly::Executor* executor() const override {
     return executor_;

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -516,6 +516,15 @@ class HiveDataSink : public DataSink {
       CommitStrategy commitStrategy,
       const std::shared_ptr<const HiveConfig>& hiveConfig);
 
+  HiveDataSink(
+      RowTypePtr inputType,
+      std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      uint32_t bucketCount,
+      std::unique_ptr<core::PartitionFunction> bucketFunction);
+
   static uint32_t maxBucketCount() {
     static const uint32_t kMaxBucketCount = 100'000;
     return kMaxBucketCount;

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -88,4 +88,22 @@ class HivePartitionFunction : public core::PartitionFunction {
   // Precomputed hashes for constant partition keys (one per key).
   std::vector<uint32_t> precomputedHashes_;
 };
+
+// PartitionFunction implementation which uses the value extracted
+// from a column channel as the partition index.
+class HiveIdentityPartitionFunction : public core::PartitionFunction {
+ public:
+  HiveIdentityPartitionFunction(int numBuckets, column_index_t keyChannel);
+
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override;
+
+ private:
+  const int numBuckets_;
+  const column_index_t keyChannel_;
+  std::unique_ptr<DecodedVector> decodedVector_ =
+      std::make_unique<DecodedVector>();
+};
+
 } // namespace facebook::velox::connector::hive


### PR DESCRIPTION
Summary:
This refactors HiveDataSink to support overriding the PartitionFunction that is used as the `bucketFunction_` to generate bucket IDs as part of the HiveWriteId used to key writer instances in `writerIndexMap_`:
* the existing `HivePartitionFunction` implementation is retained as the default when bucketing is in use
* a new `HiveIdentityPartitionFunction` is added, which uses bucket IDs from the `bucketedBy` column in the bucketing property.

Reviewed By: Yuhta

Differential Revision: D67437472


