### PR TITLE
Fix `-Wambiguous-reversed-operator` in velox/core/Expressions.h + 1

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -590,15 +590,21 @@ class LambdaTypedExpr : public ITypedExpr {
       const ITypedExprVisitor& visitor,
       ITypedExprVisitorContext& context) const override;
 
+  friend bool operator==(
+      const LambdaTypedExpr& lhs,
+      const LambdaTypedExpr& rhs) {
+    if (*lhs.type() != *rhs.type()) {
+      return false;
+    }
+    return lhs.signature_ == rhs.signature_ && lhs.body_ == rhs.body_;
+  }
+
   bool operator==(const ITypedExpr& other) const override {
     const auto* casted = dynamic_cast<const LambdaTypedExpr*>(&other);
     if (!casted) {
       return false;
     }
-    if (*casted->type() != *this->type()) {
-      return false;
-    }
-    return *signature_ == *casted->signature_ && *body_ == *casted->body_;
+    return *this == *casted;
   }
 
   folly::dynamic serialize() const override;


### PR DESCRIPTION
Summary:
`-Wambiguous-reversed-operator` warns about ambiguous reversed operators, e.g. `a < b` and `b > a` are both valid. Such operators are disallowed in C++20. This codemod fixes the warnings.

#buildsonlynotests - If this diff compiles, it works.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D73132753


