### PR TITLE
fix: Fix wrong memory pool capacity log

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -763,7 +763,7 @@ class MemoryPoolImpl : public MemoryPool {
       std::unique_ptr<MemoryReclaimer> reclaimer) override;
 
   FOLLY_ALWAYS_INLINE int64_t capacityLocked() const {
-    return parent_ != nullptr ? toImpl(parent_)->capacity_ : capacity_;
+    return toImpl(root())->capacity_;
   }
 
   FOLLY_ALWAYS_INLINE int64_t availableReservationLocked() const {

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -208,14 +208,14 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
        false,
        std::vector<std::string>{
            "allocateContiguous failed with .* pages",
-           "max capacity 128.00MB unlimited capacity used .* available .*",
+           "max capacity 128.00MB capacity 128.00MB used .* available .*",
            ".* reservation .used .*MB, reserved .*MB, min 0B. counters",
            "allocs .*, frees .*, reserves .*, releases .*, collisions .*"}},
       {64LL << 20,
        true,
        std::vector<std::string>{
            "allocateContiguous failed with .* pages",
-           "max capacity 128.00MB unlimited capacity used .* available .*",
+           "max capacity 128.00MB capacity 128.00MB used .* available .*",
            ".* reservation .used .*MB, reserved .*MB, min .*B. counters",
            ".*, frees .*, reserves .*, releases .*, collisions .*"}}};
   for (const auto& testData : testSettings) {


### PR DESCRIPTION
Summary: MemoryPoolImpl::capacityLocked() should give root's capacity instead of its direct parents'

Differential Revision: D74505323


