### PR TITLE
fix: Remove unnecessaryTDigest.h sum check

### DIFF
--- a/velox/functions/lib/TDigest.h
+++ b/velox/functions/lib/TDigest.h
@@ -135,12 +135,6 @@ class TDigest {
     double x = (x1 * w1 + x2 * w2) / (w1 + w2);
     return std::max(x1, std::min(x, x2));
   }
-
-  // Performs sanity check for the sum: verifies that the given sum is close to
-  // the calculated sum.
-  static void
-  checkTheSum(int32_t numEntries, double sum, double* weights, double* means);
-
   std::vector<double, Allocator> weights_;
   std::vector<double, Allocator> means_;
   double compression_;
@@ -476,10 +470,6 @@ void TDigest<A>::mergeDeserialized(
       VELOX_CHECK(!std::isnan(means[i]));
     }
 
-    if (version >= 1) {
-      checkTheSum(numNew, sum, weights, means);
-    }
-
     double actualTotalWeight = std::accumulate(weights, weights + numNew, 0.0);
     VELOX_CHECK_LT(std::abs(actualTotalWeight - totalWeight), kEpsilon);
   } else {
@@ -488,42 +478,6 @@ void TDigest<A>::mergeDeserialized(
   }
   if (weights_.size() >= maxBufferSize_) {
     mergeNewValues(positions, 2 * compression_);
-  }
-}
-
-template <typename A>
-void TDigest<A>::checkTheSum(
-    int32_t numEntries,
-    double sum,
-    double* weights,
-    double* means) {
-  double actualSum = 0;
-  for (auto i = 0; i < numEntries; ++i) {
-    actualSum += weights[i] * means[i];
-  }
-
-  // Simple check for sums matching first.
-  const double difference = std::abs(sum - actualSum);
-  if (FOLLY_UNLIKELY(difference >= kEpsilon)) {
-    // According to http://floating-point-gui.de/errors/comparison/
-    const double controlMean = sum / numEntries;
-    const double testMean = actualSum / numEntries;
-    bool sumIsGood = true;
-    if (std::abs(controlMean) < kEpsilon || std::abs(testMean) < kEpsilon) {
-      sumIsGood =
-          std::abs(controlMean) < kEpsilon && std::abs(testMean) < kEpsilon;
-    } else {
-      const double relativeError = difference /
-          std::min((std::abs(sum) + std::abs(actualSum)) / 2,
-                   std::numeric_limits<double>::max());
-      sumIsGood = relativeError < kRelativeErrorEpsilon;
-    }
-    VELOX_CHECK(
-        sumIsGood,
-        "TDigest declared sum: {} and actual sum: {} differ too much: {}",
-        sum,
-        actualSum,
-        difference);
   }
 }
 

--- a/velox/functions/lib/tests/TDigestTest.cpp
+++ b/velox/functions/lib/tests/TDigestTest.cpp
@@ -27,19 +27,6 @@ namespace {
 
 constexpr double kSumError = 1e-4;
 constexpr double kRankError = 0.01;
-
-// Small hack to modify the TDigest sum in the serilaized buffer, so we can test
-// that the relative error algorithm in sum testing code works.
-void alterTDigestSumInTheBuffer(std::string& buf, const TDigest<>& digest) {
-  // Find and adjust the sum in the buffer.
-  double originalSum = digest.sum();
-  // Based on the TDigest::serialize() we expect the sum at this position.
-  const size_t sumOffset = sizeof(int8_t) * 2 + sizeof(double) * 2;
-  ASSERT_EQ(memcmp(buf.data() + sumOffset, &originalSum, sizeof(double)), 0);
-
-  *(double*)(buf.data() + sumOffset) += TDigest<>::kEpsilon * 2;
-}
-
 constexpr double kQuantiles[] = {
     0.0001, 0.0200, 0.0300, 0.04000, 0.0500, 0.1000, 0.2000,
     0.3000, 0.4000, 0.5000, 0.6000,  0.7000, 0.8000, 0.9000,
@@ -399,11 +386,7 @@ TEST(TDigestTest, merge) {
   std::default_random_engine gen(common::testutil::getRandomSeed(42));
   std::vector<double> values;
   std::string buf;
-  auto test = [&](int numDigests,
-                  int size,
-                  double mean,
-                  double stddev,
-                  bool alterSum = false) {
+  auto test = [&](int numDigests, int size, double mean, double stddev) {
     SCOPED_TRACE(fmt::format(
         "numDigests={} size={} mean={} stddev={}",
         numDigests,
@@ -424,9 +407,6 @@ TEST(TDigestTest, merge) {
       current.compress(positions);
       buf.resize(current.serializedByteSize());
       current.serialize(buf.data());
-      if (alterSum) {
-        alterTDigestSumInTheBuffer(buf, current);
-      }
       digest.mergeDeserialized(positions, buf.data());
     }
     digest.compress(positions);
@@ -436,8 +416,6 @@ TEST(TDigestTest, merge) {
   test(2, 5e4, 0, 50);
   test(100, 1000, 500, 20);
   test(1e4, 10, 500, 20);
-
-  test(5, 5e4, 0, 50, true);
 }
 
 TEST(TDigestTest, infinity) {


### PR DESCRIPTION
Summary:
Remove unnecessaryTDigest.h sum check. This is too strict and not required 
Issue: https://www.internalfb.com/tasks/?t=221381362

Differential Revision: D73147059


