### PR TITLE
feat: Geometry overlay operations

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -126,6 +126,31 @@ function you are using.
 
 .. _DE-9IM: https://en.wikipedia.org/wiki/DE-9IM
 
+Spatial Operations
+------------------
+
+.. function:: ST_Difference(geometry1: Geometry, geometry2: Geometry) -> difference: Geometry
+
+    Returns the geometry that represents the portion of ``geometry1`` that is
+    not contained in ``geometry2``.
+
+.. function:: ST_Intersection(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
+
+    Returns the geometry that represents the portion of ``geometry1`` that is
+    also contained in ``geometry2``.
+
+.. function:: ST_SymDifference(geometry1: Geometry, geometry2: Geometry) -> symdifference: Geometry
+
+    Returns the geometry that represents the portion of ``geometry1`` that is
+    not contained in ``geometry2`` as well as the portion of ``geometry1`` that
+    is not congtained in ``geometry1``.
+
+.. function:: ST_Union(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
+
+    Returns the geometry that represents the all points in either ``geometry1``
+    or ``geometry2``.
+
+
 Bing Tile Functions
 -------------------
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -142,6 +142,10 @@ int main(int argc, char** argv) {
       "st_overlaps",
       "st_touches",
       "st_within",
+      "st_difference",
+      "st_intersection",
+      "st_symdifference",
+      "st_union",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -291,4 +291,104 @@ struct StWithinFunction {
   }
 };
 
+// Overlay operations
+
+template <typename T>
+struct StDifferenceFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& leftGeometry,
+      const arg_type<Geometry>& rightGeometry) {
+    // TODO: When #12771 is merged, check envelopes and short-circuit
+    // if envelopes are disjoint
+    std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
+        geospatial::deserializeGeometry(leftGeometry);
+    std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
+        geospatial::deserializeGeometry(rightGeometry);
+
+    std::unique_ptr<geos::geom::Geometry> outputGeometry;
+    GEOS_TRY(outputGeometry = leftGeosGeometry->difference(&*rightGeosGeometry);
+             , "Failed to compute geometry difference");
+
+    result = geospatial::serializeGeometry(*outputGeometry);
+    return Status::OK();
+  }
+};
+
+template <typename T>
+struct StIntersectionFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& leftGeometry,
+      const arg_type<Geometry>& rightGeometry) {
+    // TODO: When #12771 is merged, check envelopes and short-circuit
+    // if envelopes are disjoint
+    std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
+        geospatial::deserializeGeometry(leftGeometry);
+    std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
+        geospatial::deserializeGeometry(rightGeometry);
+
+    std::unique_ptr<geos::geom::Geometry> outputGeometry;
+    GEOS_TRY(
+        outputGeometry = leftGeosGeometry->intersection(&*rightGeosGeometry);
+        , "Failed to compute geometry intersection");
+
+    result = geospatial::serializeGeometry(*outputGeometry);
+    return Status::OK();
+  }
+};
+
+template <typename T>
+struct StSymDifferenceFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& leftGeometry,
+      const arg_type<Geometry>& rightGeometry) {
+    // TODO: When #12771 is merged, check envelopes and short-circuit
+    // if envelopes are disjoint
+    std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
+        geospatial::deserializeGeometry(leftGeometry);
+    std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
+        geospatial::deserializeGeometry(rightGeometry);
+
+    std::unique_ptr<geos::geom::Geometry> outputGeometry;
+    GEOS_TRY(
+        outputGeometry = leftGeosGeometry->symDifference(&*rightGeosGeometry);
+        , "Failed to compute geometry symdifference");
+
+    result = geospatial::serializeGeometry(*outputGeometry);
+    return Status::OK();
+  }
+};
+
+template <typename T>
+struct StUnionFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& leftGeometry,
+      const arg_type<Geometry>& rightGeometry) {
+    // TODO: When #12771 is merged, check envelopes and short-circuit if
+    // one/both are empty
+    std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
+        geospatial::deserializeGeometry(leftGeometry);
+    std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
+        geospatial::deserializeGeometry(rightGeometry);
+
+    std::unique_ptr<geos::geom::Geometry> outputGeometry;
+    GEOS_TRY(outputGeometry = leftGeosGeometry->Union(&*rightGeosGeometry);
+             , "Failed to compute geometry union");
+
+    result = geospatial::serializeGeometry(*outputGeometry);
+    return Status::OK();
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -44,6 +44,17 @@ void registerRelationPredicates(const std::string& prefix) {
       {{prefix + "ST_Within"}});
 }
 
+void registerOverlayOperations(const std::string& prefix) {
+  registerFunction<StDifferenceFunction, Geometry, Geometry, Geometry>(
+      {{prefix + "ST_Difference"}});
+  registerFunction<StIntersectionFunction, Geometry, Geometry, Geometry>(
+      {{prefix + "ST_Intersection"}});
+  registerFunction<StSymDifferenceFunction, Geometry, Geometry, Geometry>(
+      {{prefix + "ST_SymDifference"}});
+  registerFunction<StUnionFunction, Geometry, Geometry, Geometry>(
+      {{prefix + "ST_Union"}});
+}
+
 } // namespace
 
 void registerGeometryFunctions(const std::string& prefix) {
@@ -61,6 +72,7 @@ void registerGeometryFunctions(const std::string& prefix) {
       {{prefix + "ST_AsBinary"}});
 
   registerRelationPredicates(prefix);
+  registerOverlayOperations(prefix);
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
This implements the four core overlay operations: Union, Intersection, Difference, and Symmetric Difference.
For Union, this only implements the binary operation, leaving `geometry_union(array<geometry>)` for a later PR.

Differential Revision: D74671626


