### PR TITLE
docs(s3fs): Add metrics

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Counters.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Counters.h
@@ -19,38 +19,38 @@ namespace facebook::velox::filesystems {
 
 // The number of connections open for S3 read operations.
 constexpr std::string_view kMetricS3ActiveConnections{
-    "velox.s3.active_connections"};
+    "velox.s3_active_connections"};
 
 // The number of S3 upload calls that started.
-constexpr std::string_view kMetricS3StartedUploads{"velox.s3.started_uploads"};
+constexpr std::string_view kMetricS3StartedUploads{"velox.s3_started_uploads"};
 
 // The number of S3 upload calls that were completed.
 constexpr std::string_view kMetricS3SuccessfulUploads{
-    "velox.s3.successful_uploads"};
+    "velox.s3_successful_uploads"};
 
 // The number of S3 upload calls that failed.
-constexpr std::string_view kMetricS3FailedUploads{"velox.s3.failed_uploads"};
+constexpr std::string_view kMetricS3FailedUploads{"velox.s3_failed_uploads"};
 
 // The number of S3 head (metadata) calls.
-constexpr std::string_view kMetricS3MetadataCalls{"velox.s3.metadata_calls"};
+constexpr std::string_view kMetricS3MetadataCalls{"velox.s3_metadata_calls"};
 
 // The number of S3 head (metadata) calls that failed.
 constexpr std::string_view kMetricS3GetMetadataErrors{
-    "velox.s3.get_metadata_errors"};
+    "velox.s3_get_metadata_errors"};
 
 // The number of retries made during S3 head (metadata) calls.
 constexpr std::string_view kMetricS3GetMetadataRetries{
-    "velox.s3.get_metadata_retries"};
+    "velox.s3_get_metadata_retries"};
 
 // The number of S3 getObject calls.
-constexpr std::string_view kMetricS3GetObjectCalls{"velox.s3.get_object_calls"};
+constexpr std::string_view kMetricS3GetObjectCalls{"velox.s3_get_object_calls"};
 
 // The number of S3 getObject calls that failed.
 constexpr std::string_view kMetricS3GetObjectErrors{
-    "velox.s3.get_object_errors"};
+    "velox.s3_get_object_errors"};
 
 // The number of retries made during S3 getObject calls.
 constexpr std::string_view kMetricS3GetObjectRetries{
-    "velox.s3.get_object_retries"};
+    "velox.s3_get_object_retries"};
 
 } // namespace facebook::velox::filesystems

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -616,7 +616,7 @@ Table Scan
      - The time distribution of table scan batch processing time in range of [0,
        16s] with 512 buckets and reports P50, P90, P99, and P100.
 
-S3 File System
+S3 FileSystem
 --------------
 
 .. list-table::
@@ -626,33 +626,33 @@ S3 File System
    * - Metric Name
      - Type
      - Description
-   * - s3.active_connections
+   * - s3_active_connections
      - Sum
      - The number of connections open for S3 read operations.
-   * - s3.started_uploads
+   * - s3_started_uploads
      - Count
      - The number of S3 upload calls that were started.
-   * - s3.successful_uploads
+   * - s3_successful_uploads
      - Count
      - The number of S3 upload calls that were completed.
-   * - s3.failed_uploads
+   * - s3_failed_uploads
      - Count
      - The number of S3 upload calls that failed.
-   * - s3.metadata_calls
+   * - s3_metadata_calls
      - Count
      - The number of S3 head (metadata) calls.
-   * - s3.get_metadata_errors
+   * - s3_get_metadata_errors
      - Count
      - The number of S3 head (metadata) calls that failed.
-   * - s3.get_metadata_retries
+   * - s3_get_metadata_retries
      - Count
      - The number of retries made during S3 head (metadata) calls.
-   * - s3.get_object_calls
+   * - s3_get_object_calls
      - Count
      - The number of S3 getObject calls.
-   * - s3.get_object_errors
+   * - s3_get_object_errors
      - Count
      - The number of S3 getObject calls that failed.
-   * - s3.get_object_retries
+   * - s3_get_object_retries
      - Count
      - The number of retries made during S3 getObject calls.

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -615,3 +615,44 @@ Table Scan
      - Histogram
      - The time distribution of table scan batch processing time in range of [0,
        16s] with 512 buckets and reports P50, P90, P99, and P100.
+
+S3 File System
+--------------
+
+.. list-table::
+   :widths: 40 10 50
+   :header-rows: 1
+
+   * - Metric Name
+     - Type
+     - Description
+   * - s3.active_connections
+     - Sum
+     - The number of connections open for S3 read operations.
+   * - s3.started_uploads
+     - Count
+     - The number of S3 upload calls that were started.
+   * - s3.successful_uploads
+     - Count
+     - The number of S3 upload calls that were completed.
+   * - s3.failed_uploads
+     - Count
+     - The number of S3 upload calls that failed.
+   * - s3.metadata_calls
+     - Count
+     - The number of S3 head (metadata) calls.
+   * - s3.get_metadata_errors
+     - Count
+     - The number of S3 head (metadata) calls that failed.
+   * - s3.get_metadata_retries
+     - Count
+     - The number of retries made during S3 head (metadata) calls.
+   * - s3.get_object_calls
+     - Count
+     - The number of S3 getObject calls.
+   * - s3.get_object_errors
+     - Count
+     - The number of S3 getObject calls that failed.
+   * - s3.get_object_retries
+     - Count
+     - The number of retries made during S3 getObject calls.


### PR DESCRIPTION
We've added the S3 File System metrics in #12213. This PR adds the metrics in the docs.

Background:
https://github.com/prestodb/presto/pull/24554#issuecomment-2784096752