### PR TITLE
fix: Fix corner case in processConstantFilterResults()

### DIFF
--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -190,15 +190,70 @@ class OperatorUtilsTest : public OperatorTestBase {
 };
 
 TEST_F(OperatorUtilsTest, processFilterResults) {
-  auto filteredResults = makeArrayVector<int64_t>({{1}});
-  SelectivityVector filterRows(1);
-  filterRows.setValid(0, false);
-  filterRows.updateBounds();
   exec::FilterEvalCtx filterEvalCtx;
-  EXPECT_EQ(
-      exec::processFilterResults(
-          filteredResults, filterRows, filterEvalCtx, pool_.get()),
-      0);
+  VectorPtr filteredResults;
+
+  // Run case is when filteredResults is a const vector with all rows
+  // selected. We should not have selected indices buffer.
+  {
+    filteredResults = makeConstant(true, 10);
+    SelectivityVector filterRows(10);
+    filterRows.setAll();
+    filterRows.updateBounds();
+    EXPECT_EQ(
+        exec::processFilterResults(
+            filteredResults, filterRows, filterEvalCtx, pool_.get()),
+        10);
+    EXPECT_EQ(nullptr, filterEvalCtx.selectedIndices);
+  }
+
+  // Run case with 50 rows with the last 10 of them valid to get large
+  // indices in the selected indices buffer.
+  {
+    SelectivityVector filterRows(50);
+    filteredResults = makeFlatVector<bool>(50, [&](vector_size_t row) {
+      filterRows.setValid(row, row >= 40);
+      return true;
+    });
+    filterRows.updateBounds();
+    EXPECT_EQ(
+        exec::processFilterResults(
+            filteredResults, filterRows, filterEvalCtx, pool_.get()),
+        10);
+    const auto* rawIndices = filterEvalCtx.selectedIndices->as<vector_size_t>();
+    EXPECT_EQ(rawIndices[0], 40);
+    EXPECT_EQ(rawIndices[9], 49);
+  }
+
+  // Run case is when filteredResults is a const vector with all rows
+  // but one selected. We check that we get back correct indices.
+  {
+    filteredResults = makeConstant(true, 10);
+    SelectivityVector filterRows(10);
+    filterRows.setAll();
+    filterRows.setValid(4, false);
+    filterRows.updateBounds();
+    EXPECT_EQ(
+        exec::processFilterResults(
+            filteredResults, filterRows, filterEvalCtx, pool_.get()),
+        9);
+    const auto* rawIndices = filterEvalCtx.selectedIndices->as<vector_size_t>();
+    EXPECT_EQ(rawIndices[0], 0);
+    EXPECT_EQ(rawIndices[3], 3);
+    EXPECT_EQ(rawIndices[4], 5);
+    EXPECT_EQ(rawIndices[8], 9);
+  }
+
+  {
+    filteredResults = makeArrayVector<int64_t>({{1}});
+    SelectivityVector filterRows(1);
+    filterRows.setValid(0, false);
+    filterRows.updateBounds();
+    EXPECT_EQ(
+        exec::processFilterResults(
+            filteredResults, filterRows, filterEvalCtx, pool_.get()),
+        0);
+  }
 }
 
 TEST_F(OperatorUtilsTest, wrapChildConstant) {


### PR DESCRIPTION
Summary:
processFilterResults() from OperatorUtils is being used in HiveDataSource to filter data coming from the SplitReader.
We call is from HiveDataSource::evaluateRemainingFilter().
Normally, it returns the number of rows remaining after running the remaining filter and also it populates indices in the filterEvalCtx_.selectedIndices.
These indices are then used to wrap child vectors of the output row vector into Dictionaries in case some rows were filtered out.

There is a corner case when HiveDataSource applies bucket conversion (which can filter some rows and then it applies the remainig filter).
In this corner case the code path does not generate the new selected indices and HiveDataSource wraps vectors using the selected indices from the previous batch, which can result in correctness issues or crashes.

We hit a corner case when all these conditions are met:
- We have bucket conversion (I don't know what it is exactly, but looks like an extra filtering per thread based on the bucketed column when only single bucket is allowed, could be to improve following aggegation performance).
- Bucket conversion did not filter out all rows (some rows passed it).
- We have remaining filter.
- For all rows in a batch which passed bucket conversion filter we have remaining filter evaluates to true, thus causing the filterResult_ encoding to be constant.

To fix the issue we adding a check in processConstantFilterResults() to see if we are reducing the selection compared to the filterResult.
If we do, then we need to fill up the selected indices.

Differential Revision: D73288408


