### PR TITLE
feat: poc of lazy local merge

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -49,6 +49,7 @@ velox_add_library(
   MarkDistinct.cpp
   MemoryReclaimer.cpp
   Merge.cpp
+  MergeBuffer.cpp
   MergeJoin.cpp
   MergeSource.cpp
   NestedLoopJoinBuild.cpp

--- a/velox/exec/MergeBuffer.cpp
+++ b/velox/exec/MergeBuffer.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MergeBuffer.h"
+
+#include <utility>
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/OperatorUtils.h"
+
+namespace facebook::velox::exec {
+namespace {
+const auto kSpillPartitionId = SpillPartitionId{0};
+}
+
+MergeBuffer::MergeBuffer(
+    RowTypePtr type,
+    velox::memory::MemoryPool* const pool,
+    common::SpillConfig spillConfig,
+    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    : type_(std::move(type)),
+      pool_(pool),
+      spillConfig_(std::move(spillConfig)),
+      spillStats_(spillStats),
+      inputSpiller_(std::make_unique<NoRowContainerSpiller>(
+          type_,
+          std::nullopt,
+          HashBitRange{},
+          &spillConfig_,
+          spillStats_)) {}
+
+void MergeBuffer::addInput(RowVectorPtr input) {
+  numInputRows_ += input->size();
+  // Ensure vector are lazy loaded before spilling.
+  for (auto i = 0; i < input->childrenSize(); ++i) {
+    input->childAt(i)->loadedVector();
+  }
+  inputSpiller_->spill(kSpillPartitionId, input);
+}
+
+void MergeBuffer::noMoreInput() {
+  VELOX_CHECK(!noMoreInput_);
+  noMoreInput_ = true;
+  finishSpill();
+}
+
+RowVectorPtr MergeBuffer::getOutput(vector_size_t maxOutputRows) {
+  VELOX_CHECK(noMoreInput_);
+
+  if (numOutputRows_ == numInputRows_) {
+    return nullptr;
+  }
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+  prepareOutput(batchSize);
+  getOutputWithSpill();
+  return output_;
+}
+
+void MergeBuffer::prepareOutput(vector_size_t batchSize) {
+  if (output_ != nullptr) {
+    VectorPtr output = std::move(output_);
+    BaseVector::prepareForReuse(output, batchSize);
+    output_ = std::static_pointer_cast<RowVector>(output);
+  } else {
+    output_ = std::static_pointer_cast<RowVector>(
+        BaseVector::create(type_, batchSize, pool_));
+  }
+
+  for (auto& child : output_->children()) {
+    child->resize(batchSize);
+  }
+
+  spillSources_.resize(batchSize);
+  spillSourceRows_.resize(batchSize);
+  prepareOutputWithSpill();
+
+  VELOX_CHECK_GT(output_->size(), 0);
+  VELOX_CHECK_LE(output_->size() + numOutputRows_, numInputRows_);
+}
+
+void MergeBuffer::getOutputWithSpill() {
+  VELOX_CHECK_NOT_NULL(spillMerger_);
+
+  int32_t outputRow = 0;
+  int32_t outputSize = 0;
+  bool isEndOfBatch = false;
+  while (outputRow + outputSize < output_->size()) {
+    SpillMergeStream* stream = spillMerger_->next();
+    VELOX_CHECK_NOT_NULL(stream);
+
+    spillSources_[outputSize] = &stream->current();
+    spillSourceRows_[outputSize] = stream->currentIndex(&isEndOfBatch);
+    ++outputSize;
+    if (FOLLY_UNLIKELY(isEndOfBatch)) {
+      // The stream is at end of input batch. Need to copy out the rows before
+      // fetching next batch in 'pop'.
+      gatherCopy(
+          output_.get(),
+          outputRow,
+          outputSize,
+          spillSources_,
+          spillSourceRows_,
+          {});
+      outputRow += outputSize;
+      outputSize = 0;
+    }
+    // Advance the stream.
+    stream->pop();
+  }
+  VELOX_CHECK_EQ(outputRow + outputSize, output_->size());
+
+  if (FOLLY_LIKELY(outputSize != 0)) {
+    gatherCopy(
+        output_.get(),
+        outputRow,
+        outputSize,
+        spillSources_,
+        spillSourceRows_,
+        {});
+  }
+
+  numOutputRows_ += output_->size();
+}
+
+void MergeBuffer::finishSpill() {
+  VELOX_CHECK_NULL(spillMerger_);
+  VELOX_CHECK(!inputSpiller_->finalized());
+  inputSpiller_->finishSpill(spillPartitionSet_);
+  VELOX_CHECK_EQ(spillPartitionSet_.size(), 1);
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/MergeBuffer.h
+++ b/velox/exec/MergeBuffer.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/spiller.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+class SortInputSpiller;
+class SortOutputSpiller;
+
+/// A utility class to accumulate data inside and output the merged result.
+/// Spilling would be triggered if spilling is enabled and memory usage exceeds
+/// limit.
+class MergeBuffer {
+ public:
+  MergeBuffer(
+      RowTypePtr type,
+      velox::memory::MemoryPool* pool,
+      common::SpillConfig spillConfig,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+
+  ~MergeBuffer();
+
+  void addInput(RowVectorPtr input);
+
+  /// Indicates no more input and triggers finish spilling and setup the sort
+  ///  merge reader for processing spilled data.
+  void noMoreInput();
+
+  /// Gathers and returns the sort merge output rows in batch.
+  RowVectorPtr getOutput(vector_size_t maxOutputRows);
+
+ private:
+  // Ensures there is sufficient memory reserved to process 'input'.
+  void ensureInputFits(const VectorPtr& input);
+
+  void updateEstimatedOutputRowSize();
+
+  // Invoked to initialize or reset the reusable output buffer to get output.
+  void prepareOutput(vector_size_t outputBatchSize);
+
+  // Invoked to initialize reader to read the spilled data from storage for
+  // output processing.
+  void prepareOutputWithSpill();
+
+  void getOutputWithSpill();
+
+  // Spill during input stage.
+  void spillInput();
+
+  // Finish spill, and we shouldn't get any rows from non-spilled partition as
+  // there is only one hash partition for MergeBuffer.
+  void finishSpill();
+
+  const RowTypePtr type_;
+  velox::memory::MemoryPool* const pool_;
+  const common::SpillConfig spillConfig_;
+  folly::Synchronized<common::SpillStats>* const spillStats_;
+  const std::unique_ptr<NoRowContainerSpiller> inputSpiller_;
+
+  // Indicates no more input. Once it is set, addInput() can't be called on this
+  // sort buffer object.
+  bool noMoreInput_ = false;
+
+  // The number of received input rows.
+  uint64_t numInputRows_ = 0;
+
+  // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
+
+  // Records the source rows to copy to 'output_' in order.
+  std::vector<const RowVector*> spillSources_;
+
+  std::vector<vector_size_t> spillSourceRows_;
+
+  SpillPartitionSet spillPartitionSet_;
+
+  // Reusable output vector.
+  RowVectorPtr output_;
+
+  // The number of rows that has been returned.
+  uint64_t numOutputRows_{0};
+};
+} // namespace facebook::velox::exec


### PR DESCRIPTION
# Lazy local merge方案

## Merge算子

- Merge::init
Merge算子在初始化时会创建MergeBuffer

- Merge::isBlocked
  1. 如果mergeBuffer_ == nullptr则进入常规模式，无需后续操作
  2. 如果partialInputMerger_ == nullptr，用部分未启动到sources创建一个如果partialInputMerger_
  3. 启动partialInputMerger_底层的sources
  4. 如果source futures为空调用partialInputMerger_的partialMergeStream_::isBlocked
  5. 如果source futures非空就返回kBlocked和future

- Merge::getOutput
  1. 如果finished返回nullptr，或者mergeBuffer_ == nullptr则进入常规模式，无需后续操作
  2. partialInputMerger_->next，如果到达output size阈值，或者某个stream的batch末尾，则copyOutput之后调用MergeBuffer::addInput
  3. 如果partialInputMerger_->atEnd()，partialInputMerger_ = nullptr，partialMergeStream_.clear后
  4. 如果此时没有更多的source，调用MergeBuffer::noMoreInput
  5. 如果partialInputMerger_ == nullptr，说明进入了output result状态，调用MergeBuffer::output
  6. 如果有result返回result，如果返回nullptr设置isFinished_ = true并返回null


## MergeBuffer

- MergeBuffer::init
根据传入的data type创建一个NoRowContainerSpiller

- MergeBuffer::addInput
  1. NoRowContainerSpiller::spill(input)

- MergeBuffer::noMoreInput
  1. finish spill，得到spilled partition，single partition
  2. 创建一个MergeBuffer::spillReader_

- MergeBuffer::getOutput
  1. gather各个stream已经pop的row index索引的batch中row为一个vector
  2. 返回vector
  3. 如果结束close spiller和reader后返回null
