### PR TITLE
fix: Return VeloxUserError for Non-Boolean WHERE Clause Masks

### DIFF
--- a/velox/exec/AggregationMasks.cpp
+++ b/velox/exec/AggregationMasks.cpp
@@ -37,7 +37,7 @@ void AggregationMasks::addInput(
 
     // Get the projection column vector that would be our mask.
     const auto& maskVector = input->childAt(entry.first);
-    VELOX_CHECK_EQ(
+    VELOX_USER_CHECK_EQ(
         maskVector->type(),
         BOOLEAN(),
         "FILTER(WHERE..) clause must use masks that are BOOLEAN");

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1603,7 +1603,7 @@ TEST_F(AggregationTest, disableNonBooleanMasks) {
                       false)
                   .planNode();
 
-  VELOX_ASSERT_THROW(
+  VELOX_ASSERT_USER_THROW(
       AssertQueryBuilder(plan).copyResults(pool()),
       "FILTER(WHERE..) clause must use masks that are BOOLEAN");
 


### PR DESCRIPTION
Summary:
We encountered some Velox internal error ```maskVector->type() == BOOLEAN() (BIGINT vs.
BOOLEAN) FILTER(WHERE..) clause must use masks that are BOOLEAN Operator``` .  
https://fburl.com/scuba/presto_queries/kufon8tv

we should return an VeloxUserError for this assertion.

Differential Revision: D73379523


