### PR TITLE
feat: Allow ParquetWriter to specify column encoding

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
 
 namespace facebook::velox::parquet {
 
@@ -63,6 +64,9 @@ class ColumnChunkMetaDataPtr {
 
   /// The compression.
   common::CompressionKind compression() const;
+
+  /// The encodings.
+  std::vector<arrow::Encoding::type> encodings() const;
 
   /// Total byte size of all the compressed (and potentially encrypted)
   /// column data in this row group.

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   velox_parquet_writer_test
   velox_dwio_parquet_writer
   velox_dwio_parquet_reader
+  velox_dwio_arrow_parquet_writer
   velox_dwio_common_test_utils
   velox_link_libs
   Boost::regex

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -141,6 +141,11 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
         columnCompressionValues.first,
         getArrowParquetCompression(columnCompressionValues.second));
   }
+  for (const auto& columnEncodingValues : options.columnEncodingsMap) {
+    properties->encoding(
+        columnEncodingValues.first, columnEncodingValues.second);
+  }
+  properties = properties->encoding(options.encoding);
   properties = properties->encoding(options.encoding);
   properties = properties->data_pagesize(options.dataPageSize.value_or(
       facebook::velox::parquet::arrow::kDefaultDataPageSize));

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -101,6 +101,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::unordered_map<std::string, common::CompressionKind>
       columnCompressionsMap;
 
+  std::unordered_map<std::string, arrow::Encoding::type> columnEncodingsMap;
+
   /// Timestamp unit for Parquet write through Arrow bridge.
   /// Default if not specified: TimestampPrecision::kNanoseconds (9).
   std::optional<TimestampPrecision> parquetWriteTimestampUnit;


### PR DESCRIPTION

In this issue https://github.com/facebookincubator/velox/issues/9499 , I noticed that Parquet Write did not have any encoding-related tests. When I added relevant tests, I found that I could not specify the encoding of columns. I improved the logic here and added relevant tests.