### PR TITLE
feat: Support AggregateOption in PlanSummaryOptions

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -139,6 +139,16 @@ struct PlanSummaryOptions {
   /// well as up to 2 fields of a struct: ARRAY(REAL), MAP(INTEGER, ARRAY),
   /// ROW(VARCHAR, ARRAY,...).
   size_t maxChildTypes = 0;
+
+  /// Options that apply specifically to AGGREGATION nodes.
+  struct AggregateOptions {
+    /// For a given AGGREGATION node, maximum number of aggregate expressions
+    /// to include in the summary. By default, no aggregate expression is
+    /// included.
+    size_t maxAggregations = 0;
+  };
+
+  AggregateOptions aggregate = {};
 };
 
 class PlanNode : public ISerializable {
@@ -1256,6 +1266,11 @@ class AggregationNode : public PlanNode {
   static const std::optional<FieldAccessTypedExprPtr> kDefaultGroupId;
 
   void addDetails(std::stringstream& stream) const override;
+
+  void addSummaryDetails(
+      const std::string& indentation,
+      const PlanSummaryOptions& options,
+      std::stringstream& stream) const override;
 
   const Step step_;
   const std::vector<FieldAccessTypedExprPtr> groupingKeys_;


### PR DESCRIPTION
Summary:
Koski's [PlanSummaryOptions](https://www.internalfb.com/code/fbsource/[1dce16441700]/fbcode/koski/core/PlanPrinter.h?lines=12) supports options specific to aggregations. It would be nice to have the equivalent in Velox too. 

With maxAggregations = 3, the output looks like 

```
-- Aggregation[1]: 6 fields: a INTEGER, a0 BIGINT, a1 DOUBLE, a2 BIGINT, a3 INTEGER, ...
      expressions: call: 6, field: 6
      functions: avg: 1, count: 1, max: 2, plus: 1, sum: 1
      aggregations: 5
         0: sum(ROW[\"b\"])
         1: avg(plus(ROW[\"b\"],ROW[\"a\"]))
         2: DISTINCTcount(ROW[\"c\"])
         ... 2 more
  -- TableScan[0]: 3 fields: a INTEGER, b INTEGER, c INTEGER
        table: hive_table\n
```

Reviewed By: xiaoxmeng

Differential Revision: D71782119


