### PR TITLE
fix: Prevent copying vector of shared_pointer velox vectors

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -74,8 +74,8 @@ void serializeOne<TypeKind::ROW>(
   // The layout is given by the type, not the instance. This will work
   // in the case of missing elements which will come out as null in
   // deserialization.
-  auto childrenSize = type.size();
-  auto children = row->children();
+  const auto childrenSize = type.size();
+  const auto& children = row->children();
   std::vector<uint64_t> nulls(bits::nwords(childrenSize));
   for (auto i = 0; i < childrenSize; ++i) {
     if (i >= children.size() || !children[i] ||


### PR DESCRIPTION
Summary:
Looking at round profiles, saw ~10% cycles on de-allocing vector of shared_ptr<velox vectors> on container serde path. Likely happens when we have many many vectors in the child and this function is called a lot.

Internal profile shows 10% cycles spent when sampled on 5 hosts in a fleet of 300.

Differential Revision: D73932727


