### PR TITLE
feat: Enable maximum elements for repeat configurable

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -140,6 +140,9 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialTopNRowNumberMinPct =
       "abandon_partial_topn_row_number_min_pct";
 
+  static constexpr const char* kMaxElementsSizeInRepeatAndSequence =
+      "max_elements_size_in_repeat_and_sequence";
+
   /// The maximum number of bytes to buffer in PartitionedOutput operator to
   /// avoid creating tiny SerializedPages.
   ///
@@ -606,6 +609,10 @@ class QueryConfig {
 
   int32_t abandonPartialTopNRowNumberMinPct() const {
     return get<int32_t>(kAbandonPartialTopNRowNumberMinPct, 80);
+  }
+
+  int32_t maxElementsSizeInRepeatAndSequence() const {
+    return get<int32_t>(kMaxElementsSizeInRepeatAndSequence, 10'000);
   }
 
   uint64_t maxSpillRunRows() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -27,6 +27,10 @@ Generic Configuration
      - 10000
      - Max number of rows that could be return by operators from Operator::getOutput. It is used when an estimate of
        average row size is known and preferred_output_batch_bytes is used to compute the number of output rows.
+   * - max_elements_size_in_repeat_and_sequence
+     - integer
+     - 10000
+     - Max number of elements that can be set in `repeat` and `sequence` functions.
    * - table_scan_getoutput_time_limit_ms
      - integer
      - 5000

--- a/velox/functions/lib/tests/RepeatTest.cpp
+++ b/velox/functions/lib/tests/RepeatTest.cpp
@@ -97,6 +97,52 @@ TEST_F(RepeatTest, repeat) {
   testExpression("try(repeat(C0, '0'::INTEGER))", {elementVector}, expected);
 }
 
+TEST_F(RepeatTest, repeatWithEntriesWithMaxElementsSize) {
+  const auto elementVector =
+      makeNullableFlatVector<float>({0.0, 2.0, std::nullopt, 3.0});
+  execCtx_.queryCtx()->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kMaxElementsSizeInRepeatAndSequence, "15000"},
+  });
+
+  const int32_t within_limit = 13'000;
+  auto countVectorWithinLimit = makeNullableFlatVector<int32_t>(
+      {within_limit, within_limit, within_limit, std::nullopt});
+
+  auto withinLimitData = makeRowVector({elementVector, countVectorWithinLimit});
+  auto typedExprWithinLimit =
+      makeTypedExpr("repeat(C0, C1)", asRowType(withinLimitData->type()));
+
+  exec::ExprSet exprSetWithinLimit({typedExprWithinLimit}, &execCtx_);
+  exec::EvalCtx evalCtxWithinLimit(
+      &execCtx_, &exprSetWithinLimit, withinLimitData.get());
+
+  auto result = evaluate(exprSetWithinLimit, withinLimitData);
+
+  VectorPtr expected = makeNullableArrayVector<float>({
+      std::vector<std::optional<float>>(within_limit, 0.0),
+      std::vector<std::optional<float>>(within_limit, 2.0),
+      std::vector<std::optional<float>>(within_limit, std::nullopt),
+      std::nullopt,
+  });
+
+  assertEqualVectors(expected, result);
+
+  const int32_t over_limit = 15'200;
+  auto countVectorOverLimit = makeNullableFlatVector<int32_t>(
+      {over_limit, over_limit, over_limit, std::nullopt});
+
+  auto overLimitData = makeRowVector({elementVector, countVectorOverLimit});
+  auto typedExprWithOverLimit =
+      makeTypedExpr("repeat(C0, C1)", asRowType(overLimitData->type()));
+
+  exec::ExprSet exprSetOverLimit({typedExprWithOverLimit}, &execCtx_);
+  exec::EvalCtx evalCtx(&execCtx_, &exprSetOverLimit, overLimitData.get());
+
+  VELOX_ASSERT_THROW(
+      evaluate(exprSetOverLimit, overLimitData),
+      "Count argument of repeat function must be less than or equal to 15000");
+}
+
 TEST_F(RepeatTest, repeatWithInvalidCount) {
   const auto elementVector =
       makeNullableFlatVector<float>({0.0, 2.0, 3.333333});


### PR DESCRIPTION
The diff will make maxElementsSize configurable so that user could formally use large number.

Enable maximum elements for sequence configurable will be sent in a subsequent diff.

Differential Revision: D73493321


