### PR TITLE
fix: Ensure memory in classification functions are set to 0 during extractValues

### DIFF
--- a/velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h
@@ -52,9 +52,8 @@ class ClassificationAggregationInputGenerator : public InputGenerator {
         size, [&](auto /*row*/) { return bucket_.value(); });
 
     auto pred = vectorMaker.flatVector<double>(size, [&](auto /*row*/) {
-      /// Predictions must be > 0.
-      return std::uniform_real_distribution<double>(
-          0, std::numeric_limits<double>::max())(rng);
+      /// Predictions must be > 0 and < 1.0.
+      return std::uniform_real_distribution<double>(0, 1.0)(rng);
     });
 
     result.emplace_back(std::move(bucket));


### PR DESCRIPTION
Summary: Always ensure that the prediction for ClassificationAggregationInputGenerator is between (0, 1) so that it is considered a valid input.

Differential Revision: D72987273


