### PR TITLE
fix: Fix anti join result mismatch with filter and multi duplicated rows

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -1281,7 +1281,7 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
     // If all matches for a given left-side row fail the filter, add a row to
     // the output with nulls for the right-side columns.
     const auto onMiss = [&](auto row) {
-      if (isAntiJoin(joinType_) || isSemiFilterJoin(joinType_)) {
+      if (isSemiFilterJoin(joinType_)) {
         return;
       }
       rawIndices[numPassed++] = row;
@@ -1368,12 +1368,6 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
             decodedFilterResult_.valueAt<bool>(i);
 
         joinTracker_->processFilterResult(i, passed, onMiss, onMatch);
-
-        if (isAntiJoin(joinType_)) {
-          if (!passed) {
-            rawIndices[numPassed++] = i;
-          }
-        }
       } else {
         // This row doesn't have a match on the right side. Keep it
         // unconditionally.


### PR DESCRIPTION
For an anti join, if a row in the left table has multiple matched rows in the right table, and these matched rows are distributed across different batches, we need to traverse all matched rows in different batches to determine the final result.
For example, in the case below, the left table has columns a and b, and the right table has columns c and d. The join condition is a == c and b < d:

```
a b    c  d
1 3    1  2
       1  2
       1  4
```
Meanwhile, the output batch size is 2, so the first batch1 is:
```
a b c d
1 3 1 2
1 3 1 2
```
If we do not wait for the subsequent batch, such as `1 3 1 4`, the result for batch1 would output a record `1 3`. However, the final result should be null because `1 3 1 4` satisfies `b < d`.

The current PR relies on the joinTracker mechanism to ensure that the final result is output only after all matched rows have been traversed.