### PR TITLE
fix: Allow executor test to work with older GTest versions

### DIFF
--- a/velox/common/base/tests/LazyCPUThreadPoolExecutorTest.cpp
+++ b/velox/common/base/tests/LazyCPUThreadPoolExecutorTest.cpp
@@ -50,7 +50,11 @@ TEST(LazyCPUThreadPoolExecutorTest, delayedInitialization) {
   folly::ThreadPoolExecutor::withAll(
       [&](folly::ThreadPoolExecutor& ex) { after.push_back(ex.getName()); });
 
-  ASSERT_THAT(after, testing::Contains(prefix).Times(1));
+  std::vector<std::string> matching;
+  std::copy_if(after.begin(), after.end(), std::back_inserter(matching),
+               [&prefix](const std::string& name) { return name == prefix; });
+
+  ASSERT_THAT(matching, testing::SizeIs(1));
 }
 } // namespace
 } // namespace facebook::velox

--- a/velox/common/base/tests/LazyCPUThreadPoolExecutorTest.cpp
+++ b/velox/common/base/tests/LazyCPUThreadPoolExecutorTest.cpp
@@ -50,11 +50,8 @@ TEST(LazyCPUThreadPoolExecutorTest, delayedInitialization) {
   folly::ThreadPoolExecutor::withAll(
       [&](folly::ThreadPoolExecutor& ex) { after.push_back(ex.getName()); });
 
-  std::vector<std::string> matching;
-  std::copy_if(after.begin(), after.end(), std::back_inserter(matching),
-               [&prefix](const std::string& name) { return name == prefix; });
-
-  ASSERT_THAT(matching, testing::SizeIs(1));
+  auto count = std::count(after.begin(), after.end(), prefix);
+  ASSERT_THAT(count, testing::Eq(1));
 }
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
With older versions of google test, the commit "e4e4532b4 - refactor: Followup LazyCPUThreadPoolExecutor (#13102)" leads to the error mentioned in issue #13141.

This change updates the LazyCPUThreadPoolExecutorTest to make it compatible with older versions of gtest.

This ensures that the test behaves correctly even when Times matcher is unavailable.

### Related issue

Fixes #13141.