### PR TITLE
fix: Array_min/max_by function empty arrays handling

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -125,8 +125,6 @@ int main(int argc, char** argv) {
       "array_join(array(real),varchar,varchar) -> varchar",
       "array_join(array(double),varchar) -> varchar",
       "array_join(array(double),varchar,varchar) -> varchar",
-      "array_min_by", // https://github.com/facebookincubator/velox/issues/12934
-      "array_max_by", // https://github.com/facebookincubator/velox/issues/12934
       // https://github.com/facebookincubator/velox/issues/13047
       "inverse_poisson_cdf",
       // Geometry functions don't yet have a ValuesGenerator


### PR DESCRIPTION
Summary:
Fix array min/max by function to handle null/empty arrays:
- use addNullsForUnselectedRows to take care of unselected rows
- add null for case where flatArray is empty and std::max_element returns range.end()

Also some other fuzzer found issues:
- incorrect behavior when the lambda function returns the same results for all elements - should return first element for array_min_by and last for array_max_by
- fail with "Ordering nulls unsupported" error like Presto when lambda function returns array with null elements


Unit tests:
- added unit tests for the above
- add tests for constant and dictionary encoded arrays

Differential Revision: D74204373


