### PR TITLE
fix: Supply field name for the row vector created

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -207,6 +207,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
   folly::Executor* executor_;
   dwio::common::ParallelFor parallelForOnKeyNodes_;
   BufferPtr mergedNulls_;
+  std::shared_ptr<const Type> actualType_;
 };
 
 class FlatMapColumnReaderFactory {

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -244,7 +244,7 @@ TEST_F(OrcReaderTest, testOrcReadAllType) {
         "2 elements starting at 0 {foo => 1, bar => 2}");
 
     EXPECT_EQ(structCol->size(), 1);
-    EXPECT_EQ(structCol->type()->toString(), "ROW<\"\":BIGINT,\"\":DOUBLE>");
+    EXPECT_EQ(structCol->type()->toString(), "ROW<x:BIGINT,y:DOUBLE>");
     EXPECT_EQ(structCol->toString(0, 2, ",", false), "{1, 2}");
   }
 }


### PR DESCRIPTION
Summary:
names of the row type are missing in both:
1. actual row type
2. flatmap as row type

The fix addressed both places

Differential Revision: D74055408


