### PR TITLE
fix: Fix the merge join source testvalue naming

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -263,7 +263,7 @@ BlockingReason MergeJoinSource::next(
     ContinueFuture* future,
     RowVectorPtr* data) {
   common::testutil::TestValue::adjust(
-      "facebook::velox::exec::MergeSource::next", this);
+      "facebook::velox::exec::MergeJoinSource::next", this);
   PromiseNotifier notifier(1);
   return state_.withWLock([&](auto& state) {
     if (state.data != nullptr) {
@@ -288,7 +288,7 @@ BlockingReason MergeJoinSource::enqueue(
     RowVectorPtr data,
     ContinueFuture* future) {
   common::testutil::TestValue::adjust(
-      "facebook::velox::exec::MergeSource::enqueue", this);
+      "facebook::velox::exec::MergeJoinSource::enqueue", this);
   PromiseNotifier notifier(1);
   return state_.withWLock([&](auto& state) {
     if (state.atEnd) {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -1499,14 +1499,14 @@ DEBUG_ONLY_TEST_F(MergeJoinTest, failureOnRightSide) {
   // this to be called at least once to ensure consumerPromise_ is created in
   // the MergeSource.
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::MergeSource::next",
+      "facebook::velox::exec::MergeJoinSource::next",
       std::function<void(const MergeJoinSource*)>([&](const MergeJoinSource*) {
         nextCalled = true;
         nextCalledWait.notifyAll();
       }));
 
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::MergeSource::enqueue",
+      "facebook::velox::exec::MergeJoinSource::enqueue",
       std::function<void(const MergeJoinSource*)>([&](const MergeJoinSource*) {
         // Only call this the first time, otherwise if we throw an exception
         // during Driver.close the process will crash.


### PR DESCRIPTION
Summary: The current naming uses merge source but not merge join source,

Differential Revision: D73444570


