### PR TITLE
fix: Add batched deserialization in Exchange for CompactRowr in exchange

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -2652,15 +2652,94 @@ TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
     test(100'000, 1);
   } else if (GetParam().serdeKind == VectorSerde::Kind::kCompactRow) {
     test(1, 1'000);
-    test(1'000, 38);
-    test(10'000, 4);
-    test(100'000, 1);
+    test(1'000, 39);
+    test(10'000, 5);
+    test(100'000, 2);
   } else {
     test(1, 1'000);
     test(1'000, 72);
     test(10'000, 7);
     test(100'000, 1);
   }
+}
+
+TEST_P(MultiFragmentTest, splitLargeCompactRowsInExchange) {
+  if (GetParam().serdeKind != VectorSerde::Kind::kCompactRow) {
+    return;
+  }
+  const uint64_t kNumColumns = 100;
+  const uint64_t kNumRows = 2'000;
+  const int32_t kNumPartitions = 2;
+
+  std::vector<int64_t> columnElements;
+  for (auto i = 0; i < kNumRows; ++i) {
+    columnElements.push_back(i);
+  }
+  std::vector<VectorPtr> columns;
+  for (auto i = 0; i < kNumColumns; ++i) {
+    columns.push_back(makeFlatVector<int64_t>(columnElements));
+  }
+
+  // 'data' is a wide vector of 20k rows and 100 columns(children vectors). Each
+  // row estimated to be 100 * 8b = 800b.
+  auto data = makeRowVector(columns);
+
+  auto producerPlan = test::PlanBuilder()
+                          .values({data})
+                          .partitionedOutput(
+                              {"c0"},
+                              kNumPartitions,
+                              /*outputLayout=*/{},
+                              VectorSerde::Kind::kCompactRow)
+                          .planNode();
+  const auto producerTaskId = "local://t1";
+
+  auto plan =
+      test::PlanBuilder()
+          .exchange(asRowType(data->type()), VectorSerde::Kind::kCompactRow)
+          .planNode();
+
+  auto expected = makeRowVector(columns);
+
+  auto test = [&](uint64_t maxBytes, int32_t expectedBatches) {
+    auto producerTask = makeTask(producerTaskId, producerPlan);
+
+    bufferManager_->initializeTask(
+        producerTask,
+        core::PartitionedOutputNode::Kind::kPartitioned,
+        kNumPartitions,
+        1);
+
+    auto cleanupGuard = folly::makeGuard([&]() {
+      producerTask->requestCancel();
+      bufferManager_->removeTask(producerTaskId);
+    });
+
+    // Enqueue a single large page.
+    enqueue(producerTaskId, 0, data);
+
+    bufferManager_->noMoreData(producerTaskId);
+
+    auto task = test::AssertQueryBuilder(plan)
+                    .split(remoteSplit(producerTaskId))
+                    .destination(0)
+                    .config(
+                        core::QueryConfig::kPreferredOutputBatchBytes,
+                        std::to_string(maxBytes))
+                    .assertResults(expected);
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    const auto& stats = taskStats.at("0");
+
+    ASSERT_EQ(expected->size(), stats.outputRows);
+    ASSERT_EQ(expectedBatches, stats.outputVectors);
+    ASSERT_EQ(1, stats.customStats.at("numReceivedPages").sum);
+  };
+
+  test(1, kNumRows / 64 + 1);
+  test(1'000, kNumRows / 64 + 1);
+  test(160'000, 14);
+  test(10'000'000, 2);
 }
 
 TEST_P(MultiFragmentTest, compression) {

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -90,8 +90,34 @@ void CompactRowVectorSerde::deserialize(
     const Options* options) {
   std::vector<std::string_view> serializedRows;
   std::vector<std::unique_ptr<std::string>> serializedBuffers;
-  RowDeserializer<std::string_view>::deserialize<RowIteratorImpl>(
+  RowDeserializer<std::string_view>::deserialize(
       source, serializedRows, serializedBuffers, options);
+
+  if (serializedRows.empty()) {
+    *result = BaseVector::create<RowVector>(type, 0, pool);
+    return;
+  }
+
+  *result = row::CompactRow::deserialize(serializedRows, type, pool);
+}
+
+void CompactRowVectorSerde::deserialize(
+    ByteInputStream* source,
+    std::unique_ptr<RowIterator>& sourceRowIterator,
+    uint64_t maxRows,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    velox::memory::MemoryPool* pool,
+    const Options* options) {
+  std::vector<std::string_view> serializedRows;
+  std::vector<std::unique_ptr<std::string>> serializedBuffers;
+  RowDeserializer<std::string_view>::deserialize(
+      source,
+      maxRows,
+      sourceRowIterator,
+      serializedRows,
+      serializedBuffers,
+      options);
 
   if (serializedRows.empty()) {
     *result = BaseVector::create<RowVector>(type, 0, pool);

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -29,21 +29,29 @@ class CompactRowVectorSerde : public VectorSerde {
       const folly::Range<const vector_size_t*>& rows,
       vector_size_t** sizes) override;
 
-  // This method is not used in production code. It is only used to
-  // support round-trip tests for deserialization.
+  /// This method is not used in production code. It is only used to
+  /// support round-trip tests for deserialization.
   std::unique_ptr<IterativeVectorSerializer> createIterativeSerializer(
       RowTypePtr type,
       int32_t numRows,
       StreamArena* streamArena,
       const Options* options) override;
 
-  // This method is used when reading data from the exchange.
   void deserialize(
       ByteInputStream* source,
       velox::memory::MemoryPool* pool,
       RowTypePtr type,
       RowVectorPtr* result,
       const Options* options) override;
+
+  void deserialize(
+      ByteInputStream* source,
+      std::unique_ptr<RowIterator>& sourceRowIterator,
+      uint64_t maxRows,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      velox::memory::MemoryPool* pool,
+      const Options* options = nullptr) override;
 
   static void registerVectorSerde();
   static void registerNamedVectorSerde();

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -46,8 +46,8 @@ void UnsafeRowVectorSerde::deserialize(
     const Options* options) {
   std::vector<std::optional<std::string_view>> serializedRows;
   std::vector<std::unique_ptr<std::string>> serializedBuffers;
-  RowDeserializer<std::optional<std::string_view>>::deserialize<
-      RowIteratorImpl>(source, serializedRows, serializedBuffers, options);
+  RowDeserializer<std::optional<std::string_view>>::deserialize(
+      source, serializedRows, serializedBuffers, options);
 
   if (serializedRows.empty()) {
     *result = BaseVector::create<RowVector>(type, 0, pool);


### PR DESCRIPTION
Summary:
Exchange memory usage explodes in some cases when deserializing row-wise pages. Currently deserialization of compact row encoded pages goes one entire page at a time. The deserialization of a page to row vector can result in increment in memory (the result row vector has larger memory than the serialized page, with or without compression) due to the mix of complex structures and nulls. In extreme cases the memory can explode >40x in Meta internal cases. 
This PR introduces iterative deserialization of a compact row encoded page, along with adjusted memory control in getOutput in Exchange operator for compact row case.

Reviewed By: xiaoxmeng

Differential Revision: D72816651


