### PR TITLE
refactor(StringView): Remove unneeded compare condition

### DIFF
--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -158,8 +158,8 @@ struct StringView {
   //       > 0, if this > other
   int32_t compare(const StringView& other) const {
     if (prefixAsInt() != other.prefixAsInt()) {
-      // The result is decided on prefix. The shorter will be less
-      // because the prefix is padded with zeros.
+      // The result is decided on prefix. The shorter will be less because the
+      // prefix is padded with zeros.
       return memcmp(prefix_, other.prefix_, kPrefixSize);
     }
     int32_t size = std::min(size_, other.size_) - kPrefixSize;
@@ -167,7 +167,7 @@ struct StringView {
       // One ends within the prefix.
       return size_ - other.size_;
     }
-    if (size <= kInlineSize && isInline() && other.isInline()) {
+    if (isInline() && other.isInline()) {
       int32_t result = memcmp(value_.inlined, other.value_.inlined, size);
       return (result != 0) ? result : size_ - other.size_;
     }


### PR DESCRIPTION
`isInline() && other.isInline()` can already ensure that both operands 
are inline, and because `StringView::isInline()` is an inline function, 
it is also efficient enough, so the condition `size <= kInlineSize` is 
not needed. This PR removes the useless condition.

Also, since `size` is not actually the smaller of the two lengths (note 
that it is minus `kPrefixSize` above), the meaning of this condition 
is unclear.

No functional changes.  

Fixes #13172 