### PR TITLE
feat(expressions): Evaluate array/map match lambda functions over batches of elements vector

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -462,6 +462,15 @@ class QueryConfig {
   static constexpr const char* kDebugMemoryPoolNameRegex =
       "debug_memory_pool_name_regex";
 
+  /// Some lambda functions over arrays and maps are evaluated in batches of the
+  /// underlying elements that comprise the arrays/maps. This is done to make
+  /// the batch size managable as array vectors can have thousands of elements
+  /// each and hit scaling limits as implementations typically expect
+  /// BaseVectors to a couple of thousand entries. This lets up tune those batch
+  /// sizes.
+  static constexpr const char* kDebugLambdaFunctionEvaluationBatchSize =
+      "debug_lambda_function_evaluation_batch_size";
+
   /// Temporary flag to control whether selective Nimble reader should be used
   /// in this query or not.  Will be removed after the selective Nimble reader
   /// is fully rolled out.
@@ -574,6 +583,10 @@ class QueryConfig {
   std::optional<uint32_t> debugAggregationApproxPercentileFixedRandomSeed()
       const {
     return get<uint32_t>(kDebugAggregationApproxPercentileFixedRandomSeed);
+  }
+
+  int32_t debugLambdaFunctionEvaluationBatchSize() const {
+    return get<int32_t>(kDebugLambdaFunctionEvaluationBatchSize, 10'000);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -218,6 +218,10 @@ Expression Evaluation Configuration
      - bool
      - false
      - Disable optimization in expression evaluation to delay loading of lazy inputs unless required. Should only be used for debugging.
+   * - debug_lambda_function_evaluation_batch_size
+     - integer
+     - 10000
+     - Some lambda functions over arrays and maps are evaluated in batches of the underlying elements that comprise the arrays/maps. This is done to make the batch size managable as array vectors can have thousands of elements each and hit scaling limits as implementations typically expect BaseVectors to a couple of thousand entries. This lets up tune those batch sizes. Setting this to zero is setting unlimited batch size.
 
 Memory Management
 -----------------

--- a/velox/functions/lib/tests/RowsTranslationUtilTest.cpp
+++ b/velox/functions/lib/tests/RowsTranslationUtilTest.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <velox/type/Type.h>
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+
+using namespace facebook::velox::test;
+
+namespace {
+
+SelectivityVector expectedRows(std::vector<bool> selectedRows) {
+  SelectivityVector ret(selectedRows.size(), false);
+  for (int i = 0; i < selectedRows.size(); i++) {
+    ret.setValid(i, selectedRows[i]);
+  }
+  ret.updateBounds();
+  return ret;
+}
+
+class RowsTranslationUtilTest : public test::FunctionBaseTest {};
+TEST_F(RowsTranslationUtilTest, elementRowsIterator) {
+  // Verify that the elementRowsIterator correctly partitions the rows among
+  // iterations based on a set max row limit. We use an array vector and vary
+  // the element size of each row and the max row limit to exercise various edge
+  // cases.
+
+  const vector_size_t maxElementRowsPerIteration = 3;
+  {
+    ArrayVectorPtr inputArrayVector = makeArrayVectorFromJson<int32_t>(
+        {"[0, 1]", "[2, 3, 4]", "[5]", "[6,7]", "[8, 9]"});
+
+    SelectivityVector rows(inputArrayVector->size(), true);
+    // To be resued among test cases.
+    SelectivityVector actualTopLevelRows(inputArrayVector->size(), false);
+    SelectivityVector expectedTopLevelRows(inputArrayVector->size(), false);
+
+    SelectivityVector actualElementRows(
+        inputArrayVector->elements()->size(), false);
+    SelectivityVector expectedElementRows(
+        inputArrayVector->elements()->size(), false);
+    ElementRowsIterator elementRowsIter(
+        maxElementRowsPerIteration, rows, inputArrayVector.get());
+
+    // Iteration ends in the middle of an array value
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({1, 1, 0, 0, 0}));
+    EXPECT_EQ(actualElementRows, expectedRows({1, 1, 1, 1, 1, 0, 0, 0, 0, 0}));
+
+    // Iteration ends at the end of an array value
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({0, 0, 1, 1, 0}));
+    EXPECT_EQ(actualElementRows, expectedRows({0, 0, 0, 0, 0, 1, 1, 1, 0, 0}));
+
+    // Iteration ends at the ends of elements vector without hitting the max
+    // element limit
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({0, 0, 0, 0, 1}));
+    EXPECT_EQ(actualElementRows, expectedRows({0, 0, 0, 0, 0, 0, 0, 0, 1, 1}));
+
+    EXPECT_FALSE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+  }
+  {
+    ArrayVectorPtr inputArrayVector = makeArrayVectorFromJson<int32_t>(
+        {"[0, 1]",
+         "null", // null top level array
+         "[2,3,4]",
+         "[null]", // null array element
+         "[5]",
+         "[6]",
+         "[]", // empty array
+         "[7, 8, 9]"});
+
+    SelectivityVector rows(inputArrayVector->size(), true);
+    // To be resued among test cases.
+    SelectivityVector actualTopLevelRows(inputArrayVector->size(), false);
+    SelectivityVector expectedTopLevelRows(inputArrayVector->size(), false);
+
+    SelectivityVector actualElementRows(
+        inputArrayVector->elements()->size(), false);
+    SelectivityVector expectedElementRows(
+        inputArrayVector->elements()->size(), false);
+
+    ElementRowsIterator elementRowsIter(
+        maxElementRowsPerIteration, rows, inputArrayVector.get());
+    // Iteration includes top level row which is null at the top level.
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({1, 1, 1, 0, 0, 0, 0, 0}));
+    EXPECT_EQ(
+        actualElementRows, expectedRows({1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0}));
+
+    // Iteration includes element row which has null element inside array.
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({0, 0, 0, 1, 1, 1, 0, 0}));
+    EXPECT_EQ(
+        actualElementRows, expectedRows({0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0}));
+
+    // Iteration includes top level row for an empty array.
+    EXPECT_TRUE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+    EXPECT_EQ(actualTopLevelRows, expectedRows({0, 0, 0, 0, 0, 0, 1, 1}));
+    EXPECT_EQ(
+        actualElementRows, expectedRows({0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1}));
+
+    EXPECT_FALSE(elementRowsIter.next(actualElementRows, actualTopLevelRows));
+  }
+}
+} // namespace
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAllMatchTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class ArrayAllMatchTest : public functions::test::FunctionBaseTest {
+class ArrayAllMatchTest : public functions::test::LambdaParameterizedBaseTest {
  protected:
   void testAllMatchExpr(
       const std::vector<std::optional<bool>>& expected,
@@ -44,12 +44,12 @@ class ArrayAllMatchTest : public functions::test::FunctionBaseTest {
       const std::vector<std::optional<bool>>& expected,
       const std::string& expression,
       const RowVectorPtr& input) {
-    auto result = evaluate(expression, (input));
+    auto result = evaluateParameterized(expression, (input));
     assertEqualVectors(makeNullableFlatVector<bool>(expected), result);
   }
 };
 
-TEST_F(ArrayAllMatchTest, basic) {
+TEST_P(ArrayAllMatchTest, basic) {
   std::vector<std::vector<std::optional<int32_t>>> ints{
       {std::nullopt, 2, 3},
       {-1, 3},
@@ -91,7 +91,7 @@ TEST_F(ArrayAllMatchTest, basic) {
   testAllMatchExpr(expectedResult, "x", bools);
 }
 
-TEST_F(ArrayAllMatchTest, complexTypes) {
+TEST_P(ArrayAllMatchTest, complexTypes) {
   auto arrayOfArrays = makeNestedArrayVectorFromJson<int32_t>({
       "[[1, 2, 3]]",
       "[[2, 2], [3, 3], [4, 4], [5, 5]]",
@@ -114,7 +114,7 @@ TEST_F(ArrayAllMatchTest, complexTypes) {
   testAllMatchExpr(expectedResult, "cardinality(x) > 2", arrayOfArrays);
 }
 
-TEST_F(ArrayAllMatchTest, strings) {
+TEST_P(ArrayAllMatchTest, strings) {
   std::vector<std::vector<std::optional<StringView>>> input{
       {},
       {"abc"},
@@ -126,7 +126,7 @@ TEST_F(ArrayAllMatchTest, strings) {
   testAllMatchExpr(expectedResult, "x = 'abc'", input);
 }
 
-TEST_F(ArrayAllMatchTest, doubles) {
+TEST_P(ArrayAllMatchTest, doubles) {
   std::vector<std::vector<std::optional<double>>> input{
       {},
       {1.2},
@@ -142,7 +142,7 @@ TEST_F(ArrayAllMatchTest, doubles) {
   testAllMatchExpr(expectedResult, "x > 1.1", input);
 }
 
-TEST_F(ArrayAllMatchTest, errors) {
+TEST_P(ArrayAllMatchTest, errors) {
   // No throw and return false if there are unmatched elements except nulls
   auto expression = "(10 / x) > 2";
   std::vector<std::vector<std::optional<int8_t>>> input{
@@ -179,7 +179,7 @@ TEST_F(ArrayAllMatchTest, errors) {
       expectedResult, "all_match(c0, x -> (TRY((10 / x) > 2)))", errorInputRow);
 }
 
-TEST_F(ArrayAllMatchTest, conditional) {
+TEST_P(ArrayAllMatchTest, conditional) {
   // No throw and return false if there are unmatched elements except nulls
   auto c0 = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
   auto c1 = makeNullableArrayVector<int32_t>({
@@ -202,3 +202,8 @@ TEST_F(ArrayAllMatchTest, conditional) {
       "all_match(c1, if (c0 <= 2, x -> (x > 100), x -> (10 / x > 2)))",
       input);
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    ArrayAllMatchTest,
+    ArrayAllMatchTest,
+    testing::ValuesIn(ArrayAllMatchTest::getTestParams()));

--- a/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "FunctionBaseTest.h"
+
+namespace facebook::velox::functions::test {
+
+typedef int32_t ElementRowsPerIteration;
+
+class LambdaParameterizedBaseTest
+    : public FunctionBaseTest,
+      public testing::WithParamInterface<ElementRowsPerIteration> {
+ public:
+  static std::vector<ElementRowsPerIteration> getTestParams() {
+    const std::vector<ElementRowsPerIteration> params({0, 2, 1000});
+    return params;
+  }
+
+  VectorPtr evaluateParameterized(
+      const std::string& expression,
+      const RowVectorPtr& data) {
+    std::vector<core::TypedExprPtr> parseExpr = {
+        parseExpression(expression, asRowType(data->type()))};
+    auto exprSet = std::make_unique<exec::ExprSet>(
+        std::move(parseExpr), &execCtxParametrized_);
+
+    return evaluate(*exprSet, data);
+  }
+
+ private:
+  std::shared_ptr<core::QueryCtx> queryCtxParametrized_{core::QueryCtx::create(
+      executor_.get(),
+      core::QueryConfig(
+          {{core::QueryConfig::kDebugLambdaFunctionEvaluationBatchSize,
+            std::to_string(GetParam())}}))};
+  core::ExecCtx execCtxParametrized_{pool_.get(), queryCtxParametrized_.get()};
+};
+
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Normally, lambda functions are applied to the entire elements vector
of an array or map. This can cause issues when arrays have a large
number of elements and cause issues in code paths that are not
designed to deal with such large vectors. Recently we saw two
instances: 1. A lambda used as a capture is wrapped with wrap capture
indices and then flattened during evaluation which caused
vector_size_t keeping track of rows to overflow. 2. Multiple drives
evaluating a lambda end up storing more than 5 million exception
pointers that cause process OOM crashes.

With this change we introduce a utility that helps iterate through
the elements vector in smaller batches. We also add a debug query
config `debug_lambda_function_evaluation_batch_size` to tune the
size of batch if it causes any regressions (currently defaulted to
10,000 rows per batch). We only integrate this change to array/map
match lambda functions namely any/all/none_match,
any/all/no_keys_match and any/no_values_match.

TODO: Large vectors may still form if active elements are deep in the
original vector. To address this, consider wrapping only the required
element rows for evaluation and aligning wrap capture indices accordingly.
This however would rely on another feature we plan to add to peeling where
peeling would be skipped if the peeled vector is much larger than the
wrapped vector.

Differential Revision: D73404919


