### PR TITLE
fix: Replace space with underscore in generated task id from cursor

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -684,7 +684,7 @@ class MemoryPoolImpl : public MemoryPool {
   ///
   /// Exceeded memory cap of 5.00MB when requesting 2.00MB
   /// default_root_1 usage 5.00MB peak 5.00MB
-  ///     task.test_cursor 1 usage 5.00MB peak 5.00MB
+  ///     task.test_cursor_1 usage 5.00MB peak 5.00MB
   ///         node.N/A usage 0B peak 0B
   ///             op.N/A.0.0.CallbackSink usage 0B peak 0B
   ///         node.2 usage 4.00MB peak 4.00MB

--- a/velox/docs/develop/debugging/tracing.rst
+++ b/velox/docs/develop/debugging/tracing.rst
@@ -338,7 +338,7 @@ Then we can re-execute the query using the following command in the terminal or 
   Stats of replaying operator HashProbe : Output: 13578240 rows (1.17GB, 13280 batches), Cpu time: 3.99s, Wall time: 4.01s, Blocked wall time: 98.58ms, Peak memory: 108.00KB, Memory allocations: 12534, Threads: 2, CPU breakdown: B/I/O/F (8.52ms/1.59s/2.39s/20.29us)
 
   Memory usage: TaskCursorQuery_0 usage 0B reserved 0B peak 10.00MB
-      task.test_cursor 1 usage 0B reserved 0B peak 10.00MB
+      task.test_cursor_1 usage 0B reserved 0B peak 10.00MB
           node.2 usage 0B reserved 0B peak 0B
               op.2.1.1.OperatorTraceScan usage 0B reserved 0B peak 0B
               op.2.1.0.OperatorTraceScan usage 0B reserved 0B peak 0B

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -142,7 +142,7 @@ class TaskCursorBase : public TaskCursor {
       const CursorParameters& params,
       const std::shared_ptr<folly::Executor>& executor) {
     static std::atomic<int32_t> cursorId;
-    taskId_ = fmt::format("test_cursor {}", ++cursorId);
+    taskId_ = fmt::format("test_cursor_{}", ++cursorId);
 
     if (params.queryCtx) {
       queryCtx_ = params.queryCtx;

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -49,7 +49,7 @@ void recordSilentThrows(Operator& op) {
 
 // Used to generate context for exceptions that are thrown while executing an
 // operator. Eg output: 'Operator: FilterProject(1) PlanNodeId: 1 TaskId:
-// test_cursor 1 PipelineId: 0 DriverId: 0 OperatorAddress: 0x61a000003c80'
+// test_cursor_1 PipelineId: 0 DriverId: 0 OperatorAddress: 0x61a000003c80'
 std::string addContextOnException(
     VeloxException::Type exceptionType,
     void* arg) {

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -367,7 +367,7 @@ TEST_F(OperatorTraceTest, task) {
       return fmt::format(
           "taskRegExpr: {}, expectedNumDirs: ", taskRegExpr, expectedNumDirs);
     }
-  } testSettings[]{{".*", 1}, {"test_cursor .*", 1}, {"xxx_yyy \\d+", 0}};
+  } testSettings[]{{".*", 1}, {"test_cursor_.*", 1}, {"xxx_yyy \\d+", 0}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     const auto outputDir = TempDirectoryPath::create();
@@ -550,8 +550,8 @@ TEST_F(OperatorTraceTest, traceTableWriter) {
       {".*", 10UL << 30, numBatch, false},
       {".*", 0, numBatch, true},
       {"wrong id", 10UL << 30, 0, false},
-      {"test_cursor \\d+", 10UL << 30, numBatch, false},
-      {"test_cursor \\d+", 800, 2, true}};
+      {"test_cursor_\\d+", 10UL << 30, numBatch, false},
+      {"test_cursor_\\d+", 800, 2, true}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -655,8 +655,8 @@ TEST_F(OperatorTraceTest, filterProject) {
       {".*", 10UL << 30, numBatch, false},
       {".*", 0, numBatch, true},
       {"wrong id", 10UL << 30, 0, false},
-      {"test_cursor \\d+", 10UL << 30, numBatch, false},
-      {"test_cursor \\d+", 800, 2, true}};
+      {"test_cursor_\\d+", 10UL << 30, numBatch, false},
+      {"test_cursor_\\d+", 800, 2, true}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -1018,8 +1018,8 @@ TEST_F(OperatorTraceTest, hashJoin) {
       {".*", 10UL << 30, numBatch, false},
       {".*", 0, numBatch, true},
       {"wrong id", 10UL << 30, 0, false},
-      {"test_cursor \\d+", 10UL << 30, numBatch, false},
-      {"test_cursor \\d+", 800, 2, true}};
+      {"test_cursor_\\d+", 10UL << 30, numBatch, false},
+      {"test_cursor_\\d+", 800, 2, true}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -76,7 +76,7 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinSeperateDriverThread) {
 #ifndef IS_BUILDING_WITH_SAN
   ASSERT_DEATH(
       (assertQuery(op, vector)),
-      ".*Fatal signal handler. Query Id= TaskCursorQuery_0 Task Id= test_cursor 1.*");
+      ".*Fatal signal handler. Query Id= TaskCursorQuery_0 Task Id= test_cursor_1.*");
 #endif
 }
 
@@ -90,7 +90,7 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinQueryCompilation) {
 #ifndef IS_BUILDING_WITH_SAN
   ASSERT_DEATH(
       (assertQuery(op, vector)),
-      ".*Fatal signal handler. Query Id= TaskCursorQuery_0 Task Id= test_cursor 1.*");
+      ".*Fatal signal handler. Query Id= TaskCursorQuery_0 Task Id= test_cursor_1.*");
 #endif
 }
 


### PR DESCRIPTION
Summary: The space in current task id generated from task cursor might introduce issues when we use it to generate other stuffs like dir path. Replacing it with '_'.

Differential Revision: D73678898


