### PR TITLE
fix: Add SQL generation case for CallExpr with function switch

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -309,6 +309,24 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
     sql << "[";
     toCallInputsSql({call->inputs()[1]}, sql);
     sql << "]";
+  } else if (call->name() == "switch") {
+    VELOX_CHECK_GE(
+        call->inputs().size(),
+        2,
+        "Expected at least two arguments to function 'switch'");
+    sql << "case";
+    int i = 0;
+    for (; i < call->inputs().size() - 1; i += 2) {
+      sql << " when ";
+      toCallInputsSql({call->inputs()[i]}, sql);
+      sql << " then ";
+      toCallInputsSql({call->inputs()[i + 1]}, sql);
+    }
+    if (i < call->inputs().size()) {
+      sql << " else ";
+      toCallInputsSql({call->inputs()[i]}, sql);
+    }
+    sql << " end";
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -326,6 +326,46 @@ TEST(PrestoSqlTest, toCallSql) {
           "subscript")),
       "Expected two arguments to function 'subscript'");
 
+  // Function SWITCH, builds 'CASE WHEN ... THEN ... ELSE ... END' SQL
+  // SWITCH cases with no ELSE.
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1")},
+          "switch")),
+      "case when c0 then c1 end");
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3")},
+          "switch")),
+      "case when c0 then c1 when c2 then c3 end");
+  // SWITCH case with ELSE.
+  EXPECT_EQ(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c4")},
+          "switch")),
+      "case when c0 then c1 when c2 then c3 else c4 end");
+  VELOX_ASSERT_THROW(
+      toCallSql(std::make_shared<core::CallTypedExpr>(
+          INTEGER(),
+          std::vector<core::TypedExprPtr>{
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
+          "switch")),
+      "Expected at least two arguments to function 'switch'");
+
   // Generic functions
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(


### PR DESCRIPTION
Summary:
Add case to function `toCallSql` of PrestoSql to generate special SQL syntax for function `switch`. In Velox expression evaluation, the function is registered as `switch`, while in Presto Java there is no such conception. `switch` in Presto refers to case blocks. For example,
`case when true then "hello" end`
`case when true then "hello" when false then "goodbye" else "wave" end`
This PR adds SQL syntax for the above. It also handles the special case where two arguments passed to `switch` is treated as an `if` clause. This will fix our cogwheel runs that invoke special form `switch` and are currently failing due to the errors noted below.

Differential Revision: D73517749


