### PR TITLE
feat: Add Spark luhn_check function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -192,6 +192,17 @@ String Functions
 
         SELECT ltrim('ps', 'spark'); -- "ark"
 
+.. spark:function:: luhn_check(string) -> boolean
+
+    Returns true if ``string`` passes the Luhn algorithm check. Otherwise, returns false.
+    The Luhn algorithm is a simple check digit formula used to validate a variety of identification numbers,
+    defined in US patent 2950048A.
+    Returns NULL if ``string`` is NULL. ::
+
+        SELECT luhn_check('4111111111111111'); -- true
+        SELECT luhn_check('378282246310006'); -- false
+        SELECT luhn_check(NULL); -- NULL
+
 .. spark:function:: mask(string[, upperChar, lowerChar, digitChar, otherChar]) -> string
 
     Returns a masked version of the input ``string``.

--- a/velox/functions/sparksql/LuhnCheckFunction.h
+++ b/velox/functions/sparksql/LuhnCheckFunction.h
@@ -17,8 +17,6 @@
 
 #include "velox/functions/Macros.h"
 
-#include <glog/logging.h>
-
 namespace facebook::velox::functions::sparksql {
 
 /// luhn_check(input) -> boolean

--- a/velox/functions/sparksql/LuhnCheckFunction.h
+++ b/velox/functions/sparksql/LuhnCheckFunction.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+#include <glog/logging.h>
+
+namespace facebook::velox::functions::sparksql {
+
+/// luhn_check(input) -> boolean
+///
+/// Checks if a given number string is a valid Luhn number.
+template <typename T>
+struct LuhnCheckFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<Varchar>& input) {
+    // Empty string is not a valid Luhn number.
+    if (input.empty()) {
+      result = false;
+      return;
+    }
+
+    int32_t checkSum = 0;
+    bool isSecond = false;
+
+    for (auto it = input.end(); it != input.begin();) {
+      --it;
+      if (!std::isdigit(*it)) {
+        result = false;
+        return;
+      }
+
+      const int digit = *it - '0';
+      // Double the digit if it's the second digit in the sequence.
+      const int doubled = isSecond ? digit * 2 : digit;
+      // Add the two digits of the doubled number to the sum.
+      checkSum += doubled % 10 + doubled / 10;
+      // Toggle the isSecond flag for the next iteration.
+      isSecond = !isSecond;
+    }
+
+    // Keep checkSum as int32_t as Apache Spark. Just log a warning if it
+    // overflows.
+    if (checkSum < 0) {
+      LOG(WARNING) << "Arithmetic overflow with checkSum: " << checkSum;
+    }
+    // Check if the final sum is divisible by 10.
+    result = checkSum % 10 == 0;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/LuhnCheckFunction.h
+++ b/velox/functions/sparksql/LuhnCheckFunction.h
@@ -51,16 +51,11 @@ struct LuhnCheckFunction {
       // Double the digit if it's the second digit in the sequence.
       const int doubled = isSecond ? digit * 2 : digit;
       // Add the two digits of the doubled number to the sum.
-      checkSum += doubled % 10 + doubled / 10;
+      checkSum = checkedPlus<int32_t>(checkSum, doubled % 10 + doubled / 10);
       // Toggle the isSecond flag for the next iteration.
       isSecond = !isSecond;
     }
 
-    // Keep checkSum as int32_t as Apache Spark. Just log a warning if it
-    // overflows.
-    if (checkSum < 0) {
-      LOG(WARNING) << "Arithmetic overflow with checkSum: " << checkSum;
-    }
     // Check if the final sum is divisible by 10.
     result = checkSum % 10 == 0;
   }

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/prestosql/URLFunctions.h"
 #include "velox/functions/sparksql/ConcatWs.h"
+#include "velox/functions/sparksql/LuhnCheckFunction.h"
 #include "velox/functions/sparksql/MaskFunction.h"
 #include "velox/functions/sparksql/Split.h"
 #include "velox/functions/sparksql/String.h"
@@ -147,6 +148,7 @@ void registerStringFunctions(const std::string& prefix) {
   registerFunctionCallToSpecialForm(
       ConcatWsCallToSpecialForm::kConcatWs,
       std::make_unique<ConcatWsCallToSpecialForm>());
+  registerFunction<LuhnCheckFunction, bool, Varchar>({prefix + "luhn_check"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(
   JsonArrayLengthTest.cpp
   JsonObjectKeysTest.cpp
   LeastGreatestTest.cpp
+  LuhnCheckTest.cpp
   MakeDecimalTest.cpp
   MakeTimestampTest.cpp
   MapConcatTest.cpp

--- a/velox/functions/sparksql/tests/LuhnCheckTest.cpp
+++ b/velox/functions/sparksql/tests/LuhnCheckTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class LuhnCheckTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<bool> luhnCheck(const std::optional<std::string>& str) {
+    return evaluateOnce<bool>("luhn_check(c0)", str);
+  }
+};
+
+TEST_F(LuhnCheckTest, luhnCheck) {
+  EXPECT_EQ(luhnCheck("4111111111111111"), true);
+  EXPECT_EQ(luhnCheck("5500000000000004"), true);
+  EXPECT_EQ(luhnCheck("340000000000009"), true);
+  EXPECT_EQ(luhnCheck("6011000000000004"), true);
+  EXPECT_EQ(luhnCheck("6011000000000005"), false);
+  EXPECT_EQ(luhnCheck("378282246310006"), false);
+  EXPECT_EQ(luhnCheck("0"), true);
+  EXPECT_EQ(luhnCheck("4111111111111111    "), false);
+  EXPECT_EQ(luhnCheck("4111111 111111111"), false);
+  EXPECT_EQ(luhnCheck(" 4111111111111111"), false);
+  EXPECT_EQ(luhnCheck(""), false);
+  EXPECT_EQ(luhnCheck("  "), false);
+  EXPECT_EQ(luhnCheck("510B105105105106"), false);
+  EXPECT_EQ(luhnCheck("ABCDED"), false);
+  EXPECT_EQ(luhnCheck(std::nullopt), std::nullopt);
+  EXPECT_EQ(luhnCheck("6011111111111117"), true);
+  EXPECT_EQ(luhnCheck("6011111111111118"), false);
+  EXPECT_EQ(luhnCheck("123.456"), false);
+}
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
This PR adds the Spark `luhn_check` function, which checks if a given number 
string is a valid Luhn number. The Luhn algorithm is a simple check digit 
formula used to validate a variety of identification numbers, defined in US 
patent 2950048A. This function is widely applied on credit card numbers and 
government identification numbers to distinguish valid numbers from mistyped, 
incorrect numbers.

Spark implementation:  https://github.com/apache/spark/blob/e50fe86dda2ee742721fe77a3b18ed17e3e2c1da/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L3683-L3721

Fixes #13064.