### PR TITLE
feat: Velox atomic counter performance improvements

### DIFF
--- a/velox/common/io/IoStatistics.cpp
+++ b/velox/common/io/IoStatistics.cpp
@@ -109,11 +109,12 @@ IoStatistics::operationStats() const {
 }
 
 void IoStatistics::merge(const IoStatistics& other) {
-  rawBytesRead_ += other.rawBytesRead_;
-  rawBytesWritten_ += other.rawBytesWritten_;
-  totalScanTime_ += other.totalScanTime_;
+  rawBytesRead_.fetch_add(other.rawBytesRead_, std::memory_order_relaxed);
+  rawBytesWritten_.fetch_add(other.rawBytesWritten_, std::memory_order_relaxed);
+  totalScanTime_.fetch_add(other.totalScanTime_, std::memory_order_relaxed);
 
-  rawOverreadBytes_ += other.rawOverreadBytes_;
+  rawOverreadBytes_.fetch_add(
+      other.rawOverreadBytes_, std::memory_order_relaxed);
   prefetch_.merge(other.prefetch_);
   read_.merge(other.read_);
   ramHit_.merge(other.ramHit_);

--- a/velox/common/io/IoStatistics.h
+++ b/velox/common/io/IoStatistics.h
@@ -60,15 +60,15 @@ class IoCounter {
   }
 
   void increment(uint64_t amount) {
-    ++count_;
-    sum_ += amount;
+    count_.fetch_add(1, std::memory_order_relaxed);
+    sum_.fetch_add(amount, std::memory_order_relaxed);
     casLoop(min_, amount, std::greater());
     casLoop(max_, amount, std::less());
   }
 
   void merge(const IoCounter& other) {
-    sum_ += other.sum_;
-    count_ += other.count_;
+    sum_.fetch_add(other.sum_, std::memory_order_relaxed);
+    count_.fetch_add(other.count_, std::memory_order_relaxed);
     casLoop(min_, other.min_, std::greater());
     casLoop(max_, other.max_, std::less());
   }

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -100,8 +100,9 @@ struct Stats {
       auto index = sizeIndex(bytes);
       velox::ClockTimer timer(sizes[index].allocateClocks);
       op();
-      sizes[index].numAllocations += count;
-      sizes[index].totalBytes += bytes * count;
+      sizes[index].numAllocations.fetch_add(count, std::memory_order_relaxed);
+      sizes[index].totalBytes.fetch_add(
+          bytes * count, std::memory_order_relaxed);
     } else {
       op();
     }

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1085,7 +1085,8 @@ void HashTable<ignoreNullKeys>::buildJoinPartition(
           numRows,
           &partitionInfo,
           allocator);
-      table->numParallelBuildRows_ += numRows;
+      table->numParallelBuildRows_.fetch_add(
+          numRows, std::memory_order_relaxed);
     }
   }
 }

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -103,8 +103,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
         pages.push_back(std::make_unique<SerializedPage>(std::move(inputPage)));
         inputPage = nullptr;
       }
-      numPages_ += pages.size();
-      totalBytes_ += totalBytes;
+      numPages_.fetch_add(pages.size(), std::memory_order_relaxed);
+      totalBytes_.fetch_add(totalBytes, std::memory_order_relaxed);
       if (data.empty()) {
         common::testutil::TestValue::adjust(
             "facebook::velox::exec::test::LocalExchangeSource::timeout", this);

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -77,7 +77,8 @@ void TableScan::updateStats(
   }
   for (const auto& [name, counter] : connectorStats) {
     if (name == "ioWaitNanos") {
-      ioWaitNanos_ += counter.value - lastIoWaitNanos_;
+      ioWaitNanos_.fetch_add(
+          counter.value - lastIoWaitNanos_, std::memory_order_relaxed);
       lastIoWaitNanos_ = counter.value;
     }
     if (UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {


### PR DESCRIPTION
Summary: Relax memory order of misc atomic counters and rely on fetch_add/sub over +=/-=

Reviewed By: xiaoxmeng

Differential Revision: D73466800


