### PR TITLE
misc: Avoid acquiring lock in QueryCtx::checkUnderArbitration if unnecessary

### DIFF
--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -123,7 +123,12 @@ uint64_t QueryCtx::MemoryReclaimer::reclaim(
 
 bool QueryCtx::checkUnderArbitration(ContinueFuture* future) {
   VELOX_CHECK_NOT_NULL(future);
+  if (!underArbitration_) {
+    return false;
+  }
+
   std::lock_guard<std::mutex> l(mutex_);
+  // Check again under the lock to avoid data race.
   if (!underArbitration_) {
     VELOX_CHECK(arbitrationPromises_.empty());
     return false;

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -225,7 +225,7 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
 
   mutable std::mutex mutex_;
   // Indicates if this query is under memory arbitration or not.
-  bool underArbitration_{false};
+  std::atomic_bool underArbitration_{false};
   std::vector<ContinuePromise> arbitrationPromises_;
 };
 


### PR DESCRIPTION
Summary: When the number of Driver is large, the lock in QueryCtx::checkUnderArbitration() can cause lock contention. This change makes checkUnderArbitration() acquire the lock only if underArbitration_ is true.

Differential Revision: D72753248


