### PR TITLE
fix(type): Fix use after free in BaseVector

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -602,11 +602,11 @@ void BaseVector::ensureWritable(
     }
     return;
   }
-  const auto& resultType = result->type();
-  bool isUnknownType = resultType->containsUnknown();
   if (result->encoding() == VectorEncoding::Simple::LAZY) {
     result = BaseVector::loadedVectorShared(result);
   }
+  const auto& resultType = result->type();
+  const bool isUnknownType = resultType->containsUnknown();
   if (result.use_count() == 1 && !isUnknownType) {
     switch (result->encoding()) {
       case VectorEncoding::Simple::FLAT:


### PR DESCRIPTION
Summary:
In `BaseVector::ensureWriteable`, we store a reference to `result->type()` on line 605.  However, if the vector is lazily encoded, we end up re-assigning `result` later on line 608, causing this reference to become invalid.  This was causing heap use after free errors in validation service: https://fburl.com/scuba/dwrf_reader_checksum/a6ieb95n.

The fix is to store type by value instead.  It's a shared pointer, so this copy is not expensive.

Differential Revision: D74420826


