### PR TITLE
fix: Change pushback global arbitration to be based on promised capacity

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -474,10 +474,13 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   // Invoked to reclaim the used memory capacity to abort the participant with
   // the largest capacity to free up memory. The function returns the actually
-  // reclaimed capacity in bytes. The function returns zero if there is no
-  // eligible participant to abort. If 'force' is true, it picks up the youngest
-  // participant which has largest participant id to abort if there is no
-  // eligible one.
+  // reclaimed capacity in bytes.
+  //
+  // The function returns the total of released and to be released capacity,
+  // including the soon to be released capacity from the victim query. Returns
+  // zero if there is no eligible participant to abort. If 'force' is true,
+  // it picks up the youngest participant which has largest participant id to
+  // abort if there is no eligible one.
   uint64_t reclaimUsedMemoryByAbort(bool force);
 
   // Finds the participant victim to abort to free used memory based on the


### PR DESCRIPTION
Summary: Global arbitration (both shrink capacity API and bg global arbitration) make decisions on sufficient arbitrated capacity by immediately freed capacity. This way it is often the arbitrator over commit targets because the soon to be aborted query capacity is not accounted, resulting in more queries got killed. Change it to take into consideration of the part soon to be freed by query abortion as well.

Differential Revision: D74186831


