### PR TITLE
feat: Use binary search to calculate string offset in vector saver

### DIFF
--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -377,8 +377,9 @@ TEST_F(VectorSaverTest, flatVarchar) {
   testRoundTrip(opts, VARCHAR());
 
   // Make short strings only.
-  opts.stringLength = 6;
-  opts.vectorSize = 1024;
+  opts.containerVariableLength = true;
+  opts.stringLength = 100000;
+  opts.vectorSize = 10000;
   testRoundTrip(opts, VARCHAR());
 }
 


### PR DESCRIPTION
Summary:
When calculating stringOffset in vector saver, we can have arguments like `stringBuffers.size()=71671 size=109871110`, this would be `~8T` iterations. This means that a single thread has to iterate through this and can take over > 13 hours.

Observations:
1. `computeStringOffset()` finds the **first** buffer which contains the stringView
2. the offset is based on the previous offset sums

How we can speed this up
1. Create a vector of `offsetSums` which contain the prefix sums up to the [0, i) index in the vector
2. Create a vector of `BufferMetadata` which contains the buffer start position, end position, and the buffers index in `stringBuffers`. We sort this buffer based on the start position
3. Check for no overlapping ranges within the vector of `BufferMetadata`, so that we can take advantage of binary sort and to ensure there is only 1 candidate which can fulfill this request.  
4. Use bisect to find the range which contains the buffer, then use the `offsetSums` to compute the offset with random access

Misc: Also fix i32 limitation by using i64 since we're anyways writing i64.

Differential Revision: D73322740


