### PR TITLE
refactor: Refactor streaming aggregation eager flush to row size

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -543,14 +543,13 @@ class QueryConfig {
   static constexpr const char* kRequestDataSizesMaxWaitSec =
       "request_data_sizes_max_wait_sec";
 
-  /// If this is false (the default), in streaming aggregation, wait until we
-  /// have enough number of output rows to produce a batch of size specified by
-  /// Operator::outputBatchRows.
-  ///
-  /// If this is true, we put the rows in output batch, as soon as the
-  /// corresponding groups are fully aggregated.  This is useful for reducing
-  /// memory consumption, if the downstream operators are not sensitive to small
-  /// batch size.
+  /// In streaming aggregation, wait until we have enough number of output rows
+  /// to produce a batch of size specified by this. If set to 0, then
+  /// Operator::outputBatchRows will be used as the min output batch rows.
+  static constexpr const char* kStreamingAggregationMinOutputBatchRows =
+      "streaming_aggregation_min_output_batch_rows";
+
+  /// TODO: Remove after dependencies are cleaned up.
   static constexpr const char* kStreamingAggregationEagerFlush =
       "streaming_aggregation_eager_flush";
 
@@ -1012,8 +1011,13 @@ class QueryConfig {
     return get<bool>(kThrowExceptionOnDuplicateMapKeys, false);
   }
 
+  /// TODO: Remove after dependencies are cleaned up.
   bool streamingAggregationEagerFlush() const {
     return get<bool>(kStreamingAggregationEagerFlush, false);
+  }
+
+  int32_t streamingAggregationMinOutputBatchRows() const {
+    return get<int32_t>(kStreamingAggregationMinOutputBatchRows, 0);
   }
 
   bool isFieldNamesInJsonCastEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -417,15 +417,12 @@ Aggregation
      - integer
      - 80
      - Abandons partial aggregation if number of groups equals or exceeds this percentage of the number of input rows.
-   * - streaming_aggregation_eager_flush
-     - bool
-     - false
-     - If this is false (the default), in streaming aggregation, wait until we
-       have enough number of output rows to produce a batch of size specified by
-       Operator::outputBatchRows.  If this is true, we put the rows in output
-       batch, as soon as the corresponding groups are fully aggregated.  This is
-       useful for reducing memory consumption, if the downstream operators are
-       not sensitive to small batch size.
+   * - streaming_aggregation_min_output_batch_rows
+     - integer
+     - 0
+     - In streaming aggregation, wait until we have enough number of output rows
+       to produce a batch of size specified by this. If set to 0, then
+       Operator::outputBatchRows will be used as the min output batch rows.
 
 Table Scan
 ------------

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -84,14 +84,15 @@ class StreamingAggregation : public Operator {
   void initializeAggregates(uint32_t numKeys);
 
   /// Maximum number of rows in the output batch.
-  const vector_size_t outputBatchSize_;
+  const vector_size_t maxOutputBatchSize_;
+
+  /// Maximum number of rows in the output batch.
+  const vector_size_t minOutputBatchSize_;
 
   // Used at initialize() and gets reset() afterward.
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
 
   const core::AggregationNode::Step step_;
-
-  const bool eagerFlush_;
 
   std::vector<column_index_t> groupingKeys_;
   std::vector<AggregateInfo> aggregates_;

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -490,13 +490,14 @@ TEST_F(ArbitraryTest, clusteredInput) {
         expected = "select c0, first(c1) from tmp group by 1";
       }
       auto plan = builder.finalAggregation().planNode();
-      for (bool eagerFlush : {false, true}) {
+      for (int32_t flushRows : {0, 1}) {
         SCOPED_TRACE(fmt::format(
-            "mask={} batchRows={} eagerFlush={}", mask, batchRows, eagerFlush));
+            "mask={} batchRows={} flushRows={}", mask, batchRows, flushRows));
         AssertQueryBuilder(plan, duckDbQueryRunner_)
             .config(core::QueryConfig::kPreferredOutputBatchRows, batchRows)
             .config(
-                core::QueryConfig::kStreamingAggregationEagerFlush, eagerFlush)
+                core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
+                flushRows)
             .assertResults(expected);
       }
     }

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -585,13 +585,14 @@ TEST_F(ArrayAggTest, clusteredInput) {
         expected = "select c0, array_agg(c1) from tmp group by 1";
       }
       auto plan = builder.finalAggregation().planNode();
-      for (bool eagerFlush : {false, true}) {
+      for (int32_t flushRows : {0, 1}) {
         SCOPED_TRACE(fmt::format(
-            "mask={} batchRows={} eagerFlush={}", mask, batchRows, eagerFlush));
+            "mask={} batchRows={} flushRows={}", mask, batchRows, flushRows));
         AssertQueryBuilder(plan, duckDbQueryRunner_)
             .config(core::QueryConfig::kPreferredOutputBatchRows, batchRows)
             .config(
-                core::QueryConfig::kStreamingAggregationEagerFlush, eagerFlush)
+                core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
+                flushRows)
             .assertResults(expected);
       }
     }


### PR DESCRIPTION
Summary: To leverage the memory control of eager flush in streaming aggregation as well as not losing performance on small group scenarios, we change the query config from boolean to integer, with configurable size.

Differential Revision: D73883057


