### PR TITLE
fix(fuzzer): Solved the StringWriter overflows StringView len issue

### DIFF
--- a/velox/expression/StringWriter.h
+++ b/velox/expression/StringWriter.h
@@ -45,7 +45,7 @@ class StringWriter : public UDFOutputString {
     auto actualCapacity = newDataBuffer->capacity() - newDataBuffer->size();
 
     // Impossible to be the same due to the way the capacity is computed.
-    DCHECK(dataBuffer_ != newDataBuffer);
+    VELOX_DCHECK(dataBuffer_ != newDataBuffer);
 
     auto newStartAddress =
         newDataBuffer->asMutable<char>() + newDataBuffer->size();
@@ -64,8 +64,9 @@ class StringWriter : public UDFOutputString {
   void finalize() {
     if (!finalized_) {
       VELOX_DCHECK(size() == 0 || data());
+      VELOX_USER_CHECK_LE(size(), INT32_MAX);
       if LIKELY (size()) {
-        DCHECK(dataBuffer_);
+        VELOX_CHECK_NOT_NULL(dataBuffer_);
         dataBuffer_->setSize(dataBuffer_->size() + size());
       }
       vector_->setNoCopy(offset_, StringView(data(), size()));
@@ -111,12 +112,12 @@ class StringWriter : public UDFOutputString {
 
   template <typename T>
   void append(const T& input) {
-    DCHECK(!finalized_);
+    VELOX_DCHECK(!finalized_);
     auto oldSize = size();
     resize(this->size() + input.size());
     if (input.size() != 0) {
-      DCHECK(data());
-      DCHECK(input.data());
+      VELOX_DCHECK(data());
+      VELOX_DCHECK(input.data());
       std::memcpy(data() + oldSize, input.data(), input.size());
     }
   }

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -116,7 +116,12 @@ int main(int argc, char** argv) {
       // make other functions throw VeloxRuntimeErrors.
       "from_unixtime",
       // JSON not supported, Real doesn't match exactly, etc.
-      "array_join",
+      "array_join(array(json),varchar) -> varchar",
+      "array_join(array(json),varchar,varchar) -> varchar",
+      "array_join(array(real),varchar) -> varchar",
+      "array_join(array(real),varchar,varchar) -> varchar",
+      "array_join(array(double),varchar) -> varchar",
+      "array_join(array(double),varchar,varchar) -> varchar",
       // BingTiles throw VeloxUserError when zoom/x/y are out of range.
       "bing_tile",
       "bing_tile_zoom_level",

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -18,6 +18,7 @@
 #include <glog/logging.h>
 #include "folly/Range.h"
 #include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
@@ -104,6 +105,15 @@ TEST_F(StringWriterTest, copyFromCString) {
   writer.finalize();
 
   ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
+}
+
+TEST_F(StringWriterTest, CheckSizeLimit) {
+  auto vector = makeFlatVector<StringView>(4);
+  auto writer = exec::StringWriter(vector.get(), 0);
+
+  size_t limit = (size_t)INT32_MAX + 1;
+  writer.resize(limit);
+  VELOX_ASSERT_THROW(writer.finalize(), "(2147483648 vs. 2147483647)");
 }
 
 TEST_F(StringWriterTest, vectorWriter) {


### PR DESCRIPTION
Summary: StringWriter size is size_t type which failed both in setSize and creating StringView(overflow int32_t len) when running ExpressionFuzzerTest. The reason to choose adding the check in StringWriter is because this is the only place that causes the overflow error (implicit type transfer from size_t to int32_t), and we want to fail fast as the size issue could also cause resize() gives error and StringView is a common interface which has have many callers that some has right type such as cosci, besides, we want to keep the consistency between velox and presto local run result and minimize the change scope and risk.

Reviewed By: xiaoxmeng

Differential Revision: D73012452


