### PR TITLE
misc: Allow disabling LocalExchangeVectorPool through QueryConfig

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -380,6 +380,11 @@ class QueryConfig {
   static constexpr const char* kMaxSharedSubexprResultsCached =
       "max_shared_subexpr_results_cached";
 
+  /// If true, enable LocalExchangeVectorPool to reuse RowVectors during local
+  /// exchange.
+  static constexpr const char* kEnableLocalExchangeQueueCache =
+      "enable_local_exchange_queue_cache";
+
   /// Maximum number of splits to preload. Set to 0 to disable preloading.
   static constexpr const char* kMaxSplitPreloadPerDriver =
       "max_split_preload_per_driver";
@@ -912,6 +917,10 @@ class QueryConfig {
 
   bool isExpressionEvaluationCacheEnabled() const {
     return get<bool>(kEnableExpressionEvaluationCache, true);
+  }
+
+  bool isLocalExchangeQueueCacheEnabled() const {
+    return get<bool>(kEnableLocalExchangeQueueCache, true);
   }
 
   uint32_t maxSharedSubexprResultsCached() const {

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ target_link_libraries(
     velox_core
     velox_exception
     velox_exec_test_lib
+    velox_exec
+    velox_aggregates
     velox_presto_types
     velox_type
     velox_vector_test_lib

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1174,7 +1174,7 @@ bool HashTable<ignoreNullKeys>::arrayPushRow(
   auto* existingRow = table_[index];
   if (existingRow != nullptr) {
     if (nextOffset_ > 0) {
-      hasDuplicates_ = true;
+      hasDuplicates_.set();
       rows->appendNextRow(existingRow, row, allocator);
     }
     return false;
@@ -1190,7 +1190,7 @@ void HashTable<ignoreNullKeys>::pushNext(
     char* next,
     HashStringAllocator* allocator) {
   VELOX_CHECK_GT(nextOffset_, 0);
-  hasDuplicates_ = true;
+  hasDuplicates_.set();
   rows->appendNextRow(row, next, allocator);
 }
 
@@ -1660,8 +1660,8 @@ std::string HashTable<ignoreNullKeys>::toString() {
     int64_t occupied = 0;
 
     // Count of buckets indexed by the number of non-empty slots.
-    // Each bucket has 16 slots. Hence, the number of non-empty slots is between
-    // 0 and 16 (17 possible values).
+    // Each bucket has 16 slots. Hence, the number of non-empty slots is
+    // between 0 and 16 (17 possible values).
     int64_t numBuckets[sizeof(TagVector) + 1] = {};
     for (int64_t bucketOffset = 0; bucketOffset < sizeMask_;
          bucketOffset += kBucketSize) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -17,10 +17,10 @@
 
 #include "velox/common/base/Portability.h"
 #include "velox/common/memory/MemoryAllocator.h"
+#include "velox/exec/OneWayStatusFlag.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
 #include "velox/exec/VectorHasher.h"
-
 namespace facebook::velox::exec {
 
 using PartitionBoundIndexType = int64_t;
@@ -569,7 +569,7 @@ class HashTable : public BaseHashTable {
   }
 
   bool hasDuplicateKeys() const override {
-    return hasDuplicates_;
+    return hasDuplicates_.check();
   }
 
   HashMode hashMode() const override {
@@ -1048,7 +1048,7 @@ class HashTable : public BaseHashTable {
   // Set at join build time if the table has duplicates, meaning that
   // the join can be cardinality increasing. Atomic for tsan because
   // many threads can set this.
-  std::atomic<bool> hasDuplicates_{false};
+  OneWayStatusFlag hasDuplicates_;
 
   // Offset of next row link for join build side set from 'rows_'.
   int32_t nextOffset_{0};

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -172,7 +172,7 @@ BlockingReason LocalExchangeQueue::next(
     return BlockingReason::kNotBlocked;
   });
   notify(memoryPromises);
-  if (*data != nullptr) {
+  if (*data != nullptr && vectorPool_ != nullptr) {
     vectorPool_->push(*data, size);
   }
   return blockingReason;
@@ -197,6 +197,10 @@ bool LocalExchangeQueue::isFinished() {
 bool LocalExchangeQueue::testingProducersDone() const {
   return queue_.withRLock(
       [&](auto& queue) { return noMoreProducers_ && pendingProducers_ == 0; });
+}
+
+bool LocalExchangeQueue::testingVectorPoolEnabled() const {
+  return vectorPool_ != nullptr;
 }
 
 void LocalExchangeQueue::close() {

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -121,13 +121,19 @@ class LocalExchangeQueue {
   void close();
 
   /// Get a reusable vector from the vector pool.  Return nullptr if none is
-  /// available.
+  /// available or if vector pool is not enabled.
   RowVectorPtr getVector() {
-    return vectorPool_->pop();
+    if (vectorPool_ != nullptr) {
+      return vectorPool_->pop();
+    }
+    return nullptr;
   }
 
   /// Returns true if all producers have sent no more data signal.
   bool testingProducersDone() const;
+
+  /// Returns true if vectorPool_ is enabled.
+  bool testingVectorPoolEnabled() const;
 
  private:
   using Queue = std::queue<std::pair<RowVectorPtr, int64_t>>;

--- a/velox/exec/OneWayStatusFlag.h
+++ b/velox/exec/OneWayStatusFlag.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+namespace facebook::velox::exec {
+
+// A simple one way status flag that uses a non atomic flag to avoid
+// unnecessary atomic operations.
+class OneWayStatusFlag {
+ public:
+  bool check() const {
+    return fastStatus_ || atomicStatus_.load(std::memory_order_acquire);
+  }
+
+  void set() {
+    if (!fastStatus_) {
+      atomicStatus_.store(true, std::memory_order_relaxed);
+      fastStatus_ = true;
+    }
+  }
+
+  // Operator overload to convert OneWayStatusFlag to bool
+  operator bool() const {
+    return check();
+  }
+
+ private:
+  bool fastStatus_{false};
+  std::atomic<bool> atomicStatus_{false};
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2638,8 +2638,11 @@ void Task::createLocalExchangeQueuesLocked(
   LocalExchangeState exchange;
   exchange.memoryManager = std::make_shared<LocalExchangeMemoryManager>(
       queryCtx_->queryConfig().maxLocalExchangeBufferSize());
-  exchange.vectorPool = std::make_shared<LocalExchangeVectorPool>(
-      queryCtx_->queryConfig().maxLocalExchangeBufferSize());
+  exchange.vectorPool =
+      queryCtx_->queryConfig().isLocalExchangeQueueCacheEnabled()
+      ? std::make_shared<LocalExchangeVectorPool>(
+            queryCtx_->queryConfig().maxLocalExchangeBufferSize())
+      : nullptr;
   exchange.queues.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
     exchange.queues.emplace_back(std::make_shared<LocalExchangeQueue>(

--- a/velox/exec/benchmarks/AtomicsBench.cpp
+++ b/velox/exec/benchmarks/AtomicsBench.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <vector>
+#include "velox/exec/OneWayStatusFlag.h"
+
+using namespace ::testing;
+using namespace facebook::velox;
+static const size_t kNumThreads = 88;
+static const size_t kNumIterations = 10000;
+
+void runParallelUpdates(
+    std::function<void(size_t iter)> callback,
+    int threadCount,
+    int updateCount) {
+  std::vector<std::thread> threads;
+
+  for (size_t i = 0; i < threadCount; ++i) {
+    threads.emplace_back([&]() {
+      for (size_t j = 0; j < updateCount; ++j) {
+        callback(j);
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+}
+
+BENCHMARK(std_atomic_bool_write) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.store(true);
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_write_relaxed) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.store(true, std::memory_order_relaxed);
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_write_relaxed) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          if (!flag.load(std::memory_order_relaxed)) {
+            flag.store(true, std::memory_order_acq_rel);
+          }
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(one_way_flag_write) {
+  exec::OneWayStatusFlag flag;
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.set();
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+// Read Benchmarks
+BENCHMARK(std_atomic_bool_read) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load());
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_relaxed_read) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load(std::memory_order_relaxed));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_relaxed_acquire) {
+  std::atomic<bool> flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(
+              flag.load(std::memory_order_relaxed) ||
+              flag.load(std::memory_order_acquire));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(one_way_flag_read) {
+  exec::OneWayStatusFlag flag;
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.check());
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  folly::runBenchmarks();
+}


### PR DESCRIPTION
Summary: We observed that TPC-H q13 spends 10% CPU cycles in the lock on LocalExchangeVectorPool when there is a relatively large number of drivers. So diff makes LocalExchangeVectorPool configurable so that we can disable it on Impulse cluster.

Differential Revision: D73456419
