### PR TITLE
fix(parser): Change Velox parser errors to user errors

### DIFF
--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -38,7 +38,7 @@
 %token <long long>   NUMBER
 %token YYEOF         0
 
-%nterm <std::shared_ptr<const Type>> type type_single_word 
+%nterm <std::shared_ptr<const Type>> type type_single_word
 %nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
@@ -70,11 +70,11 @@ special_type : array_type     { $$ = $1; }
              | decimal_type   { $$ = $1; }
              | custom_type_with_children { $$ = $1; }
 
-/* 
- * Types with spaces have at least two words. They are joined in an 
+/*
+ * Types with spaces have at least two words. They are joined in an
  * std::vector here, and resolved by `inferTypeWithSpaces()`. The first
- * word is special to allow for tokens such as "map", "array", etc, to 
- * be used as field names. 
+ * word is special to allow for tokens such as "map", "array", etc, to
+ * be used as field names.
  */
 type_with_spaces : type_with_spaces WORD  { $1.push_back($2); $$ = std::move($1); }
                  | field_name WORD        { $$.push_back($1); $$.push_back($2); }
@@ -90,7 +90,7 @@ field_name : WORD     { $$ = $1; }
            | VARIABLE { $$ = $1; }
            ;
 
-/* 
+/*
  * Varchar and varbinary have an optional `(int)`
  * e.g. both `varchar` and `varchar(4)` are valid.
  */
@@ -120,27 +120,27 @@ type_list : type                   { $$.push_back($1); }
           | type_list COMMA type   { $1.push_back($3); $$ = std::move($1); }
           ;
 
-/* 
+/*
  * Consecutive list of types which can optionally have a "name".
  * Only allowed inside row definitions.
  */
-type_list_opt_names : type_list_opt_names COMMA named_type   { $1.names.push_back($3.first); 
+type_list_opt_names : type_list_opt_names COMMA named_type   { $1.names.push_back($3.first);
                                                                $1.types.push_back($3.second);
-                                                               $$.names = std::move($1.names); 
+                                                               $$.names = std::move($1.names);
                                                                $$.types = std::move($1.types); }
                     | named_type                             { $$.names.push_back($1.first); $$.types.push_back($1.second); }
                     ;
 
 /*
- * Named type is a type definition with an optional name. The name can be 
+ * Named type is a type definition with an optional name. The name can be
  * quoted. Since types with spaces are allowed, there is potential ambiguity
  * in definitions with multiple words, for example:
  *
  * > my type
- * 
+ *
  * Is "my" the name and "type" the type, or "my type" is the type name? We first
- * check if there is a type matching all words ("my type"), and if not, check if 
- * there is a type matching all but the first wor ("type") and assume the first 
+ * check if there is a type matching all words ("my type"), and if not, check if
+ * there is a type matching all but the first wor ("type") and assume the first
  * ("my") to be the field name. See `inferTypeWithSpaces()`.
  */
 named_type : type_single_word        { $$ = std::make_pair("", $1); }
@@ -152,5 +152,5 @@ named_type : type_single_word        { $$ = std::make_pair("", $1); }
 %%
 
 void facebook::velox::type::Parser::error(const std::string& msg) {
-  VELOX_FAIL("Failed to parse type [{}]. {}", scanner->input(), msg);
+  VELOX_UNSUPPORTED("Failed to parse type [{}]. {}", scanner->input(), msg);
 }

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -89,6 +89,11 @@ TEST_F(TypeParserTest, varcharType) {
   ASSERT_EQ(*parseType("varchar(4)"), *VARCHAR());
 }
 
+TEST_F(TypeParserTest, charType) {
+  VELOX_ASSERT_UNSUPPORTED_THROW(parseType("char"), "");
+  VELOX_ASSERT_UNSUPPORTED_THROW(parseType("char(4)"), "");
+}
+
 TEST_F(TypeParserTest, varbinary) {
   ASSERT_EQ(*parseType("varbinary"), *VARBINARY());
 }


### PR DESCRIPTION
Summary:
This will enable engines to handle unsupported grammar related errors (and rethrow w/ context to users if need be) as these are non-retriable anyways.

Added a unit test for specific case like CHAR(10) which is Presto syntax but not supported in Velox.

Differential Revision: D73383288


