### PR TITLE
feat: Add client result value tracer and benchmark tool

### DIFF
--- a/velox/common/base/TraceConfig.cpp
+++ b/velox/common/base/TraceConfig.cpp
@@ -19,7 +19,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/TraceConfig.h"
 
-namespace facebook::velox::exec::trace {
+namespace facebook::velox {
 
 TraceConfig::TraceConfig(
     std::unordered_set<std::string> _queryNodeIds,
@@ -32,4 +32,4 @@ TraceConfig::TraceConfig(
       taskRegExp(std::move(_taskRegExp)) {
   VELOX_CHECK(!queryNodes.empty(), "Query trace nodes cannot be empty");
 }
-} // namespace facebook::velox::exec::trace
+} // namespace facebook::velox

--- a/velox/common/base/TraceConfig.h
+++ b/velox/common/base/TraceConfig.h
@@ -21,7 +21,7 @@
 #include <string>
 #include <unordered_set>
 
-namespace facebook::velox::exec::trace {
+namespace facebook::velox {
 
 #define VELOX_TRACE_LIMIT_EXCEEDED(errorMessage)                    \
   _VELOX_THROW(                                                     \
@@ -52,4 +52,4 @@ struct TraceConfig {
       UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
       std::string _taskRegExp);
 };
-} // namespace facebook::velox::exec::trace
+} // namespace facebook::velox

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -582,10 +582,6 @@ Index Join
      - Histogram
      - The time distribution of index lookup time in range of [0, 16s] with 512
        buckets and reports P50, P90, P99, and P100.
-   * - index_lookup_wait_time_ms
-     - Histogram
-     - The time distribution of index lookup time in range of [0, 16s] with 512
-       buckets and reports P50, P90, P99, and P100.
    * - index_lookup_blocked_wait_time_ms
      - Histogram
      - The time distribution of index lookup operator blocked wait time in range

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -95,7 +95,7 @@ const core::QueryConfig& DriverCtx::queryConfig() const {
   return task->queryCtx()->queryConfig();
 }
 
-const std::optional<trace::TraceConfig>& DriverCtx::traceConfig() const {
+const std::optional<TraceConfig>& DriverCtx::traceConfig() const {
   return task->traceConfig();
 }
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -295,7 +295,7 @@ struct DriverCtx {
 
   const core::QueryConfig& queryConfig() const;
 
-  const std::optional<trace::TraceConfig>& traceConfig() const;
+  const std::optional<TraceConfig>& traceConfig() const;
 
   velox::memory::MemoryPool* addOperatorPool(
       const core::PlanNodeId& planNodeId,

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -36,7 +36,7 @@ class OperatorTraceInputWriter {
  public:
   /// 'traceOp' is the operator to trace. 'traceDir' specifies the trace
   /// directory for the operator.
-  explicit OperatorTraceInputWriter(
+  OperatorTraceInputWriter(
       Operator* traceOp,
       std::string traceDir,
       memory::MemoryPool* pool,

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3056,7 +3056,7 @@ std::shared_ptr<ExchangeClient> Task::getExchangeClientLocked(
   return exchangeClients_[pipelineId];
 }
 
-std::optional<trace::TraceConfig> Task::maybeMakeTraceConfig() const {
+std::optional<TraceConfig> Task::maybeMakeTraceConfig() const {
   const auto& queryConfig = queryCtx_->queryConfig();
   if (!queryConfig.queryTraceEnabled()) {
     return std::nullopt;
@@ -3110,11 +3110,11 @@ std::optional<trace::TraceConfig> Task::maybeMakeTraceConfig() const {
   LOG(INFO) << "Trace input for plan nodes " << traceNodes << " from task "
             << taskId_;
 
-  trace::UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB =
+  UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB =
       [this](uint64_t bytes) {
         queryCtx_->updateTracedBytesAndCheckLimit(bytes);
       };
-  return trace::TraceConfig(
+  return TraceConfig(
       std::move(traceNodeIdSet),
       traceDir,
       std::move(updateAndCheckTraceLimitCB),

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -163,7 +163,7 @@ class Task : public std::enable_shared_from_this<Task> {
   }
 
   /// Returns query trace config if specified.
-  const std::optional<trace::TraceConfig>& traceConfig() const {
+  const std::optional<TraceConfig>& traceConfig() const {
     return traceConfig_;
   }
 
@@ -1036,7 +1036,7 @@ class Task : public std::enable_shared_from_this<Task> {
       int32_t pipelineId) const;
 
   // Builds the query trace config.
-  std::optional<trace::TraceConfig> maybeMakeTraceConfig() const;
+  std::optional<TraceConfig> maybeMakeTraceConfig() const;
 
   // Create a 'QueryMetadtaWriter' to trace the query metadata if the query
   // trace enabled.
@@ -1071,7 +1071,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   core::PlanFragment planFragment_;
 
-  const std::optional<trace::TraceConfig> traceConfig_;
+  const std::optional<TraceConfig> traceConfig_;
 
   // Hook in the system wide task list.
   TaskListEntry taskListEntry_;


### PR DESCRIPTION
Summary: Add client tracer to collect the lookup result value in ss client and persistent for offline replay to analyze decode overhead. This PR also integrate with ss connector and make it configurable through ss connector config, and provide a replay tool

Differential Revision: D73898602
