### PR TITLE
feat: Support any match function following binary-valued logical

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -342,6 +342,9 @@ class QueryConfig {
   static constexpr const char* kSparkLegacyStatisticalAggregate =
       "spark.legacy_statistical_aggregate";
 
+  static constexpr const char* kSparkLegacyFollowThreeValuedLogicInArrayExists =
+      "spark.follow_three_valued_logic_in_array_exists";
+
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
 
@@ -898,6 +901,10 @@ class QueryConfig {
 
   bool sparkLegacyStatisticalAggregate() const {
     return get<bool>(kSparkLegacyStatisticalAggregate, false);
+  }
+
+  bool sparkLegacyFollowThreeValuedLogicInArrayExists() const {
+    return get<bool>(kSparkLegacyFollowThreeValuedLogicInArrayExists, true);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/functions/prestosql/ArrayAndMapMatch.cpp
+++ b/velox/functions/prestosql/ArrayAndMapMatch.cpp
@@ -25,7 +25,11 @@ namespace facebook::velox::functions {
 namespace {
 
 // @tparam TContainer Either ArrayVector or MapVector.
-template <typename TContainer, bool initialValue, bool earlyReturn, bool followNull = true>
+template <
+    typename TContainer,
+    bool initialValue,
+    bool earlyReturn,
+    bool followNull = true>
 class MatchFunction : public exec::VectorFunction {
  protected:
   virtual std::shared_ptr<TContainer> flattenContainer(
@@ -333,17 +337,19 @@ exec::VectorFunctionFactory anyMatchFactory() {
   // For example, any([1, 2, null], x -> x == 3) is false.
   const auto anyMatch2VL = std::make_shared<AnyMatchFunction<false>>();
 
-  return [anyMatch3VL, anyMatch2VL](const std::string&,
-    const std::vector<exec::VectorFunctionArg>&,
-    const core::QueryConfig& config) -> std::shared_ptr<exec::VectorFunction> {
-      if (config.sparkLegacyFollowThreeValuedLogicInArrayExists()) {
-        return anyMatch3VL;
-      } else {
-        return anyMatch2VL;
-      }
+  return [anyMatch3VL, anyMatch2VL](
+             const std::string&,
+             const std::vector<exec::VectorFunctionArg>&,
+             const core::QueryConfig& config)
+             -> std::shared_ptr<exec::VectorFunction> {
+    if (config.sparkLegacyFollowThreeValuedLogicInArrayExists()) {
+      return anyMatch3VL;
+    } else {
+      return anyMatch2VL;
+    }
   };
 }
-}
+} // namespace
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(
     udf_any_match,

--- a/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
@@ -48,9 +48,9 @@ class ArrayAnyMatchTest : public functions::test::LambdaParameterizedBaseTest {
   }
 
   void toggleFollowThreeValuedLogical(bool v) {
-    queryCtx_->testingOverrideConfigUnsafe({
-      {core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists, v ? "true" : "false"}
-    });
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists,
+          v ? "true" : "false"}});
   }
 };
 
@@ -245,22 +245,28 @@ TEST_P(ArrayAnyMatchTest, followThreeValuedLogic) {
   };
 
   toggleFollowThreeValuedLogical(false);
-  testAnyMatchExpr({
-      true,
-      true,
-      false,
-      false,
-      false,
-  }, "x > 1", ints);
+  testAnyMatchExpr(
+      {
+          true,
+          true,
+          false,
+          false,
+          false,
+      },
+      "x > 1",
+      ints);
 
   toggleFollowThreeValuedLogical(true);
-  testAnyMatchExpr({
-      true,
-      true,
-      std::nullopt,
-      false,
-      std::nullopt,
-  }, "x > 1", ints);
+  testAnyMatchExpr(
+      {
+          true,
+          true,
+          std::nullopt,
+          false,
+          std::nullopt,
+      },
+      "x > 1",
+      ints);
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayAnyMatchTest.cpp
@@ -48,7 +48,7 @@ class ArrayAnyMatchTest : public functions::test::LambdaParameterizedBaseTest {
   }
 
   void toggleFollowThreeValuedLogical(bool v) {
-    queryCtx_->testingOverrideConfigUnsafe(
+    queryCtxParametrized_->testingOverrideConfigUnsafe(
         {{core::QueryConfig::kSparkLegacyFollowThreeValuedLogicInArrayExists,
           v ? "true" : "false"}});
   }

--- a/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
@@ -41,7 +41,7 @@ class LambdaParameterizedBaseTest
     return evaluate(*exprSet, data);
   }
 
- private:
+ protected:
   std::shared_ptr<core::QueryCtx> queryCtxParametrized_{core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig(


### PR DESCRIPTION
In spark, the behavior of `array_exists` (`any_match` in velox) can be changed by `spark.sql.legacy.followThreeValuedLogicInArrayExists`. For three-valued boolean logic, if the predicate returns any nulls and no true is obtained, then exists returns null instead of false. For example, exists(array(1, null, 3), x -> x % 2 == 0) is null. For binary-valued boolean logic, the result is false instead of null. This PR add a config `kSparkLegacyFollowThreeValuedLogicInArrayExists` to support this behavior.