### PR TITLE
misc: Throw user error when unsupported character found during casting to number types

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -344,10 +344,11 @@ void CastExpr::applyCastKernel(
           ToKind == TypeKind::INTEGER || ToKind == TypeKind::BIGINT ||
           ToKind == TypeKind::HUGEINT) {
         if constexpr (TPolicy::throwOnUnicode) {
-          VELOX_USER_CHECK(
-              functions::stringCore::isAscii(
-                  inputRowValue.data(), inputRowValue.size()),
-              "Unicode characters are not supported for conversion to integer types");
+          if (!functions::stringCore::isAscii(
+                  inputRowValue.data(), inputRowValue.size())) {
+            VELOX_USER_FAIL(
+                "Unicode characters are not supported for conversion to integer types");
+          }
         }
       }
     }


### PR DESCRIPTION
Summary: We are not supporting conversion of unicode chars to integer. Throwing unsupported error to notify users and proper classification of erros. VELOX_USER_FAIL has [invalid_error_code](https://github.com/facebookincubator/velox/blob/478c73d8c0ef2f486640e4dcc0688698fcc326f6/velox/common/base/Exceptions.h#L426) which maps to [Presto user error](https://github.com/prestodb/presto/blob/e936ad06e9e205df978ad74287a490f552870047/presto-native-execution/presto_cpp/main/common/Exception.h#L105)

Differential Revision: D74148164


