### PR TITLE
fix: Remove public from VELOX_DEFINE_CLASS_NAME

### DIFF
--- a/velox/common/base/ClassName.h
+++ b/velox/common/base/ClassName.h
@@ -16,7 +16,6 @@
 
 #pragma once
 #define VELOX_DEFINE_CLASS_NAME(name)          \
- public:                                       \
   static const char* getClassName() noexcept { \
     return #name;                              \
   }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -577,6 +577,8 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   bool containsUnknown() const;
 
+  VELOX_DEFINE_CLASS_NAME(Type)
+
  protected:
   FOLLY_ALWAYS_INLINE bool hasSameTypeId(const Type& other) const {
     return typeid(*this) == typeid(other);
@@ -595,8 +597,6 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
  private:
   const TypeKind kind_;
   const bool providesCustomComparison_;
-
-  VELOX_DEFINE_CLASS_NAME(Type)
 };
 
 #undef VELOX_FLUENT_CAST


### PR DESCRIPTION
Summary:
When this macro is used in the middle of the class definition, the `public` specifier will make everything below also public, which is unintended. This diff removes `public` specifier so that the macro doesn't change variable visibility for the rest of the class.

Because member visibility will changed, this diff also moves VELOX_DEFINE_CLASS_NAME into public.

Reviewed By: mbasmanova

Differential Revision: D72421576


