### PR TITLE
fix: Fix merge join issues

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -1058,6 +1058,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
           return std::move(output_);
         }
         input_ = nullptr;
+        rightInput_ = nullptr;
       }
     }
 

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -303,10 +303,7 @@ BlockingReason MergeJoinSource::enqueue(
       return BlockingReason::kNotBlocked;
     }
 
-    if (state.data != nullptr) {
-      return waitForConsumer(future);
-    }
-
+    VELOX_CHECK_NULL(state.data);
     state.data = std::move(data);
     deferNotify(consumerPromise_, promises);
     return waitForConsumer(future);


### PR DESCRIPTION
Summary:
Fix two merge join issues:
(1) merge join source shouldn't expect non-null data when enqueue if the source is not closed by join operator. This
diff adds a check instead of silently overwriting the data
(2) for inner join, if either side input is empty and has received no more input from either side, we shall reset both inputs, currently we
only reset probe or left side input.

Differential Revision: D72946626


