### PR TITLE
feat: Add subfield filter feature into tableevolutionfuzzer

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -102,7 +102,9 @@ class TableEvolutionFuzzer {
 
   std::unique_ptr<TaskCursor> makeScanTask(
       const RowTypePtr& tableSchema,
-      std::vector<Split> splits);
+      std::vector<Split> splits,
+      bool hasPushDown,
+      const PushdownConfig& pushdownConfig);
 
   const Config config_;
   VectorFuzzer vectorFuzzer_;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -32,6 +32,10 @@ enum class Table : uint8_t;
 
 namespace facebook::velox::exec::test {
 
+struct PushdownConfig {
+  common::SubfieldFilters subfieldFiltersMap;
+};
+
 /// A builder class with fluent API for building query plans. Plans are built
 /// bottom up starting with the source node (table scan or similar). Expressions
 /// and orders can be specified using SQL. See filter, project and orderBy
@@ -172,6 +176,24 @@ class PlanBuilder {
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& assignments = {});
 
+  /// Add a TableScanNode to scan a Hive table with direct SubfieldFilters.
+  ///
+  /// @param outputType List of column names and types to read from the table.
+  /// @param PushdownConfig Contains pushdown configs for the table scan.
+  /// @param remainingFilter SQL expression for the additional conjunct.
+  /// @param dataColumns Optional data columns that may differ from outputType.
+  /// @param assignments Optional ColumnHandles.
+
+  PlanBuilder& tableScan(
+      const RowTypePtr& outputType,
+      bool hasPushDown,
+      const PushdownConfig& pushdownConfig,
+      const std::string& remainingFilter = "",
+      const RowTypePtr& dataColumns = nullptr,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+
   /// Add a TableScanNode to scan a TPC-H table.
   ///
   /// @param tpchTableHandle The handle that specifies the target TPC-H table
@@ -238,6 +260,10 @@ class PlanBuilder {
     /// >  column < v1
     /// >  column >= v2
     TableScanBuilder& subfieldFilters(std::vector<std::string> subfieldFilters);
+
+    // @param subfieldFiltersMap A map of Subfield to Filters.
+    TableScanBuilder& subfieldFiltersMap(
+        const common::SubfieldFilters& filtersMap);
 
     /// @param subfieldFilter A single SQL expression to be applied to an
     /// individual column.
@@ -316,6 +342,9 @@ class PlanBuilder {
 
     // Generates the id of a FilterNode if 'filtersAsNode_'.
     std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator_;
+
+    // SubfieldFilters object containing filters to apply.
+    common::SubfieldFilters subfieldFiltersMap_;
   };
 
   /// Start a TableScanBuilder.


### PR DESCRIPTION
Summary:
enable tableevolutionfuzzer to have the feature of testing subfield filters randomly generated

We can do refactor in subsequent diffs, this diff is mainly focusing on adding the functionality.

Differential Revision: D74492387


