### PR TITLE
fix: Enable cache fuzz test

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -848,8 +848,6 @@ jobs:
     container: ghcr.io/facebookincubator/velox-dev:centos9
     needs: compile
     timeout-minutes: 120
-    # Temporarily disable on PRs till flakiness is fixed #12167
-    if: ${{ github.event_name != 'pull_request' }}
     steps:
 
       - name: Download cache fuzzer


### PR DESCRIPTION
This patch re-enabled cache fuzz test. It was disabled due to flaky and should be fixed now