### PR TITLE
fix: Fix cpu and wall time accounting for parallelJoinBuild

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -838,15 +838,16 @@ template <typename Source>
 void syncWorkItems(
     std::vector<std::shared_ptr<Source>>& items,
     std::exception_ptr& error,
-    CpuWallTiming time,
+    CpuWallTiming& time,
     bool log = false) {
   // All items must be synced also in case of error because the items
   // hold references to the table and rows which could be destructed
   // if unwinding the stack did not pause to sync.
   for (auto& item : items) {
     try {
-      item->move();
-      time.add(item->prepareTiming());
+      if (item->move()) {
+        time.add(item->prepareTiming());
+      }
     } catch (const std::exception& e) {
       if (log) {
         LOG(ERROR) << "Error in async hash build: " << e.what();


### PR DESCRIPTION
Summary:
1. Update offThreadBuildTiming_ by reference
2. Make sure timing is only accounted once

Differential Revision: D73923607


