### PR TITLE
feat: Add 'planned' state to TaskState

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -287,6 +287,12 @@ class Task : public std::enable_shared_from_this<Task> {
     return state_;
   }
 
+  /// Same as state(), but will return 'planned' state if the Task is not
+  /// started yet.
+  /// We will use it for reporting purposes in the pilot implementation of
+  /// Task-level pushback when the worker is overloaded.
+  TaskState stateIncludingPlanned() const;
+
   /// Returns a future which is realized when the task's state has changed and
   /// the Task is ready to report some progress (such as split group finished or
   /// task is completed).

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -33,7 +33,8 @@ enum class TaskState : int {
   kFinished = 1,
   kCanceled = 2,
   kAborted = 3,
-  kFailed = 4
+  kFailed = 4,
+  kPlanned = 5
 };
 
 std::string taskStateString(TaskState state);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2198,7 +2198,9 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
       0,
       std::move(queryCtx),
       Task::ExecutionMode::kParallel);
+  ASSERT_EQ(task->stateIncludingPlanned(), TaskState::kPlanned);
   task->start(4, 1);
+  ASSERT_EQ(task->stateIncludingPlanned(), TaskState::kRunning);
 
   // Wait for the task driver starts to run.
   taskPauseWait.await([&]() { return !taskPauseWaitFlag.load(); });


### PR DESCRIPTION
Summary:
We plan to distinguish time when Task is created but have not started
running yet. Presto has PLANNED state for this, but Velox does not.
This change adds this state.
We also add realState() member function, which returns 'planned' if Task has
not started yet (executionStartTimeMs is zero).

Differential Revision: D73061260


