### PR TITLE
build(pyvelox): Build pyvelox wheels for 3.10 through 3.13

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -114,8 +114,7 @@ jobs:
         uses: pypa/cibuildwheel@6cccd09a31908ffd175b012fb8bf4e1dbda3bc6c # v2
         env:
           BUILD_VERSION: "${{ inputs.version }}"
-          # Only build for 3.12 for now
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp312-*' || 'cp312-*' }}
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           CIBW_ENVIRONMENT_PASS_LINUX:  "BUILD_VERSION"
           CIBW_ENVIRONMENT_LINUX: "CCACHE_DIR=/host${{ github.workspace }}/ccache"
           # for macos

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -86,6 +86,9 @@ jobs:
             source scripts/setup-macos.sh
             install_build_prerequisites
             install_velox_deps_from_brew
+            # CMake 4.0 causes issues with arrows bundled dependencies
+            brew uninstall cmake
+            pipx install --force cmake==3.31
 
       - name: Install macOS dependencies
         if: ${{ startsWith(matrix.os, 'macos') && steps.restore-deps.outputs.stash-hit != 'true' }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ VELOX_MONO_LIBRARY = true
 TREAT_WARNINGS_AS_ERRORS = true
 MAX_HIGH_MEM_JOBS = { env = "MAX_HIGH_MEM_JOBS", default = "" }
 MAX_HIGH_LINK_JOBS = { env = "MAX_HIGH_LINK_JOBS", default = "" }
+CMAKE_POLICY_VERSION_MINIMUM = "3.5" # required for deps that don't support cmake 4.0
 
 [[tool.scikit-build.overrides]]
 if.env.DEBUG = true        # 1 maps to true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires = [
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "pyvelox"
+name = "PyVelox"
 dynamic = ["version"]
 description = "Python bindings and extensions for Velox"
 readme = "README.md"


### PR DESCRIPTION
During development of the new systems we where only using 3.12 for validation but we want to provide wheels for more versions when releasing.