### PR TITLE
fix: Change velox buffer copy and serialization interfaces to take size in i64 instead of i32

### DIFF
--- a/velox/common/base/Crc.h
+++ b/velox/common/base/Crc.h
@@ -22,7 +22,7 @@ namespace facebook::velox::bits {
 // A boost compatible CRC32 calculator.
 class Crc32 {
  public:
-  void process_bytes(const void* data, int32_t size) {
+  void process_bytes(const void* data, int64_t size) {
     checksum_ =
         folly::crc32(reinterpret_cast<const uint8_t*>(data), size, checksum_);
   }

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -340,7 +340,7 @@ struct CopyWord<xsimd::batch<int8_t, A>, A> {
 // Copies one element of T and advances 'to', 'from', and 'bytes' by
 // sizeof(T). Returns false if 'bytes' went to 0.
 template <typename T, typename A>
-inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
+inline bool copyNextWord(void*& to, const void*& from, int64_t& bytes) {
   if (bytes >= sizeof(T)) {
     CopyWord<T, A>::apply(to, from);
     bytes -= sizeof(T);
@@ -356,7 +356,7 @@ inline bool copyNextWord(void*& to, const void*& from, int32_t& bytes) {
 } // namespace detail
 
 template <typename A>
-inline void memcpy(void* to, const void* from, int32_t bytes, const A& arch) {
+inline void memcpy(void* to, const void* from, int64_t bytes, const A& arch) {
   while (bytes >= batchByteSize(arch)) {
     if (!detail::copyNextWord<xsimd::batch<int8_t, A>, A>(to, from, bytes)) {
       return;

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -452,7 +452,7 @@ inline T* addBytes(T* pointer, int32_t bytes) {
 // 'memcpy' implementation that copies at maximum width and unrolls
 // when 'bytes' is constant.
 template <typename A = xsimd::default_arch>
-inline void memcpy(void* to, const void* from, int32_t bytes, const A& = {});
+inline void memcpy(void* to, const void* from, int64_t bytes, const A& = {});
 
 // memset implementation that writes at maximum width and unrolls for
 // constant values of 'bytes'.

--- a/velox/common/file/FileInputStream.cpp
+++ b/velox/common/file/FileInputStream.cpp
@@ -183,7 +183,7 @@ void FileInputStream::readBytes(uint8_t* bytes, int32_t size) {
   }
 }
 
-std::string_view FileInputStream::nextView(int32_t size) {
+std::string_view FileInputStream::nextView(int64_t size) {
   VELOX_CHECK_GE(size, 0, "Attempting to view negative number of bytes");
   if (remainingSize() == 0) {
     return std::string_view(nullptr, 0);

--- a/velox/common/file/FileInputStream.h
+++ b/velox/common/file/FileInputStream.h
@@ -55,7 +55,7 @@ class FileInputStream : public ByteInputStream {
 
   void readBytes(uint8_t* bytes, int32_t size) override;
 
-  std::string_view nextView(int32_t size) override;
+  std::string_view nextView(int64_t size) override;
 
   std::string toString() const override;
 

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -283,7 +283,7 @@ void HashStringAllocator::newSlab() {
 }
 
 void HashStringAllocator::newRange(
-    int32_t bytes,
+    int64_t bytes,
     ByteRange* lastRange,
     ByteRange* range,
     bool contiguous) {
@@ -316,7 +316,7 @@ void HashStringAllocator::newRange(
 }
 
 void HashStringAllocator::newRange(
-    int32_t bytes,
+    int64_t bytes,
     ByteRange* lastRange,
     ByteRange* range) {
   newRange(bytes, lastRange, range, false);
@@ -371,7 +371,7 @@ void HashStringAllocator::removeFromFreeList(Header* header) {
 }
 
 HashStringAllocator::Header* HashStringAllocator::allocate(
-    int32_t size,
+    int64_t size,
     bool exactSize) {
   if (size > kMaxAlloc && exactSize) {
     VELOX_CHECK_LE(size, Header::kSizeMask);

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -285,7 +285,7 @@ class HashStringAllocator : public StreamArena {
   /// ranges will not overwrite the next pointer.
   ///
   /// May allocate less than 'bytes'.
-  void newRange(int32_t bytes, ByteRange* lastRange, ByteRange* range) override;
+  void newRange(int64_t bytes, ByteRange* lastRange, ByteRange* range) override;
 
   /// Allocates a new range of at least 'bytes' size.
   void newContiguousRange(int32_t bytes, ByteRange* range);
@@ -353,7 +353,7 @@ class HashStringAllocator : public StreamArena {
   static constexpr uint32_t kHeaderSize = sizeof(Header);
 
   void newRange(
-      int32_t bytes,
+      int64_t bytes,
       ByteRange* lastRange,
       ByteRange* range,
       bool contiguous);
@@ -367,7 +367,7 @@ class HashStringAllocator : public StreamArena {
 
   // Allocates a block of specified size. If exactSize is false, the block may
   // be smaller or larger. Checks free list before allocating new memory.
-  Header* allocate(int32_t size, bool exactSize);
+  Header* allocate(int64_t size, bool exactSize);
 
   // Allocates memory from free list. Returns nullptr if no memory in free list,
   // otherwise returns a header of a free block of some size. if 'mustHaveSize'
@@ -591,7 +591,7 @@ class HashStringAllocator::InputStream : public ByteInputStream {
     }
   }
 
-  std::string_view nextView(int32_t size) final {
+  std::string_view nextView(int64_t size) final {
     if (atEnd()) {
       return {};
     }

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox {
 StreamArena::StreamArena(memory::MemoryPool* pool) : pool_(pool) {}
 
 void StreamArena::newRange(
-    int32_t bytes,
+    int64_t bytes,
     ByteRange* /*lastRange*/,
     ByteRange* range) {
   VELOX_CHECK_GT(bytes, 0, "StreamArena::newRange can't be zero length");
@@ -54,7 +54,7 @@ void StreamArena::newRange(
   }
   auto run = allocation_.runAt(currentRun_);
   range->buffer = run.data() + currentOffset_;
-  const int32_t availableBytes = run.numBytes() - currentOffset_;
+  const int64_t availableBytes = run.numBytes() - currentOffset_;
   range->size = std::min(bytes, availableBytes);
   range->position = 0;
   currentOffset_ += range->size;

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -47,7 +47,7 @@ class StreamArena {
   ///
   /// NOTE: The method does not guarantee returned 'range' has size of 'bytes',
   /// it is caller's responsibility to check.
-  virtual void newRange(int32_t bytes, ByteRange* lastRange, ByteRange* range);
+  virtual void newRange(int64_t bytes, ByteRange* lastRange, ByteRange* range);
 
   /// Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {


### PR DESCRIPTION
Summary:
Many internal queries crash at places like crc computation, or serialization because we have an restriction on the size of the buffer since the input to many of these functions are int32_t. Let's change this to be int64_t and let the application specific logic take care of the large buffer if need be.

The components/functions changed are:
- A few simd utils (memcopies)
- newView API in byteStream
- process_bytes in the crc computation
- byteRange struct
- Functions in ByteStream to internally use int64_t
- StreamArena's newRange and allocate


For example, Presto queries that would crash at crc computation or serialization time would now throw memory exceeded or spill error similar to Java.

Differential Revision: D73310051


