### PR TITLE
feat: Add  variant::tryOpaque method to cast without throwing

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -572,6 +572,19 @@ class variant {
     return std::static_pointer_cast<T>(capsule.obj);
   }
 
+  /// Try to cast to the target custom type
+  /// Throw if the variant is not an opaque type
+  /// Return nullptr if it's opaque type but the underlying custom type doesn't
+  /// match the target. Otherwise return the data in custom type.
+  template <class T>
+  std::shared_ptr<T> tryOpaque() const {
+    const auto& capsule = value<TypeKind::OPAQUE>();
+    if (capsule.type->typeIndex() == std::type_index(typeid(T))) {
+      return std::static_pointer_cast<T>(capsule.obj);
+    }
+    return nullptr;
+  }
+
   std::shared_ptr<const Type> inferType() const {
     switch (kind_) {
       case TypeKind::MAP: {

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -124,6 +124,22 @@ TEST(VariantTest, opaque) {
     EXPECT_NE(v1.hash(), v3.hash());
     EXPECT_NE(v2.hash(), v3.hash());
   }
+
+  // Test opaque casting.
+  {
+    variant fooOpaque = variant::opaque(foo);
+    variant barOpaque = variant::opaque(bar);
+    variant int1 = variant((int64_t)123);
+
+    auto castFoo1 = fooOpaque.tryOpaque<Foo>();
+    auto castBar1 = fooOpaque.tryOpaque<Bar>();
+    auto castBar2 = barOpaque.tryOpaque<Bar>();
+
+    EXPECT_EQ(castFoo1, foo);
+    EXPECT_EQ(castBar1, nullptr);
+    EXPECT_EQ(castBar2, bar);
+    EXPECT_THROW(int1.tryOpaque<Foo>(), std::invalid_argument);
+  }
 }
 
 /// Test variant::equalsWithEpsilon by summing up large 64-bit integers (> 15


### PR DESCRIPTION
Summary: need a lightweight non-throwing cast method

Differential Revision: D73414779


