### PR TITLE
fix(json): Ensure invalid escaped unicode characters are ignored by simdjson

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -1616,6 +1616,16 @@ TEST_F(JsonCastTest, castInTry) {
 }
 
 TEST_F(JsonCastTest, tryCastFromJson) {
+  // Ensure bad unicode characters are handled correctly during casts.
+  auto dataj = makeFlatVector<JsonNativeType>(
+      {
+          R"("\uD83E褙")"_sv,
+      },
+      JSON());
+  auto expectedj = makeFlatVector<StringView>({R"(�褙)"}, VARCHAR());
+  evaluateAndVerify(
+      JSON(), VARCHAR(), makeRowVector({dataj}), expectedj, false);
+
   // Test try_cast to map when there are error in the conversions of map
   // elements.
   // To map(bigint, real).

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -785,7 +785,7 @@ struct CastFromJsonTypedImpl {
         std::string_view s;
         switch (type) {
           case simdjson::ondemand::json_type::string: {
-            SIMDJSON_ASSIGN_OR_RAISE(s, value.get_string());
+            SIMDJSON_ASSIGN_OR_RAISE(s, value.get_string(true));
             break;
           }
           case simdjson::ondemand::json_type::number:


### PR DESCRIPTION
Summary: Currently Illformed and illegal escaped unicode characters cause simdjson to throw - this behavior is different from Presto Java , especially for escape characters like : \uD83E which form the first part of a surrogate pair.

Differential Revision: D73815909


