### PR TITLE
test: Enable fuzz tests for BingTile functions (#12924)

### DIFF
--- a/velox/common/fuzzer/CMakeLists.txt
+++ b/velox/common/fuzzer/CMakeLists.txt
@@ -18,8 +18,12 @@ velox_link_libraries(velox_common_fuzzer_util velox_type velox_exception)
 
 velox_add_library(velox_constrained_input_generators ConstrainedGenerators.cpp)
 
-velox_link_libraries(velox_constrained_input_generators Folly::folly velox_type
-                     velox_common_fuzzer_util)
+velox_link_libraries(
+  velox_constrained_input_generators
+  Folly::folly
+  velox_type
+  velox_common_fuzzer_util
+  velox_functions_prestosql)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -489,4 +489,15 @@ class TDigestInputGenerator : public AbstractInputGenerator {
   variant generate() override;
 };
 
+class BingTileInputGenerator : public AbstractInputGenerator {
+ public:
+  BingTileInputGenerator(size_t seed, const TypePtr& type, double nullRatio);
+
+  ~BingTileInputGenerator() override;
+
+  variant generate() override;
+
+ private:
+  int64_t generateImpl();
+};
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -123,13 +123,6 @@ int main(int argc, char** argv) {
       "array_join(array(real),varchar,varchar) -> varchar",
       "array_join(array(double),varchar) -> varchar",
       "array_join(array(double),varchar,varchar) -> varchar",
-      // BingTiles throw VeloxUserError when zoom/x/y are out of range.
-      "bing_tile",
-      "bing_tile_zoom_level",
-      "bing_tile_coordinates",
-      "bing_tile_parent",
-      "bing_tile_children",
-      "bing_tile_quadkey",
       "array_min_by", // https://github.com/facebookincubator/velox/issues/12934
       "array_max_by", // https://github.com/facebookincubator/velox/issues/12934
       // https://github.com/facebookincubator/velox/issues/13047

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/prestosql/types/BingTileRegistration.h"
 
+#include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 
@@ -130,8 +131,9 @@ class BingTileTypeFactories : public CustomTypeFactories {
   }
 
   AbstractInputGeneratorPtr getInputGenerator(
-      const InputGeneratorConfig& /*config*/) const override {
-    return nullptr;
+      const InputGeneratorConfig& config) const override {
+    return std::make_shared<fuzzer::BingTileInputGenerator>(
+        config.seed_, BINGTILE(), config.nullRatio_);
   }
 };
 

--- a/velox/functions/prestosql/types/BingTileType.cpp
+++ b/velox/functions/prestosql/types/BingTileType.cpp
@@ -38,7 +38,7 @@ std::optional<std::string> BingTileType::bingTileInvalidReason(uint64_t tile) {
         BingTileType::kBingTileMaxZoomLevel);
   }
 
-  uint64_t coordinateBound = 1 << zoom;
+  uint64_t coordinateBound = 1ul << zoom;
 
   if (BingTileType::bingTileX(tile) >= coordinateBound) {
     return fmt::format(

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -120,7 +120,7 @@ class BingTileType : public BigintType {
   /// Returns true if the tile (as uint64) is valid
   static inline bool isBingTileIntValid(uint64_t tile) {
     uint8_t zoom = bingTileZoom(tile);
-    uint64_t coordinateBound = 1 << zoom;
+    uint64_t coordinateBound = 1ul << zoom;
     // Using bitwise & so that it's branchless and the data
     // can be prefetched and the ops pipelined.
     // Linter wants the bools cast to uint8 for bitwise ops.


### PR DESCRIPTION
Summary:

Previously, fuzz tests would raise errors for functions that
took BingTile arguments, because the fuzzer would default to bigint,
and most bigints are not valid BingTiles.  Thus we'd get runtime errors.

This creates a BingTile input type generator that only creates valid
BingTiles.  Since BingTiles are validated on creation, if the argument
is already a BingTile, it is valid.  Thus our fuzzer should also use
valid BingTiles.

Reviewed By: kgpai

Differential Revision: D72434294


