### PR TITLE
fix(arrow): Use `VELOX_DCHECK*` instead of `DCHECK*`

### DIFF
--- a/velox/dwio/parquet/common/LevelConversionUtil.h
+++ b/velox/dwio/parquet/common/LevelConversionUtil.h
@@ -269,7 +269,7 @@ int64_t DefLevelsBatchToBitmap(
     int64_t upperBoundRemaining,
     LevelInfo levelInfo,
     ::arrow::internal::FirstTimeBitmapWriter* writer) {
-  DCHECK_LE(batchSize, kExtractBitsSize);
+  VELOX_DCHECK_LE(batchSize, kExtractBitsSize);
 
   // Greater than levelInfo.defLevel - 1 implies >= the defLevel
   auto definedBitmap = static_cast<extractBitmapT>(

--- a/velox/dwio/parquet/writer/arrow/ArrowSchema.cpp
+++ b/velox/dwio/parquet/writer/arrow/ArrowSchema.cpp
@@ -30,10 +30,10 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/ArrowSchemaInternal.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Metadata.h"
@@ -1055,13 +1055,13 @@ std::function<std::shared_ptr<::arrow::DataType>(FieldVector)> GetNestedFactory(
     case ::arrow::Type::LIST:
       if (origin_type.id() == ::arrow::Type::LIST) {
         return [](FieldVector fields) {
-          DCHECK_EQ(fields.size(), 1);
+          VELOX_DCHECK_EQ(fields.size(), 1);
           return ::arrow::list(std::move(fields[0]));
         };
       }
       if (origin_type.id() == ::arrow::Type::LARGE_LIST) {
         return [](FieldVector fields) {
-          DCHECK_EQ(fields.size(), 1);
+          VELOX_DCHECK_EQ(fields.size(), 1);
           return ::arrow::large_list(std::move(fields[0]));
         };
       }
@@ -1070,7 +1070,7 @@ std::function<std::shared_ptr<::arrow::DataType>(FieldVector)> GetNestedFactory(
             checked_cast<const ::arrow::FixedSizeListType&>(origin_type)
                 .list_size();
         return [list_size](FieldVector fields) {
-          DCHECK_EQ(fields.size(), 1);
+          VELOX_DCHECK_EQ(fields.size(), 1);
           return ::arrow::fixed_size_list(std::move(fields[0]), list_size);
         };
       }
@@ -1092,7 +1092,7 @@ Result<bool> ApplyOriginalStorageMetadata(
   const int num_children = inferred_type->num_fields();
 
   if (num_children > 0 && origin_type->num_fields() == num_children) {
-    DCHECK_EQ(static_cast<int>(inferred->children.size()), num_children);
+    VELOX_DCHECK_EQ(static_cast<int>(inferred->children.size()), num_children);
     const auto factory = GetNestedFactory(*origin_type, *inferred_type);
     if (factory) {
       // The type may be modified (e.g. LargeList) while the children stay the

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -38,9 +38,9 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/type_traits.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/common/LevelConversion.h"
 #include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
 #include "velox/dwio/parquet/writer/arrow/Encoding.h"
@@ -67,6 +67,12 @@ using arrow::Result;
 using arrow::Status;
 using arrow::internal::checked_cast;
 using arrow::internal::checked_pointer_cast;
+
+namespace arrow {
+fmt::underlying_t<Type::type> format_as(Type::type type) {
+  return fmt::underlying(type);
+}
+}; // namespace arrow
 
 namespace facebook::velox::parquet::arrow {
 using util::CodecOptions;
@@ -404,7 +410,7 @@ class SerializedPageWriter : public PageWriter {
    */
   void Compress(const Buffer& src_buffer, ResizableBuffer* dest_buffer)
       override {
-    DCHECK(compressor_ != nullptr);
+    VELOX_DCHECK_NOT_NULL(compressor_);
 
     // Compress the data
     int64_t max_compressed_size =
@@ -966,14 +972,14 @@ class ColumnWriterImpl {
 
   // Write multiple definition levels
   void WriteDefinitionLevels(int64_t num_levels, const int16_t* levels) {
-    DCHECK(!closed_);
+    VELOX_DCHECK(!closed_);
     PARQUET_THROW_NOT_OK(
         definition_levels_sink_.Append(levels, sizeof(int16_t) * num_levels));
   }
 
   // Write multiple repetition levels
   void WriteRepetitionLevels(int64_t num_levels, const int16_t* levels) {
-    DCHECK(!closed_);
+    VELOX_DCHECK(!closed_);
     PARQUET_THROW_NOT_OK(
         repetition_levels_sink_.Append(levels, sizeof(int16_t) * num_levels));
   }
@@ -1100,7 +1106,7 @@ int64_t ColumnWriterImpl::RleEncodeLevels(
   int encoded = level_encoder_.Encode(
       static_cast<int>(num_buffered_values_),
       reinterpret_cast<const int16_t*>(src_buffer));
-  DCHECK_EQ(encoded, num_buffered_values_);
+  VELOX_DCHECK_EQ(encoded, num_buffered_values_);
 
   if (include_length_prefix) {
     reinterpret_cast<int32_t*>(dest_buffer->mutable_data())[0] =
@@ -1270,7 +1276,8 @@ void ColumnWriterImpl::BuildDataPageV2(
 
   // page_stats.null_count is not set when page_statistics_ is nullptr. It is
   // only used here for safety check.
-  DCHECK(!page_stats.has_null_count || page_stats.null_count == null_count);
+  VELOX_DCHECK(
+      !page_stats.has_null_count || page_stats.null_count == null_count);
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
@@ -1390,7 +1397,7 @@ inline void DoInBatches(
       // boundary. It is a good chance to check the page size.
       action(offset, end_offset - offset, /*check_page_size=*/true);
     } else {
-      DCHECK_EQ(end_offset, num_levels);
+      VELOX_DCHECK_EQ(end_offset, num_levels);
       // This is the last chunk of batch, and we do not know whether end_offset
       // is a record boundary. Find the offset to beginning of last record in
       // this chunk, so we can check page size.
@@ -1418,7 +1425,7 @@ inline void DoInBatches(
 }
 
 bool DictionaryDirectWriteSupported(const ::arrow::Array& array) {
-  DCHECK_EQ(array.type_id(), ::arrow::Type::DICTIONARY);
+  VELOX_DCHECK_EQ(array.type_id(), ::arrow::Type::DICTIONARY);
   const ::arrow::DictionaryType& dict_type =
       static_cast<const ::arrow::DictionaryType&>(*array.type());
   return ::arrow::is_base_binary_like(dict_type.value_type()->id());
@@ -1515,7 +1522,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
 
       // PARQUET-780
       if (values_to_write > 0) {
-        DCHECK_NE(nullptr, values);
+        VELOX_DCHECK_NOT_NULL(values);
       }
       const int64_t num_nulls = batch_size - values_to_write;
       WriteValues(
@@ -1671,7 +1678,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       bool maybe_parent_nulls);
 
   void WriteDictionaryPage() override {
-    DCHECK(current_dict_encoder_);
+    VELOX_DCHECK(current_dict_encoder_);
     std::shared_ptr<ResizableBuffer> buffer = AllocateBuffer(
         properties_->memory_pool(), current_dict_encoder_->dict_encoded_size());
     current_dict_encoder_->WriteDict(buffer->mutable_data());
@@ -1811,7 +1818,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
         // need to output counts which will always be equal to
         // the batch size passed in (max def_level == 0 indicates
         // there cannot be repeated or null fields).
-        DCHECK_EQ(def_levels, nullptr);
+        VELOX_DCHECK_NULL(def_levels);
         *out_values_to_write = batch_size;
         *out_spaced_values_to_write = batch_size;
         *null_count = 0;
@@ -1855,7 +1862,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     }
     buffers[0] = bits_buffer_;
     // Should be a leaf array.
-    DCHECK_GT(buffers.size(), 1);
+    VELOX_DCHECK_GT(buffers.size(), 1);
     ValueBufferSlicer slicer{memory_pool};
     if (array->data()->offset > 0) {
       RETURN_NOT_OK(util::VisitArrayInline(*array, &slicer, &buffers[1]));
@@ -2227,7 +2234,7 @@ Status WriteArrowZeroCopy(
   if (data.values() != nullptr) {
     values = reinterpret_cast<const T*>(data.values()->data()) + data.offset();
   } else {
-    DCHECK_EQ(data.length(), 0);
+    VELOX_DCHECK_EQ(data.length(), 0);
   }
   bool no_nulls = writer->descr()->schema_node()->is_required() ||
       (array.null_count() == 0);
@@ -2522,7 +2529,7 @@ struct SerializeFunctor<Int64Type, ::arrow::TimestampType> {
                                  [static_cast<int>(target_unit)];
 
     // .first -> coercion operation; .second -> scale factor
-    DCHECK_NE(coercion.first, COERCE_INVALID);
+    VELOX_DCHECK_NE(coercion.first, COERCE_INVALID);
     return coercion.first == COERCE_DIVIDE ? DivideBy(coercion.second)
                                            : MultiplyBy(coercion.second);
   }

--- a/velox/dwio/parquet/writer/arrow/Encoding.cpp
+++ b/velox/dwio/parquet/writer/arrow/Encoding.cpp
@@ -40,9 +40,10 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/bitmap_writer.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_data_inline.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/common/RleEncodingInternal.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Platform.h"
@@ -172,7 +173,7 @@ class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
   }
 
   void UnsafePutByteArray(const void* data, uint32_t length) {
-    DCHECK(length == 0 || data != nullptr) << "Value ptr cannot be NULL";
+    VELOX_DCHECK(length == 0 || data != nullptr, "Value ptr cannot be NULL");
     sink_.UnsafeAppend(&length, sizeof(uint32_t));
     sink_.UnsafeAppend(data, static_cast<int64_t>(length));
   }
@@ -300,7 +301,7 @@ inline void PlainEncoder<ByteArrayType>::Put(const ::arrow::Array& values) {
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
 }
@@ -349,7 +350,7 @@ inline void PlainEncoder<FLBAType>::Put(
   }
   for (int i = 0; i < num_values; ++i) {
     // Write the result to the output stream
-    DCHECK(src[i].ptr != nullptr) << "Value ptr cannot be NULL";
+    VELOX_DCHECK(src[i].ptr != nullptr, "Value ptr cannot be NULL");
     PARQUET_THROW_NOT_OK(sink_.Append(src[i].ptr, descr_->type_length()));
   }
 }
@@ -665,7 +666,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
 
   template <typename ArrayType>
   void PutBinaryDictionaryArray(const ArrayType& array) {
-    DCHECK_EQ(array.null_count(), 0);
+    VELOX_DCHECK_EQ(array.null_count(), 0);
     for (int64_t i = 0; i < array.length(); i++) {
       auto v = array.GetView(i);
       if (ARROW_PREDICT_FALSE(v.size() > kMaxByteArraySize)) {
@@ -688,7 +689,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
 template <typename DType>
 void DictEncoderImpl<DType>::WriteDict(uint8_t* buffer) const {
   // For primitive types, only a memcpy
-  DCHECK_EQ(
+  VELOX_DCHECK_EQ(
       static_cast<size_t>(dict_encoded_size_), sizeof(T) * memo_table_.size());
   memo_table_.CopyValues(0 /* start_pos */, reinterpret_cast<T*>(buffer));
 }
@@ -708,7 +709,7 @@ void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) const {
 template <>
 void DictEncoderImpl<FLBAType>::WriteDict(uint8_t* buffer) const {
   memo_table_.VisitValues(0, [&](std::string_view v) {
-    DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
+    VELOX_DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
     memcpy(buffer, v.data(), type_length_);
     buffer += type_length_;
   });
@@ -732,7 +733,7 @@ template <typename DType>
 inline void DictEncoderImpl<DType>::PutByteArray(
     const void* ptr,
     int32_t length) {
-  DCHECK(false);
+  VELOX_DCHECK(false);
 }
 
 template <>
@@ -746,7 +747,7 @@ inline void DictEncoderImpl<ByteArrayType>::PutByteArray(
     dict_encoded_size_ += static_cast<int>(length + sizeof(uint32_t));
   };
 
-  DCHECK(ptr != nullptr || length == 0);
+  VELOX_DCHECK(ptr != nullptr || length == 0);
   ptr = (ptr != nullptr) ? ptr : empty;
   int32_t memo_index;
   PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
@@ -768,7 +769,7 @@ inline void DictEncoderImpl<FLBAType>::Put(const FixedLenByteArray& v) {
     dict_encoded_size_ += type_length_;
   };
 
-  DCHECK(v.ptr != nullptr || type_length_ == 0);
+  VELOX_DCHECK(v.ptr != nullptr || type_length_ == 0);
   const void* ptr = (v.ptr != nullptr) ? v.ptr : empty;
   int32_t memo_index;
   PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
@@ -830,7 +831,7 @@ void DictEncoderImpl<ByteArrayType>::Put(const ::arrow::Array& values) {
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
 }
@@ -890,7 +891,7 @@ void DictEncoderImpl<ByteArrayType>::PutDictionary(
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryDictionaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryDictionaryArray(
         checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
@@ -1399,16 +1400,16 @@ struct ArrowBinaryHelper<ByteArrayType> {
   }
 
   void UnsafeAppend(const uint8_t* data, int32_t length) {
-    DCHECK(CanFit(length));
-    DCHECK_GT(entries_remaining_, 0);
+    VELOX_DCHECK(CanFit(length));
+    VELOX_DCHECK_GT(entries_remaining_, 0);
     chunk_space_remaining_ -= length;
     --entries_remaining_;
     acc_->builder->UnsafeAppend(data, length);
   }
 
   Status Append(const uint8_t* data, int32_t length) {
-    DCHECK(CanFit(length));
-    DCHECK_GT(entries_remaining_, 0);
+    VELOX_DCHECK(CanFit(length));
+    VELOX_DCHECK_GT(entries_remaining_, 0);
     chunk_space_remaining_ -= length;
     --entries_remaining_;
     return acc_->builder->Append(data, length);
@@ -1459,13 +1460,13 @@ struct ArrowBinaryHelper<FLBAType> {
   }
 
   void UnsafeAppend(const uint8_t* data, int32_t length) {
-    DCHECK_GT(entries_remaining_, 0);
+    VELOX_DCHECK_GT(entries_remaining_, 0);
     --entries_remaining_;
     acc_->UnsafeAppend(data);
   }
 
   Status Append(const uint8_t* data, int32_t length) {
-    DCHECK_GT(entries_remaining_, 0);
+    VELOX_DCHECK_GT(entries_remaining_, 0);
     --entries_remaining_;
     return acc_->Append(data);
   }
@@ -2599,7 +2600,7 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
   // Call to GetNextBytePtr reserves mini_blocks_per_block_ bytes of space to
   // write bit widths of miniblocks as they become known during the encoding.
   uint8_t* bit_width_data = bit_writer_.GetNextBytePtr(mini_blocks_per_block_);
-  DCHECK(bit_width_data != nullptr);
+  VELOX_DCHECK(bit_width_data != nullptr);
 
   const uint32_t num_miniblocks = static_cast<uint32_t>(std::ceil(
       static_cast<double>(values_current_block_) /
@@ -2640,7 +2641,7 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
   for (uint32_t i = num_miniblocks; i < mini_blocks_per_block_; i++) {
     bit_width_data[i] = 0;
   }
-  DCHECK_EQ(values_current_block_, 0);
+  VELOX_DCHECK_EQ(values_current_block_, 0);
 
   bit_writer_.Flush();
   PARQUET_THROW_NOT_OK(
@@ -2873,7 +2874,7 @@ class DeltaBitPackDecoder : public DecoderImpl,
   }
 
   void InitBlock() {
-    DCHECK_GT(total_values_remaining_, 0) << "InitBlock called at EOF";
+    VELOX_DCHECK_GT(total_values_remaining_, 0, "InitBlock called at EOF");
 
     if (!decoder_->GetZigZagVlqInt(&min_delta_))
       ParquetException::EofException("InitBlock EOF");
@@ -2932,7 +2933,7 @@ class DeltaBitPackDecoder : public DecoderImpl,
       InitBlock();
     }
 
-    DCHECK(first_block_initialized_);
+    VELOX_DCHECK(first_block_initialized_);
     while (i < max_values) {
       // Ensure we have an initialized mini-block
       if (ARROW_PREDICT_FALSE(values_remaining_current_mini_block_ == 0)) {
@@ -3164,7 +3165,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
     // Decode up to `max_values` strings into an internal buffer
     // and reference them into `buffer`.
     max_values = std::min(max_values, num_valid_values_);
-    DCHECK_GE(max_values, 0);
+    VELOX_DCHECK_GE(max_values, 0);
     if (max_values == 0) {
       return 0;
     }
@@ -3237,7 +3238,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
     int ret = len_decoder_.Decode(
         reinterpret_cast<int32_t*>(buffered_length_->mutable_data()),
         num_length);
-    DCHECK_EQ(ret, num_length);
+    VELOX_DCHECK_EQ(ret, num_length);
     length_idx_ = 0;
     num_valid_values_ = num_length;
   }
@@ -3284,7 +3285,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
           return Status::OK();
         }));
 
-    DCHECK_EQ(null_count, 0);
+    VELOX_DCHECK_EQ(null_count, 0);
     *out_num_values = num_valid_values;
     return Status::OK();
   }
@@ -3780,13 +3781,13 @@ class DeltaByteArrayDecoderImpl : public DecoderImpl,
     int ret = prefix_len_decoder_.Decode(
         reinterpret_cast<int32_t*>(buffered_prefix_length_->mutable_data()),
         num_prefix);
-    DCHECK_EQ(ret, num_prefix);
+    VELOX_DCHECK_EQ(ret, num_prefix);
     prefix_len_offset_ = 0;
     num_valid_values_ = num_prefix;
 
     int bytes_left = decoder_->bytesLeft();
     // If len < bytes_left, prefix_len_decoder.Decode will throw exception.
-    DCHECK_GE(len, bytes_left);
+    VELOX_DCHECK_GE(len, bytes_left);
     int suffix_begins = len - bytes_left;
     // at this time, the decoder_ will be at the start of the encoded suffix
     // data.
@@ -3891,7 +3892,7 @@ class DeltaByteArrayDecoderImpl : public DecoderImpl,
     std::vector<ByteArray> values(num_values);
     const int num_valid_values =
         GetInternal(values.data(), num_values - null_count);
-    DCHECK_EQ(num_values - null_count, num_valid_values);
+    VELOX_DCHECK_EQ(num_values - null_count, num_valid_values);
 
     auto values_ptr = reinterpret_cast<const ByteArray*>(values.data());
     int value_idx = 0;
@@ -3914,7 +3915,7 @@ class DeltaByteArrayDecoderImpl : public DecoderImpl,
           return Status::OK();
         }));
 
-    DCHECK_EQ(null_count, 0);
+    VELOX_DCHECK_EQ(null_count, 0);
     *out_num_values = num_valid_values;
     return Status::OK();
   }
@@ -4149,7 +4150,7 @@ std::unique_ptr<Encoder> MakeEncoder(
       case Type::FIXED_LEN_BYTE_ARRAY:
         return std::make_unique<DictEncoderImpl<FLBAType>>(descr, pool);
       default:
-        DCHECK(false) << "Encoder not implemented";
+        VELOX_DCHECK(false, "Encoder not implemented");
         break;
     }
   } else if (encoding == Encoding::PLAIN) {
@@ -4171,7 +4172,7 @@ std::unique_ptr<Encoder> MakeEncoder(
       case Type::FIXED_LEN_BYTE_ARRAY:
         return std::make_unique<PlainEncoder<FLBAType>>(descr, pool);
       default:
-        DCHECK(false) << "Encoder not implemented";
+        VELOX_DCHECK(false, "Encoder not implemented");
         break;
     }
   } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
@@ -4225,7 +4226,7 @@ std::unique_ptr<Encoder> MakeEncoder(
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 
@@ -4299,7 +4300,7 @@ std::unique_ptr<Decoder> MakeDecoder(
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 
@@ -4329,7 +4330,7 @@ std::unique_ptr<Decoder> MakeDictDecoder(
     default:
       break;
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 

--- a/velox/dwio/parquet/writer/arrow/FileWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/FileWriter.cpp
@@ -25,7 +25,8 @@
 #include <vector>
 
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
 #include "velox/dwio/parquet/writer/arrow/EncryptionInternal.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
@@ -322,10 +323,10 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
         column_writers_.size() > 0) { // when
                                       // buffered_row_group
                                       // = true
-      DCHECK(column_writers_[0] != nullptr);
+      VELOX_DCHECK_NOT_NULL(column_writers_[0]);
       int64_t current_col_rows = column_writers_[0]->rows_written();
       for (int i = 1; i < static_cast<int>(column_writers_.size()); i++) {
-        DCHECK(column_writers_[i] != nullptr);
+        VELOX_DCHECK_NOT_NULL(column_writers_[i]);
         int64_t current_col_rows_i = column_writers_[i]->rows_written();
         if (current_col_rows != current_col_rows_i) {
           ThrowRowsMisMatchError(i, current_col_rows_i, current_col_rows);

--- a/velox/dwio/parquet/writer/arrow/Metadata.cpp
+++ b/velox/dwio/parquet/writer/arrow/Metadata.cpp
@@ -28,7 +28,8 @@
 
 #include "arrow/io/memory.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/EncryptionInternal.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/FileDecryptorInternal.h"
@@ -295,7 +296,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   // 1) Must be set in the metadata
   // 2) Statistics must not be corrupted
   inline bool is_stats_set() const {
-    DCHECK(writer_version_ != nullptr);
+    VELOX_DCHECK_NOT_NULL(writer_version_);
     // If the column statistics don't exist or column sort order is unknown
     // we cannot use the column stats
     if (!column_metadata_->__isset.statistics ||
@@ -1608,12 +1609,12 @@ bool ApplicationVersion::VersionLt(
     return true;
   if (version.major > other_version.version.major)
     return false;
-  DCHECK_EQ(version.major, other_version.version.major);
+  VELOX_DCHECK_EQ(version.major, other_version.version.major);
   if (version.minor < other_version.version.minor)
     return true;
   if (version.minor > other_version.version.minor)
     return false;
-  DCHECK_EQ(version.minor, other_version.version.minor);
+  VELOX_DCHECK_EQ(version.minor, other_version.version.minor);
   return version.patch < other_version.version.patch;
 }
 

--- a/velox/dwio/parquet/writer/arrow/PageIndex.cpp
+++ b/velox/dwio/parquet/writer/arrow/PageIndex.cpp
@@ -126,7 +126,7 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
         [](int32_t num_non_null_pages, bool null_page) {
           return num_non_null_pages + (null_page ? 0 : 1);
         }));
-    DCHECK_LE(num_non_null_pages, num_pages);
+    VELOX_DCHECK_LE(num_non_null_pages, num_pages);
 
     // Allocate slots for decoded values.
     min_values_.resize(num_pages);
@@ -146,7 +146,7 @@ class TypedColumnIndexImpl : public TypedColumnIndex<DType> {
             plain_decoder, column_index_.max_values[i], &max_values_, i);
       }
     }
-    DCHECK_EQ(num_non_null_pages, non_null_page_indices_.size());
+    VELOX_DCHECK_EQ(num_non_null_pages, non_null_page_indices_.size());
   }
 
   const std::vector<bool>& null_pages() const override {
@@ -613,7 +613,7 @@ class ColumnIndexBuilderImpl final : public ColumnIndexBuilder {
   BoundaryOrder::type DetermineBoundaryOrder(
       const std::vector<T>& min_values,
       const std::vector<T>& max_values) const {
-    DCHECK_EQ(min_values.size(), max_values.size());
+    VELOX_DCHECK_EQ(min_values.size(), max_values.size());
     if (min_values.empty()) {
       return BoundaryOrder::Unordered;
     }
@@ -745,9 +745,10 @@ class PageIndexBuilderImpl final : public PageIndexBuilder {
     column_index_builders_.back().resize(num_columns);
     offset_index_builders_.back().resize(num_columns);
 
-    DCHECK_EQ(column_index_builders_.size(), offset_index_builders_.size());
-    DCHECK_EQ(column_index_builders_.back().size(), num_columns);
-    DCHECK_EQ(offset_index_builders_.back().size(), num_columns);
+    VELOX_DCHECK_EQ(
+        column_index_builders_.size(), offset_index_builders_.size());
+    VELOX_DCHECK_EQ(column_index_builders_.back().size(), num_columns);
+    VELOX_DCHECK_EQ(offset_index_builders_.back().size(), num_columns);
   }
 
   ColumnIndexBuilder* GetColumnIndexBuilder(int32_t i) override {
@@ -824,7 +825,7 @@ class PageIndexBuilderImpl final : public PageIndexBuilder {
          ++row_group) {
       const auto& row_group_page_index_builders =
           page_index_builders[row_group];
-      DCHECK_EQ(row_group_page_index_builders.size(), num_columns);
+      VELOX_DCHECK_EQ(row_group_page_index_builders.size(), num_columns);
 
       bool has_valid_index = false;
       std::vector<std::optional<IndexLocation>> locations(

--- a/velox/dwio/parquet/writer/arrow/PathInternal.cpp
+++ b/velox/dwio/parquet/writer/arrow/PathInternal.cpp
@@ -110,10 +110,10 @@
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_visit.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/visit_array_inline.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
 
 namespace facebook::velox::parquet::arrow::arrow {
@@ -306,7 +306,7 @@ struct NullableTerminalNode {
     int64_t elements = range.Size();
     RETURN_IF_ERROR(context->ReserveDefLevels(elements));
 
-    DCHECK_GT(elements, 0);
+    VELOX_DCHECK_GT(elements, 0);
 
     auto bit_visitor = [&](bool is_set) {
       context->UnsafeAppendDefLevel(
@@ -448,8 +448,7 @@ class ListPathNode {
       RETURN_IF_ERROR(context->AppendRepLevel(prev_rep_level_));
       RETURN_IF_ERROR(
           context->AppendRepLevels(size_check.Size() - 1, rep_level_));
-      DCHECK_EQ(size_check.start, child_range->end)
-          << size_check.start << " != " << child_range->end;
+      VELOX_DCHECK_EQ(size_check.start, child_range->end);
       child_range->end = size_check.end;
       ++range->start;
     }
@@ -535,7 +534,7 @@ class NullableNode {
     child_range->end = child_range->start = range->start;
     child_range->end += run.length;
 
-    DCHECK(!child_range->Empty());
+    VELOX_DCHECK(!child_range->Empty());
     range->start += child_range->Size();
     new_range_ = false;
     return kNext;
@@ -656,7 +655,7 @@ Status WritePath(
     IterationResult result = std::visit(visitor, node);
 
     if (ARROW_PREDICT_FALSE(result == kError)) {
-      DCHECK(!context.last_status.ok());
+      VELOX_DCHECK(!context.last_status.ok());
       return context.last_status;
     }
     stack_position += static_cast<int>(result);

--- a/velox/dwio/parquet/writer/arrow/Properties.cpp
+++ b/velox/dwio/parquet/writer/arrow/Properties.cpp
@@ -23,7 +23,6 @@
 
 #include "arrow/io/buffered.h"
 #include "arrow/io/memory.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/thread_pool.h"
 
 namespace facebook::velox::parquet::arrow {

--- a/velox/dwio/parquet/writer/arrow/Schema.cpp
+++ b/velox/dwio/parquet/writer/arrow/Schema.cpp
@@ -27,7 +27,6 @@
 #include <type_traits>
 #include <utility>
 
-#include "arrow/util/logging.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 
 using facebook::velox::parquet::thrift::SchemaElement;

--- a/velox/dwio/parquet/writer/arrow/Statistics.cpp
+++ b/velox/dwio/parquet/writer/arrow/Statistics.cpp
@@ -31,9 +31,10 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_data_inline.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Encoding.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Platform.h"
@@ -266,7 +267,7 @@ struct BinaryLikeComparer<T, /*is_signed=*/true> {
         lead_end = a.ptr + lead_length;
         a_start += lead_length;
       } else {
-        DCHECK_LT(a_length, b_length);
+        VELOX_DCHECK_LT(a_length, b_length);
         int lead_length = b_length - a_length;
         lead_start = b.ptr;
         lead_end = b.ptr + lead_length;
@@ -425,7 +426,7 @@ class TypedComparatorImpl : virtual public TypedComparator<DType> {
   }
 
   std::pair<T, T> GetMinMax(const T* values, int64_t length) override {
-    DCHECK_GT(length, 0);
+    VELOX_DCHECK_GT(length, 0);
 
     T min = Helper::DefaultMin();
     T max = Helper::DefaultMax();
@@ -446,7 +447,7 @@ class TypedComparatorImpl : virtual public TypedComparator<DType> {
       int64_t length,
       const uint8_t* valid_bits,
       int64_t valid_bits_offset) override {
-    DCHECK_GT(length, 0);
+    VELOX_DCHECK_GT(length, 0);
 
     T min = Helper::DefaultMin();
     T max = Helper::DefaultMax();
@@ -482,7 +483,7 @@ std::pair<int32_t, int32_t>
 TypedComparatorImpl</*is_signed=*/false, Int32Type>::GetMinMax(
     const int32_t* values,
     int64_t length) {
-  DCHECK_GT(length, 0);
+  VELOX_DCHECK_GT(length, 0);
 
   const uint32_t* unsigned_values = reinterpret_cast<const uint32_t*>(values);
   uint32_t min = std::numeric_limits<uint32_t>::max();
@@ -524,7 +525,7 @@ std::pair<ByteArray, ByteArray> GetMinMaxBinaryHelper(
     ::arrow::VisitArraySpanInline<::arrow::BinaryType>(
         *values.data(), std::move(valid_func), std::move(null_func));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     ::arrow::VisitArraySpanInline<::arrow::LargeBinaryType>(
         *values.data(), std::move(valid_func), std::move(null_func));
   }
@@ -886,8 +887,8 @@ void TypedStatisticsImpl<DType>::Update(
     const T* values,
     int64_t num_values,
     int64_t null_count) {
-  DCHECK_GE(num_values, 0);
-  DCHECK_GE(null_count, 0);
+  VELOX_DCHECK_GE(num_values, 0);
+  VELOX_DCHECK_GE(null_count, 0);
 
   IncrementNullCount(null_count);
   IncrementNumValues(num_values);
@@ -905,8 +906,8 @@ void TypedStatisticsImpl<DType>::UpdateSpaced(
     int64_t num_spaced_values,
     int64_t num_values,
     int64_t null_count) {
-  DCHECK_GE(num_values, 0);
-  DCHECK_GE(null_count, 0);
+  VELOX_DCHECK_GE(num_values, 0);
+  VELOX_DCHECK_GE(null_count, 0);
 
   IncrementNullCount(null_count);
   IncrementNumValues(num_values);
@@ -1062,7 +1063,7 @@ std::shared_ptr<Statistics> Statistics::Make(
       break;
   }
 #undef MAKE_STATS
-  DCHECK(false) << "Cannot reach here";
+  VELOX_DCHECK(false, "Cannot reach here");
   return nullptr;
 }
 
@@ -1071,7 +1072,7 @@ std::shared_ptr<Statistics> Statistics::Make(
     const EncodedStatistics* encoded_stats,
     int64_t num_values,
     ::arrow::MemoryPool* pool) {
-  DCHECK(encoded_stats != nullptr);
+  VELOX_DCHECK(encoded_stats != nullptr);
   return Make(
       descr,
       encoded_stats->min(),
@@ -1122,7 +1123,7 @@ std::shared_ptr<Statistics> Statistics::Make(
       break;
   }
 #undef MAKE_STATS
-  DCHECK(false) << "Cannot reach here";
+  VELOX_DCHECK(false, "Cannot reach here");
   return nullptr;
 }
 

--- a/velox/dwio/parquet/writer/arrow/ThriftInternal.h
+++ b/velox/dwio/parquet/writer/arrow/ThriftInternal.h
@@ -34,8 +34,7 @@
 #include <thrift/protocol/TCompactProtocol.h>
 #include <thrift/transport/TBufferTransports.h>
 
-#include "arrow/util/logging.h"
-
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/FileDecryptorInternal.h"
 #include "velox/dwio/parquet/writer/arrow/FileEncryptorInternal.h"
@@ -98,7 +97,7 @@ static inline Compression::type FromThriftUnsafe(
     case facebook::velox::parquet::thrift::CompressionCodec::ZSTD:
       return Compression::ZSTD;
     default:
-      DCHECK(false) << "Cannot reach here";
+      VELOX_DCHECK(false, "Cannot reach here");
       return Compression::UNCOMPRESSED;
   }
 }
@@ -284,13 +283,18 @@ static inline facebook::velox::parquet::thrift::Type::type ToThrift(
   return static_cast<facebook::velox::parquet::thrift::Type::type>(type);
 }
 
+static fmt::underlying_t<ConvertedType::type> format_as(
+    ConvertedType::type type) {
+  return fmt::underlying(type);
+}
+
 static inline facebook::velox::parquet::thrift::ConvertedType::type ToThrift(
     ConvertedType::type type) {
   // item 0 is NONE
-  DCHECK_NE(type, ConvertedType::NONE);
+  VELOX_DCHECK_NE(type, ConvertedType::NONE);
   // it is forbidden to emit "NA" (PARQUET-1990)
-  DCHECK_NE(type, ConvertedType::NA);
-  DCHECK_NE(type, ConvertedType::UNDEFINED);
+  VELOX_DCHECK_NE(type, ConvertedType::NA);
+  VELOX_DCHECK_NE(type, ConvertedType::UNDEFINED);
   return static_cast<facebook::velox::parquet::thrift::ConvertedType::type>(
       static_cast<int>(type) - 1);
 }
@@ -327,7 +331,7 @@ static inline facebook::velox::parquet::thrift::CompressionCodec::type ToThrift(
     case Compression::ZSTD:
       return facebook::velox::parquet::thrift::CompressionCodec::ZSTD;
     default:
-      DCHECK(false) << "Cannot reach here";
+      VELOX_DCHECK(false, "Cannot reach here");
       return facebook::velox::parquet::thrift::CompressionCodec::UNCOMPRESSED;
   }
 }
@@ -341,7 +345,7 @@ static inline facebook::velox::parquet::thrift::BoundaryOrder::type ToThrift(
       return static_cast<facebook::velox::parquet::thrift::BoundaryOrder::type>(
           type);
     default:
-      DCHECK(false) << "Cannot reach here";
+      VELOX_DCHECK(false, "Cannot reach here");
       return facebook::velox::parquet::thrift::BoundaryOrder::UNORDERED;
   }
 }

--- a/velox/dwio/parquet/writer/arrow/Types.cpp
+++ b/velox/dwio/parquet/writer/arrow/Types.cpp
@@ -23,13 +23,19 @@
 #include <string>
 
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
 
 using arrow::internal::checked_cast;
 
 namespace facebook::velox::parquet::arrow {
+
+fmt::underlying_t<LogicalType::TimeUnit::unit> format_as(
+    LogicalType::TimeUnit::unit unit) {
+  return fmt::underlying(unit);
+}
 
 bool IsCodecSupported(Compression::type codec) {
   switch (codec) {
@@ -486,7 +492,7 @@ std::shared_ptr<const LogicalType> LogicalType::Date() {
 std::shared_ptr<const LogicalType> LogicalType::Time(
     bool is_adjusted_to_utc,
     LogicalType::TimeUnit::unit time_unit) {
-  DCHECK(time_unit != LogicalType::TimeUnit::UNKNOWN);
+  VELOX_DCHECK_NE(time_unit, LogicalType::TimeUnit::UNKNOWN);
   return TimeLogicalType::Make(is_adjusted_to_utc, time_unit);
 }
 
@@ -495,7 +501,7 @@ std::shared_ptr<const LogicalType> LogicalType::Timestamp(
     LogicalType::TimeUnit::unit time_unit,
     bool is_from_converted_type,
     bool force_set_converted_type) {
-  DCHECK(time_unit != LogicalType::TimeUnit::UNKNOWN);
+  VELOX_DCHECK_NE(time_unit, LogicalType::TimeUnit::UNKNOWN);
   return TimestampLogicalType::Make(
       is_adjusted_to_utc,
       time_unit,
@@ -510,7 +516,7 @@ std::shared_ptr<const LogicalType> LogicalType::Interval() {
 std::shared_ptr<const LogicalType> LogicalType::Int(
     int bit_width,
     bool is_signed) {
-  DCHECK(
+  VELOX_DCHECK(
       bit_width == 64 || bit_width == 32 || bit_width == 16 || bit_width == 8);
   return IntLogicalType::Make(bit_width, is_signed);
 }
@@ -1252,7 +1258,7 @@ LogicalType::Impl::Time::ToThrift() const {
   facebook::velox::parquet::thrift::LogicalType type;
   facebook::velox::parquet::thrift::TimeType time_type;
   facebook::velox::parquet::thrift::TimeUnit time_unit;
-  DCHECK(unit_ != LogicalType::TimeUnit::UNKNOWN);
+  VELOX_DCHECK_NE(unit_, LogicalType::TimeUnit::UNKNOWN);
   if (unit_ == LogicalType::TimeUnit::MILLIS) {
     facebook::velox::parquet::thrift::MilliSeconds millis;
     time_unit.__set_MILLIS(millis);
@@ -1420,7 +1426,7 @@ LogicalType::Impl::Timestamp::ToThrift() const {
   facebook::velox::parquet::thrift::LogicalType type;
   facebook::velox::parquet::thrift::TimestampType timestamp_type;
   facebook::velox::parquet::thrift::TimeUnit time_unit;
-  DCHECK(unit_ != LogicalType::TimeUnit::UNKNOWN);
+  VELOX_DCHECK_NE(unit_, LogicalType::TimeUnit::UNKNOWN);
   if (unit_ == LogicalType::TimeUnit::MILLIS) {
     facebook::velox::parquet::thrift::MilliSeconds millis;
     time_unit.__set_MILLIS(millis);
@@ -1628,7 +1634,7 @@ facebook::velox::parquet::thrift::LogicalType LogicalType::Impl::Int::ToThrift()
     const {
   facebook::velox::parquet::thrift::LogicalType type;
   facebook::velox::parquet::thrift::IntType int_type;
-  DCHECK(width_ == 64 || width_ == 32 || width_ == 16 || width_ == 8);
+  VELOX_DCHECK(width_ == 64 || width_ == 32 || width_ == 16 || width_ == 8);
   int_type.__set_bitWidth(static_cast<int8_t>(width_));
   int_type.__set_isSigned(signed_);
   type.__set_INTEGER(int_type);

--- a/velox/dwio/parquet/writer/arrow/Writer.cpp
+++ b/velox/dwio/parquet/writer/arrow/Writer.cpp
@@ -35,9 +35,9 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/parallel.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/ArrowSchema.h"
 #include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
@@ -96,7 +96,7 @@ int CalculateLeafCount(const DataType* type) {
 bool HasNullableRoot(
     const SchemaManifest& schema_manifest,
     const SchemaField* schema_field) {
-  DCHECK(schema_field != nullptr);
+  VELOX_DCHECK_NOT_NULL(schema_field);
   const SchemaField* current_field = schema_field;
   bool nullable = schema_field->field->nullable();
   while (current_field != nullptr) {
@@ -144,7 +144,7 @@ class ArrowColumnWriterV2 {
             leaf_idx, ctx, [&](const MultipathLevelBuilderResult& result) {
               size_t visited_component_size =
                   result.post_list_visited_elements.size();
-              DCHECK_GT(visited_component_size, 0);
+              VELOX_DCHECK_GT(visited_component_size, 0);
               if (visited_component_size != 1) {
                 return Status::NotImplemented(
                     "Lists with non-zero length null components are not supported");
@@ -479,7 +479,7 @@ class FileWriterImpl : public FileWriter {
       }
 
       if (arrow_properties_->use_threads()) {
-        DCHECK_EQ(parallel_column_write_contexts_.size(), writers.size());
+        VELOX_DCHECK_EQ(parallel_column_write_contexts_.size(), writers.size());
         RETURN_NOT_OK(::arrow::internal::ParallelFor(
             static_cast<int>(writers.size()),
             [&](int i) {

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilter.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilter.cpp
@@ -21,9 +21,9 @@
 #include <memory>
 
 #include "arrow/result.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
 #include "velox/dwio/parquet/writer/arrow/tests/BloomFilter.h"
@@ -61,7 +61,7 @@ void BlockSplitBloomFilter::Init(uint32_t num_bytes) {
 }
 
 void BlockSplitBloomFilter::Init(const uint8_t* bitset, uint32_t num_bytes) {
-  DCHECK(bitset != nullptr);
+  VELOX_DCHECK_NOT_NULL(bitset);
 
   if (num_bytes < kMinimumBloomFilterBytes ||
       num_bytes > kMaximumBloomFilterBytes ||
@@ -129,7 +129,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
         reinterpret_cast<const uint8_t*>(header_buf->data()),
         &header_size,
         &header);
-    DCHECK_LE(header_size, header_buf->size());
+    VELOX_DCHECK_LE(header_size, header_buf->size());
   } catch (std::exception& e) {
     std::stringstream ss;
     ss << "Deserializing bloom filter header failed.\n" << e.what();
@@ -173,7 +173,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
 }
 
 void BlockSplitBloomFilter::WriteTo(ArrowOutputStream* sink) const {
-  DCHECK(sink != nullptr);
+  VELOX_DCHECK_NOT_NULL(sink);
 
   facebook::velox::parquet::thrift::BloomFilterHeader header;
   if (ARROW_PREDICT_FALSE(algorithm_ != BloomFilter::Algorithm::BLOCK)) {

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilter.h
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilter.h
@@ -23,7 +23,8 @@
 #include <memory>
 
 #include "arrow/util/bit_util.h"
-#include "arrow/util/logging.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/writer/arrow/Platform.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
@@ -237,7 +238,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   /// kMaximumBloomFilterBytes, and the return value is always a power of 2
   static uint32_t OptimalNumOfBytes(uint32_t ndv, double fpp) {
     uint32_t optimal_num_of_bits = OptimalNumOfBits(ndv, fpp);
-    DCHECK(::arrow::bit_util::IsMultipleOf8(optimal_num_of_bits));
+    VELOX_DCHECK(::arrow::bit_util::IsMultipleOf8(optimal_num_of_bits));
     return optimal_num_of_bits >> 3;
   }
 
@@ -249,7 +250,7 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   /// @return it always return a value between kMinimumBloomFilterBytes * 8 and
   /// kMaximumBloomFilterBytes * 8, and the return value is always a power of 16
   static uint32_t OptimalNumOfBits(uint32_t ndv, double fpp) {
-    DCHECK(fpp > 0.0 && fpp < 1.0);
+    VELOX_DCHECK(fpp > 0.0 && fpp < 1.0);
     const double m = -8.0 * ndv / log(1 - pow(fpp, 1.0 / 8));
     uint32_t num_bits;
 

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReader.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReader.cpp
@@ -41,7 +41,8 @@
 #include "arrow/util/compression.h"
 #include "arrow/util/crc32.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/common/LevelComparison.h"
 #include "velox/dwio/parquet/common/LevelConversion.h"
 #include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
@@ -60,6 +61,11 @@ using arrow::internal::MultiplyWithOverflow;
 namespace bit_util = arrow::bit_util;
 
 namespace facebook::velox::parquet::arrow {
+
+fmt::underlying_t<Type::type> format_as(Type::type type) {
+  return fmt::underlying(type);
+}
+
 namespace {
 
 // The minimum number of repetition/definition levels to decode at a time, for
@@ -354,7 +360,7 @@ class SerializedPageReader : public PageReader {
 void SerializedPageReader::InitDecryption() {
   // Prepare the AAD for quick update later.
   if (crypto_ctx_.data_decryptor != nullptr) {
-    ARROW_DCHECK(!crypto_ctx_.data_decryptor->file_aad().empty());
+    VELOX_DCHECK(!crypto_ctx_.data_decryptor->file_aad().empty());
     data_page_aad_ = encryption::CreateModuleAad(
         crypto_ctx_.data_decryptor->file_aad(),
         encryption::kDataPage,
@@ -363,7 +369,7 @@ void SerializedPageReader::InitDecryption() {
         kNonPageOrdinal);
   }
   if (crypto_ctx_.meta_decryptor != nullptr) {
-    ARROW_DCHECK(!crypto_ctx_.meta_decryptor->file_aad().empty());
+    VELOX_DCHECK(!crypto_ctx_.meta_decryptor->file_aad().empty());
     data_page_header_aad_ = encryption::CreateModuleAad(
         crypto_ctx_.meta_decryptor->file_aad(),
         encryption::kDataPageHeader,
@@ -377,7 +383,7 @@ void SerializedPageReader::UpdateDecryption(
     const std::shared_ptr<Decryptor>& decryptor,
     int8_t module_type,
     std::string* page_aad) {
-  ARROW_DCHECK(decryptor != nullptr);
+  VELOX_DCHECK_NOT_NULL(decryptor);
   if (crypto_ctx_.start_decrypt_with_dictionary_page) {
     std::string aad = encryption::CreateModuleAad(
         decryptor->file_aad(),
@@ -858,7 +864,7 @@ class ColumnReaderImplBase {
 
     new_dictionary_ = true;
     current_decoder_ = decoders_[encoding].get();
-    ARROW_DCHECK(current_decoder_);
+    VELOX_DCHECK(current_decoder_);
   }
 
   // Initialize repetition and definition level decoders on the next data page.
@@ -970,7 +976,7 @@ class ColumnReaderImplBase {
 
     auto it = decoders_.find(static_cast<int>(encoding));
     if (it != decoders_.end()) {
-      ARROW_DCHECK(it->second.get() != nullptr);
+      VELOX_DCHECK_NOT_NULL(it->second.get());
       current_decoder_ = it->second.get();
     } else {
       switch (encoding) {
@@ -1426,7 +1432,7 @@ int64_t TypedColumnReaderImpl<DType>::Skip(int64_t num_values_to_skip) {
       // Jump to the right offset in the Page
       int64_t values_read = 0;
       InitScratchForSkip();
-      ARROW_DCHECK_NE(this->scratch_for_skip_, nullptr);
+      VELOX_DCHECK_NOT_NULL(this->scratch_for_skip_);
       do {
         int64_t batch_size = std::min(kSkipScratchBatchSize, values_to_skip);
         values_read = ReadBatch(
@@ -1614,10 +1620,10 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
   // accordingly and move the levels to left to fill in the gap.
   // It will resize the buffer without releasing the memory allocation.
   void ThrowAwayLevels(int64_t start_levels_position) {
-    ARROW_DCHECK_LE(levels_position_, levels_written_);
-    ARROW_DCHECK_LE(start_levels_position, levels_position_);
-    ARROW_DCHECK_GT(this->max_def_level_, 0);
-    ARROW_DCHECK_NE(def_levels_, nullptr);
+    VELOX_DCHECK_LE(levels_position_, levels_written_);
+    VELOX_DCHECK_LE(start_levels_position, levels_position_);
+    VELOX_DCHECK_GT(this->max_def_level_, 0);
+    VELOX_DCHECK_NOT_NULL(def_levels_);
 
     int64_t gap = levels_position_ - start_levels_position;
     if (gap == 0)
@@ -1639,7 +1645,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     left_shift(def_levels_.get());
 
     if (this->max_rep_level_ > 0) {
-      ARROW_DCHECK_NE(rep_levels_, nullptr);
+      VELOX_DCHECK_NOT_NULL(rep_levels_);
       left_shift(rep_levels_.get());
     }
 
@@ -1651,7 +1657,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
   // Skip records that we have in our buffer. This function is only for
   // non-repeated fields.
   int64_t SkipRecordsInBufferNonRepeated(int64_t num_records) {
-    ARROW_DCHECK_EQ(this->max_rep_level_, 0);
+    VELOX_DCHECK_EQ(this->max_rep_level_, 0);
     if (!this->has_values_to_process() || num_records == 0)
       return 0;
 
@@ -1726,7 +1732,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
   // reach the desired number of records or we run out of values in the column
   // chunk. Returns number of skipped records.
   int64_t SkipRecordsRepeated(int64_t num_records) {
-    ARROW_DCHECK_GT(this->max_rep_level_, 0);
+    VELOX_DCHECK_GT(this->max_rep_level_, 0);
     int64_t skipped_records = 0;
 
     // First consume what is in the buffer.
@@ -1797,7 +1803,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     // Allocate enough scratch space to accommodate 16-bit levels or any
     // value type
     this->InitScratchForSkip();
-    ARROW_DCHECK_NE(this->scratch_for_skip_, nullptr);
+    VELOX_DCHECK_NOT_NULL(this->scratch_for_skip_);
     do {
       int64_t batch_size =
           std::min<int64_t>(kSkipScratchBatchSize, values_left);
@@ -1828,7 +1834,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
       // First consume whatever is in the buffer.
       skipped_records = SkipRecordsInBufferNonRepeated(num_records);
 
-      ARROW_DCHECK_LE(skipped_records, num_records);
+      VELOX_DCHECK_LE(skipped_records, num_records);
 
       // For records that we have not buffered, we will use the column
       // reader's Skip to do the remaining Skip. Since the field is not
@@ -1886,7 +1892,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     const int16_t* def_levels = this->def_levels() + levels_position_;
     const int16_t* rep_levels = this->rep_levels() + levels_position_;
 
-    ARROW_DCHECK_GT(this->max_rep_level_, 0);
+    VELOX_DCHECK_GT(this->max_rep_level_, 0);
 
     // Count logical records and number of values to read
     while (levels_position_ < levels_written_) {
@@ -2063,7 +2069,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     if (!nullable_values() || read_dense_for_nullable_) {
       ReadValuesDense(*values_to_read);
       // null_count is always 0 for required.
-      ARROW_DCHECK_EQ(*null_count, 0);
+      VELOX_DCHECK_EQ(*null_count, 0);
     } else {
       ReadSpacedForOptionalOrRepeated(
           start_levels_position, values_to_read, null_count);
@@ -2090,7 +2096,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
       ReadDenseForOptional(start_levels_position, values_to_read);
       // We don't need to update null_count when reading dense. It should be
       // already set to 0.
-      ARROW_DCHECK_EQ(*null_count, 0);
+      VELOX_DCHECK_EQ(*null_count, 0);
     } else {
       ReadSpacedForOptionalOrRepeated(
           start_levels_position, values_to_read, null_count);
@@ -2113,7 +2119,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
       int64_t* values_to_read) {
     // levels_position_ must already be incremented based on number of records
     // read.
-    ARROW_DCHECK_GE(levels_position_, start_levels_position);
+    VELOX_DCHECK_GE(levels_position_, start_levels_position);
 
     // When reading dense we need to figure out number of values to read.
     const int16_t* def_levels = this->def_levels();
@@ -2132,7 +2138,7 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
       int64_t* null_count) {
     // levels_position_ must already be incremented based on number of records
     // read.
-    ARROW_DCHECK_GE(levels_position_, start_levels_position);
+    VELOX_DCHECK_GE(levels_position_, start_levels_position);
     ValidityBitmapInputOutput validity_io;
     validity_io.valuesReadUpperBound = levels_position_ - start_levels_position;
     validity_io.validBits = valid_bits_->mutable_data();
@@ -2145,8 +2151,8 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
         &validity_io);
     *values_to_read = validity_io.valuesRead - validity_io.nullCount;
     *null_count = validity_io.nullCount;
-    ARROW_DCHECK_GE(*values_to_read, 0);
-    ARROW_DCHECK_GE(*null_count, 0);
+    VELOX_DCHECK_GE(*values_to_read, 0);
+    VELOX_DCHECK_GE(*null_count, 0);
     ReadValuesSpaced(validity_io.valuesRead, *null_count);
   }
 
@@ -2173,22 +2179,22 @@ class TypedRecordReader : public TypedColumnReaderImpl<DType>,
     } else if (this->max_def_level_ > 0) {
       // Non-repeated optional values are always nullable.
       // This call updates levels_position_.
-      ARROW_DCHECK(nullable_values());
+      VELOX_DCHECK(nullable_values());
       records_read =
           ReadOptionalRecords(num_records, &values_to_read, &null_count);
     } else {
-      ARROW_DCHECK(!nullable_values());
+      VELOX_DCHECK(!nullable_values());
       records_read = ReadRequiredRecords(num_records, &values_to_read);
       // We don't need to update null_count, since it is 0.
     }
 
-    ARROW_DCHECK_GE(records_read, 0);
-    ARROW_DCHECK_GE(values_to_read, 0);
-    ARROW_DCHECK_GE(null_count, 0);
+    VELOX_DCHECK_GE(records_read, 0);
+    VELOX_DCHECK_GE(values_to_read, 0);
+    VELOX_DCHECK_GE(null_count, 0);
 
     if (read_dense_for_nullable_) {
       values_written_ += values_to_read;
-      ARROW_DCHECK_EQ(null_count, 0);
+      VELOX_DCHECK_EQ(null_count, 0);
     } else {
       values_written_ += values_to_read + null_count;
       null_count_ += null_count;
@@ -2270,7 +2276,7 @@ class FLBARecordReader : public TypedRecordReader<FLBAType>,
             pool,
             read_dense_for_nullable),
         builder_(nullptr) {
-    ARROW_DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
+    VELOX_DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
     int byte_width = descr_->type_length();
     std::shared_ptr<::arrow::DataType> type =
         ::arrow::fixed_size_binary(byte_width);
@@ -2307,7 +2313,7 @@ class FLBARecordReader : public TypedRecordReader<FLBAType>,
         static_cast<int>(null_count),
         valid_bits,
         valid_bits_offset);
-    ARROW_DCHECK_EQ(num_decoded, values_to_read);
+    VELOX_DCHECK_EQ(num_decoded, values_to_read);
 
     for (int64_t i = 0; i < num_decoded; i++) {
       if (::arrow::bit_util::GetBit(valid_bits, valid_bits_offset + i)) {
@@ -2336,7 +2342,7 @@ class ByteArrayChunkedRecordReader : public TypedRecordReader<ByteArrayType>,
             leaf_info,
             pool,
             read_dense_for_nullable) {
-    ARROW_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
+    VELOX_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
     accumulator_.builder = std::make_unique<::arrow::BinaryBuilder>(pool);
   }
 
@@ -2461,7 +2467,7 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
       /// Flush values since they have been copied into the builder
       ResetValues();
     }
-    ARROW_DCHECK_EQ(num_decoded, values_to_read - null_count);
+    VELOX_DCHECK_EQ(num_decoded, values_to_read - null_count);
   }
 
  private:

--- a/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
@@ -40,10 +40,10 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hashing.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_data_inline.h"
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/dwio/parquet/common/RleEncodingInternal.h"
 #include "velox/dwio/parquet/writer/arrow/Exception.h"
 #include "velox/dwio/parquet/writer/arrow/Platform.h"
@@ -147,7 +147,7 @@ class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
   }
 
   void UnsafePutByteArray(const void* data, uint32_t length) {
-    DCHECK(length == 0 || data != nullptr) << "Value ptr cannot be NULL";
+    VELOX_DCHECK(length == 0 || data != nullptr, "Value ptr cannot be NULL");
     sink_.UnsafeAppend(&length, sizeof(uint32_t));
     sink_.UnsafeAppend(data, static_cast<int64_t>(length));
   }
@@ -275,7 +275,7 @@ inline void PlainEncoder<ByteArrayType>::Put(const ::arrow::Array& values) {
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
 }
@@ -324,7 +324,7 @@ inline void PlainEncoder<FLBAType>::Put(
   }
   for (int i = 0; i < num_values; ++i) {
     // Write the result to the output stream
-    DCHECK(src[i].ptr != nullptr) << "Value ptr cannot be NULL";
+    VELOX_DCHECK_NOT_NULL(src[i].ptr, "Value ptr cannot be NULL");
     PARQUET_THROW_NOT_OK(sink_.Append(src[i].ptr, descr_->type_length()));
   }
 }
@@ -546,7 +546,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
         memo_table_(pool, kInitialHashTableSize) {}
 
   ~DictEncoderImpl() override {
-    DCHECK(buffered_indices_.empty());
+    VELOX_DCHECK(buffered_indices_.empty());
   }
 
   int dict_encoded_size() const override {
@@ -709,7 +709,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
 
   template <typename ArrayType>
   void PutBinaryDictionaryArray(const ArrayType& array) {
-    DCHECK_EQ(array.null_count(), 0);
+    VELOX_DCHECK_EQ(array.null_count(), 0);
     for (int64_t i = 0; i < array.length(); i++) {
       auto v = array.GetView(i);
       if (ARROW_PREDICT_FALSE(v.size() > kMaxByteArraySize)) {
@@ -732,7 +732,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
 template <typename DType>
 void DictEncoderImpl<DType>::WriteDict(uint8_t* buffer) const {
   // For primitive types, only a memcpy
-  DCHECK_EQ(
+  VELOX_DCHECK_EQ(
       static_cast<size_t>(dict_encoded_size_), sizeof(T) * memo_table_.size());
   memo_table_.CopyValues(0 /* start_pos */, reinterpret_cast<T*>(buffer));
 }
@@ -752,7 +752,7 @@ void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) const {
 template <>
 void DictEncoderImpl<FLBAType>::WriteDict(uint8_t* buffer) const {
   memo_table_.VisitValues(0, [&](::std::string_view v) {
-    DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
+    VELOX_DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
     memcpy(buffer, v.data(), type_length_);
     buffer += type_length_;
   });
@@ -776,7 +776,7 @@ template <typename DType>
 inline void DictEncoderImpl<DType>::PutByteArray(
     const void* ptr,
     int32_t length) {
-  DCHECK(false);
+  VELOX_DCHECK(false);
 }
 
 template <>
@@ -790,7 +790,7 @@ inline void DictEncoderImpl<ByteArrayType>::PutByteArray(
     dict_encoded_size_ += static_cast<int>(length + sizeof(uint32_t));
   };
 
-  DCHECK(ptr != nullptr || length == 0);
+  VELOX_DCHECK(ptr != nullptr || length == 0);
   ptr = (ptr != nullptr) ? ptr : empty;
   int32_t memo_index;
   PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
@@ -812,7 +812,7 @@ inline void DictEncoderImpl<FLBAType>::Put(const FixedLenByteArray& v) {
     dict_encoded_size_ += type_length_;
   };
 
-  DCHECK(v.ptr != nullptr || type_length_ == 0);
+  VELOX_DCHECK(v.ptr != nullptr || type_length_ == 0);
   const void* ptr = (v.ptr != nullptr) ? v.ptr : empty;
   int32_t memo_index;
   PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
@@ -874,7 +874,7 @@ void DictEncoderImpl<ByteArrayType>::Put(const ::arrow::Array& values) {
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
 }
@@ -934,7 +934,7 @@ void DictEncoderImpl<ByteArrayType>::PutDictionary(
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryDictionaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    VELOX_DCHECK(::arrow::is_large_binary_like(values.type_id()));
     PutBinaryDictionaryArray(
         checked_cast<const ::arrow::LargeBinaryArray&>(values));
   }
@@ -2570,7 +2570,7 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
   // Call to GetNextBytePtr reserves mini_blocks_per_block_ bytes of space to
   // write bit widths of miniblocks as they become known during the encoding.
   uint8_t* bit_width_data = bit_writer_.GetNextBytePtr(mini_blocks_per_block_);
-  DCHECK(bit_width_data != nullptr);
+  VELOX_DCHECK(bit_width_data != nullptr);
 
   const uint32_t num_miniblocks = static_cast<uint32_t>(std::ceil(
       static_cast<double>(values_current_block_) /
@@ -2611,7 +2611,7 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
   for (uint32_t i = num_miniblocks; i < mini_blocks_per_block_; i++) {
     bit_width_data[i] = 0;
   }
-  DCHECK_EQ(values_current_block_, 0);
+  VELOX_DCHECK_EQ(values_current_block_, 0);
 
   bit_writer_.Flush();
   PARQUET_THROW_NOT_OK(
@@ -2844,7 +2844,7 @@ class DeltaBitPackDecoder : public DecoderImpl,
   }
 
   void InitBlock() {
-    DCHECK_GT(total_values_remaining_, 0) << "InitBlock called at EOF";
+    VELOX_DCHECK_GT(total_values_remaining_, 0, "InitBlock called at EOF");
 
     if (!decoder_->GetZigZagVlqInt(&min_delta_))
       ParquetException::EofException("InitBlock EOF");
@@ -2885,7 +2885,7 @@ class DeltaBitPackDecoder : public DecoderImpl,
       if (ARROW_PREDICT_FALSE(values_remaining_current_mini_block_ == 0)) {
         if (ARROW_PREDICT_FALSE(!first_block_initialized_)) {
           buffer[i++] = last_value_;
-          DCHECK_EQ(i, 1); // we're at the beginning of the page
+          VELOX_DCHECK_EQ(i, 1); // we're at the beginning of the page
           if (ARROW_PREDICT_FALSE(i == max_values)) {
             // When block is uninitialized and i reaches max_values we have two
             // different possibilities:
@@ -3129,7 +3129,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
     // Decode up to `max_values` strings into an internal buffer
     // and reference them into `buffer`.
     max_values = std::min(max_values, num_valid_values_);
-    DCHECK_GE(max_values, 0);
+    VELOX_DCHECK_GE(max_values, 0);
     if (max_values == 0) {
       return 0;
     }
@@ -3202,7 +3202,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
     int ret = len_decoder_.Decode(
         reinterpret_cast<int32_t*>(buffered_length_->mutable_data()),
         num_length);
-    DCHECK_EQ(ret, num_length);
+    VELOX_DCHECK_EQ(ret, num_length);
     length_idx_ = 0;
     num_valid_values_ = num_length;
   }
@@ -3250,7 +3250,7 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
           return Status::OK();
         }));
 
-    DCHECK_EQ(null_count, 0);
+    VELOX_DCHECK_EQ(null_count, 0);
     *out_num_values = num_valid_values;
     return Status::OK();
   }
@@ -3501,13 +3501,13 @@ class DeltaByteArrayDecoder : public DecoderImpl,
     int ret = prefix_len_decoder_.Decode(
         reinterpret_cast<int32_t*>(buffered_prefix_length_->mutable_data()),
         num_prefix);
-    DCHECK_EQ(ret, num_prefix);
+    VELOX_DCHECK_EQ(ret, num_prefix);
     prefix_len_offset_ = 0;
     num_valid_values_ = num_prefix;
 
     int bytes_left = decoder_->bytesLeft();
     // If len < bytes_left, prefix_len_decoder.Decode will throw exception.
-    DCHECK_GE(len, bytes_left);
+    VELOX_DCHECK_GE(len, bytes_left);
     int suffix_begins = len - bytes_left;
     // at this time, the decoder_ will be at the start of the encoded suffix
     // data.
@@ -3617,7 +3617,7 @@ class DeltaByteArrayDecoder : public DecoderImpl,
     std::vector<ByteArray> values(num_values);
     const int num_valid_values =
         GetInternal(values.data(), num_values - null_count);
-    DCHECK_EQ(num_values - null_count, num_valid_values);
+    VELOX_DCHECK_EQ(num_values - null_count, num_valid_values);
 
     auto values_ptr = reinterpret_cast<const ByteArray*>(values.data());
     int value_idx = 0;
@@ -3642,7 +3642,7 @@ class DeltaByteArrayDecoder : public DecoderImpl,
           return Status::OK();
         }));
 
-    DCHECK_EQ(null_count, 0);
+    VELOX_DCHECK_EQ(null_count, 0);
     *out_num_values = num_valid_values;
     return Status::OK();
   }
@@ -3840,7 +3840,7 @@ std::unique_ptr<Encoder> MakeEncoder(
       case Type::FIXED_LEN_BYTE_ARRAY:
         return std::make_unique<DictEncoderImpl<FLBAType>>(descr, pool);
       default:
-        DCHECK(false) << "Encoder not implemented";
+        VELOX_DCHECK(false, "Encoder not implemented");
         break;
     }
   } else if (encoding == Encoding::PLAIN) {
@@ -3862,7 +3862,7 @@ std::unique_ptr<Encoder> MakeEncoder(
       case Type::FIXED_LEN_BYTE_ARRAY:
         return std::make_unique<PlainEncoder<FLBAType>>(descr, pool);
       default:
-        DCHECK(false) << "Encoder not implemented";
+        VELOX_DCHECK(false, "Encoder not implemented");
         break;
     }
   } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
@@ -3905,7 +3905,7 @@ std::unique_ptr<Encoder> MakeEncoder(
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 
@@ -3973,7 +3973,7 @@ std::unique_ptr<Decoder> MakeDecoder(
   } else {
     ParquetException::NYI("Selected encoding is not supported");
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 
@@ -4003,7 +4003,7 @@ std::unique_ptr<Decoder> MakeDictDecoder(
     default:
       break;
   }
-  DCHECK(false) << "Should not be able to reach this code";
+  VELOX_DCHECK(false, "Should not be able to reach this code");
   return nullptr;
 }
 

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -553,7 +553,7 @@ TYPED_TEST(PageFilterTest, TestPageFilterCallback) {
     std::vector<int64_t> read_num_values;
     std::vector<std::optional<int32_t>> read_num_rows;
     auto read_all_pages = [&](const DataPageStats& stats) -> bool {
-      DCHECK_NE(stats.encoded_statistics, nullptr);
+      VELOX_DCHECK_NOT_NULL(stats.encoded_statistics);
       read_stats.push_back(*stats.encoded_statistics);
       read_num_values.push_back(stats.num_values);
       read_num_rows.push_back(stats.num_rows);

--- a/velox/dwio/parquet/writer/arrow/tests/FileReader.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileReader.cpp
@@ -34,7 +34,6 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 
 #include "velox/dwio/parquet/writer/arrow/EncryptionInternal.h"

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -460,7 +460,7 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
     for (int i = 0; i < 2; i++) {
       int64_t batchNumValues = i ? numValues - numValues / 2 : numValues / 2;
       int64_t batchNullCount = i ? nullCount : 0;
-      DCHECK(nullCount <= numValues); // avoid too much headache
+      VELOX_DCHECK(nullCount <= numValues); // avoid too much headache
       std::vector<int16_t> definitionLevels(batchNullCount, 0);
       definitionLevels.insert(
           definitionLevels.end(), batchNumValues - batchNullCount, 1);

--- a/velox/dwio/parquet/writer/arrow/util/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/util/CMakeLists.txt
@@ -24,6 +24,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_dwio_arrow_parquet_writer_util_lib
+  velox_dwio_common
   arrow
   Snappy::snappy
   zstd::zstd

--- a/velox/dwio/parquet/writer/arrow/util/CompressionLZ4.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionLZ4.cpp
@@ -27,9 +27,10 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"
+
+#include "velox/common/base/Exceptions.h"
 
 using std::size_t;
 
@@ -83,7 +84,7 @@ class LZ4Decompressor : public Decompressor {
   Status Reset() override {
 #if defined(LZ4_VERSION_NUMBER) && LZ4_VERSION_NUMBER >= 10800
     // LZ4F_resetDecompressionContext appeared in 1.8.0
-    DCHECK_NE(ctx_, nullptr);
+    VELOX_DCHECK_NOT_NULL(ctx_);
     LZ4F_resetDecompressionContext(ctx_);
     finished_ = false;
     return Status::OK();
@@ -194,7 +195,7 @@ class LZ4Compressor : public Compressor {
       return LZ4Error(ret, "LZ4 compress update failed: ");
     }
     bytes_written += static_cast<int64_t>(ret);
-    DCHECK_LE(bytes_written, output_len);
+    VELOX_DCHECK_LE(bytes_written, output_len);
     return CompressResult{input_len, bytes_written};
   }
 
@@ -216,7 +217,7 @@ class LZ4Compressor : public Compressor {
       return LZ4Error(ret, "LZ4 flush failed: ");
     }
     bytes_written += static_cast<int64_t>(ret);
-    DCHECK_LE(bytes_written, output_len);
+    VELOX_DCHECK_LE(bytes_written, output_len);
     return FlushResult{bytes_written, false};
   }
 
@@ -238,7 +239,7 @@ class LZ4Compressor : public Compressor {
       return LZ4Error(ret, "LZ4 end failed: ");
     }
     bytes_written += static_cast<int64_t>(ret);
-    DCHECK_LE(bytes_written, output_len);
+    VELOX_DCHECK_LE(bytes_written, output_len);
     return EndResult{bytes_written, false};
   }
 

--- a/velox/dwio/parquet/writer/arrow/util/CompressionSnappy.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionSnappy.cpp
@@ -26,8 +26,9 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+
+#include "velox/common/base/Exceptions.h"
 
 using std::size_t;
 
@@ -73,7 +74,7 @@ class SnappyCodec : public Codec {
   int64_t MaxCompressedLen(
       int64_t input_len,
       const uint8_t* ARROW_ARG_UNUSED(input)) override {
-    DCHECK_GE(input_len, 0);
+    VELOX_DCHECK_GE(input_len, 0);
     return snappy::MaxCompressedLength(static_cast<size_t>(input_len));
   }
 

--- a/velox/dwio/parquet/writer/arrow/util/CompressionZstd.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/CompressionZstd.cpp
@@ -26,8 +26,9 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+
+#include "velox/common/base/Exceptions.h"
 
 using std::size_t;
 
@@ -201,7 +202,7 @@ class ZSTDCodec : public Codec {
       // We may pass a NULL 0-byte output buffer but some zstd versions demand
       // a valid pointer: https://github.com/facebook/zstd/issues/1385
       static uint8_t empty_buffer;
-      DCHECK_EQ(output_buffer_len, 0);
+      VELOX_DCHECK_EQ(output_buffer_len, 0);
       output_buffer = &empty_buffer;
     }
 
@@ -222,7 +223,7 @@ class ZSTDCodec : public Codec {
   int64_t MaxCompressedLen(
       int64_t input_len,
       const uint8_t* ARROW_ARG_UNUSED(input)) override {
-    DCHECK_GE(input_len, 0);
+    VELOX_DCHECK_GE(input_len, 0);
     return ZSTD_compressBound(static_cast<size_t>(input_len));
   }
 

--- a/velox/dwio/parquet/writer/arrow/util/Hashing.cpp
+++ b/velox/dwio/parquet/writer/arrow/util/Hashing.cpp
@@ -85,8 +85,8 @@ hash_t ComputeBitmapHash(
     hash_t seed,
     int64_t bits_offset,
     int64_t num_bits) {
-  DCHECK_GE(bits_offset, 0);
-  DCHECK_GE(num_bits, 0);
+  VELOX_DCHECK_GE(bits_offset, 0);
+  VELOX_DCHECK_GE(num_bits, 0);
   return MurmurHashBitmap64(bitmap, seed, bits_offset, num_bits);
 }
 


### PR DESCRIPTION
`DCHECK*` are for internal use. Users should not use them.

FYI: `DCHECK*` will be hidden since Apache Arrow C++ 20.0.0: https://github.com/apache/arrow/pull/46015

We should use `VELOX_DCHECK*` instead of `DCHECK*` provided by Apache Arrow because we forked Apache Parquet C++ to adapt our use case.

Here are basic conversion rules for `DCHECK*` -> `VELOX_DCHECK*`:

* `DCHECK*` -> `VELOX_DCHECK*`
* `DCHECK*() << "XXX"` -> `VELOX_DCHECK*(..., "XXX")`
* `DCHECK_EQ(XXX, nullptr)` -> `VELOX_DCHECK_NULL(XXX)`
* `DCHECK_NE(XXX, nullptr)` -> `VELOX_DCHECK_NOT_NULL(XXX)`

We need some `format_as()`s for `VELOX_DCHECK_*(ENUM_VALUE1, ENUM_VALUE2)`.

This also converts `DCHECK(XXX != nullptr)` to `VELOX_DCHECK_NOT_NULL(XXX)` for better error message.