### PR TITLE
fix: Prevent leaking promises in HashProbe

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -493,6 +493,7 @@ void HashProbe::wakeupPeerOperators() {
   for (auto& promise : promises) {
     promise.setValue();
   }
+  promises_.clear();
 }
 
 std::vector<HashProbe*> HashProbe::findPeerOperators() {
@@ -2057,6 +2058,11 @@ void HashProbe::close() {
   spillOutputPartitionSet_.clear();
   spillOutputReader_.reset();
   clearBuffers();
+
+  // Fullfill any pending promises
+  if (lastProber_) {
+    wakeupPeerOperators();
+  }
 }
 
 void HashProbe::clearBuffers() {


### PR DESCRIPTION
Summary:
HashProbe my create promises by calling `noMoreInputInternal()` which calls `allPeersFinished()` to create async tasks that are to be fullfilled at a later point in time.

 Drivers/Tasks which own this operator can be aborted/cancelled at any point in time, and HashProbe must still fullfill the promise even when tis happens.

Differential Revision: D74442158


