### PR TITLE
fix: Load lazy input before order by operation

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -364,6 +364,11 @@ vector_size_t Operator::outputBatchRows(
   return std::max<vector_size_t>(batchSize, 1);
 }
 
+void Operator::loadLazyReclaimable(RowVectorPtr& vector) {
+  ReclaimableSectionGuard guard(this);
+  vector->loadedVector();
+}
+
 void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
   uint64_t now =
       std::chrono::duration_cast<std::chrono::microseconds>(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -589,6 +589,14 @@ class Operator : public BaseRuntimeStatWriter {
   vector_size_t outputBatchRows(
       std::optional<uint64_t> averageRowSize = std::nullopt) const;
 
+  /// Load 'vector' if lazy. Potential large memory usage site that might
+  /// trigger arbitration. Hence this call is made reclaimable. This is often
+  /// used at the start of 'addInput()' call to load the input if needed.
+  ///
+  /// NOTE: Caller must make sure operator is in a reclaimable state when making
+  /// this call.
+  void loadLazyReclaimable(RowVectorPtr& vector);
+
   /// Invoked to record spill stats in operator stats.
   virtual void recordSpillStats();
 

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -71,6 +71,7 @@ OrderBy::OrderBy(
 }
 
 void OrderBy::addInput(RowVectorPtr input) {
+  loadLazyReclaimable(input);
   sortBuffer_->addInput(input);
 }
 

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -200,6 +200,8 @@ class VectorLoaderWrap : public VectorLoader {
       ValueHook* hook,
       vector_size_t resultSize,
       VectorPtr* result) override {
+    velox::common::testutil::TestValue::adjust(
+        "facebook::velox::{}::VectorLoaderWrap::loadInternal", this);
     VELOX_CHECK(!hook, "VectorLoaderWrap doesn't support ValueHook");
     SelectivityVector rows(rowSet.back() + 1, false);
     for (auto row : rowSet) {


### PR DESCRIPTION
Summary: Order by operator is under unreclaimable state when loading lazy input vector. We load input vector at the beginning of addInput() call to fix this corner case scenario. Also extracted the reclaimable lazy loading to a common utility in base Operator class.

Differential Revision: D73606256


