### PR TITLE
feat: Add barrier support for index lookup join

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1596,6 +1596,12 @@ bool IndexLookupJoinNode::isSupported(core::JoinType joinType) {
   }
 }
 
+bool isIndexLookupJoin(const core::PlanNode* planNode) {
+  const auto* indexLookupJoin =
+      dynamic_cast<const core::IndexLookupJoinNode*>(planNode);
+  return indexLookupJoin != nullptr;
+}
+
 // static
 const JoinType NestedLoopJoinNode::kDefaultJoinType = JoinType::kInner;
 // static
@@ -2989,8 +2995,10 @@ void collectLeafPlanNodeIds(
     return;
   }
 
-  for (const auto& child : planNode.sources()) {
-    collectLeafPlanNodeIds(*child, leafIds);
+  const auto& sources = planNode.sources();
+  const auto numSources = isIndexLookupJoin(&planNode) ? 1 : sources.size();
+  for (int i = 0; i < numSources; ++i) {
+    collectLeafPlanNodeIds(*sources[i], leafIds);
   }
 }
 } // namespace

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3328,6 +3328,10 @@ class IndexLookupJoinNode : public AbstractJoinNode {
     std::optional<std::vector<IndexLookupConditionPtr>> joinConditions_;
   };
 
+  bool supportsBarrier() const override {
+    return true;
+  }
+
   const TableScanNodePtr& lookupSource() const {
     return lookupSourceNode_;
   }
@@ -3357,6 +3361,9 @@ class IndexLookupJoinNode : public AbstractJoinNode {
 
   const std::vector<IndexLookupConditionPtr> joinConditions_;
 };
+
+/// Returns true if 'planNode' is index lookup join node.
+bool isIndexLookupJoin(const core::PlanNode* planNode);
 
 /// Represents inner/outer nested loop joins. Translates to an
 /// exec::NestedLoopJoinProbe and exec::NestedLoopJoinBuild. A separate

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -17,11 +17,32 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/PlanNode.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace ::facebook::velox;
 using namespace ::facebook::velox::core;
 
-TEST(TestPlanNode, findFirstNode) {
+namespace {
+class PlanNodeTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  PlanNodeTest() {
+    rowType_ = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()});
+
+    VectorFuzzer::Options opts;
+    VectorFuzzer fuzzer(opts, pool_.get());
+    rowData_.push_back(fuzzer.fuzzInputRow(rowType_));
+  }
+
+  RowTypePtr rowType_;
+  std::vector<RowVectorPtr> rowData_;
+};
+
+TEST_F(PlanNodeTest, findFirstNode) {
   auto rowType = ROW({"name1"}, {BIGINT()});
 
   std::shared_ptr<connector::ConnectorTableHandle> tableHandle;
@@ -65,7 +86,7 @@ TEST(TestPlanNode, findFirstNode) {
       }));
 }
 
-TEST(TestPlanNode, sortOrder) {
+TEST_F(PlanNodeTest, sortOrder) {
   struct {
     SortOrder order1;
     SortOrder order2;
@@ -99,7 +120,7 @@ TEST(TestPlanNode, sortOrder) {
   }
 }
 
-TEST(TestPlanNode, duplicateSortKeys) {
+TEST_F(PlanNodeTest, duplicateSortKeys) {
   auto sortingKeys = std::vector<FieldAccessTypedExprPtr>{
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1"),
@@ -112,3 +133,75 @@ TEST(TestPlanNode, duplicateSortKeys) {
           "orderBy", sortingKeys, sortingOrders, false, nullptr),
       "Duplicate sorting keys are not allowed: c0");
 }
+class TestIndexTableHandle : public connector::ConnectorTableHandle {
+ public:
+  TestIndexTableHandle()
+      : connector::ConnectorTableHandle("TestIndexConnnector") {}
+
+  ~TestIndexTableHandle() override = default;
+
+  std::string toString() const override {
+    return "TestIndexTableHandle";
+  }
+
+  const std::string& name() const override {
+    static const std::string kName = "TestIndexTableHandle";
+    return kName;
+  }
+
+  bool supportsIndexLookup() const override {
+    return true;
+  }
+
+  folly::dynamic serialize() const override {
+    return {};
+  }
+
+  static std::shared_ptr<TestIndexTableHandle> create(
+      const folly::dynamic& obj,
+      void* context) {
+    return std::make_shared<TestIndexTableHandle>();
+  }
+};
+
+TEST_F(PlanNodeTest, isIndexLookupJoin) {
+  const auto rowType = ROW({"name"}, {BIGINT()});
+  const auto valueNode = std::make_shared<ValuesNode>("orderBy", rowData_);
+  ASSERT_FALSE(isIndexLookupJoin(valueNode.get()));
+
+  const RowTypePtr probeType = ROW({"c0"}, {BIGINT()});
+  const RowTypePtr buildType = ROW({"c1"}, {BIGINT()});
+  const RowTypePtr outputType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
+  auto indexTableHandle = std::make_shared<TestIndexTableHandle>();
+  const auto probeNode = std::make_shared<TableScanNode>(
+      "tableScan-probe",
+      probeType,
+      nullptr,
+      std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>{});
+  ASSERT_FALSE(isIndexLookupJoin(probeNode.get()));
+  const auto buildNode = std::make_shared<TableScanNode>(
+      "tableScan-build",
+      buildType,
+      indexTableHandle,
+      std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>{});
+  ASSERT_FALSE(isIndexLookupJoin(buildNode.get()));
+  const std::vector<FieldAccessTypedExprPtr> leftKeys{
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+  const std::vector<FieldAccessTypedExprPtr> rightKeys{
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c1")};
+  const auto indexJoinNode = std::make_shared<IndexLookupJoinNode>(
+      "indexJoinNode",
+      core::JoinType::kInner,
+      leftKeys,
+      rightKeys,
+      std::vector<IndexLookupConditionPtr>{},
+      probeNode,
+      buildNode,
+      outputType);
+  ASSERT_TRUE(isIndexLookupJoin(indexJoinNode.get()));
+}
+} // namespace

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -29,6 +29,8 @@ class IndexLookupJoin : public Operator {
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
+  bool startDrain() override;
+
   bool needsInput() const override;
 
   void addInput(RowVectorPtr input) override;

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -72,12 +72,6 @@ bool mustStartNewPipeline(
   return sourceId != 0;
 }
 
-bool isIndexLookupJoin(core::PlanNodePtr planNode) {
-  const auto indexLookupJoin =
-      std::dynamic_pointer_cast<const core::IndexLookupJoinNode>(planNode);
-  return indexLookupJoin != nullptr;
-}
-
 // Creates the customized local partition operator for table writer scaling.
 std::unique_ptr<Operator> createScaleWriterLocalPartition(
     const std::shared_ptr<const core::LocalPartitionNode>& localPartitionNode,
@@ -202,7 +196,7 @@ void plan(
     driverFactories->back()->inputDriver = true;
   } else {
     const auto numSourcesToPlan =
-        isIndexLookupJoin(planNode) ? 1 : sources.size();
+        isIndexLookupJoin(planNode.get()) ? 1 : sources.size();
     for (int32_t i = 0; i < numSourcesToPlan; ++i) {
       plan(
           sources[i],

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -119,7 +119,7 @@ void buildSplitStates(
     const core::PlanNode* planNode,
     std::unordered_set<core::PlanNodeId>& allIds,
     std::unordered_map<core::PlanNodeId, SplitsState>& splitStateMap) {
-  bool ok = allIds.insert(planNode->id()).second;
+  const bool ok = allIds.insert(planNode->id()).second;
   VELOX_USER_CHECK(
       ok,
       "Plan node IDs must be unique. Found duplicate ID: {}.",
@@ -137,8 +137,10 @@ void buildSplitStates(
     return;
   }
 
-  for (const auto& child : planNode->sources()) {
-    buildSplitStates(child.get(), allIds, splitStateMap);
+  const auto& sources = planNode->sources();
+  const auto numSources = isIndexLookupJoin(planNode) ? 1 : sources.size();
+  for (auto i = 0; i < numSources; ++i) {
+    buildSplitStates(sources[i].get(), allIds, splitStateMap);
   }
 }
 

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -42,22 +42,22 @@ class IndexLookupJoinTestBase
 
   int getNumRows(const std::vector<int>& cardinalities);
 
-  // Generate probe input for lookup join.
-  // @param numBatches: number of probe batches.
-  // @param batchSize: number of rows in each probe batch.
-  // @param numDuplicateProbeRows: number of duplicates for each probe row so
-  // the actual batch size is batchSize * numDuplicatesProbeRows.
-  // @param tableData: contains the sequence table data including key vectors
-  // and min/max key values.
-  // @param probeJoinKeys: the prefix key colums used for equality joins.
-  // @param inColumns: the ordered list of in conditions.
-  // @param betweenColumns: the ordered list of between conditions.
-  // @param equalMatchPct: percentage of rows in the probe input that matches
-  // with the rows in index table.
-  // @param betweenMatchPct: percentage of rows in the probe input that matches
-  // the rows in index table with between conditions.
-  // @param inMatchPct: percentage of rows in the probe input that matches the
-  // rows in index table with in conditions.
+  /// Generate probe input for lookup join.
+  /// @param numBatches: number of probe batches.
+  /// @param batchSize: number of rows in each probe batch.
+  /// @param numDuplicateProbeRows: number of duplicates for each probe row so
+  /// the actual batch size is batchSize * numDuplicatesProbeRows.
+  /// @param tableData: contains the sequence table data including key vectors
+  /// and min/max key values.
+  /// @param probeJoinKeys: the prefix key colums used for equality joins.
+  /// @param inColumns: the ordered list of in conditions.
+  /// @param betweenColumns: the ordered list of between conditions.
+  /// @param equalMatchPct: percentage of rows in the probe input that matches
+  /// with the rows in index table.
+  /// @param betweenMatchPct: percentage of rows in the probe input that matches
+  /// the rows in index table with between conditions.
+  /// @param inMatchPct: percentage of rows in the probe input that matches the
+  /// rows in index table with in conditions.
   std::vector<facebook::velox::RowVectorPtr> generateProbeInput(
       size_t numBatches,
       size_t batchSize,
@@ -72,15 +72,15 @@ class IndexLookupJoinTestBase
       std::optional<int> inMatchPct = std::nullopt,
       std::optional<int> betweenMatchPct = std::nullopt);
 
-  // Makes lookup join plan with the following parameters:
-  // @param indexScanNode: the index table scan node.
-  // @param probeVectors: the probe input vectors.
-  // @param leftKeys: the left join keys of index lookup join.
-  // @param rightKeys: the right join keys of index lookup join.
-  // @param joinType: the join type of index lookup join.
-  // @param outputColumns: the output column names of index lookup join.
-  // @param joinNodeId: returns the plan node id of the index lookup join
-  // node.
+  /// Makes lookup join plan with the following parameters:
+  /// @param indexScanNode: the index table scan node.
+  /// @param probeVectors: the probe input vectors.
+  /// @param leftKeys: the left join keys of index lookup join.
+  /// @param rightKeys: the right join keys of index lookup join.
+  /// @param joinType: the join type of index lookup join.
+  /// @param outputColumns: the output column names of index lookup join.
+  /// @param joinNodeId: returns the plan node id of the index lookup join
+  /// node.
   facebook::velox::core::PlanNodePtr makeLookupPlan(
       const std::shared_ptr<facebook::velox::core::PlanNodeIdGenerator>&
           planNodeIdGenerator,
@@ -93,14 +93,36 @@ class IndexLookupJoinTestBase
       const std::vector<std::string>& outputColumns,
       facebook::velox::core::PlanNodeId& joinNodeId);
 
+  /// Makes lookup join plan with the following parameters:
+  /// @param indexScanNode: the index table scan node.
+  /// @param probeVectors: the probe input vectors.
+  /// @param leftKeys: the left join keys of index lookup join.
+  /// @param rightKeys: the right join keys of index lookup join.
+  /// @param joinType: the join type of index lookup join.
+  /// @param outputColumns: the output column names of index lookup join.
+  /// @param joinNodeId: returns the plan node id of the index lookup join
+  /// node.
+  /// @param probeScanNodeId: returns the plan node id of the probe table scan
+  facebook::velox::core::PlanNodePtr makeLookupPlan(
+      const std::shared_ptr<facebook::velox::core::PlanNodeIdGenerator>&
+          planNodeIdGenerator,
+      facebook::velox::core::TableScanNodePtr indexScanNode,
+      const std::vector<std::string>& leftKeys,
+      const std::vector<std::string>& rightKeys,
+      const std::vector<std::string>& joinConditions,
+      facebook::velox::core::JoinType joinType,
+      const std::vector<std::string>& outputColumns,
+      facebook::velox::core::PlanNodeId& joinNodeId,
+      facebook::velox::core::PlanNodeId& probeScanNodeId);
+
   void createDuckDbTable(
       const std::string& tableName,
       const std::vector<facebook::velox::RowVectorPtr>& data);
 
-  // Makes index table scan node with the specified index table handle.
-  // @param outputType: the output schema of the index table scan node.
-  // @param scanNodeId: returns the plan node id of the index table scan
-  // node.
+  /// Makes index table scan node with the specified index table handle.
+  /// @param outputType: the output schema of the index table scan node.
+  /// @param scanNodeId: returns the plan node id of the index table scan
+  /// node.
   facebook::velox::core::TableScanNodePtr makeIndexScanNode(
       const std::shared_ptr<facebook::velox::core::PlanNodeIdGenerator>&
           planNodeIdGenerator,
@@ -113,26 +135,43 @@ class IndexLookupJoinTestBase
           std::shared_ptr<facebook::velox::connector::ColumnHandle>>&
           assignments);
 
-  // Generate sequence storage table which will be persisted by mock zippydb
-  // client for testing.
-  // @param keyCardinalities: specifies the number of unique keys per each index
-  // column, which also determines the total number of rows stored in the
-  // sequence storage table.
-  // @param tableData: returns the sequence table data stats including the key
-  // vector, value vector, table vector, and the min and max key values for each
-  // index column.
+  /// Generate sequence storage table which will be persisted by mock zippydb
+  /// client for testing.
+  /// @param keyCardinalities: specifies the number of unique keys per each
+  /// index column, which also determines the total number of rows stored in the
+  /// sequence storage table.
+  /// @param tableData: returns the sequence table data stats including the key
+  /// vector, value vector, table vector, and the min and max key values for
+  /// each index column.
   void generateIndexTableData(
       const std::vector<int>& keyCardinalities,
       SequenceTableData& tableData,
       std::shared_ptr<facebook::velox::memory::MemoryPool>& pool);
 
-  // Makes output schema from the index table scan node with the specified
-  // column names.
+  /// Write 'probeVectors' to a number of files with one per each file.
+  std::vector<std::shared_ptr<facebook::velox::exec::test::TempFilePath>>
+  createProbeFiles(
+      const std::vector<facebook::velox::RowVectorPtr>& probeVectors);
+
+  /// Makes output schema from the index table scan node with the specified
+  /// column names.
   facebook::velox::RowTypePtr makeScanOutputType(
       std::vector<std::string> outputNames);
 
   std::shared_ptr<facebook::velox::exec::Task> runLookupQuery(
       const facebook::velox::core::PlanNodePtr& plan,
+      int numPrefetchBatches,
+      const std::string& duckDbVefifySql);
+
+  std::shared_ptr<facebook::velox::exec::Task> runLookupQuery(
+      const facebook::velox::core::PlanNodePtr& plan,
+      const facebook::velox::core::PlanNodeId& probeScanId,
+      const std::vector<
+          std::shared_ptr<facebook::velox::exec::test::TempFilePath>>&
+          probeFiles,
+      bool serialExecution,
+      bool barrierExecution,
+      int maxBatchRows,
       int numPrefetchBatches,
       const std::string& duckDbVefifySql);
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1878,7 +1878,7 @@ PlanBuilder& PlanBuilder::indexLookupJoin(
       std::move(planNode_),
       right,
       std::move(outputType));
-  VELOX_CHECK(!planNode_->supportsBarrier());
+  VELOX_CHECK(planNode_->supportsBarrier());
   return *this;
 }
 

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -40,7 +40,7 @@ struct TestIndexTable {
         table(std::move(_table)) {}
 };
 
-/// The index table handle which provides the index table for index lookup.
+// The index table handle which provides the index table for index lookup.
 class TestIndexTableHandle : public connector::ConnectorTableHandle {
  public:
   explicit TestIndexTableHandle(


### PR DESCRIPTION
Summary:
Add barrier support for index lookup join to make sure when barrier reaches, all the buffer data like prefetch batches are flushed out. Also change in Koski side that skip index scan node in index lookup join as it doesn't accept split. And we skip creating split group for it.
The follow is to cover more test in sequential mode for index join.

Differential Revision: D74161139


