### PR TITLE
refactor: Use new recursive spill structure in hash join

### DIFF
--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -173,7 +173,7 @@ class HashJoinBridge : public JoinBridge {
   // information provided by the HashBuild operators if spilling is enabled.
   // This set can grow if HashBuild operator cannot load full partition in
   // memory and engages in recursive spilling.
-  SpillPartitionSet spillPartitionSets_;
+  IterableSpillPartitionSet spillPartitionSet_;
 
   // A flag indicating if any probe operator has poked 'this' join bridge to
   // attempt to get table. It is reset after probe side finish the (sub) table

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -298,7 +298,7 @@ class HashProbe : public Operator {
   // Invoked to prepare indices buffers for input spill processing.
   void prepareInputIndicesBuffers(
       vector_size_t numInput,
-      const folly::F14FastSet<uint32_t>& spillPartitions);
+      const SpillPartitionIdSet& spillPartitionIds);
 
   /// Decode join key inputs and populate 'nonNullInputRows_'.
   void decodeAndDetectNonNullKeys();
@@ -689,15 +689,16 @@ class HashProbe : public Operator {
   SpillPartitionIdSet spillInputPartitionIds_;
 
   // Used to calculate the spill partition numbers of the probe inputs.
-  std::unique_ptr<HashPartitionFunction> spillHashFunction_;
+  std::unique_ptr<SpillPartitionFunction> spillPartitionFunction_;
 
   // Reusable memory for spill hash partition calculation.
-  std::vector<uint32_t> spillPartitions_;
+  std::vector<SpillPartitionId> spillPartitions_;
 
   // Reusable memory for probe input spilling processing.
-  std::vector<vector_size_t> numSpillInputs_;
-  std::vector<BufferPtr> spillInputIndicesBuffers_;
-  std::vector<vector_size_t*> rawSpillInputIndicesBuffers_;
+  folly::F14FastMap<SpillPartitionId, vector_size_t> numSpillInputs_;
+  folly::F14FastMap<SpillPartitionId, BufferPtr> spillInputIndicesBuffers_;
+  folly::F14FastMap<SpillPartitionId, vector_size_t*>
+      rawSpillInputIndicesBuffers_;
   BufferPtr nonSpillInputIndicesBuffer_;
   vector_size_t* rawNonSpillInputIndicesBuffer_;
 

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -59,7 +59,7 @@ class RowNumber : public Operator {
     return spillConfig_.has_value();
   }
 
-  void setupInputSpiller(const SpillPartitionNumSet& spillPartitionSet);
+  void setupInputSpiller(const SpillPartitionIdSet& spillPartitionIdSet);
 
   void ensureInputFits(const RowVectorPtr& input);
 
@@ -69,7 +69,7 @@ class RowNumber : public Operator {
 
   void restoreNextSpillPartition();
 
-  SpillPartitionNumSet spillHashTable();
+  SpillPartitionIdSet spillHashTable();
 
   int64_t numRows(char* partition);
 

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -372,6 +372,11 @@ void IterableSpillPartitionSet::reset() {
   spillPartitionIter_ = spillPartitions_.begin();
 }
 
+void IterableSpillPartitionSet::clear() {
+  spillPartitions_.clear();
+  spillPartitionIter_ = spillPartitions_.begin();
+}
+
 uint32_t FileSpillMergeStream::id() const {
   VELOX_CHECK(!closed_);
   return spillFile_->id();
@@ -651,26 +656,6 @@ SpillPartitionIdSet toSpillPartitionIdSet(
     partitionIdSet.insert(partitionEntry.first);
   }
   return partitionIdSet;
-}
-
-SpillPartitionIdSet toSpillPartitionIdSet(
-    const SpillPartitionNumSet& partitionNumSet) {
-  SpillPartitionIdSet partitionIdSet;
-  partitionIdSet.reserve(partitionNumSet.size());
-  for (const auto& partitionNum : partitionNumSet) {
-    partitionIdSet.emplace(SpillPartitionId(partitionNum));
-  }
-  return partitionIdSet;
-}
-
-SpillPartitionNumSet toPartitionNumSet(
-    const SpillPartitionIdSet& partitionIdSet) {
-  SpillPartitionNumSet partitionNumSet;
-  partitionNumSet.reserve(partitionIdSet.size());
-  for (const auto& partitionId : partitionIdSet) {
-    partitionNumSet.emplace(partitionId.partitionNumber());
-  }
-  return partitionNumSet;
 }
 
 namespace {

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -490,6 +490,8 @@ class IterableSpillPartitionSet {
 
   void reset();
 
+  void clear();
+
  private:
   // Iterator on 'spillPartitions_' pointing to the next returning spill
   // partition.
@@ -638,16 +640,6 @@ uint8_t partitionBitOffset(
 /// Generate partition id set from given spill partition set.
 SpillPartitionIdSet toSpillPartitionIdSet(
     const SpillPartitionSet& partitionSet);
-
-/// TODO(jtan6): Temporary helper method. Remove after migrating all spill cases
-/// fully to SpillPartitionId
-SpillPartitionIdSet toSpillPartitionIdSet(
-    const SpillPartitionNumSet& partitionNumSet);
-
-/// TODO(jtan6): Temporary helper method. Remove after migrating all spill cases
-/// fully to SpillPartitionId
-SpillPartitionNumSet toPartitionNumSet(
-    const SpillPartitionIdSet& partitionIdSet);
 
 /// Scoped spill percentage utility that allows user to set the behavior of
 /// triggered spill.


### PR DESCRIPTION
Summary: Use SpillPartitionId to replace the number based spill id in hash join. This is the preparation change for mixed grouped execution mode hash join spill.

Differential Revision: D73820671


