### PR TITLE
build: Fix macOS clang17 duckdb dependency build

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -161,7 +161,9 @@ function install_duckdb {
   if [[ "$BUILD_DUCKDB" == "true" ]]; then
     echo 'Building DuckDB'
     wget_and_untar https://github.com/duckdb/duckdb/archive/refs/tags/${DUCKDB_VERSION}.tar.gz duckdb
-    cmake_install_dir duckdb -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release
+    # The warning -Wno-missing-template-arg-list-after-template-kw can likely be removed when upgrading to
+    # the latest duckDB version. This code has changed quite significantly and likely isn't a problem anymore.
+    cmake_install_dir duckdb -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw"
   fi
 }
 


### PR DESCRIPTION
With the recent upgrade to Clang17 macOS fails to build the current duckdb version. The error is “error: a template argument list is expected after a name prefixed by the template keyword”

This PR adds a warning suppression for this error and can be removed in the future when upgrading duckDB.