### PR TITLE
fix: Report task split status based on driver status

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1717,6 +1717,8 @@ void HashProbe::checkRunning() const {
 }
 
 void HashProbe::setRunning() {
+  // A point for test code injection.
+  TestValue::adjust("facebook::velox::exec::HashProbe::setRunning", this);
   setState(ProbeOperatorState::kRunning);
 }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -51,6 +51,10 @@ class TableScan : public SourceOperator {
       column_index_t outputChannel,
       const std::shared_ptr<common::Filter>& filter) override;
 
+  int64_t splitWeight() {
+    return currentSplitWeight_;
+  }
+
   /// The name of runtime stats specific to table scan.
   /// The number of running table scan drivers.
   ///

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -708,6 +708,15 @@ class Task : public std::enable_shared_from_this<Task> {
     return cancellationSource_.getToken();
   }
 
+  struct SplitStatus {
+    int32_t runningTableScanSplitsNum{0};
+    int32_t queuedTableScanSplitsNum{0};
+    int64_t runningTableScanSplitsWeight{0};
+    int64_t queuedTableScanSplitsWeight{0};
+  };
+
+  SplitStatus getSplitStatus();
+
   void testingIncrementThreads() {
     std::lock_guard l(mutex_);
     ++numThreads_;

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -56,6 +56,7 @@ struct TaskStats {
   std::unordered_set<int32_t> completedSplitGroups;
 
   /// Table scan split stats.
+  // TODO: Remove after presto switches to use the new API
   int32_t numRunningTableScanSplits{0};
   int32_t numQueuedTableScanSplits{0};
   int64_t runningTableScanSplitWeights{0};


### PR DESCRIPTION
In presto, table scan split status has three types: running, queued and blocked. And presto worker only reports running and queued split info to coordinator scheduler.

Velox calculates running and queued split differently and it’s based on addSplitLocked, getSplitLocked and splitFinished API:
- addSplitLocked will put the split into splitStore then queued++
- getSplitLocked will fetch split from splitStore then running++ and queued--
- splitFinished running—

As a result:
- queued contains both queued and blocked state
- running contains both running and blocked state

Change to calculate split status based on driver status:
- Count splits which are on running drivers as runningSplit
- Count running table scan node's remaining splits in splitStore as queuedSplit

In this way, we will be aligned with presto’s reporting and in the future, we can add blocked splits if needed


Issue
https://github.com/facebookincubator/velox/issues/13089