### PR TITLE
fix(qdigest): Fix undefined behavior when total weight is greater than max value of int64_t

### DIFF
--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -533,6 +533,12 @@ void QuantileDigest<T, Allocator>::add(T value, double weight) {
   auto previousCount = weightedCount_;
   insert(longToBits(processedValue), weight);
   auto compressionFactor = calculateCompressionFactor();
+
+  VELOX_USER_CHECK_LT(
+      weightedCount_,
+      std::numeric_limits<int64_t>::max(),
+      "Weighted count in digest is too large: {}",
+      weightedCount_);
   if (needsCompression ||
       checkedDivide(
           static_cast<int64_t>(previousCount),

--- a/velox/functions/lib/tests/QuantileDigestTest.cpp
+++ b/velox/functions/lib/tests/QuantileDigestTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/lib/QuantileDigest.h"
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/RandomSeed.h"
 #include "velox/functions/lib/tests/QuantileDigestTestBase.h"
 
@@ -69,6 +70,17 @@ class QuantileDigestTest : public QuantileDigestTestBase {
   }
 
   template <typename T>
+  void testHugeWeight() {
+    constexpr int N = 10;
+    constexpr double kAccuracy = 0.99;
+    constexpr T kMaxValue = std::numeric_limits<T>::max();
+    QuantileDigest<T> digest{StlAllocator<T>(allocator()), kAccuracy};
+    for (auto i = 0; i < N; ++i) {
+      digest.add(T(i), kMaxValue);
+    }
+  }
+
+  template <typename T>
   void testLargeInputSize() {
     constexpr int N = 1e5;
     constexpr double kAccuracy = 0.8;
@@ -101,7 +113,6 @@ class QuantileDigestTest : public QuantileDigestTestBase {
   void testEquivalentMerge() {
     constexpr double kAccuracy = 0.5;
     QuantileDigest<T> digest1{allocator(), kAccuracy};
-    // QuantileDigest<T> digest2{allocator(), kAccuracy};
 
     std::default_random_engine gen(common::testutil::getRandomSeed(42));
     std::uniform_real_distribution<> dist;
@@ -109,10 +120,6 @@ class QuantileDigestTest : public QuantileDigestTestBase {
       auto v = T(dist(gen));
       auto w = (i + 2) % 3 + 1;
       digest1.add(v, w);
-
-      /*v = T(dist(gen));
-      w = (i + 3) % 7 + 1;
-      digest2.add(v, w);*/
     }
 
     QuantileDigest<T> mergeResult{allocator(), kAccuracy};
@@ -536,6 +543,15 @@ TEST_F(QuantileDigestTest, scale) {
   testScale<int64_t>();
   testScale<double>();
   testScale<float>();
+}
+
+TEST_F(QuantileDigestTest, hugeWeight) {
+  VELOX_ASSERT_THROW(
+      testHugeWeight<int64_t>(), "Weighted count in digest is too large");
+  VELOX_ASSERT_THROW(
+      testHugeWeight<double>(), "Weighted count in digest is too large");
+  VELOX_ASSERT_THROW(
+      testHugeWeight<float>(), "Weighted count in digest is too large");
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary: 
QuantileDigest static_cast the double weightedCount_ to int64_t during 
QuantileDigest::add. If weightedCount_ is greater than the max value can be 
represented by int64_t, it causes undefined behavior. This diff fixes this bug by 
checking the value of weightedCount_ explicitly before the static_cast.

Differential Revision: D74684860


