### PR TITLE
feat: Eliminate data copy in Spark UnscaledValueFunction

### DIFF
--- a/velox/functions/sparksql/UnscaledValueFunction.cpp
+++ b/velox/functions/sparksql/UnscaledValueFunction.cpp
@@ -41,7 +41,6 @@ class UnscaledValueFunction final : public exec::VectorFunction {
           context.pool(), rows.end(), false, BIGINT(), std::move(value));
     } else {
       auto flatInput = arg->asFlatVector<int64_t>();
-      VELOX_CHECK_LE(rows.end(), flatInput->size());
       localResult = std::make_shared<FlatVector<int64_t>>(
           context.pool(),
           BIGINT(),

--- a/velox/functions/sparksql/UnscaledValueFunction.cpp
+++ b/velox/functions/sparksql/UnscaledValueFunction.cpp
@@ -33,15 +33,24 @@ class UnscaledValueFunction final : public exec::VectorFunction {
         args[0]->type()->isShortDecimal(),
         "Expect short decimal type, but got: {}",
         args[0]->type());
-    exec::DecodedArgs decodedArgs(rows, args, context);
-    auto decimalVector = decodedArgs.at(0);
-    context.ensureWritable(rows, BIGINT(), result);
-    result->clearNulls(rows);
-    auto flatResult =
-        result->asUnchecked<FlatVector<int64_t>>()->mutableRawValues();
-    rows.applyToSelected([&](auto row) {
-      flatResult[row] = decimalVector->valueAt<int64_t>(row);
-    });
+    VectorPtr localResult;
+    const auto& arg = args[0];
+    if (arg->isConstantEncoding()) {
+      auto value = arg->as<ConstantVector<int64_t>>()->valueAt(0);
+      localResult = std::make_shared<ConstantVector<int64_t>>(
+          context.pool(), rows.end(), false, BIGINT(), std::move(value));
+    } else {
+      auto flatInput = arg->asFlatVector<int64_t>();
+      VELOX_CHECK_LE(rows.end(), flatInput->size());
+      localResult = std::make_shared<FlatVector<int64_t>>(
+          context.pool(),
+          BIGINT(),
+          nullptr,
+          rows.end(),
+          flatInput->values(),
+          std::vector<BufferPtr>());
+    }
+    context.moveOrCopyResult(localResult, rows, result);
   }
 };
 } // namespace

--- a/velox/functions/sparksql/tests/UnscaledValueFunctionTest.cpp
+++ b/velox/functions/sparksql/tests/UnscaledValueFunctionTest.cpp
@@ -24,18 +24,44 @@ namespace {
 class UnscaledValueFunctionTest : public SparkFunctionBaseTest {};
 
 TEST_F(UnscaledValueFunctionTest, unscaledValue) {
-  auto testUnscaledValue = [&](const std::vector<int64_t>& unscaledValue,
-                               const TypePtr& decimalType) {
-    auto input = makeFlatVector<int64_t>(unscaledValue, decimalType);
-    auto expected = makeFlatVector<int64_t>(unscaledValue);
+  auto testUnscaledValue = [&](const VectorPtr& input,
+                               const VectorPtr& expected) {
     auto result = evaluate("unscaled_value(c0)", makeRowVector({input}));
     assertEqualVectors(expected, result);
   };
 
-  testUnscaledValue({1000, 2000, -3000, -4000}, DECIMAL(18, 3));
+  auto flatInput =
+      makeFlatVector<int64_t>({1000, 2000, -3000, -4000}, DECIMAL(18, 3));
+  auto flatExpected = makeFlatVector<int64_t>({1000, 2000, -3000, -4000});
+  auto nullableFlatInput =
+      makeNullableFlatVector<int64_t>({0, std::nullopt}, DECIMAL(18, 3));
+  auto nullableFlatExpected =
+      makeNullableFlatVector<int64_t>({0, std::nullopt});
 
-  VELOX_ASSERT_THROW(
-      testUnscaledValue({1000, 2000, -3000, -4000}, DECIMAL(20, 3)),
+  auto constInput = makeConstant<int64_t>(1000, 4, DECIMAL(18, 3));
+  auto constExpected = makeConstant<int64_t>(1000, 4);
+  auto constNullInput = makeConstant<int64_t>(std::nullopt, 4, DECIMAL(18, 3));
+  auto constNullExpected = makeConstant<int64_t>(std::nullopt, 4);
+
+  auto indices = makeIndices(8, [](auto row) { return row % 4; });
+  auto dictInput = wrapInDictionary(indices, 8, flatInput);
+  auto dictExpected = wrapInDictionary(indices, 8, flatExpected);
+  auto dictConstInput = wrapInDictionary(indices, 8, constNullInput);
+  auto dictConstExpected = wrapInDictionary(indices, 8, constNullExpected);
+
+  auto invalidInput = makeFlatVector<int64_t>({0, 0, 0, 0}, DECIMAL(20, 3));
+
+  testUnscaledValue(flatInput, flatExpected);
+  testUnscaledValue(nullableFlatInput, nullableFlatExpected);
+
+  testUnscaledValue(constInput, constExpected);
+  testUnscaledValue(constNullInput, constNullExpected);
+
+  testUnscaledValue(dictInput, dictExpected);
+  testUnscaledValue(dictConstInput, dictConstExpected);
+
+  VELOX_ASSERT_USER_THROW(
+      testUnscaledValue(invalidInput, flatExpected),
       "Expect short decimal type, but got: DECIMAL(20, 3)");
 }
 } // namespace


### PR DESCRIPTION
Since the input and output vectors only differ in logical type but share the 
same physical type (int64_t), there is no need to always copy data between them.