### PR TITLE
feat: Zip the sorting column indices and compare flags

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -421,8 +421,7 @@ class AggregationInputSpiller : public SpillerBase {
       RowContainer* container,
       RowTypePtr rowType,
       const HashBitRange& hashBitRange,
-      int32_t numSortingKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
+      const std::vector<SpillSortKey>& sortingKeys,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1185,7 +1185,6 @@ HashBuildSpiller::HashBuildSpiller(
           container,
           std::move(rowType),
           bits,
-          0,
           {},
           spillConfig->maxFileSize,
           spillConfig->maxSpillRunRows,

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/Exchange.h"
 #include "velox/exec/MergeSource.h"
+#include "velox/exec/Spill.h"
 #include "velox/exec/TreeOfLosers.h"
 
 namespace facebook::velox::exec {
@@ -64,7 +65,7 @@ class Merge : public SourceOperator {
   /// Maximum number of rows in the output batch.
   const vector_size_t outputBatchSize_;
 
-  std::vector<std::pair<column_index_t, CompareFlags>> sortingKeys_;
+  std::vector<SpillSortKey> sortingKeys_;
 
   /// A list of cursors over batches of ordered source data. One per source.
   /// Aligned with 'sources'.
@@ -89,7 +90,7 @@ class SourceStream final : public MergeStream {
  public:
   SourceStream(
       MergeSource* source,
-      const std::vector<std::pair<column_index_t, CompareFlags>>& sortingKeys,
+      const std::vector<SpillSortKey>& sortingKeys,
       uint32_t outputBatchSize)
       : source_{source},
         sortingKeys_{sortingKeys},
@@ -141,7 +142,7 @@ class SourceStream final : public MergeStream {
 
   MergeSource* source_;
 
-  const std::vector<std::pair<column_index_t, CompareFlags>>& sortingKeys_;
+  const std::vector<SpillSortKey>& sortingKeys_;
 
   /// Ordered source rows.
   RowVectorPtr data_;

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -549,7 +549,6 @@ RowNumberHashTableSpiller::RowNumberHashTableSpiller(
           container,
           std::move(rowType),
           bits,
-          0,
           {},
           spillConfig->maxFileSize,
           spillConfig->maxSpillRunRows,

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -346,13 +346,9 @@ void SortBuffer::updateEstimatedOutputRowSize() {
 void SortBuffer::spillInput() {
   if (inputSpiller_ == nullptr) {
     VELOX_CHECK(!noMoreInput_);
+    const auto sortingKeys = SpillState::makeSortingKeys(sortCompareFlags_);
     inputSpiller_ = std::make_unique<SortInputSpiller>(
-        data_.get(),
-        spillerStoreType_,
-        data_->keyTypes().size(),
-        sortCompareFlags_,
-        spillConfig_,
-        spillStats_);
+        data_.get(), spillerStoreType_, sortingKeys, spillConfig_, spillStats_);
   }
   inputSpiller_->spill();
   data_->clear();

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -179,14 +179,9 @@ void SortWindowBuild::ensureSortFits() {
 
 void SortWindowBuild::setupSpiller() {
   VELOX_CHECK_NULL(spiller_);
-
+  const auto sortingKeys = SpillState::makeSortingKeys(compareFlags_);
   spiller_ = std::make_unique<SortInputSpiller>(
-      data_.get(),
-      inputType_,
-      compareFlags_.size(),
-      compareFlags_,
-      spillConfig_,
-      spillStats_);
+      data_.get(), inputType_, sortingKeys, spillConfig_, spillStats_);
 }
 
 void SortWindowBuild::spill() {

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -55,8 +55,7 @@ class SpillerBase {
       RowContainer* container,
       RowTypePtr rowType,
       HashBitRange bits,
-      int32_t numSortingKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
+      const std::vector<SpillSortKey>& sortingKeys,
       uint64_t targetFileSize,
       uint64_t maxSpillRunRows,
       std::optional<SpillPartitionId> parentId,
@@ -151,6 +150,8 @@ class SpillerBase {
 
   folly::Synchronized<common::SpillStats>* const spillStats_;
 
+  const std::vector<CompareFlags> compareFlags_;
+
   // True if all rows of spilling partitions are in 'spillRuns_', so
   // that one can start reading these back.
   bool finalized_{false};
@@ -205,6 +206,14 @@ class NoRowContainerSpiller : public SpillerBase {
       RowTypePtr rowType,
       std::optional<SpillPartitionId> parentId,
       HashBitRange bits,
+      const std::vector<SpillSortKey>& sortingKeys,
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
+
+  NoRowContainerSpiller(
+      RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
+      HashBitRange bits,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
 
@@ -235,16 +244,14 @@ class SortInputSpiller : public SpillerBase {
   SortInputSpiller(
       RowContainer* container,
       RowTypePtr rowType,
-      int32_t numSortingKeys,
-      const std::vector<CompareFlags>& sortCompareFlags,
+      const std::vector<SpillSortKey>& sortingKeys,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats)
       : SpillerBase(
             container,
             std::move(rowType),
             HashBitRange{},
-            numSortingKeys,
-            sortCompareFlags,
+            sortingKeys,
             std::numeric_limits<uint64_t>::max(),
             spillConfig->maxSpillRunRows,
             std::nullopt,

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -756,12 +756,11 @@ void TopNRowNumber::spill() {
 void TopNRowNumber::setupSpiller() {
   VELOX_CHECK_NULL(spiller_);
   VELOX_CHECK(spillConfig_.has_value());
-
+  const auto sortingKeys = SpillState::makeSortingKeys(spillCompareFlags_);
   spiller_ = std::make_unique<SortInputSpiller>(
       data_.get(),
       inputType_,
-      spillCompareFlags_.size(),
-      spillCompareFlags_,
+      sortingKeys,
       &spillConfig_.value(),
       &spillStats_);
 }

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -148,6 +148,8 @@ std::unique_ptr<SpillerBase> AggregateSpillBenchmarkBase::makeSpiller() {
   spillConfig.numPartitionBits = 3;
 
   if (spillerType_ == AggregationInputSpiller::kType) {
+    const auto sortingKeys = SpillState::makeSortingKeys(
+        std::vector<CompareFlags>(rowContainer_->keyTypes().size()));
     return std::make_unique<AggregationInputSpiller>(
         rowContainer_.get(),
         rowType_,
@@ -155,8 +157,7 @@ std::unique_ptr<SpillerBase> AggregateSpillBenchmarkBase::makeSpiller() {
             spillConfig.startPartitionBit,
             static_cast<uint8_t>(
                 spillConfig.startPartitionBit + spillConfig.numPartitionBits)},
-        rowContainer_->keyTypes().size(),
-        std::vector<CompareFlags>{},
+        sortingKeys,
         &spillConfig,
         &spillStats_);
   } else {

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -120,8 +120,7 @@ class HashJoinBridgeTest : public testing::Test,
            rowType_,
            tempDir_->getPath() + "/Spill_" + std::to_string(fileId),
            1024,
-           1,
-           std::vector<CompareFlags>({}),
+           SpillState::makeSortingKeys(std::vector<CompareFlags>(1)),
            common::CompressionKind_NONE});
     }
     return files;

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -637,11 +637,14 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       spiller_ = std::make_unique<NoRowContainerSpiller>(
           rowType_, std::nullopt, hashBits_, &spillConfig_, &spillStats_);
     } else if (type_ == SpillerType::SORT_INPUT) {
+      const auto sortingKeys = SpillState::makeSortingKeys(
+          compareFlags_.empty()
+              ? std::vector<CompareFlags>(rowContainer_->keyTypes().size())
+              : compareFlags_);
       spiller_ = std::make_unique<SortInputSpiller>(
           rowContainer_.get(),
           rowType_,
-          rowContainer_->keyTypes().size(),
-          compareFlags_,
+          sortingKeys,
           &spillConfig_,
           &spillStats_);
     } else if (type_ == SpillerType::SORT_OUTPUT) {
@@ -657,12 +660,15 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           &spillConfig_,
           &spillStats_);
     } else if (type_ == SpillerType::AGGREGATION_INPUT) {
+      const auto sortingKeys = SpillState::makeSortingKeys(
+          compareFlags_.empty()
+              ? std::vector<CompareFlags>(rowContainer_->keyTypes().size())
+              : compareFlags_);
       spiller_ = std::make_unique<AggregationInputSpiller>(
           rowContainer_.get(),
           rowType_,
           hashBits_,
-          rowContainer_->keyTypes().size(),
-          compareFlags_,
+          sortingKeys,
           &spillConfig_,
           &spillStats_);
     } else if (type_ == SpillerType::AGGREGATION_OUTPUT) {


### PR DESCRIPTION
Currently, the sorted spiller moves the sorting columns to the front
and uses the number of sorting keys to access them. Zip the sorting
column indices and compare flags into a vector of pairs, decoupling
the RowVector layout from the sorting process. Hence, it can handle
both cases: when the sorting keys are adjusted and when no adjustment
is made.

Part of #13260 