### PR TITLE
feat: add memory allocator size stats to periodic stats reporter

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -85,6 +85,21 @@ void registerVeloxMetrics() {
   // NOTE: This applies only to MmapAllocator
   DEFINE_METRIC(kMetricMmapDelegatedAllocBytes, facebook::velox::StatType::AVG);
 
+  #define REGISTER_SINGLE_SIZE_STATS_METRIC(i, field)      \
+    DEFINE_METRIC(                                         \
+        kMetricAllocatorSizeStats_##i##_##field,           \
+        facebook::velox::StatType::COUNT)
+  
+  #define REGISTER_SIZE_STATS_METRICS(i)                  \
+    REGISTER_SINGLE_SIZE_STATS_METRIC(i, allocateClocks); \
+    REGISTER_SINGLE_SIZE_STATS_METRIC(i, freeClocks);     \
+    REGISTER_SINGLE_SIZE_STATS_METRIC(i, numAllocations); \
+    REGISTER_SINGLE_SIZE_STATS_METRIC(i, totalBytes)
+  
+  #define REGISTER_ALL_SIZE_STATS_METRICS EXPAND_SIZE_STATS_CLASSES(REGISTER_SIZE_STATS_METRICS)
+
+  REGISTER_ALL_SIZE_STATS_METRICS
+
   /// ================== AsyncDataCache Counters =================
 
   // Max possible age of AsyncDataCache and SsdCache entries since the raw file

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -190,6 +190,25 @@ constexpr folly::StringPiece kMetricMmapExternalMappedBytes{
 constexpr folly::StringPiece kMetricMmapDelegatedAllocBytes{
     "velox.mmap_allocator_delegated_alloc_bytes"};
 
+#define EXPAND_SIZE_STATS_CLASSES(X)                                        \
+  X(0) X(1) X(2) X(3) X(4) X(5) X(6) X(7) X(8) X(9) X(10) X(11) X(12) X(13) \
+  X(14) X(15) X(16) X(17) X(18) X(19)
+
+#define DEFINE_SINGLE_SIZE_STATS_METRIC(i, field, suffix)                     \
+  constexpr folly::StringPiece kMetricAllocatorSizeStats_##i##_##field { \
+    "velox.memory_allocator_size_stats.size_4k_2_" #i "." #suffix             \
+  }
+
+#define DEFINE_SIZE_STATS_METRICS(i)                                   \
+  DEFINE_SINGLE_SIZE_STATS_METRIC(i, allocateClocks, allocate_clocks); \
+  DEFINE_SINGLE_SIZE_STATS_METRIC(i, freeClocks, free_clocks);         \
+  DEFINE_SINGLE_SIZE_STATS_METRIC(i, numAllocations, num_allocations); \
+  DEFINE_SINGLE_SIZE_STATS_METRIC(i, totalBytes, total_bytes);
+
+#define DEFINE_ALL_SIZE_STATS_METRICS EXPAND_SIZE_STATS_CLASSES(DEFINE_SIZE_STATS_METRICS)
+
+DEFINE_ALL_SIZE_STATS_METRICS
+
 constexpr folly::StringPiece kMetricCacheMaxAgeSecs{"velox.cache_max_age_secs"};
 
 constexpr folly::StringPiece kMetricMemoryCacheNumEntries{

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -82,7 +82,7 @@ struct SizeClassStats {
 };
 
 struct Stats {
-  /// 20 size classes in powers of 2 are tracked, from 4K to 4G. The
+  /// 20 size classes in powers of 2 are tracked, from 4K to 2G. The
   /// allocation is recorded to the class corresponding to the closest
   /// power of 2 >= the allocation size.
   static constexpr int32_t kNumSizes = 20;


### PR DESCRIPTION
This PR implements adding MemoryAllocator SizeStat statistics to PeriodicStatsReporter. Because there are 20*4=80 SizeStat related information, macros are used for implementation;

Currently commented, unit testing has not been implemented yet, and will be improved after confirming that the code implementation idea is correct;

I think the following need to be aligned:
1. Naming rules in counters.h.
2. Whether it is necessary to add a switch in PeriodicStatsReporter.Options to allow external shutdown of SizeStat related reporting.