### PR TITLE
feat: Allow SpillPartitionId support recursive spilling history

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1537,6 +1537,7 @@ AggregationInputSpiller::AggregationInputSpiller(
           sortCompareFlags,
           std::numeric_limits<uint64_t>::max(),
           spillConfig->maxSpillRunRows,
+          std::nullopt,
           spillConfig,
           spillStats) {}
 
@@ -1553,6 +1554,7 @@ AggregationOutputSpiller::AggregationOutputSpiller(
           {},
           std::numeric_limits<uint64_t>::max(),
           spillConfig->maxSpillRunRows,
+          std::nullopt,
           spillConfig,
           spillStats) {}
 

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -289,6 +289,9 @@ class HashBuild final : public Operator {
 
   // Used to read input from previously spilled data for restoring.
   std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
+  // The spill partition id for the currently restoring partition. Not set if
+  // build hasn't spilled yet.
+  std::optional<SpillPartitionId> restoringPartitionId_;
   // Vector used to read from spilled input with type of 'spillType_'.
   RowVectorPtr spillInput_;
 
@@ -324,6 +327,7 @@ class HashBuildSpiller : public SpillerBase {
 
   HashBuildSpiller(
       core::JoinType joinType,
+      std::optional<SpillPartitionId> parentId,
       RowContainer* container,
       RowTypePtr rowType,
       HashBitRange bits,

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -246,6 +246,7 @@ std::vector<std::unique_ptr<HashJoinTableSpillResult>> spillHashJoinTable(
 /// hash probe or hash join bridge to spill a fully built table.
 SpillPartitionSet spillHashJoinTable(
     std::shared_ptr<BaseHashTable> table,
+    std::optional<SpillPartitionId> parentId,
     const HashBitRange& hashBitRange,
     const std::shared_ptr<const core::HashJoinNode>& joinNode,
     const common::SpillConfig* spillConfig,

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -249,14 +249,16 @@ void HashProbe::maybeSetupInputSpiller(
     return;
   }
 
+  const auto bitOffset = partitionBitOffset(
+      *spillInputPartitionIds_.begin(),
+      spillConfig()->startPartitionBit,
+      spillConfig()->numPartitionBits);
   // If 'spillInputPartitionIds_' is not empty, then we set up a spiller to
   // spill the incoming probe inputs.
   inputSpiller_ = std::make_unique<NoRowContainerSpiller>(
       probeType_,
-      HashBitRange(
-          spillInputPartitionIds_.begin()->partitionBitOffset(),
-          spillInputPartitionIds_.begin()->partitionBitOffset() +
-              spillConfig()->numPartitionBits),
+      restoringPartitionId_,
+      HashBitRange(bitOffset, bitOffset + spillConfig()->numPartitionBits),
       spillConfig(),
       &spillStats_);
   // Set the spill partitions to the corresponding ones at the build side. The
@@ -290,6 +292,7 @@ void HashProbe::maybeSetupSpillInputReader(
   VELOX_CHECK(iter != inputSpillPartitionSet_.end());
   auto partition = std::move(iter->second);
   VELOX_CHECK_EQ(partition->id(), restoredPartitionId.value());
+  restoringPartitionId_ = restoredPartitionId;
   spillInputReader_ = partition->createUnorderedReader(
       spillConfig_->readBufferSize, pool(), &spillStats_);
   inputSpillPartitionSet_.erase(iter);
@@ -473,6 +476,7 @@ void HashProbe::prepareForSpillRestore() {
   table_.reset();
   inputSpiller_.reset();
   spillInputReader_.reset();
+  restoringPartitionId_.reset();
   spillInputPartitionIds_.clear();
   spillOutputReader_.reset();
   lastProbeIterator_.reset();
@@ -1844,7 +1848,12 @@ void HashProbe::reclaim(
     // Only spill hash table if any hash probe operators still has input probe
     // data, otherwise we skip this step.
     spillPartitionSet = spillHashJoinTable(
-        table_, tableSpillHashBits_, joinNode_, spillConfig(), &spillStats_);
+        table_,
+        restoringPartitionId_,
+        tableSpillHashBits_,
+        joinNode_,
+        spillConfig(),
+        &spillStats_);
     VELOX_CHECK(!spillPartitionSet.empty());
   }
   const auto spillPartitionIdSet = toSpillPartitionIdSet(spillPartitionSet);
@@ -1925,7 +1934,7 @@ void HashProbe::spillOutput() {
   }
   // We spill all the outputs produced from 'input_' into a single partition.
   auto outputSpiller = std::make_unique<NoRowContainerSpiller>(
-      outputType_, HashBitRange{}, spillConfig(), &spillStats_);
+      outputType_, std::nullopt, HashBitRange{}, spillConfig(), &spillStats_);
   outputSpiller->setPartitionsSpilled({0});
 
   RowVectorPtr output{nullptr};
@@ -1980,8 +1989,11 @@ void HashProbe::checkMaxSpillLevel(
   const auto* config = spillConfig();
   uint8_t startPartitionBit = config->startPartitionBit;
   if (restoredPartitionId.has_value()) {
-    startPartitionBit =
-        restoredPartitionId->partitionBitOffset() + config->numPartitionBits;
+    startPartitionBit = partitionBitOffset(
+                            restoredPartitionId.value(),
+                            config->startPartitionBit,
+                            config->numPartitionBits) +
+        config->numPartitionBits;
     // Disable spilling if exceeding the max spill level and the query might
     // run out of memory if the restored partition still can't fit in memory.
     if (config->exceedSpillLevelLimit(startPartitionBit)) {
@@ -2007,6 +2019,7 @@ void HashProbe::close() {
   inputSpiller_.reset();
   table_.reset();
   spillInputReader_.reset();
+  restoringPartitionId_.reset();
   spillOutputPartitionSet_.clear();
   spillOutputReader_.reset();
   clearBuffers();

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -706,6 +706,11 @@ class HashProbe : public Operator {
   // corresponding spilled data on disk.
   std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
 
+  // The spill partition id for the currently restoring input partition,
+  // corresponding to 'spillInputReader_'. Not set if hash probe hasn't spilled
+  // yet.
+  std::optional<SpillPartitionId> restoringPartitionId_;
+
   // Sets to true after read all the probe inputs from 'spillInputReader_'.
   bool noMoreSpillInput_{false};
 

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -135,6 +135,10 @@ class RowNumber : public Operator {
   // Used to restore previously spilled input.
   std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
 
+  // The spill partition id for the currently restoring partition, corresponding
+  // to 'spillInputReader_'. Not set if row number hasn't spilled yet.
+  std::optional<SpillPartitionId> restoringPartitionId_;
+
   SpillPartitionSet spillInputPartitionSet_;
 
   // Used to calculate the spill partition numbers of the inputs.
@@ -153,6 +157,7 @@ class RowNumberHashTableSpiller : public SpillerBase {
 
   RowNumberHashTableSpiller(
       RowContainer* container,
+      std::optional<SpillPartitionId> parentId,
       RowTypePtr rowType,
       HashBitRange bits,
       const common::SpillConfig* spillConfig,

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -197,61 +197,80 @@ class FileSpillBatchStream : public BatchStream {
 };
 
 /// Identifies a spill partition generated from a given spilling operator. It
-/// consists of partition start bit offset and the actual partition number.
-/// The start bit offset is used to calculate the partition number of spill
-/// data. It is required for the recursive spilling handling as we advance the
-/// start bit offset when we go to the next level of recursive spilling.
+/// provides with informattion on spill level and the partition number of each
+/// spill level. When recursive spilling happens, there will be more than one
+/// spill level.
 ///
 /// NOTE: multiple shards created from the same SpillPartition by split()
 /// will share the same id.
 class SpillPartitionId {
  public:
-  SpillPartitionId(uint8_t partitionBitOffset, int32_t partitionNumber)
-      : partitionBitOffset_(partitionBitOffset),
-        partitionNumber_(partitionNumber) {}
+  /// Maximum spill level supported by 'SpillPartitionId'.
+  static constexpr uint32_t kMaxSpillLevel{3};
 
-  bool operator==(const SpillPartitionId& other) const {
-    return std::tie(partitionBitOffset_, partitionNumber_) ==
-        std::tie(other.partitionBitOffset_, other.partitionNumber_);
-  }
+  /// Maximum number of partitions per spill level supported by
+  /// 'SpillPartitionId'.
+  static constexpr uint32_t kMaxPartitionNum{8};
 
-  bool operator!=(const SpillPartitionId& other) const {
-    return !(*this == other);
-  }
+  /// Constructs a root spill level id.
+  explicit SpillPartitionId(uint32_t partitionNumber);
+
+  /// Constructs a child spill level id, descending from provided 'parent'.
+  SpillPartitionId(SpillPartitionId parent, uint32_t partitionNumber);
+
+  bool operator==(const SpillPartitionId& other) const;
+
+  bool operator!=(const SpillPartitionId& other) const;
 
   /// Customize the compare operator for recursive spilling control. It
-  /// ensures the partition with higher partition bit is handled prior than
-  /// one with lower partition bit. With the same partition bit, the one with
-  /// smaller partition number is handled first. We put all spill partitions
-  /// in an ordered map sorted based on the partition id. The recursive
-  /// spilling will advance the partition start bit when go to the next level
-  /// of recursive spilling.
-  bool operator<(const SpillPartitionId& other) const {
-    if (partitionBitOffset_ != other.partitionBitOffset_) {
-      return partitionBitOffset_ > other.partitionBitOffset_;
-    }
-    return partitionNumber_ < other.partitionNumber_;
-  }
+  /// ensures the partition with higher partition bit (deeper spill level) is
+  /// handled prior than one with lower partition bit (lower spill level). With
+  /// the same partition bit, the one with smaller partition number is handled
+  /// first. We put all spill partitions in an ordered map sorted based on the
+  /// partition id. The recursive spilling will advance the partition start bit
+  /// when go to the next level of recursive spilling.
+  bool operator<(const SpillPartitionId& other) const;
 
   bool operator>(const SpillPartitionId& other) const {
     return (*this != other) && !(*this < other);
   }
 
-  std::string toString() const {
-    return fmt::format("[{},{}]", partitionBitOffset_, partitionNumber_);
-  }
+  std::string toString() const;
 
-  uint8_t partitionBitOffset() const {
-    return partitionBitOffset_;
-  }
+  uint32_t spillLevel() const;
 
-  int32_t partitionNumber() const {
-    return partitionNumber_;
-  }
+  /// Returns the partition number of the current spill level.
+  uint32_t partitionNumber() const;
+
+  /// Overloaded method that returns the partition number of the requested spill
+  /// level.
+  uint32_t partitionNumber(uint32_t spillLevel) const;
+
+  uint32_t encodedId() const;
 
  private:
-  uint8_t partitionBitOffset_{0};
-  int32_t partitionNumber_{0};
+  // Number of bits to represent one spill level, details see 'encodedId_'.
+  static constexpr uint8_t kNumPartitionBits = 3;
+  static constexpr uint8_t kSpillLevelBitOffset = 29;
+
+  // Bit mask for the partition number of the spill level, details see
+  // 'encodedId_'
+  static constexpr uint32_t kPartitionBitMask = 0x00000007;
+
+  // Bit mask for the depth of this spill level, details see 'encodedId_'.
+  static constexpr uint32_t kSpillLevelBitMask = 0xE0000000;
+
+  // Encoded hirachical spill partition id. Below shows the layout from the low
+  // bits.
+  //   <LSB>
+  //   (0 ~ 2 bits): Represents the partition number at the 1st level.
+  //   (3 ~ 5 bits): Represents the partition number at the 2nd level.
+  //   (6 ~ 8 bits): Represents the partition number at the 3rd level.
+  //   (9 ~ 11 bits): Represents the partition number at the 4th level.
+  //   (12 ~ 28 bits): Unused
+  //   (29 ~ 31 bits): Represents the current spill level.
+  //   <MSB>
+  uint32_t encodedId_{0};
 };
 
 inline std::ostream& operator<<(std::ostream& os, SpillPartitionId id) {
@@ -279,6 +298,10 @@ class SpillPartition {
       size_ += file.size;
       files_.push_back(std::move(file));
     }
+  }
+
+  SpillFiles files() const {
+    return files_;
   }
 
   const SpillPartitionId& id() const {
@@ -476,6 +499,12 @@ class SpillState {
   std::vector<std::unique_ptr<SpillWriter>> partitionWriters_;
 };
 
+/// Returns the partition bit offset of the current spill level of 'id'.
+uint8_t partitionBitOffset(
+    const SpillPartitionId& id,
+    uint8_t startPartitionBitOffset,
+    uint8_t numPartitionBits);
+
 /// Generate partition id set from given spill partition set.
 SpillPartitionIdSet toSpillPartitionIdSet(
     const SpillPartitionSet& partitionSet);
@@ -515,9 +544,9 @@ void removeEmptyPartitions(SpillPartitionSet& partitionSet);
 namespace std {
 template <>
 struct hash<::facebook::velox::exec::SpillPartitionId> {
-  size_t operator()(const ::facebook::velox::exec::SpillPartitionId& id) const {
-    return facebook::velox::bits::hashMix(
-        id.partitionBitOffset(), id.partitionNumber());
+  uint32_t operator()(
+      const ::facebook::velox::exec::SpillPartitionId& id) const {
+    return std::hash<uint32_t>()(id.encodedId());
   }
 };
 } // namespace std

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -31,6 +31,7 @@ class SpillerBase {
 
   virtual ~SpillerBase() = default;
 
+  /// Finishes the current spiller.
   void finishSpill(SpillPartitionSet& partitionSet);
 
   const HashBitRange& hashBits() const {
@@ -58,6 +59,7 @@ class SpillerBase {
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
       uint64_t maxSpillRunRows,
+      std::optional<SpillPartitionId> parentId,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
 
@@ -141,6 +143,8 @@ class SpillerBase {
 
   const uint64_t maxSpillRunRows_;
 
+  const std::optional<SpillPartitionId> parentId_;
+
   folly::Synchronized<common::SpillStats>* const spillStats_;
 
   // True if all rows of spilling partitions are in 'spillRuns_', so
@@ -195,6 +199,7 @@ class NoRowContainerSpiller : public SpillerBase {
 
   NoRowContainerSpiller(
       RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
       HashBitRange bits,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
@@ -236,6 +241,7 @@ class SortInputSpiller : public SpillerBase {
             sortCompareFlags,
             std::numeric_limits<uint64_t>::max(),
             spillConfig->maxSpillRunRows,
+            std::nullopt,
             spillConfig,
             spillStats) {}
 

--- a/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
@@ -53,7 +53,7 @@ DEFINE_bool(enable_spill, true, "Whether to test plans with spilling enabled.");
 DEFINE_int32(
     max_spill_level,
     -1,
-    "Max spill level, -1 means random [0, 7], otherwise the actual level.");
+    "Max spill level, -1 means random [0, 3], otherwise the actual level.");
 
 DEFINE_bool(
     enable_oom_injection,
@@ -257,7 +257,7 @@ void RowNumberFuzzerBase::testPlan(
   if (FLAGS_enable_spill) {
     LOG(INFO) << "Testing plan #" << testNumber << " with spilling";
     const auto fuzzMaxSpillLevel =
-        FLAGS_max_spill_level == -1 ? randInt(0, 7) : FLAGS_max_spill_level;
+        FLAGS_max_spill_level == -1 ? randInt(0, 3) : FLAGS_max_spill_level;
     actual = execute(
         plan,
         pool_,

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2411,14 +2411,14 @@ TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
       .referenceQuery(
           "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t.t_k0 = u.u_k0")
       .maxSpillLevel(-1)
-      .config(core::QueryConfig::kSpillStartPartitionBit, "48")
+      .config(core::QueryConfig::kSpillStartPartitionBit, "51")
       .config(core::QueryConfig::kSpillNumPartitionBits, "3")
       .checkSpillStats(false)
       .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
         if (!hasSpill) {
           return;
         }
-        ASSERT_EQ(maxHashBuildSpillLevel(*task), 4);
+        ASSERT_EQ(maxHashBuildSpillLevel(*task), 3);
       })
       .run();
 }

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -46,7 +46,7 @@ void JoinSpillInputBenchmarkBase::setUp() {
   spillConfig.fileCreateConfig = {};
 
   spiller_ = std::make_unique<NoRowContainerSpiller>(
-      rowType_, HashBitRange{29, 29}, &spillConfig, &spillStats_);
+      rowType_, std::nullopt, HashBitRange{29, 29}, &spillConfig, &spillStats_);
   dynamic_cast<NoRowContainerSpiller*>(spiller_.get())
       ->setPartitionsSpilled({0});
 }


### PR DESCRIPTION
Summary: This change allows SpillPartitionId to support recursive spilling history. The partition bit offset is moved out of the class as it could be obtained from a simple computation give static information of start partition bit offset and spill level.

Differential Revision: D73193720


