### PR TITLE
fix: Fix the right join result mismatch issue

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -861,31 +861,32 @@ RowVectorPtr MergeJoin::getOutput() {
   }
 }
 
-std::pair<bool, RowVectorPtr> MergeJoin::handleRightSideNullRows() {
-  auto rightFirstNonNullIndex = firstNonNull(rightInput_, rightKeyChannels_);
+RowVectorPtr MergeJoin::handleRightSideNullRows() {
+  const auto rightFirstNonNullIndex =
+      firstNonNull(rightInput_, rightKeyChannels_);
   if ((isRightJoin(joinType_) || isFullJoin(joinType_)) &&
       rightFirstNonNullIndex > rightRowIndex_) {
     if (prepareOutput(nullptr, rightInput_)) {
       output_->resize(outputSize_);
-      return std::make_pair(true, std::move(output_));
+      return std::move(output_);
     }
-    for (int i = rightRowIndex_; i < rightFirstNonNullIndex; i++) {
+    for (int i = rightRowIndex_; i < rightFirstNonNullIndex; ++i) {
       if (!tryAddOutputRowForRightJoin()) {
         rightRowIndex_ = i;
-        return std::make_pair(true, std::move(output_));
+        return std::move(output_);
       }
 
       if (finishedRightBatch()) {
         // Ran out of rows on the right side.
         rightInput_ = nullptr;
-        return std::make_pair(true, nullptr);
+        return nullptr;
       }
     }
 
     rightRowIndex_ = rightFirstNonNullIndex;
   }
 
-  return std::make_pair(false, nullptr);
+  return nullptr;
 }
 
 RowVectorPtr MergeJoin::doGetOutput() {
@@ -1087,10 +1088,11 @@ RowVectorPtr MergeJoin::doGetOutput() {
     return nullptr;
   }
 
-  auto pair = handleRightSideNullRows();
-  if (pair.first) {
-    return pair.second;
+  const auto output = handleRightSideNullRows();
+  if (output != nullptr || rightInput_ == nullptr) {
+    return output;
   }
+  VELOX_CHECK_NOT_NULL(rightInput_);
 
   // Look for a new match starting with index_ row on the left and rightIndex_
   // row on the right.

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -75,6 +75,9 @@ class MergeJoin : public Operator {
       const RowTypePtr& leftType,
       const RowTypePtr& rightType);
 
+  // Advances handling of null rows on the right side for right and full joins.
+  std::pair<bool, RowVectorPtr> handleRightSideNullRows();
+
   RowVectorPtr doGetOutput();
 
   static int32_t compare(

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -75,8 +75,9 @@ class MergeJoin : public Operator {
       const RowTypePtr& leftType,
       const RowTypePtr& rightType);
 
-  // Advances handling of null rows on the right side for right and full joins.
-  std::pair<bool, RowVectorPtr> handleRightSideNullRows();
+  // The handling of null rows on the right side for right and full type of
+  // joins.
+  RowVectorPtr handleRightSideNullRows();
 
   RowVectorPtr doGetOutput();
 


### PR DESCRIPTION
```
left    right
null    null
null    null
3       3
```

When performing a right join operation using above data, if we directly set rightRowIndex_ to 0 [here](https://github.com/facebookincubator/velox/pull/13039/files#diff-8279da91a596a4b97a73bc4d9aa635da1baaf254dcdb2f7f8049bd21e7a9551eL833), it will result in all final outcomes being empty in left side. This is because during the comparison process, the first value of the right input is null, leading to a comparison result of -1 consistently. Consequently, all the left-side data will be fully traversed, and the input will be set to null columns, resulting in the final output returning only the right-side columns, with all left-side columns set to null. And this PR addresses the above issue by skipping the null row index prior to comparing the results.