### PR TITLE
fix: Support small value type in dictionary encoding

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -343,13 +343,6 @@ class ColumnVisitor {
     return currentRow() - rowAt(rowIndex_ - 1) - 1;
   }
 
-  // Returns space for 'size' items of T for a scan to fill. The scan
-  // calls addResults and related to mark which elements are part of
-  // the result.
-  inline T* mutableValues(int32_t size) {
-    return reader_->mutableValues<T>(size);
-  }
-
   SelectiveColumnReader& reader() const {
     return *reader_;
   }


### PR DESCRIPTION
Summary:
Turns out that we are not using column reader values buffer to keep
indices, so we can enable this case without any change.

Differential Revision: D73072370


