### PR TITLE
feat: Add Aggregate::addRawClusteredInput and streaming_aggregation_eager_flush

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -531,6 +531,17 @@ class QueryConfig {
   static constexpr const char* kRequestDataSizesMaxWaitSec =
       "request_data_sizes_max_wait_sec";
 
+  /// If this is false (the default), in streaming aggregation, wait until we
+  /// have enough number of output rows to produce a batch of size specified by
+  /// Operator::outputBatchRows.
+  ///
+  /// If this is true, we put the rows in output batch, as soon as the
+  /// corresponding groups are fully aggregated.  This is useful for reducing
+  /// memory consumption, if the downstream operators are not sensitive to small
+  /// batch size.
+  static constexpr const char* kStreamingAggregationEagerFlush =
+      "streaming_aggregation_eager_flush";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -974,6 +985,10 @@ class QueryConfig {
 
   bool throwExceptionOnDuplicateMapKeys() const {
     return get<bool>(kThrowExceptionOnDuplicateMapKeys, false);
+  }
+
+  bool streamingAggregationEagerFlush() const {
+    return get<bool>(kStreamingAggregationEagerFlush, false);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -31,14 +31,6 @@ Generic Configuration
      - integer
      - 5000
      - TableScan operator will exit getOutput() method after this many milliseconds even if it has no data to return yet. Zero means 'no time limit'.
-   * - abandon_partial_aggregation_min_rows
-     - integer
-     - 100,000
-     - Number of input rows to receive before starting to check whether to abandon partial aggregation.
-   * - abandon_partial_aggregation_min_pct
-     - integer
-     - 80
-     - Abandons partial aggregation if number of groups equals or exceeds this percentage of the number of input rows.
    * - abandon_partial_topn_row_number_min_rows
      - integer
      - 100,000
@@ -398,6 +390,34 @@ Spilling
      - integer
      - 0
      - Percentage of aggregation or join input batches that will be forced to spill for testing. 0 means no extra spilling.
+
+Aggregation
+-----------
+.. list-table::
+   :widths: 20 10 10 70
+   :header-rows: 1
+
+   * - Property Name
+     - Type
+     - Default Value
+     - Description
+   * - abandon_partial_aggregation_min_rows
+     - integer
+     - 100,000
+     - Number of input rows to receive before starting to check whether to abandon partial aggregation.
+   * - abandon_partial_aggregation_min_pct
+     - integer
+     - 80
+     - Abandons partial aggregation if number of groups equals or exceeds this percentage of the number of input rows.
+   * - streaming_aggregation_eager_flush
+     - bool
+     - false
+     - If this is false (the default), in streaming aggregation, wait until we
+       have enough number of output rows to produce a batch of size specified by
+       Operator::outputBatchRows.  If this is true, we put the rows in output
+       batch, as soon as the corresponding groups are fully aggregated.  This is
+       useful for reducing memory consumption, if the downstream operators are
+       not sensitive to small batch size.
 
 Table Scan
 ------------

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -91,6 +91,8 @@ class StreamingAggregation : public Operator {
 
   const core::AggregationNode::Step step_;
 
+  const bool eagerFlush_;
+
   std::vector<column_index_t> groupingKeys_;
   std::vector<AggregateInfo> aggregates_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
@@ -116,6 +118,10 @@ class StreamingAggregation : public Operator {
 
   // Pointers to groups for all input rows.
   std::vector<char*> inputGroups_;
+
+  // Indices into `groups` indicating the row after last row of each group.  The
+  // last element of this is the total size of input.
+  std::vector<vector_size_t> groupBoundaries_;
 
   // A subset of input rows to evaluate the aggregate function on. Rows
   // where aggregation mask is false are excluded.

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
+#include "folly/container/small_vector.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
@@ -26,13 +27,30 @@ struct ArrayAccumulator {
   ValueList elements;
 };
 
+struct SourceRange {
+  VectorPtr vector;
+  vector_size_t offset;
+  vector_size_t size;
+};
+
+// Accumulator for clustered input.  We keep the ranges from different source
+// vectors that should be collected in this group.
+struct ClusteredAccumulator {
+  folly::small_vector<SourceRange, 2> sources;
+};
+
 class ArrayAggAggregate : public exec::Aggregate {
  public:
   explicit ArrayAggAggregate(TypePtr resultType, bool ignoreNulls)
       : Aggregate(resultType), ignoreNulls_(ignoreNulls) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(ArrayAccumulator);
+    return clusteredInput_ ? sizeof(ClusteredAccumulator)
+                           : sizeof(ArrayAccumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
   }
 
   bool isFixedSize() const override {
@@ -97,26 +115,70 @@ class ArrayAggAggregate : public exec::Aggregate {
     auto vector = (*result)->as<ArrayVector>();
     VELOX_CHECK(vector);
     vector->resize(numGroups);
-
-    auto elements = vector->elements();
-    elements->resize(countElements(groups, numGroups));
-
     uint64_t* rawNulls = getRawNulls(vector);
-    vector_size_t offset = 0;
-    for (int32_t i = 0; i < numGroups; ++i) {
-      auto& values = value<ArrayAccumulator>(groups[i])->elements;
-      auto arraySize = values.size();
-      if (arraySize) {
-        clearNull(rawNulls, i);
+    auto* resultOffsets =
+        vector->mutableOffsets(numGroups)->asMutable<vector_size_t>();
+    auto* resultSizes =
+        vector->mutableSizes(numGroups)->asMutable<vector_size_t>();
+    auto& elements = vector->elements();
+    elements->resize(countElements(groups, numGroups));
+    vector_size_t arrayOffset = 0;
 
-        ValueListReader reader(values);
-        for (auto index = 0; index < arraySize; ++index) {
-          reader.next(*elements, offset + index);
+    if (clusteredInput_) {
+      VectorPtr* currentSource = nullptr;
+      std::vector<BaseVector::CopyRange> ranges;
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[i]);
+        resultOffsets[i] = arrayOffset;
+        vector_size_t arraySize = 0;
+        for (auto& source : accumulator->sources) {
+          if (currentSource && currentSource->get() != source.vector.get()) {
+            elements->copyRanges(currentSource->get(), ranges);
+            ranges.clear();
+          }
+          if (!currentSource || currentSource->get() != source.vector.get()) {
+            currentSource = &source.vector;
+            ranges.push_back({source.offset, arrayOffset, source.size});
+          } else if (
+              ranges.back().sourceIndex + ranges.back().count ==
+              source.offset) {
+            ranges.back().count += source.size;
+          } else {
+            VELOX_DCHECK_LT(
+                ranges.back().sourceIndex + ranges.back().count, source.offset);
+            ranges.push_back({source.offset, arrayOffset, source.size});
+          }
+          arrayOffset += source.size;
+          arraySize += source.size;
         }
-        vector->setOffsetAndSize(i, offset, arraySize);
-        offset += arraySize;
-      } else {
-        vector->setNull(i, true);
+        resultSizes[i] = arraySize;
+        if (arraySize == 0) {
+          vector->setNull(i, true);
+        } else {
+          clearNull(rawNulls, i);
+        }
+      }
+      if (currentSource) {
+        VELOX_DCHECK(!ranges.empty());
+        elements->copyRanges(currentSource->get(), ranges);
+      }
+
+    } else {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto& values = value<ArrayAccumulator>(groups[i])->elements;
+        auto arraySize = values.size();
+        if (arraySize) {
+          clearNull(rawNulls, i);
+          ValueListReader reader(values);
+          for (auto index = 0; index < arraySize; ++index) {
+            reader.next(*elements, arrayOffset + index);
+          }
+          resultOffsets[i] = arrayOffset;
+          resultSizes[i] = arraySize;
+          arrayOffset += arraySize;
+        } else {
+          vector->setNull(i, true);
+        }
       }
     }
   }
@@ -131,6 +193,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
+    VELOX_CHECK(!clusteredInput_);
     decodedElements_.decode(*args[0], rows);
     rows.applyToSelected([&](vector_size_t row) {
       if (ignoreNulls_ && decodedElements_.isNullAt(row)) {
@@ -141,6 +204,51 @@ class ArrayAggAggregate : public exec::Aggregate {
       value<ArrayAccumulator>(group)->elements.appendValue(
           decodedElements_, row, allocator_);
     });
+  }
+
+  bool supportsAddRawClusteredInput() const override {
+    return clusteredInput_;
+  }
+
+  void addRawClusteredInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      const folly::Range<const vector_size_t*>& groupBoundaries) override {
+    VELOX_CHECK(clusteredInput_);
+    decodedElements_.decode(*args[0]);
+    vector_size_t groupStart = 0;
+    auto forEachAccumulator = [&](auto func) {
+      for (auto groupEnd : groupBoundaries) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[groupEnd - 1]);
+        func(groupEnd, accumulator);
+        groupStart = groupEnd;
+      }
+    };
+    if (rows.isAllSelected() &&
+        (!ignoreNulls_ || !decodedElements_.mayHaveNulls())) {
+      forEachAccumulator([&](auto groupEnd, auto* accumulator) {
+        accumulator->sources.push_back(
+            {args[0], groupStart, groupEnd - groupStart});
+      });
+    } else {
+      forEachAccumulator([&](auto groupEnd, auto* accumulator) {
+        for (auto i = groupStart; i < groupEnd; ++i) {
+          if (!rows.isValid(i) ||
+              (ignoreNulls_ && decodedElements_.isNullAt(i))) {
+            if (i > groupStart) {
+              accumulator->sources.push_back(
+                  {args[0], groupStart, i - groupStart});
+            }
+            groupStart = i + 1;
+          }
+        }
+        if (groupEnd > groupStart) {
+          accumulator->sources.push_back(
+              {args[0], groupStart, groupEnd - groupStart});
+        }
+      });
+    }
   }
 
   void addIntermediateResults(
@@ -171,6 +279,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
+    VELOX_CHECK(!clusteredInput_);
     auto& values = value<ArrayAccumulator>(group)->elements;
 
     decodedElements_.decode(*args[0], rows);
@@ -188,6 +297,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
+    VELOX_CHECK(!clusteredInput_);
     decodedIntermediate_.decode(*args[0], rows);
     auto arrayVector = decodedIntermediate_.base()->as<ArrayVector>();
 
@@ -210,14 +320,23 @@ class ArrayAggAggregate : public exec::Aggregate {
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto index : indices) {
-      new (groups[index] + offset_) ArrayAccumulator();
+      if (clusteredInput_) {
+        new (groups[index] + offset_) ClusteredAccumulator();
+      } else {
+        new (groups[index] + offset_) ArrayAccumulator();
+      }
     }
   }
 
   void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
       if (isInitialized(group)) {
-        value<ArrayAccumulator>(group)->elements.free(allocator_);
+        if (clusteredInput_) {
+          auto* accumulator = value<ClusteredAccumulator>(group);
+          std::destroy_at(accumulator);
+        } else {
+          value<ArrayAccumulator>(group)->elements.free(allocator_);
+        }
       }
     }
   }
@@ -225,8 +344,17 @@ class ArrayAggAggregate : public exec::Aggregate {
  private:
   vector_size_t countElements(char** groups, int32_t numGroups) const {
     vector_size_t size = 0;
-    for (int32_t i = 0; i < numGroups; ++i) {
-      size += value<ArrayAccumulator>(groups[i])->elements.size();
+    if (clusteredInput_) {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[i]);
+        for (auto& source : accumulator->sources) {
+          size += source.size;
+        }
+      }
+    } else {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        size += value<ArrayAccumulator>(groups[i])->elements.size();
+      }
     }
     return size;
   }

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -557,5 +557,46 @@ TEST_F(ArrayAggTest, mask) {
   testFunction("simple_array_agg");
 }
 
+TEST_F(ArrayAggTest, clusteredInput) {
+  constexpr int kSize = 1000;
+  for (int batchRows : {kSize, 13}) {
+    std::vector<RowVectorPtr> data;
+    for (int i = 0; i < kSize; i += batchRows) {
+      auto size = std::min(batchRows, kSize - i);
+      data.push_back(makeRowVector({
+          makeFlatVector<int64_t>(size, [&](auto j) { return (i + j) / 17; }),
+          makeFlatVector<int32_t>(
+              size,
+              [&](auto j) { return i + j; },
+              [&](auto j) { return (i + j) % 19 == 0; }),
+          makeFlatVector<bool>(size, [&](auto j) { return (i + j) % 11 == 0; }),
+      }));
+    }
+    createDuckDbTable(data);
+    for (bool mask : {false, true}) {
+      auto builder = PlanBuilder().values(data);
+      std::string expected;
+      if (mask) {
+        builder.partialStreamingAggregation({"c0"}, {"array_agg(c1)"}, {"c2"});
+        expected =
+            "select c0, array_agg(c1) filter (where c2) from tmp group by 1";
+      } else {
+        builder.partialStreamingAggregation({"c0"}, {"array_agg(c1)"});
+        expected = "select c0, array_agg(c1) from tmp group by 1";
+      }
+      auto plan = builder.finalAggregation().planNode();
+      for (bool eagerFlush : {false, true}) {
+        SCOPED_TRACE(fmt::format(
+            "mask={} batchRows={} eagerFlush={}", mask, batchRows, eagerFlush));
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .config(core::QueryConfig::kPreferredOutputBatchRows, batchRows)
+            .config(
+                core::QueryConfig::kStreamingAggregationEagerFlush, eagerFlush)
+            .assertResults(expected);
+      }
+    }
+  }
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -430,6 +430,12 @@ class BaseVector {
     vector_size_t sourceIndex;
     vector_size_t targetIndex;
     vector_size_t count;
+
+    /// Whether `next` can be merged with this range to form a new range.
+    bool mergeable(const CopyRange& next) const {
+      return next.sourceIndex == sourceIndex + count &&
+          next.targetIndex == targetIndex + count;
+    }
   };
 
   /// Sets null flags for each row in 'ranges' to 'isNull'.


### PR DESCRIPTION
Summary:
Add fast path for streaming aggregation where we have input rows from same group located together.  For certain functions, we can leverage this property to reduce the number of copy calls and create larger and fewer ranges for copy.  This brings 3x improvements for a specific query shape common in data loading for AI training.

We implement this optimization for `arbitrary` and `array_agg`.  For `arbitrary`, if the input is clustered, we just keep a reference to the input vector and index that is selected; when we extract values from the container, we group all copies from same vector to one `copyRange` call so the cost is minimized.  For `array_agg`, we do similar thing, only track the range (offset and size) where the input will be taken for each group, and do the copy in bulk when we extract value.

There is another optimization to flush the streaming aggregation output whenever there is result available, via a new query config `streaming_aggregation_eager_flush`.  This allows us to minimize the memory used by accumulators.

Differential Revision: D72677410


