### PR TITLE
fix: Unescape json elements in array_join

### DIFF
--- a/velox/functions/prestosql/json/JsonStringUtil.h
+++ b/velox/functions/prestosql/json/JsonStringUtil.h
@@ -88,6 +88,22 @@ inline bool needNormalizeForJsonParse(const char* input, size_t length) {
   return false;
 }
 
+/// Unescape for JSON functions.
+/// @param input: Input string to unescape.
+/// @param length: Length of the input string.
+/// @param output: Output string to write the unescaped input to.
+/// @param fully: If true, unescape all characters. If false, unescape only
+/// unicode and forward slash. The false case is used for json cast.
+void unescapeForJsonFunctions(
+    const char* input,
+    size_t length,
+    char* output,
+    bool fully);
+
+/// Size of output buffer required when unescaping for json functions.
+size_t
+unescapeSizeForJsonFunctions(const char* input, size_t length, bool fully);
+
 /// Unescape for JSON casting. This is used when going from
 /// JSON  -> ARRAY(JSON) or JSON -> MAP(_, JSON) etc.
 /// In these cases Presto unescapes the string, replacing \\ with \, \n with

--- a/velox/functions/prestosql/tests/ArrayJoinTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayJoinTest.cpp
@@ -193,21 +193,21 @@ TEST_F(ArrayJoinTest, jsonTest) {
 
   // JSON strings with special characters
   input = {
-      R"({"key": "value\with\backslash"})",
+      R"({"key": "value\with\slash"})",
       std::nullopt,
-      R"('value\with\backslash')",
+      R"("value\with\slash")",
   };
   testArrayJoinNoReplacement<StringView>(
       input,
       ", ",
-      R"({"key": "value\with\backslash"}, 'value\with\backslash')",
+      "{\"key\": \"value\\with\\slash\"}, value\\with\\slash"_sv,
       false,
       true);
   testArrayJoinReplacement<StringView>(
       input,
       ", ",
       "0",
-      R"({"key": "value\with\backslash"}, 0, 'value\with\backslash')",
+      "{\"key\": \"value\\with\\slash\"}, 0, value\\with\\slash"_sv,
       false,
       true);
 
@@ -219,14 +219,33 @@ TEST_F(ArrayJoinTest, jsonTest) {
   testArrayJoinNoReplacement<StringView>(
       input,
       ", ",
-      R"({"key": "value\nwith\nnewline"}, value\nwith\nnewline)",
+      "{\"key\": \"value\nwith\nnewline\"}, value\nwith\nnewline"_sv,
       false,
       true);
   testArrayJoinReplacement<StringView>(
       input,
       ", ",
       "0",
-      R"({"key": "value\nwith\nnewline"}, 0, value\nwith\nnewline)",
+      "{\"key\": \"value\nwith\nnewline\"}, 0, value\nwith\nnewline"_sv,
+      false,
+      true);
+
+  input = {
+      R"("tab\t")",
+      R"("backslash\/new line\ntab\tcarriage return\rbackspace\bform feed\fdouble quote\"Unicode code point\u00A9")",
+      std::nullopt,
+  };
+  testArrayJoinNoReplacement<StringView>(
+      input,
+      ", ",
+      "tab\t, backslash/new line\ntab\tcarriage return\rbackspace\bform feed\fdouble quote\"Unicode code point\u00A9"_sv,
+      false,
+      true);
+  testArrayJoinReplacement<StringView>(
+      input,
+      ", ",
+      "0",
+      "tab\t, backslash/new line\ntab\tcarriage return\rbackspace\bform feed\fdouble quote\"Unicode code point\u00A9, 0"_sv,
       false,
       true);
 
@@ -238,14 +257,14 @@ TEST_F(ArrayJoinTest, jsonTest) {
   testArrayJoinNoReplacement<StringView>(
       input,
       ", ",
-      R"({"key": "value with \u00A9 and \u20AC"}, value with \u00A9 and \u20AC)",
+      "{\"key\": \"value with \u00A9 and \u20AC\"}, value with \u00A9 and \u20AC"_sv,
       false,
       true);
   testArrayJoinReplacement<StringView>(
       input,
       ", ",
       "0",
-      R"({"key": "value with \u00A9 and \u20AC"}, 0, value with \u00A9 and \u20AC)",
+      "{\"key\": \"value with \u00A9 and \u20AC\"}, 0, value with \u00A9 and \u20AC"_sv,
       false,
       true);
 


### PR DESCRIPTION
Summary:
Added unescaping for json elements for array_join using the unescape logic from json cast. In Presto, for json cast,  only certain sequences are unescaped, for instance newline and tab show up as \n and \t. Extended this to be able to unescape those remaining sequences for array_join without altering jsoncast behavior.


For array_join, everything is unescaped
```
SELECT
    ARRAY_JOIN(x, ' ')
FROM (
    VALUES
        (
            ARRAY[
                 JSON '"backslash\/"',
                JSON '"new line\n"',
                JSON '"tab\t"',
                JSON '"carriage return\r"',
                JSON '"backspace\b"',
                JSON '"form feed\f"',
                JSON '"Unicode code point\u00A9"',
                JSON '"double quote\""'
            ]
        )
) AS t(x);
```
returns
```
 backslash/ new line
  tab    carriage return^M backspac form feed^L Unicode code point© double quote"
```

(for json cast in Presto, some are *not* unescaped)
```
SELECT
    CAST(c0 AS ARRAY(JSON))
FROM (
    VALUES
        JSON '["backslash\/new line\ntab\tcarriage return\rbackspace\bform feed\fUnicode code point\u00A9double quote\"", "some"]'
) AS t(c0);
```
returns 
```
["backslash/new line\ntab\tcarriage return\rbackspace\bform feed\fUnicode code point©double quote\"", "some"]
```

Differential Revision: D74064707


