### PR TITLE
fix: Added type validation for intermediate and output vectors

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -347,6 +347,12 @@ class Aggregate {
       const std::string& name,
       const std::vector<TypePtr>& argTypes);
 
+  // Returns the final type for 'name' with signature
+  // 'argTypes'. Throws if cannot resolve.
+  static TypePtr finalType(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes);
+
  protected:
   virtual void setAllocatorInternal(HashStringAllocator* allocator);
 

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1840,7 +1840,7 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
   auto maxCallExpr = std::make_shared<const core::CallTypedExpr>(
       SMALLINT(), std::vector<core::TypedExprPtr>{intInputField}, "max");
   auto distinctCountCallExpr = std::make_shared<const core::CallTypedExpr>(
-      VARCHAR(),
+      VARBINARY(),
       std::vector<core::TypedExprPtr>{intInputField},
       "approx_distinct");
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/verax/pull/11

Fixed a crash in D74199165. Adding validation to Velox to simplify future debugging.

TL;DR We don't validate output types in aggregate functions.
For example, if intermediateType in Coordinator is `Row<int>` and in Velox it's `Row<double>`, no validation will occur. Dynamic cast for FlatVectors doesn't catch this mismatch either, because `RowVector` isn't a template. Without validation we can write by wrong offset in the result vector.

Differential Revision: D74435817
