### PR TITLE
fix: Remove type fbsampleset from PQR supported signatures

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -323,6 +323,7 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
+      usesInputTypeName(signature, "fbsampleset") ||
       usesInputTypeName(signature, "uuid"));
 }
 


### PR DESCRIPTION
Summary:
Remove type `fbsampleset` from Presto Expression Fuzzer runs. This type was newly added D72876369 and is breaking fuzzer runs:

https://www.internalfb.com/chronos/job_instance/silver/1125908543530718/simple-logs
https://www.internalfb.com/chronos/job_instance/silver/1125908543530835/simple-logs

Differential Revision: D73947016


