### PR TITLE
fix: Calling freeNonContiguous in removeEntryLocked does not update allocClocks

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -358,6 +358,7 @@ void CacheShard::removeEntryLocked(AsyncDataCacheEntry* entry) {
   const auto numPages = entry->data().numPages();
   if (numPages > 0) {
     cache_->incrementCachedPages(-numPages);
+    ClockTimer t(allocClocks_);
     cache_->allocator()->freeNonContiguous(entry->data());
   }
   entry->tinyData_.clear();


### PR DESCRIPTION
Calling freeNonContiguous in removeEntryLocked does not update allocClocks.

 https://github.com/facebookincubator/velox/issues/13135 If the separation of alloc and free is considered a feasible solution (compatibility), I can merge these two PRs into one