### PR TITLE
docs: Format `array_union` function in array.rst

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -158,6 +158,7 @@ Array Functions
         SELECT array_sort(array(NULL, 2, 1)); -- [1, 2, NULL]
 
 .. spark:function:: array_union(array(E) x, array(E) y) -> array(E)
+
     Returns an array of the elements in the union of ``x`` and ``y``, without duplicates. ::
 
         SELECT array_union(array(1, 2, 3), array(1, 3, 5)); -- [1, 2, 3, 5]


### PR DESCRIPTION
This PR aims to format the `array_union` function in the document. With this 
change the array_union function could display properly.

Fixes #12990.