### PR TITLE
fix: Do not support hash join mixed grouped execution for certain types

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -142,6 +142,13 @@ OperatorSupplier makeConsumerSupplier(
   if (auto join =
           std::dynamic_pointer_cast<const core::HashJoinNode>(planNode)) {
     return [join](int32_t operatorId, DriverCtx* ctx) {
+      if (ctx->task->hasMixedExecutionGroup() &&
+          needRightSideJoin(join->joinType())) {
+        VELOX_UNSUPPORTED(
+            "Hash join currently does not support mixed grouped execution for join "
+            "type {}",
+            core::joinTypeName(join->joinType()));
+      }
       return std::make_unique<HashBuild>(operatorId, ctx, join);
     };
   }


### PR DESCRIPTION
Summary: We cannot obtain a stable signal for telling if the current probe is the last group's last probe, hence unable to support this mode for the join types that needs last probe (joins needing right side). Currently it is producing extra rows for this type. Blocking it to prevent wrong data been produced.

Differential Revision: D74211165


