### PR TITLE
fix: Casting complex types is only supposed to cast recursively if a child's type will change

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -382,7 +382,7 @@ VectorPtr CastExpr::applyMap(
 
   // Cast keys
   VectorPtr newMapKeys;
-  if (fromType.keyType() == toType.keyType()) {
+  if (*fromType.keyType() == *toType.keyType()) {
     newMapKeys = input->mapKeys();
   } else {
     {
@@ -399,7 +399,7 @@ VectorPtr CastExpr::applyMap(
 
   // Cast values
   VectorPtr newMapValues;
-  if (fromType.valueType() == toType.valueType()) {
+  if (*fromType.valueType() == *toType.valueType()) {
     newMapValues = mapValues;
   } else {
     {
@@ -582,7 +582,7 @@ VectorPtr CastExpr::applyRow(
       outputChild->addNulls(rows);
     } else {
       const auto& inputChild = input->children()[fromChildrenIndex];
-      if (toChildType == inputChild->type()) {
+      if (*toChildType == *inputChild->type()) {
         outputChild = inputChild;
       } else {
         // Apply cast for the child.

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(
   velox_parse_parser
   velox_parse_expression
   velox_presto_serializer
+  velox_type_test_lib
   velox_vector_test_lib
   velox_vector_fuzzer
   GTest::gtest


### PR DESCRIPTION
Summary:
There is logic in CastExpr so that when we cast a row or map to a different row or map type, 
we only apply the cast to the children recursively if their types are different in the new type.

However, this comparison is done by comparing shared_ptrs (TypePtrs) which compares the
pointer addresses.  This only works for primitive types that have singleton Types. For complex
types this needs to compare the Type objects themselves.

This came up in fuzzer testing when casting a Row that contained an Array(Timestamp) field
that only changed the names of the fields not the types of any of the fields. The array types
were the same but had different addresses.  Array correctly assumes that if it's being casted
to another array type it's children must be different (otherwise the type would be the same
and cast should never have been called). So we attempted to cast a Timestamp to a
Timestamp which is not supported.

Differential Revision: D74260775


