### PR TITLE
feat(vector): Flat map in-memory layout

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -335,9 +335,10 @@ class BaseVector {
   /// When CompareFlags is ASCENDING, returns < 0 if 'this' at 'index' is less
   /// than 'other' at 'otherIndex', 0 if equal and > 0 otherwise.
   /// When CompareFlags is DESCENDING, returns < 0 if 'this' at 'index' is
-  /// larger than 'other' at 'otherIndex', 0 if equal and < 0 otherwise. If
-  /// flags.nullHandlingMode is not NullAsValue, the function may returns
-  /// std::nullopt if null encountered.
+  /// larger than 'other' at 'otherIndex', 0 if equal and < 0 otherwise.
+  ///
+  /// If flags.nullHandlingMode is not NullAsValue, the function may return
+  /// std::nullopt if nulls are encountered.
   virtual std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -18,6 +18,7 @@ velox_add_library(
   ConstantVector.cpp
   DecodedVector.cpp
   EncodedVectorCopy.cpp
+  FlatMapVector.cpp
   FlatVector.cpp
   LazyVector.cpp
   SelectivityVector.cpp

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -178,7 +178,7 @@ class RowVector : public BaseVector {
         type_,
         AlignedBuffer::copy(selfPool, nulls_),
         length_,
-        copiedChildren,
+        std::move(copiedChildren),
         nullCount_);
   }
 

--- a/velox/vector/FlatMapVector.cpp
+++ b/velox/vector/FlatMapVector.cpp
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/FlatMapVector.h"
+#include <folly/hash/Hash.h>
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox {
+namespace {
+
+// Up to # of elements to show as debug string for `toString()`.
+constexpr vector_size_t kToStringMaxFlatMapElements = 5;
+constexpr std::string_view kToStringDelimiter{", "};
+
+template <typename T, typename TMap>
+std::optional<column_index_t> getKeyChannelImpl(
+    const VectorPtr& distinctKeys,
+    const TMap& keyToChannel,
+    T keyValue) {
+  if (distinctKeys == nullptr) {
+    return std::nullopt;
+  }
+
+  auto distinctFlatKeys = distinctKeys->as<FlatVector<T>>();
+  VELOX_CHECK(
+      distinctFlatKeys != nullptr,
+      "Incompatible vector type for flat map vector keys: {}",
+      distinctKeys->toString());
+
+  uint64_t hash = folly::hasher<T>{}(keyValue);
+  auto range = keyToChannel.equal_range(hash);
+
+  // Key hash wasn't found on the map.
+  if (range.first == range.second) {
+    return std::nullopt;
+  }
+
+  // Here there was at least one hash match. Need to compare to the keys vector
+  // to ensure it's an actual match and not a hash collision.
+  for (auto it = range.first; it != range.second; ++it) {
+    if (distinctFlatKeys->valueAtFast(it->second) == keyValue) {
+      return it->second;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace
+
+std::optional<column_index_t> FlatMapVector::getKeyChannel(
+    int32_t scalarValue) const {
+  return getKeyChannelImpl(distinctKeys_, keyToChannel_, scalarValue);
+}
+
+std::optional<column_index_t> FlatMapVector::getKeyChannel(
+    int64_t scalarValue) const {
+  return getKeyChannelImpl(distinctKeys_, keyToChannel_, scalarValue);
+}
+
+std::optional<column_index_t> FlatMapVector::getKeyChannel(
+    StringView scalarValue) const {
+  return getKeyChannelImpl(distinctKeys_, keyToChannel_, scalarValue);
+}
+
+std::optional<column_index_t> FlatMapVector::getKeyChannel(
+    const VectorPtr& keysVector,
+    vector_size_t index) const {
+  uint64_t hash = keysVector->hashValueAt(index);
+  auto range = keyToChannel_.equal_range(hash);
+
+  // Key hash wasn't found on the map.
+  if (range.first == range.second) {
+    return std::nullopt;
+  }
+
+  for (auto it = range.first; it != range.second; ++it) {
+    if (keysVector->equalValueAt(distinctKeys_.get(), index, it->second)) {
+      return it->second;
+    }
+  }
+  return std::nullopt;
+}
+
+vector_size_t FlatMapVector::sizeAt(vector_size_t index) const {
+  VELOX_CHECK_LT(index, size());
+  vector_size_t size = 0;
+
+  for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+    if (i < inMaps_.size() && inMaps_[i] != nullptr) {
+      size += bits::isBitSet(inMaps_[i]->asMutable<uint64_t>(), index);
+    } else {
+      // By default assume the key exists.
+      ++size;
+    }
+  }
+  return size;
+}
+
+void FlatMapVector::resize(vector_size_t newSize, bool setNotNull) {
+  const auto oldSize = size();
+  BaseVector::resize(newSize, setNotNull);
+
+  // Resize all the map values vectors.
+  for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+    auto& values = mapValues_[i];
+    if (values != nullptr) {
+      VELOX_CHECK(!values->isLazy(), "Resize on a lazy vector is not allowed.");
+
+      // If we are just reducing the size of the vector, its safe
+      // to skip uniqueness check since effectively we are just changing
+      // the length.
+      if (newSize > oldSize) {
+        VELOX_CHECK_EQ(
+            values.use_count(), 1, "Resizing shared map values vector");
+        values->resize(newSize, setNotNull);
+
+        if (i < inMaps_.size() && inMaps_[i] != nullptr) {
+          VELOX_CHECK(inMaps_[i]->unique(), "Resizing shared in map vector");
+          AlignedBuffer::reallocate<bool>(&inMaps_[i], newSize, 0);
+        }
+      }
+    }
+  }
+}
+
+VectorPtr FlatMapVector::slice(vector_size_t offset, vector_size_t length)
+    const {
+  std::vector<VectorPtr> mapValues(mapValues_.size());
+  for (int i = 0; i < mapValues_.size(); ++i) {
+    mapValues[i] = mapValues_[i]->slice(offset, length);
+  }
+
+  std::vector<BufferPtr> inMaps(inMaps_.size());
+  for (int i = 0; i < inMaps_.size(); ++i) {
+    if (inMaps_[i]) {
+      inMaps[i] = Buffer::slice<bool>(inMaps_[i], offset, length, pool_);
+    }
+  }
+
+  return std::make_shared<FlatMapVector>(
+      pool_,
+      type_,
+      sliceNulls(offset, length),
+      length,
+      distinctKeys_,
+      std::move(mapValues),
+      std::move(inMaps),
+      std::nullopt,
+      sortedKeys_);
+}
+
+VectorPtr FlatMapVector::testingCopyPreserveEncodings(
+    velox::memory::MemoryPool* pool) const {
+  std::vector<VectorPtr> copiedMapValues(mapValues_.size());
+  std::vector<BufferPtr> copiedInMaps(inMaps_.size());
+  std::transform(
+      mapValues_.begin(),
+      mapValues_.end(),
+      copiedMapValues.begin(),
+      [&pool](const auto& mapValue) {
+        return mapValue->testingCopyPreserveEncodings(pool);
+      });
+
+  auto selfPool = pool ? pool : pool_;
+
+  for (auto i = 0; i < inMaps_.size(); ++i) {
+    copiedInMaps[i] = AlignedBuffer::copy(selfPool, inMaps_[i]);
+  }
+
+  return std::make_shared<FlatMapVector>(
+      selfPool,
+      type_,
+      AlignedBuffer::copy(selfPool, nulls_),
+      length_,
+      distinctKeys_->testingCopyPreserveEncodings(pool),
+      std::move(copiedMapValues),
+      std::move(copiedInMaps),
+      nullCount_,
+      sortedKeys_);
+}
+
+std::string FlatMapVector::toString(vector_size_t index) const {
+  VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
+  if (isNullAt(index)) {
+    return "null";
+  }
+
+  vector_size_t size = sizeAt(index);
+
+  if (size == 0) {
+    return "<empty>";
+  }
+
+  std::stringstream out;
+  out << size << " elements {";
+  const vector_size_t limitedSize = std::min(size, kToStringMaxFlatMapElements);
+  vector_size_t printedElements = 0;
+
+  for (vector_size_t i = 0;
+       i < numDistinctKeys() && printedElements < kToStringMaxFlatMapElements;
+       ++i) {
+    if (!isInMap(i, index)) {
+      continue;
+    }
+
+    if (printedElements > 0) {
+      out << kToStringDelimiter;
+    }
+
+    out << distinctKeys_->toString(i) << " => "
+        << mapValues_[i]->toString(index);
+    ++printedElements;
+  }
+
+  if (size > limitedSize) {
+    if (limitedSize) {
+      out << kToStringDelimiter;
+    }
+    out << "...";
+  }
+  out << "}";
+  return out.str();
+}
+
+bool FlatMapVector::containsNullAt(vector_size_t index) const {
+  if (BaseVector::isNullAt(index)) {
+    return true;
+  }
+
+  // If the key/value pair exists in the map, return true if either the key or
+  // value are nulls (mirroring the MapVector behavior).
+  for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+    if (isInMap(i, index)) {
+      if (distinctKeys_->containsNullAt(i)) {
+        return true;
+      }
+
+      if (mapValues_[i]->containsNullAt(i)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+uint64_t FlatMapVector::hashValueAt(vector_size_t index) const {
+  if (isNullAt(index)) {
+    return BaseVector::kNullHash;
+  }
+
+  uint64_t hash = BaseVector::kNullHash;
+
+  for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+    if (isInMap(i, index)) {
+      hash = bits::commutativeHashMix(hash, distinctKeys_->hashValueAt(i));
+      hash = bits::commutativeHashMix(hash, mapValues_[i]->hashValueAt(index));
+    }
+  }
+  return hash;
+}
+
+std::unique_ptr<SimpleVector<uint64_t>> FlatMapVector::hashAll() const {
+  // Method not implemented for any complex vectors in ComplexVectors.h also.
+  VELOX_NYI();
+}
+
+std::vector<vector_size_t> FlatMapVector::sortedKeyIndices(
+    vector_size_t index) const {
+  std::vector<vector_size_t> indices;
+  indices.reserve(numDistinctKeys());
+
+  for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+    if (isInMap(i, index)) {
+      indices.push_back(i);
+    }
+  }
+
+  if (!sortedKeys_ && distinctKeys_) {
+    distinctKeys_->sortIndices(indices, CompareFlags());
+  }
+  return indices;
+}
+
+// This function's logic is largely based on MapVector::compare().
+std::optional<int32_t> FlatMapVector::compare(
+    const BaseVector* other,
+    vector_size_t index,
+    vector_size_t otherIndex,
+    CompareFlags flags) const {
+  VELOX_CHECK(
+      flags.nullAsValue() || flags.equalsOnly, "Map is not orderable type");
+
+  // If maps are null.
+  bool isNull = isNullAt(index);
+  bool otherNull = other->isNullAt(otherIndex);
+  if (isNull || otherNull) {
+    return BaseVector::compareNulls(isNull, otherNull, flags);
+  }
+
+  // Validate we have compatible map types for comparison.
+  auto otherValue = other->wrappedVector();
+  auto wrappedOtherIndex = other->wrappedIndex(otherIndex);
+  VELOX_CHECK_EQ(
+      VectorEncoding::Simple::FLAT_MAP,
+      otherValue->encoding(),
+      "Compare of FLAT_MAP and non-FLAT_MAP: {} and {}",
+      BaseVector::toString(),
+      otherValue->BaseVector::toString());
+  auto otherFlatMap = otherValue->as<FlatMapVector>();
+
+  if (keyType()->kind() != otherFlatMap->keyType()->kind() ||
+      valueType()->kind() != otherFlatMap->valueType()->kind()) {
+    VELOX_FAIL(
+        "Compare of maps of different key/value types: {} and {}",
+        BaseVector::toString(),
+        otherFlatMap->BaseVector::toString());
+  }
+
+  // We first get sorted key indices for both maps.
+  auto leftIndices = sortedKeyIndices(index);
+  auto rightIndices = otherFlatMap->sortedKeyIndices(wrappedOtherIndex);
+
+  // If equalsOnly and maps have different sizes, we can bail fast.
+  if (flags.equalsOnly && leftIndices.size() != rightIndices.size()) {
+    int result = leftIndices.size() - rightIndices.size();
+    return flags.ascending ? result : result * -1;
+  }
+
+  // Compare each key value pair, using the sorted key order.
+  auto compareSize = std::min(leftIndices.size(), rightIndices.size());
+  bool resultIsIndeterminate = false;
+
+  for (auto i = 0; i < compareSize; ++i) {
+    // First compare the keys.
+    auto result = distinctKeys_->compare(
+        otherFlatMap->distinctKeys_.get(),
+        leftIndices[i],
+        rightIndices[i],
+        flags);
+
+    // Key mismatch; comparison can stop.
+    if (result == kIndeterminate) {
+      VELOX_DCHECK(
+          flags.equalsOnly,
+          "Compare should have thrown when null is encountered in child.");
+      resultIsIndeterminate = true;
+    } else if (result.value() != 0) {
+      return result;
+    }
+    // If keys are same, compare values.
+    else {
+      auto valueResult = mapValues_[leftIndices[i]]->compare(
+          otherFlatMap->mapValues_[rightIndices[i]].get(),
+          index,
+          wrappedOtherIndex,
+          flags);
+
+      // If value mismatch, comparison can also stop.
+      if (valueResult == kIndeterminate) {
+        VELOX_DCHECK(
+            flags.equalsOnly,
+            "Compare should have thrown when null is encountered in child.");
+        resultIsIndeterminate = true;
+      } else if (valueResult.value() != 0) {
+        return valueResult;
+      }
+    }
+  }
+
+  if (resultIsIndeterminate) {
+    return kIndeterminate;
+  }
+
+  // If one map was smaller than the other.
+  int result = leftIndices.size() - rightIndices.size();
+  return flags.ascending ? result : result * -1;
+}
+
+} // namespace facebook::velox

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox {
+
+/// FlatMapVector implements the flat map layout, which is an alternative way of
+/// encoding logical maps.
+///
+/// Flat maps represent logical maps (the MAP() TypePtr), but instead of keeping
+/// two inner vectors, one for keys and one for values (and buffers for
+/// lengths/offsets), like MapVector, flat maps group values for different keys
+/// in different vectors.
+///
+/// The entire purpose of this layout is to support efficient key projection on
+/// large maps, since projecting a particular key from the map can be done in a
+/// zero-copy manner by just returning the map values vector for a particular
+/// key.
+///
+/// For example, take the following datasets containing maps for 4 records:
+///
+/// {
+///   {{101, 1}, {102, 2}},
+///   {{101, 2}, {102, 2}},
+///   {{101, 3}},
+///   {{101, null}, {103, 4}},
+/// }
+///
+/// While a map vector would organize data in the following way:
+///
+/// keys:
+///   {101, 102, 101, 102, 101, 101, 103}
+/// values:
+///   {1, 2, 2, 2, 3, null, 4}
+/// lengths/offsets:
+///   {2, 2, 1, 2}, {0, 2, 4, 5}
+///
+/// A flat map organizes data as follows:
+///
+/// distinct keys:
+///   {101, 102, 103}
+/// map values:
+///   0: {1, 2, 3, null}
+///   1: {2, 2, null, null}
+///   2: {null, null, null, 4}
+///
+/// To differentiate a null map value from a non-existing key in the map, an
+/// optional bitmask is kept for each map values (the "in-map" buffers):
+///
+/// in-map:
+///   0: {} // empty buffer means all exist / all 1s.
+///   1: {1, 1, 0, 0}
+///   3: {0, 0, 0, 1}
+///
+/// To allow mapping a key to the correct index in the map values vector (its
+/// "channel"), a hash map is maintained inside the object. To enable generic
+/// key types, projecting a key can be done by using a vector of abitrary type
+/// (see "getKeyChannel()" below), but fast-paths for common key types are
+/// provided (INTEGER/BIGINT/VARCHAR).
+///
+class FlatMapVector : public BaseVector {
+ public:
+  FlatMapVector(const FlatMapVector&) = delete;
+  FlatMapVector& operator=(const FlatMapVector&) = delete;
+
+  // Move the shared_ptr instead.
+  FlatMapVector(FlatMapVector&& other) = delete;
+  FlatMapVector& operator=(FlatMapVector&&) = delete;
+
+  // The size of the distinct keys vector must match the size of map values (the
+  // in-map buffers may not be present).
+  FlatMapVector(
+      velox::memory::MemoryPool* pool,
+      std::shared_ptr<const Type> type,
+      BufferPtr nulls,
+      size_t length,
+      VectorPtr distinctKeys,
+      std::vector<VectorPtr> mapValues,
+      std::vector<BufferPtr> inMaps,
+      std::optional<vector_size_t> nullCount = std::nullopt,
+      bool sortedKeys = false)
+      : BaseVector(
+            pool,
+            type,
+            VectorEncoding::Simple::FLAT_MAP,
+            nulls,
+            length,
+            std::nullopt,
+            nullCount),
+        mapValues_(std::move(mapValues)),
+        inMaps_(std::move(inMaps)),
+        sortedKeys_(sortedKeys) {
+    VELOX_CHECK(type->isMap(), "FlatMapVector requires a MAP type.");
+    distinctKeys_ = BaseVector::getOrCreateEmpty(
+        std::move(distinctKeys), type->childAt(0), pool);
+    setDistinctKeysImpl(distinctKeys_);
+
+    VELOX_CHECK_EQ(
+        numDistinctKeys(),
+        mapValues_.size(),
+        "Wrong number of map value vectors.");
+    VELOX_CHECK_LE(
+        inMaps_.size(), numDistinctKeys(), "Wrong number of in map buffers.");
+  }
+
+  virtual ~FlatMapVector() override {}
+
+  /// Overwrites the existing distinct keys vector, resizing map values and
+  /// clearing in-map buffers.
+  void setDistinctKeys(VectorPtr distinctKeys, bool sortedKeys = false) {
+    setDistinctKeysImpl(std::move(distinctKeys));
+    mapValues_.resize(numDistinctKeys());
+    inMaps_.clear();
+    sortedKeys_ = sortedKeys;
+  }
+
+  TypePtr keyType() const {
+    return type()->asMap().keyType();
+  }
+
+  TypePtr valueType() const {
+    return type()->asMap().valueType();
+  }
+
+  /// Returns the distinct keys on this map. Note that this is different than
+  /// simply returning (all) keys from a map, since these are deduplicated
+  /// across all rows from the map.
+  const VectorPtr& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  vector_size_t numDistinctKeys() const {
+    return distinctKeys_ != nullptr ? distinctKeys_->size() : 0;
+  }
+
+  bool hasSortedKeys() const {
+    return sortedKeys_;
+  }
+
+  const std::vector<VectorPtr>& mapValues() const {
+    return mapValues_;
+  }
+
+  const std::vector<BufferPtr>& inMaps() const {
+    return inMaps_;
+  }
+
+  /// Returns the channel for a particular key present in `keysVector` at index
+  /// `index`. This is a general version that works for every key type,
+  /// including complex types. Below, fast-paths are provided for common key
+  /// types.
+  ///
+  /// This channel can be used to fetch mapValues and inMap buffers. Returns
+  /// std::nullopt if there is no key match.
+  std::optional<column_index_t> getKeyChannel(
+      const VectorPtr& keysVector,
+      vector_size_t index) const;
+
+  /// Fast-path for returning the channel for a particular primitive type key.
+  /// The returned channel can then be used to fetch the map values vectors and
+  /// in-map buffers.
+  ///
+  /// When using these functions, it is the caller's reponsibility to provide a
+  /// parameter that is compatible with the distinct keys flat vector in the
+  /// object (int64_t for BIGINT(), int32_t for INTEGER(), and so forth).
+  ///
+  /// The function throws in case the types are not compatible, and returns
+  /// std::nullopt if the types are compatible but the key wasn't not found.
+  ///
+  /// For key types other than the ones below (such as complex type keys),
+  /// callers should use the general version based on VectorPtr above.
+  std::optional<column_index_t> getKeyChannel(int32_t scalarKey) const;
+  std::optional<column_index_t> getKeyChannel(int64_t scalarKey) const;
+  std::optional<column_index_t> getKeyChannel(StringView scalarKey) const;
+
+  /// Returns a vector containing a projection for a specific primitive key.
+  /// This is an efficient operation in flat maps (zero-copy).
+  ///
+  /// The key restrictions are the same as the ones listed above for
+  /// `getKeyChannel()`.
+  template <typename TKey>
+  VectorPtr projectKey(TKey scalarKey) const {
+    if (auto channel = getKeyChannel(scalarKey)) {
+      return mapValues_[channel.value()];
+    }
+    return nullptr;
+  }
+
+  /// Returns the size for the map at position `index`. Size means the number of
+  /// logical key value pairs in the map. Note that this is not a particularly
+  /// efficient operation in flat maps as it requires accessing the inMap bitmap
+  /// for each distinct key.
+  vector_size_t sizeAt(vector_size_t index) const;
+
+  bool isInMap(column_index_t keyChannel, vector_size_t index) const {
+    auto* inMap = inMapsAt(keyChannel)->asMutable<uint64_t>();
+    return inMap ? bits::isBitSet(inMap, index) : true;
+  }
+
+  /// Get the map values vector at a given a map key channel.
+  const VectorPtr& mapValuesAt(column_index_t index) const {
+    VELOX_CHECK_LT(
+        index,
+        mapValues_.size(),
+        "Trying to access non-existing key channel in FlatMapVector.");
+    return mapValues_[index];
+  }
+
+  /// Non-const version of the method above.
+  VectorPtr& mapValuesAt(column_index_t index) {
+    VELOX_CHECK_LT(
+        index,
+        mapValues_.size(),
+        "Trying to access non-existing key channel in FlatMapVector.");
+    return mapValues_[index];
+  }
+
+  /// Get the in map buffer for a given a map key channel.
+  const BufferPtr& inMapsAt(column_index_t index) const {
+    VELOX_CHECK_LT(
+        index,
+        inMaps_.size(),
+        "Trying to access non-existing key channel in FlatMapVector.");
+    return inMaps_[index];
+  }
+
+  using BaseVector::toString;
+  std::string toString(vector_size_t index) const override;
+
+  // Resize will recursively change the size of each map value vector (nullptr
+  // vectors will remain nullptr), in-map, and top level null buffers.
+  void resize(vector_size_t newSize, bool setNotNull = true) override;
+
+  VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
+
+  VectorPtr testingCopyPreserveEncodings(
+      velox::memory::MemoryPool* pool = nullptr) const override;
+
+  /// Returns true if the map is null, or either one of the key or value of its
+  /// entries are null.
+  bool containsNullAt(vector_size_t index) const override;
+
+  /// Returns indices into the map at 'index' such
+  /// that keys[indices[i]] < keys[indices[i + 1]].
+  std::vector<vector_size_t> sortedKeyIndices(vector_size_t index) const;
+
+  // Flat map comparison logic follows the comparison logic from MapVector.
+  std::optional<int32_t> compare(
+      const BaseVector* other,
+      vector_size_t index,
+      vector_size_t otherIndex,
+      CompareFlags flags) const override;
+
+  /// Returns the hash of the value at the given index in this vector.
+  uint64_t hashValueAt(vector_size_t index) const override;
+
+  std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
+
+ private:
+  void setDistinctKeysImpl(VectorPtr distinctKeys) {
+    VELOX_CHECK(distinctKeys != nullptr);
+    VELOX_CHECK(
+        *distinctKeys->type() == *keyType(),
+        "Unexpected key type: {}",
+        distinctKeys->type()->toString());
+
+    distinctKeys_ = distinctKeys;
+    keyToChannel_.clear();
+
+    for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+      keyToChannel_.insert({distinctKeys->hashValueAt(i), i});
+    }
+  }
+
+  // Vector containing the distinct map keys.
+  VectorPtr distinctKeys_;
+
+  // Map values - one VectorPtr per distinct key value. Indices on this vector
+  // are aligned with the indices on distinctKeys.
+  std::vector<VectorPtr> mapValues_;
+
+  // In-map buffers indicate whether a particular key logically exists in the
+  // map. The key is dictated by the std::vector position (aligned with
+  // distinctKeys_).
+  //
+  // Note that key not existing is different from a key existing but having a
+  // null value.
+  std::vector<BufferPtr> inMaps_;
+
+  // Hash table that enables flat map keys to find the channel (the index on
+  // mapValues_ and inMaps_ for that key).
+  //
+  // To avoid having to template this class and supporting arbitrarily nested
+  // keys, the hash table key is the hash of the flat map key. This means that
+  // hash collisions need to be manually handled by comparing the actual key
+  // values, and hence a multimap is needed.
+  std::unordered_multimap<uint64_t, column_index_t> keyToChannel_;
+
+  // Whether the distinct keys vector stores sorted keys.
+  bool sortedKeys_;
+};
+
+using FlatMapVectorPtr = std::shared_ptr<FlatMapVector>;
+
+} // namespace facebook::velox

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -17,6 +17,7 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/ConstantVector.h"
+#include "velox/vector/FlatMapVector.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox {
@@ -189,6 +190,15 @@ void FlatVector<StringView>::acquireSharedStringBuffersRecursive(
           source->asUnchecked<MapVector>()->mapKeys().get());
       acquireSharedStringBuffersRecursive(
           source->asUnchecked<MapVector>()->mapValues().get());
+      return;
+    }
+
+    case VectorEncoding::Simple::FLAT_MAP: {
+      acquireSharedStringBuffersRecursive(
+          source->asUnchecked<FlatMapVector>()->distinctKeys().get());
+      for (auto& mapValue : source->asUnchecked<FlatMapVector>()->mapValues()) {
+        acquireSharedStringBuffersRecursive(mapValue.get());
+      }
       return;
     }
 

--- a/velox/vector/VectorEncoding.cpp
+++ b/velox/vector/VectorEncoding.cpp
@@ -32,6 +32,7 @@ Simple mapNameToSimple(const std::string& name) {
       {"SEQUENCE", Simple::SEQUENCE},
       {"ROW", Simple::ROW},
       {"MAP", Simple::MAP},
+      {"FLAT_MAP", Simple::FLAT_MAP},
       {"ARRAY", Simple::ARRAY}};
 
   if (vecNameMap.find(name) == vecNameMap.end()) {

--- a/velox/vector/VectorEncoding.h
+++ b/velox/vector/VectorEncoding.h
@@ -21,14 +21,11 @@
 
 namespace facebook::velox {
 
-/**
- * Contains the types of vector encodings available for various classes of
- * vectors.
- */
+/// Contains the types of vector encodings available for various classes of
+/// vectors.
 namespace VectorEncoding {
-/**
- * Provides an enumeration of vector encoding types.
- */
+
+/// Provides an enumeration of vector encoding types.
 enum class Simple {
   BIASED,
   CONSTANT,
@@ -37,6 +34,7 @@ enum class Simple {
   SEQUENCE,
   ROW,
   MAP,
+  FLAT_MAP,
   ARRAY,
   LAZY,
   FUNCTION
@@ -60,6 +58,8 @@ inline std::ostream& operator<<(
       return out << "ROW";
     case VectorEncoding::Simple::MAP:
       return out << "MAP";
+    case VectorEncoding::Simple::FLAT_MAP:
+      return out << "FLAT_MAP";
     case VectorEncoding::Simple::ARRAY:
       return out << "ARRAY";
     case VectorEncoding::Simple::LAZY:
@@ -93,5 +93,6 @@ inline bool isDictionary(VectorEncoding::Simple encoding) {
 }
 
 VectorEncoding::Simple mapNameToSimple(const std::string& name);
+
 } // namespace VectorEncoding
 } // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   EncodedVectorCopyTest.cpp
   EncodingTest.cpp
   EnsureWritableVectorTest.cpp
+  FlatMapVectorTest.cpp
   IsWritableVectorTest.cpp
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp

--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+namespace {
+
+class FlatMapVectorTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  VectorMaker maker_{pool_.get()};
+};
+
+TEST_F(FlatMapVectorTest, fail) {
+  auto buildVector = [&](const TypePtr& type,
+                         const VectorPtr& keys = nullptr,
+                         const std::vector<VectorPtr>& mapValues = {},
+                         const std::vector<BufferPtr>& inMaps = {}) {
+    return std::make_shared<FlatMapVector>(
+        pool_.get(), type, nullptr, 3, keys, mapValues, inMaps);
+  };
+
+  // Wrong type.
+  VELOX_ASSERT_THROW(
+      buildVector(BIGINT()), "FlatMapVector requires a MAP type.");
+
+  auto type = MAP(INTEGER(), BIGINT());
+
+  // Wrong distinct keys vectors type and encoding.
+  auto wrongKeys = maker_.flatVector<int64_t>({101, 102});
+
+  VELOX_ASSERT_THROW(
+      buildVector(type, wrongKeys), "Unexpected key type: BIGINT");
+
+  // Wrong number of map value vectors/buffers.
+  auto keys = maker_.flatVector<int32_t>({101, 102});
+
+  VELOX_ASSERT_THROW(
+      buildVector(type, keys), "(2 vs. 0) Wrong number of map value vectors.");
+
+  std::vector<VectorPtr> mapValues = {
+      maker_.flatVector<int32_t>({0, 0, 0}),
+      maker_.flatVector<int32_t>({1, 1, 1}),
+  };
+
+  // It's ok if in maps are not provided.
+  ASSERT_NO_THROW(buildVector(type, keys, mapValues));
+
+  // All good including in maps.
+  ASSERT_NO_THROW(buildVector(
+      type, keys, mapValues, std::vector<BufferPtr>{nullptr, nullptr}));
+}
+
+TEST_F(FlatMapVectorTest, empty) {
+  auto flatMapVector = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      MAP(BIGINT(), REAL()),
+      nullptr,
+      0,
+      nullptr,
+      std::vector<VectorPtr>{},
+      std::vector<BufferPtr>{});
+
+  EXPECT_EQ(flatMapVector->size(), 0);
+  EXPECT_FALSE(flatMapVector->mayHaveNulls());
+
+  EXPECT_EQ(*flatMapVector->type(), *MAP(BIGINT(), REAL()));
+  EXPECT_EQ(flatMapVector->encoding(), VectorEncoding::Simple::FLAT_MAP);
+
+  EXPECT_NE(flatMapVector->distinctKeys(), nullptr);
+  EXPECT_EQ(flatMapVector->distinctKeys()->size(), 0);
+  EXPECT_EQ(flatMapVector->numDistinctKeys(), 0);
+  EXPECT_TRUE(flatMapVector->mapValues().empty());
+  EXPECT_TRUE(flatMapVector->inMaps().empty());
+
+  EXPECT_EQ(flatMapVector->projectKey((int64_t)0), nullptr);
+  EXPECT_EQ(flatMapVector->projectKey((int64_t)1), nullptr);
+  EXPECT_EQ(flatMapVector->projectKey((int64_t)101), nullptr);
+
+  VELOX_ASSERT_THROW(flatMapVector->sizeAt(0), "");
+  VELOX_ASSERT_THROW(
+      flatMapVector->mapValuesAt(0),
+      "(0 vs. 0) Trying to access non-existing key channel in FlatMapVector.");
+  VELOX_ASSERT_THROW(
+      flatMapVector->toString(0), "Vector index should be less than length.");
+}
+
+TEST_F(FlatMapVectorTest, simple) {
+  auto flatMapVector = maker_.flatMapVector<std::string, std::string>({
+      {{"a", "1"}, {"b", "2"}},
+      {{"a", "This is a test"}, {"b", "This is another test"}, {"c", "test"}},
+      {{"b", "5"}, {"d", "last"}},
+  });
+
+  EXPECT_EQ(flatMapVector->size(), 3);
+  EXPECT_EQ(*MAP(VARCHAR(), VARCHAR()), *flatMapVector->type());
+  EXPECT_FALSE(flatMapVector->mayHaveNulls());
+
+  // Validate we have the right distinct keys.
+  auto distinctKeys = flatMapVector->distinctKeys();
+  EXPECT_NE(distinctKeys, nullptr);
+  EXPECT_EQ(distinctKeys->size(), 4);
+  EXPECT_EQ(flatMapVector->numDistinctKeys(), 4);
+
+  // Map sizes for each row.
+  EXPECT_EQ(flatMapVector->sizeAt(0), 2);
+  EXPECT_EQ(flatMapVector->sizeAt(1), 3);
+  EXPECT_EQ(flatMapVector->sizeAt(2), 2);
+
+  // Validate values of key projections.
+  auto mapValues = flatMapVector->projectKey("a")->as<FlatVector<StringView>>();
+  EXPECT_EQ(mapValues->size(), 3);
+  EXPECT_EQ(mapValues->valueAt(0), "1");
+  EXPECT_EQ(mapValues->valueAt(1), "This is a test");
+  EXPECT_TRUE(mapValues->isNullAt(2)); // not in map is also set to null.
+
+  mapValues = flatMapVector->projectKey("b")->as<FlatVector<StringView>>();
+  EXPECT_EQ(mapValues->size(), 3);
+  EXPECT_EQ(mapValues->valueAt(0), "2");
+  EXPECT_EQ(mapValues->valueAt(1), "This is another test");
+  EXPECT_EQ(mapValues->valueAt(2), "5");
+
+  EXPECT_EQ(flatMapVector->projectKey("xyz"), nullptr);
+
+  // Getting key channels.
+  EXPECT_EQ(*flatMapVector->getKeyChannel("a"), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel("b"), 1);
+  EXPECT_EQ(*flatMapVector->getKeyChannel("c"), 2);
+  EXPECT_EQ(*flatMapVector->getKeyChannel("d"), 3);
+  EXPECT_EQ(flatMapVector->getKeyChannel("e"), std::nullopt);
+
+  // Validate in maps.
+  auto channel = flatMapVector->getKeyChannel("a");
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 0));
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 1));
+  EXPECT_FALSE(flatMapVector->isInMap(*channel, 2));
+
+  channel = flatMapVector->getKeyChannel("b");
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 0));
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 1));
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 2));
+
+  channel = flatMapVector->getKeyChannel("a");
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 0));
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 1));
+  EXPECT_FALSE(flatMapVector->isInMap(*channel, 2));
+}
+
+TEST_F(FlatMapVectorTest, withNulls) {
+  // Nullable flat map.
+  auto flatMapVector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      // null row.
+      std::nullopt,
+      // empty vector/map.
+      std::vector<std::pair<int64_t, std::optional<int64_t>>>{},
+      // null value.
+      {{{42L, std::nullopt}}},
+  });
+
+  EXPECT_EQ(flatMapVector->size(), 3);
+  EXPECT_EQ(*MAP(BIGINT(), BIGINT()), *flatMapVector->type());
+  EXPECT_TRUE(flatMapVector->mayHaveNulls());
+
+  // Top-level nulls.
+  EXPECT_TRUE(flatMapVector->isNullAt(0));
+  EXPECT_FALSE(flatMapVector->isNullAt(1));
+  EXPECT_FALSE(flatMapVector->isNullAt(2));
+
+  EXPECT_TRUE(flatMapVector->containsNullAt(0));
+  EXPECT_FALSE(flatMapVector->containsNullAt(1));
+  EXPECT_TRUE(flatMapVector->containsNullAt(2));
+
+  // Check sizes of maps for each row.
+  EXPECT_EQ(flatMapVector->sizeAt(0), 0);
+  EXPECT_EQ(flatMapVector->sizeAt(1), 0);
+  EXPECT_EQ(flatMapVector->sizeAt(2), 1);
+
+  // Check values for projected key 42.
+  auto channel = flatMapVector->getKeyChannel((int64_t)42);
+  ASSERT_NE(channel, std::nullopt);
+
+  auto projectedKey = flatMapVector->mapValuesAt(*channel);
+
+  EXPECT_TRUE(projectedKey->isNullAt(0)); // not in map.
+  EXPECT_TRUE(projectedKey->isNullAt(1)); // not in map.
+  EXPECT_TRUE(projectedKey->isNullAt(2)); // actual null.
+
+  EXPECT_FALSE(flatMapVector->isInMap(*channel, 0));
+  EXPECT_FALSE(flatMapVector->isInMap(*channel, 1));
+  EXPECT_TRUE(flatMapVector->isInMap(*channel, 2));
+}
+
+TEST_F(FlatMapVectorTest, primitiveKeys) {
+  // bigint key.
+  auto flatMapVector = maker_.flatMapVector<int64_t, double>({
+      {{101, 0}, {102, 0}, {1'234'567'890, 0}},
+  });
+  EXPECT_EQ(*flatMapVector->keyType(), *BIGINT());
+
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)101), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)102), 1);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)100), std::nullopt);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)103), std::nullopt);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)1'234'567'890), 2);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)1'234'567'891), std::nullopt);
+
+  // Wrong key type.
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel((int32_t)101),
+      "Incompatible vector type for flat map vector keys");
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel("bad key"),
+      "Incompatible vector type for flat map vector keys");
+
+  // integer key.
+  flatMapVector = maker_.flatMapVector<int32_t, double>({
+      {{10'987, 0}, {99, 0}, {1'234'567, 0}},
+  });
+
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int32_t)10'987), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int32_t)99), 1);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int32_t)100), std::nullopt);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int32_t)1'234'567), 2);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int32_t)1'234'568), std::nullopt);
+
+  // Wrong key type.
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel((int64_t)101),
+      "Incompatible vector type for flat map vector keys");
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel("bad key"),
+      "Incompatible vector type for flat map vector keys");
+
+  // string key.
+  flatMapVector = maker_.flatMapVector<std::string, double>({
+      {{"k1", 0}, {"k2", 0}},
+  });
+
+  EXPECT_EQ(*flatMapVector->getKeyChannel("k1"), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel("k2"), 1);
+  EXPECT_EQ(flatMapVector->getKeyChannel("k3"), std::nullopt);
+
+  // Wrong key type.
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel((int64_t)101),
+      "Incompatible vector type for flat map vector keys");
+  VELOX_ASSERT_THROW(
+      *flatMapVector->getKeyChannel((int32_t)1),
+      "Incompatible vector type for flat map vector keys");
+}
+
+TEST_F(FlatMapVectorTest, complexKeys) {
+  // Distinct keys vector.
+  auto arrayVector = maker_.arrayVector<int64_t>({
+      {{1, 2, 3}, {1, 2}, {1}},
+  });
+
+  std::vector<VectorPtr> mapValues{
+      // For key [1, 2, 3]
+      maker_.flatVector<int64_t>({101, 102}),
+
+      // For key [1, 2]
+      maker_.flatVector<int64_t>({201, 202}),
+
+      // For key [1]
+      maker_.flatVector<int64_t>({301, 302}),
+  };
+
+  auto flatMapVector = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      MAP(ARRAY(BIGINT()), REAL()),
+      nullptr,
+      2,
+      arrayVector,
+      std::move(mapValues),
+      std::vector<BufferPtr>{nullptr, nullptr, nullptr});
+
+  EXPECT_EQ(*flatMapVector->keyType(), *ARRAY(BIGINT()));
+
+  // For key [1, 2, 3]
+  auto channel = flatMapVector->getKeyChannel(arrayVector, 0);
+  ASSERT_NE(channel, std::nullopt);
+  auto projectedKey =
+      flatMapVector->mapValuesAt(*channel)->as<FlatVector<int64_t>>();
+
+  EXPECT_EQ(projectedKey->size(), 2);
+  EXPECT_EQ(projectedKey->valueAt(0), 101);
+  EXPECT_EQ(projectedKey->valueAt(1), 102);
+
+  // For key [1, 2]
+  channel = flatMapVector->getKeyChannel(arrayVector, 1);
+  ASSERT_NE(channel, std::nullopt);
+  projectedKey =
+      flatMapVector->mapValuesAt(*channel)->as<FlatVector<int64_t>>();
+
+  EXPECT_EQ(projectedKey->size(), 2);
+  EXPECT_EQ(projectedKey->valueAt(0), 201);
+  EXPECT_EQ(projectedKey->valueAt(1), 202);
+}
+
+TEST_F(FlatMapVectorTest, setDistinctKeys) {
+  // Distinct keys vector.
+  auto distinctKeys = maker_.flatVector<int64_t>({
+      {101, 102, 103},
+  });
+
+  auto type = MAP(BIGINT(), REAL());
+  auto flatMapVector = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      2,
+      distinctKeys,
+      std::vector<VectorPtr>{nullptr, nullptr, nullptr},
+      std::vector<BufferPtr>{nullptr, nullptr, nullptr});
+
+  EXPECT_EQ(flatMapVector->numDistinctKeys(), 3);
+  EXPECT_EQ(flatMapVector->mapValues().size(), 3);
+  EXPECT_EQ(flatMapVector->inMaps().size(), 3);
+
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)101), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)102), 1);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)103), 2);
+
+  // New vector of distinct keys.
+  distinctKeys = maker_.flatVector<int64_t>({
+      {20, 21, 22, 23, 24, 25, 26, 27, 28, 29},
+  });
+  flatMapVector->setDistinctKeys(distinctKeys);
+
+  EXPECT_EQ(flatMapVector->numDistinctKeys(), 10);
+  EXPECT_EQ(flatMapVector->mapValues().size(), 10);
+  EXPECT_EQ(flatMapVector->inMaps().size(), 0);
+
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)20), 0);
+  EXPECT_EQ(*flatMapVector->getKeyChannel((int64_t)29), 9);
+
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)101), std::nullopt);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)102), std::nullopt);
+  EXPECT_EQ(flatMapVector->getKeyChannel((int64_t)103), std::nullopt);
+}
+
+TEST_F(FlatMapVectorTest, sortedKeyIndices) {
+  auto flatMapVector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      {{{101, 1}, {105, 5}, {100, 0}, {102, 2}}},
+      {{{104, 4}, {102, 2}}},
+      {std::nullopt},
+  });
+
+  auto indices = flatMapVector->sortedKeyIndices(0);
+  ASSERT_THAT(indices, ::testing::ElementsAre(2, 0, 3, 1));
+
+  indices = flatMapVector->sortedKeyIndices(1);
+  ASSERT_THAT(indices, ::testing::ElementsAre(3, 4));
+
+  indices = flatMapVector->sortedKeyIndices(2);
+  ASSERT_THAT(indices, ::testing::ElementsAre());
+}
+
+TEST_F(FlatMapVectorTest, toString) {
+  auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      {{}},
+      {std::nullopt},
+      {{{1, 0}}},
+      {{{1, 1}, {2, std::nullopt}}},
+      {{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}},
+  });
+
+  EXPECT_EQ(
+      vector->toString(), "[FLAT_MAP MAP<BIGINT,BIGINT>: 5 elements, 1 nulls]");
+
+  EXPECT_EQ(vector->toString(0), "<empty>");
+  EXPECT_EQ(vector->toString(1), "null");
+  EXPECT_EQ(vector->toString(2), "1 elements {1 => 0}");
+  EXPECT_EQ(vector->toString(3), "2 elements {1 => 1, 2 => null}");
+  EXPECT_EQ(
+      vector->toString(4),
+      "6 elements {1 => 1, 2 => 2, 0 => 0, 3 => 3, 4 => 4, ...}");
+}
+
+TEST_F(FlatMapVectorTest, compare) {
+  auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      {std::nullopt}, // 0
+      {{{1, 0}}}, // 1
+      {{{1, 0}, {2, 0}}}, // 2
+      {{{1, 0}, {3, 0}, {4, 0}}}, // 3
+      {{{1, 0}, {3, 0}, {2, 0}}}, // 4
+      {{{1, 0}, {2, 0}, {3, 0}}}, // 5
+      {{{3, 0}, {1, 0}, {2, 1}}}, // 6
+  });
+
+  // Null map equals to null.
+  EXPECT_EQ(vector->compare(vector.get(), 0, 0, {}), 0);
+
+  // Maps of different sizes.
+  EXPECT_NE(vector->compare(vector.get(), 1, 2, {.equalsOnly = true}), 0);
+
+  EXPECT_LT(vector->compare(vector.get(), 2, 3, {.equalsOnly = true}), 0);
+  EXPECT_GT(vector->compare(vector.get(), 3, 2, {.equalsOnly = true}), 0);
+
+  EXPECT_LT(vector->compare(vector.get(), 2, 3, {}), 0);
+  EXPECT_GT(vector->compare(vector.get(), 3, 2, {}), 0);
+
+  EXPECT_LT(vector->compare(vector.get(), 2, 4, {}), 0);
+  EXPECT_GT(vector->compare(vector.get(), 4, 2, {}), 0);
+
+  EXPECT_EQ(vector->compare(vector.get(), 4, 5, {}), 0);
+  EXPECT_EQ(vector->compare(vector.get(), 5, 4, {}), 0);
+
+  EXPECT_LT(vector->compare(vector.get(), 5, 6, {}), 0);
+  EXPECT_GT(vector->compare(vector.get(), 6, 5, {}), 0);
+
+  // Descending.
+  EXPECT_GT(vector->compare(vector.get(), 5, 6, {.ascending = false}), 0);
+  EXPECT_LT(vector->compare(vector.get(), 6, 5, {.ascending = false}), 0);
+
+  // Cannot compare maps with nulls as indeterminate.
+  VELOX_ASSERT_THROW(
+      vector->compare(
+          vector.get(),
+          6,
+          5,
+          {.nullHandlingMode =
+               CompareFlags::NullHandlingMode::kNullAsIndeterminate}),
+      "Map is not orderable type");
+}
+
+TEST_F(FlatMapVectorTest, hash) {
+  auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      {std::nullopt}, // 0
+      {{{6, 0}}}, // 1
+      {{{1, 0}, {2, 0}}}, // 2
+      {{{1, 0}, {3, 0}, {2, 0}}}, // 3
+      {{{1, 0}, {2, 0}, {3, 0}}}, // 4
+      {{{1, 0}, {2, 0}, {3, 1}}}, // 5
+      {{{1, 0}, {2, 0}, {3, std::nullopt}}}, // 6
+      {std::nullopt}, // 7
+  });
+
+  // Nulls.
+  EXPECT_EQ(vector->hashValueAt(0), vector->hashValueAt(7));
+
+  EXPECT_NE(vector->hashValueAt(0), vector->hashValueAt(1));
+  EXPECT_NE(vector->hashValueAt(1), vector->hashValueAt(2));
+  EXPECT_NE(vector->hashValueAt(2), vector->hashValueAt(3));
+  EXPECT_NE(vector->hashValueAt(4), vector->hashValueAt(5));
+  EXPECT_NE(vector->hashValueAt(5), vector->hashValueAt(6));
+  EXPECT_NE(vector->hashValueAt(4), vector->hashValueAt(6));
+
+  EXPECT_EQ(vector->hashValueAt(3), vector->hashValueAt(4));
+}
+
+TEST_F(FlatMapVectorTest, slice) {
+  auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
+      {{{101, 1}, {102, 2}, {103, 3}}},
+      {{{105, 0}, {106, 0}}},
+      {std::nullopt},
+      {{{101, 11}, {103, 13}, {105, std::nullopt}}},
+      {{{101, 1}, {102, 2}, {103, 3}}},
+  });
+
+  auto slicedVector = vector->slice(1, 3);
+
+  EXPECT_EQ(slicedVector->size(), 3);
+  EXPECT_EQ(slicedVector->compare(vector.get(), 0, 1), 0);
+  EXPECT_EQ(slicedVector->compare(vector.get(), 1, 2), 0);
+  EXPECT_EQ(slicedVector->compare(vector.get(), 2, 3), 0);
+
+  EXPECT_NE(slicedVector->compare(vector.get(), 0, 0), 0);
+}
+
+} // namespace
+} // namespace facebook::velox::test

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -433,7 +433,12 @@ TEST_F(VectorCompareTest, compareNullAsIndeterminateNullMap) {
                   const std::string& map2,
                   CompareFlags flags,
                   std::optional<int32_t> expected) {
-    auto vector = makeMapVectorFromJson<int64_t, int64_t>({map1, map2});
+    // First test regular map.
+    VectorPtr vector = makeMapVectorFromJson<int64_t, int64_t>({map1, map2});
+    testCompare(vector, 0, 1, flags, expected);
+
+    // Then test a flat map.
+    vector = makeFlatMapVectorFromJson<int64_t, int64_t>({map1, map2});
     testCompare(vector, 0, 1, flags, expected);
   };
 

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::test {

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::test {

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -597,12 +597,31 @@ class VectorTestBase {
   /// @tparam V Type of map value. Can be an integer or a floating point number.
   /// @param jsonMaps A list of JSON maps. JSON map cannot be an empty
   /// string.
-  template <typename K, typename V>
+  template <typename TKey, typename TValue>
   MapVectorPtr makeMapVectorFromJson(
       const std::vector<std::string>& jsonMaps,
       const TypePtr& mapType =
-          MAP(CppToType<K>::create(), CppToType<V>::create())) {
-    return vectorMaker_.mapVectorFromJson<K, V>(jsonMaps, mapType);
+          MAP(CppToType<TKey>::create(), CppToType<TValue>::create())) {
+    return vectorMaker_.mapVectorFromJson<TKey, TValue>(jsonMaps, mapType);
+  }
+
+  /// Same as above but constructs a FlatMapVector instead of a MapVector.
+  template <typename TKey, typename TValue>
+  FlatMapVectorPtr makeFlatMapVector(
+      const std::vector<std::vector<std::pair<TKey, std::optional<TValue>>>>&
+          maps,
+      const TypePtr& mapType =
+          MAP(CppToType<TKey>::create(), CppToType<TValue>::create())) {
+    return vectorMaker_.flatMapVector(maps, mapType);
+  }
+
+  /// Same as above but constructs a FlatMapVector instead of a MapVector.
+  template <typename TKey, typename TValue>
+  FlatMapVectorPtr makeFlatMapVectorFromJson(
+      const std::vector<std::string>& jsonMaps,
+      const TypePtr& mapType =
+          MAP(CppToType<TKey>::create(), CppToType<TValue>::create())) {
+    return vectorMaker_.flatMapVectorFromJson<TKey, TValue>(jsonMaps, mapType);
   }
 
   // Convenience function to create vector from vectors of keys and values.


### PR DESCRIPTION
Summary:

Adding an in-memory vector layout for flat maps. FlatMapVector implements
the flat map layout, which is an alternative way of encoding logical maps.

Flat maps represent logical maps (the MAP() TypePtr), but instead of keeping
two inner vectors, one for keys and one for values (and buffers for
lenghts/offsets), like MapVector, flat maps group values for different keys
in different vectors.

The entire purpose of this layout is to support efficient key projection on
large maps, since projecting a particular key from the map can be done in a
zero-copy manner by just returning the map values vector for a particular
key.

See header documentation for a full description of the format. The next PRs 
will add more integration with different parts of the codebase.

Differential Revision: D74041657


