### PR TITLE
fix: make format-fix should run without extra manual installations

### DIFF
--- a/scripts/check.py
+++ b/scripts/check.py
@@ -44,7 +44,7 @@ def get_diff(file, formatted):
 class CppFormatter(str):
     def diff(self, commit):
         if commit == "":
-            return get_diff(self, util.run(f"clang-format --style=file {self}")[1])
+            return get_diff(self, util.run(f"clang-format-16 --style=file {self}")[1])
         else:
             return util.run(
                 f"{SCRIPTS}/git-clang-format -q --extensions='{EXTENSIONS}' --diff --style=file {commit} {self}"
@@ -52,7 +52,7 @@ class CppFormatter(str):
 
     def fix(self, commit):
         if commit == "":
-            return util.run(f"clang-format -i --style=file {self}")[0] == 0
+            return util.run(f"clang-format-16 -i --style=file {self}")[0] == 0
         else:
             return (
                 util.run(

--- a/scripts/git-clang-format
+++ b/scripts/git-clang-format
@@ -133,7 +133,7 @@ def main():
     usage=usage, formatter_class=argparse.RawDescriptionHelpFormatter,
     description=desc)
   p.add_argument('--binary',
-                 default=config.get('clangformat.binary', 'clang-format'),
+                 default=config.get('clangformat.binary', 'clang-format-16'),
                  help='path to clang-format'),
   p.add_argument('--commit',
                  default=config.get('clangformat.commit', 'HEAD'),
@@ -387,7 +387,7 @@ def create_tree_from_workdir(filenames):
 
 
 def run_clang_format_and_save_to_tree(changed_lines, revision=None,
-                                      binary='clang-format', style=None):
+                                      binary='clang-format-16', style=None):
   """Run clang-format on each file and save the result to a git tree.
 
   Returns the object ID (SHA-1) of the created tree."""
@@ -440,7 +440,7 @@ def create_tree(input_lines, mode):
 
 
 def clang_format_to_blob(filename, line_ranges, revision=None,
-                         binary='clang-format', style=None):
+                         binary='clang-format-16', style=None):
   """Run clang-format on the given file and save the result to a git blob.
 
   Runs on the file in `revision` if not None, or on the file in the working

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -119,10 +119,13 @@ function install_build_prerequisites {
 
 # Install packages required to fix format
 function install_format_prerequisites {
-  pip3 install regex
-  ${SUDO} apt install -y \
-    clang-format \
-    cmake-format
+  pip3 install regex black
+  ${SUDO} apt install -y cmake-format
+  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | ${SUDO} apt-key add -
+  ${SUDO} add-apt-repository "deb http://apt.llvm.org/$(lsb_release -cs)/ llvm-toolchain-$(lsb_release -cs)-16 main"
+
+  ${SUDO} apt update
+  ${SUDO} apt install -y clang-format-16
 }
 
 # Install packages required for build.
@@ -314,6 +317,7 @@ function install_geos {
 }
 
 function install_velox_deps {
+  run_and_time install_format_prerequisites
   run_and_time install_velox_deps_from_apt
   run_and_time install_fmt
   run_and_time install_protobuf


### PR DESCRIPTION
This PR fixes the issue of unsupported key error while running make format-fix by installing clang-format-16.

### Relevant issue

Fixes #13210 