### PR TITLE
feat: Add Spark  initcap function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -108,6 +108,20 @@ String Functions
         SELECT find_in_set(NULL, ',123'); -- NULL
         SELECT find_in_set("abc", NULL); -- NULL
 
+.. spark:function:: initcap(string) -> varchar
+
+   The ``initcap`` function converts the first character of each word to uppercase
+   and all other characters in the word to lowercase. It supports UTF-8 multibyte
+   characters, up to four bytes per character.
+
+   A *word* is defined as a sequence of characters separated by whitespace. ::
+
+        SELECT initcap('spark sql'); -- Spark Sql
+        SELECT initcap('spARK sQL'); -- Spark Sql
+        SELECT initcap('123abc DEF!ghi'); -- 123abc Def!ghi
+        SELECT initcap('élan vital für alle'); -- Élan Vital Für Alle
+        SELECT initcap('hello-world test_case'); -- Hello-world Test_case
+
 .. spark:function:: instr(string, substring) -> integer
 
     Returns the starting position of the first instance of ``substring`` in

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -111,6 +111,103 @@ class StringImplTest : public testing::Test {
         {"\u1E8A", "\u1E8B"},
         {"\u1E8E", "\u1E8F"}};
   }
+
+  static std::vector<std::pair<std::string, std::string>>
+  getInitcapUnicodePrestoTestData() {
+    return {
+        {"BİLGİ", "Bilgi"},
+        {"\u0130\u0130", "\u0130\u0069"},
+        {"foo\u0020bar", "Foo\u0020Bar"},
+        {"foo\u0009bar", "Foo\u0009Bar"},
+        {"foo\u000Abar", "Foo\u000ABar"},
+        {"foo\u000Dbar", "Foo\u000DBar"},
+        {"foo\u000Bbar", "Foo\u000BBar"},
+        {"foo\u000Cbar", "Foo\u000CBar"},
+        {"foo\u0009\u000A\u000D\u000B\u000Cbar",
+         "Foo\u0009\u000A\u000D\u000B\u000CBar"},
+        {"foo\u0020\u0009\u000Abar", "Foo\u0020\u0009\u000ABar"},
+        {"foo\u1680bar", "Foo\u1680Bar"},
+        {"foo\u2000bar", "Foo\u2000Bar"},
+        {"foo\u2001bar", "Foo\u2001Bar"},
+        {"foo\u2002bar", "Foo\u2002Bar"},
+        {"foo\u2003bar", "Foo\u2003Bar"},
+        {"foo\u2004bar", "Foo\u2004Bar"},
+        {"foo\u2005bar", "Foo\u2005Bar"},
+        {"foo\u2006bar", "Foo\u2006Bar"},
+        {"foo\u2008bar", "Foo\u2008Bar"},
+        {"foo\u2009bar", "Foo\u2009Bar"},
+        {"foo\u200Abar", "Foo\u200ABar"},
+        {"foo\u2028bar", "Foo\u2028Bar"},
+        {"foo\u2029bar", "Foo\u2029Bar"},
+        {"foo\u205Fbar", "Foo\u205FBar"},
+        {"foo\u3000bar", "Foo\u3000Bar"},
+        {"foo\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2008\u2009\u200Abar",
+         "Foo\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2008\u2009\u200ABar"},
+        {"\u00E9l\u00E8ve\u000Atr\u00E8s-intelligent",
+         "\u00C9l\u00E8ve\u000ATr\u00E8s-intelligent"},
+        // Below whitespaces are not considered as whitespace in presto
+        {"foo\u0085Bar", "Foo\u0085bar"},
+        {"foo\u00A0Bar", "Foo\u00A0bar"},
+        {"foo\u2007Bar", "Foo\u2007bar"},
+    };
+  }
+
+  static std::vector<std::pair<std::string, std::string>>
+  getInitcapAsciiPrestoTestData() {
+    return {
+        {"foo bar", "Foo Bar"},
+        {"foo\nbar", "Foo\nBar"},
+        {"foo \t\nbar", "Foo \t\nBar"}};
+  }
+
+  static std::vector<std::pair<std::string, std::string>>
+  getInitcapUnicodeSparkTestData() {
+    return {
+        {"àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ", "Àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ"},
+        {"αβγδεζηθικλμνξοπρςστυφχψ", "Αβγδεζηθικλμνξοπρςστυφχψ"},
+        {"абвгдежзийклмнопрстуфхцчшщъыьэюя",
+         "Абвгдежзийклмнопрстуфхцчшщъыьэюя"},
+        {"hello world", "Hello World"},
+        {"HELLO WORLD", "Hello World"},
+        {"1234", "1234"},
+        {"1234", "1234"},
+        {"", ""},
+        {"élève très-intelligent", "Élève Très-intelligent"},
+        {"mañana-por_la_tarde!", "Mañana-por_la_tarde!"},
+        {"добро-пожаловать.тест", "Добро-пожаловать.тест"},
+        {"çalışkan öğrenci@üniversite.tr", "Çalışkan Öğrenci@üniversite.tr"},
+        {"emoji😊test🚀case", "Emoji😊test🚀case"},
+        {"тест@пример.рф", "Тест@пример.рф"},
+        {"BİLGİ", "Bi̇lgi̇"},
+        {"\u0130\u0130", "\u0130\u0069\u0307"},
+        {"İstanbul", "İstanbul"}};
+  }
+
+  static std::vector<std::pair<std::string, std::string>>
+  getInitcapAsciiSparkTestData() {
+    return {
+        {"abcdefg", "Abcdefg"},
+        {" abcdefg", " Abcdefg"},
+        {" abc defg", " Abc Defg"},
+        {"ABCDEFG", "Abcdefg"},
+        {"a B c D e F g", "A B C D E F G"},
+        {"hello world", "Hello World"},
+        {"HELLO WORLD", "Hello World"},
+        {"1234", "1234"},
+        {"", ""},
+        {"urna.Ut@egetdictumplacerat.edu", "Urna.ut@egetdictumplacerat.edu"},
+        {"nibh.enim@egestas.ca", "Nibh.enim@egestas.ca"},
+        {"in@Donecat.ca", "In@donecat.ca"},
+        {"sodales@blanditviverraDonec.ca", "Sodales@blanditviverradonec.ca"},
+        {"sociis.natoque.penatibus@vitae.org",
+         "Sociis.natoque.penatibus@vitae.org"},
+        {"john_doe-123@example-site.com", "John_doe-123@example-site.com"},
+        {"MIXED.case-EMAIL_42@domain.NET", "Mixed.case-email_42@domain.net"},
+        {"...weird..case@@", "...weird..case@@"},
+        {"user-name+filter@sub.mail.org", "User-name+filter@sub.mail.org"},
+        {"CAPS_LOCK@DOMAIN.COM", "Caps_lock@domain.com"},
+        {"__init__.py@example.dev", "__init__.py@example.dev"}};
+  }
 };
 
 TEST_F(StringImplTest, upperAscii) {
@@ -889,4 +986,35 @@ TEST_F(StringImplTest, isAscii) {
   memcpy(&s[0], alpha, strlen(alpha));
   ASSERT_FALSE(isAscii(s.data(), strlen(alpha)));
   ASSERT_FALSE(isAscii(s.data(), s.size()));
+}
+
+TEST_F(StringImplTest, initcapUnicodePresto) {
+  for (const auto& [input, expected] : getInitcapUnicodePrestoTestData()) {
+    std::string output;
+    initcap<false, false>(output, input);
+    ASSERT_EQ(output, expected);
+  }
+}
+
+TEST_F(StringImplTest, initcapAsciiPresto) {
+  for (const auto& [input, expected] : getInitcapAsciiPrestoTestData()) {
+    std::string output;
+    initcap<false, true>(output, input);
+    ASSERT_EQ(output, expected);
+  }
+}
+TEST_F(StringImplTest, initcapUnicodeSpark) {
+  for (const auto& [input, expected] : getInitcapUnicodeSparkTestData()) {
+    std::string output;
+    initcap<true, false>(output, input);
+    ASSERT_EQ(output, expected);
+  }
+}
+
+TEST_F(StringImplTest, initcapAsciiSpark) {
+  for (const auto& [input, expected] : getInitcapAsciiSparkTestData()) {
+    std::string output;
+    initcap<true, true>(output, input);
+    ASSERT_EQ(output, expected);
+  }
 }

--- a/velox/functions/sparksql/InitcapFunction.h
+++ b/velox/functions/sparksql/InitcapFunction.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "functions/Macros.h"
+#include "velox/functions/lib/string/StringImpl.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// The InitCapFunction capitalizes the first character of each word in a
+/// string, and lowercases the rest, following Spark SQL semantics. Word
+/// boundaries are determined by whitespace.
+template <typename T>
+struct InitCapFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    stringImpl::initcap<true, false>(result, input);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    stringImpl::initcap<true, true>(result, input);
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/prestosql/URLFunctions.h"
 #include "velox/functions/sparksql/ConcatWs.h"
+#include "velox/functions/sparksql/InitcapFunction.h"
 #include "velox/functions/sparksql/LuhnCheckFunction.h"
 #include "velox/functions/sparksql/MaskFunction.h"
 #include "velox/functions/sparksql/Split.h"
@@ -170,6 +171,8 @@ void registerStringFunctions(const std::string& prefix) {
       int32_t>({prefix + "varchar_type_write_side_check"});
 
   registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});
+
+  registerFunction<InitCapFunction, Varchar, Varchar>({prefix + "initcap"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   GetJsonObjectTest.cpp
   GetStructFieldTest.cpp
   HashTest.cpp
+  InitcapTest.cpp
   InTest.cpp
   JsonArrayLengthTest.cpp
   JsonObjectKeysTest.cpp

--- a/velox/functions/sparksql/tests/InitcapTest.cpp
+++ b/velox/functions/sparksql/tests/InitcapTest.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+class InitcapTest : public SparkFunctionBaseTest {
+ public:
+  static std::vector<std::tuple<std::string, std::string>>
+  getInitcapUnicodeTestData() {
+    return {
+        {"àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ", "Àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ"},
+        {"αβγδεζηθικλμνξοπρςστυφχψ", "Αβγδεζηθικλμνξοπρςστυφχψ"},
+        {"абвгдежзийклмнопрстуфхцчшщъыьэюя",
+         "Абвгдежзийклмнопрстуфхцчшщъыьэюя"},
+        {"hello world", "Hello World"},
+        {"HELLO WORLD", "Hello World"},
+        {"1234", "1234"},
+        {"", ""},
+        {"élève très-intelligent", "Élève Très-intelligent"},
+        {"mañana-por_la_tarde!", "Mañana-por_la_tarde!"},
+        {"добро-пожаловать.тест", "Добро-пожаловать.тест"},
+        {"çalışkan öğrenci@üniversite.tr", "Çalışkan Öğrenci@üniversite.tr"},
+        {"emoji😊test🚀case", "Emoji😊test🚀case"},
+        {"тест@пример.рф", "Тест@пример.рф"}};
+  }
+
+  static std::vector<std::tuple<std::string, std::string>>
+  getInitcapAsciiTestData() {
+    return {
+        {"abcdefg", "Abcdefg"},
+        {"ABCDEFG", "Abcdefg"},
+        {"a B c D e F g", "A B C D E F G"},
+        {"hello world", "Hello World"},
+        {"HELLO WORLD", "Hello World"},
+        {"1234", "1234"},
+        {"1 2 3 4", "1 2 3 4"},
+        {"1 2 3 4a", "1 2 3 4a"},
+        {"", ""},
+        {"urna.Ut@egetdictumplacerat.edu", "Urna.ut@egetdictumplacerat.edu"},
+        {"nibh.enim@egestas.ca", "Nibh.enim@egestas.ca"},
+        {"in@Donecat.ca", "In@donecat.ca"},
+        {"sodales@blanditviverraDonec.ca", "Sodales@blanditviverradonec.ca"},
+        {"sociis.natoque.penatibus@vitae.org",
+         "Sociis.natoque.penatibus@vitae.org"},
+        {"john_doe-123@example-site.com", "John_doe-123@example-site.com"},
+        {"MIXED.case-EMAIL_42@domain.NET", "Mixed.case-email_42@domain.net"},
+        {"...weird..case@@", "...weird..case@@"},
+        {"user-name+filter@sub.mail.org", "User-name+filter@sub.mail.org"},
+        {"CAPS_LOCK@DOMAIN.COM", "Caps_lock@domain.com"},
+        {"__init__.py@example.dev", "__init__.py@example.dev"}};
+  }
+
+ protected:
+  std::optional<std::string> initcap(const std::optional<std::string>& str) {
+    return evaluateOnce<std::string>("initcap(c0)", str);
+  }
+};
+
+TEST_F(InitcapTest, initcapUnicode) {
+  for (const auto& [inputStr, expected] : getInitcapUnicodeTestData()) {
+    EXPECT_EQ(initcap(inputStr).value(), expected);
+  }
+}
+
+TEST_F(InitcapTest, initcapAscii) {
+  for (const auto& [inputStr, expected] : getInitcapAsciiTestData()) {
+    EXPECT_EQ(initcap(inputStr).value(), expected);
+  }
+}
+
+TEST_F(InitcapTest, initcap) {
+  const auto initcap = [&](const std::optional<std::string>& value) {
+    return evaluateOnce<std::string>("initcap(c0)", value);
+  };
+  // Unicode only.
+  EXPECT_EQ(
+      initcap("àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ"),
+      "Àáâãäåæçèéêëìíîïðñòóôõöøùúûüýþ");
+  EXPECT_EQ(initcap("αβγδεζηθικλμνξοπρςστυφχψ"), "Αβγδεζηθικλμνξοπρςστυφχψ");
+  // Mix of ascii and unicode.
+  EXPECT_EQ(initcap("αβγδεζ world"), "Αβγδεζ World");
+  EXPECT_EQ(initcap("αfoo wβ"), "Αfoo Wβ");
+  // Ascii only.
+  EXPECT_EQ(initcap("hello world"), "Hello World");
+  EXPECT_EQ(initcap("HELLO WORLD"), "Hello World");
+  EXPECT_EQ(initcap("1234"), "1234");
+  EXPECT_EQ(initcap("a b c d"), "A B C D");
+  EXPECT_EQ(initcap("abcd"), "Abcd");
+  // Numbers.
+  EXPECT_EQ(initcap("123"), "123");
+  EXPECT_EQ(initcap("1abc"), "1abc");
+  // Edge cases.
+  EXPECT_EQ(initcap(""), "");
+  EXPECT_EQ(initcap(std::nullopt), std::nullopt);
+
+  // Test with spaces other than whitespace
+  EXPECT_EQ(initcap("YQ\tY"), "Yq\ty");
+  EXPECT_EQ(initcap("YQ\nY"), "Yq\ny");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Add Spark initcap function. It converts the first character of each word to 
uppercase and all other characters in the word to lowercase.

Spark's implementation:
https://github.com/apache/spark/blob/v3.5.1/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1791