### PR TITLE
feat: Add Spark unbase64 function

### DIFF
--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -552,8 +552,10 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     return Status::OK();
   }
 
-  uint32_t accumulator = 0; // 24-bit buffer
-  int bitsNeeded = 18; // next shift amount
+  // 24-bit buffer.
+  uint32_t accumulator = 0;
+  // Next shift amount.
+  int bitsNeeded = 18;
   size_t idx = 0;
   char* outPtr = output;
 
@@ -561,18 +563,18 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     unsigned char c = static_cast<unsigned char>(input[idx++]);
     int val = kBase64ReverseIndexTable[c];
 
-    // Padding character
+    // Padding character.
     if (c == kPadding) {
-      // If we see '=' too early or only one '=' when two are needed → error
+      // If we see '=' too early or only one '=' when two are needed → error.
       if (bitsNeeded == 18 ||
           (bitsNeeded == 6 && (idx == inputSize || input[idx++] != kPadding))) {
         return Status::UserError(
             "Input byte array has wrong 4-byte ending unit.");
       }
-      break; // done processing meaningful data
+      break;
     }
 
-    // Skip whitespace or other non-Base64 chars
+    // Skip whitespace or other non-Base64 chars.
     if (val < 0 || val >= 0x40) {
       continue;
     }
@@ -581,7 +583,7 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     accumulator |= (static_cast<uint32_t>(val) << bitsNeeded);
     bitsNeeded -= 6;
 
-    // If we've collected 24 bits, write out 3 bytes
+    // If we've collected 24 bits, write out 3 bytes.
     if (bitsNeeded < 0) {
       *outPtr++ = static_cast<char>((accumulator >> 16) & 0xFF);
       *outPtr++ = static_cast<char>((accumulator >> 8) & 0xFF);
@@ -591,7 +593,7 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     }
   }
 
-  // Handle any remaining bits (1 or 2 bytes)
+  // Handle any remaining bits (1 or 2 bytes).
   if (bitsNeeded == 0) {
     *outPtr++ = static_cast<char>((accumulator >> 16) & 0xFF);
     *outPtr++ = static_cast<char>((accumulator >> 8) & 0xFF);
@@ -601,15 +603,15 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     return Status::UserError("Last unit does not have enough valid bits.");
   }
 
-  // Verify no illegal trailing Base64 data
+  // Verify no illegal trailing Base64 data.
   while (idx < inputSize) {
     unsigned char c = static_cast<unsigned char>(input[idx++]);
     int val = kBase64ReverseIndexTable[c];
-    // Valid data after completion is an error
+    // Valid data after completion is an error.
     if (val >= 0 && val < 0x40) {
       return Status::UserError("Input byte array has incorrect ending.");
     }
-    // '=' padding beyond handled ones is OK; other negatives are skips
+    // '=' padding beyond handled ones is OK; other negatives are skips.
   }
 
   return Status::OK();
@@ -636,7 +638,8 @@ Expected<size_t> Base64::calculateMimeDecodedSize(
     if (c == kPadding) {
       decodedSize -= inputSize - i;
       break;
-    } else if (kBase64ReverseIndexTable[static_cast<uint8_t>(c)] >= 0x40) {
+    }
+    if (kBase64ReverseIndexTable[static_cast<uint8_t>(c)] >= 0x40) {
       decodedSize--;
     }
   }

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -546,4 +546,108 @@ void Base64::decodeUrl(
   decodedOutput.resize(decodedSize.value());
 }
 
+// static
+Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
+  if (inputSize == 0) {
+    return Status::OK();
+  }
+
+  uint32_t accumulator = 0; // 24-bit buffer
+  int bitsNeeded = 18; // next shift amount
+  size_t idx = 0;
+  char* outPtr = output;
+
+  while (idx < inputSize) {
+    unsigned char c = static_cast<unsigned char>(input[idx++]);
+    int val = kBase64ReverseIndexTable[c];
+
+    // Padding character
+    if (c == kPadding) {
+      // If we see '=' too early or only one '=' when two are needed → error
+      if (bitsNeeded == 18 ||
+          (bitsNeeded == 6 && (idx == inputSize || input[idx++] != kPadding))) {
+        return Status::UserError(
+            "Input byte array has wrong 4-byte ending unit.");
+      }
+      break; // done processing meaningful data
+    }
+
+    // Skip whitespace or other non-Base64 chars
+    if (val < 0 || val >= 0x40) {
+      continue;
+    }
+
+    // Accumulate 6 bits
+    accumulator |= (static_cast<uint32_t>(val) << bitsNeeded);
+    bitsNeeded -= 6;
+
+    // If we've collected 24 bits, write out 3 bytes
+    if (bitsNeeded < 0) {
+      *outPtr++ = static_cast<char>((accumulator >> 16) & 0xFF);
+      *outPtr++ = static_cast<char>((accumulator >> 8) & 0xFF);
+      *outPtr++ = static_cast<char>(accumulator & 0xFF);
+      accumulator = 0;
+      bitsNeeded = 18;
+    }
+  }
+
+  // Handle any remaining bits (1 or 2 bytes)
+  if (bitsNeeded == 0) {
+    *outPtr++ = static_cast<char>((accumulator >> 16) & 0xFF);
+    *outPtr++ = static_cast<char>((accumulator >> 8) & 0xFF);
+  } else if (bitsNeeded == 6) {
+    *outPtr++ = static_cast<char>((accumulator >> 16) & 0xFF);
+  } else if (bitsNeeded == 12) {
+    return Status::UserError("Last unit does not have enough valid bits.");
+  }
+
+  // Verify no illegal trailing Base64 data
+  while (idx < inputSize) {
+    unsigned char c = static_cast<unsigned char>(input[idx++]);
+    int val = kBase64ReverseIndexTable[c];
+    // Valid data after completion is an error
+    if (val >= 0 && val < 0x40) {
+      return Status::UserError("Input byte array has incorrect ending.");
+    }
+    // '=' padding beyond handled ones is OK; other negatives are skips
+  }
+
+  return Status::OK();
+}
+
+// static
+Expected<size_t> Base64::calculateMimeDecodedSize(
+    const char* input,
+    const size_t inputSize) {
+  if (inputSize == 0) {
+    return 0;
+  }
+  if (inputSize < 2) {
+    if (kBase64ReverseIndexTable[static_cast<uint8_t>(input[0])] >= 0x40) {
+      return 0;
+    }
+    return folly::makeUnexpected(Status::UserError(
+        "Input should at least have 2 bytes for base64 bytes."));
+  }
+  auto decodedSize = inputSize;
+  // Compute how many true Base64 chars.
+  for (size_t i = 0; i < inputSize; ++i) {
+    auto c = input[i];
+    if (c == kPadding) {
+      decodedSize -= inputSize - i;
+      break;
+    } else if (kBase64ReverseIndexTable[static_cast<uint8_t>(c)] >= 0x40) {
+      decodedSize--;
+    }
+  }
+  // If no explicit padding but validChars ≢ 0 mod 4, infer missing '='.
+  size_t paddings = 0;
+  if ((decodedSize & 0x3) != 0) {
+    paddings = 4 - (decodedSize & 0x3);
+  }
+  // Each 4-char block yields 3 bytes; subtract padding.
+  decodedSize = 3 * ((decodedSize + 3) / 4) - paddings;
+  return decodedSize;
+}
+
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -110,6 +110,11 @@ class Base64 {
       char* outputBuffer,
       size_t outputSize);
 
+  /// Decodes a Base64 MIME‐mode buffer back to binary.
+  /// Skips any non-Base64 chars (e.g. CR/LF).
+  static Status
+  decodeMime(const char* input, size_t inputSize, char* outputBuffer);
+
   /// Calculates the encoded size based on input 'inputSize'.
   static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
 
@@ -118,6 +123,12 @@ class Base64 {
   static Expected<size_t> calculateDecodedSize(
       const char* input,
       size_t& inputSize);
+
+  /// Calculates the decoded binary size of a MIME‐mode Base64 input,
+  /// accounting for padding and ignoring whitespace.
+  static Expected<size_t> calculateMimeDecodedSize(
+      const char* input,
+      const size_t inputSize);
 
  private:
   // Padding character used in encoding.

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -433,6 +433,12 @@ String Functions
 
         SELECT trim('sprk', 'spark'); -- "a"
 
+.. spark:function:: unbase64(expr) -> varbinary
+
+    Returns a decoded base64 string as binary. ::
+
+        SELECT cast(unbase64('U3BhcmsgU1FM') AS STRING); -- 'Spark SQL'
+
 .. spark:function:: upper(string) -> string
 
     Returns string with all characters changed to uppercase. ::

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1555,5 +1555,4 @@ struct Empty2NullFunction {
     return true;
   }
 };
-
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -1555,4 +1555,5 @@ struct Empty2NullFunction {
     return true;
   }
 };
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/UnBase64Function.h
+++ b/velox/functions/sparksql/UnBase64Function.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/encode/Base64.h"
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+
+template <typename T>
+// UnBase64Function decodes a base64-encoded input string into its original
+// binary form. It uses the Base64 MIME decoding functions provided by
+// velox::encoding. Returns a Status indicating success or error during
+// decoding.
+struct UnBase64Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Decodes the base64-encoded input and stores the result in 'result'.
+  // Returns a Status object indicating success or failure.
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<Varbinary>& result, const arg_type<Varchar>& input) {
+    auto decodedSize =
+        encoding::Base64::calculateMimeDecodedSize(input.data(), input.size());
+    if (decodedSize.hasError()) {
+      return decodedSize.error();
+    }
+    result.resize(decodedSize.value());
+    return encoding::Base64::decodeMime(
+        input.data(), input.size(), result.data());
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/UnBase64Function.h
+++ b/velox/functions/sparksql/UnBase64Function.h
@@ -20,11 +20,11 @@
 
 namespace facebook::velox::functions::sparksql {
 
-template <typename T>
 // UnBase64Function decodes a base64-encoded input string into its original
 // binary form. It uses the Base64 MIME decoding functions provided by
 // velox::encoding. Returns a Status indicating success or error during
 // decoding.
+template <typename T>
 struct UnBase64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -24,6 +24,7 @@
 #include "velox/functions/sparksql/Split.h"
 #include "velox/functions/sparksql/String.h"
 #include "velox/functions/sparksql/StringToMap.h"
+#include "velox/functions/sparksql/UnBase64Function.h"
 #include "velox/functions/sparksql/VarcharTypeWriteSideCheck.h"
 
 namespace facebook::velox::functions {
@@ -167,6 +168,8 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       int32_t>({prefix + "varchar_type_write_side_check"});
+
+  registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -65,6 +65,7 @@ add_executable(
   SplitTest.cpp
   StringTest.cpp
   StringToMapTest.cpp
+  UnBase64Test.cpp
   UnscaledValueFunctionTest.cpp
   UpperLowerTest.cpp
   UuidTest.cpp

--- a/velox/functions/sparksql/tests/UnBase64Test.cpp
+++ b/velox/functions/sparksql/tests/UnBase64Test.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class UnBase64Test : public SparkFunctionBaseTest {
+ protected:
+  std::optional<std::string> unbase64(const std::optional<std::string>& a) {
+    return evaluateOnce<std::string>("unbase64(c0)", a);
+  }
+};
+
+TEST_F(UnBase64Test, basic) {
+  EXPECT_EQ(unbase64(std::nullopt), std::nullopt);
+  EXPECT_EQ(unbase64("TWFu"), "Man");
+  EXPECT_EQ(unbase64("TWFu\r\nTWFu"), "ManMan");
+  EXPECT_EQ(unbase64("aGVsbG8gd29ybGQ="), "hello world");
+  EXPECT_EQ(unbase64("U3BhcmsgU1FM"), "Spark SQL");
+  EXPECT_EQ(unbase64("#"), "");
+  EXPECT_EQ(unbase64("YQ==="), "a");
+  EXPECT_EQ(unbase64("aA"), "h");
+  EXPECT_EQ(unbase64("c3d"), "sw");
+  EXPECT_EQ(unbase64("cd@"), "q");
+  EXPECT_EQ(
+      unbase64("SGVsbG8gV29ybGQgZnJvbSBWZW@@Xvece"),
+      "Hello World from Vee\xEFy\xC7");
+  EXPECT_EQ(unbase64("@@dmVsb3g="), "velox");
+}
+
+TEST_F(UnBase64Test, error) {
+  VELOX_ASSERT_USER_THROW(
+      unbase64("aGVsx"), "Last unit does not have enough valid bits");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("xx=y"), "Input byte array has wrong 4-byte ending unit");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("xx="), "Input byte array has wrong 4-byte ending unit");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("aGVs="), "Input byte array has wrong 4-byte ending unit");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("AQ==y"), "Input byte array has incorrect ending");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("a"), "Input should at least have 2 bytes for base64 bytes");
+
+  VELOX_ASSERT_USER_THROW(
+      unbase64("c@"), "Last unit does not have enough valid bits");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("=="), "Input byte array has wrong 4-byte ending unit");
+  VELOX_ASSERT_USER_THROW(
+      unbase64("SGVsbG8gV29ybGQgZnJvbSBWZW===xveCE="),
+      "Input byte array has incorrect ending");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Spark’s `unbase64` function follows the RFC 2045 (MIME) specification, whereas 
Presto’s `from_base64` function followss the RFC 4648 (Basic) specification.

Spark: https://github.com/apache/spark/blob/6f9bf73c345d70c3d27ea2e1ebadaa03a275fb3c/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L2917

Presto: https://github.com/prestodb/presto/blob/26e1b66f9baf6e81a5c2335faa114ef484fd89a9/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java#L122

They differ in the following ways, so we need to re-implement Spark’s
`unbase64` semantics.

Differences:
Whitespace: RFC 2045 decoders ignore spaces/CR/LF; RFC 4648 rejects any non-
alphabet chars.
Strictness: RFC 2045 only errors on bad padding at end when decoding; RFC 4648 
errors on any invalid char.