### PR TITLE
fix: Optimize RowType::hashKind

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -531,6 +531,17 @@ class QueryConfig {
   static constexpr const char* kRequestDataSizesMaxWaitSec =
       "request_data_sizes_max_wait_sec";
 
+  /// If this is false (the default), in streaming aggregation, wait until we
+  /// have enough number of output rows to produce a batch of size specified by
+  /// Operator::outputBatchRows.
+  ///
+  /// If this is true, we put the rows in output batch, as soon as the
+  /// corresponding groups are fully aggregated.  This is useful for reducing
+  /// memory consumption, if the downstream operators are not sensitive to small
+  /// batch size.
+  static constexpr const char* kStreamingAggregationEagerFlush =
+      "streaming_aggregation_eager_flush";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -974,6 +985,10 @@ class QueryConfig {
 
   bool throwExceptionOnDuplicateMapKeys() const {
     return get<bool>(kThrowExceptionOnDuplicateMapKeys, false);
+  }
+
+  bool streamingAggregationEagerFlush() const {
+    return get<bool>(kStreamingAggregationEagerFlush, false);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -399,6 +399,26 @@ Spilling
      - 0
      - Percentage of aggregation or join input batches that will be forced to spill for testing. 0 means no extra spilling.
 
+Aggregation
+-----------
+.. list-table::
+   :widths: 20 10 10 70
+   :header-rows: 1
+
+   * - Property Name
+     - Type
+     - Default Value
+     - Description
+   * - streaming_aggregation_eager_flush
+     - bool
+     - false
+     - If this is false (the default), in streaming aggregation, wait until we
+       have enough number of output rows to produce a batch of size specified by
+       Operator::outputBatchRows.  If this is true, we put the rows in output
+       batch, as soon as the corresponding groups are fully aggregated.  This is
+       useful for reducing memory consumption, if the downstream operators are
+       not sensitive to small batch size.
+
 Table Scan
 ------------
 .. list-table::

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -171,6 +171,35 @@ class Aggregate {
       const std::vector<VectorPtr>& args,
       bool mayPushdown) = 0;
 
+  /// Called by aggregation operator to set whether the input data is eligible
+  /// for clustered input optimization.  This is turned off, in cases for
+  /// example if the input rows from same group are not contiguous, or the
+  /// aggregate is sorted or distinct.
+  void setClusteredInput(bool value) {
+    clusteredInput_ = value;
+  }
+
+  /// Whether the function itself supports clustered input optimization.
+  ///
+  /// When this returns true, `addRawClusteredInput` should be implemented.
+  virtual bool supportsAddRawClusteredInput() const {
+    return false;
+  }
+
+  /// Fast path for the function when the input rows from same group are
+  /// clustered together. `groups`, `rows`, and `args` are the same as
+  /// `addRawInput`, `groupBoundaries` is the indices into `groups` indicating
+  /// the row after last row of each group.
+  ///
+  /// Will only be called when `supportAddRawClusteredInput` returns true.
+  virtual void addRawClusteredInput(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      const folly::Range<const vector_size_t*>& /*groupBoundaries*/) {
+    VELOX_NYI("Unimplemented: {} {}", typeid(*this).name(), __func__);
+  }
+
   // Updates final accumulators from intermediate results.
   // @param groups Pointers to the start of the group rows. These are aligned
   // with the 'args', e.g. data in the i-th row of the 'args' goes to the i-th
@@ -468,6 +497,8 @@ class Aggregate {
   std::vector<vector_size_t> pushdownCustomIndices_;
 
   bool validateIntermediateInputs_ = false;
+
+  bool clusteredInput_ = false;
 };
 
 using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -91,6 +91,8 @@ class StreamingAggregation : public Operator {
 
   const core::AggregationNode::Step step_;
 
+  const bool eagerFlush_;
+
   std::vector<column_index_t> groupingKeys_;
   std::vector<AggregateInfo> aggregates_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
@@ -116,6 +118,10 @@ class StreamingAggregation : public Operator {
 
   // Pointers to groups for all input rows.
   std::vector<char*> inputGroups_;
+
+  // Indices into `groups` indicating the row after last row of each group.  The
+  // last element of this is the total size of input.
+  std::vector<vector_size_t> groupBoundaries_;
 
   // A subset of input rows to evaluate the aggregate function on. Rows
   // where aggregation mask is false are excluded.

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -152,6 +152,12 @@ inline int32_t ArbitraryAggregate<int128_t>::accumulatorAlignmentSize() const {
   return static_cast<int32_t>(sizeof(int128_t));
 }
 
+// In case of clustered input, we just keep a reference to the input vector.
+struct ClusteredNonNumericAccumulator {
+  VectorPtr vector;
+  vector_size_t index;
+};
+
 // Arbitrary for non-numeric types. We always keep the first (non-NULL) element
 // seen. Arbitrary (x) will produce partial and final aggregations of type x.
 class NonNumericArbitrary : public exec::Aggregate {
@@ -159,10 +165,13 @@ class NonNumericArbitrary : public exec::Aggregate {
   explicit NonNumericArbitrary(const TypePtr& resultType)
       : exec::Aggregate(resultType) {}
 
-  // We use singleValueAccumulator to save the results for each group. This
-  // struct will allow us to save variable-width value.
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(SingleValueAccumulator);
+    return clusteredInput_ ? sizeof(ClusteredNonNumericAccumulator)
+                           : sizeof(SingleValueAccumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
   }
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
@@ -172,14 +181,41 @@ class NonNumericArbitrary : public exec::Aggregate {
 
     auto* rawNulls = exec::Aggregate::getRawNulls(result->get());
 
-    for (int32_t i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      auto accumulator = value<SingleValueAccumulator>(group);
-      if (!accumulator->hasValue()) {
-        (*result)->setNull(i, true);
-      } else {
-        exec::Aggregate::clearNull(rawNulls, i);
-        accumulator->read(*result, i);
+    if (clusteredInput_) {
+      VectorPtr* currentSource = nullptr;
+      VELOX_DCHECK(copyRanges_.empty());
+      for (vector_size_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<ClusteredNonNumericAccumulator>(groups[i]);
+        if (!accumulator->vector) {
+          (*result)->setNull(i, true);
+          continue;
+        }
+        if (currentSource &&
+            currentSource->get() != accumulator->vector.get()) {
+          result->get()->copyRanges(currentSource->get(), copyRanges_);
+          copyRanges_.clear();
+        }
+        currentSource = &accumulator->vector;
+        BaseVector::CopyRange range = {accumulator->index, i, 1};
+        if (!copyRanges_.empty() && copyRanges_.back().mergeable(range)) {
+          ++copyRanges_.back().count;
+        } else {
+          copyRanges_.push_back(range);
+        }
+      }
+      if (currentSource) {
+        result->get()->copyRanges(currentSource->get(), copyRanges_);
+        copyRanges_.clear();
+      }
+    } else {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<SingleValueAccumulator>(groups[i]);
+        if (!accumulator->hasValue()) {
+          (*result)->setNull(i, true);
+        } else {
+          exec::Aggregate::clearNull(rawNulls, i);
+          accumulator->read(*result, i);
+        }
       }
     }
   }
@@ -194,16 +230,17 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
-    DecodedVector decoded(*args[0], rows, true);
-    if (decoded.isConstantMapping() && decoded.isNullAt(rows.begin())) {
+    VELOX_CHECK(!clusteredInput_);
+    decoded_.decode(*args[0], rows, true);
+    if (decoded_.isConstantMapping() && decoded_.isNullAt(rows.begin())) {
       // nothing to do; all values are nulls
       return;
     }
 
-    const auto* indices = decoded.indices();
-    const auto* baseVector = decoded.base();
+    const auto* indices = decoded_.indices();
+    const auto* baseVector = decoded_.base();
     rows.applyToSelected([&](vector_size_t i) {
-      if (decoded.isNullAt(i)) {
+      if (decoded_.isNullAt(i)) {
         return;
       }
       auto* accumulator = value<SingleValueAccumulator>(groups[i]);
@@ -211,6 +248,47 @@ class NonNumericArbitrary : public exec::Aggregate {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
+  }
+
+  bool supportsAddRawClusteredInput() const override {
+    return clusteredInput_;
+  }
+
+  void addRawClusteredInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      const folly::Range<const vector_size_t*>& groupBoundaries) override {
+    VELOX_CHECK(clusteredInput_);
+    decoded_.decode(*args[0]);
+    VELOX_DCHECK(copyRanges_.empty());
+    vector_size_t groupStart = 0;
+    auto forEachEmptyAccumulator = [&](auto func) {
+      for (auto groupEnd : groupBoundaries) {
+        auto* accumulator =
+            value<ClusteredNonNumericAccumulator>(groups[groupEnd - 1]);
+        if (!accumulator->vector) {
+          func(groupEnd, accumulator);
+        }
+        groupStart = groupEnd;
+      }
+    };
+    if (rows.isAllSelected() && !decoded_.mayHaveNulls()) {
+      forEachEmptyAccumulator([&](auto /*groupEnd*/, auto* accumulator) {
+        accumulator->vector = args[0];
+        accumulator->index = groupStart;
+      });
+    } else {
+      forEachEmptyAccumulator([&](auto groupEnd, auto* accumulator) {
+        for (auto i = groupStart; i < groupEnd; ++i) {
+          if (rows.isValid(i) && !decoded_.isNullAt(i)) {
+            accumulator->vector = args[0];
+            accumulator->index = i;
+            break;
+          }
+        }
+      });
+    }
   }
 
   void addIntermediateResults(
@@ -226,22 +304,23 @@ class NonNumericArbitrary : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
+    VELOX_CHECK(!clusteredInput_);
     auto* accumulator = value<SingleValueAccumulator>(group);
     if (accumulator->hasValue()) {
       return;
     }
 
-    DecodedVector decoded(*args[0], rows, true);
-    if (decoded.isConstantMapping() && decoded.isNullAt(rows.begin())) {
+    decoded_.decode(*args[0], rows, true);
+    if (decoded_.isConstantMapping() && decoded_.isNullAt(rows.begin())) {
       // nothing to do; all values are nulls
       return;
     }
 
-    const auto* indices = decoded.indices();
-    const auto* baseVector = decoded.base();
+    const auto* indices = decoded_.indices();
+    const auto* baseVector = decoded_.base();
     // Find the first non-null value.
     rows.testSelected([&](vector_size_t i) {
-      if (!decoded.isNullAt(i)) {
+      if (!decoded_.isNullAt(i)) {
         accumulator->write(baseVector, indices[i], allocator_);
         return false; // Stop
       }
@@ -258,23 +337,40 @@ class NonNumericArbitrary : public exec::Aggregate {
   }
 
  protected:
-  // Initialize each group, we will not use the null flags because
-  // SingleValueAccumulator has its own flag.
+  // Initialize each group, we will not use the null flags because the
+  // accumulator has its own flag.
   void initializeNewGroupsInternal(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto i : indices) {
-      new (groups[i] + offset_) SingleValueAccumulator();
+      if (clusteredInput_) {
+        new (groups[i] + offset_) ClusteredNonNumericAccumulator();
+      } else {
+        new (groups[i] + offset_) SingleValueAccumulator();
+      }
     }
   }
 
   void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
       if (isInitialized(group)) {
-        value<SingleValueAccumulator>(group)->destroy(allocator_);
+        if (clusteredInput_) {
+          auto* accumulator = value<ClusteredNonNumericAccumulator>(group);
+          std::destroy_at(accumulator);
+        } else {
+          auto* accumulator = value<SingleValueAccumulator>(group);
+          accumulator->destroy(allocator_);
+        }
       }
     }
   }
+
+ private:
+  // Decoded input vector.
+  DecodedVector decoded_;
+
+  // Copy ranges used when extracting from ClusteredNonNumericAccumulator.
+  std::vector<BaseVector::CopyRange> copyRanges_;
 };
 
 } // namespace

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
+#include "folly/container/small_vector.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
@@ -26,13 +27,28 @@ struct ArrayAccumulator {
   ValueList elements;
 };
 
+struct SourceRange {
+  VectorPtr vector;
+  vector_size_t offset;
+  vector_size_t size;
+};
+
+struct ClusteredAccumulator {
+  folly::small_vector<SourceRange, 2> sources;
+};
+
 class ArrayAggAggregate : public exec::Aggregate {
  public:
   explicit ArrayAggAggregate(TypePtr resultType, bool ignoreNulls)
       : Aggregate(resultType), ignoreNulls_(ignoreNulls) {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(ArrayAccumulator);
+    return clusteredInput_ ? sizeof(ClusteredAccumulator)
+                           : sizeof(ArrayAccumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
   }
 
   bool isFixedSize() const override {
@@ -97,26 +113,70 @@ class ArrayAggAggregate : public exec::Aggregate {
     auto vector = (*result)->as<ArrayVector>();
     VELOX_CHECK(vector);
     vector->resize(numGroups);
-
-    auto elements = vector->elements();
-    elements->resize(countElements(groups, numGroups));
-
     uint64_t* rawNulls = getRawNulls(vector);
-    vector_size_t offset = 0;
-    for (int32_t i = 0; i < numGroups; ++i) {
-      auto& values = value<ArrayAccumulator>(groups[i])->elements;
-      auto arraySize = values.size();
-      if (arraySize) {
-        clearNull(rawNulls, i);
+    auto* resultOffsets =
+        vector->mutableOffsets(numGroups)->asMutable<vector_size_t>();
+    auto* resultSizes =
+        vector->mutableSizes(numGroups)->asMutable<vector_size_t>();
+    auto& elements = vector->elements();
+    elements->resize(countElements(groups, numGroups));
+    vector_size_t arrayOffset = 0;
 
-        ValueListReader reader(values);
-        for (auto index = 0; index < arraySize; ++index) {
-          reader.next(*elements, offset + index);
+    if (clusteredInput_) {
+      VectorPtr* currentSource = nullptr;
+      std::vector<BaseVector::CopyRange> ranges;
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[i]);
+        resultOffsets[i] = arrayOffset;
+        vector_size_t arraySize = 0;
+        for (auto& source : accumulator->sources) {
+          if (currentSource && currentSource->get() != source.vector.get()) {
+            elements->copyRanges(currentSource->get(), ranges);
+            ranges.clear();
+          }
+          if (!currentSource || currentSource->get() != source.vector.get()) {
+            currentSource = &source.vector;
+            ranges.push_back({source.offset, arrayOffset, source.size});
+          } else if (
+              ranges.back().sourceIndex + ranges.back().count ==
+              source.offset) {
+            ranges.back().count += source.size;
+          } else {
+            VELOX_DCHECK_LT(
+                ranges.back().sourceIndex + ranges.back().count, source.offset);
+            ranges.push_back({source.offset, arrayOffset, source.size});
+          }
+          arrayOffset += source.size;
+          arraySize += source.size;
         }
-        vector->setOffsetAndSize(i, offset, arraySize);
-        offset += arraySize;
-      } else {
-        vector->setNull(i, true);
+        resultSizes[i] = arraySize;
+        if (arraySize == 0) {
+          vector->setNull(i, true);
+        } else {
+          clearNull(rawNulls, i);
+        }
+      }
+      if (currentSource) {
+        VELOX_DCHECK(!ranges.empty());
+        elements->copyRanges(currentSource->get(), ranges);
+      }
+
+    } else {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto& values = value<ArrayAccumulator>(groups[i])->elements;
+        auto arraySize = values.size();
+        if (arraySize) {
+          clearNull(rawNulls, i);
+          ValueListReader reader(values);
+          for (auto index = 0; index < arraySize; ++index) {
+            reader.next(*elements, arrayOffset + index);
+          }
+          resultOffsets[i] = arrayOffset;
+          resultSizes[i] = arraySize;
+          arrayOffset += arraySize;
+        } else {
+          vector->setNull(i, true);
+        }
       }
     }
   }
@@ -131,6 +191,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
+    VELOX_CHECK(!clusteredInput_);
     decodedElements_.decode(*args[0], rows);
     rows.applyToSelected([&](vector_size_t row) {
       if (ignoreNulls_ && decodedElements_.isNullAt(row)) {
@@ -141,6 +202,51 @@ class ArrayAggAggregate : public exec::Aggregate {
       value<ArrayAccumulator>(group)->elements.appendValue(
           decodedElements_, row, allocator_);
     });
+  }
+
+  bool supportsAddRawClusteredInput() const override {
+    return clusteredInput_;
+  }
+
+  void addRawClusteredInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      const folly::Range<const vector_size_t*>& groupBoundaries) override {
+    VELOX_CHECK(clusteredInput_);
+    decodedElements_.decode(*args[0]);
+    vector_size_t groupStart = 0;
+    auto forEachAccumulator = [&](auto func) {
+      for (auto groupEnd : groupBoundaries) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[groupEnd - 1]);
+        func(groupEnd, accumulator);
+        groupStart = groupEnd;
+      }
+    };
+    if (rows.isAllSelected() &&
+        (!ignoreNulls_ || !decodedElements_.mayHaveNulls())) {
+      forEachAccumulator([&](auto groupEnd, auto* accumulator) {
+        accumulator->sources.push_back(
+            {args[0], groupStart, groupEnd - groupStart});
+      });
+    } else {
+      forEachAccumulator([&](auto groupEnd, auto* accumulator) {
+        for (auto i = groupStart; i < groupEnd; ++i) {
+          if (!rows.isValid(i) ||
+              (ignoreNulls_ && decodedElements_.isNullAt(i))) {
+            if (i > groupStart) {
+              accumulator->sources.push_back(
+                  {args[0], groupStart, i - groupStart});
+            }
+            groupStart = i + 1;
+          }
+        }
+        if (groupEnd > groupStart) {
+          accumulator->sources.push_back(
+              {args[0], groupStart, groupEnd - groupStart});
+        }
+      });
+    }
   }
 
   void addIntermediateResults(
@@ -171,6 +277,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
+    VELOX_CHECK(!clusteredInput_);
     auto& values = value<ArrayAccumulator>(group)->elements;
 
     decodedElements_.decode(*args[0], rows);
@@ -188,6 +295,7 @@ class ArrayAggAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
+    VELOX_CHECK(!clusteredInput_);
     decodedIntermediate_.decode(*args[0], rows);
     auto arrayVector = decodedIntermediate_.base()->as<ArrayVector>();
 
@@ -210,14 +318,23 @@ class ArrayAggAggregate : public exec::Aggregate {
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
     for (auto index : indices) {
-      new (groups[index] + offset_) ArrayAccumulator();
+      if (clusteredInput_) {
+        new (groups[index] + offset_) ClusteredAccumulator();
+      } else {
+        new (groups[index] + offset_) ArrayAccumulator();
+      }
     }
   }
 
   void destroyInternal(folly::Range<char**> groups) override {
     for (auto group : groups) {
       if (isInitialized(group)) {
-        value<ArrayAccumulator>(group)->elements.free(allocator_);
+        if (clusteredInput_) {
+          auto* accumulator = value<ClusteredAccumulator>(group);
+          std::destroy_at(accumulator);
+        } else {
+          value<ArrayAccumulator>(group)->elements.free(allocator_);
+        }
       }
     }
   }
@@ -225,8 +342,17 @@ class ArrayAggAggregate : public exec::Aggregate {
  private:
   vector_size_t countElements(char** groups, int32_t numGroups) const {
     vector_size_t size = 0;
-    for (int32_t i = 0; i < numGroups; ++i) {
-      size += value<ArrayAccumulator>(groups[i])->elements.size();
+    if (clusteredInput_) {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        auto* accumulator = value<ClusteredAccumulator>(groups[i]);
+        for (auto& source : accumulator->sources) {
+          size += source.size;
+        }
+      }
+    } else {
+      for (int32_t i = 0; i < numGroups; ++i) {
+        size += value<ArrayAccumulator>(groups[i])->elements.size();
+      }
     }
     return size;
   }

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -465,5 +465,39 @@ TEST_F(ArbitraryTest, spilling) {
   ::facebook::velox::test::assertEqualVectors(expected, result);
 }
 
+TEST_F(ArbitraryTest, clusteredInput) {
+  constexpr int kSize = 1000;
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(kSize, [](auto i) { return i / 13; }),
+      makeFlatVector<std::string>(
+          kSize, [](auto i) { return std::to_string(i); }),
+      makeFlatVector<bool>(kSize, [](auto i) { return i % 11 == 0; }),
+  });
+  createDuckDbTable({data});
+  for (bool mask : {false, true}) {
+    auto builder = PlanBuilder().values({data});
+    std::string expected;
+    if (mask) {
+      builder.partialStreamingAggregation({"c0"}, {"arbitrary(c1)"}, {"c2"});
+      expected = "select c0, first(c1) filter (where c2) from tmp group by 1";
+    } else {
+      builder.partialStreamingAggregation({"c0"}, {"arbitrary(c1)"});
+      expected = "select c0, first(c1) from tmp group by 1";
+    }
+    auto plan = builder.finalAggregation().planNode();
+    for (int batchRows : {1024, 17}) {
+      for (bool eagerFlush : {false, true}) {
+        SCOPED_TRACE(fmt::format(
+            "mask={} batchRows={} eagerFlush={}", mask, batchRows, eagerFlush));
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .config(core::QueryConfig::kPreferredOutputBatchRows, batchRows)
+            .config(
+                core::QueryConfig::kStreamingAggregationEagerFlush, eagerFlush)
+            .assertResults(expected);
+      }
+    }
+  }
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -488,6 +488,14 @@ bool RowType::equals(const Type& other) const {
   return true;
 }
 
+size_t RowType::hashKind() const {
+  if (!hashKindComputed_.load(std::memory_order_relaxed)) {
+    hashKind_ = TypeBase<TypeKind::ROW>::hashKind();
+    hashKindComputed_ = true;
+  }
+  return hashKind_;
+}
+
 void RowType::printChildren(std::stringstream& ss, std::string_view delimiter)
     const {
   bool any = false;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -535,7 +535,7 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
   static void registerSerDe();
 
   /// Recursive kind hashing (uses only TypeKind).
-  size_t hashKind() const;
+  virtual size_t hashKind() const;
 
   /// Recursive kind match (uses only TypeKind).
   bool kindEquals(const std::shared_ptr<const Type>& other) const;
@@ -1070,6 +1070,8 @@ class RowType : public TypeBase<TypeKind::ROW> {
     return *parameters;
   }
 
+  size_t hashKind() const override;
+
  protected:
   bool equals(const Type& other) const override;
 
@@ -1079,6 +1081,8 @@ class RowType : public TypeBase<TypeKind::ROW> {
   const std::vector<std::string> names_;
   const std::vector<std::shared_ptr<const Type>> children_;
   mutable std::atomic<std::vector<TypeParameter>*> parameters_{nullptr};
+  mutable std::atomic_bool hashKindComputed_{false};
+  mutable std::atomic_size_t hashKind_;
 };
 
 using RowTypePtr = std::shared_ptr<const RowType>;

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -430,6 +430,12 @@ class BaseVector {
     vector_size_t sourceIndex;
     vector_size_t targetIndex;
     vector_size_t count;
+
+    /// Whether `next` can be merged with this range to form a new range.
+    bool mergeable(const CopyRange& next) const {
+      return next.sourceIndex == sourceIndex + count &&
+          next.targetIndex == targetIndex + count;
+    }
   };
 
   /// Sets null flags for each row in 'ranges' to 'isNull'.


### PR DESCRIPTION
Summary:
Avoid recurively rehash for `RowType`.  This reduces the expression
compilation time significantly for flatmap types commonly seen in ML workload.

Differential Revision: D72803509


