### PR TITLE
fix(Peeling): Support peeling of dictionaries without nulls wrapping a constant

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -214,11 +214,8 @@ bool PeeledEncoding::peelInternal(
     }
     decodedVector.makeIndices(*firstWrapper, rows, numLevels);
     if (decodedVector.isConstantMapping()) {
-      // This can only happen if the attempt to peel a constant encoding layer
-      // exposed a null complex constant as the base.
       VELOX_CHECK(peeledVectors.size() == 1);
       auto innerIdx = decodedVector.index(rows.begin());
-      VELOX_CHECK(peeledVectors.back()->isNullAt(innerIdx));
       wrapEncoding_ = VectorEncoding::Simple::CONSTANT;
       constantWrapIndex_ = innerIdx;
     } else {


### PR DESCRIPTION
Summary:
Currently, dictionaries without nulls wrapping a constant vector
cannot be created via BaseVector::wrapInDictionary() API as they
get converted into a Constant. However, after
https://github.com/facebookincubator/velox/pull/12002 the only
case where this can occur is in LocalPartitioned operator that
re-uses dictionary vectors from previous iterations and
overwrites the base vector.

Differential Revision: D73896030


