### PR TITLE
feat(python): Add index lookup join

### DIFF
--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -289,6 +289,24 @@ PyPlanBuilder& PyPlanBuilder::mergeJoin(
   return *this;
 }
 
+PyPlanBuilder& PyPlanBuilder::indexLookupJoin(
+    const std::vector<std::string>& leftKeys,
+    const std::vector<std::string>& rightKeys,
+    const PyPlanNode& indexPlanSubtree,
+    const std::vector<std::string>& output,
+    core::JoinType joinType) {
+  if (const auto tableScanNode =
+          std::dynamic_pointer_cast<const core::TableScanNode>(
+              indexPlanSubtree.planNode())) {
+    planBuilder_.indexLookupJoin(
+        leftKeys, rightKeys, tableScanNode, {}, output, joinType);
+  } else {
+    throw std::runtime_error(
+        "Index Loop Join subtree must be a single TableScanNode.");
+  }
+  return *this;
+}
+
 PyPlanBuilder& PyPlanBuilder::sortedMerge(
     const std::vector<std::string>& keys,
     const std::vector<std::optional<PyPlanNode>>& pySources) {

--- a/velox/python/plan_builder/PyPlanBuilder.h
+++ b/velox/python/plan_builder/PyPlanBuilder.h
@@ -273,6 +273,24 @@ class PyPlanBuilder {
       const std::string& filter,
       core::JoinType joinType);
 
+  /// Add an index lookup join node. It requires the index_plan_node
+  /// subtree to be composed of a single table scan on a connector with
+  /// indexed access support.
+  ///
+  /// @param leftKeys Set of join keys from the left (current plan builder)
+  /// plan subtree.
+  /// @param leftKeys Set of join keys from the right plan subtree.
+  /// @param index_plan_node The subtree containing the lookup table scan.
+  /// @param output List of column names to project in the output of the
+  /// join.
+  /// @param joinType The type of join (kInner, kLeft, kRight, or kFull)
+  PyPlanBuilder& indexLookupJoin(
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const PyPlanNode& indexPlanSubtree,
+      const std::vector<std::string>& output,
+      core::JoinType joinType);
+
   /// Takes N sorted `source` subtrees and merges them into a sorted output.
   /// Assumes that all sources are sorted on `keys`.
   ///

--- a/velox/python/plan_builder/plan_builder.cpp
+++ b/velox/python/plan_builder/plan_builder.cpp
@@ -257,6 +257,26 @@ PYBIND11_MODULE(plan_builder, m) {
           join_type: Join type (inner, left, right, full, etc).
       )"))
       .def(
+          "index_lookup_join",
+          &velox::py::PyPlanBuilder::indexLookupJoin,
+          py::arg("left_keys"),
+          py::arg("right_keys"),
+          py::arg("index_plan_node"),
+          py::arg("output") = std::vector<std::string>{},
+          py::arg("join_type") = velox::core::JoinType::kInner,
+          py::doc(R"(
+        Adds an index lookup join node. It requires the index_plan_node
+        subtree to be composed of a single table scan on a connector with
+        indexed access support.
+
+        Args:
+          left_keys: List of keys from the left table.
+          right_keys: List of keys from the right table.
+          index_plan_node: The subtree containing the lookup table scan.
+          output: List of columns to be projected out of the join.
+          join_type: Join type (inner, left, right, full, etc).
+      )"))
+      .def(
           "sorted_merge",
           &velox::py::PyPlanBuilder::sortedMerge,
           py::arg("keys"),


### PR DESCRIPTION
Summary: Add plan builder API to add an index lookup join plan node.

Reviewed By: kgpai

Differential Revision: D72494071


