### PR TITLE
fix: Add check for overflow in Presto's from_unixtime

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -87,7 +87,8 @@ struct FromUnixtimeFunction {
       const arg_type<int64_t>* hours,
       const arg_type<int64_t>* minutes) {
     if (hours != nullptr && minutes != nullptr) {
-      tzID_ = tz::getTimeZoneID(*hours * 60 + *minutes);
+      tzID_ = tz::getTimeZoneID(
+          checkedPlus(checkedMultiply<int64_t>(*hours, 60), *minutes));
     }
   }
 
@@ -96,8 +97,8 @@ struct FromUnixtimeFunction {
       const arg_type<double>& unixtime,
       const arg_type<int64_t>& hours,
       const arg_type<int64_t>& minutes) {
-    int16_t timezoneId =
-        tzID_.value_or(tz::getTimeZoneID(hours * 60 + minutes));
+    int16_t timezoneId = tzID_.value_or(tz::getTimeZoneID(
+        checkedPlus(checkedMultiply<int64_t>(hours, 60), minutes)));
     result = pack(fromUnixtime(unixtime).toMillis(), timezoneId);
   }
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -351,6 +351,13 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeTzOffset) {
       TimestampWithTimezone(123'450, "+05:30"), fromOffset(123.45, 5, 30));
   EXPECT_EQ(
       TimestampWithTimezone(123'450, "-08:00"), fromOffset(123.45, -8, 0));
+
+  EXPECT_THROW(
+      fromOffset(
+          123.45,
+          std::numeric_limits<int64_t>::max(),
+          std::numeric_limits<int64_t>::max()),
+      VeloxUserError);
 }
 
 TEST_F(DateTimeFunctionsTest, fromUnixtime) {


### PR DESCRIPTION
Summary:
from_unixtime computes the minutes from UTC when the time zone is passed as an offset.
This can overflow with extreme values. Updated it to use checked arithmetic and throw a user
error if it overflow.

This was discovered in ExpressionFuzzer after TimestampWithTimeZone was enabled.

Differential Revision: D74346703


