### PR TITLE
fix(s3): Add retry logic for retryable errors

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -76,6 +76,7 @@ class S3Config {
     kRetryMode,
     kUseProxyFromEnv,
     kCredentialsProvider,
+    kMaxClientRetries,
     kEnd
   };
 
@@ -114,6 +115,8 @@ class S3Config {
              std::make_pair("use-proxy-from-env", "false")},
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
+            {Keys::kMaxClientRetries,
+             std::make_pair("max-client-retries", std::nullopt)},
         };
     return config;
   }
@@ -224,6 +227,15 @@ class S3Config {
   /// Retry mode for a single http client.
   std::optional<std::string> retryMode() const {
     return config_.find(Keys::kRetryMode)->second;
+  }
+
+  /// Maximum retry attempts for a single http client.
+  std::optional<uint32_t> maxClientRetries() const {
+    auto val = config_.find(Keys::kMaxClientRetries)->second;
+    if (val.has_value()) {
+      return folly::to<uint32_t>(val.value());
+    }
+    return std::optional<uint32_t>();
   }
 
   bool useProxyFromEnv() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -48,6 +48,20 @@
 #include <aws/s3/model/HeadObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 
+namespace {
+bool shouldRetryRequest(
+    Aws::Client::AWSError<Aws::S3::S3Errors>& error,
+    uint32_t retries,
+    uint32_t maxErrorRetries) {
+  if (retries < maxErrorRetries &&
+      (error.ShouldRetry() ||
+       error.GetErrorType() == Aws::S3::S3Errors::UNKNOWN)) {
+    return true;
+  }
+  return false;
+}
+} // namespace
+
 namespace facebook::velox::filesystems {
 namespace {
 // Reference: https://issues.apache.org/jira/browse/ARROW-8692
@@ -98,8 +112,11 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> getCredentialsProviderByName(
 
 class S3ReadFile final : public ReadFile {
  public:
-  S3ReadFile(std::string_view path, Aws::S3::S3Client* client)
-      : client_(client) {
+  S3ReadFile(
+      std::string_view path,
+      Aws::S3::S3Client* client,
+      uint32_t maxClientRetries)
+      : client_(client), maxClientRetries_(maxClientRetries) {
     getBucketAndKeyFromPath(path, bucket_, key_);
   }
 
@@ -216,11 +233,22 @@ class S3ReadFile final : public ReadFile {
         AwsWriteableStreamFactory(position, length));
     RECORD_METRIC_VALUE(kMetricS3ActiveConnections);
     RECORD_METRIC_VALUE(kMetricS3GetObjectCalls);
-    auto outcome = client_->GetObject(request);
-    if (!outcome.IsSuccess()) {
+
+    Aws::S3::Model::GetObjectOutcome outcome;
+    uint32_t retries = 0;
+    Aws::Client::AWSError<Aws::S3::S3Errors> getObjectError;
+    do {
+      outcome = client_->GetObject(request);
+      if (outcome.IsSuccess()) {
+        break;
+      }
+      getObjectError = outcome.GetError();
+      auto s3ClientRetryCount = outcome.GetRetryCount();
       RECORD_METRIC_VALUE(kMetricS3GetObjectErrors);
-    }
-    RECORD_METRIC_VALUE(kMetricS3GetObjectRetries, outcome.GetRetryCount());
+      retries += s3ClientRetryCount > 0 ? s3ClientRetryCount : 1;
+    } while (shouldRetryRequest(getObjectError, retries, maxClientRetries_));
+
+    RECORD_METRIC_VALUE(kMetricS3GetObjectRetries, retries);
     RECORD_METRIC_VALUE(kMetricS3ActiveConnections, -1);
     VELOX_CHECK_AWS_OUTCOME(outcome, "Failed to get S3 object", bucket_, key_);
   }
@@ -229,6 +257,7 @@ class S3ReadFile final : public ReadFile {
   std::string bucket_;
   std::string key_;
   int64_t length_ = -1;
+  uint32_t maxClientRetries_;
 };
 
 Aws::Utils::Logging::LogLevel inferS3LogLevel(std::string_view logLevel) {
@@ -690,6 +719,10 @@ class S3FileSystem::Impl {
 
     auto credentialsProvider = getCredentialsProvider(s3Config);
 
+    if (s3Config.maxClientRetries().has_value()) {
+      maxClientRetries_ = s3Config.maxClientRetries().value();
+    }
+
     client_ = std::make_shared<Aws::S3::S3Client>(
         credentialsProvider, nullptr /* endpointProvider */, clientConfig);
     ++fileSystemCount;
@@ -837,8 +870,13 @@ class S3FileSystem::Impl {
     return getAwsInstance()->getLogPrefix();
   }
 
+  uint32_t getMaxClientRetries() const {
+    return maxClientRetries_;
+  }
+
  private:
   std::shared_ptr<Aws::S3::S3Client> client_;
+  uint32_t maxClientRetries_;
 };
 
 S3FileSystem::S3FileSystem(
@@ -861,7 +899,8 @@ std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(
     std::string_view s3Path,
     const FileOptions& options) {
   const auto path = getPath(s3Path);
-  auto s3file = std::make_unique<S3ReadFile>(path, impl_->s3Client());
+  auto s3file = std::make_unique<S3ReadFile>(
+      path, impl_->s3Client(), impl_->getMaxClientRetries());
   s3file->initialize(options);
   return s3file;
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemMetricsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemMetricsTest.cpp
@@ -118,6 +118,7 @@ class S3FileSystemMetricsTest : public S3Test {
  protected:
   static void SetUpTestSuite() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    registerS3Metrics();
   }
 
   void SetUp() override {
@@ -132,23 +133,22 @@ class S3FileSystemMetricsTest : public S3Test {
     filesystems::finalizeS3();
   }
   std::shared_ptr<S3TestReporter> s3Reporter;
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::memoryManager()->addLeafPool("S3FileSystemMetricsTest");
 };
 
 } // namespace
 
 TEST_F(S3FileSystemMetricsTest, metrics) {
-  registerS3Metrics();
-
   const auto bucketName = "metrics";
   const auto file = "test.txt";
   const auto filename = localPath(bucketName) + "/" + file;
   const auto s3File = s3URI(bucketName, file);
   auto hiveConfig = minioServer_->hiveConfig();
   S3FileSystem s3fs(bucketName, hiveConfig);
-  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemMetricsTest");
 
   auto writeFile =
-      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+      s3fs.openFileForWrite(s3File, {{}, pool_.get(), std::nullopt});
   EXPECT_EQ(1, s3Reporter->counterMap[std::string{kMetricS3MetadataCalls}]);
   EXPECT_EQ(1, s3Reporter->counterMap[std::string{kMetricS3GetMetadataErrors}]);
 
@@ -168,6 +168,34 @@ TEST_F(S3FileSystemMetricsTest, metrics) {
   EXPECT_EQ(1, s3Reporter->counterMap[std::string{kMetricS3GetObjectCalls}]);
 }
 
+// This test takes two to three minutes to run.
+TEST_F(S3FileSystemMetricsTest, retryMetricTest) {
+  const auto bucketName = "metrics";
+  const auto file = "test.txt";
+  const auto filename = localPath(bucketName) + "/" + file;
+  const auto s3File = s3URI(bucketName, file);
+  auto hiveConfig =
+      minioServer_->hiveConfig({{"hive.s3.max-client-retries", "2"}});
+  S3FileSystem s3fs(bucketName, hiveConfig);
+
+  auto writeFile =
+      s3fs.openFileForWrite(s3File, {{}, pool_.get(), std::nullopt});
+  constexpr std::string_view kDataContent =
+      "Dance me to your beauty with a burning violin"
+      "Dance me through the panic till I'm gathered safely in"
+      "Lift me like an olive branch and be my homeward dove"
+      "Dance me to the end of love";
+  writeFile->append(kDataContent);
+  writeFile->close();
+  EXPECT_EQ(1, s3Reporter->counterMap[std::string{kMetricS3SuccessfulUploads}]);
+
+  auto readFile = s3fs.openFileForRead(s3File);
+  minioServer_->stop();
+  VELOX_ASSERT_THROW(
+      readFile->pread(0, kDataContent.length()),
+      "Failed to get S3 object due to: 'Network connection'. Path:'s3://metrics/test.txt', SDK Error Type:99, HTTP Status Code:-1, S3 Service:'Unknown', Message:'curlCode: 7, Couldn't connect to server', RequestID:''");
+  EXPECT_EQ(s3Reporter->counterMap[std::string{kMetricS3GetObjectRetries}], 2);
+}
 } // namespace facebook::velox::filesystems
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/13061
This PR adds
1) Retry logic for client errors where the SDK returns the error with RETRYABLE set to true and any custom errors that we want to be retried.
2) Default values for `retry-mode` and `max-attempts` that will be used by the aws-sdk to retry in case of some failures.