### PR TITLE
fix: Fix HashJoinBridgeTest.multiThreading

### DIFF
--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -394,7 +394,7 @@ std::optional<HashJoinBridge::SpillInput> HashJoinBridge::spillInputOrFuture(
 
 bool HashJoinBridge::testingHasMoreSpilledPartitions() {
   std::lock_guard<std::mutex> l(mutex_);
-  return spillPartitionSet_.hasNext() || restoringSpillPartitionId_.has_value();
+  return spillPartitionSet_.hasNext();
 }
 
 bool isLeftNullAwareJoinWithFilter(

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -248,8 +248,8 @@ TEST_P(HashJoinBridgeTest, withoutSpill) {
     ASSERT_TRUE(futures[0].valid());
 
     // Probe side completion.
-    joinBridge->probeFinished();
     ASSERT_FALSE(joinBridge->testingHasMoreSpilledPartitions());
+    joinBridge->probeFinished();
     ASSERT_FALSE(helper.buildResult().has_value());
 
     futures[0].wait();
@@ -365,8 +365,8 @@ TEST_P(HashJoinBridgeTest, withSpill) {
       }
 
       // Probe table.
-      joinBridge->probeFinished();
       ASSERT_EQ(hasMoreSpill, joinBridge->testingHasMoreSpilledPartitions());
+      joinBridge->probeFinished();
       // Probe can't set spilled table partitions after it finishes probe.
       VELOX_ASSERT_THROW(
           joinBridge->appendSpilledHashTablePartitions({}),
@@ -542,10 +542,10 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
             probeFuture.wait();
           } else {
             proberBarrier.reset(new BarrierState());
-            joinBridge->probeFinished();
             ASSERT_EQ(
                 joinBridge->testingHasMoreSpilledPartitions(),
                 !spillPartitionIdSet.empty());
+            joinBridge->probeFinished();
             for (auto& promise : promises) {
               promise.setValue();
             }
@@ -557,10 +557,10 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
       });
     }
 
-    for (auto& th : builderThreads) {
+    for (auto& th : proberThreads) {
       th.join();
     }
-    for (auto& th : proberThreads) {
+    for (auto& th : builderThreads) {
       th.join();
     }
   }


### PR DESCRIPTION
Summary:
The flaky test was caused by the flakiness in the test itself. There's no regression in the production code.

The test was flaky because we make the has next spill partition check after probe notifies the build side in a multi threaded environment. Build side can process very fast and finishes the processing of the partition before the check happens on the probe thread, making the check failing.

This diff fixes the test by doing the check before probeFinished() call to avoid such race condition.

Differential Revision: D74536491


