### PR TITLE
fix: Ensure constant filter results are properly handled in processFilterResults

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -189,7 +189,7 @@ vector_size_t processConstantFilterResults(
   // If not all rows are selected we need to update the selected indices.
   // If we don't do this, the caller will use the indices from the previous
   // batch.
-  if (numSelected < filterResult->size()) {
+  if (!rows.isAllSelected()) {
     auto* rawSelected = filterEvalCtx.getRawSelectedIndices(numSelected, pool);
     vector_size_t passed = 0;
     rows.applyToSelected([&](auto row) { rawSelected[passed++] = row; });


### PR DESCRIPTION
Summary:
In tableScan with filtering, we can get an edge case in `HiveDataSource::next()` such that when we call `processFilterResults` on a `filterResult` with constant encoding, we may not be setting the `FilterEvalCtx.selectedIndices` correctly. As a consequence, when we wrap the vector in `HiveDataSource`, we either crash, get undefined behavior, or fail at dictionary construction time.

The fix here is that if the `selectivityVector` did not have all of its rows selected, we will update the indices again. This ensures that the selectedIndices and rows are correctly updated. Essentially, this addresses the edge case where `numSelected = filterResult->size()`.

Differential Revision: D73636993


