### PR TITLE
fix(type): Prevent overflow by updating member variable in NegatedBigintValuesUsingBitmask

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1266,8 +1266,8 @@ class NegatedBigintValuesUsingBitmask final : public Filter {
   std::unique_ptr<Filter>
   mergeWith(int64_t min, int64_t max, const Filter* other) const;
 
-  int min_;
-  int max_;
+  int64_t min_;
+  int64_t max_;
   std::unique_ptr<BigintValuesUsingBitmask> nonNegated_;
 };
 


### PR DESCRIPTION
Differential Revision: D73808213


