### PR TITLE
misc: Refactor table scan and add batch size metric for monitoring

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -634,6 +634,11 @@ void registerVeloxMetrics() {
   DEFINE_HISTOGRAM_METRIC(
       kMetricTableScanBatchProcessTimeMs, 32, 0, 16L << 10, 50, 90, 99, 100);
 
+  // The size distribution of table scan output batch in range of [0, 512MB]
+  // with 512 buckets and reports P50, P90, P99, and P100
+  DEFINE_HISTOGRAM_METRIC(
+      kMetricTableScanBatchBytes, 1L << 20, 0, 512L << 20, 50, 90, 99, 100);
+
   /// ================== Storage Counters =================
 
   // The time distribution of storage IO throttled duration in range of [0, 30s]

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -381,6 +381,9 @@ constexpr folly::StringPiece kMetricIndexLookupBlockedWaitTimeMs{
 constexpr folly::StringPiece kMetricTableScanBatchProcessTimeMs{
     "velox.table_scan_batch_process_time_ms"};
 
+constexpr folly::StringPiece kMetricTableScanBatchBytes{
+    "velox.table_scan_batch_bytes"};
+
 constexpr folly::StringPiece kMetricTaskBatchProcessTimeMs{
     "velox.task_batch_process_time_ms"};
 } // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -615,6 +615,10 @@ Table Scan
      - Histogram
      - The time distribution of table scan batch processing time in range of [0,
        16s] with 512 buckets and reports P50, P90, P99, and P100.
+   * - table_scan_batch_bytes
+     - Histogram
+     - The size distribution of table scan output batch in range of [0, 512MB]
+       with 512 buckets and reports P50, P90, P99, and P100
 
 S3 FileSystem
 --------------

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -28,8 +28,6 @@ class TableScan : public SourceOperator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::TableScanNode>& tableScanNode);
 
-  folly::dynamic toJson() const override;
-
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* future) override {
@@ -73,6 +71,9 @@ class TableScan : public SourceOperator {
   // Checks if this table scan operator needs to stop because the task has been
   // terminated.
   bool shouldStop(StopReason taskStopReason) const;
+
+  // Returns true if a new split is fetched from the task otherwise false.
+  bool getSplit();
 
   // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching splits is
   // appropriate. The preloader will be applied to the 'first 'maxPreloadSplits'
@@ -142,10 +143,6 @@ class TableScan : public SourceOperator {
 
   // String shown in ExceptionContext inside DataSource and LazyVector loading.
   std::string debugString_;
-
-  // Holds the current status of the operator. Used when debugging to understand
-  // what operator is doing.
-  std::atomic<const char*> curStatus_{""};
 
   // The total number of raw input rows read up till the last finished split.
   // This is used to detect if a finished split is empty or not.

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -663,7 +663,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, timeLimitInGetOutput) {
   // Ensure the getOutput is long enough to trigger the maxGetOutputTimeMs in
   // TableScan, so we can test early exit (bail) from the TableScan::getOutput.
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::TableScan::getOutput",
+      "facebook::velox::exec::TableScan::getSplit",
       std::function<void(const TableScan*)>(
           ([&](const TableScan* /*tableScan*/) {
             /* sleep override */
@@ -1720,7 +1720,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
   std::shared_mutex pauseTableScan;
   std::shared_mutex pauseSplitProcessing;
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::TableScan::getOutput",
+      "facebook::velox::exec::TableScan::getSplit",
       std::function<void(const TableScan*)>(
           ([&](const TableScan* /*tableScan*/) {
             pauseTableScan.lock_shared();
@@ -5461,7 +5461,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, cancellationToken) {
 
   std::atomic<Task*> task{nullptr};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::TableScan::getOutput",
+      "facebook::velox::exec::TableScan::getSplit",
       std::function<void(Operator*)>([&](Operator* op) {
         task = op->testingOperatorCtx()->task().get();
       }));


### PR DESCRIPTION
Summary:
Current table scan get output is a big function handles get split, add split, get next batch and a couple of edge case condition
handing. This diff simplify the logic by moving the get split into a separate function to ease extension for feature like task barrier.
Also remove cur stats monitoring logic which is a step by step debugging message which is not required as the code becomes
mature. 
This PR also adds batch size metric for monitoring in non-presto use case.

Differential Revision: D72946387


