### PR TITLE
refactor: Use SpillPartitionId in SpillState to replace simple integer

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -176,9 +176,7 @@ class HashBuild final : public Operator {
   void maybeSetupSpillChildVectors(const RowVectorPtr& input);
 
   // Invoked to prepare indices buffers for input spill processing.
-  void prepareInputIndicesBuffers(
-      vector_size_t numInput,
-      const SpillPartitionNumSet& spillPartitions);
+  void prepareInputIndicesBuffers(vector_size_t numInput);
 
   // Invoked to reset the operator state to restore previously spilled data. It
   // setup (recursive) spiller and spill input reader from 'spillInput' received
@@ -339,7 +337,13 @@ class HashBuildSpiller : public SpillerBase {
   void spill();
 
   /// Invoked to spill a given partition from the input vector 'spillVector'.
-  void spill(uint32_t partition, const RowVectorPtr& spillVector);
+  void spill(
+      const SpillPartitionId& partitionId,
+      const RowVectorPtr& spillVector);
+
+  bool spillTriggered() const {
+    return spillTriggered_;
+  }
 
  private:
   void extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr)
@@ -354,6 +358,8 @@ class HashBuildSpiller : public SpillerBase {
   }
 
   const bool spillProbeFlag_;
+
+  bool spillTriggered_{false};
 };
 } // namespace facebook::velox::exec
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5618,10 +5618,10 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   std::atomic_bool testWaitFlag{true};
   folly::EventCount testWait;
 
-  Operator* op;
+  Operator* op{nullptr};
   std::atomic<bool> injectSpillOnce{true};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Driver::runInternal::addInput",
+      "facebook::velox::exec::HashBuild::finishHashBuild",
       std::function<void(Operator*)>(([&](Operator* testOp) {
         if (testOp->operatorType() != "HashBuild") {
           return;
@@ -5633,11 +5633,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         auto* driver = op->testingOperatorCtx()->driver();
         auto task = driver->task();
         memory::ScopedMemoryArbitrationContext ctx(op->pool());
-        TestSuspendedSection suspendedSection(driver);
-        auto taskPauseWait = task->requestPause();
-        taskPauseWait.wait();
-        op->reclaim(0, reclaimerStats_);
-        Task::resume(task);
+        Operator::ReclaimableSectionGuard guard(testOp);
+        testingRunArbitration(testOp->pool());
       })));
 
   std::atomic<bool> injectOnce{true};
@@ -6268,7 +6265,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, exceededMaxSpillLevel) {
         ASSERT_FALSE(hashProbe->testingExceededMaxSpillLevelLimit());
       })));
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::HashBuild::addInput",
+      "facebook::velox::exec::HashBuild::finishHashBuild",
       std::function<void(exec::HashBuild*)>(([&](exec::HashBuild* hashBuild) {
         Operator::ReclaimableSectionGuard guard(hashBuild);
         testingRunArbitration(hashBuild->pool());

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -48,7 +48,7 @@ void JoinSpillInputBenchmarkBase::setUp() {
   spiller_ = std::make_unique<NoRowContainerSpiller>(
       rowType_, std::nullopt, HashBitRange{29, 29}, &spillConfig, &spillStats_);
   dynamic_cast<NoRowContainerSpiller*>(spiller_.get())
-      ->setPartitionsSpilled({0});
+      ->setPartitionsSpilled({SpillPartitionId(0)});
 }
 
 void JoinSpillInputBenchmarkBase::run() {
@@ -57,7 +57,8 @@ void JoinSpillInputBenchmarkBase::run() {
       dynamic_cast<NoRowContainerSpiller*>(spiller_.get());
   VELOX_CHECK_NOT_NULL(noRowContainerSpiller);
   for (auto i = 0; i < numInputVectors_; ++i) {
-    noRowContainerSpiller->spill(0, rowVectors_[i % numSampleVectors]);
+    noRowContainerSpiller->spill(
+        SpillPartitionId(0), rowVectors_[i % numSampleVectors]);
   }
 }
 

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -29,8 +29,8 @@ class RowNumberTest : public OperatorTestBase {
   RowNumberTest() {
     filesystems::registerLocalFileSystem();
     rowType_ = ROW(
-        {{"c0", INTEGER()},
-         {"c1", INTEGER()},
+        {{"c0", BIGINT()},
+         {"c1", BIGINT()},
          {"c2", VARCHAR()},
          {"c3", VARCHAR()}});
     fuzzerOpts_.vectorSize = 1024;


### PR DESCRIPTION
Summary: Use SpillPartitionId in SpillState to replace the originally used integer partition number. This is to generalize spilling framework on supporting the newly introduced SpillPartitionId in both single level spilling and nested level spilling. The changes are limited to Spill.* and Spiller.* and simple temporary adaptors were introduced in some operators to help to limit the changes' propagation to be too much. The next refactor will continue the change.

Differential Revision: D73562773


