### PR TITLE
fix: Fix Spark try_cast and cast function error case handling

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -251,7 +251,7 @@ void CastTypedExpr::accept(
 
 folly::dynamic CastTypedExpr::serialize() const {
   auto obj = ITypedExpr::serializeBase("CastTypedExpr");
-  obj["nullOnFailure"] = nullOnFailure_;
+  obj["isTryCast"] = isTryCast_;
   return obj;
 }
 
@@ -261,7 +261,7 @@ TypedExprPtr CastTypedExpr::create(const folly::dynamic& obj, void* context) {
   auto inputs = deserializeInputs(obj, context);
 
   return std::make_shared<CastTypedExpr>(
-      std::move(type), std::move(inputs), obj["nullOnFailure"].asBool());
+      std::move(type), std::move(inputs), obj["isTryCast"].asBool());
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -685,7 +685,8 @@ class CastTypedExpr : public ITypedExpr {
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
-  // Whether this expression is used for `try_cast`.
+  // Whether this expression is used for `try_cast`. When true, Presto cast
+  // suppresses exception and return null on failure to case.
   const bool isTryCast_;
 };
 

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -623,18 +623,15 @@ class CastTypedExpr : public ITypedExpr {
   /// expresion.
   /// @param input Single input. The type of input is referred to as from-type
   /// and expected to be different from to-type.
-  /// @param nullOnFailure Whether to suppress cast errors and return null.
-  CastTypedExpr(
-      const TypePtr& type,
-      const TypedExprPtr& input,
-      bool nullOnFailure)
-      : ITypedExpr{type, {input}}, nullOnFailure_(nullOnFailure) {}
+  /// @param isTryCast Whether to suppress cast errors and return null.
+  CastTypedExpr(const TypePtr& type, const TypedExprPtr& input, bool isTryCast)
+      : ITypedExpr{type, {input}}, isTryCast_(isTryCast) {}
 
   CastTypedExpr(
       const TypePtr& type,
       const std::vector<TypedExprPtr>& inputs,
-      bool nullOnFailure)
-      : ITypedExpr{type, inputs}, nullOnFailure_(nullOnFailure) {
+      bool isTryCast)
+      : ITypedExpr{type, inputs}, isTryCast_(isTryCast) {
     VELOX_USER_CHECK_EQ(
         1, inputs.size(), "Cast expression requires exactly one input");
   }
@@ -643,11 +640,11 @@ class CastTypedExpr : public ITypedExpr {
       const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
     return std::make_shared<CastTypedExpr>(
-        type(), rewriteInputsRecursive(mapping), nullOnFailure_);
+        type(), rewriteInputsRecursive(mapping), isTryCast_);
   }
 
   std::string toString() const override {
-    if (nullOnFailure_) {
+    if (isTryCast_) {
       return fmt::format(
           "try_cast {} as {}", inputs()[0]->toString(), type()->toString());
     } else {
@@ -658,7 +655,7 @@ class CastTypedExpr : public ITypedExpr {
 
   size_t localHash() const override {
     static const size_t kBaseHash = std::hash<const char*>()("CastTypedExpr");
-    return bits::hashMix(kBaseHash, std::hash<bool>()(nullOnFailure_));
+    return bits::hashMix(kBaseHash, std::hash<bool>()(isTryCast_));
   }
 
   void accept(
@@ -672,15 +669,15 @@ class CastTypedExpr : public ITypedExpr {
     }
     if (inputs().empty()) {
       return type() == otherCast->type() && otherCast->inputs().empty() &&
-          nullOnFailure_ == otherCast->nullOnFailure();
+          isTryCast_ == otherCast->isTryCast();
     }
     return *type() == *otherCast->type() &&
         *inputs()[0] == *otherCast->inputs()[0] &&
-        nullOnFailure_ == otherCast->nullOnFailure();
+        isTryCast_ == otherCast->isTryCast();
   }
 
-  bool nullOnFailure() const {
-    return nullOnFailure_;
+  bool isTryCast() const {
+    return isTryCast_;
   }
 
   folly::dynamic serialize() const override;
@@ -689,7 +686,7 @@ class CastTypedExpr : public ITypedExpr {
 
  private:
   // Suppress exception and return null on failure to cast.
-  const bool nullOnFailure_;
+  const bool isTryCast_;
 };
 
 using CastTypedExprPtr = std::shared_ptr<const CastTypedExpr>;

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -623,7 +623,7 @@ class CastTypedExpr : public ITypedExpr {
   /// expresion.
   /// @param input Single input. The type of input is referred to as from-type
   /// and expected to be different from to-type.
-  /// @param isTryCast Whether to suppress cast errors and return null.
+  /// @param isTryCast Whether this expression is used for `try_cast`.
   CastTypedExpr(const TypePtr& type, const TypedExprPtr& input, bool isTryCast)
       : ITypedExpr{type, {input}}, isTryCast_(isTryCast) {}
 
@@ -685,7 +685,7 @@ class CastTypedExpr : public ITypedExpr {
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
-  // Suppress exception and return null on failure to cast.
+  // Whether this expression is used for `try_cast`.
   const bool isTryCast_;
 };
 

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -5,21 +5,25 @@ Conversion Functions
 .. spark:function:: cast(value AS type) -> type
 
     Explicitly cast a ``value`` to a specified ``type``.
-    Behavior when ANSI mode is disabled:
+    Follows the behavior when Spark ANSI mode is disabled, and does not support 
+    the behavior when ANSI is turned on:
     
-    * If the ``value`` exceeds the range of the ``type``, no error is raised. Instead, the ``value`` is "wrapped" around.
+    * If the ``value`` exceeds the range of the ``type``, no error is raised. 
+      Instead, the ``value`` is "wrapped" around.
 
-    * If the ``value`` has an invalid format or contains characters incompatible with the target ``type``, the cast function returns NULL. ::
+    * If the ``value`` has an invalid format or contains characters incompatible 
+      with the target ``type``, the cast function returns NULL. ::
 
         SELECT cast(128 as tinyint); -- -128
         SELECT cast('2012-Oct-23' as date); -- NULL
 
 .. spark:function:: try_cast(value AS type) -> type
 
-    Returns the ``value`` cast to data type ``type`` if possible, or NULL if not possible.
-    try_cast's behavior is consistent regardless of the ANSI mode setting, it behaves similarly to cast with ANSI mode enabled, 
-    but returns NULL instead of throwing errors.
-    try_cast differs from cast function with ANSI mode disabled in following case: 
+    Returns the ``value`` cast to ``type`` if possible, or NULL if not possible.
+    Its behavior is independent of the ANSI mode setting, and it acts identically 
+    to cast with ANSI mode enabled but returns NULL rather than throwing errors 
+    for failure to cast.
+    ``try_cast`` differs from ``cast`` function with ANSI mode disabled in following case: 
     
     * If the ``value`` cannot fit within the domain of ``type``, the result is NULL. ::
 

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -5,13 +5,13 @@ Conversion Functions
 .. spark:function:: cast(value AS type) -> type
 
     Explicitly cast a ``value`` to a specified ``type``.
-    Follows the behavior when Spark ANSI mode is disabled, and does not support 
+    Follows the behavior when Spark ANSI mode is disabled, and does not support
     the behavior when ANSI is turned on:
-    
-    * If the ``value`` exceeds the range of the ``type``, no error is raised. 
+
+    * If the ``value`` exceeds the range of the ``type``, no error is raised.
       Instead, the ``value`` is "wrapped" around.
 
-    * If the ``value`` has an invalid format or contains characters incompatible 
+    * If the ``value`` has an invalid format or contains characters incompatible
       with the target ``type``, the cast function returns NULL. ::
 
         SELECT cast(128 as tinyint); -- -128
@@ -20,11 +20,11 @@ Conversion Functions
 .. spark:function:: try_cast(value AS type) -> type
 
     Returns the ``value`` cast to ``type`` if possible, or NULL if not possible.
-    Its behavior is independent of the ANSI mode setting, and it acts identically 
-    to cast with ANSI mode enabled but returns NULL rather than throwing errors 
+    Its behavior is independent of the ANSI mode setting, and it acts identically
+    to cast with ANSI mode enabled but returns NULL rather than throwing errors
     for failure to cast.
-    ``try_cast`` differs from ``cast`` function with ANSI mode disabled in following case: 
-    
+    ``try_cast`` differs from ``cast`` function with ANSI mode disabled in following case:
+
     * If the ``value`` cannot fit within the domain of ``type``, the result is NULL. ::
 
         SELECT try_cast(128 as tinyint); -- NULL

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -2,6 +2,29 @@
 Conversion Functions
 ====================
 
+Conversion Functions
+--------------------
+
+.. spark:function:: cast(value AS type) -> type
+
+    Explicitly cast a value as a type. As ANSI mode is OFF, an overflow will not cause an error but 
+    instead will “wrap” the result. The ``value`` with an invalid format or invalid characters for 
+    ``type`` will result in a NULL. ::
+
+      SELECT cast(128 as tinyint); -- -128
+      SELECT cast('2012-Oct-23' as date); -- NULL
+
+.. spark:function:: try_cast(value AS type) -> type
+
+    Returns the ``value`` cast to data type ``type`` if possible, or NULL if not possible.
+    try_cast differs from cast function in following cases: If the ``value`` cannot fit within 
+    the domain of ``type`` the result is NULL. ::
+
+      SELECT try_cast(128 as tinyint); -- NULL
+
+Cast from UNKNOWN Type
+----------------------
+
 Casting from UNKNOWN type to all other scalar types is supported, e.g., cast(NULL as int).
 
 Cast to Integral Types
@@ -74,13 +97,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1234567' as tinyint); -- Out of range
-  SELECT cast('1a' as tinyint); -- Invalid argument
-  SELECT cast('' as tinyint); -- Invalid argument
-  SELECT cast('1,234,567' as bigint); -- Invalid argument
-  SELECT cast('1'234'567' as bigint); -- Invalid argument
-  SELECT cast('nan' as bigint); -- Invalid argument
-  SELECT cast('infinity' as bigint); -- Invalid argument
+  SELECT cast('1234567' as tinyint); -- NULL
+  SELECT cast('1a' as tinyint); -- NULL
+  SELECT cast('' as tinyint); -- NULL
+  SELECT cast('1,234,567' as bigint); -- NULL
+  SELECT cast('1'234'567' as bigint); -- NULL
+  SELECT cast('nan' as bigint); -- NULL
+  SELECT cast('infinity' as bigint); -- NULL
 
 From decimal
 ^^^^^^^^^^^^
@@ -145,13 +168,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1.7E308' as boolean); -- Invalid argument
-  SELECT cast('nan' as boolean); -- Invalid argument
-  SELECT cast('infinity' as boolean); -- Invalid argument
-  SELECT cast('12' as boolean); -- Invalid argument
-  SELECT cast('-1' as boolean); -- Invalid argument
-  SELECT cast('tr' as boolean); -- Invalid argument
-  SELECT cast('tru' as boolean); -- Invalid argument
+  SELECT cast('1.7E308' as boolean); -- NULL
+  SELECT cast('nan' as boolean); -- NULL
+  SELECT cast('infinity' as boolean); -- NULL
+  SELECT cast('12' as boolean); -- NULL
+  SELECT cast('-1' as boolean); -- NULL
+  SELECT cast('tr' as boolean); -- NULL
+  SELECT cast('tru' as boolean); -- NULL
 
 Cast to String
 --------------
@@ -215,9 +238,9 @@ Invalid examples
 
 ::
 
-  SELECT cast('2012-Oct-23' as date); -- Invalid argument
-  SELECT cast('2012/10/23' as date); -- Invalid argument
-  SELECT cast('2012.10.23' as date); -- Invalid argument
+  SELECT cast('2012-Oct-23' as date); -- NULL
+  SELECT cast('2012/10/23' as date); -- NULL
+  SELECT cast('2012.10.23' as date); -- NULL
 
 Cast to Decimal
 ---------------

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -2,25 +2,26 @@
 Conversion Functions
 ====================
 
-Conversion Functions
---------------------
-
 .. spark:function:: cast(value AS type) -> type
 
-    Explicitly cast a value as a type. As ANSI mode is OFF, an overflow will not cause an error but 
-    instead will “wrap” the result. The ``value`` with an invalid format or invalid characters for 
-    ``type`` will result in a NULL. ::
+    Explicitly cast a ``value`` to a specified ``type``.
+    Behavior when ANSI mode is disabled:
+    
+    * If the ``value`` exceeds the range of the ``type``, no error is raised. Instead, the ``value`` is "wrapped" around.
 
-      SELECT cast(128 as tinyint); -- -128
-      SELECT cast('2012-Oct-23' as date); -- NULL
+    * If the ``value`` has an invalid format or contains characters incompatible with the target ``type``, the cast function returns NULL. ::
+
+        SELECT cast(128 as tinyint); -- -128
+        SELECT cast('2012-Oct-23' as date); -- NULL
 
 .. spark:function:: try_cast(value AS type) -> type
 
     Returns the ``value`` cast to data type ``type`` if possible, or NULL if not possible.
-    try_cast differs from cast function in following cases: If the ``value`` cannot fit within 
-    the domain of ``type`` the result is NULL. ::
+    try_cast differs from cast function in following case: 
+    
+    * If the ``value`` cannot fit within the domain of ``type``, the result is NULL. ::
 
-      SELECT try_cast(128 as tinyint); -- NULL
+        SELECT try_cast(128 as tinyint); -- NULL
 
 Cast from UNKNOWN Type
 ----------------------

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -106,13 +106,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1234567' as tinyint); -- NULL(Out of range)
-  SELECT cast('1a' as tinyint); -- NULL(Invalid argument)
-  SELECT cast('' as tinyint); -- NULL(Invalid argument)
-  SELECT cast('1,234,567' as bigint); -- NULL(Invalid argument)
-  SELECT cast('1'234'567' as bigint); -- NULL(Invalid argument)
-  SELECT cast('nan' as bigint); -- NULL(Invalid argument)
-  SELECT cast('infinity' as bigint); -- NULL(Invalid argument)
+  SELECT cast('1234567' as tinyint); -- NULL // Reason: Out of range
+  SELECT cast('1a' as tinyint); -- NULL // Invalid argument
+  SELECT cast('' as tinyint); -- NULL // Invalid argument
+  SELECT cast('1,234,567' as bigint); -- NULL // Invalid argument
+  SELECT cast('1'234'567' as bigint); -- NULL // Invalid argument
+  SELECT cast('nan' as bigint); -- NULL // Invalid argument
+  SELECT cast('infinity' as bigint); -- NULL // Invalid argument
 
 From decimal
 ^^^^^^^^^^^^
@@ -177,13 +177,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1.7E308' as boolean); -- NULL(Invalid argument)
-  SELECT cast('nan' as boolean); -- NULL(Invalid argument)
-  SELECT cast('infinity' as boolean); -- NULL(Invalid argument)
-  SELECT cast('12' as boolean); -- NULL(Invalid argument)
-  SELECT cast('-1' as boolean); -- NULL(Invalid argument)
-  SELECT cast('tr' as boolean); -- NULL(Invalid argument)
-  SELECT cast('tru' as boolean); -- NULL(Invalid argument)
+  SELECT cast('1.7E308' as boolean); -- NULL // Invalid argument
+  SELECT cast('nan' as boolean); -- NULL // Invalid argument
+  SELECT cast('infinity' as boolean); -- NULL // Invalid argument
+  SELECT cast('12' as boolean); -- NULL // Invalid argument
+  SELECT cast('-1' as boolean); -- NULL // Invalid argument
+  SELECT cast('tr' as boolean); -- NULL // Invalid argument
+  SELECT cast('tru' as boolean); -- NULL // Invalid argument
 
 Cast to String
 --------------
@@ -247,9 +247,9 @@ Invalid examples
 
 ::
 
-  SELECT cast('2012-Oct-23' as date); -- NULL(Invalid argument)
-  SELECT cast('2012/10/23' as date); -- NULL(Invalid argument)
-  SELECT cast('2012.10.23' as date); -- NULL(Invalid argument)
+  SELECT cast('2012-Oct-23' as date); -- NULL // Invalid argument
+  SELECT cast('2012/10/23' as date); -- NULL // Invalid argument
+  SELECT cast('2012.10.23' as date); -- NULL // Invalid argument
 
 Cast to Decimal
 ---------------

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -17,11 +17,15 @@ Conversion Functions
 .. spark:function:: try_cast(value AS type) -> type
 
     Returns the ``value`` cast to data type ``type`` if possible, or NULL if not possible.
-    try_cast differs from cast function in following case: 
+    try_cast's behavior is consistent regardless of the ANSI mode setting, it behaves similarly to cast with ANSI mode enabled, 
+    but returns NULL instead of throwing errors.
+    try_cast differs from cast function with ANSI mode disabled in following case: 
     
     * If the ``value`` cannot fit within the domain of ``type``, the result is NULL. ::
 
         SELECT try_cast(128 as tinyint); -- NULL
+        SELECT try_cast(cast(550000.0 as DECIMAL(8, 1)) as smallint); -- NULL
+        SELECT try_cast(1e12 as int); -- NULL
 
 Cast from UNKNOWN Type
 ----------------------

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -102,13 +102,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1234567' as tinyint); -- NULL
-  SELECT cast('1a' as tinyint); -- NULL
-  SELECT cast('' as tinyint); -- NULL
-  SELECT cast('1,234,567' as bigint); -- NULL
-  SELECT cast('1'234'567' as bigint); -- NULL
-  SELECT cast('nan' as bigint); -- NULL
-  SELECT cast('infinity' as bigint); -- NULL
+  SELECT cast('1234567' as tinyint); -- NULL(Out of range)
+  SELECT cast('1a' as tinyint); -- NULL(Invalid argument)
+  SELECT cast('' as tinyint); -- NULL(Invalid argument)
+  SELECT cast('1,234,567' as bigint); -- NULL(Invalid argument)
+  SELECT cast('1'234'567' as bigint); -- NULL(Invalid argument)
+  SELECT cast('nan' as bigint); -- NULL(Invalid argument)
+  SELECT cast('infinity' as bigint); -- NULL(Invalid argument)
 
 From decimal
 ^^^^^^^^^^^^
@@ -173,13 +173,13 @@ Invalid examples
 
 ::
 
-  SELECT cast('1.7E308' as boolean); -- NULL
-  SELECT cast('nan' as boolean); -- NULL
-  SELECT cast('infinity' as boolean); -- NULL
-  SELECT cast('12' as boolean); -- NULL
-  SELECT cast('-1' as boolean); -- NULL
-  SELECT cast('tr' as boolean); -- NULL
-  SELECT cast('tru' as boolean); -- NULL
+  SELECT cast('1.7E308' as boolean); -- NULL(Invalid argument)
+  SELECT cast('nan' as boolean); -- NULL(Invalid argument)
+  SELECT cast('infinity' as boolean); -- NULL(Invalid argument)
+  SELECT cast('12' as boolean); -- NULL(Invalid argument)
+  SELECT cast('-1' as boolean); -- NULL(Invalid argument)
+  SELECT cast('tr' as boolean); -- NULL(Invalid argument)
+  SELECT cast('tru' as boolean); -- NULL(Invalid argument)
 
 Cast to String
 --------------
@@ -243,9 +243,9 @@ Invalid examples
 
 ::
 
-  SELECT cast('2012-Oct-23' as date); -- NULL
-  SELECT cast('2012/10/23' as date); -- NULL
-  SELECT cast('2012.10.23' as date); -- NULL
+  SELECT cast('2012-Oct-23' as date); -- NULL(Invalid argument)
+  SELECT cast('2012/10/23' as date); -- NULL(Invalid argument)
+  SELECT cast('2012.10.23' as date); -- NULL(Invalid argument)
 
 Cast to Decimal
 ---------------

--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -586,9 +586,9 @@ std::shared_ptr<const core::IExpr> parseCastExpr(
     }
   }
 
-  const bool nullOnFailure = castExpr.try_cast;
+  const bool isTryCast = castExpr.try_cast;
   return std::make_shared<const core::CastExpr>(
-      targetType, params[0], nullOnFailure, getAlias(expr));
+      targetType, params[0], isTryCast, getAlias(expr));
 }
 
 std::shared_ptr<const core::IExpr> parseLambdaExpr(

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -339,7 +339,7 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
 
 std::string toCastSql(const core::CastTypedExpr& cast) {
   std::stringstream sql;
-  if (cast.nullOnFailure()) {
+  if (cast.isTryCast()) {
     sql << "try_cast(";
   } else {
     sql << "cast(";

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -568,11 +568,14 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
       auto value = simpleInput->valueAt(row);
       auto integralPart = value / scaleFactor;
-      auto fractionPart = value % scaleFactor;
-      auto sign = value >= 0 ? 1 : -1;
-      bool needsRoundUp =
-          (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));
-      integralPart += needsRoundUp ? sign : 0;
+      if (hooks_->getPolicy() != SparkTryCastPolicy) {
+        auto fractionPart = value % scaleFactor;
+        auto sign = value >= 0 ? 1 : -1;
+        bool needsRoundUp =
+            (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));
+        integralPart += needsRoundUp ? sign : 0;
+      }
+
       if (integralPart > std::numeric_limits<To>::max() ||
           integralPart < std::numeric_limits<To>::min()) {
         if (setNullInResultAtError()) {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -722,6 +722,12 @@ void CastExpr::applyCastPrimitives(
             row, context, inputSimpleVector, resultFlatVector);
       });
       break;
+    case SparkTryCastPolicy:
+      applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+        applyCastKernel<ToKind, FromKind, util::SparkTryCastPolicy>(
+            row, context, inputSimpleVector, resultFlatVector);
+      });
+      break;
 
     default:
       VELOX_NYI("Policy {} not yet implemented.", hooks_->getPolicy());

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -996,7 +996,7 @@ void CastExpr::evalSpecialForm(
   auto toType = std::const_pointer_cast<const Type>(type_);
 
   inTopLevel = true;
-  if (nullOnFailure()) {
+  if (isTryCast()) {
     ScopedVarSetter holder{context.mutableThrowOnError(), false};
     ScopedVarSetter captureErrorDetails(
         context.mutableCaptureErrorDetails(), false);

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -87,15 +87,15 @@ class CastExpr : public SpecialForm {
       TypePtr type,
       ExprPtr&& expr,
       bool trackCpuUsage,
-      bool nullOnFailure,
+      bool isTryCast,
       std::shared_ptr<CastHooks> hooks)
       : SpecialForm(
             type,
             std::vector<ExprPtr>({expr}),
-            nullOnFailure ? kTryCast.data() : kCast.data(),
+            isTryCast ? kTryCast.data() : kCast.data(),
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
-        nullOnFailure_(nullOnFailure),
+        isTryCast_(isTryCast),
         hooks_(std::move(hooks)) {}
 
   void evalSpecialForm(
@@ -303,12 +303,12 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
-  bool nullOnFailure() const {
-    return nullOnFailure_;
+  bool isTryCast() const {
+    return isTryCast_;
   }
 
   bool setNullInResultAtError() const {
-    return nullOnFailure() && inTopLevel;
+    return isTryCast() && inTopLevel;
   }
 
   CastOperatorPtr getCastOperator(const TypePtr& type);
@@ -316,7 +316,7 @@ class CastExpr : public SpecialForm {
   // Custom cast operators for to and from top-level as well as nested types.
   folly::F14FastMap<std::string, CastOperatorPtr> castOperators_;
 
-  bool nullOnFailure_;
+  bool isTryCast_;
   std::shared_ptr<CastHooks> hooks_;
 
   bool inTopLevel = false;

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -21,7 +21,12 @@
 
 namespace facebook::velox::exec {
 
-enum PolicyType { LegacyCastPolicy = 1, PrestoCastPolicy, SparkCastPolicy };
+enum PolicyType {
+  LegacyCastPolicy = 1,
+  PrestoCastPolicy,
+  SparkCastPolicy,
+  SparkTryCastPolicy
+};
 
 fmt::underlying_t<PolicyType> format_as(PolicyType f);
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -408,7 +408,7 @@ ExprPtr compileRewrittenExpression(
     } else {
       result = getSpecialForm(
           config,
-          cast->nullOnFailure() ? "try_cast" : "cast",
+          cast->isTryCast() ? "try_cast" : "cast",
           resultType,
           std::move(compiledInputs),
           trackCpuUsage);

--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -1094,8 +1094,8 @@ core::TypedExprPtr ExpressionFuzzer::generateCastExpression(
   markSelected("cast");
 
   // Generate try_cast expression with 50% chance.
-  bool nullOnFailure = vectorFuzzer_->coinToss(0.5);
-  return std::make_shared<core::CastTypedExpr>(returnType, args, nullOnFailure);
+  bool isTryCast = vectorFuzzer_->coinToss(0.5);
+  return std::make_shared<core::CastTypedExpr>(returnType, args, isTryCast);
 }
 
 core::TypedExprPtr ExpressionFuzzer::generateRowConstructorExpression(

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1668,10 +1668,10 @@ TEST_F(CastExprTest, testNullOnFailure) {
   auto expected = makeNullableFlatVector<int32_t>(
       {1, 2, std::nullopt, std::nullopt, std::nullopt});
 
-  // nullOnFailure is true, so we should return null instead of throwing.
+  // isTryCast is true, so we should return null instead of throwing.
   testCast(input, expected, true);
 
-  // nullOnFailure is false, so we should throw.
+  // isTryCast is false, so we should throw.
   EXPECT_THROW(testCast(input, expected, false), VeloxUserError);
 }
 
@@ -1841,7 +1841,7 @@ TEST_F(CastExprTest, decimalToDecimal) {
       testCast(longFlat, expectedShort),
       "Cannot cast DECIMAL '-1000.000' to DECIMAL(6, 4)");
 
-  // nullOnFailure is true.
+  // isTryCast is true.
   testCast(longFlat, expectedShort, true);
 
   // long to short, big numbers.

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -312,9 +312,9 @@ class CastBaseTest : public FunctionBaseTest {
   std::shared_ptr<core::CastTypedExpr> makeCastExpr(
       const core::TypedExprPtr& input,
       const TypePtr& toType,
-      bool nullOnFailure) {
+      bool isTryCast) {
     std::vector<core::TypedExprPtr> inputs = {input};
-    return std::make_shared<core::CastTypedExpr>(toType, inputs, nullOnFailure);
+    return std::make_shared<core::CastTypedExpr>(toType, inputs, isTryCast);
   }
 
   const float kInf = std::numeric_limits<float>::infinity();

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -28,12 +28,15 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       1,
       "CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
+  // TODO：​If the upstream has ANSI mode enabled
+  // (spark.sql.ansi.enabled=true), we should set 'nullOnFailure' to false to
+  // maintain compatibility.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),
       trackCpuUsage,
-      false,
-      std::make_shared<SparkCastHooks>(config));
+      true,
+      std::make_shared<SparkCastHooks>(config, false));
 }
 
 exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
@@ -51,6 +54,6 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<SparkCastHooks>(config));
+      std::make_shared<SparkCastHooks>(config, true));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -28,17 +28,11 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       1,
       "CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
-  // We set isTryCast to true because Spark's cast function (with ANSI mode
-  // disabled) returns NULL when given invalid input, matching the velox
-  // try_cast behavior.
-  // TODO: If an ANSI mode configuration is added, the value of isTryCast should
-  // be set according to that configuration.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),
       trackCpuUsage,
-      true,
-      std::make_shared<SparkCastHooks>(config, false));
+      std::make_shared<SparkCastHooks>(config, true));
 }
 
 exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
@@ -55,7 +49,6 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       type,
       std::move(compiledChildren[0]),
       trackCpuUsage,
-      true,
-      std::make_shared<SparkCastHooks>(config, true));
+      std::make_shared<SparkCastHooks>(config, false));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -28,10 +28,16 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       1,
       "CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
+  // In Spark SQL (with ANSI mode off), both CAST and TRY_CAST behave like
+  // Velox's try_cast, so we set 'isTryCast' to true by default in CastExpr.
+  // The distinction between CAST (ANSI off) and TRY_CAST is limited to
+  // overflow handling, which is managed by the 'allowOverflow' flag in
+  // SparkCastHooks.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),
       trackCpuUsage,
+      true,
       std::make_shared<SparkCastHooks>(config, true));
 }
 
@@ -49,6 +55,7 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       type,
       std::move(compiledChildren[0]),
       trackCpuUsage,
+      true,
       std::make_shared<SparkCastHooks>(config, false));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -28,6 +28,11 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       1,
       "CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
+  // We set isTryCast to true because Spark's cast function (with ANSI mode
+  // disabled) returns NULL when given invalid input, matching the velox
+  // try_cast behavior.
+  // TODO: If an ANSI mode configuration is added, the value of isTryCast should
+  // be set according to that configuration.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -28,9 +28,6 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       1,
       "CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
-  // TODO：​If the upstream has ANSI mode enabled
-  // (spark.sql.ansi.enabled=true), we should set 'nullOnFailure' to false to
-  // maintain compatibility.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -30,14 +30,10 @@ class SparkCastExpr : public exec::CastExpr {
       TypePtr type,
       exec::ExprPtr&& expr,
       bool trackCpuUsage,
-      bool nullOnFailure,
+      bool isTryCast,
       std::shared_ptr<SparkCastHooks> hooks)
-      : exec::CastExpr(
-            type,
-            std::move(expr),
-            trackCpuUsage,
-            nullOnFailure,
-            hooks) {}
+      : exec::CastExpr(type, std::move(expr), trackCpuUsage, isTryCast, hooks) {
+  }
 };
 
 class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -26,14 +26,17 @@ class SparkCastExpr : public exec::CastExpr {
   /// @param type The target type of the cast expression
   /// @param expr The expression to cast
   /// @param trackCpuUsage Whether to track CPU usage
+  /// In Spark SQL (with ANSI mode off), both CAST and TRY_CAST behave like
+  /// Velox's try_cast, so we set 'isTryCast' to true by default in CastExpr.
+  /// The distinction between CAST (ANSI off) and TRY_CAST is limited to
+  /// overflow handling, which is managed by the 'allowOverflow' flag in
+  /// SparkCastHooks.
   SparkCastExpr(
       TypePtr type,
       exec::ExprPtr&& expr,
       bool trackCpuUsage,
-      bool isTryCast,
       std::shared_ptr<SparkCastHooks> hooks)
-      : exec::CastExpr(type, std::move(expr), trackCpuUsage, isTryCast, hooks) {
-  }
+      : exec::CastExpr(type, std::move(expr), trackCpuUsage, true, hooks) {}
 };
 
 class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -26,17 +26,14 @@ class SparkCastExpr : public exec::CastExpr {
   /// @param type The target type of the cast expression
   /// @param expr The expression to cast
   /// @param trackCpuUsage Whether to track CPU usage
-  /// In Spark SQL (with ANSI mode off), both CAST and TRY_CAST behave like
-  /// Velox's try_cast, so we set 'isTryCast' to true by default in CastExpr.
-  /// The distinction between CAST (ANSI off) and TRY_CAST is limited to
-  /// overflow handling, which is managed by the 'allowOverflow' flag in
-  /// SparkCastHooks.
   SparkCastExpr(
       TypePtr type,
       exec::ExprPtr&& expr,
       bool trackCpuUsage,
+      bool isTryCast,
       std::shared_ptr<SparkCastHooks> hooks)
-      : exec::CastExpr(type, std::move(expr), trackCpuUsage, true, hooks) {}
+      : exec::CastExpr(type, std::move(expr), trackCpuUsage, isTryCast, hooks) {
+  }
 };
 
 class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -21,8 +21,10 @@
 
 namespace facebook::velox::functions::sparksql {
 
-SparkCastHooks::SparkCastHooks(const velox::core::QueryConfig& config)
-    : config_(config) {
+SparkCastHooks::SparkCastHooks(
+    const velox::core::QueryConfig& config,
+    bool isTryCast)
+    : config_(config), isTryCast_(isTryCast) {
   const auto sessionTzName = config.sessionTimezone();
   if (!sessionTzName.empty()) {
     timestampToStringOptions_.timeZone = tz::locateZone(sessionTzName);
@@ -125,6 +127,9 @@ StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
 }
 
 exec::PolicyType SparkCastHooks::getPolicy() const {
+  if (isTryCast_) {
+    return exec::PolicyType::SparkTryCastPolicy;
+  }
   return exec::PolicyType::SparkCastPolicy;
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -23,8 +23,8 @@ namespace facebook::velox::functions::sparksql {
 
 SparkCastHooks::SparkCastHooks(
     const velox::core::QueryConfig& config,
-    bool isTryCast)
-    : config_(config), isTryCast_(isTryCast) {
+    bool allowOverflow)
+    : config_(config), allowOverflow_(allowOverflow) {
   const auto sessionTzName = config.sessionTimezone();
   if (!sessionTzName.empty()) {
     timestampToStringOptions_.timeZone = tz::locateZone(sessionTzName);
@@ -127,7 +127,7 @@ StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {
 }
 
 exec::PolicyType SparkCastHooks::getPolicy() const {
-  if (isTryCast_) {
+  if (!allowOverflow_) {
     return exec::PolicyType::SparkTryCastPolicy;
   }
   return exec::PolicyType::SparkCastPolicy;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -69,7 +69,7 @@ class SparkCastHooks : public exec::CastHooks {
   }
 
   bool truncate() const override {
-    return true;
+    return !isTryCast_;
   }
 
   exec::PolicyType getPolicy() const override;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -82,6 +82,8 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castNumberToTimestamp(T seconds) const;
 
   const core::QueryConfig& config_;
+
+  // If true, the cast will truncate the overflow value to fit the target type.
   const bool allowOverflow_;
 
   /// 1) Does not follow 'isLegacyCast'. 2) The conversion precision is

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -24,7 +24,9 @@ namespace facebook::velox::functions::sparksql {
 // This class provides cast hooks following Spark semantics.
 class SparkCastHooks : public exec::CastHooks {
  public:
-  explicit SparkCastHooks(const velox::core::QueryConfig& config);
+  explicit SparkCastHooks(
+      const velox::core::QueryConfig& config,
+      bool isTryCast);
 
   // TODO: Spark hook allows more string patterns than Presto.
   Expected<Timestamp> castStringToTimestamp(
@@ -80,6 +82,7 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castNumberToTimestamp(T seconds) const;
 
   const core::QueryConfig& config_;
+  const bool isTryCast_;
 
   /// 1) Does not follow 'isLegacyCast'. 2) The conversion precision is
   /// microsecond. 3) Does not append trailing zeros. 4) Adds a positive

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -26,7 +26,7 @@ class SparkCastHooks : public exec::CastHooks {
  public:
   explicit SparkCastHooks(
       const velox::core::QueryConfig& config,
-      bool isTryCast);
+      bool allowOverflow);
 
   // TODO: Spark hook allows more string patterns than Presto.
   Expected<Timestamp> castStringToTimestamp(
@@ -69,7 +69,7 @@ class SparkCastHooks : public exec::CastHooks {
   }
 
   bool truncate() const override {
-    return !isTryCast_;
+    return allowOverflow_;
   }
 
   exec::PolicyType getPolicy() const override;
@@ -82,7 +82,7 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<Timestamp> castNumberToTimestamp(T seconds) const;
 
   const core::QueryConfig& config_;
-  const bool isTryCast_;
+  const bool allowOverflow_;
 
   /// 1) Does not follow 'isLegacyCast'. 2) The conversion precision is
   /// microsecond. 3) Does not append trailing zeros. 4) Adds a positive

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -211,53 +211,26 @@ TEST_F(SparkCastExprTest, invalidDate) {
       "date", {12.99}, "Cast from DOUBLE to DATE is not supported", DOUBLE());
 
   // Parsing ill-formated dates.
-  testInvalidCast<std::string>(
-      "date",
-      {"2012-Oct-23"},
-      "Unable to parse date value: \"2012-Oct-23\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-03-18X"},
-      "Unable to parse date value: \"2015-03-18X\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015/03/18"},
-      "Unable to parse date value: \"2015/03/18\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015.03.18"},
-      "Unable to parse date value: \"2015.03.18\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"20150318"},
-      "Unable to parse date value: \"20150318\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"2015-031-8"},
-      "Unable to parse date value: \"2015-031-8\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date", {"-1-1-1"}, "Unable to parse date value: \"-1-1-1\"", VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"-11-1-1"},
-      "Unable to parse date value: \"-11-1-1\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"-111-1-1"},
-      "Unable to parse date value: \"-111-1-1\"",
-      VARCHAR());
-  testInvalidCast<std::string>(
-      "date",
-      {"- 1111-1-1"},
-      "Unable to parse date value: \"- 1111-1-1\"",
-      VARCHAR());
+  testCast<std::string, int32_t>(
+      "date", {"2012-Oct-23"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-03-18X"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015/03/18"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015.03.18"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"20150318"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-031-8"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"-1-1-1"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"-11-1-1"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"-111-1-1"}, {std::nullopt}, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"- 1111-1-1"}, {std::nullopt}, VARCHAR(), DATE());
 }
 
 TEST_F(SparkCastExprTest, stringToTimestamp) {
@@ -468,56 +441,32 @@ TEST_F(SparkCastExprTest, primitiveInvalidCornerCases) {
   // To integer.
   {
     // Invalid strings.
-    testInvalidCast<std::string>(
-        "tinyint",
-        {"1234567"},
-        "Cannot cast VARCHAR '1234567' to TINYINT. TINYINT overflow: 123 * 10");
-    testInvalidCast<std::string>(
-        "tinyint", {"1a"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>("tinyint", {""}, "Empty string");
-    testInvalidCast<std::string>(
-        "integer", {"1'234'567"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "integer", {"1,234,567"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "bigint", {"infinity"}, "Encountered a non-digit character");
-    testInvalidCast<std::string>(
-        "bigint", {"nan"}, "Encountered a non-digit character");
+    testCast<std::string, int8_t>("tinyint", {"1234567"}, {std::nullopt});
+    testCast<std::string, int8_t>("tinyint", {"1a"}, {std::nullopt});
+    testCast<std::string, int8_t>("tinyint", {""}, {std::nullopt});
+    testCast<std::string, int32_t>("integer", {"1'234'567"}, {std::nullopt});
+    testCast<std::string, int32_t>("integer", {"1,234,567"}, {std::nullopt});
+    testCast<std::string, int64_t>("bigint", {"infinity"}, {std::nullopt});
+    testCast<std::string, int64_t>("bigint", {"nan"}, {std::nullopt});
   }
 
   // To floating-point.
   {
     // Invalid strings.
-    testInvalidCast<std::string>(
-        "real",
-        {"1.2a"},
-        "Non-whitespace character found after end of conversion");
-    testInvalidCast<std::string>(
-        "real",
-        {"1.2.3"},
-        "Non-whitespace character found after end of conversion");
+    testCast<std::string, float>("real", {"1.2a"}, {std::nullopt});
+    testCast<std::string, float>("real", {"1.2.3"}, {std::nullopt});
   }
 
   // To boolean.
   {
-    testInvalidCast<std::string>(
-        "boolean", {"1.7E308"}, "Cannot cast 1.7E308 to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"nan"}, "Cannot cast nan to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"infinity"}, "Cannot cast infinity to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"12"}, "Cannot cast 12 to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"-1"}, "Cannot cast -1 to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"tr"}, "Cannot cast tr to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"tru"}, "Cannot cast tru to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"on"}, "Cannot cast on to BOOLEAN");
-    testInvalidCast<std::string>(
-        "boolean", {"off"}, "Cannot cast off to BOOLEAN");
+    testCast<std::string, bool>("boolean", {"1.7E308"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"nan"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"12"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"-1"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"tr"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"tru"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"on"}, {std::nullopt});
+    testCast<std::string, bool>("boolean", {"off"}, {std::nullopt});
   }
 }
 
@@ -642,14 +591,25 @@ TEST_F(SparkCastExprTest, errorHandling) {
        std::nullopt,
        std::nullopt,
        std::nullopt,
-       125,
+       std::nullopt,
        127,
        -128});
 
-  testTryCast<double, int>(
+  testTryCast<double, int32_t>(
       "integer",
       {1e12, 2.5, 3.6, 100.44, -100.101},
-      {std::numeric_limits<int32_t>::max(), 2, 3, 100, -100});
+      {std::nullopt, 2, 3, 100, -100});
+  testTryCast<int64_t, int8_t>("tinyint", {456}, {std::nullopt});
+  testTryCast<int64_t, int16_t>("smallint", {1234567}, {std::nullopt});
+  testTryCast<int64_t, int32_t>("integer", {2147483649}, {std::nullopt});
+
+  testTryCast<std::string, int8_t>("tinyint", {"166"}, {std::nullopt});
+  testTryCast<std::string, int16_t>("smallint", {"52769"}, {std::nullopt});
+  testTryCast<std::string, int32_t>("integer", {"17515055537"}, {std::nullopt});
+  testTryCast<std::string, int32_t>(
+      "integer", {"-17515055537"}, {std::nullopt});
+  testTryCast<std::string, int64_t>(
+      "bigint", {"9663372036854775809"}, {std::nullopt});
 }
 
 TEST_F(SparkCastExprTest, overflow) {
@@ -692,26 +652,12 @@ TEST_F(SparkCastExprTest, overflow) {
       makeNullableFlatVector<int64_t>({214748364890}, DECIMAL(12, 2)),
       makeNullableFlatVector<int64_t>({2147483648}));
 
-  testInvalidCast<std::string>(
-      "tinyint",
-      {"166"},
-      "Cannot cast VARCHAR '166' to TINYINT. TINYINT overflow: 16 * 10");
-  testInvalidCast<std::string>(
-      "smallint",
-      {"52769"},
-      "Cannot cast VARCHAR '52769' to SMALLINT. SMALLINT overflow: 5276 * 10");
-  testInvalidCast<std::string>(
-      "integer",
-      {"17515055537"},
-      "Cannot cast VARCHAR '17515055537' to INTEGER. INTEGER overflow: 1751505553 * 10");
-  testInvalidCast<std::string>(
-      "integer",
-      {"-17515055537"},
-      "Cannot cast VARCHAR '-17515055537' to INTEGER. INTEGER overflow: -1751505553 * 10");
-  testInvalidCast<std::string>(
-      "bigint",
-      {"9663372036854775809"},
-      "Cannot cast VARCHAR '9663372036854775809' to BIGINT. BIGINT overflow: 966337203685477580 * 10");
+  testCast<std::string, int8_t>("tinyint", {"166"}, {std::nullopt});
+  testCast<std::string, int16_t>("smallint", {"52769"}, {std::nullopt});
+  testCast<std::string, int32_t>("integer", {"17515055537"}, {std::nullopt});
+  testCast<std::string, int32_t>("integer", {"-17515055537"}, {std::nullopt});
+  testCast<std::string, int64_t>(
+      "bigint", {"9663372036854775809"}, {std::nullopt});
 }
 
 TEST_F(SparkCastExprTest, timestampToString) {

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -143,7 +143,7 @@ TypedExprPtr createWithImplicitCast(
   if (adjusted) {
     return adjusted;
   }
-  auto type = resolveTypeImpl(inputs, expr, false /*nullOnFailure*/);
+  auto type = resolveTypeImpl(inputs, expr, /*isTryCast=*/false);
   return std::make_shared<CallTypedExpr>(
       type, std::move(inputs), std::string{expr->getFunctionName()});
 }
@@ -280,7 +280,7 @@ TypedExprPtr Expressions::inferTypes(
   }
   if (auto cast = std::dynamic_pointer_cast<const CastExpr>(expr)) {
     return std::make_shared<const CastTypedExpr>(
-        cast->type(), std::move(children), cast->nullOnFailure());
+        cast->type(), std::move(children), cast->isTryCast());
   }
   if (auto alreadyTyped = std::dynamic_pointer_cast<const ITypedExpr>(expr)) {
     return alreadyTyped;

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -237,19 +237,19 @@ class CastExpr : public IExpr, public std::enable_shared_from_this<CastExpr> {
   const TypePtr type_;
   const std::shared_ptr<const IExpr> expr_;
   const std::vector<std::shared_ptr<const IExpr>> inputs_;
-  bool nullOnFailure_;
+  bool isTryCast_;
 
  public:
   explicit CastExpr(
       const TypePtr& type,
       const std::shared_ptr<const IExpr>& expr,
-      bool nullOnFailure,
+      bool isTryCast,
       std::optional<std::string> alias)
       : IExpr{std::move(alias)},
         type_(type),
         expr_(expr),
         inputs_({expr}),
-        nullOnFailure_(nullOnFailure) {}
+        isTryCast_(isTryCast) {}
 
   std::string toString() const override {
     return appendAliasIfExists(
@@ -268,8 +268,8 @@ class CastExpr : public IExpr, public std::enable_shared_from_this<CastExpr> {
     return expr_;
   }
 
-  bool nullOnFailure() const {
-    return nullOnFailure_;
+  bool isTryCast() const {
+    return isTryCast_;
   }
 
   VELOX_DEFINE_CLASS_NAME(CastExpr)

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -407,7 +407,7 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
     substraitCastExpr->mutable_input()->MergeFrom(
         toSubstraitExpr(arena, arg, inputType));
   }
-  if (castExpr->nullOnFailure()) {
+  if (castExpr->isTryCast()) {
     substraitCastExpr->set_failure_behavior(
         ::substrait::
             Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);


### PR DESCRIPTION
Currently, the semantics of Spark functions are implemented with ANSI mode disabled. 
Correct the corresponding behavior for:
1. Spark cast function should return null if invalid format or invalid characters in the inputs. 
2. Spark try_cast function should return null if the value overflows.

Given there are other behavioral variations besides the NULL handling between 
Spark try_cast and cast, this PR renames the `nullOnFailure` to `isTryCast`.