### PR TITLE
fix: MapSubset ARRAY comparison should not be supported for null elements

### DIFF
--- a/velox/functions/prestosql/tests/MapSubsetTest.cpp
+++ b/velox/functions/prestosql/tests/MapSubsetTest.cpp
@@ -194,6 +194,24 @@ TEST_F(MapSubsetTest, arrayKey) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(MapSubsetTest, compareNullElementsThrowsException) {
+  auto data = makeRowVector({
+      makeMapVector(
+          {0},
+          makeArrayVectorFromJson<int32_t>({
+              "[1, 2]",
+          }),
+          makeFlatVector<int32_t>(1)),
+      makeNestedArrayVectorFromJson<int32_t>({
+          "[[1, null], [1, null]]",
+      }),
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate("map_subset(c0, c1)", data),
+      "Comparison on null elements is not supported");
+}
+
 TEST_F(MapSubsetTest, floatNaNs) {
   testFloatNaNs<float>();
   testFloatNaNs<double>();


### PR DESCRIPTION
Summary:
Presto java and Velox should be consistent on handling null elements compare for query such as:

```
SELECT
    map_subset(c0, c1)
FROM (
    VALUES
        (
            MAP(ARRAY[ARRAY[1, 2]], ARRAY[1]),
            ARRAY[ARRAY[1, NULL], ARRAY[1, NULL]]
        )
) t(c0, c1)
LIMIT
    1000
```
https://github.com/facebookincubator/velox/issues/10571

the diff will fix so that velox also throw out exception.

link to newly created issue https://github.com/prestodb/presto/issues/25011

Differential Revision: D73242028


