### PR TITLE
build: Add support for Arm Neoverse V2 CPU

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -136,6 +136,7 @@ function get_cxx_flags {
       Neoverse_N1="d0c"
       Neoverse_N2="d49"
       Neoverse_V1="d40"
+      Neoverse_V2="d4f"
       if [ -f "$ARM_CPU_FILE" ]; then
         hex_ARM_CPU_DETECT=`cat $ARM_CPU_FILE`
         # PartNum, [15:4]: The primary part number such as Neoverse N1/N2 core.
@@ -147,6 +148,8 @@ function get_cxx_flags {
           echo -n "-mcpu=neoverse-n2 "
         elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_V1" ]; then
           echo -n "-mcpu=neoverse-v1 "
+        elif [ "$ARM_CPU_PRODUCT" = "$Neoverse_V2" ]; then
+          echo -n "-mcpu=neoverse-v2 "
         else
           echo -n "-march=armv8-a+crc+crypto "
         fi


### PR DESCRIPTION
Summary:
Add support for Arm Neoverse V2 in get_cxx_flags. A new check for Neoverse V2 ("d4f") now outputs "-mcpu=neoverse-v2", which prevents falling back to the generic "-march=armv8-a+crc+crypto" flag.

Background:
It was observed that code compiled on Neoverse V2 suffered a performance drop because the CPU was not correctly detected. Instead of applying the optimal "-mcpu=neoverse-v2" flag, the build fell back to the less optimal "-march=armv8-a+crc+crypto" flag. This commit explicitly adds support for Neoverse V2, ensuring that the appropriate flag is used.

Verification:
This change has been successfully verified on Arm Neoverse V2 system.

Results:
Updated build flags are now applied on Arm Neoverse V2 systems, which are restoring optimal performance.

Change-Id: I4da17f1b70ad380a39a7f38cb662461cca4fd67c