### PR TITLE
fix: Change invalid input internal errors to user errors

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -344,9 +344,7 @@ void CastExpr::applyCastKernel(
           ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT ||
           ToKind == TypeKind::HUGEINT) {
         if constexpr (TPolicy::throwOnUnicode) {
-          // This is a special case where we intentionally throw
-          // VeloxRuntimeError to avoid it being suppressed by TRY().
-          VELOX_CHECK_UNSUPPORTED_INPUT_UNCATCHABLE(
+          VELOX_USER_CHECK(
               functions::stringCore::isAscii(
                   inputRowValue.data(), inputRowValue.size()),
               "Unicode characters are not supported for conversion to integer types");

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1142,8 +1142,7 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
         "bigint",
         {"٣"},
         "Unicode characters are not supported for conversion to integer types",
-        VARCHAR(),
-        true);
+        VARCHAR());
   }
 
   // To floating-point.

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -248,7 +248,7 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
           std::chrono::seconds(std::numeric_limits<int64_t>::min() / 1000) ||
       timePoint.time_since_epoch() >
           std::chrono::seconds(std::numeric_limits<int64_t>::max() / 1000)) {
-    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
+    VELOX_USER_FAIL(
         "Timepoint is outside of supported timestamp seconds since epoch range: [{}, {}], got {}",
         std::chrono::seconds(std::numeric_limits<int64_t>::min() / 1000)
             .count(),
@@ -261,7 +261,7 @@ void validateRangeImpl(time_point<TDuration> timePoint) {
   if (year < kMinYear || year > kMaxYear) {
     // This is a special case where we intentionally throw
     // VeloxRuntimeError to avoid it being suppressed by TRY().
-    VELOX_FAIL_UNSUPPORTED_INPUT_UNCATCHABLE(
+    VELOX_USER_FAIL(
         "Timepoint is outside of supported year range: [{}, {}], got {}",
         static_cast<int64_t>(kMinYear),
         static_cast<int64_t>(kMaxYear),


### PR DESCRIPTION
Summary: Changing Timepoint out of supported range errors and unicode to integer conversion not supported errors to user errors as we will not be supporting them, so they should be classified as user errors.

Differential Revision: D73703930


