### PR TITLE
feat: Add PageSpill for OutputBuffer spill

### DIFF
--- a/velox/exec/SerializedPageSpiller.cpp
+++ b/velox/exec/SerializedPageSpiller.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SerializedPageSpiller.h"
+#include "velox/exec/SpillFile.h"
+
+namespace facebook::velox::exec {
+
+void SerializedPageSpiller::spill(
+    const std::vector<std::shared_ptr<SerializedPage>>& pages) {
+  writeWithBufferControl([&]() {
+    if (pages.empty()) {
+      return 0UL;
+    }
+
+    if (bufferStream_ == nullptr) {
+      bufferStream_ = std::make_unique<IOBufOutputStream>(*pool_);
+    }
+
+    // Spill file layout:
+    //  --- Page 0 ---
+    //
+    //  (1 Byte) is null page
+    //  (8 Bytes) payload size
+    //  (1 Bytes) has num rows
+    //  (8 Bytes) num rows
+    //  (x Bytes) payload
+    //
+    //  --- Page 1 ---
+    //        ...
+    //  --- Page n ---
+    //        ...
+    const auto totalBytesBeforeSpill = totalBytes_;
+    uint64_t totalRows{0};
+    for (const auto& page : pages) {
+      if (page != nullptr) {
+        const auto pageSize = page->size();
+        totalBytes_ += pageSize;
+        totalRows += page->numRows().value_or(0);
+      }
+
+      // Spill payload headers.
+      const uint8_t isNull = (page == nullptr) ? 1 : 0;
+      bufferStream_->write(
+          reinterpret_cast<const char*>(&isNull), sizeof(uint8_t));
+      if (page == nullptr) {
+        continue;
+      }
+
+      auto pageBytes = static_cast<int64_t>(page->size());
+      bufferStream_->write(
+          reinterpret_cast<char*>(&pageBytes), sizeof(int64_t));
+
+      const auto numRowsOpt = page->numRows();
+      uint8_t hasNumRows = numRowsOpt.has_value() ? 1 : 0;
+      bufferStream_->write(reinterpret_cast<const char*>(&hasNumRows), 1);
+      if (numRowsOpt.has_value()) {
+        const int64_t numRows = numRowsOpt.value();
+        bufferStream_->write(
+            reinterpret_cast<const char*>(&numRows), sizeof(int64_t));
+      }
+
+      // Spill payload.
+      auto iobuf = page->getIOBuf();
+      for (auto range = iobuf->begin(); range != iobuf->end(); ++range) {
+        bufferStream_->write(
+            reinterpret_cast<const char*>(range->data()),
+            static_cast<int64_t>(range->size()));
+      }
+    }
+
+    VELOX_CHECK_GE(totalBytes_, totalBytesBeforeSpill);
+    totalPages_ += pages.size();
+    return totalRows;
+  });
+}
+
+SerializedPageSpiller::Result SerializedPageSpiller::finishSpill() {
+  auto spillFiles = finish();
+  return {std::move(spillFiles), totalPages_};
+}
+
+void SerializedPageSpiller::flushBuffer(
+    SpillWriteFile* file,
+    uint64_t& writtenBytes,
+    uint64_t& flushTimeNs,
+    uint64_t& writeTimeNs) {
+  flushTimeNs = 0;
+  {
+    NanosecondTimer timer(&writeTimeNs);
+    writtenBytes = file->write(bufferStream_->getIOBuf());
+  }
+}
+
+bool SerializedPageSpiller::bufferEmpty() const {
+  return bufferStream_ == nullptr;
+}
+
+uint64_t SerializedPageSpiller::bufferSize() const {
+  return bufferStream_ == nullptr
+      ? 0
+      : static_cast<uint64_t>(bufferStream_->tellp());
+}
+
+void SerializedPageSpiller::addFinishedFile(SpillWriteFile* file) {
+  SpillFileInfo spillFileInfo;
+  spillFileInfo.path = file->path();
+  finishedFiles_.push_back(std::move(spillFileInfo));
+}
+
+bool SerializedPageSpillReader::empty() const {
+  return numPages_ == 0;
+}
+
+uint64_t SerializedPageSpillReader::numPages() const {
+  return numPages_;
+}
+
+std::shared_ptr<SerializedPage> SerializedPageSpillReader::at(uint64_t index) {
+  ensurePages(index);
+  return bufferedPages_[index];
+}
+
+void SerializedPageSpillReader::deleteAll() {
+  spillFilePaths_.clear();
+  curFileStream_.reset();
+  bufferedPages_.clear();
+  numPages_ = 0;
+}
+
+void SerializedPageSpillReader::deleteFront(uint64_t numPages) {
+  if (numPages == 0) {
+    return;
+  }
+  ensurePages(numPages - 1);
+  bufferedPages_.erase(
+      bufferedPages_.begin(), bufferedPages_.begin() + numPages);
+  numPages_ -= numPages;
+}
+
+void SerializedPageSpillReader::ensureSpillFile() {
+  if (curFileStream_ != nullptr) {
+    return;
+  }
+  VELOX_CHECK(!spillFilePaths_.empty());
+  auto filePath = spillFilePaths_.front();
+  auto fs = filesystems::getFileSystem(filePath, nullptr);
+  auto file = fs->openFileForRead(filePath);
+  curFileStream_ = std::make_unique<common::FileInputStream>(
+      std::move(file), readBufferSize_, pool_);
+  spillFilePaths_.pop_front();
+}
+
+void SerializedPageSpillReader::ensurePages(uint64_t index) {
+  VELOX_CHECK_LT(index, numPages_);
+  if (index < bufferedPages_.size()) {
+    return;
+  }
+
+  while (index >= bufferedPages_.size()) {
+    bufferedPages_.push_back(unspillNextPage());
+  }
+}
+
+namespace {
+struct FreeData {
+  const std::shared_ptr<memory::MemoryPool> pool;
+  int64_t bytesToFree{0};
+};
+
+void freeFunc(void* data, void* userData) {
+  auto* freeData = reinterpret_cast<FreeData*>(userData);
+  freeData->pool->free(data, freeData->bytesToFree);
+  delete freeData;
+}
+} // namespace
+
+std::shared_ptr<SerializedPage> SerializedPageSpillReader::unspillNextPage() {
+  VELOX_CHECK(!empty());
+  ensureSpillFile();
+
+  SCOPE_EXIT {
+    if (curFileStream_->atEnd()) {
+      curFileStream_.reset();
+    }
+  };
+
+  // Read payload headers
+  const auto isNull = !!(curFileStream_->read<uint8_t>());
+  if (isNull) {
+    return nullptr;
+  }
+  const auto iobufBytes = curFileStream_->read<int64_t>();
+  const auto hasNumRows = curFileStream_->read<uint8_t>() == 0 ? false : true;
+  int64_t numRows{0};
+  if (hasNumRows) {
+    numRows = curFileStream_->read<int64_t>();
+  }
+
+  // Read payload
+  VELOX_CHECK_GE(curFileStream_->remainingSize(), iobufBytes);
+  void* rawBuf = pool_->allocate(iobufBytes);
+  curFileStream_->readBytes(reinterpret_cast<uint8_t*>(rawBuf), iobufBytes);
+
+  auto* userData = new FreeData(pool_->shared_from_this(), iobufBytes);
+  auto iobuf =
+      folly::IOBuf::takeOwnership(rawBuf, iobufBytes, freeFunc, userData, true);
+
+  return std::make_shared<SerializedPage>(
+      std::move(iobuf),
+      nullptr,
+      hasNumRows ? std::optional(numRows) : std::nullopt);
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/SerializedPageSpiller.h
+++ b/velox/exec/SerializedPageSpiller.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/base/SpillStats.h"
+#include "velox/common/file/FileInputStream.h"
+#include "velox/exec/ExchangeQueue.h"
+#include "velox/exec/SpillFile.h"
+
+namespace facebook::velox::exec {
+namespace test {
+class SerializedPageSpillerHelper;
+class SerializedPageSpillReaderHelper;
+} // namespace test
+
+/// Used for spilling a sequence of 'SerializedPage'. The spiller preserves the
+/// order of the pages.
+class SerializedPageSpiller : public SpillWriterBase {
+ public:
+  struct Result {
+    SpillFiles spillFiles;
+    uint64_t totalPages;
+  };
+
+  SerializedPageSpiller(
+      uint64_t writeBufferSize,
+      uint64_t targetFileSize,
+      const std::string& pathPrefix,
+      const std::string& fileCreateConfig,
+      common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
+      memory::MemoryPool* pool,
+      folly::Synchronized<common::SpillStats>* stats)
+      : SpillWriterBase(
+            writeBufferSize,
+            targetFileSize,
+            pathPrefix,
+            fileCreateConfig,
+            updateAndCheckSpillLimitCb,
+            pool,
+            stats) {
+    VELOX_CHECK_NOT_NULL(pool_);
+  }
+
+  /// Spill 'pages' to disk. The method does not free the original in-memory
+  /// structure of 'pages'. It is caller's responsibility to free them.
+  void spill(const std::vector<std::shared_ptr<SerializedPage>>& pages);
+
+  /// Finishes the spilling and return the spilled result.
+  Result finishSpill();
+
+ private:
+  void flushBuffer(
+      SpillWriteFile* file,
+      uint64_t& writtenBytes,
+      uint64_t& flushTimeNs,
+      uint64_t& writeTimeNs) override;
+
+  bool bufferEmpty() const override;
+
+  uint64_t bufferSize() const override;
+
+  void addFinishedFile(SpillWriteFile* file) override;
+
+  uint64_t totalBytes_{0};
+
+  uint64_t totalPages_{0};
+
+  std::unique_ptr<IOBufOutputStream> bufferStream_;
+
+  friend class test::SerializedPageSpillerHelper;
+};
+
+/// Used for reading a sequence of 'SerializedPage' that were spilled by
+/// 'SerializedPageSpiller'. The reader preserves the page order, and provides
+/// random index access functionality in a load-on-read manner. It is used by
+/// 'DestinationBuffer' and provides convenient APIs for reading and deleting
+/// the pages, with unspilling handled transparently.
+class SerializedPageSpillReader {
+ public:
+  SerializedPageSpillReader(
+      SerializedPageSpiller::Result&& spillResult,
+      uint64_t readBufferSize,
+      memory::MemoryPool* pool,
+      folly::Synchronized<common::SpillStats>* spillStats)
+      : readBufferSize_(readBufferSize),
+        pool_(pool),
+        spillStats_(spillStats),
+        numPages_(spillResult.totalPages) {
+    for (const auto& spillFileInfo : spillResult.spillFiles) {
+      spillFilePaths_.push_back(spillFileInfo.path);
+    }
+  }
+
+  /// Returns true if there are any remaining pages left to read.
+  bool empty() const;
+
+  /// Returns the current number of pages in the reader.
+  uint64_t numPages() const;
+
+  /// Returns the page at 'index' in the reader.
+  std::shared_ptr<SerializedPage> at(uint64_t index);
+
+  /// Delete 'numPages' from the front.
+  void deleteFront(uint64_t numPages);
+
+  /// Delete all pages from the reader.
+  void deleteAll();
+
+ private:
+  // Ensures the current file stream is open. If not, opens the next file.
+  void ensureSpillFile();
+
+  // Ensures all pages up to 'index' are loaded in memory.
+  void ensurePages(uint64_t index);
+
+  // Unspills one serialized page and returns it.
+  std::shared_ptr<SerializedPage> unspillNextPage();
+
+  const uint64_t readBufferSize_;
+
+  memory::MemoryPool* const pool_;
+
+  folly::Synchronized<common::SpillStats>* const spillStats_;
+
+  // The current file stream.
+  std::unique_ptr<common::FileInputStream> curFileStream_;
+
+  // A small number of front pages buffered in memory from spilled pages.
+  // These pages will be kept in memory and won't be spilled again.
+  std::vector<std::shared_ptr<SerializedPage>> bufferedPages_;
+
+  std::deque<std::string> spillFilePaths_;
+
+  uint64_t numPages_;
+
+  friend class test::SerializedPageSpillReaderHelper;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -54,6 +54,8 @@ class SpillWriteFile {
 
   uint64_t write(std::unique_ptr<folly::IOBuf> iobuf);
 
+  void write(const char* data, uint64_t bytes);
+
   WriteFile* file() {
     return file_.get();
   }

--- a/velox/exec/tests/SerializedPageSpillerTest.cpp
+++ b/velox/exec/tests/SerializedPageSpillerTest.cpp
@@ -1,0 +1,467 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SerializedPageSpiller.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/SerializedPageUtil.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+namespace facebook::velox::exec::test {
+class SerializedPageSpillerHelper {
+ public:
+  SerializedPageSpillerHelper(SerializedPageSpiller& spiller)
+      : spiller_(spiller) {}
+
+  void checkSpillerConsistency() {
+    if (spiller_.totalPages_ == 0) {
+      ASSERT_EQ(spiller_.totalBytes_, 0);
+      ASSERT_EQ(spiller_.bufferStream_, nullptr);
+    }
+    if (spiller_.totalBytes_ > 0) {
+      ASSERT_GT(spiller_.totalPages_, 0);
+      ASSERT_GT(spiller_.bufferStream_->tellp(), spiller_.totalBytes_);
+    }
+  }
+
+ private:
+  SerializedPageSpiller const& spiller_;
+};
+
+class SerializedPageSpillReaderHelper {
+ public:
+  SerializedPageSpillReaderHelper(SerializedPageSpillReader& reader)
+      : reader_(reader) {}
+
+  void checkReaderConsistency() {
+    ASSERT_GE(reader_.numPages_, reader_.bufferedPages_.size());
+  }
+
+  void assertNumBufferedPages(uint64_t numPages) {
+    ASSERT_EQ(reader_.bufferedPages_.size(), numPages);
+  }
+
+ private:
+  SerializedPageSpillReader const& reader_;
+};
+
+class SerializedPageSpillerTest : public exec::test::OperatorTestBase {
+ public:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    rng_.seed(0);
+  }
+
+ protected:
+  std::vector<std::shared_ptr<SerializedPage>> generateData(
+      uint32_t numPages,
+      int64_t maxPageSize,
+      bool hasVoidedNumRows,
+      int64_t maxNumRows) {
+    std::vector<std::shared_ptr<SerializedPage>> pages;
+    pages.reserve(numPages);
+    for (auto i = 0; i < numPages; ++i) {
+      auto iobufBytes = folly::Random().rand64(maxPageSize, rng_);
+
+      // Setup a chained iobuf.
+      std::unique_ptr<folly::IOBuf> iobuf;
+      if (iobufBytes > 1) {
+        auto firstHalfBytes = iobufBytes / 2;
+        iobuf = folly::IOBuf::create(firstHalfBytes);
+        std::memset(iobuf->writableData(), 'x', firstHalfBytes);
+        iobuf->append(firstHalfBytes);
+
+        auto secondHalfBytes = iobufBytes - firstHalfBytes;
+        auto secondHalfBuf = folly::IOBuf::create(secondHalfBytes);
+        std::memset(secondHalfBuf->writableData(), 'y', secondHalfBytes);
+        secondHalfBuf->append(secondHalfBytes);
+        iobuf->prependChain(std::move(secondHalfBuf));
+      } else {
+        iobuf = folly::IOBuf::create(iobufBytes);
+        std::memset(iobuf->writableData(), 'x', iobufBytes);
+        iobuf->append(iobufBytes);
+      }
+
+      std::optional<int64_t> numRowsOpt;
+      if (!hasVoidedNumRows || folly::Random().oneIn(2, rng_)) {
+        numRowsOpt = std::optional(folly::Random().rand64(maxNumRows, rng_));
+      }
+      pages.push_back(std::make_shared<SerializedPage>(
+          std::move(iobuf), nullptr, numRowsOpt));
+    }
+    return pages;
+  }
+
+  void checkIOBufsEqual(
+      std::unique_ptr<folly::IOBuf>& buf1,
+      std::unique_ptr<folly::IOBuf>& buf2) {
+    auto coalescedBuf1 = buf1->coalesce();
+    auto coalescedBuf2 = buf2->coalesce();
+    ASSERT_EQ(coalescedBuf1.size(), coalescedBuf2.size());
+    ASSERT_EQ(
+        std::memcmp(
+            coalescedBuf1.data(), coalescedBuf2.data(), coalescedBuf1.size()),
+        0);
+  }
+
+  void checkSerializedPageEqual(SerializedPage& page1, SerializedPage& page2) {
+    ASSERT_EQ(page1.numRows().has_value(), page2.numRows().has_value());
+    if (page1.numRows().has_value()) {
+      ASSERT_EQ(page1.numRows().value(), page1.numRows().value());
+    }
+    auto buf1 = page1.getIOBuf();
+    auto buf2 = page2.getIOBuf();
+    checkIOBufsEqual(buf1, buf2);
+  }
+
+  folly::Random::DefaultGenerator rng_;
+  common::UpdateAndCheckSpillLimitCB updateAndCheckSpillLimitCB_{
+      [](uint64_t /* unused */) {}};
+};
+} // namespace facebook::velox::exec::test
+
+TEST_F(SerializedPageSpillerTest, pageSpillerBasic) {
+  auto pool = rootPool_->addLeafChild("destinationBufferSpiller");
+
+  struct TestValue {
+    uint32_t numPages;
+    int64_t maxPageSize;
+    bool hasVoidedNumRows;
+    int64_t maxNumRows;
+    uint64_t readBufferSize;
+    uint64_t writeBufferSize;
+    uint64_t targetFileSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "numPages {}, maxPageSize {}, hasVoidedNumRows {}, maxNumRows {}, "
+          "readBufferSize {}, writeBufferSize {}, targetFileSize {}",
+          numPages,
+          maxPageSize,
+          hasVoidedNumRows,
+          maxNumRows,
+          readBufferSize,
+          writeBufferSize,
+          targetFileSize);
+    }
+  };
+
+  std::vector<TestValue> testValues{
+      {10, 64, true, 20, 1024, 1024, 2048},
+      {10, 64, false, 20, 1024, 0, 2048},
+      {0, 64, true, 20, 1024, 256, 2048},
+      {10, 64, true, 20, 1, 2048, 128},
+      {10, 0, true, 20, 128, 2048, 128}};
+
+  for (const auto& testValue : testValues) {
+    SCOPED_TRACE(testValue.debugString());
+
+    auto tempFile = exec::test::TempFilePath::create();
+    const auto& prefixPath = tempFile->getPath();
+    auto fs = filesystems::getFileSystem(prefixPath, {});
+    SCOPE_EXIT {
+      fs->remove(prefixPath);
+    };
+
+    auto pages = generateData(
+        testValue.numPages,
+        testValue.maxPageSize,
+        testValue.hasVoidedNumRows,
+        testValue.maxNumRows);
+
+    folly::Synchronized<common::SpillStats> spillStats;
+    SerializedPageSpiller spiller(
+        testValue.writeBufferSize,
+        testValue.targetFileSize,
+        prefixPath,
+        "",
+        updateAndCheckSpillLimitCB_,
+        pool.get(),
+        &spillStats);
+    SerializedPageSpillerHelper spillerHelper(spiller);
+    spillerHelper.checkSpillerConsistency();
+
+    spiller.spill(pages);
+    spillerHelper.checkSpillerConsistency();
+
+    auto spillResults = spiller.finishSpill();
+
+    SerializedPageSpillReader reader(
+        std::move(spillResults),
+        testValue.readBufferSize,
+        pool.get(),
+        &spillStats);
+    SerializedPageSpillReaderHelper readerHelper(reader);
+
+    ASSERT_EQ(reader.empty(), pages.empty());
+    ASSERT_EQ(reader.numPages(), pages.size());
+
+    VELOX_ASSERT_THROW(reader.at(pages.size()), "");
+    readerHelper.checkReaderConsistency();
+
+    VELOX_ASSERT_THROW(reader.deleteFront(pages.size() + 1), "");
+    readerHelper.checkReaderConsistency();
+
+    if (pages.empty()) {
+      ASSERT_TRUE(reader.empty());
+      continue;
+    }
+
+    ASSERT_FALSE(reader.empty());
+    uint32_t i = 0;
+    while (!reader.empty()) {
+      if (reader.at(0) != nullptr) {
+        ASSERT_EQ(reader.at(0)->size(), pages[i]->size());
+      } else {
+        ASSERT_EQ(pages[i], nullptr);
+      }
+      readerHelper.checkReaderConsistency();
+
+      auto unspilledPage = reader.at(0);
+      readerHelper.checkReaderConsistency();
+
+      ASSERT_LT(i, pages.size());
+      ASSERT_EQ(unspilledPage->numRows(), pages[i]->numRows());
+      ASSERT_EQ(unspilledPage->size(), pages[i]->size());
+      auto originalIOBuf = pages[i]->getIOBuf();
+      auto unspilledIOBuf = unspilledPage->getIOBuf();
+      checkIOBufsEqual(originalIOBuf, unspilledIOBuf);
+      if (testValue.maxPageSize == 0) {
+        ASSERT_GE(pool->usedBytes(), 0);
+      } else {
+        ASSERT_GT(pool->usedBytes(), 0);
+      }
+      reader.deleteFront(1);
+      ++i;
+    }
+    ASSERT_EQ(i, pages.size());
+    ASSERT_TRUE(reader.empty());
+    ASSERT_EQ(reader.numPages(), 0);
+
+    VELOX_ASSERT_THROW(reader.at(0), "");
+    readerHelper.checkReaderConsistency();
+
+    VELOX_ASSERT_THROW(reader.deleteFront(1), "");
+    readerHelper.checkReaderConsistency();
+
+    ASSERT_NO_THROW(reader.deleteAll());
+    readerHelper.checkReaderConsistency();
+  }
+  ASSERT_EQ(pool->usedBytes(), 0);
+}
+
+TEST_F(SerializedPageSpillerTest, spillReaderAccessors) {
+  auto pool = rootPool_->addLeafChild("spillReaderAccessors");
+  auto pages = generateData(20, 1LL << 20, true, 1000);
+
+  struct TestValue {
+    std::string testName;
+    std::function<void(
+        std::vector<std::shared_ptr<SerializedPage>>&,
+        SerializedPageSpillReader&,
+        uint64_t)>
+        accessorVerifier;
+    std::string debugString() {
+      return testName;
+    }
+  };
+
+  std::vector<TestValue> testValues{
+      {"SerializedPageSpillReader::at",
+       [this](auto& originalPages, auto& reader, auto index) {
+         // Accessor verifier for SerializedPageSpillReader::at()
+         if (index >= originalPages.size()) {
+           VELOX_ASSERT_THROW(reader.at(index), "");
+           return;
+         }
+         auto originalPage = originalPages[index];
+         auto unspilledPage = reader.at(index);
+         if (originalPage == nullptr) {
+           ASSERT_EQ(unspilledPage, nullptr);
+           return;
+         }
+         ASSERT_EQ(originalPage->size(), unspilledPage->size());
+         ASSERT_EQ(originalPage->numRows(), unspilledPage->numRows());
+         auto originalIOBuf = originalPage->getIOBuf();
+         auto unspilledIOBuf = unspilledPage->getIOBuf();
+         checkIOBufsEqual(originalIOBuf, unspilledIOBuf);
+       }}};
+
+  for (auto& testValue : testValues) {
+    SCOPED_TRACE(testValue.debugString());
+    auto tempFile = exec::test::TempFilePath::create();
+    const auto& prefixPath = tempFile->getPath();
+    auto fs = filesystems::getFileSystem(prefixPath, {});
+    SCOPE_EXIT {
+      fs->remove(prefixPath);
+    };
+
+    folly::Synchronized<common::SpillStats> spillStats;
+    SerializedPageSpiller spiller(
+        1024,
+        2048,
+        prefixPath,
+        "",
+        updateAndCheckSpillLimitCB_,
+        pool.get(),
+        &spillStats);
+    SerializedPageSpillerHelper spillerHelper(spiller);
+    spiller.spill(pages);
+    spillerHelper.checkSpillerConsistency();
+    auto spillResults = spiller.finishSpill();
+
+    SerializedPageSpillReader reader(
+        std::move(spillResults), 1024, pool.get(), &spillStats);
+    SerializedPageSpillReaderHelper readerHelper(reader);
+
+    testValue.accessorVerifier(pages, reader, 1);
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(2);
+
+    testValue.accessorVerifier(pages, reader, 10);
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(11);
+
+    testValue.accessorVerifier(pages, reader, 25);
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(11);
+
+    testValue.accessorVerifier(pages, reader, 19);
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(20);
+
+    testValue.accessorVerifier(pages, reader, 5);
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(20);
+  }
+  ASSERT_EQ(pool->usedBytes(), 0);
+}
+
+TEST_F(SerializedPageSpillerTest, spillReaderDelete) {
+  auto pool = rootPool_->addLeafChild("spillReaderDelete");
+  const auto kNumPages = 20;
+  auto pages = generateData(kNumPages, 1LL << 20, true, 1000);
+
+  struct TestValue {
+    uint32_t numBufferedPages;
+    uint32_t numDelete;
+
+    std::string debugString() {
+      return fmt::format(
+          "numBufferedPages {}, numDelete {}", numBufferedPages, numDelete);
+    }
+  };
+
+  std::vector<TestValue> testValues{
+      {0, 0},
+      {0, 10},
+      {0, 20},
+      {0, 25},
+      {10, 0},
+      {10, 5},
+      {10, 15},
+      {10, 20},
+      {10, 25}};
+  for (auto& testValue : testValues) {
+    SCOPED_TRACE(testValue.debugString());
+    // Test delete front.
+    auto tempFile = exec::test::TempFilePath::create();
+    const auto& prefixPath = tempFile->getPath();
+    auto fs = filesystems::getFileSystem(prefixPath, {});
+    SCOPE_EXIT {
+      fs->remove(prefixPath);
+    };
+
+    folly::Synchronized<common::SpillStats> spillStats;
+    SerializedPageSpiller spiller(
+        1024,
+        2048,
+        prefixPath,
+        "",
+        updateAndCheckSpillLimitCB_,
+        pool.get(),
+        &spillStats);
+    SerializedPageSpillerHelper spillerHelper(spiller);
+    spiller.spill(pages);
+    spillerHelper.checkSpillerConsistency();
+    auto spillResult = spiller.finishSpill();
+
+    SerializedPageSpillReader reader(
+        std::move(spillResult), 1024, pool.get(), &spillStats);
+    SerializedPageSpillReaderHelper readerHelper(reader);
+
+    // Unspill pages to buffer
+    if (testValue.numBufferedPages > 0) {
+      reader.at(testValue.numBufferedPages - 1);
+    }
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(testValue.numBufferedPages);
+
+    if (testValue.numDelete > kNumPages) {
+      VELOX_ASSERT_THROW(reader.deleteFront(testValue.numDelete), "");
+      readerHelper.checkReaderConsistency();
+      readerHelper.assertNumBufferedPages(testValue.numBufferedPages);
+      continue;
+    } else {
+      reader.deleteFront(testValue.numDelete);
+    }
+    readerHelper.checkReaderConsistency();
+    if (testValue.numDelete <= testValue.numBufferedPages) {
+      readerHelper.assertNumBufferedPages(
+          testValue.numBufferedPages - testValue.numDelete);
+    } else {
+      readerHelper.assertNumBufferedPages(0);
+    }
+  }
+
+  {
+    // Test delete all.
+    auto tempFile = exec::test::TempFilePath::create();
+    const auto& prefixPath = tempFile->getPath();
+    auto fs = filesystems::getFileSystem(prefixPath, {});
+    SCOPE_EXIT {
+      fs->remove(prefixPath);
+    };
+
+    folly::Synchronized<common::SpillStats> spillStats;
+    SerializedPageSpiller spiller(
+        1024,
+        2048,
+        prefixPath,
+        "",
+        updateAndCheckSpillLimitCB_,
+        pool.get(),
+        &spillStats);
+    SerializedPageSpillerHelper spillerHelper(spiller);
+    spiller.spill(pages);
+    spillerHelper.checkSpillerConsistency();
+    auto spillResult = spiller.finishSpill();
+
+    SerializedPageSpillReader reader(
+        std::move(spillResult), 1024, pool.get(), &spillStats);
+    SerializedPageSpillReaderHelper readerHelper(reader);
+
+    reader.at(10);
+    reader.deleteAll();
+    readerHelper.checkReaderConsistency();
+    readerHelper.assertNumBufferedPages(0);
+  }
+}


### PR DESCRIPTION
Summary: Add SerializedPageSpiller and SerializedPageSpillReader to facilitate spilling for DestinationBuffer.

Differential Revision: D74381170


