### PR TITLE
test(types): Add custom opaque type test for signature binder

### DIFF
--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -82,6 +82,10 @@ class OpaqueCustomTypeRegister {
     return VeloxType::get();
   }
 
+  static const TypePtr& get() {
+    return VeloxType::get();
+  }
+
  private:
   class TypeFactory : public CustomTypeFactories {
    public:


### PR DESCRIPTION
Summary:
Adding unit test to exemplify the usage of custom opaque types with
signature binder - which was previsouly uncovered. No logic changes, just
adding the test.

Differential Revision: D73377407


