### PR TITLE
fix(build): Build Wave dwio tests only when enabled

### DIFF
--- a/velox/experimental/wave/dwio/decode/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-add_subdirectory(tests)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()
 
 add_library(velox_wave_decode GpuDecoder.cu)
 


### PR DESCRIPTION
If gpu is enabled, dwio/tests will be always build. This patch fixes the build behavior