### PR TITLE
build: Add VELOX_WAVE_NVRTC_INCLUDE_PATH flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -418,6 +418,11 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
     velox_set_source(cudf)
     velox_resolve_dependency(cudf)
   endif()
+  if(VELOX_ENABLE_WAVE)
+    set(VELOX_WAVE_NVRTC_INCLUDE_PATH
+        "/usr/local/cuda/include"
+        CACHE STRING "Specify the default include path to use for RTC in Wave")
+  endif()
 endif()
 
 # Set after the test of the CUDA compiler. Otherwise, the test fails with

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -34,7 +34,10 @@ target_link_libraries(
   CUDA::cudart
   breeze_cuda)
 
-target_compile_definitions(velox_wave_common PRIVATE VELOX_OSS_BUILD=1)
+target_compile_definitions(
+  velox_wave_common
+  PRIVATE VELOX_OSS_BUILD=1
+          VELOX_WAVE_NVRTC_INCLUDE_PATH=${VELOX_WAVE_NVRTC_INCLUDE_PATH})
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/experimental/wave/common/Compile.cu
+++ b/velox/experimental/wave/common/Compile.cu
@@ -43,6 +43,9 @@ DEFINE_int32(
 #include "velox/facebook/NvrtcUtil.h"
 #endif
 
+// FIXME: Use FOLLY_PP_STRINGIZE_MACRO when available.
+#define PP_STRINGIZE_MACRO(x) FOLLY_PP_STRINGIZE(x)
+
 namespace facebook::velox::wave {
 
 void nvrtcCheck(nvrtcResult result) {
@@ -93,9 +96,10 @@ void addFlag(
 
 #ifdef VELOX_OSS_BUILD
 void getDefaultNvrtcOptions(std::vector<std::string>& data) {
-  constexpr const char* kUsrLocalCuda = "/usr/local/cuda/include";
-  LOG(INFO) << "Using " << kUsrLocalCuda;
-  addFlag("-I", kUsrLocalCuda, strlen(kUsrLocalCuda), data);
+  constexpr const char* kIncludePath =
+      PP_STRINGIZE_MACRO(VELOX_WAVE_NVRTC_INCLUDE_PATH);
+  LOG(INFO) << "Using " << kIncludePath;
+  addFlag("-I", kIncludePath, strlen(kIncludePath), data);
 }
 #endif
 


### PR DESCRIPTION
Add compile time flag that can be used to specify the default include path for RTC in Wave. WAVE_NVRTC_INCLUDE_PATH env var can still be used to override this at runtime.