### PR TITLE
fix: No Filters Generated

### DIFF
--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -348,14 +348,11 @@ void FilterGenerator::collectFilterableSubFields(
     auto kind = rowType->childAt(i)->kind();
     switch (kind) {
       // ignore these types for filtering
-      case TypeKind::ARRAY:
-      case TypeKind::MAP:
       case TypeKind::UNKNOWN:
       case TypeKind::FUNCTION:
       case TypeKind::OPAQUE:
       case TypeKind::VARBINARY:
       case TypeKind::TIMESTAMP:
-      case TypeKind::ROW:
       case TypeKind::INVALID:
         continue;
 


### PR DESCRIPTION
Summary:
The RootValidationStage was failing with the error "Filters file does not exist or was not populated". This issue occurred when random subfield column selections only chose complex types, resulting in no filters being generated.

This diff addresses handling cases where no filters are generated due to complex type selections.

With these changes, the RootValidationStage should now correctly handle scenarios where no filters are generated, and provide more informative error messages when failures occur.

We will also handle filter files not being populated for in later selective stages to prevent failing other stages.

Differential Revision: D74423751


