### PR TITLE
fix: Make precision recall functions always use size() for termination condition

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/ClassificationAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ClassificationAggregationTest.cpp
@@ -152,7 +152,7 @@ TEST_F(ClassificationAggregationTest, basic) {
     }
   }
 
-  /// Test invalid threshold.
+  /// Test invalid Weight.
   for (const auto function : functions) {
     VELOX_ASSERT_THROW(
         runTest(
@@ -162,13 +162,18 @@ TEST_F(ClassificationAggregationTest, basic) {
         "Weight must be non-negative.");
   }
 
-  /// Test invalid predictions. Note, a prediction of > 1
-  /// will never actually be hit because convert the pred = std::min(pred,
-  /// 0.99999999999)
+  /// Test invalid predictions.
   for (const auto function : functions) {
     VELOX_ASSERT_THROW(
         runTest(
             fmt::format("{}({}, {}, {})", function, 5, "c0", -0.1),
+            input,
+            expected),
+        "Prediction value must be between 0 and 1");
+
+    VELOX_ASSERT_THROW(
+        runTest(
+            fmt::format("{}({}, {}, {})", function, 5, "c0", 1.2),
             input,
             expected),
         "Prediction value must be between 0 and 1");

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -79,17 +79,7 @@ getCustomInputGenerators() {
       {"approx_distinct", std::make_shared<ApproxDistinctInputGenerator>()},
       {"approx_set", std::make_shared<ApproxDistinctInputGenerator>()},
       {"approx_percentile", std::make_shared<ApproxPercentileInputGenerator>()},
-      {"map_union_sum", std::make_shared<MapUnionSumInputGenerator>()},
-      {"classification_fall_out",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_precision",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_recall",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_miss_rate",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_thresholds",
-       std::make_shared<ClassificationAggregationInputGenerator>()}};
+      {"map_union_sum", std::make_shared<MapUnionSumInputGenerator>()}};
 }
 
 } // namespace
@@ -123,6 +113,12 @@ int main(int argc, char** argv) {
 
   // List of functions that have known bugs that cause crashes or failures.
   static const std::unordered_set<std::string> skipFunctions = {
+      // https://github.com/prestodb/presto/issues/24936
+      "classification_fall_out",
+      "classification_precision",
+      "classification_recall",
+      "classification_miss_rate",
+      "classification_thresholds",
       // Skip internal functions used only for result verifications.
       "$internal$count_distinct",
       "$internal$array_agg",

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -26,7 +26,6 @@
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ApproxPercentileResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/AverageResultVerifier.h"
-#include "velox/functions/prestosql/fuzzer/ClassificationAggregationInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/WindowOffsetInputGenerator.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -77,17 +76,7 @@ getCustomInputGenerators() {
       {"lead", std::make_shared<WindowOffsetInputGenerator>(1)},
       {"lag", std::make_shared<WindowOffsetInputGenerator>(1)},
       {"nth_value", std::make_shared<WindowOffsetInputGenerator>(1)},
-      {"ntile", std::make_shared<WindowOffsetInputGenerator>(0)},
-      {"classification_fall_out",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_precision",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_recall",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_miss_rate",
-       std::make_shared<ClassificationAggregationInputGenerator>()},
-      {"classification_thresholds",
-       std::make_shared<ClassificationAggregationInputGenerator>()}};
+      {"ntile", std::make_shared<WindowOffsetInputGenerator>(0)}};
 }
 
 } // namespace
@@ -112,6 +101,12 @@ int main(int argc, char** argv) {
 
   // List of functions that have known bugs that cause crashes or failures.
   static const std::unordered_set<std::string> skipFunctions = {
+      // https://github.com/prestodb/presto/issues/24936
+      "classification_fall_out",
+      "classification_precision",
+      "classification_recall",
+      "classification_miss_rate",
+      "classification_thresholds",
       // Skip internal functions used only for result verifications.
       "$internal$count_distinct",
       "$internal$array_agg",
@@ -173,11 +168,6 @@ int main(int argc, char** argv) {
       "any_value",
       "arbitrary",
       "array_agg",
-      "classification_fall_out",
-      "classification_precision",
-      "classification_recall",
-      "classification_miss_rate",
-      "classification_thresholds",
       "set_agg",
       "set_union",
       "map_agg",


### PR DESCRIPTION
Summary:
Precision recall functions output a list of doubles based on the used size of the bucket. The original implementation copied Java's termination condition for outputting the aggregated values here: https://github.com/prestodb/presto/blob/47a708022aba003ebfda483ea3c940231fdbd282/presto-main-base/src/main/java/com/facebook/presto/operator/aggregation/PrecisionRecallAggregation.java#L205

which translates to index < bucketCount && totalTrueWeight > runningTrueWeight. However, this is equivalently used to what I introduced as `maxUsedIndex_`, which is the last index in the bucketCount. This accomplishes the condition in the Java implementation, and avoids an O(bucketCount) computation. 

This optimization actually exposed a bug in Java because of precision loss during decimal adding, causing more terms in Java to returned. 

Made up fake example:
- bucket_count = 5
- true_weights = [0, 0.01, 0.02, 0, 0] 
- total_true_weigh_sum = 0.03

It won't happen in this example, but you can imagine when we add the 3rd index to the running sum, we can get something like 0.0299999. As a result of this in-precision adding, we won't stop at 3 but will return bucket_count (5). This is what happens in Java.


See https://github.com/prestodb/presto/issues/24936 for more detail

In this diff, alway use `size()`, the max index used, which is more correct instead of using Java's implementation.

Differential Revision: D73084745


