### PR TITLE
feat: Add Spark base64 function

### DIFF
--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -655,34 +655,34 @@ Expected<size_t> Base64::calculateMimeDecodedSize(
 
 // static
 void Base64::encodeMime(const char* input, size_t inputSize, char* output) {
-  // If there's nothing to encode, do nothing
+  // If there's nothing to encode, do nothing.
   if (inputSize == 0) {
     return;
   }
 
-  const char* readPtr = input; // pointer to read from
-  const char* endPtr = input + inputSize; // end of input
-  char* writePtr = output; // pointer to write to
-  const size_t bytesPerLine =
-      (kMaxLineLength / 4) * 3; // bytes per 76-char line
-  size_t remaining = inputSize; // how many bytes left
+  const char* readPtr = input;
+  const char* endPtr = input + inputSize;
+  char* writePtr = output;
+  // Bytes per 76-char line.
+  const size_t bytesPerLine = (kMaxLineLength / 4) * 3;
+  size_t remaining = inputSize;
 
-  // Process full lines of up to 'bytesPerLine' bytes
+  // Process full lines of up to 'bytesPerLine' bytes.
   while (remaining >= 3) {
-    // Round down to a multiple of 3, but not more than one line
+    // Round down to a multiple of 3, but not more than one line.
     size_t chunk = std::min(bytesPerLine, (remaining / 3) * 3);
     const char* chunkEnd = readPtr + chunk;
 
-    // Encode each group of 3 bytes into 4 Base64 characters
+    // Encode each group of 3 bytes into 4 Base64 characters.
     while (readPtr + 2 < chunkEnd) {
-      // Read three bytes separately to avoid undefined behavior
+      // Read three bytes separately to avoid undefined behavior.
       uint8_t b0 = static_cast<uint8_t>(*readPtr++);
       uint8_t b1 = static_cast<uint8_t>(*readPtr++);
       uint8_t b2 = static_cast<uint8_t>(*readPtr++);
-      // Pack into a 24-bit value
+      // Pack into a 24-bit value.
       uint32_t trio = (static_cast<uint32_t>(b0) << 16) |
           (static_cast<uint32_t>(b1) << 8) | static_cast<uint32_t>(b2);
-      // Emit four Base64 characters
+      // Emit four Base64 characters.
       *writePtr++ = kBase64Charset[(trio >> 18) & 0x3F];
       *writePtr++ = kBase64Charset[(trio >> 12) & 0x3F];
       *writePtr++ = kBase64Charset[(trio >> 6) & 0x3F];
@@ -691,26 +691,26 @@ void Base64::encodeMime(const char* input, size_t inputSize, char* output) {
 
     remaining -= chunk;
 
-    // Insert CRLF if we filled exactly one line and still have more data
+    // Insert CRLF if we filled exactly one line and still have more data.
     if (chunk == bytesPerLine && remaining > 0) {
       *writePtr++ = kNewline[0];
       *writePtr++ = kNewline[1];
     }
   }
 
-  // Handle the final 1 or 2 leftover bytes with padding
+  // Handle the final 1 or 2 leftover bytes with padding.
   if (remaining > 0) {
     uint8_t b0 = static_cast<uint8_t>(*readPtr++);
-    // First Base64 character from the high 6 bits
+    // First Base64 character from the high 6 bits.
     *writePtr++ = kBase64Charset[b0 >> 2];
 
     if (remaining == 1) {
-      // Only one byte remains: produce two chars + two '=' paddings
+      // Only one byte remains: produce two chars + two '=' paddings.
       *writePtr++ = kBase64Charset[(b0 & 0x03) << 4];
       *writePtr++ = kPadding;
       *writePtr = kPadding;
     } else {
-      // Two bytes remain: produce three chars + one '=' padding
+      // Two bytes remain: produce three chars + one '=' padding.
       uint8_t b1 = static_cast<uint8_t>(*readPtr);
       *writePtr++ = kBase64Charset[((b0 & 0x03) << 4) | (b1 >> 4)];
       *writePtr++ = kBase64Charset[(b1 & 0x0F) << 2];

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -653,4 +653,82 @@ Expected<size_t> Base64::calculateMimeDecodedSize(
   return decodedSize;
 }
 
+// static
+void Base64::encodeMime(const char* input, size_t inputSize, char* output) {
+  // If there's nothing to encode, do nothing
+  if (inputSize == 0) {
+    return;
+  }
+
+  const char* readPtr = input; // pointer to read from
+  const char* endPtr = input + inputSize; // end of input
+  char* writePtr = output; // pointer to write to
+  const size_t bytesPerLine =
+      (kMaxLineLength / 4) * 3; // bytes per 76-char line
+  size_t remaining = inputSize; // how many bytes left
+
+  // Process full lines of up to 'bytesPerLine' bytes
+  while (remaining >= 3) {
+    // Round down to a multiple of 3, but not more than one line
+    size_t chunk = std::min(bytesPerLine, (remaining / 3) * 3);
+    const char* chunkEnd = readPtr + chunk;
+
+    // Encode each group of 3 bytes into 4 Base64 characters
+    while (readPtr + 2 < chunkEnd) {
+      // Read three bytes separately to avoid undefined behavior
+      uint8_t b0 = static_cast<uint8_t>(*readPtr++);
+      uint8_t b1 = static_cast<uint8_t>(*readPtr++);
+      uint8_t b2 = static_cast<uint8_t>(*readPtr++);
+      // Pack into a 24-bit value
+      uint32_t trio = (static_cast<uint32_t>(b0) << 16) |
+          (static_cast<uint32_t>(b1) << 8) | static_cast<uint32_t>(b2);
+      // Emit four Base64 characters
+      *writePtr++ = kBase64Charset[(trio >> 18) & 0x3F];
+      *writePtr++ = kBase64Charset[(trio >> 12) & 0x3F];
+      *writePtr++ = kBase64Charset[(trio >> 6) & 0x3F];
+      *writePtr++ = kBase64Charset[trio & 0x3F];
+    }
+
+    remaining -= chunk;
+
+    // Insert CRLF if we filled exactly one line and still have more data
+    if (chunk == bytesPerLine && remaining > 0) {
+      *writePtr++ = kNewline[0];
+      *writePtr++ = kNewline[1];
+    }
+  }
+
+  // Handle the final 1 or 2 leftover bytes with padding
+  if (remaining > 0) {
+    uint8_t b0 = static_cast<uint8_t>(*readPtr++);
+    // First Base64 character from the high 6 bits
+    *writePtr++ = kBase64Charset[b0 >> 2];
+
+    if (remaining == 1) {
+      // Only one byte remains: produce two chars + two '=' paddings
+      *writePtr++ = kBase64Charset[(b0 & 0x03) << 4];
+      *writePtr++ = kPadding;
+      *writePtr = kPadding;
+    } else {
+      // Two bytes remain: produce three chars + one '=' padding
+      uint8_t b1 = static_cast<uint8_t>(*readPtr);
+      *writePtr++ = kBase64Charset[((b0 & 0x03) << 4) | (b1 >> 4)];
+      *writePtr++ = kBase64Charset[(b1 & 0x0F) << 2];
+      *writePtr = kPadding;
+    }
+  }
+}
+
+// static
+size_t Base64::calculateMimeEncodedSize(size_t inputSize) {
+  if (inputSize == 0) {
+    return 0;
+  }
+
+  size_t encodedSize = calculateEncodedSize(inputSize, true);
+  // Add CRLFs: one per full kMaxLineLength block.
+  encodedSize += (encodedSize - 1) / kMaxLineLength * kNewline.size();
+  return encodedSize;
+}
+
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -115,6 +115,11 @@ class Base64 {
   static Status
   decodeMime(const char* input, size_t inputSize, char* outputBuffer);
 
+  /// Encodes the input buffer into Base64 MIME format.
+  /// Inserts a CRLF every kMaxLineLength output characters.
+  static void
+  encodeMime(const char* input, size_t inputSize, char* outputBuffer);
+
   /// Calculates the encoded size based on input 'inputSize'.
   static size_t calculateEncodedSize(size_t inputSize, bool withPadding = true);
 
@@ -130,9 +135,18 @@ class Base64 {
       const char* input,
       const size_t inputSize);
 
+  /// Computes the exact output length for MIME‐mode Base64 encoding,
+  /// including required CRLF line breaks.
+  static size_t calculateMimeEncodedSize(size_t inputSize);
+
  private:
   // Padding character used in encoding.
   static const char kPadding = '=';
+
+  // Soft Line breaks used in mime encoding as defined in RFC 2045, section 6.8:
+  // https://www.rfc-editor.org/rfc/rfc2045#section-6.8
+  inline static const std::string kNewline{"\r\n"};
+  static const size_t kMaxLineLength = 76;
 
   // Checks if the input Base64 string is padded.
   static inline bool isPadded(const char* input, size_t inputSize) {

--- a/velox/common/encode/tests/Base64Test.cpp
+++ b/velox/common/encode/tests/Base64Test.cpp
@@ -150,4 +150,32 @@ TEST_F(Base64Test, decodeMime) {
   VELOX_ASSERT_USER_THROW(
       decodeMime("AQ==y"), "Input byte array has incorrect ending");
 }
+
+TEST_F(Base64Test, calculateMimeEncodedSize) {
+  EXPECT_EQ(0, Base64::calculateMimeEncodedSize(0));
+  EXPECT_EQ(8, Base64::calculateMimeEncodedSize(4));
+  EXPECT_EQ(76, Base64::calculateMimeEncodedSize(57));
+  EXPECT_EQ(82, Base64::calculateMimeEncodedSize(58));
+  EXPECT_EQ(274, Base64::calculateMimeEncodedSize(200));
+}
+
+TEST_F(Base64Test, encodeMime) {
+  auto encodeMime = [](const std::string& in) {
+    size_t len = Base64::calculateMimeEncodedSize(in.size());
+    std::string out(len, '\0');
+    Base64::encodeMime(in.data(), in.size(), out.data());
+    return out;
+  };
+  EXPECT_EQ("", encodeMime(""));
+  EXPECT_EQ("TWFu", encodeMime("Man"));
+  EXPECT_EQ("AQ==", encodeMime("\x01"));
+  EXPECT_EQ("/+4=", encodeMime("\xff\xee"));
+  EXPECT_EQ(
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB",
+      encodeMime(std::string(57, 'A')));
+  EXPECT_EQ(
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB\r\nQQ==",
+      encodeMime(std::string(58, 'A')));
+}
+
 } // namespace facebook::velox::encoding

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -13,6 +13,11 @@ String Functions
 
     Returns unicode code point of the first character of ``string``. Returns 0 if ``string`` is empty.
 
+.. spark:function:: base64(expr) -> varchar
+    Converts ``expr`` to a base 64 string using RFC2045 Base64 transfer encoding for MIME. ::
+        
+        SELECT base64('Spark SQL'); -- 'U3BhcmsgU1FM'
+
 .. spark:function:: bit_length(string/binary) -> integer
 
     Returns the bit length for the specified string column. ::

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -15,7 +15,7 @@ String Functions
 
 .. spark:function:: base64(expr) -> varchar
     Converts ``expr`` to a base 64 string using RFC2045 Base64 transfer encoding for MIME. ::
-        
+
         SELECT base64('Spark SQL'); -- 'U3BhcmsgU1FM'
 
 .. spark:function:: bit_length(string/binary) -> integer

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -14,6 +14,7 @@ String Functions
     Returns unicode code point of the first character of ``string``. Returns 0 if ``string`` is empty.
 
 .. spark:function:: base64(expr) -> varchar
+
     Converts ``expr`` to a base 64 string using RFC2045 Base64 transfer encoding for MIME. ::
 
         SELECT base64('Spark SQL'); -- 'U3BhcmsgU1FM'

--- a/velox/functions/sparksql/Base64Function.h
+++ b/velox/functions/sparksql/Base64Function.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/encode/Base64.h"
+#include "velox/functions/Macros.h"
+namespace facebook::velox::functions::sparksql {
+
+// Encodes the input binary data into a Base64-encoded string using MIME
+// encoding.
+template <typename T>
+struct Base64Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varbinary>& input) {
+    result.resize(encoding::Base64::calculateMimeEncodedSize(input.size()));
+    encoding::Base64::encodeMime(input.data(), input.size(), result.data());
+  }
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Base64Function.h
+++ b/velox/functions/sparksql/Base64Function.h
@@ -17,10 +17,11 @@
 
 #include "velox/common/encode/Base64.h"
 #include "velox/functions/Macros.h"
+
 namespace facebook::velox::functions::sparksql {
 
-// Encodes the input binary data into a Base64-encoded string using MIME
-// encoding.
+/// Encodes the input binary data into a Base64-encoded string using MIME
+/// encoding.
 template <typename T>
 struct Base64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/UnBase64Function.h
+++ b/velox/functions/sparksql/UnBase64Function.h
@@ -20,10 +20,10 @@
 
 namespace facebook::velox::functions::sparksql {
 
-// UnBase64Function decodes a base64-encoded input string into its original
-// binary form. It uses the Base64 MIME decoding functions provided by
-// velox::encoding. Returns a Status indicating success or error during
-// decoding.
+/// UnBase64Function decodes a base64-encoded input string into its original
+/// binary form. It uses the Base64 MIME decoding functions provided by
+/// velox::encoding. Returns a Status indicating success or error during
+/// decoding.
 template <typename T>
 struct UnBase64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/lib/UpperLower.h"
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/prestosql/URLFunctions.h"
+#include "velox/functions/sparksql/Base64Function.h"
 #include "velox/functions/sparksql/ConcatWs.h"
 #include "velox/functions/sparksql/LuhnCheckFunction.h"
 #include "velox/functions/sparksql/MaskFunction.h"
@@ -169,6 +170,7 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       int32_t>({prefix + "varchar_type_write_side_check"});
 
+  registerFunction<Base64Function, Varchar, Varbinary>({prefix + "base64"});
   registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});
 }
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/Base64Test.cpp
+++ b/velox/functions/sparksql/tests/Base64Test.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class Base64Test : public SparkFunctionBaseTest {
+ protected:
+  std::optional<std::string> base64(const std::optional<std::string>& a) {
+    return evaluateOnce<std::string>("base64(c0)", VARBINARY(), a);
+  }
+};
+
+TEST_F(Base64Test, basic) {
+  EXPECT_EQ(base64(std::nullopt), std::nullopt);
+  EXPECT_EQ(base64("Man"), "TWFu");
+  EXPECT_EQ(base64("\x01"), "AQ==");
+  EXPECT_EQ(base64("\xff\xee"), "/+4=");
+  EXPECT_EQ(base64("hello world"), "aGVsbG8gd29ybGQ=");
+  EXPECT_EQ(base64("Spark SQL"), "U3BhcmsgU1FM");
+  EXPECT_EQ(
+      base64(std::string(57, 'A')),
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB");
+  EXPECT_EQ(
+      base64(std::string(58, 'A')),
+      "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFB\r\nQQ==");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   ArrayUnionTest.cpp
   ArgTypesGeneratorTest.cpp
   AtLeastNNonNullsTest.cpp
+  Base64Test.cpp
   BitwiseTest.cpp
   ComparisonsTest.cpp
   ConcatWsTest.cpp


### PR DESCRIPTION
Spark’s base64 function follows the RFC 2045 (MIME) specification, whereas 
Presto’s to_base64 function follows the RFC 4648 (Basic) specification.
Spark: https://github.com/apache/spark/blob/6f9bf73c345d70c3d27ea2e1ebadaa03a275fb3c/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L2917
Presto: https://github.com/prestodb/presto/blob/26e1b66f9baf6e81a5c2335faa114ef484fd89a9/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java#L122

They differ in the following ways, so we need to re-implement Spark’s base64 
semantics.

Difference:
Line breaks: RFC 2045 inserts CRLF every 76 chars when encoding; RFC 4648 never 
breaks the output.