### PR TITLE
fix: Update call function for map_key_exists to handle only null-free arguments

### DIFF
--- a/velox/functions/prestosql/MapFunctions.h
+++ b/velox/functions/prestosql/MapFunctions.h
@@ -24,10 +24,10 @@ template <typename TExec>
 struct MapKeyExists {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-  void call(
+  void callNullFree(
       bool& out,
-      const arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
-      const arg_type<Generic<T1>>& key) {
+      const null_free_arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
+      const null_free_arg_type<Generic<T1>>& key) {
     out = (inputMap.find(key) != inputMap.end());
   }
 };


### PR DESCRIPTION
Summary:
Update the `call` method of `map_key_exists` to handle only null-free input. This decreases the parity gap between Presto and Prestissimo for this function as the former requires null-free arguments and will fail otherwise as we see identified by this chronos run:

https://www.internalfb.com/chronos/job_instance/silver/1125908543509627/simple-logs

```
I0424 14:23:04.528930 3055547 PrestoQueryRunner.cpp:858] Execute presto sql: SELECT map_key_exists(c0, c1) as p0, row_number as p1 FROM (t_values)
E0424 14:23:04.603541 3055547 Exceptions.h:66] Line: fbcode/velox/exec/fuzzer/PrestoQueryRunner.cpp:603, Function:throwIfFailed, Expression:  Presto query failed: 13 contains does not support arrays with elements that are null or contain null, Source: RUNTIME, ErrorCode: INVALID_STATE
W0424 14:23:04.604208 3055547 PrestoQueryRunner.cpp:836] Query failed in Presto
```

Differential Revision: D73625318


