### PR TITLE
feat(fuzzer): Add custom input generation for URL functions

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -480,6 +480,33 @@ class CastVarcharInputGenerator : public AbstractInputGenerator {
   std::string generateValidPrimitiveAsString();
 };
 
+class URLInputGenerator : public AbstractInputGenerator {
+ public:
+  URLInputGenerator(
+      size_t seed,
+      const TypePtr& type,
+      double nullRatio,
+      std::string functionName,
+      std::vector<std::string> functionsToSkipForMailTo,
+      std::vector<std::string> functionsToSkipForTruncate);
+
+  ~URLInputGenerator() override;
+
+  variant generate() override;
+
+ private:
+  std::shared_ptr<RuleList> generateURLRules();
+  std::shared_ptr<RuleList> generateMailToRules();
+  std::shared_ptr<RuleList> generateChromeExtensionRules();
+
+  const std::string functionName_;
+  // Particular UDFs are known to have mismatches for mailto and trucated input.
+  // Let's skip those test cases for now. More info can be found in
+  // https://github.com/facebookincubator/velox/issues/14204.
+  const std::vector<std::string> functionsToSkipForMailTo_;
+  const std::vector<std::string> functionsToSkipForTruncate_;
+};
+
 class TDigestInputGenerator : public AbstractInputGenerator {
  public:
   TDigestInputGenerator(size_t seed, const TypePtr& type, double nullRatio);

--- a/velox/expression/fuzzer/ArgValuesGenerators.h
+++ b/velox/expression/fuzzer/ArgValuesGenerators.h
@@ -93,6 +93,17 @@ class CastVarcharAndJsonArgValuesGenerator : public ArgValuesGenerator {
       ExpressionFuzzerState& state) override;
 };
 
+class URLArgValuesGenerator : public ArgValuesGenerator {
+ public:
+  ~URLArgValuesGenerator() override = default;
+
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
+};
+
 class TDigestArgValuesGenerator : public ArgValuesGenerator {
  public:
   explicit TDigestArgValuesGenerator(std::string functionName) {

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -64,6 +64,7 @@ using facebook::velox::fuzzer::JsonParseArgValuesGenerator;
 using facebook::velox::fuzzer::QDigestArgValuesGenerator;
 using facebook::velox::fuzzer::TDigestArgValuesGenerator;
 using facebook::velox::fuzzer::UnifiedDigestArgValuesGenerator;
+using facebook::velox::fuzzer::URLArgValuesGenerator;
 using facebook::velox::test::ReferenceQueryRunner;
 
 int main(int argc, char** argv) {
@@ -215,6 +216,15 @@ int main(int argc, char** argv) {
           {"cast", std::make_shared<CastVarcharAndJsonArgValuesGenerator>()},
           {"json_parse", std::make_shared<JsonParseArgValuesGenerator>()},
           {"json_extract", std::make_shared<JsonExtractArgValuesGenerator>()},
+          {"scale_tdigest",
+           std::make_shared<TDigestArgValuesGenerator>("scale_tdigest")},
+          {"url_extract_fragment", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_host", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_parameter", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_path", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_port", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_protocol", std::make_shared<URLArgValuesGenerator>()},
+          {"url_extract_query", std::make_shared<URLArgValuesGenerator>()},
           {"value_at_quantile",
            std::make_shared<UnifiedDigestArgValuesGenerator>(
                "value_at_quantile")},
@@ -262,14 +272,11 @@ int main(int argc, char** argv) {
         "array_intersect", // https://github.com/facebookincubator/velox/issues/10740
         "f_cdf", // https://github.com/facebookincubator/velox/issues/10633
         "truncate", // https://github.com/facebookincubator/velox/issues/10628
-        "url_extract_query", // https://github.com/facebookincubator/velox/issues/10659
         "laplace_cdf", // https://github.com/facebookincubator/velox/issues/10974
         "inverse_beta_cdf", // https://github.com/facebookincubator/velox/issues/11802
         "conjunct", // https://github.com/facebookincubator/velox/issues/10678
-        "url_extract_host", // https://github.com/facebookincubator/velox/issues/10578
         "weibull_cdf", // https://github.com/facebookincubator/velox/issues/10977
         "zip_with", // https://github.com/facebookincubator/velox/issues/10844
-        "url_extract_path", // https://github.com/facebookincubator/velox/issues/10579
         "bitwise_shift_left", // https://github.com/facebookincubator/velox/issues/10870
         "split_part", // https://github.com/facebookincubator/velox/issues/10839
         "bitwise_arithmetic_shift_right", // https://github.com/facebookincubator/velox/issues/10750
@@ -281,8 +288,6 @@ int main(int argc, char** argv) {
         "format_datetime", // https://github.com/facebookincubator/velox/issues/10779
         "inverse_cauchy_cdf", // https://github.com/facebookincubator/velox/issues/10840
         "array_position", // https://github.com/facebookincubator/velox/issues/10580
-        "url_extract_fragment", // https://github.com/facebookincubator/velox/issues/12324
-        "url_extract_protocol", // https://github.com/facebookincubator/velox/issues/12325
         "chi_squared_cdf", // https://github.com/facebookincubator/velox/issues/12327
         "bitwise_left_shift", // https://github.com/facebookincubator/velox/issues/12330
         "log2", // https://github.com/facebookincubator/velox/issues/12338


### PR DESCRIPTION
Summary: Add custom input generation for URL functions. In this diff, we add custom input for URLs by constructing a valid URL (using standard protocol and facebook hostname/domain). We then randomly add ports, fragements and queries to generate a valid random URL. Finally, we make small permutations on the input randomly to occasionally invalidate input and see how the results look.

Differential Revision: D73807620


