### PR TITLE
fix: Make vector function factory honor config

### DIFF
--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -257,8 +257,8 @@ template <typename T>
 VectorFunctionFactory makeVectorFunctionFactory() {
   return [](const std::string& name,
             const std::vector<VectorFunctionArg>& inputArgs,
-            const core::QueryConfig& /*config*/) {
-    return std::make_shared<T>(name, inputArgs);
+            const core::QueryConfig& config) {
+    return std::make_shared<T>(name, inputArgs, config);
   };
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1406,9 +1406,10 @@ TEST_P(ParameterizedExprTest, selectiveLazyLoadingIf) {
 namespace {
 class StatefulVectorFunction : public exec::VectorFunction {
  public:
-  explicit StatefulVectorFunction(
+  StatefulVectorFunction(
       const std::string& /*name*/,
-      const std::vector<exec::VectorFunctionArg>& inputs)
+      const std::vector<exec::VectorFunctionArg>& inputs,
+      const core::QueryConfig& /* config */)
       : numInputs_(inputs.size()) {}
 
   void apply(


### PR DESCRIPTION
Summary: The existing logic allows config to be passed, but didn't propagate that to the constructor of the vector function. The proposed changes wire it up.

Differential Revision: D74016078


