### PR TITLE
fix: Optimize selective ARRAY and MAP reader

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -93,7 +93,16 @@ void SelectiveRepeatedColumnReader::makeNestedRowSet(
   // Reads the lengths, leaves an uninitialized gap for a null
   // map/list. Reading these checks the null mask.
   readLengths(allLengths_, maxRow + 1, nulls);
-  vector_size_t nestedLength{0};
+
+  vector_size_t nestedLength;
+  if (nestedRowsAllSelected_) {
+    nestedLength = sumLengths(allLengths_, nulls, 0, maxRow + 1);
+    childTargetReadOffset_ += nestedLength;
+    nestedRows_ = RowSet(iota(nestedLength, nestedRowsHolder_), nestedLength);
+    return;
+  }
+
+  nestedLength = 0;
   for (auto row : rows) {
     if (!nulls || !bits::isBitNull(nulls, row)) {
       nestedLength += prunedLengthAt(row);
@@ -133,8 +142,23 @@ void SelectiveRepeatedColumnReader::makeOffsetsAndSizes(
       result.mutableOffsets(rows.size())->asMutable<vector_size_t>();
   auto* rawSizes = result.mutableSizes(rows.size())->asMutable<vector_size_t>();
   auto* nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
-  vector_size_t currentRow = 0;
+  numValues_ = rows.size();
   vector_size_t currentOffset = 0;
+  if (nestedRowsAllSelected_ && rows.size() == outputRows().size()) {
+    for (int i = 0; i < rows.size(); ++i) {
+      VELOX_DCHECK_EQ(i, rows[i]);
+      rawOffsets[i] = currentOffset;
+      if (nulls && bits::isBitNull(nulls, i)) {
+        rawSizes[i] = 0;
+        anyNulls_ = true;
+      } else {
+        rawSizes[i] = allLengths_[i];
+        currentOffset += allLengths_[i];
+      }
+    }
+    return;
+  }
+  vector_size_t currentRow = 0;
   vector_size_t nestedRowIndex = 0;
   for (int i = 0; i < rows.size(); ++i) {
     const auto row = rows[i];
@@ -154,7 +178,6 @@ void SelectiveRepeatedColumnReader::makeOffsetsAndSizes(
       nestedRowIndex = newNestedRowIndex;
     }
   }
-  numValues_ = rows.size();
 }
 
 RowSet SelectiveRepeatedColumnReader::applyFilter(const RowSet& rows) {
@@ -216,6 +239,9 @@ void SelectiveListColumnReader::read(
   child_->seekTo(childTargetReadOffset_, false);
   prepareRead<char>(offset, rows, incomingNulls);
   auto activeRows = applyFilter(rows);
+  nestedRowsAllSelected_ = activeRows.size() == rows.back() + 1 &&
+      scanSpec_->maxArrayElementsCount() ==
+          std::numeric_limits<vector_size_t>::max();
   makeNestedRowSet(activeRows, rows.back());
   if (child_ && !nestedRows_.empty()) {
     child_->read(child_->readOffset(), nestedRows_, nullptr);
@@ -291,9 +317,15 @@ void SelectiveMapColumnReader::read(
 
   prepareRead<char>(offset, rows, incomingNulls);
   const auto activeRows = applyFilter(rows);
+  nestedRowsAllSelected_ = activeRows.size() == rows.back() + 1;
+  VELOX_DCHECK_EQ(
+      scanSpec_->maxArrayElementsCount(),
+      std::numeric_limits<vector_size_t>::max());
   makeNestedRowSet(activeRows, rows.back());
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
     keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
+    nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
+        nestedRows_.size() == keyReader_->outputRows().size();
     nestedRows_ = keyReader_->outputRows();
     if (!nestedRows_.empty()) {
       elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -91,6 +91,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   vector_size_t* allLengths_;
   RowSet nestedRows_;
   raw_vector<vector_size_t> nestedRowsHolder_;
+  bool nestedRowsAllSelected_;
 
   // The position in the child readers that corresponds to the position in the
   // length stream. The child readers can be behind if the last parents were


### PR DESCRIPTION
Summary:
When all rows are selected and there is no array pruning, all the
nested rows are selected as well.  We can use the global dense row set memory
instead of allocating and initializing memory for each column reader separately.

Also avoid reallocating lengths buffer for ARRAY and MAP in Nimble reader.

This gives us more than 15% CPU improvement and visible memory usage reduction.

Differential Revision: D74207747


