### PR TITLE
feat: Pass mapping from PlanNodeId to ExchangeClient to TaskListener::onCompletion

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -113,6 +113,10 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
     return kRequestDataSizesMaxWaitSec_;
   }
 
+  const std::unordered_set<std::string>& getRemoteTaskIdList() const {
+    return remoteTaskIds_;
+  }
+
  private:
   struct RequestSpec {
     std::shared_ptr<ExchangeSource> source;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2418,7 +2418,13 @@ void Task::onTaskCompletion() {
 
     for (auto& listener : listeners) {
       listener->onTaskCompletion(
-          uuid_, taskId_, state, exception, stats, planFragment_);
+          uuid_,
+          taskId_,
+          state,
+          exception,
+          stats,
+          planFragment_,
+          exchangeClientByPlanNode_);
     }
   });
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1326,7 +1326,10 @@ class TaskListener {
       TaskState state,
       std::exception_ptr error,
       const TaskStats& stats,
-      const core::PlanFragment& /*fragment*/) {
+      const core::PlanFragment& /*fragment*/,
+      const std::
+          unordered_map<core::PlanNodeId, std::shared_ptr<ExchangeClient>>&
+      /*exchangeClientMap*/) {
     onTaskCompletion(taskUuid, taskId, state, error, stats);
   }
 };


### PR DESCRIPTION
We're using TaskListener to log query plan fragments so that we can rerun the query 
later. To do that, we need to know the relation among plan fragments, i.e., the 
producers and consumers of shuffles. This diff makes TaskListener::onCompletion 
receives a map from consumer PlanNode id to a ExchangeClient with which we can 
log the mapping from consumer PlanNode id to a list of producer Task id in 
TaskListener.

Differential Revision: D69828745


