### PR TITLE
fix: Add alias substring for SubstrFunction

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -233,6 +233,8 @@ String Functions
     Returns the last ``N`` characters of the input ``string`` up to at most the length of ``string``.
 
 .. function:: substr(string, start) -> varchar
+.. function:: substring(string, start) -> varchar
+    :noindex:
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
@@ -240,6 +242,8 @@ String Functions
     value of ``start`` is greater then length of the ``string``.
 
 .. function:: substr(string, start, length) -> varchar
+    :noindex:
+.. function:: substring(string, start, length) -> varchar
     :noindex:
 
     Returns a substring from ``string`` of length ``length`` from the starting

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -61,16 +61,16 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "trail"});
 
   registerFunction<SubstrFunction, Varchar, Varchar, int64_t>(
-      {prefix + "substr"});
+      {prefix + "substr", prefix + "substring"});
   registerFunction<SubstrFunction, Varchar, Varchar, int64_t, int64_t>(
-      {prefix + "substr"});
+      {prefix + "substr", prefix + "substring"});
 
   // TODO Presto doesn't allow INTEGER types for 2nd and 3rd arguments. Remove
   // these signatures.
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
-      {prefix + "substr"});
+      {prefix + "substr", prefix + "substring"});
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
-      {prefix + "substr"});
+      {prefix + "substr", prefix + "substring"});
 
   registerFunction<SubstrVarbinaryFunction, Varbinary, Varbinary, int64_t>(
       {prefix + "substr"});

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -359,6 +359,7 @@ TEST_F(StringFunctionsTest, substrConstant) {
  */
 TEST_F(StringFunctionsTest, substrVariable) {
   std::shared_ptr<FlatVector<StringView>> result;
+  std::shared_ptr<FlatVector<StringView>> substringResult;
   vector_size_t size = 100;
   std::vector<std::string> ref_strings(size);
 
@@ -378,29 +379,55 @@ TEST_F(StringFunctionsTest, substrVariable) {
 
   auto stringVector = makeStrings(size, strings);
 
+  // Test substr function
   result = evaluateSubstr(
       "substr(c0, c1, c2)", {stringVector, startVector, lengthVector});
+
+  // Test substring alias function with the same arguments
+  substringResult = evaluateSubstr(
+      "substring(c0, c1, c2)", {stringVector, startVector, lengthVector});
+
   EXPECT_EQ(stringVector.use_count(), 1);
   // Destroying string vector
   stringVector = nullptr;
 
-  for (int i = 0; i < size; ++i) {
-    // Checking the null results
-    if (expectNullString(i) || expectNullStart(i) || expectNullLength(i)) {
-      EXPECT_TRUE(result->isNullAt(i)) << "expected null at " << i;
-    } else {
-      if (expectedStart(i) != 0) {
-        EXPECT_EQ(result->valueAt(i).size(), expectedLength(i)) << "at " << i;
-        for (int l = 0; l < expectedLength(i); l++) {
-          EXPECT_EQ(
-              result->valueAt(i).data()[l],
-              strings[i][expectedStart(i) - 1 + l])
-              << "at " << i;
+  auto validateResult =
+      [&strings](
+          const std::shared_ptr<FlatVector<StringView>>& vector,
+          const std::string& funcName) {
+        for (int i = 0; i < vector->size(); ++i) {
+          // Checking the null results
+          if (expectNullString(i) || expectNullStart(i) ||
+              expectNullLength(i)) {
+            EXPECT_TRUE(vector->isNullAt(i))
+                << "expected null at " << i << " for " << funcName;
+          } else {
+            if (expectedStart(i) != 0) {
+              EXPECT_EQ(vector->valueAt(i).size(), expectedLength(i))
+                  << "at " << i << " for " << funcName;
+              for (int l = 0; l < expectedLength(i); l++) {
+                EXPECT_EQ(
+                    vector->valueAt(i).data()[l],
+                    strings[i][expectedStart(i) - 1 + l])
+                    << "at " << i << " for " << funcName;
+              }
+            } else {
+              EXPECT_EQ(vector->valueAt(i).size(), 0)
+                  << "at " << i << " for " << funcName;
+            }
+          }
         }
-      } else {
-        // Special test for start = 0. The Presto semantic expect empty string
-        EXPECT_EQ(result->valueAt(i).size(), 0);
-      }
+      };
+
+  validateResult(result, "substr");
+  validateResult(substringResult, "substring");
+
+  for (int i = 0; i < size; ++i) {
+    if (!expectNullString(i) && !expectNullStart(i) && !expectNullLength(i)) {
+      EXPECT_EQ(
+          result->valueAt(i).getString(),
+          substringResult->valueAt(i).getString())
+          << "at " << i << ": substr and substring results should match";
     }
   }
 }


### PR DESCRIPTION
This is for fixing presto error 
Error in log presto.default.substring, called with arguments: (VARCHAR, BIGINT, BIGINT)