### PR TITLE
feat: Optimize Hash Table atomic bools

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1174,7 +1174,7 @@ bool HashTable<ignoreNullKeys>::arrayPushRow(
   auto* existingRow = table_[index];
   if (existingRow != nullptr) {
     if (nextOffset_ > 0) {
-      hasDuplicates_ = true;
+      hasDuplicates_.set();
       rows->appendNextRow(existingRow, row, allocator);
     }
     return false;
@@ -1190,7 +1190,7 @@ void HashTable<ignoreNullKeys>::pushNext(
     char* next,
     HashStringAllocator* allocator) {
   VELOX_CHECK_GT(nextOffset_, 0);
-  hasDuplicates_ = true;
+  hasDuplicates_.set();
   rows->appendNextRow(row, next, allocator);
 }
 
@@ -1660,8 +1660,8 @@ std::string HashTable<ignoreNullKeys>::toString() {
     int64_t occupied = 0;
 
     // Count of buckets indexed by the number of non-empty slots.
-    // Each bucket has 16 slots. Hence, the number of non-empty slots is between
-    // 0 and 16 (17 possible values).
+    // Each bucket has 16 slots. Hence, the number of non-empty slots is
+    // between 0 and 16 (17 possible values).
     int64_t numBuckets[sizeof(TagVector) + 1] = {};
     for (int64_t bucketOffset = 0; bucketOffset < sizeMask_;
          bucketOffset += kBucketSize) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -17,6 +17,7 @@
 
 #include "velox/common/base/Portability.h"
 #include "velox/common/memory/MemoryAllocator.h"
+#include "velox/exec/OneWayStatusFlag.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
 #include "velox/exec/VectorHasher.h"
@@ -569,7 +570,7 @@ class HashTable : public BaseHashTable {
   }
 
   bool hasDuplicateKeys() const override {
-    return hasDuplicates_;
+    return hasDuplicates_.check();
   }
 
   HashMode hashMode() const override {
@@ -1048,7 +1049,7 @@ class HashTable : public BaseHashTable {
   // Set at join build time if the table has duplicates, meaning that
   // the join can be cardinality increasing. Atomic for tsan because
   // many threads can set this.
-  std::atomic<bool> hasDuplicates_{false};
+  OneWayStatusFlag hasDuplicates_;
 
   // Offset of next row link for join build side set from 'rows_'.
   int32_t nextOffset_{0};

--- a/velox/exec/OneWayStatusFlag.h
+++ b/velox/exec/OneWayStatusFlag.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/synchronization/SanitizeThread.h>
+#include <atomic>
+
+namespace facebook::velox::exec {
+
+/// A simple one way status flag that uses a non atomic flag to avoid
+/// unnecessary atomic operations.
+class OneWayStatusFlag {
+ public:
+  bool check() const {
+#if defined(__x86_64__)
+    /// This flag is can only go from false to true, and must is only checked at
+    /// the end of a loop. Given that once a flag is true it can never go back
+    /// to false, we are ok to use this in a non synchronized manner to avoid
+    /// the overhead. As such we consciously exempt ourselves here from TSAN
+    /// detection.
+    folly::annotate_ignore_thread_sanitizer_guard g(__FILE__, __LINE__);
+    return fastStatus_ || atomicStatus_.load();
+#else
+    return atomicStatus_.load(std::memory_order_relaxed) ||
+        atomicStatus_.load();
+#endif
+  }
+
+  void set() {
+#if defined(__x86_64__)
+    if (!fastStatus_) {
+      atomicStatus_.store(true);
+      fastStatus_ = true;
+    }
+#else
+    if (!atomicStatus_.load(std::memory_order_relaxed)) {
+      atomicStatus_.store(true);
+    }
+#endif
+  }
+
+  /// Operator overload to convert OneWayStatusFlag to bool
+  operator bool() const {
+    return check();
+  }
+
+ private:
+#if defined(__x86_64__)
+  bool fastStatus_{false};
+#endif
+  std::atomic_bool atomicStatus_{false};
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/AtomicsBench.cpp
+++ b/velox/exec/benchmarks/AtomicsBench.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+#include "velox/exec/OneWayStatusFlag.h"
+
+using namespace ::testing;
+using namespace facebook::velox;
+static const size_t kNumThreads = 88;
+static const size_t kNumIterations = 10000;
+
+void runParallelUpdates(
+    std::function<void(size_t iter)> callback,
+    int threadCount,
+    int updateCount) {
+  std::vector<std::thread> threads;
+
+  for (size_t i = 0; i < threadCount; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < updateCount; ++j) {
+        callback(j);
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+BENCHMARK(std_atomic_bool_write) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.store(true);
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_write_relaxed) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.store(true, std::memory_order_relaxed);
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_write_relaxed) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          if (!flag.load(std::memory_order_relaxed)) {
+            flag.store(true, std::memory_order_acq_rel);
+          }
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(one_way_flag_write) {
+  exec::OneWayStatusFlag flag;
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.set();
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+// Read Benchmarks
+BENCHMARK(std_atomic_bool_read) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load());
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_relaxed_read) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load(std::memory_order_relaxed));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_relaxed_acquire) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(
+              flag.load(std::memory_order_relaxed) ||
+              flag.load(std::memory_order_acquire));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(one_way_flag_read) {
+  exec::OneWayStatusFlag flag;
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.check());
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+}

--- a/velox/exec/tests/OneWayStatusFlagTest.cpp
+++ b/velox/exec/tests/OneWayStatusFlagTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/OneWayStatusFlag.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::exec::test {
+
+TEST(OneWayStatusFlagTest, basicCorrectnessTest) {
+  OneWayStatusFlag statusFlag;
+  EXPECT_FALSE(statusFlag.check());
+  EXPECT_FALSE(statusFlag);
+  statusFlag.set();
+  EXPECT_TRUE(statusFlag.check());
+  EXPECT_TRUE(statusFlag);
+}
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
HashTable repeatedly sets std::atomic<bool> hasDuplicates_ for each row. This flag can only go from false to true. Every subsequent call to this set is likely redundant. 

Microbenchmarks show a 28000x improvement by using a simple wrapper that avoids the atomic once the flag is already set. TPCH Sf100 on a 88c Bergamo node improved by a factor of >4x while enabling significantly higher cpu utilization. 

A cursory look in Velox shows several other "one way atomic flags" that we could likely replace as well : 

MemoryPool::aborted_
AsyncDataCache::isFirstUse_;
AsyncDataCache::ssdSavable_;
Driver::isEnqueued_
Driver::isTerminated_
ExchangeDataSource::requestPending_
Task::terminateRequested_

Differential Revision: D73003608


