### PR TITLE
refactor: Refactor the logic for constructing Join plans from JoinFuzzer into JoinMaker

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -117,7 +117,8 @@ target_link_libraries(
   velox_topn_row_number_fuzzer velox_topn_row_number_fuzzer_lib)
 
 # Join Fuzzer.
-add_executable(velox_join_fuzzer JoinFuzzerRunner.cpp JoinFuzzer.cpp)
+add_executable(velox_join_fuzzer JoinFuzzerRunner.cpp JoinFuzzer.cpp
+                                 JoinMaker.cpp)
 
 target_link_libraries(
   velox_join_fuzzer

--- a/velox/exec/fuzzer/JoinMaker.cpp
+++ b/velox/exec/fuzzer/JoinMaker.cpp
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/fuzzer/JoinMaker.h"
+
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/fuzzer/FuzzerUtil.h"
+
+namespace facebook::velox::exec {
+namespace {
+// Get the batches of data to use in the join from `joinSource` given
+// `inputType`.
+const std::vector<RowVectorPtr>& getBatches(
+    const std::shared_ptr<JoinSource>& joinSource,
+    const JoinMaker::InputType inputType) {
+  switch (inputType) {
+    case JoinMaker::InputType::ENCODED:
+      return joinSource->batches();
+    case JoinMaker::InputType::FLAT:
+      return joinSource->flatBatches();
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+// Returns a PlanBuilder that reads from `joinSource` using a Values node,
+// respecting `inputType`, and applying any necessary projections.
+test::PlanBuilder makeJoinSourcePlan(
+    const std::shared_ptr<JoinSource>& joinSource,
+    const JoinMaker::InputType inputType,
+    const std::shared_ptr<core::PlanNodeIdGenerator>& planNodeIdGenerator) {
+  return test::PlanBuilder(planNodeIdGenerator)
+      .values(getBatches(joinSource, inputType))
+      .projectExpressions(joinSource->projections());
+}
+
+// Breaks the batches from joinSource (respecting `inputType`) into up to 4
+// partitions. And returns PlanNodes to read each of those partitions, applying
+// any necessary projections.
+std::vector<core::PlanNodePtr> makeSourcesForPartitionedJoinPlan(
+    const std::shared_ptr<JoinSource> joinSource,
+    const JoinMaker::InputType inputType,
+    const std::shared_ptr<core::PlanNodeIdGenerator>& planNodeIdGenerator) {
+  const auto& batches = getBatches(joinSource, inputType);
+  auto numSources = std::min<size_t>(4, batches.size());
+  std::vector<std::vector<RowVectorPtr>> sourceInputs(numSources);
+  for (auto i = 0; i < batches.size(); ++i) {
+    sourceInputs[i % numSources].push_back(batches[i]);
+  }
+
+  std::vector<core::PlanNodePtr> sourceNodes;
+  for (const auto& sourceInput : sourceInputs) {
+    sourceNodes.push_back(test::PlanBuilder(planNodeIdGenerator)
+                              .values(sourceInput)
+                              .projectExpressions(joinSource->projections())
+                              .planNode());
+  }
+
+  return sourceNodes;
+}
+
+// Returns a PlanBuilder that breaks `joinSource` into partitions, reads those
+// and adds a localPartition step to apply `partitionStrategy`.
+test::PlanBuilder makePartitionedJoinSourcePlan(
+    const JoinMaker::PartitionStrategy partitionStrategy,
+    const std::shared_ptr<JoinSource>& joinSource,
+    const JoinMaker::InputType inputType,
+    const std::shared_ptr<core::PlanNodeIdGenerator>& planNodeIdGenerator) {
+  switch (partitionStrategy) {
+    case JoinMaker::PartitionStrategy::NONE:
+      VELOX_FAIL(
+          "makePartitionedJoinSource called with a partitionStrategy of NONE.");
+    case JoinMaker::PartitionStrategy::HASH:
+      return test::PlanBuilder(planNodeIdGenerator)
+          .localPartition(
+              joinSource->keys(),
+              makeSourcesForPartitionedJoinPlan(
+                  joinSource, inputType, planNodeIdGenerator));
+    case JoinMaker::PartitionStrategy::ROUND_ROBIN:
+      return test::PlanBuilder(planNodeIdGenerator)
+          .localPartitionRoundRobin(makeSourcesForPartitionedJoinPlan(
+              joinSource, inputType, planNodeIdGenerator));
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+// Returns a PlanBuilder that reads from `joinSource` using a TableScan node,
+// respecting `inputType` and converting it to splits, and applying any
+// necessary projections.
+// `tableScanId` is populated with the PlanNodeId for the TableScan.
+test::PlanBuilder makeTableScanJoinSourcePlan(
+    const std::shared_ptr<JoinSource>& joinSource,
+    const std::shared_ptr<core::PlanNodeIdGenerator>& planNodeIdGenerator,
+    core::PlanNodeId& tableScanId) {
+  return test::PlanBuilder(planNodeIdGenerator)
+      .tableScan(joinSource->outputType())
+      .capturePlanNodeId(tableScanId)
+      .projectExpressions(joinSource->projections());
+}
+
+// Returns the reversed JoinType if the JoinType can be reversed, otherwise
+// returns std::nullopt.
+std::optional<core::JoinType> tryFlipJoinType(core::JoinType joinType) {
+  switch (joinType) {
+    case core::JoinType::kInner:
+      return joinType;
+    case core::JoinType::kLeft:
+      return core::JoinType::kRight;
+    case core::JoinType::kRight:
+      return core::JoinType::kLeft;
+    case core::JoinType::kFull:
+      return joinType;
+    case core::JoinType::kLeftSemiFilter:
+      return core::JoinType::kRightSemiFilter;
+    case core::JoinType::kLeftSemiProject:
+      return core::JoinType::kRightSemiProject;
+    case core::JoinType::kRightSemiFilter:
+      return core::JoinType::kLeftSemiFilter;
+    case core::JoinType::kRightSemiProject:
+      return core::JoinType::kLeftSemiProject;
+    default:
+      return std::nullopt;
+  }
+}
+
+// Returns the reversed JoinType if the JoinType can be reversed, otherwise
+// throws an exception.
+core::JoinType flipJoinType(core::JoinType joinType) {
+  auto flippedJoinType = tryFlipJoinType(joinType);
+
+  if (!flippedJoinType.has_value()) {
+    VELOX_UNSUPPORTED(fmt::format("Unable to flip join type: {}", joinType));
+  }
+
+  return *flippedJoinType;
+}
+
+// Returns an equality join filter between probeKeys and buildKeys.
+std::string makeJoinFilter(
+    const std::vector<std::string>& probeKeys,
+    const std::vector<std::string>& buildKeys) {
+  const auto numKeys = probeKeys.size();
+  std::string filter;
+  VELOX_CHECK_EQ(numKeys, buildKeys.size());
+  for (auto i = 0; i < numKeys; ++i) {
+    if (i > 0) {
+      filter += " AND ";
+    }
+    filter += fmt::format("{} = {}", probeKeys[i], buildKeys[i]);
+  }
+  return filter;
+}
+} // namespace
+
+const std::vector<RowVectorPtr>& JoinSource::flatBatches() const {
+  if (!flatBatches_.has_value()) {
+    flatBatches_ = flatten(batches_);
+  }
+
+  return *flatBatches_;
+}
+
+const std::vector<Split>& JoinSource::splits() const {
+  if (!splits_.has_value()) {
+    splits_ = test::makeSplits(batches_, splitsDir_, writerPool_);
+  }
+
+  return *splits_;
+}
+
+const std::vector<Split>& JoinSource::groupedSplits(
+    const int32_t numGroups) const {
+  auto it = groupedSplits_.find(numGroups);
+
+  if (it != groupedSplits_.end()) {
+    return it->second;
+  }
+
+  const std::vector<std::vector<RowVectorPtr>> inputVectorsByGroup =
+      splitInputByGroup(numGroups);
+
+  std::vector<exec::Split> splitsWithGroup;
+  for (int32_t groupId = 0; groupId < numGroups; ++groupId) {
+    for (auto i = 0; i < inputVectorsByGroup[groupId].size(); ++i) {
+      const std::string filePath = fmt::format(
+          "{}/grouped[{}].{}.{}", splitsDir_, groupId, numGroups, i);
+      test::writeToFile(
+          filePath, inputVectorsByGroup[groupId][i], writerPool_.get());
+      splitsWithGroup.emplace_back(test::makeConnectorSplit(filePath), groupId);
+    }
+    splitsWithGroup.emplace_back(nullptr, groupId);
+  }
+
+  return groupedSplits_.insert(std::make_pair(numGroups, splitsWithGroup))
+      .first->second;
+}
+
+std::vector<RowVectorPtr> JoinSource::flatten(
+    const std::vector<RowVectorPtr>& vectors) const {
+  std::vector<RowVectorPtr> flatVectors;
+  for (const auto& vector : vectors) {
+    auto flat = BaseVector::create<RowVector>(
+        vector->type(), vector->size(), vector->pool());
+    flat->copy(vector.get(), 0, 0, vector->size());
+    flatVectors.push_back(flat);
+  }
+
+  return flatVectors;
+}
+
+std::vector<std::vector<RowVectorPtr>> JoinSource::splitInputByGroup(
+    int32_t numGroups) const {
+  if (numGroups == 1) {
+    return {batches_};
+  }
+
+  // Partition 'input' based on the join keys for group execution with one
+  // partition per each group.
+  std::vector<column_index_t> partitionChannels(keys_.size());
+  std::iota(partitionChannels.begin(), partitionChannels.end(), 0);
+  std::vector<std::unique_ptr<exec::VectorHasher>> hashers;
+  hashers.reserve(keys_.size());
+  for (auto channel : partitionChannels) {
+    hashers.emplace_back(
+        exec::VectorHasher::create(outputType_->childAt(channel), channel));
+  }
+
+  std::vector<std::vector<RowVectorPtr>> inputsByGroup{
+      static_cast<size_t>(numGroups)};
+  raw_vector<uint64_t> groupHashes;
+  std::vector<BufferPtr> groupRows(numGroups);
+  std::vector<vector_size_t*> rawGroupRows(numGroups);
+  std::vector<vector_size_t> groupSizes(numGroups, 0);
+  SelectivityVector inputRows;
+
+  for (const auto& input : batches_) {
+    const int numRows = input->size();
+    inputRows.resize(numRows);
+    inputRows.setAll();
+    groupHashes.resize(numRows);
+    std::fill(groupSizes.begin(), groupSizes.end(), 0);
+    std::fill(groupHashes.begin(), groupHashes.end(), 0);
+
+    for (auto i = 0; i < hashers.size(); ++i) {
+      auto& hasher = hashers[i];
+      auto* keyVector = input->childAt(hashers[i]->channel())->loadedVector();
+      hashers[i]->decode(*keyVector, inputRows);
+      if (hasher->channel() != kConstantChannel) {
+        hashers[i]->hash(inputRows, i > 0, groupHashes);
+      } else {
+        hashers[i]->hashPrecomputed(inputRows, i > 0, groupHashes);
+      }
+    }
+
+    for (int row = 0; row < numRows; ++row) {
+      const int32_t groupId = groupHashes[row] % numGroups;
+      if (groupRows[groupId] == nullptr ||
+          (groupRows[groupId]->capacity() < numRows * sizeof(vector_size_t))) {
+        groupRows[groupId] = allocateIndices(numRows, input->pool());
+        rawGroupRows[groupId] = groupRows[groupId]->asMutable<vector_size_t>();
+      }
+      rawGroupRows[groupId][groupSizes[groupId]++] = row;
+    }
+
+    for (int32_t groupId = 0; groupId < numGroups; ++groupId) {
+      const size_t groupSize = groupSizes[groupId];
+      if (groupSize != 0) {
+        VELOX_CHECK_NOT_NULL(groupRows[groupId]);
+        groupRows[groupId]->setSize(
+            groupSizes[groupId] * sizeof(vector_size_t));
+        inputsByGroup[groupId].push_back(
+            (groupSize == numRows)
+                ? input
+                : exec::wrap(groupSize, std::move(groupRows[groupId]), input));
+      }
+    }
+  }
+  return inputsByGroup;
+}
+
+std::vector<std::shared_ptr<JoinSource>> JoinMaker::getJoinSources(
+    const JoinOrder joinOrder) const {
+  auto joinSources = sources_;
+
+  switch (joinOrder) {
+    case JoinMaker::JoinOrder::NATURAL:
+      break;
+    case JoinMaker::JoinOrder::FLIPPED:
+      std::reverse(joinSources.begin(), joinSources.end());
+      break;
+    default:
+      VELOX_UNREACHABLE();
+  }
+
+  return joinSources;
+}
+
+core::JoinType JoinMaker::getJoinType(const JoinOrder joinOrder) const {
+  switch (joinOrder) {
+    case JoinMaker::JoinOrder::NATURAL:
+      return joinType_;
+    case JoinMaker::JoinOrder::FLIPPED:
+      return flipJoinType(joinType_);
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
+std::string JoinMaker::makeNestedLoopJoinFilter(
+    const std::shared_ptr<JoinSource>& left,
+    const std::shared_ptr<JoinSource>& right) const {
+  const std::string keysFilter = makeJoinFilter(left->keys(), right->keys());
+  return filter_.empty() ? keysFilter
+                         : fmt::format("{} AND {}", keysFilter, filter_);
+}
+
+core::PlanNodePtr JoinMaker::makeHashJoinPlan(
+    test::PlanBuilder& probePlan,
+    test::PlanBuilder& buildPlan,
+    const std::shared_ptr<JoinSource>& probeSource,
+    const std::shared_ptr<JoinSource>& buildSource,
+    const core::JoinType joinType) const {
+  return probePlan
+      .hashJoin(
+          probeSource->keys(),
+          buildSource->keys(),
+          buildPlan.planNode(),
+          filter_,
+          outputColumns_,
+          joinType,
+          nullAware_)
+      .planNode();
+}
+
+core::PlanNodePtr JoinMaker::makeMergeJoinPlan(
+    test::PlanBuilder& probePlan,
+    test::PlanBuilder& buildPlan,
+    const std::shared_ptr<JoinSource>& probeSource,
+    const std::shared_ptr<JoinSource>& buildSource,
+    const core::JoinType joinType) const {
+  return probePlan.orderBy(probeSource->keys(), false)
+      .mergeJoin(
+          probeSource->keys(),
+          buildSource->keys(),
+          buildPlan.orderBy(buildSource->keys(), false).planNode(),
+          filter_,
+          outputColumns_,
+          joinType)
+      .planNode();
+}
+
+core::PlanNodePtr JoinMaker::makeNestedLoopJoinPlan(
+    test::PlanBuilder& probePlan,
+    test::PlanBuilder& buildPlan,
+    const std::shared_ptr<JoinSource>& probeSource,
+    const std::shared_ptr<JoinSource>& buildSource,
+    const core::JoinType joinType) const {
+  return probePlan
+      .nestedLoopJoin(
+          buildPlan.planNode(),
+          makeNestedLoopJoinFilter(probeSource, buildSource),
+          outputColumns_,
+          joinType)
+      .planNode();
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeHashJoin(
+    const InputType inputType,
+    const PartitionStrategy partitionStrategy,
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  test::PlanBuilder probeSourcePlan;
+  test::PlanBuilder buildSourcePlan;
+
+  if (partitionStrategy == PartitionStrategy::NONE) {
+    probeSourcePlan =
+        makeJoinSourcePlan(probeSource, inputType, planNodeIdGenerator);
+    buildSourcePlan =
+        makeJoinSourcePlan(buildSource, inputType, planNodeIdGenerator);
+  } else {
+    probeSourcePlan = makePartitionedJoinSourcePlan(
+        partitionStrategy, probeSource, inputType, planNodeIdGenerator);
+    buildSourcePlan = makePartitionedJoinSourcePlan(
+        partitionStrategy, buildSource, inputType, planNodeIdGenerator);
+  }
+
+  return PlanWithSplits(makeHashJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder)));
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeHashJoinWithTableScan(
+    const std::optional<int32_t> numGroups,
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  core::PlanNodeId probeTableScanId;
+  core::PlanNodeId buildTableScanId;
+
+  test::PlanBuilder probeSourcePlan = makeTableScanJoinSourcePlan(
+      probeSource, planNodeIdGenerator, probeTableScanId);
+  test::PlanBuilder buildSourcePlan = makeTableScanJoinSourcePlan(
+      buildSource, planNodeIdGenerator, buildTableScanId);
+
+  const auto plan = makeHashJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder));
+
+  if (!numGroups.has_value()) {
+    return PlanWithSplits(
+        plan,
+        probeTableScanId,
+        buildTableScanId,
+        {{probeTableScanId, probeSource->splits()},
+         {buildTableScanId, buildSource->splits()}});
+  } else {
+    return PlanWithSplits(
+        plan,
+        probeTableScanId,
+        buildTableScanId,
+        {{probeTableScanId, probeSource->groupedSplits(*numGroups)},
+         {buildTableScanId, buildSource->groupedSplits(*numGroups)}},
+        core::ExecutionStrategy::kGrouped,
+        *numGroups);
+  }
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeMergeJoin(
+    const InputType inputType,
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  auto probeSourcePlan =
+      makeJoinSourcePlan(probeSource, inputType, planNodeIdGenerator);
+  auto buildSourcePlan =
+      makeJoinSourcePlan(buildSource, inputType, planNodeIdGenerator);
+
+  return PlanWithSplits(makeMergeJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder)));
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeMergeJoinWithTableScan(
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  core::PlanNodeId probeTableScanId;
+  core::PlanNodeId buildTableScanId;
+
+  test::PlanBuilder probeSourcePlan = makeTableScanJoinSourcePlan(
+      probeSource, planNodeIdGenerator, probeTableScanId);
+  test::PlanBuilder buildSourcePlan = makeTableScanJoinSourcePlan(
+      buildSource, planNodeIdGenerator, buildTableScanId);
+
+  const auto plan = makeMergeJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder));
+
+  return PlanWithSplits(
+      plan,
+      probeTableScanId,
+      buildTableScanId,
+      {{probeTableScanId, probeSource->splits()},
+       {buildTableScanId, buildSource->splits()}});
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeNestedLoopJoin(
+    const InputType inputType,
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  auto probeSourcePlan =
+      makeJoinSourcePlan(probeSource, inputType, planNodeIdGenerator);
+  auto buildSourcePlan =
+      makeJoinSourcePlan(buildSource, inputType, planNodeIdGenerator);
+
+  return PlanWithSplits(makeNestedLoopJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder)));
+}
+
+JoinMaker::PlanWithSplits JoinMaker::makeNestedLoopJoinWithTableScan(
+    const JoinOrder joinOrder) const {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto joinSources = getJoinSources(joinOrder);
+
+  const auto& probeSource = joinSources[0];
+  const auto& buildSource = joinSources[1];
+
+  core::PlanNodeId probeTableScanId;
+  core::PlanNodeId buildTableScanId;
+
+  test::PlanBuilder probeSourcePlan = makeTableScanJoinSourcePlan(
+      probeSource, planNodeIdGenerator, probeTableScanId);
+  test::PlanBuilder buildSourcePlan = makeTableScanJoinSourcePlan(
+      buildSource, planNodeIdGenerator, buildTableScanId);
+
+  const auto plan = makeNestedLoopJoinPlan(
+      probeSourcePlan,
+      buildSourcePlan,
+      probeSource,
+      buildSource,
+      getJoinType(joinOrder));
+
+  return PlanWithSplits(
+      plan,
+      probeTableScanId,
+      buildTableScanId,
+      {{probeTableScanId, probeSource->splits()},
+       {buildTableScanId, buildSource->splits()}});
+}
+
+bool JoinMaker::supportsFlippingHashJoin() const {
+  //  Null-aware right semi project join doesn't support filter.
+  if (!filter_.empty() && joinType_ == core::JoinType::kLeftSemiProject &&
+      nullAware_) {
+    return false;
+  }
+
+  return tryFlipJoinType(joinType_).has_value();
+}
+
+bool JoinMaker::supportsFlippingMergeJoin() const {
+  const auto flippedJoinType = tryFlipJoinType(joinType_);
+
+  if (!flippedJoinType.has_value()) {
+    return false;
+  }
+
+  return core::MergeJoinNode::isSupported(*flippedJoinType);
+}
+
+bool JoinMaker::supportsFlippingNestedLoopJoin() const {
+  const auto flippedJoinType = tryFlipJoinType(joinType_);
+
+  if (!flippedJoinType.has_value()) {
+    return false;
+  }
+
+  return core::NestedLoopJoinNode::isSupported(*flippedJoinType);
+}
+
+bool JoinMaker::supportsTableScan() const {
+  for (const auto& source : sources_) {
+    if (!test::isTableScanSupported(source->outputType())) {
+      return false;
+    }
+  }
+
+  return true;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/fuzzer/JoinMaker.h
+++ b/velox/exec/fuzzer/JoinMaker.h
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "velox/core/PlanFragment.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Split.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/IExpr.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+/// Represents a single input "table" to a join plan created using JoinMaker.
+/// This can be converted to a ValuesNode or a TableScanNode in the resulting
+/// plan.
+struct JoinSource {
+ public:
+  /// @param outputType The RowType the source node will eventually produce,
+  /// this should match the Types of the Vectors in `batches`.
+  /// @param keys The names of the key fields in `outputType`.
+  /// @param batches The data this source will produce.
+  /// @param projections Projections to be applied to batches after they are
+  /// output.
+  /// @param splitsDir A temporary directory to write files containing `batches`
+  /// into when generating splits for a TableScan.
+  /// @param writerPool A MemoryPool that can be used by the Writers when
+  /// writing out splits.
+  JoinSource(
+      const RowTypePtr& outputType,
+      const std::vector<std::string>& keys,
+      const std::vector<RowVectorPtr>& batches,
+      const std::vector<core::ExprPtr>& projections,
+      const std::string& splitsDir,
+      const std::shared_ptr<memory::MemoryPool> writerPool)
+      : outputType_(outputType),
+        keys_(keys),
+        batches_(batches),
+        projections_(projections),
+        splitsDir_(splitsDir),
+        writerPool_(writerPool) {}
+
+  const RowTypePtr& outputType() const {
+    return outputType_;
+  }
+
+  const std::vector<std::string>& keys() const {
+    return keys_;
+  }
+
+  const std::vector<RowVectorPtr>& batches() const {
+    return batches_;
+  }
+
+  /// Get `batches` as flat Vectors.
+  const std::vector<RowVectorPtr>& flatBatches() const;
+
+  /// Get `batches` as splits.
+  const std::vector<Split>& splits() const;
+
+  /// Get `batches` as splits grouped into `numGroups` groups.
+  const std::vector<Split>& groupedSplits(const int32_t numGroups) const;
+
+  const std::vector<core::ExprPtr>& projections() const {
+    return projections_;
+  }
+
+ private:
+  std::vector<RowVectorPtr> flatten(
+      const std::vector<RowVectorPtr>& vectors) const;
+
+  std::vector<std::vector<RowVectorPtr>> splitInputByGroup(
+      int32_t numGroups) const;
+
+  const RowTypePtr outputType_;
+  const std::vector<std::string> keys_;
+  const std::vector<RowVectorPtr> batches_;
+  const std::vector<core::ExprPtr> projections_;
+  const std::string splitsDir_;
+  const std::shared_ptr<memory::MemoryPool> writerPool_;
+
+  // The following are used to cache `batches_` when it is converted to other
+  // forms.
+  mutable std::optional<std::vector<RowVectorPtr>> flatBatches_;
+  mutable std::optional<std::vector<Split>> splits_;
+  mutable std::unordered_map<int32_t, std::vector<Split>> groupedSplits_;
+};
+
+/// Can be used to construct a variety of join plans that should produce
+/// equivalent results.
+class JoinMaker {
+ public:
+  /// @param joinType The type of join: inner, left, full outer, etc.
+  /// @param nullAware Whether the join is null aware, only applies to join
+  /// types that support it (semi and anti).
+  /// @param sources Specifies the inputs to the join, currently we only
+  /// support exactly 2 sources.
+  /// @param outputColumns The names of the columns to extract from the input
+  /// sources and return as the result of the join.
+  /// @param filter A SQL filter to apply as part of the join, it will be parsed
+  /// using DuckDB. This can be empty.
+  JoinMaker(
+      const core::JoinType joinType,
+      const bool nullAware,
+      const std::vector<std::shared_ptr<JoinSource>>& sources,
+      const std::vector<std::string>& outputColumns,
+      const std::string& filter)
+      : joinType_(joinType),
+        nullAware_(nullAware),
+        sources_(sources),
+        outputColumns_(outputColumns),
+        filter_(filter) {
+    VELOX_CHECK(
+        sources.size() == 2, "For now we only support joining 2 tables");
+  }
+
+  /// What sort of input to use in the join, either the original encoded
+  /// Vectors, or flattened copies.
+  enum class InputType { ENCODED, FLAT };
+
+  /// What PartitionStrategy to use, only applies to HashJoin.
+  /// `NONE` means the data is read in a single partition.
+  /// `HASH` and `ROUND_ROBIN` cause a LocalPartition step to be added to both
+  /// sides of the join using the specified algorithm.
+  enum class PartitionStrategy { NONE, HASH, ROUND_ROBIN };
+
+  /// Specifies what order to include the sources in the join.
+  /// `NATURAL` uses the order as specified in the JoinMaker constructor.
+  /// `FLIPPED` reversed that order.
+  enum class JoinOrder { NATURAL, FLIPPED };
+
+  struct PlanWithSplits {
+    core::PlanNodePtr plan;
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId buildScanId;
+    std::unordered_map<core::PlanNodeId, std::vector<velox::exec::Split>>
+        splits;
+    core::ExecutionStrategy executionStrategy{
+        core::ExecutionStrategy::kUngrouped};
+    int32_t numGroups;
+
+    explicit PlanWithSplits(
+        const core::PlanNodePtr& _plan,
+        const core::PlanNodeId& _probeScanId = "",
+        const core::PlanNodeId& _buildScanId = "",
+        const std::unordered_map<
+            core::PlanNodeId,
+            std::vector<velox::exec::Split>>& _splits = {},
+        core::ExecutionStrategy _executionStrategy =
+            core::ExecutionStrategy::kUngrouped,
+        int32_t _numGroups = 0)
+        : plan(_plan),
+          probeScanId(_probeScanId),
+          buildScanId(_buildScanId),
+          splits(_splits),
+          executionStrategy(_executionStrategy),
+          numGroups(_numGroups) {}
+  };
+
+  PlanWithSplits makeHashJoin(
+      const InputType inputType,
+      const PartitionStrategy partitionStrategy,
+      const JoinOrder joinOrder) const;
+
+  PlanWithSplits makeHashJoinWithTableScan(
+      const std::optional<int32_t> numGroups,
+      const JoinOrder joinOrder) const;
+
+  PlanWithSplits makeMergeJoin(
+      const InputType inputType,
+      const JoinOrder joinOrder) const;
+
+  PlanWithSplits makeMergeJoinWithTableScan(const JoinOrder joinOrder) const;
+
+  PlanWithSplits makeNestedLoopJoin(
+      const InputType inputType,
+      const JoinOrder joinOrder) const;
+
+  PlanWithSplits makeNestedLoopJoinWithTableScan(
+      const JoinOrder joinOrder) const;
+
+  /// Returns whether or not the join type supports reversing the order of the
+  /// inputs in a hash join.
+  bool supportsFlippingHashJoin() const;
+
+  /// Returns whether or not the join type supports reversing the order of the
+  /// inputs in a merge join.
+  bool supportsFlippingMergeJoin() const;
+
+  /// Returns whether or not the join type supports reversing the order of the
+  /// inputs in a nested loop join.
+  bool supportsFlippingNestedLoopJoin() const;
+
+  bool supportsMergeJoin() const {
+    return core::MergeJoinNode::isSupported(joinType_);
+  }
+
+  bool supportsNestedLoopJoin() const {
+    return core::NestedLoopJoinNode::isSupported(joinType_);
+  }
+
+  /// Returns whether or not the types of the sources allow them to be read as
+  /// splits using a TableScan.
+  bool supportsTableScan() const;
+
+ private:
+  // Get the sources in the order they should be read according to `joinOrder`.
+  std::vector<std::shared_ptr<JoinSource>> getJoinSources(
+      const JoinOrder joinOrder) const;
+
+  // Get the JoinType to use given `joinOrder`. Throws if the joinType does not
+  // support the given JoinOrder.
+  core::JoinType getJoinType(const JoinOrder joinOrder) const;
+
+  std::string makeNestedLoopJoinFilter(
+      const std::shared_ptr<JoinSource>& left,
+      const std::shared_ptr<JoinSource>& righ) const;
+
+  core::PlanNodePtr makeHashJoinPlan(
+      test::PlanBuilder& probePlan,
+      test::PlanBuilder& buildPlan,
+      const std::shared_ptr<JoinSource>& probeSource,
+      const std::shared_ptr<JoinSource>& buildSource,
+      const core::JoinType joinType) const;
+
+  core::PlanNodePtr makeMergeJoinPlan(
+      test::PlanBuilder& probePlan,
+      test::PlanBuilder& buildPlan,
+      const std::shared_ptr<JoinSource>& probeSource,
+      const std::shared_ptr<JoinSource>& buildSource,
+      const core::JoinType joinType) const;
+
+  core::PlanNodePtr makeNestedLoopJoinPlan(
+      test::PlanBuilder& probePlan,
+      test::PlanBuilder& buildPlan,
+      const std::shared_ptr<JoinSource>& probeSource,
+      const std::shared_ptr<JoinSource>& buildSource,
+      const core::JoinType joinType) const;
+
+  const core::JoinType joinType_;
+  const bool nullAware_;
+  const std::vector<std::shared_ptr<JoinSource>> sources_;
+  const std::vector<std::string> outputColumns_;
+  const std::string filter_;
+};
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
JoinFuzzer has become monolithic (>1500 lines) and functional. We have a lot of functions to 
construct join plans that take the same or very similar long lists of arguments. These functions 
also do a lot of the same things but do not share code. It makes it very difficult to answer
basic questions like: what join plans are we testing in JoinFuzzer?

To try to improve this I've added a JoinMaker class. This class holds the state that's needed to
construct the various plan alternatives, e.g. the inputs, the join type, the filter, and the output 
columns. This way we can call clear functions like makeHashJoin and the arguments specify
just what adjustments we're making to the join plan (are we using flat inputs, are we reversing 
the order of the inputs, are we partitioning the inputs, etc.)

In addition I saw we were passing a lot of the same arguments for the probe and build sides of 
the join. So I added a JoinSource class to capture that (the input data, the key columns, the
type of the data, etc.). Besides making it cleaner I think this will help support fuzzing plans
that join more than 2 tables eventually.

Differential Revision: D73044135


