### PR TITLE
fix: Inverse_poisson_cdf doesn't handle case where results exceed bounds of int32_t

### DIFF
--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -398,7 +398,12 @@ struct InversePoissonCDFFunction {
         "inversePoissonCdf Function: lambda must be greater than 0");
 
     boost::math::poisson_distribution<> dist(lambda);
-    result = static_cast<int32_t>(boost::math::quantile(dist, p));
+    double quantile = boost::math::quantile(dist, p);
+    if (quantile > std::numeric_limits<int32_t>::max()) {
+      result = std::numeric_limits<int32_t>::max();
+    } else {
+      result = static_cast<int32_t>(quantile);
+    }
   }
 };
 

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -735,6 +735,9 @@ TEST_F(ProbabilityTest, invPoissonCDF) {
   // EXPECT_EQ(2, invPoissonCDF(3, 0.3)); // 1.499999... round to floor to 1
   EXPECT_EQ(6, invPoissonCDF(3, 0.95));
   EXPECT_EQ(17, invPoissonCDF(3, 0.99999999));
+  EXPECT_EQ(
+      std::numeric_limits<int32_t>::max(),
+      invPoissonCDF(1.8819579427461317E18, 0.659094));
 
   EXPECT_EQ(std::nullopt, invPoissonCDF(std::nullopt, 0.5));
   EXPECT_EQ(std::nullopt, invPoissonCDF(0.5, std::nullopt));


### PR DESCRIPTION
Summary:
inverse_poisson_cdf doesn't handle the case where results exceed the bounds of int32_t, so
it throws an exception (at least with sanitizers enabled) when converting the result to an 
int32_t.

Presto Java handles this by bounding the result to Integer.MAX_VALUE. The change applies
the same restriction to Velox's implementation.

Differential Revision: D73143995


