### PR TITLE
feat: Enable the hash join to accept a pre-built hash table for joining

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3107,7 +3107,8 @@ class HashJoinNode : public AbstractJoinNode {
       TypedExprPtr filter,
       PlanNodePtr left,
       PlanNodePtr right,
-      RowTypePtr outputType)
+      RowTypePtr outputType,
+      void* reusedHashTableAddress = nullptr)
       : AbstractJoinNode(
             id,
             joinType,
@@ -3117,9 +3118,9 @@ class HashJoinNode : public AbstractJoinNode {
             std::move(left),
             std::move(right),
             std::move(outputType)),
-        nullAware_{nullAware} {
+        nullAware_{nullAware},
+        reusedHashTableAddress_(reusedHashTableAddress) {
     validate();
-
     if (nullAware) {
       VELOX_USER_CHECK(
           isNullAwareSupported(joinType),
@@ -3202,6 +3203,10 @@ class HashJoinNode : public AbstractJoinNode {
     return nullAware_;
   }
 
+  void* reusedHashTableAddress() const {
+    return reusedHashTableAddress_;
+  }
+
   folly::dynamic serialize() const override;
 
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
@@ -3210,6 +3215,8 @@ class HashJoinNode : public AbstractJoinNode {
   void addDetails(std::stringstream& stream) const override;
 
   const bool nullAware_;
+
+  void* reusedHashTableAddress_;
 };
 
 using HashJoinNodePtr = std::shared_ptr<const HashJoinNode>;

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -107,6 +107,14 @@ class HashBuild final : public Operator {
   bool isRunning() const;
   void checkRunning() const;
 
+  // Reuse the pre-built hash table.
+  void reuseHashTable(
+      exec::BaseHashTable* baseHashTable,
+      std::shared_ptr<const core::ReusedHashTableInfo> reusedHashTableInfo);
+
+  // Build the hash table.
+  void buildHashTable();
+
   // Invoked to set up hash table to build.
   void setupTable();
 

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -68,6 +68,9 @@ class HashBuild final : public Operator {
   }
 
   bool needsInput() const override {
+    if (reusedHashTableAddress_ != nullptr) {
+      return false;
+    }
     return !noMoreInput_;
   }
 
@@ -310,6 +313,8 @@ class HashBuild final : public Operator {
 
   // Maps key channel in 'input_' to channel in key.
   folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
+
+  void* reusedHashTableAddress_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -258,7 +258,8 @@ void HashJoinBridge::setHashTable(
 
 void HashJoinBridge::setHashTable(
     std::shared_ptr<BaseHashTable> table,
-    bool hasNullKeys) {
+    bool hasNullKeys,
+    bool reused) {
   VELOX_CHECK_NOT_NULL(table, "setHashTable called with null table");
 
   std::vector<ContinuePromise> promises;
@@ -268,7 +269,7 @@ void HashJoinBridge::setHashTable(
     VELOX_CHECK(!buildResult_.has_value());
     VELOX_CHECK(restoringSpillShards_.empty());
 
-    buildResult_ = HashBuildResult(std::move(table), hasNullKeys);
+    buildResult_ = HashBuildResult(std::move(table), hasNullKeys, reused);
     promises = std::move(promises_);
   }
   notify(std::move(promises));

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -63,6 +63,8 @@ class HashJoinBridge : public JoinBridge {
       std::shared_ptr<wave::HashTableHolder> table,
       bool hasNullKeys);
 
+  void setHashTable(std::shared_ptr<BaseHashTable> table, bool hasNullKeys);
+
   /// Invoked by the probe operator to append the spilled hash table partitions
   /// while probing. The function appends the spilled table partitions into
   /// 'spillPartitionSets_' stack. This only applies if the disk spilling is
@@ -92,6 +94,9 @@ class HashJoinBridge : public JoinBridge {
         std::shared_ptr<wave::HashTableHolder> _table,
         bool _hasNullKeys)
         : hasNullKeys(_hasNullKeys), waveTable(std::move(_table)) {}
+
+    HashBuildResult(std::shared_ptr<BaseHashTable> _table, bool _hasNullKeys)
+        : hasNullKeys(_hasNullKeys), table(std::move(_table)) {}
 
     bool hasNullKeys;
     std::shared_ptr<BaseHashTable> table;

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -63,7 +63,10 @@ class HashJoinBridge : public JoinBridge {
       std::shared_ptr<wave::HashTableHolder> table,
       bool hasNullKeys);
 
-  void setHashTable(std::shared_ptr<BaseHashTable> table, bool hasNullKeys);
+  void setHashTable(
+      std::shared_ptr<BaseHashTable> table,
+      bool hasNullKeys,
+      bool reused = false);
 
   /// Invoked by the probe operator to append the spilled hash table partitions
   /// while probing. The function appends the spilled table partitions into
@@ -95,10 +98,16 @@ class HashJoinBridge : public JoinBridge {
         bool _hasNullKeys)
         : hasNullKeys(_hasNullKeys), waveTable(std::move(_table)) {}
 
-    HashBuildResult(std::shared_ptr<BaseHashTable> _table, bool _hasNullKeys)
-        : hasNullKeys(_hasNullKeys), table(std::move(_table)) {}
+    HashBuildResult(
+        std::shared_ptr<BaseHashTable> _table,
+        bool _hasNullKeys,
+        bool _reused)
+        : hasNullKeys(_hasNullKeys),
+          reused(_reused),
+          table(std::move(_table)) {}
 
     bool hasNullKeys;
+    bool reused{false};
     std::shared_ptr<BaseHashTable> table;
 
     std::shared_ptr<wave::HashTableHolder> waveTable;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -441,6 +441,9 @@ class HashProbe : public Operator {
   // side. Used by anti and left semi project join.
   bool buildSideHasNullKeys_{false};
 
+  // Indicates whether the hash table can be reused.
+  bool reused_{false};
+
   // Indicates whether there are rows with null join keys on the probe
   // side. Used by right semi project join.
   bool probeSideHasNullKeys_{false};

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -53,14 +53,12 @@ HashTable<ignoreNullKeys>::HashTable(
     bool isJoinBuild,
     bool hasProbedFlag,
     uint32_t minTableSizeForParallelJoinBuild,
-    memory::MemoryPool* pool,
-    bool reused)
+    memory::MemoryPool* pool)
     : BaseHashTable(std::move(hashers)),
       pool_(pool),
       minTableSizeForParallelJoinBuild_(minTableSizeForParallelJoinBuild),
       isJoinBuild_(isJoinBuild),
-      buildPartitionBounds_(raw_vector<PartitionBoundIndexType>(pool)),
-      reused_(reused) {
+      buildPartitionBounds_(raw_vector<PartitionBoundIndexType>(pool)) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
     keys.push_back(hasher->type());
@@ -1720,66 +1718,61 @@ void HashTable<ignoreNullKeys>::prepareJoinTable(
     std::vector<std::unique_ptr<BaseHashTable>> tables,
     int8_t spillInputStartPartitionBit,
     folly::Executor* executor) {
-  std::lock_guard<std::mutex> l(mutex_);
-  if (!prepared_) {
-    buildExecutor_ = executor;
-    otherTables_.reserve(tables.size());
-    for (auto& table : tables) {
-      otherTables_.emplace_back(
-          std::unique_ptr<HashTable<ignoreNullKeys>>(
-              dynamic_cast<HashTable<ignoreNullKeys>*>(table.release())));
-    }
+  buildExecutor_ = executor;
+  otherTables_.reserve(tables.size());
+  for (auto& table : tables) {
+    otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(
+        dynamic_cast<HashTable<ignoreNullKeys>*>(table.release())));
+  }
 
-    // If there are multiple tables, we need to merge the 'columnHasNulls' flags
-    // from the containers of each table and store them in the main table. This
-    // is necessary because, when extracting results, 'rows' may contain row
-    // pointers from multiple containers. We need to ensure the correctness of
-    // the 'columnHasNulls' flags.
-    for (int i = 0; i < rows_->columnTypes().size(); ++i) {
-      columnHasNulls_.emplace_back(rows_->columnHasNulls(i));
-      for (auto& other : otherTables_) {
-        columnHasNulls_[i] =
-            columnHasNulls_[i] || other->rows()->columnHasNulls(i);
+  // If there are multiple tables, we need to merge the 'columnHasNulls' flags
+  // from the containers of each table and store them in the main table. This
+  // is necessary because, when extracting results, 'rows' may contain row
+  // pointers from multiple containers. We need to ensure the correctness of
+  // the 'columnHasNulls' flags.
+  for (int i = 0; i < rows_->columnTypes().size(); ++i) {
+    columnHasNulls_.emplace_back(rows_->columnHasNulls(i));
+    for (auto& other : otherTables_) {
+      columnHasNulls_[i] =
+          columnHasNulls_[i] || other->rows()->columnHasNulls(i);
+    }
+  }
+
+  bool useValueIds = mayUseValueIds(*this);
+  if (useValueIds) {
+    for (auto& other : otherTables_) {
+      if (!mayUseValueIds(*other)) {
+        useValueIds = false;
+        break;
       }
     }
-
-    bool useValueIds = mayUseValueIds(*this);
     if (useValueIds) {
       for (auto& other : otherTables_) {
-        if (!mayUseValueIds(*other)) {
-          useValueIds = false;
-          break;
-        }
-      }
-      if (useValueIds) {
-        for (auto& other : otherTables_) {
-          for (auto i = 0; i < hashers_.size(); ++i) {
-            hashers_[i]->merge(*other->hashers_[i]);
-            if (!hashers_[i]->mayUseValueIds()) {
-              useValueIds = false;
-              break;
-            }
-          }
-          if (!useValueIds) {
+        for (auto i = 0; i < hashers_.size(); ++i) {
+          hashers_[i]->merge(*other->hashers_[i]);
+          if (!hashers_[i]->mayUseValueIds()) {
+            useValueIds = false;
             break;
           }
         }
+        if (!useValueIds) {
+          break;
+        }
       }
     }
-    numDistinct_ = rows()->numRows();
-    for (const auto& other : otherTables_) {
-      numDistinct_ += other->rows()->numRows();
-    }
-    if (!useValueIds) {
-      if (hashMode_ != HashMode::kHash) {
-        setHashMode(HashMode::kHash, 0, spillInputStartPartitionBit);
-      } else {
-        checkSize(0, true, spillInputStartPartitionBit);
-      }
+  }
+  numDistinct_ = rows()->numRows();
+  for (const auto& other : otherTables_) {
+    numDistinct_ += other->rows()->numRows();
+  }
+  if (!useValueIds) {
+    if (hashMode_ != HashMode::kHash) {
+      setHashMode(HashMode::kHash, 0, spillInputStartPartitionBit);
     } else {
-      decideHashMode(0, spillInputStartPartitionBit);
+      checkSize(0, true, spillInputStartPartitionBit);
     }
-    prepared_ = true;
+  } else {
+    decideHashMode(0, spillInputStartPartitionBit);
   }
 }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8524,8 +8524,7 @@ TEST_F(HashJoinTest, reuseHashTable) {
       true /*allowDuplicates*/,
       true /*hasProbedFlag*/,
       1 /*minTableSizeForParallelJoinBuild*/,
-      pool(),
-      true);
+      pool());
 
   auto rowContainer = table->rows();
   std::vector<DecodedVector> decodedVectors;
@@ -8541,6 +8540,9 @@ TEST_F(HashJoinTest, reuseHashTable) {
       rowContainer->store(decodedVectors[j], i, row, j);
     }
   }
+
+  table->prepareJoinTable({}, BaseHashTable::kNoSpillInputStartPartitionBit);
+  auto reusedHashTableInfo = std::make_shared<core::ReusedHashTableInfo>();
 
   core::PlanNodeId probeScanId;
   core::PlanNodeId buildScanId;
@@ -8559,6 +8561,7 @@ TEST_F(HashJoinTest, reuseHashTable) {
                       {"u0", "match"},
                       core::JoinType::kRightSemiProject,
                       true /*nullAware*/,
+                      reusedHashTableInfo,
                       table.get())
                   .planNode();
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8493,5 +8493,88 @@ DEBUG_ONLY_TEST_F(
 
   ASSERT_TRUE(spillTriggered.load());
 }
+
+TEST_F(HashJoinTest, reuseHashTable) {
+  auto probe = makeRowVector(
+      {"t0"},
+      {
+          makeNullableFlatVector<int64_t>({1, std::nullopt, 2}),
+      });
+  auto build = makeRowVector(
+      {"u0"},
+      {
+          makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt}),
+      });
+  std::shared_ptr<TempFilePath> probeFile = TempFilePath::create();
+  writeToFile(probeFile->getPath(), {probe});
+
+  std::shared_ptr<TempFilePath> buildFile = TempFilePath::create();
+  writeToFile(buildFile->getPath(), {build});
+
+  createDuckDbTable("t", {probe});
+  createDuckDbTable("u", {build});
+
+  // Build the HashTable for build side data
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.push_back(std::make_unique<VectorHasher>(BIGINT(), 0));
+
+  auto table = HashTable<false>::createForJoin(
+      std::move(hashers),
+      {}, /*dependentTypes*/
+      true /*allowDuplicates*/,
+      true /*hasProbedFlag*/,
+      1 /*minTableSizeForParallelJoinBuild*/,
+      pool(),
+      true);
+
+  auto rowContainer = table->rows();
+  std::vector<DecodedVector> decodedVectors;
+  for (auto& vector : build->children()) {
+    decodedVectors.emplace_back(*vector);
+  }
+
+  std::vector<char*> rows;
+  for (auto i = 0; i < build->size(); ++i) {
+    auto* row = rowContainer->newRow();
+
+    for (auto j = 0; j < decodedVectors.size(); ++j) {
+      rowContainer->store(decodedVectors[j], i, row, j);
+    }
+  }
+
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .tableScan(asRowType(probe->type()))
+                  .capturePlanNodeId(probeScanId)
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .tableScan(asRowType(build->type()))
+                          .capturePlanNodeId(buildScanId)
+                          .planNode(),
+                      "",
+                      {"u0", "match"},
+                      core::JoinType::kRightSemiProject,
+                      true /*nullAware*/,
+                      table.get())
+                  .planNode();
+
+  SplitInput splitInput = {
+      {probeScanId,
+       {exec::Split(makeHiveConnectorSplit(probeFile->getPath()))}},
+      {buildScanId,
+       {exec::Split(makeHiveConnectorSplit(buildFile->getPath()))}},
+  };
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .planNode(plan)
+      .inputSplits(splitInput)
+      .checkSpillStats(false)
+      .referenceQuery("SELECT u0, u0 IN (SELECT t0 FROM t) FROM u")
+      .run();
+}
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1646,7 +1646,8 @@ PlanBuilder& PlanBuilder::hashJoin(
     const std::string& filter,
     const std::vector<std::string>& outputLayout,
     core::JoinType joinType,
-    bool nullAware) {
+    bool nullAware,
+    void* reusedHashTableAddress) {
   VELOX_CHECK_NOT_NULL(planNode_, "HashJoin cannot be the source node");
   VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
 
@@ -1687,7 +1688,8 @@ PlanBuilder& PlanBuilder::hashJoin(
       std::move(filterExpr),
       std::move(planNode_),
       build,
-      outputType);
+      outputType,
+      reusedHashTableAddress);
   VELOX_CHECK(!planNode_->supportsBarrier());
   return *this;
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1647,6 +1647,7 @@ PlanBuilder& PlanBuilder::hashJoin(
     const std::vector<std::string>& outputLayout,
     core::JoinType joinType,
     bool nullAware,
+    std::shared_ptr<const core::ReusedHashTableInfo> reusedHashTableInfo,
     void* reusedHashTableAddress) {
   VELOX_CHECK_NOT_NULL(planNode_, "HashJoin cannot be the source node");
   VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
@@ -1689,6 +1690,7 @@ PlanBuilder& PlanBuilder::hashJoin(
       std::move(planNode_),
       build,
       outputType,
+      reusedHashTableInfo,
       reusedHashTableAddress);
   VELOX_CHECK(!planNode_->supportsBarrier());
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1276,7 +1276,8 @@ class PlanBuilder {
       const std::string& filter,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner,
-      bool nullAware = false);
+      bool nullAware = false,
+      void* reusedHashTableAddress = nullptr);
 
   /// Add a MergeJoinNode to join two inputs using one or more join keys and an
   /// optional filter. The caller is responsible to ensure that inputs are

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1277,6 +1277,8 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner,
       bool nullAware = false,
+      std::shared_ptr<const core::ReusedHashTableInfo> reusedHashTableInfo =
+          nullptr,
       void* reusedHashTableAddress = nullptr);
 
   /// Add a MergeJoinNode to join two inputs using one or more join keys and an


### PR DESCRIPTION
In Spark, the hash table is constructed only once in the driver and then broadcasted to each executor. In Gluten, we replace the broadcast hash join with a hash join, which leads to performance issues when the broadcast threshold increases. This is because each task must build its own hash table when using hash join.

This PR enables `HashBuild `to accept pre-built `HashTable`, thereby bypassing the hash table construction process. Additionally, it modifies `HashProbe ` to avoid clearing the shared hash table after use.