### PR TITLE
fix: Correct typos and grammar in velox/expression files

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -491,7 +491,8 @@ VectorPtr CastExpr::applyArray(
   // that are not selected.
   BufferPtr sizes = input->sizes();
   if (newElements->isConstantEncoding()) {
-    // If the newElements is encoded as constant, we extend its size since that is cheap.
+    // If the newElements is encoded as constant, we extend its size since that
+    // is cheap.
     newElements->resize(input->elements()->size());
   } else if (newElements->size() < input->elements()->size()) {
     sizes =

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -93,7 +93,7 @@ Status detail::parseDecimalComponents(
     if (withSign && pos == size - 1) {
       return Status::UserError("The exponent part only contains sign.");
     }
-    // Make sure all chars after sign are digits, as as folly::tryTo allows
+    // Make sure all chars after sign are digits, as folly::tryTo allows
     // leading and trailing whitespaces.
     for (auto i = static_cast<size_t>(withSign); i < size - pos; ++i) {
       if (!std::isdigit(s[pos + i])) {
@@ -418,7 +418,7 @@ VectorPtr CastExpr::applyMap(
   // that are not selected.
   BufferPtr sizes = input->sizes();
   if (newMapKeys->isConstantEncoding() && newMapValues->isConstantEncoding()) {
-    // We extends size since that is cheap.
+    // We extend the size since that is cheap.
     newMapKeys->resize(input->mapKeys()->size());
     newMapValues->resize(input->mapValues()->size());
   } else if (
@@ -491,7 +491,7 @@ VectorPtr CastExpr::applyArray(
   // that are not selected.
   BufferPtr sizes = input->sizes();
   if (newElements->isConstantEncoding()) {
-    // If the newElements we extends its size since that is cheap.
+    // If the newElements is encoded as constant, we extend its size since that is cheap.
     newElements->resize(input->elements()->size());
   } else if (newElements->size() < input->elements()->size()) {
     sizes =
@@ -545,7 +545,7 @@ VectorPtr CastExpr::applyRow(
   EvalErrorsPtr oldErrors;
   if (setNullInResultAtError()) {
     // We need to isolate errors that happen during the cast from previous
-    // errors since those translate to nulls, unlike exisiting errors.
+    // errors since those translate to nulls, unlike existing errors.
     context.swapErrors(oldErrors);
   }
 

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1203,7 +1203,7 @@ class GenericView : public ViewWithComparison<GenericView> {
             "castTo type is not compatible with type of vector, vector type is {}",
             type()->toString()));
 
-    // If its a primitive type, then the casted reader always exists at
+    // If it's a primitive type, then the casted reader always exists at
     // castReaders_[0], and is set in Vector readers.
     if constexpr (SimpleTypeTrait<ToType>::isPrimitiveType) {
       return reinterpret_cast<VectorReader<ToType>*>(castReaders_[0].get())

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -192,7 +192,7 @@ class ArrayWriter {
   }
 
   // Should be called by the user (VectorWriter) when null is committed to
-  // pretect against user miss-use (writing to the writer then committing null).
+  // protect against user miss-use (writing to the writer then committing null).
   void resetLength() {
     // No need to commit last written items and innerOffset_ stays the same for
     // the next item.
@@ -210,7 +210,7 @@ class ArrayWriter {
     length_ = size;
   }
 
-  // Functions below provide an std::like interface, and are enabled only when
+  // Functions below provide a std::like interface, and are enabled only when
   // the array element is primitive that is not string or bool.
 
   void push_back(element_t value) {
@@ -254,7 +254,7 @@ class ArrayWriter {
     add_items(data);
   }
 
-  // Don't mutate elementVecotr_ through this API unless you know what you're
+  // Don't mutate elementVector_ through this API unless you know what you're
   // doing.
   // This function returns the base of elements vector and the elements vector
   // itself.
@@ -622,11 +622,11 @@ class MapWriter {
     return length_;
   }
 
-  // Any map type iteratable in tuple like manner.
+  // Any map type iterable in tuple like manner.
   template <typename MapType>
   void copy_from(const MapType& data) {
     resize(0);
-    // TODO: acceletare this with memcpy.
+    // TODO: accelerate this with memcpy.
     for (const auto& [key, value] : data) {
       auto [keyWriter, valueWriter] = add_item();
       // copy key
@@ -650,7 +650,7 @@ class MapWriter {
       const typename VectorExec::template resolver<Map<K, V>>::in_type&
           mapView) {
     resize(0);
-    // TODO: acceletare this with memcpy.
+    // TODO: accelerate this with memcpy.
     for (const auto& [key, value] : mapView) {
       if (value.has_value()) {
         auto [keyWriter, valueWriter] = add_item();
@@ -736,7 +736,7 @@ class MapWriter {
   }
 
   // Should be called by the user (VectorWriter) when null is committed to
-  // pretect against user miss-use (writing to the writer then committing
+  // protect against user miss-use (writing to the writer then committing
   // null).
   void resetLength() {
     // No need to commit last written items and innerOffset_ stays the same

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -367,7 +367,7 @@ void EvalCtx::addNulls(
     EvalCtx& context,
     const TypePtr& type,
     VectorPtr& result) {
-  // If there's no `result` yet, return a NULL ContantVector.
+  // If there's no `result` yet, return a NULL ConstantVector.
   if (!result) {
     result = BaseVector::createNullConstant(type, rows.end(), context.pool());
     return;

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -417,7 +417,7 @@ class EvalCtx {
     return isFinalSelection_;
   }
 
-  // True if the operands will not be evaluated on rows outside of the
+  // True if the operands will not be evaluated on rows outside the
   // current SelectivityVector. For example, true for top level
   // projections or conjuncts of a top level AND. False for then and
   // else of an IF.
@@ -521,7 +521,7 @@ class EvalCtx {
 
   /// Returns true if dictionary memoization optimization is enabled, which
   /// allows the reuse of results between consecutive input batches if they are
-  /// dictionary encoded and have the same alphabet(undelying flat vector).
+  /// dictionary encoded and have the same alphabet(underlying flat vector).
   bool dictionaryMemoizationEnabled() const {
     return execCtx_->optimizationParams().dictionaryMemoizationEnabled;
   }
@@ -552,7 +552,7 @@ class EvalCtx {
   void ensureErrorsVectorSize(EvalErrorsPtr& errors, vector_size_t size) const;
 
   // Updates 'errorPtr' to clear null at 'index' to indicate an error has
-  // occured without specifying error details.
+  // occurred without specifying error details.
   void addError(vector_size_t index, EvalErrorsPtr& errorsPtr) const;
 
   // Copy error from 'from' at index 'fromIndex' to 'to' at index 'toIndex'.
@@ -588,7 +588,7 @@ class EvalCtx {
   // True if the current set of rows will not grow, e.g. not under and IF or OR.
   bool isFinalSelection_{true};
 
-  // If isFinalSelection_ is false, the set of rows for the upper-most IF or
+  // If isFinalSelection_ is false, the set of rows for the uppermost IF or
   // OR. Used to determine the set of rows for loading lazy vectors.
   const SelectivityVector* finalSelection_;
 
@@ -600,7 +600,7 @@ class EvalCtx {
 
 /// Utility wrapper struct that is used to temporarily reset the value of the
 /// EvalCtx. EvalCtx::saveAndReset() is used to achieve that. Use
-/// withContextSaver to ensure the original context is restored on a scucessful
+/// withContextSaver to ensure the original context is restored on a successful
 /// run or call EvalContext::restore to do it manually.
 struct ContextSaver {
   // The context to restore. nullptr if nothing to restore.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -454,7 +454,7 @@ void Expr::evalSimplified(
     removeSureNulls(rows, context, nonNullHolder);
   }
 
-  // If the initial non null holder couldn't be created, start with the input
+  // If the initial non-null holder couldn't be created, start with the input
   // `rows`.
   auto* remainingRows = nonNullHolder.get() ? nonNullHolder.get() : &rows;
 
@@ -979,7 +979,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
 
   // Use finalSelection to generate peel to ensure those rows can be
   // translated and ensure consistent peeling across multiple calls to this
-  // expression if its a shared subexpression.
+  // expression if it's a shared subexpression.
   const auto& rowsToPeel =
       context.isFinalSelection() ? rows : *context.finalSelection();
   [[maybe_unused]] auto numFields = context.row()->childrenSize();
@@ -1182,7 +1182,7 @@ void Expr::evalWithNulls(
 // Optimization that attempts to cache results for inputs that are dictionary
 // encoded and use the same base vector between subsequent input batches.
 // Since this hold onto a reference to the base vector and the cached results,
-// it can be memory intensive. Therefore in order to reduce this consumption
+// it can be memory intensive. Therefore, in order to reduce this consumption
 // and ensure it is only employed for cases where it can be useful, it only
 // starts caching result after it encounters the same base at least twice.
 void Expr::evalWithMemo(
@@ -1301,7 +1301,7 @@ void computeIsAsciiForInputs(
     indices.push_back(index);
   }
 
-  // Compute string encoding for input vectors at indicies.
+  // Compute string encoding for input vectors at indices.
   for (auto& index : indices) {
     // Some arguments are optional and hence may not exist. And some
     // functions operate on dynamic types, but we only scan them when the

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -169,7 +169,7 @@ class Expr {
   ///
   /// @param parentExprSet pointer to the parent ExprSet which is calling
   /// evaluate on this expression. Should only be set for top level expressions
-  /// and not passed on to child expressions as it is ssed to setup exception
+  /// and not passed on to child expressions as it is ssed to set up exception
   /// context.
   void eval(
       const SelectivityVector& rows,
@@ -188,7 +188,7 @@ class Expr {
   ///
   /// @param parentExprSet pointer to the parent ExprSet which is calling
   /// evaluate on this expression. Should only be set for top level expressions
-  /// and not passed on to child expressions as it is ssed to setup exception
+  /// and not passed on to child expressions as it is ssed to set up exception
   /// context.
   void evalFlatNoNulls(
       const SelectivityVector& rows,
@@ -463,7 +463,7 @@ class Expr {
       VectorPtr& result);
 
   // Checks 'inputValues_' for peelable wrappers (constants,
-  // dictionaries etc) and applies the function of 'this' to distinct
+  // dictionaries etc.) and applies the function of 'this' to distinct
   // values as opposed to all values. Wraps the return value into a
   // dictionary or constant so that we get the right
   // cardinality. Returns true if the function was called. Returns
@@ -538,7 +538,7 @@ class Expr {
   // error and a subsequent argument has a null for the same row the
   // error is masked and the row is removed from 'rows'. If
   // 'context.throwOnError()' is true, an error in arguments that is
-  // not cancelled by a null will be thrown. Otherwise the errors
+  // not cancelled by a null will be thrown. Otherwise, the errors
   // found in arguments are left in place and added to errors that may
   // have been in 'context' on entry. The rows where an argument had a
   // null or error are removed from 'rows' at before returning. If
@@ -599,7 +599,7 @@ class Expr {
   std::vector<FieldReference*> distinctFields_;
 
   // Fields referenced by multiple inputs, which is subset of distinctFields_.
-  // Used to determine pre-loading of lazy vectors at current expr.
+  // Used to determine preloading of lazy vectors at current expr.
   std::unordered_set<FieldReference*> multiplyReferencedFields_;
 
   // True if a null in any of 'distinctFields_' causes 'this' to be
@@ -684,7 +684,7 @@ class Expr {
   /// Runtime statistics. CPU time, wall time and number of processed rows.
   ExprStats stats_;
 
-  // If true computeMetaData returns, otherwise meta data is computed and the
+  // If true computeMetaData returns, otherwise metadata is computed and the
   // flag is set to true.
   bool metaDataComputed_ = false;
 

--- a/velox/expression/FunctionCallToSpecialForm.h
+++ b/velox/expression/FunctionCallToSpecialForm.h
@@ -30,7 +30,7 @@ class FunctionCallToSpecialForm {
   /// arguments, e.g. Try.
   virtual TypePtr resolveType(const std::vector<TypePtr>& argTypes) = 0;
 
-  /// Given the output Type, the child expresssions, and whether or not to track
+  /// Given the output Type, the child expressions, and whether or not to track
   /// CPU usage, returns the SpecialForm.
   virtual ExprPtr constructSpecialForm(
       const TypePtr& type,
@@ -47,7 +47,7 @@ TypePtr resolveTypeForSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
-/// Returns the SpeicalForm associated with the functionName.  If functionName
+/// Returns the SpecialForm associated with the functionName.  If functionName
 /// is not the name of a known SpecialForm, returns nulltpr.
 ExprPtr constructSpecialForm(
     const std::string& functionName,
@@ -56,7 +56,7 @@ ExprPtr constructSpecialForm(
     bool trackCpuUsage,
     const core::QueryConfig& config);
 
-/// Returns true iff a FunctionCallToSpeicalForm object has been registered for
+/// Returns true iff a FunctionCallToSpecialForm object has been registered for
 /// the given functionName.
 bool isFunctionCallToSpecialFormRegistered(const std::string& functionName);
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionMetadata.h
+++ b/velox/expression/FunctionMetadata.h
@@ -32,7 +32,7 @@ struct VectorFunctionMetadata {
   /// type.
   bool supportsFlattening{false};
 
-  /// True if the function is deterministic, e.g given same inputs always
+  /// True if the function is deterministic, e.g. given same inputs always
   /// returns same result.
   bool deterministic{true};
 

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -158,7 +158,7 @@ void validate(
     validateBaseTypeAndCollectTypeParams(variables, arg, usedVariables, false);
   }
 
-  // All type variables should apear in the inputs arguments.
+  // All type variables should appear in the inputs arguments.
   for (auto& [name, variable] : variables) {
     if (variable.isTypeParameter()) {
       VELOX_USER_CHECK(
@@ -189,13 +189,13 @@ SignatureVariable::SignatureVariable(
     ParameterType type,
     bool knownTypesOnly,
     bool orderableTypesOnly,
-    bool comaprableTypesOnly)
+    bool comparableTypesOnly)
     : name_{std::move(name)},
       constraint_(constraint.has_value() ? std::move(constraint.value()) : ""),
       type_{type},
       knownTypesOnly_(knownTypesOnly),
       orderableTypesOnly_(orderableTypesOnly),
-      comparableTypesOnly_(comaprableTypesOnly) {
+      comparableTypesOnly_(comparableTypesOnly) {
   VELOX_CHECK(
       !(knownTypesOnly_ || orderableTypesOnly_ || comparableTypesOnly_) ||
           isTypeParameter(),
@@ -352,7 +352,7 @@ AggregateFunctionSignatureBuilder::comparableTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ false,
           /*orderableTypesOnly*/ false,
-          /*comaprableTypesOnly*/ true));
+          /*comparableTypesOnly*/ true));
   return *this;
 }
 

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -345,7 +345,7 @@ class FunctionSignatureBuilder {
   bool variableArity_{false};
 };
 
-/// Convenience class for creating AggregageFunctionSignature instances.
+/// Convenience class for creating AggregateFunctionSignature instances.
 /// Example of usage:
 ///
 ///     - signature of covar_samp aggregate function: (double, double) ->

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -139,8 +139,8 @@ class ExprCallable : public Callable {
   RowTypePtr signature_;
   RowVectorPtr capture_;
   std::shared_ptr<Expr> body_;
-  // List of Shared Exprs that are descendants of 'body_' for which reset() needs
-  // to be called before calling `body_->eval()`.
+  // List of Shared Exprs that are descendants of 'body_' for which reset()
+  // needs to be called before calling `body_->eval()`.
   std::vector<std::shared_ptr<Expr>> sharedExprsToReset_;
 };
 

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -139,7 +139,7 @@ class ExprCallable : public Callable {
   RowTypePtr signature_;
   RowVectorPtr capture_;
   std::shared_ptr<Expr> body_;
-  // List of Shared Exprs that are decendants of 'body_' for which reset() needs
+  // List of Shared Exprs that are descendants of 'body_' for which reset() needs
   // to be called before calling `body_->eval()`.
   std::vector<std::shared_ptr<Expr>> sharedExprsToReset_;
 };

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -175,7 +175,7 @@ bool SignatureBinderBase::tryBind(
     VELOX_CHECK(variable.isTypeParameter(), "Not expecting integer variable");
 
     if (typeVariablesBindings_.count(baseName)) {
-      // If the the variable type is already mapped to a concrete type, make
+      // If the variable type is already mapped to a concrete type, make
       // sure the mapped type is equivalent to the actual type.
       return typeVariablesBindings_[baseName]->equivalent(*actualType);
     }

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -37,7 +37,7 @@ class SignatureBinderBase {
     return signature_.variables();
   }
 
-  /// The funcion signature we are trying to bind.
+  /// The function signature we are trying to bind.
   const exec::FunctionSignature& signature_;
 
   /// Record concrete types that are bound to type variables.

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -126,7 +126,7 @@ class SimpleFunctionAdapter : public VectorFunction {
       if constexpr (isVariadicType<arg_at<Is>>::value) {
         return true;
       } else if constexpr (!isArgFlatConstantFastPathEligible<Is>) {
-        return true; // We only want to check the encodings of primtive
+        return true; // We only want to check the encodings of primitive
                      // arguments if any exists.
       } else {
         return args[Is]->isFlatEncoding() || args[Is]->isConstantEncoding();
@@ -153,7 +153,7 @@ class SimpleFunctionAdapter : public VectorFunction {
 
   /// When true, a fast path for each possible combination of encodings will be
   /// used for reading arguments when all arguments are flat or constant
-  /// primitivies.
+  /// primitives.
   static constexpr bool specializeForAllEncodings = FUNC::num_args <= 3;
 
   /// If the initialize() method provided by functions throw, we don't (can't)
@@ -185,7 +185,7 @@ class SimpleFunctionAdapter : public VectorFunction {
 
       if constexpr (return_type_traits::isPrimitiveType) {
         // Avoid checking mutability during initialization.
-        // EnsureWritable gurantees uniqueness and mutability hence if
+        // EnsureWritable guarantees uniqueness and mutability hence if
         // valuesAsVoid()!= nullptr, then values is writable.
         resultWriter.init(*result, result->valuesAsVoid());
       } else {
@@ -361,8 +361,8 @@ class SimpleFunctionAdapter : public VectorFunction {
     // null buffer during iteration).
 
     if constexpr (fastPathIteration) {
-      // If result is resuing one of the inputs we do not clear nulls, instead
-      // we do that after the the input is read. It is safe because reuse only
+      // If result is reusing one of the inputs we do not clear nulls, instead
+      // we do that after the input is read. It is safe because reuse only
       // happens when the function does not generate null.
       if (!isResultReused) {
         (*reusableResult)->clearNulls(rows);
@@ -384,7 +384,7 @@ class SimpleFunctionAdapter : public VectorFunction {
     }
 
     if constexpr (fastPathIteration) {
-      // If result is resued and function is is_default_null_behavior then we do
+      // If result is reused and function is is_default_null_behavior then we do
       // not need to clear nulls.
       if constexpr (!FUNC::is_default_null_behavior) {
         if (isResultReused) {
@@ -672,7 +672,7 @@ class SimpleFunctionAdapter : public VectorFunction {
           }
         }
         applyContext.applyToSelectedNoThrow([&](auto row) INLINE_LAMBDA {
-          // Passing a stack variable have shown to be boost the performance
+          // Passing a stack variable has shown to boost the performance
           // of functions that repeatedly update the output. The opposite
           // optimization (eliminating the temp) is easier to do by the
           // compiler (assuming the function call is inlined).
@@ -772,7 +772,7 @@ class SimpleFunctionAdapter : public VectorFunction {
 
   // For default null behavior, assume everything is not null.
   // If anything is, return false.
-  // Otherwise pass all arguments as references or copies.
+  // Otherwise, pass all arguments as references or copies.
   template <
       size_t POSITION,
       typename R0,

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -146,7 +146,7 @@ class AlwaysFailingVectorFunction final : public VectorFunction {
   std::exception_ptr exceptionPtr_;
 };
 
-// This functions is used when we know a function will never be called because
+// This function is used when we know a function will never be called because
 // it is default null with a literal null input value. For example like(c0,
 // null).
 class ApplyNeverCalled final : public VectorFunction {
@@ -214,7 +214,7 @@ getVectorFunctionWithMetadata(
 
 /// Registers stateless VectorFunction. The same instance will be used for all
 /// expressions.
-/// Returns true iff an new function is inserted
+/// Returns true iff a new function is inserted
 bool registerVectorFunction(
     const std::string& name,
     std::vector<FunctionSignaturePtr> signatures,

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -62,7 +62,7 @@ struct VectorWriter : public VectorWriterBase {
 
   void copyCommit(const exec_out_t& data) {
     // this code path is called for copying nested structures to slices
-    // in future, we want to eliminate this so all writes go directly to their
+    // in the future, we want to eliminate this so all writes go directly to their
     // slice.
     data_[offset_] = data;
     vector_->setNull(offset_, false);

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -61,9 +61,9 @@ struct VectorWriter : public VectorWriterBase {
   }
 
   void copyCommit(const exec_out_t& data) {
-    // this code path is called for copying nested structures to slices
-    // in the future, we want to eliminate this so all writes go directly to their
-    // slice.
+    // This code path is called for copying nested structures to slices.
+    // In the future, we want to eliminate this so all writes go directly to
+    // their slice.
     data_[offset_] = data;
     vector_->setNull(offset_, false);
   }
@@ -73,7 +73,7 @@ struct VectorWriter : public VectorWriterBase {
   }
 
   void commit(bool isSet) override {
-    // this code path is called when the slice is top-level
+    // This code path is called when the slice is top-level.
     if (!isSet) {
       vector_->setNull(offset_, true);
     } else {
@@ -569,7 +569,7 @@ struct VectorWriter<Generic<T, comparable, orderable>>
     }
     // No need to call finalizeNull here since commitNull will call it in
     // castType_ is true.
-    // otherwse there is nothing to do.
+    // Otherwise, there is nothing to do.
   }
 
   // User can only add values after casting a generic writer to an actual type.


### PR DESCRIPTION
Summary
This PR corrects spelling and grammatical errors specifically within the code comments in the `velox/expression` directory (excluding subdirectories). This enhances the clarity and readability of the codebase.