### PR TITLE
feat: Support intergral types for the index parameter of Spark get function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -239,14 +239,15 @@ Array Functions
     Returns whether all elements of an array match the given predicate.
 
         Returns true if all the elements match the predicate (a special case is when the array is empty);
-        Returns false if one or more elements don’t match;
+        Returns false if one or more elements don't match;
         Returns NULL if the predicate function returns NULL for one or more elements and true for all other elements.
         Throws an exception if the predicate fails for one or more elements and returns true or NULL for the rest.
 
 .. spark:function:: get(array(E), index) -> E
 
-    Returns an element of the array at the specified 0-based index.
-    Returns NULL if index points outside of the array boundaries. ::
+    Returns an element of the array at the specified 0-based ``index``.
+    Returns NULL if ``index`` points outside of the array boundaries.
+    ``index`` must be of an integral type. ::
 
         SELECT get(array(1, 2, 3), 0); -- 1
         SELECT get(array(1, 2, 3), 3); -- NULL

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -262,6 +262,12 @@ class SubscriptImpl : public exec::Subscript {
     auto indexArg = args[1];
 
     switch (indexArg->typeKind()) {
+      case TypeKind::TINYINT:
+        return applyArrayTyped<int8_t>(rows, arrayArg, indexArg, context);
+
+      case TypeKind::SMALLINT:
+        return applyArrayTyped<int16_t>(rows, arrayArg, indexArg, context);
+
       case TypeKind::INTEGER:
         return applyArrayTyped<int32_t>(rows, arrayArg, indexArg, context);
 

--- a/velox/functions/sparksql/ArrayGetFunction.cpp
+++ b/velox/functions/sparksql/ArrayGetFunction.cpp
@@ -35,13 +35,19 @@ class ArrayGetFunction : public SubscriptImpl<
   explicit ArrayGetFunction() : SubscriptImpl(false) {}
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    return {// array(T), integer -> T
-            exec::FunctionSignatureBuilder()
-                .typeVariable("T")
-                .returnType("T")
-                .argumentType("array(T)")
-                .argumentType("integer")
-                .build()};
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+
+    // array(T), tinyint|smallint|integer|bigint -> T
+    for (const auto& indexType : {"tinyint", "smallint", "integer", "bigint"}) {
+      signatures.push_back(exec::FunctionSignatureBuilder()
+                               .typeVariable("T")
+                               .returnType("T")
+                               .argumentType("array(T)")
+                               .argumentType(indexType)
+                               .build());
+    }
+
+    return signatures;
   }
 };
 } // namespace


### PR DESCRIPTION
Support tinyint and smallint types for the index parameter of Spark get function.

Spark's implementation: https://github.com/apache/spark/blob/9bc8cd51b671aeab7f4652698c00a72991e216fb/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala#L248