### PR TITLE
fix: Ensure enough space in column reader values buffer when encoding dictionary with small values

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -226,7 +226,7 @@ class SelectiveColumnReader {
 
   template <typename T>
   T* mutableValues(int32_t size) {
-    DCHECK(values_->capacity() >= (numValues_ + size) * sizeof(T));
+    VELOX_DCHECK_GE(values_->capacity(), (numValues_ + size) * sizeof(T));
     return reinterpret_cast<T*>(rawValues_) + numValues_;
   }
 
@@ -457,7 +457,7 @@ class SelectiveColumnReader {
   static constexpr uint32_t kRowGroupNotSet = ~0;
 
   template <typename T>
-  void ensureValuesCapacity(vector_size_t numRows);
+  void ensureValuesCapacity(vector_size_t numRows, bool preserveData = false);
 
   // Prepares the result buffer for nulls for reading 'rows'. Leaves
   // 'extraSpace' bits worth of space in the nulls buffer.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/159

Although we do not use column reader values buffer to store the indices in the
`DictionaryEncoding` decoder, the fast path in nested decoders of indices can
use it, so need to ensure it can hold the indices.

Differential Revision: D73217953


