### PR TITLE
feat(variant): Allow hashing opaque variants

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -866,11 +866,6 @@ uint64_t variant::hash<TypeKind::MAP>() const {
       folly::Hash{}, combinedKeyHash, combinedValueHash);
 }
 
-template <>
-uint64_t variant::hash<TypeKind::OPAQUE>() const {
-  VELOX_NYI();
-}
-
 uint64_t variant::hash() const {
   if (isNull()) {
     return folly::Hash{}(static_cast<int32_t>(kind_));
@@ -1037,3 +1032,16 @@ void variant::verifyArrayElements(const std::vector<variant>& inputs) {
 }
 
 } // namespace facebook::velox
+
+namespace folly {
+
+// For opaque values, we hash the shared_ptr<void> which will hash the
+// underlying pointer.
+template <>
+struct hasher<facebook::velox::detail::OpaqueCapsule> {
+  size_t operator()(const facebook::velox::detail::OpaqueCapsule& key) const {
+    return Hash()(key.obj);
+  }
+};
+
+} // namespace folly

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -81,6 +81,8 @@ TEST(VariantTest, opaque) {
     EXPECT_THROW(v.opaque<Bar>(), std::exception);
     EXPECT_EQ(*v.inferType(), *OPAQUE<Foo>());
   }
+
+  // Check that the expected shared ptrs are acquired.
   {
     EXPECT_EQ(1, foo.use_count());
     variant v = variant::opaque(foo);
@@ -92,6 +94,8 @@ TEST(VariantTest, opaque) {
     v = 0;
     EXPECT_EQ(1, foo.use_count());
   }
+
+  // Test opaque equality.
   {
     variant v1 = variant::opaque(foo);
     variant vv1 = variant::opaque(foo);
@@ -102,6 +106,23 @@ TEST(VariantTest, opaque) {
     EXPECT_NE(v1, v2);
     EXPECT_NE(v1, v3);
     EXPECT_NE(v1, vint);
+  }
+
+  // Test hashes. The semantic of the hash follows the object it points to
+  // (it hashes the pointer).
+  {
+    variant v1 = variant::opaque(foo);
+    variant vv1 = variant::opaque(foo);
+
+    variant v2 = variant::opaque(foo2);
+    variant v3 = variant::opaque(bar);
+
+    EXPECT_EQ(v1.hash(), vv1.hash());
+    EXPECT_NE(v1.hash(), v2.hash());
+    EXPECT_NE(vv1.hash(), v2.hash());
+
+    EXPECT_NE(v1.hash(), v3.hash());
+    EXPECT_NE(v2.hash(), v3.hash());
   }
 }
 


### PR DESCRIPTION
Summary:
Since variants are used in some parts of expression compilation,
enabling a simple hashing strategy for opaque types. To make it consistent to
other places where we hash opaque types (e.g. FlatVector::hashAll()), allowing
hashes of opaque types using the physical pointer value.

This is sufficient to generate different hashes for different objects, but it
does not give users the flexibility of providing a function that could enable
different objects that semantically represent the same concept from hashing the
same. This could be added by enabling users to provide a custom hash function
for opaque types, if the use case arrives in the future.

Differential Revision: D73265149


