### PR TITLE
fix: Clear hash table as soon as probe finish

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1045,6 +1045,9 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
           joinBridge_->probeFinished(!allProbeGroupFinished());
         } else {
           joinBridge_->probeFinished();
+          if (table_ != nullptr) {
+            table_->clear(true);
+          }
         }
         wakeupPeerOperators();
       }

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -68,18 +68,6 @@ class HashProbe : public Operator {
 
   bool canReclaim() const override;
 
-  bool testingHasInputSpiller() const {
-    return inputSpiller_ != nullptr;
-  }
-
-  bool testingExceededMaxSpillLevelLimit() const {
-    return exceededMaxSpillLevelLimit_;
-  }
-
-  bool testingHasPendingInput() const {
-    return input_ != nullptr;
-  }
-
   const std::vector<IdentityProjection>& tableOutputProjections() const {
     return tableOutputProjections_;
   }
@@ -96,12 +84,28 @@ class HashProbe : public Operator {
       const std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>&
           keys);
 
-  ProbeOperatorState testingState() const {
-    return state_;
-  }
-
   const std::shared_ptr<HashJoinBridge>& joinBridge() const {
     return joinBridge_;
+  }
+
+  bool testingHasInputSpiller() const {
+    return inputSpiller_ != nullptr;
+  }
+
+  bool testingExceededMaxSpillLevelLimit() const {
+    return exceededMaxSpillLevelLimit_;
+  }
+
+  bool testingHasPendingInput() const {
+    return input_ != nullptr;
+  }
+
+  std::shared_ptr<BaseHashTable> testingTable() const {
+    return table_;
+  }
+
+  ProbeOperatorState testingState() const {
+    return state_;
   }
 
  private:


### PR DESCRIPTION
Summary:
Large memory could be unnecessarily held due to following scenario:
both hash probe and hash build side has finished. Hash build side driver pipeline is completed and hence destroyed. Hash probe side is chained with other input spilling operators having large amount of input yet to be unspilled. Hence even though probe operators are finished, the pipeline isn't, leaving hash table lingering with large memory because the hash table is cleaned only upon hash probe operator destruction.

We should clear the hash table as soon as the probe is finished (non-mixed group mode).

Differential Revision: D74327871


