### PR TITLE
build: Update FBOS to v2025.04.28.00

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -74,6 +74,7 @@ jobs:
             run_and_time install_fmt
             run_and_time install_protobuf
             run_and_time install_boost
+            run_and_time install_fast_float
             run_and_time install_folly
             run_and_time install_stemmer
             run_and_time install_thrift

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -80,6 +80,13 @@ jobs:
             run_and_time install_thrift
             run_and_time install_arrow
 
+      # Folly is built with a new flag that the cache may not have. Ensure velox build and folly have
+      # used the correct flags (disabled the coroutines)
+      - name: TEMP: Force folly rebuild and update cache
+        run: |
+            source velox/scripts/setup-ubuntu.sh
+            run_and_time install_folly
+
       - name: Save Dependencies
         if: ${{ steps.restore-deps.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3

--- a/CMake/FindXxhash.cmake
+++ b/CMake/FindXxhash.cmake
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Try to find Facebook xxhash library This will define Xxhash_FOUND
+# Xxhash_INCLUDE_DIR Xxhash_LIBRARY
+#
+
+find_path(Xxhash_INCLUDE_DIR NAMES xxhash.h)
+
+find_library(Xxhash_LIBRARY_RELEASE NAMES xxhash)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(Xxhash)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Xxhash DEFAULT_MSG Xxhash_LIBRARY
+                                  Xxhash_INCLUDE_DIR)
+
+if(Xxhash_FOUND)
+  message(STATUS "Found xxhash: ${Xxhash_LIBRARY}")
+endif()
+
+mark_as_advanced(Xxhash_INCLUDE_DIR Xxhash_LIBRARY)

--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -32,16 +32,19 @@ by Velox. See details on bundling below.
 | re2               | 2021-04-01      | Yes      |
 | fmt               | 10.1.1          | Yes      |
 | simdjson          | 3.9.3           | Yes      |
-| folly             | v2024.07.01.00  | Yes      |
-| fizz              | v2024.07.01.00  | No       |
-| wangle            | v2024.07.01.00  | No       |
-| mvfst             | v2024.07.01.00  | No       |
-| fbthrift          | v2024.07.01.00  | No       |
+| folly             | v2025.04.28.00  | Yes      |
+| fizz              | v2025.04.28.00  | No       |
+| wangle            | v2025.04.28.00  | No       |
+| mvfst             | v2025.04.28.00  | No       |
+| fbthrift          | v2025.04.28.00  | No       |
 | libstemmer        | 2.2.0           | Yes      |
 | DuckDB (testing)  | 0.8.1           | Yes      |
 | cpr (testing)     | 1.10.15         | Yes      |
 | arrow             | 15.0.0          | Yes      |
 | geos              | 3.10.2          | Yes      |
+| fast_float        | v8.0.2          | Yes      |
+| xxhash            | default         | No       |
+| thrift            | 0.16            | No       |
 
 # Bundled Dependency Management
 This module provides a dependency management system that allows us to automatically fetch and build dependencies from source if needed.

--- a/CMake/resolve_dependency_modules/fastfloat.cmake
+++ b/CMake/resolve_dependency_modules/fastfloat.cmake
@@ -1,0 +1,42 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FASTFLOAT_VERSION v8.0.2)
+set(VELOX_FASTFLOAT_BUILD_SHA256_CHECKSUM
+    e14a33089712b681d74d94e2a11362643bd7d769ae8f7e7caefe955f57f7eacd)
+set(VELOX_FASTFLOAT_SOURCE_URL
+    "https://github.com/fastfloat/fast_float/archive/refs/tags/${VELOX_FASTFLOAT_VERSION}.tar.gz"
+)
+
+velox_resolve_dependency_url(FASTFLOAT)
+
+message(STATUS "Building fast_float from source")
+FetchContent_Declare(
+  fastfloat
+  URL ${VELOX_FASTFLOAT_SOURCE_URL}
+  URL_HASH ${VELOX_FASTFLOAT_BUILD_SHA256_CHECKSUM})
+set(fastfloat_BUILD_TESTS OFF)
+FetchContent_MakeAvailable(fastfloat)
+# If folly is bundled it uses find_path fast_float/fast_float.h to locate the
+# header. But when made availabe through FetchContent it does not find it.
+# Instead, we need to explicitly point it to the location to search for it. This
+# caches the FASTFLOAT_INCLUDE_DIR variable so when folly re-runs find_path it
+# will already have located the bundled header.
+FetchContent_GetProperties(fastfloat SOURCE_DIR FASTFLOAT_SOURCE_DIR)
+find_path(
+  FASTFLOAT_INCLUDE_DIR
+  NAMES fast_float/fast_float.h
+  PATHS ${FASTFLOAT_SOURCE_DIR}
+  PATH_SUFFIXES include)

--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -14,9 +14,12 @@
 project(Folly)
 cmake_minimum_required(VERSION 3.28)
 
-set(VELOX_FOLLY_BUILD_VERSION v2024.07.01.00)
+velox_set_source(fastfloat)
+velox_resolve_dependency(fastfloat CONFIG REQUIRED)
+
+set(VELOX_FOLLY_BUILD_VERSION v2025.04.28.00)
 set(VELOX_FOLLY_BUILD_SHA256_CHECKSUM
-    e78584ab7ba9a687285f2849bc0141e2422a5c808ad6ab3558c83d85975e25ed)
+    ccbb7eac662023f9f5beba94e51350d527f33d8a7a036eb5e3d8a5cf1b49d3bc)
 set(VELOX_FOLLY_SOURCE_URL
     "https://github.com/facebook/folly/releases/download/${VELOX_FOLLY_BUILD_VERSION}/folly-${VELOX_FOLLY_BUILD_VERSION}.tar.gz"
 )
@@ -45,6 +48,8 @@ set(BUILD_SHARED_LIBS ${VELOX_BUILD_SHARED})
 
 # Enable INT128 support
 set(FOLLY_HAVE_INT128_T ON)
+set(PREVIOUS_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFOLLY_CFG_NO_COROUTINES")
 
 FetchContent_MakeAvailable(folly)
 
@@ -55,3 +60,4 @@ add_library(Folly::follybenchmark ALIAS follybenchmark)
 if(gflags_SOURCE STREQUAL "BUNDLED")
   add_dependencies(folly glog::glog gflags::gflags fmt::fmt)
 endif()
+set(CMAKE_CXX_FLAGS ${PREVIOUS_CMAKE_CXX_FLAGS})

--- a/CMake/resolve_dependency_modules/folly/folly-gflags-glog.patch
+++ b/CMake/resolve_dependency_modules/folly/folly-gflags-glog.patch
@@ -11,23 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
---- a/CMake/FollyConfigChecks.cmake
-+++ b/CMake/FollyConfigChecks.cmake
-@@ -181,7 +181,7 @@ check_cxx_source_runs("
-   HAVE_VSNPRINTF_ERRORS
- )
- 
--if (FOLLY_HAVE_LIBGFLAGS)
-+if (FOLLY_HAVE_LIBGFLAGS AND NOT FOLLY_GFLAGS_NAMESPACE)
-   # Older releases of gflags used the namespace "gflags"; newer releases
-   # use "google" but also make symbols available in the deprecated "gflags"
-   # namespace too.  The folly code internally uses "gflags" unless we tell it
 --- a/CMake/folly-deps.cmake
 +++ b/CMake/folly-deps.cmake
-@@ -52,19 +52,20 @@ find_package(DoubleConversion MODULE REQUIRED)
- list(APPEND FOLLY_LINK_LIBRARIES ${DOUBLE_CONVERSION_LIBRARY})
- list(APPEND FOLLY_INCLUDE_DIRECTORIES ${DOUBLE_CONVERSION_INCLUDE_DIR})
- 
+@@ -55,19 +55,20 @@ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${DOUBLE_CONVERSION_INCLUDE_DIR})
+ find_package(FastFloat MODULE REQUIRED)
+ list(APPEND FOLLY_INCLUDE_DIRECTORIES ${FASTFLOAT_INCLUDE_DIR})
+
 -find_package(Gflags MODULE)
 -set(FOLLY_HAVE_LIBGFLAGS ${LIBGFLAGS_FOUND})
 -if(LIBGFLAGS_FOUND)
@@ -43,7 +32,7 @@
 +  set(FOLLY_LIBGFLAGS_LIBRARY ${gflags_LIBRARY})
 +  set(FOLLY_LIBGFLAGS_INCLUDE ${gflags_INCLUDE_DIR})
  endif()
- 
+
 -find_package(Glog MODULE)
 -set(FOLLY_HAVE_LIBGLOG ${GLOG_FOUND})
 -list(APPEND FOLLY_LINK_LIBRARIES ${GLOG_LIBRARY})
@@ -53,6 +42,6 @@
 +list(APPEND FOLLY_LINK_LIBRARIES ${glog_LIBRARY})
 +list(APPEND FOLLY_INCLUDE_DIRECTORIES ${glog_INCLUDE_DIR})
 +message(STATUS "glog_LIBRARY: ${glog_LIBRARY}")
- 
+
  find_package(LibEvent MODULE REQUIRED)
  list(APPEND FOLLY_LINK_LIBRARIES ${LIBEVENT_LIB})

--- a/CMake/resolve_dependency_modules/folly/folly-no-export.patch
+++ b/CMake/resolve_dependency_modules/folly/folly-no-export.patch
@@ -13,10 +13,10 @@
 # limitations under the License.
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -456,14 +456,14 @@ target_link_libraries(folly_test_util
+@@ -500,14 +500,14 @@ target_link_libraries(folly_test_util
  apply_folly_compile_options_to_target(folly_test_util)
  list(APPEND FOLLY_INSTALL_TARGETS folly_test_util)
- 
+
 -install(TARGETS ${FOLLY_INSTALL_TARGETS}
 -  EXPORT folly
 -  RUNTIME DESTINATION bin
@@ -25,18 +25,18 @@
 -auto_install_files(folly ${FOLLY_DIR}
 -  ${hfiles}
 -)
-+# install(TARGETS ${FOLLY_INSTALL_TARGETS}
-+#   EXPORT folly
-+#   RUNTIME DESTINATION bin
-+#   LIBRARY DESTINATION ${LIB_INSTALL_DIR}
-+#   ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
-+# auto_install_files(folly ${FOLLY_DIR}
-+#   ${hfiles}
-+# )
++#install(TARGETS ${FOLLY_INSTALL_TARGETS}
++#  EXPORT folly
++#  RUNTIME DESTINATION bin
++#  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
++#  ARCHIVE DESTINATION ${LIB_INSTALL_DIR})
++#auto_install_files(folly ${FOLLY_DIR}
++#  ${hfiles}
++#)
  install(
    FILES ${CMAKE_CURRENT_BINARY_DIR}/folly/folly-config.h
    DESTINATION ${INCLUDE_INSTALL_DIR}/folly
-@@ -487,13 +487,13 @@ install(
+@@ -531,13 +531,13 @@ install(
    DESTINATION ${CMAKE_INSTALL_DIR}
    COMPONENT dev
  )
@@ -47,13 +47,13 @@
 -  FILE folly-targets.cmake
 -  COMPONENT dev
 -)
-+# install(
-+#   EXPORT folly
-+#   DESTINATION ${CMAKE_INSTALL_DIR}
-+#   NAMESPACE Folly::
-+#   FILE folly-targets.cmake
-+#   COMPONENT dev
-+# )
- 
++#install(
++#  EXPORT folly
++#  DESTINATION ${CMAKE_INSTALL_DIR}
++#  NAMESPACE Folly::
++#  FILE folly-targets.cmake
++#  COMPONENT dev
++#)
+
  # Generate a pkg-config file so that downstream projects that don't use
  # CMake can depend on folly using pkg-config.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,13 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
 endif()
 
+# Ensure that we don't bring in headers that might have coroutines enabled. The
+# dependencies turn off coroutines in folly and the other FBOS dependencies. If
+# not explicitly turned off differences in the build using GCC cause libray
+# incompatibilities of the thrift server and the remote functions library
+# causing SEGVs in the tests.
+string(APPEND CMAKE_CXX_FLAGS " -DFOLLY_CFG_NO_COROUTINES")
+
 # Under Ninja, we are able to designate certain targets large enough to require
 # restricted parallelism.
 if("${MAX_HIGH_MEM_JOBS}")

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -41,7 +41,7 @@ USE_CLANG="${USE_CLANG:-false}"
 export INSTALL_PREFIX=${INSTALL_PREFIX:-"/usr/local"}
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
 
-FB_OS_VERSION="v2024.07.01.00"
+FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
 THRIFT_VERSION="v0.16.0"
@@ -50,6 +50,11 @@ ARROW_VERSION="15.0.0"
 STEMMER_VERSION="2.2.0"
 DUCKDB_VERSION="v0.8.1"
 GEOS_VERSION="3.10.2"
+FAST_FLOAT_VERSION="v8.0.2"
+
+# Folly Portability.h being used to decide whether or not support coroutines
+# causes issues (build, lin) if the selection is not consistent across users of folly.
+EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
 
 function dnf_install {
   dnf install -y -q --setopt=install_weak_deps=False "$@"
@@ -80,7 +85,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel
+    libsodium-devel zlib-devel xxhash-devel
 
   # install sphinx for doc gen
   pip install sphinx sphinx-tabs breathe sphinx_rtd_theme
@@ -153,27 +158,32 @@ function install_protobuf {
 
 function install_fizz {
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+}
+
+function install_fast_float {
+  wget_and_untar https://github.com/fastfloat/fast_float/archive/refs/tags/${FAST_FLOAT_VERSION}.tar.gz fast_float
+  cmake_install_dir fast_float -DBUILD_TESTS=OFF
 }
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
+  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
 }
 
 function install_wangle {
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_fbthrift {
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_mvfst {
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_duckdb {
@@ -258,6 +268,7 @@ function install_velox_deps {
   run_and_time install_boost
   run_and_time install_protobuf
   run_and_time install_fmt
+  run_and_time install_fast_float
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -40,14 +40,19 @@ USE_CLANG="${USE_CLANG:-false}"
 export INSTALL_PREFIX=${INSTALL_PREFIX:-"/usr/local"}
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
 
-FB_OS_VERSION="v2024.07.01.00"
+# Folly Portability.h being used to decide whether or not support coroutines
+# causes issues (build, lin) if the selection is not consistent across users of folly.
+EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
+
+FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
-THRIFT_VERSION="v0.16.0"
+THRIFT_VERSION="v0.21.0"
 # Note: when updating arrow check if thrift needs an update as well.
 ARROW_VERSION="15.0.0"
 STEMMER_VERSION="2.2.0"
 DUCKDB_VERSION="v0.8.1"
+FAST_FLOAT_VERSION="v8.0.2"
 
 # CMake 4.0 removed support for cmake minimums of <=3.5 and will fail builds, this overrides it
 export CMAKE_POLICY_VERSION_MINIMUM="3.5"
@@ -80,7 +85,7 @@ function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
     openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
-    libsodium-devel zlib-devel
+    libsodium-devel zlib-devel xxhash-devel
 }
 
 function install_conda {
@@ -150,27 +155,32 @@ function install_protobuf {
 
 function install_fizz {
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+}
+
+function install_fast_float {
+  wget_and_untar https://github.com/fastfloat/fast_float/archive/refs/tags/${FAST_FLOAT_VERSION}.tar.gz fast_float
+  cmake_install_dir fast_float -DBUILD_TESTS=OFF
 }
 
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
+  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
 }
 
 function install_wangle {
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_fbthrift {
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_mvfst {
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_duckdb {
@@ -255,6 +265,7 @@ function install_velox_deps {
   run_and_time install_boost
   run_and_time install_protobuf
   run_and_time install_fmt
+  run_and_time install_fast_float
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -73,15 +73,20 @@ function install_gcc11_if_needed {
   fi
 }
 
-FB_OS_VERSION="v2024.07.01.00"
+# Folly Portability.h being used to decide whether or not support coroutines
+# causes issues (build, lin) if the selection is not consistent across users of folly.
+EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
+
+FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
-THRIFT_VERSION="v0.16.0"
+THRIFT_VERSION="v0.21.0"
 # Note: when updating arrow check if thrift needs an update as well.
 ARROW_VERSION="15.0.0"
 STEMMER_VERSION="2.2.0"
 DUCKDB_VERSION="v0.8.1"
 GEOS_VERSION="3.10.2"
+FAST_FLOAT_VERSION="v8.0.2"
 
 # Install packages required for build.
 function install_build_prerequisites {
@@ -150,7 +155,8 @@ function install_velox_deps_from_apt {
     bison \
     flex \
     libfl-dev \
-    tzdata
+    tzdata \
+    libxxhash-dev
 }
 
 function install_fmt {
@@ -181,29 +187,34 @@ function install_protobuf {
   cmake_install_dir protobuf -Dprotobuf_BUILD_TESTS=OFF
 }
 
+function install_fast_float {
+  wget_and_untar https://github.com/fastfloat/fast_float/archive/refs/tags/${FAST_FLOAT_VERSION}.tar.gz fast_float
+  cmake_install_dir fast_float -DBUILD_TESTS=OFF
+}
+
 function install_folly {
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
+  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
 }
 
 function install_fizz {
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_wangle {
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_mvfst {
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_fbthrift {
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
 }
 
 function install_conda {
@@ -318,6 +329,7 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_protobuf
   run_and_time install_boost
+  run_and_time install_fast_float
   run_and_time install_folly
   run_and_time install_fizz
   run_and_time install_wangle

--- a/velox/benchmarks/basic/ComparisonConjunct.cpp
+++ b/velox/benchmarks/basic/ComparisonConjunct.cpp
@@ -176,7 +176,7 @@ BENCHMARK(conjunctsNested) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<ComparisonBenchmark>(1'000);
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -189,7 +189,7 @@ BENCHMARK(decodeDictionary5Nested) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<DecodedVectorBenchmark>(10'000);
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/FeatureNormalization.cpp
+++ b/velox/benchmarks/basic/FeatureNormalization.cpp
@@ -111,7 +111,7 @@ BENCHMARK(normalizeConstant) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<FeatureNormailzationBenchmark>();
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -344,7 +344,7 @@ BENCHMARK(plusCheckedLarge) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<SimpleArithmeticBenchmark>();
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/SimpleCastExpr.cpp
+++ b/velox/benchmarks/basic/SimpleCastExpr.cpp
@@ -251,7 +251,7 @@ BENCHMARK(castStructManyFieldsNestedCastMedium) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<SimpleCastBenchmark>();
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -115,7 +115,7 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmark = std::make_unique<VectorCompareBenchmark>(1000);
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -133,7 +133,7 @@ BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -112,7 +112,7 @@ DEFINE_BENCHMARKS(row)
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
   using namespace facebook::velox;
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   VELOX_CHECK_LE(FLAGS_slice_size, kVectorSize);
   memory::MemoryManager::initialize({});
   data = std::make_unique<BenchmarkData>();

--- a/velox/common/base/benchmarks/StringSearchBenchmark.cpp
+++ b/velox/common/base/benchmarks/StringSearchBenchmark.cpp
@@ -263,7 +263,7 @@ BENCHMARK_NAMED_PARAM(
 } // namespace facebook::velox
 
 int main(int argc, char** argv) {
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -330,7 +330,7 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize({});
   benchmarkFew = std::make_unique<HivePartitionFunctionBenchmark>(1'000);
   benchmarkMany = std::make_unique<HivePartitionFunctionBenchmark>(10'000);

--- a/velox/exec/benchmarks/MergeBenchmark.cpp
+++ b/velox/exec/benchmarks/MergeBenchmark.cpp
@@ -55,7 +55,7 @@ BENCHMARK_RELATIVE(wideArray) {
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   MergeTestBase test;
   test.seed(1);
   narrow = test.makeTestData(100'000'000, 7);

--- a/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
@@ -116,7 +116,7 @@ BENCHMARK_NAMED_PARAM(merge, capacity2048, 1e6, 2048)
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -189,7 +189,7 @@ BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x80, 1e6, 80);
 
 int main(int argc, char* argv[]) {
   folly::Init init{&argc, &argv};
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  ::gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;
 }


### PR DESCRIPTION
This PR changes a few things due to changes in the new dependent libraries
- namespace issues
- coroutine support causing segv in remote functions test
- updated patch files
- new dependencies for FBOS (xxhash and fast float)