### PR TITLE
fix: FloatingPointRange::testDoubleRange

### DIFF
--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1416,7 +1416,9 @@ class FloatingPointRange final : public AbstractRange {
       return true;
     }
 
-    return !(min > upper_ || max < lower_);
+    return !(
+        (!upperUnbounded_ && min > upper_) ||
+        (!lowerUnbounded_ && max < lower_));
   }
 
   std::unique_ptr<Filter> mergeWith(const Filter* other) const final {

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -677,6 +677,16 @@ TEST(FilterTest, doubleRange) {
 
   EXPECT_THROW(betweenDouble(NAN, NAN), VeloxRuntimeError)
       << "able to create a DoubleRange with NaN";
+
+  // A filter that has upper value set but really is unbounded.
+  filter = std::make_unique<common::DoubleRange>(
+      3, false, false, 0, true, false, true);
+  EXPECT_TRUE(filter->testDoubleRange(1, 100, false));
+  EXPECT_FALSE(filter->testDoubleRange(0, 1, false));
+  EXPECT_TRUE(filter->testDoubleRange(0, 1, true));
+  EXPECT_FALSE(filter->testDouble(1));
+  EXPECT_TRUE(filter->testDouble(3));
+  EXPECT_TRUE(filter->testDouble(100));
 }
 
 TEST(FilterTest, floatRange) {
@@ -732,6 +742,16 @@ TEST(FilterTest, floatRange) {
   EXPECT_THROW(
       betweenFloat(std::nanf("NAN"), std::nanf("NAN")), VeloxRuntimeError)
       << "able to create a FloatRange with NaN";
+
+  // A filter that has upper value set but really is unbounded.
+  filter = std::make_unique<common::FloatRange>(
+      3, false, false, 0, true, false, true);
+  EXPECT_TRUE(filter->testDoubleRange(1, 100, false));
+  EXPECT_FALSE(filter->testDoubleRange(0, 1, false));
+  EXPECT_TRUE(filter->testDoubleRange(0, 1, true));
+  EXPECT_FALSE(filter->testFloat(1));
+  EXPECT_TRUE(filter->testFloat(3));
+  EXPECT_TRUE(filter->testFloat(100));
 }
 
 TEST(FilterTest, bytesRange) {


### PR DESCRIPTION
Summary:
When either side of the filter range is unbounded, and the
corresponding upper/lower is set to a finite value,
`FloatingPointRange::testDoubleRange` would use the upper/lower value and ignore
the fact that it's unbounded on that side.  In Prestissimo the upper/lower is
set to infinity or negative infinity if the side is unbounded, so we do not see
this bug there.

Differential Revision: D74538066


