### PR TITLE
fix: Support float to double schema evolution

### DIFF
--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -85,7 +85,12 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::readHelper(
     ExtractValues extractValues) {
   reinterpret_cast<Reader*>(this)->readWithVisitor(
       rows,
-      ColumnVisitor<TData, TFilter, ExtractValues, isDense>(
+      ColumnVisitor<
+          TData,
+          TFilter,
+          ExtractValues,
+          isDense,
+          std::is_same_v<TData, TRequested>>(
           *reinterpret_cast<TFilter*>(filter), this, rows, extractValues));
 }
 
@@ -131,8 +136,10 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::processFilter(
       break;
     case velox::common::FilterKind::kDoubleRange:
     case velox::common::FilterKind::kFloatRange:
-      readHelper<Reader, velox::common::FloatingPointRange<TData>, isDense>(
-          filter, rows, extractValues);
+      readHelper<
+          Reader,
+          velox::common::FloatingPointRange<TRequested>,
+          isDense>(filter, rows, extractValues);
       break;
     default:
       readHelper<Reader, velox::common::Filter, isDense>(


### PR DESCRIPTION
Summary:
Currently the Nimble selective reader is missing the schema evolution support for `float` to `double` conversion (other types are already supported).  Adding this missing support using the existing mechanism provided by the selective reader framework.

There is a caveat that when this schema evolution happens, the current `Filter::testValues` implementation would not work (which means we cannot use fast path).  In DWRF we have a dedicated `FloatingPointDecoder` that knows the requested and data type, but in Nimble, decoders are decoupled from column reader, so we cannot pass that information to decoders.  Instead we add `hasBulkPath` as a compile time constant to the decoder visitor, so it can disable the fast path when needed.

Differential Revision: D74537747


