### PR TITLE
fix: Fix mixed group mode hash join spill in non-spill case

### DIFF
--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -765,13 +765,12 @@ void JoinFuzzer::verify(core::JoinType joinType) {
         numGroups, false, JoinMaker::JoinOrder::NATURAL));
 
     // Use mixed mode grouped execution.
-    // TODO(jtan6): Unblock mixed mode after fix fuzzer.
-    // if (!needRightSideJoin(joinType)) {
-    //   // Mixed grouped mode join does not support types that needs right side
-    //   // join.
-    //   altPlans.push_back(joinMaker.makeHashJoinWithTableScan(
-    //       numGroups, true, JoinMaker::JoinOrder::NATURAL));
-    // }
+    if (!needRightSideJoin(joinType)) {
+      // Mixed grouped mode join does not support types that needs right side
+      // join.
+      altPlans.push_back(joinMaker.makeHashJoinWithTableScan(
+          numGroups, true, JoinMaker::JoinOrder::NATURAL));
+    }
 
     if (joinMaker.supportsFlippingHashJoin()) {
       // Use ungrouped execution.
@@ -783,14 +782,12 @@ void JoinFuzzer::verify(core::JoinType joinType) {
           numGroups, false, JoinMaker::JoinOrder::FLIPPED));
 
       // Use mixed mode grouped execution.
-      // TODO(jtan6): Unblock mixed mode after fix fuzzer.
-      // if (!needRightSideJoin(flipJoinType(joinType))) {
-      //   // Mixed grouped mode join does not support types that needs right
-      //   side
-      //   // join.
-      //   altPlans.push_back(joinMaker.makeHashJoinWithTableScan(
-      //       numGroups, true, JoinMaker::JoinOrder::FLIPPED));
-      // }
+      if (!needRightSideJoin(flipJoinType(joinType))) {
+        // Mixed grouped mode join does not support types that needs right side
+        // join.
+        altPlans.push_back(joinMaker.makeHashJoinWithTableScan(
+            numGroups, true, JoinMaker::JoinOrder::FLIPPED));
+      }
     }
 
     if (joinMaker.supportsMergeJoin()) {


### PR DESCRIPTION
Summary:
Mixed group mode hash join produces wrong results (missing rows) when:
1) spill and join spill are both enabled
2) query has mixed group execution mode
3) query does not actually trigger any spill

The reason is because in this condition, for each group we falsely call probeFinished(true) that resets the in memory hash table in build result, causing following groups to obtain empty hash table. In this case we shall not call probeFinished() at the end of each group which is the same behavior prior to mixed group hash join spill is added. We instead only call probeFinished() for the last group to notify bridge and build to finish.

Differential Revision: D74348687


