### PR TITLE
feat: Add lazy start with spill for LocalMerge

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2165,6 +2165,10 @@ class LocalMergeNode : public PlanNode {
     return sortingKeys_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return !sortingKeys_.empty() && queryConfig.localMergeSpillEnabled();
+  }
+
   const std::vector<SortOrder>& sortingOrders() const {
     return sortingOrders_;
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -266,9 +266,9 @@ class QueryConfig {
   /// LocalMerge spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kLocalMergeSpillEnabled = "local_merge_enabled";
 
-  /// LocalMerge max merge sources.
-  static constexpr const char* kLocalMergeMaxMergeSources =
-      "local_merge_max_merge_source";
+  /// Specify the max number of local sources to merge at a time.
+  static constexpr const char* kLocalMergeMaxNumMergeSources =
+      "local_merge_max_num_merge_sources";
 
   /// The max row numbers to fill and spill for each spill run. This is used to
   /// cap the memory used for spilling. If it is zero, then there is no limit
@@ -846,12 +846,12 @@ class QueryConfig {
   }
 
   bool localMergeSpillEnabled() const {
-    return get<bool>(kLocalMergeSpillEnabled, true);
+    return get<bool>(kLocalMergeSpillEnabled, false);
   }
 
-  uint32_t localMergeMaxMergeSources() const {
+  uint32_t localMergeMaxNumMergeSources() const {
     return get<uint32_t>(
-        kLocalMergeMaxMergeSources, std::numeric_limits<uint32_t>::max());
+        kLocalMergeMaxNumMergeSources, std::numeric_limits<uint32_t>::max());
   }
 
   int32_t maxSpillLevel() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -850,8 +850,10 @@ class QueryConfig {
   }
 
   uint32_t localMergeMaxNumMergeSources() const {
-    return get<uint32_t>(
+    const auto maxNumMergeSources = get<uint32_t>(
         kLocalMergeMaxNumMergeSources, std::numeric_limits<uint32_t>::max());
+    VELOX_CHECK_GT(maxNumMergeSources, 0);
+    return maxNumMergeSources;
   }
 
   int32_t maxSpillLevel() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -263,6 +263,13 @@ class QueryConfig {
   static constexpr const char* kTopNRowNumberSpillEnabled =
       "topn_row_number_spill_enabled";
 
+  /// LocalMerge spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kLocalMergeSpillEnabled = "local_merge_enabled";
+
+  /// LocalMerge max merge sources.
+  static constexpr const char* kLocalMergeMaxMergeSources =
+      "local_merge_max_merge_source";
+
   /// The max row numbers to fill and spill for each spill run. This is used to
   /// cap the memory used for spilling. If it is zero, then there is no limit
   /// and spilling might run out of memory.
@@ -836,6 +843,15 @@ class QueryConfig {
 
   bool topNRowNumberSpillEnabled() const {
     return get<bool>(kTopNRowNumberSpillEnabled, true);
+  }
+
+  bool localMergeSpillEnabled() const {
+    return get<bool>(kLocalMergeSpillEnabled, true);
+  }
+
+  uint32_t localMergeMaxMergeSources() const {
+    return get<uint32_t>(
+        kLocalMergeMaxMergeSources, std::numeric_limits<uint32_t>::max());
   }
 
   int32_t maxSpillLevel() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -277,6 +277,10 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashBuild and HashProbe operators can spill to disk under memory pressure.
+   * - local_merge_enabled
+     - boolean
+     - false
+     - When `spill_enabled` is true, determines whether LocalMerge operators can spill to disk to cap memory usage.
    * - mixed_grouped_mode_hash_join_spill_enabled
      - boolean
      - false

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -263,6 +263,7 @@ void Merge::close() {
   for (auto& source : sources_) {
     source->close();
   }
+  Operator::close();
 }
 
 SourceMerger::SourceMerger(

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -159,12 +159,6 @@ void Merge::maybeStartMoreSources() {
     return;
   }
 
-  if (sources_.size() == 1 && numStartedSources_ < 1) {
-    sources_[0]->start();
-    ++numStartedSources_;
-    return;
-  }
-
   // Gets the merge sources for the next partial merge run.
   std::vector<MergeSource*> sources;
   for (auto i = numStartedSources_; i <
@@ -203,20 +197,6 @@ RowVectorPtr Merge::getOutputFromSpill() {
 
 RowVectorPtr Merge::getOutputFromSource() {
   VELOX_CHECK_NULL(spillMerger_);
-  // No merging is needed if there is only one source.
-  if (sources_.size() == 1) {
-    ContinueFuture future;
-    RowVectorPtr data;
-    auto reason = sources_[0]->next(data, &future);
-    if (reason != BlockingReason::kNotBlocked) {
-      sourceBlockingFutures_.emplace_back(std::move(future));
-      return nullptr;
-    }
-
-    finished_ = data == nullptr;
-    return data;
-  }
-
   bool lastRun = false;
   output_ = sourceMerger_->getOutput(
       outputBatchSize_, sourceBlockingFutures_, lastRun);

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -71,7 +71,7 @@ class Merge : public SourceOperator {
   // Returns true if needs to spill the merged source output if all sources can
   // not be merged at once.
   bool needSpill() const {
-    return sourceMerger_ != nullptr && maxNumMergeSources_ < sources_.size();
+    return maxNumMergeSources_ < sources_.size();
   }
 
   void maybeSetupOutputSpiller();

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -698,13 +698,15 @@ class SourceOperator : public Operator {
       RowTypePtr outputType,
       int32_t operatorId,
       const std::string& planNodeId,
-      const std::string& operatorType)
+      const std::string& operatorType,
+      const std::optional<common::SpillConfig>& spillConfig = std::nullopt)
       : Operator(
             driverCtx,
             std::move(outputType),
             operatorId,
             planNodeId,
-            operatorType) {}
+            operatorType,
+            spillConfig) {}
 
   bool needsInput() const override {
     return false;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -386,6 +386,20 @@ NoRowContainerSpiller::NoRowContainerSpiller(
     RowTypePtr rowType,
     std::optional<SpillPartitionId> parentId,
     HashBitRange bits,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<common::SpillStats>* spillStats)
+    : NoRowContainerSpiller(
+          std::move(rowType),
+          parentId,
+          bits,
+          {},
+          spillConfig,
+          spillStats) {}
+
+NoRowContainerSpiller::NoRowContainerSpiller(
+    RowTypePtr rowType,
+    std::optional<SpillPartitionId> parentId,
+    HashBitRange bits,
     const std::vector<SpillSortKey>& sortingKeys,
     const common::SpillConfig* spillConfig,
     folly::Synchronized<common::SpillStats>* spillStats)
@@ -397,20 +411,6 @@ NoRowContainerSpiller::NoRowContainerSpiller(
           spillConfig->maxFileSize,
           0,
           parentId,
-          spillConfig,
-          spillStats) {}
-
-NoRowContainerSpiller::NoRowContainerSpiller(
-    RowTypePtr rowType,
-    std::optional<SpillPartitionId> parentId,
-    HashBitRange bits,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : NoRowContainerSpiller(
-          std::move(rowType),
-          parentId,
-          bits,
-          {},
           spillConfig,
           spillStats) {}
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -206,14 +206,6 @@ class NoRowContainerSpiller : public SpillerBase {
       RowTypePtr rowType,
       std::optional<SpillPartitionId> parentId,
       HashBitRange bits,
-      const std::vector<SpillSortKey>& sortingKeys,
-      const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
-
-  NoRowContainerSpiller(
-      RowTypePtr rowType,
-      std::optional<SpillPartitionId> parentId,
-      HashBitRange bits,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
 
@@ -227,6 +219,15 @@ class NoRowContainerSpiller : public SpillerBase {
     }
   }
 
+ protected:
+  NoRowContainerSpiller(
+      RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
+      HashBitRange bits,
+      const std::vector<SpillSortKey>& sortingKeys,
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
+
  private:
   std::string type() const override {
     return std::string(kType);
@@ -235,6 +236,24 @@ class NoRowContainerSpiller : public SpillerBase {
   bool needSort() const override {
     return false;
   }
+};
+
+class MergeSpiller final : public NoRowContainerSpiller {
+ public:
+  MergeSpiller(
+      RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
+      HashBitRange bits,
+      const std::vector<SpillSortKey>& sortingKeys,
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats)
+      : NoRowContainerSpiller(
+            std::move(rowType),
+            parentId,
+            bits,
+            sortingKeys,
+            spillConfig,
+            spillStats) {}
 };
 
 class SortInputSpiller : public SpillerBase {

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -67,7 +67,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
 
   SpillFiles generateSortedSpillFiles(
       const std::vector<RowVectorPtr>& sortedVectors) {
-    const auto spiller = std::make_unique<NoRowContainerSpiller>(
+    const auto spiller = std::make_unique<MergeSpiller>(
         inputType_,
         std::nullopt,
         HashBitRange{},

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -163,7 +163,9 @@ class MergeTest : public OperatorTestBase {
       params.planNode = plan;
       params.maxDrivers = 2;
       params.queryConfigs = {
-          {"spill_enabled", "true"}, {"local_merge_max_merge_source", "2"}};
+          {"spill_enabled", "true"},
+          {"local_merge_enabled", "true"},
+          {"local_merge_max_num_merge_sources", "2"}};
       params.spillDirectory = spillDirectory->getPath();
       assertQueryOrdered(
           params, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
@@ -210,7 +212,9 @@ class MergeTest : public OperatorTestBase {
         params.planNode = plan;
         params.maxDrivers = 2;
         params.queryConfigs = {
-            {"spill_enabled", "true"}, {"local_merge_max_merge_source", "2"}};
+            {"spill_enabled", "true"},
+            {"local_merge_enabled", "true"},
+            {"local_merge_max_num_merge_sources", "2"}};
         params.spillDirectory = spillDirectory->getPath();
         assertQueryOrdered(
             params, "SELECT * FROM tmp " + orderBySql, sortingKeys);
@@ -222,7 +226,7 @@ class MergeTest : public OperatorTestBase {
 TEST_F(MergeTest, localMerge) {
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < 3; ++i) {
-    constexpr vector_size_t batchSize = 23;
+    constexpr vector_size_t batchSize = 100;
     auto c0 = makeFlatVector<int64_t>(
         batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
     auto c1 = makeFlatVector<int64_t>(
@@ -246,7 +250,7 @@ TEST_F(MergeTest, localMerge) {
 TEST_F(MergeTest, localMergeWithSpill) {
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < 9; ++i) {
-    constexpr vector_size_t batchSize = 37;
+    constexpr vector_size_t batchSize = 137;
     auto c0 = makeFlatVector<int64_t>(
         batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
     auto c1 = makeFlatVector<int64_t>(

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/SerializedPageUtil.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::velox::exec::test;
 
@@ -101,8 +102,35 @@ class MultiFragmentTest : public HiveConnectorTestBase,
       int destination = 0,
       Consumer consumer = nullptr,
       int64_t maxMemory = memory::kMaxMemory,
-      folly::Executor* executor = nullptr) {
+      folly::Executor* executor = nullptr) const {
     auto configCopy = configSettings_;
+    auto queryCtx = core::QueryCtx::create(
+        executor ? executor : executor_.get(),
+        core::QueryConfig(std::move(configCopy)));
+    queryCtx->testingOverrideMemoryPool(memory::memoryManager()->addRootPool(
+        queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
+    core::PlanFragment planFragment{planNode};
+    return Task::create(
+        taskId,
+        std::move(planFragment),
+        destination,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel,
+        std::move(consumer));
+  }
+
+  std::shared_ptr<Task> makeTask(
+      const std::string& taskId,
+      const core::PlanNodePtr& planNode,
+      std::unordered_map<std::string, std::string>& extraQueryConfigs,
+      int destination = 0,
+      Consumer consumer = nullptr,
+      int64_t maxMemory = memory::kMaxMemory,
+      folly::Executor* executor = nullptr) const {
+    auto configCopy = configSettings_;
+    for (const auto& [k, v] : extraQueryConfigs) {
+      configCopy[k] = v;
+    }
     auto queryCtx = core::QueryCtx::create(
         executor ? executor : executor_.get(),
         core::QueryConfig(std::move(configCopy)));
@@ -128,8 +156,8 @@ class MultiFragmentTest : public HiveConnectorTestBase,
     return vectors;
   }
 
-  void addHiveSplits(
-      std::shared_ptr<Task> task,
+  static void addHiveSplits(
+      const std::shared_ptr<Task>& task,
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths) {
     for (auto& filePath : filePaths) {
       auto split = exec::Split(
@@ -144,11 +172,31 @@ class MultiFragmentTest : public HiveConnectorTestBase,
     task->noMoreSplits("0");
   }
 
-  exec::Split remoteSplit(const std::string& taskId) {
+  static void addHiveSplits(
+      const std::shared_ptr<Task>& task,
+      const std::vector<std::string>& scanNodeIds,
+      const std::vector<std::shared_ptr<TempFilePath>>& filePaths) {
+    for (auto i = 0; i < filePaths.size(); ++i) {
+      const auto& filePath = filePaths[i];
+      auto split = exec::Split(
+          std::make_shared<connector::hive::HiveConnectorSplit>(
+              kHiveConnectorId,
+              "file:" + filePath->getPath(),
+              facebook::velox::dwio::common::FileFormat::DWRF),
+          -1);
+      task->addSplit(scanNodeIds[i % scanNodeIds.size()], std::move(split));
+      VLOG(1) << filePath->getPath() << "\n";
+    }
+    for (const auto& id : scanNodeIds) {
+      task->noMoreSplits(id);
+    }
+  }
+
+  static exec::Split remoteSplit(const std::string& taskId) {
     return exec::Split(std::make_shared<RemoteConnectorSplit>(taskId));
   }
 
-  void addRemoteSplits(
+  static void addRemoteSplits(
       std::shared_ptr<Task> task,
       const std::vector<std::string>& remoteTaskIds) {
     for (auto& taskId : remoteTaskIds) {
@@ -525,42 +573,43 @@ TEST_P(MultiFragmentTest, abortMergeExchange) {
 
 TEST_P(MultiFragmentTest, mergeExchange) {
   setupSources(20, 1000);
-
   static const core::SortOrder kAscNullsLast(true, false);
   std::vector<std::shared_ptr<Task>> tasks;
-
   std::vector<std::shared_ptr<TempFilePath>> filePaths0(
       filePaths_.begin(), filePaths_.begin() + 10);
   std::vector<std::shared_ptr<TempFilePath>> filePaths1(
       filePaths_.begin() + 10, filePaths_.end());
-
   std::vector<std::vector<std::shared_ptr<TempFilePath>>> filePathsList = {
       filePaths0, filePaths1};
-
   std::vector<std::string> partialSortTaskIds;
   RowTypePtr outputType;
-
   core::PlanNodeId partitionNodeId;
   for (int i = 0; i < 2; ++i) {
     auto sortTaskId = makeTaskId("orderby", tasks.size());
     partialSortTaskIds.push_back(sortTaskId);
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    std::vector<std::shared_ptr<const core::PlanNode>> sources;
+    std::vector<std::string> scanNodeIds;
+    for (int j = 0; j < 5; ++j) {
+      core::PlanNodeId scanNodeId;
+      sources.push_back(PlanBuilder(planNodeIdGenerator)
+                            .tableScan(rowType_)
+                            .capturePlanNodeId(scanNodeId)
+                            .orderBy({"c0"}, true)
+                            .planNode());
+      scanNodeIds.push_back(scanNodeId);
+    }
+
     auto partialSortPlan =
         PlanBuilder(planNodeIdGenerator)
-            .localMerge(
-                {"c0"},
-                {PlanBuilder(planNodeIdGenerator)
-                     .tableScan(rowType_)
-                     .orderBy({"c0"}, true)
-                     .planNode()})
+            .localMerge({"c0"}, std::move(sources))
             .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam().serdeKind)
             .capturePlanNodeId(partitionNodeId)
             .planNode();
-
     auto sortTask = makeTask(sortTaskId, partialSortPlan, tasks.size());
     tasks.push_back(sortTask);
-    sortTask->start(4);
-    addHiveSplits(sortTask, filePathsList[i]);
+    sortTask->start(2);
+    addHiveSplits(sortTask, scanNodeIds, filePathsList[i]);
     outputType = partialSortPlan->outputType();
   }
 
@@ -793,6 +842,113 @@ TEST_P(MultiFragmentTest, partitionedOutput) {
 
     ASSERT_TRUE(waitForTaskCompletion(leafTask.get())) << leafTask->taskId();
   }
+}
+
+TEST_P(MultiFragmentTest, mergeExchangeMultiMerge) {
+  setupSources(20, 1000);
+  static const core::SortOrder kAscNullsLast(true, false);
+  std::vector<std::shared_ptr<Task>> tasks;
+  std::vector<std::shared_ptr<TempFilePath>> filePaths0(
+      filePaths_.begin(), filePaths_.begin() + 10);
+  std::vector<std::shared_ptr<TempFilePath>> filePaths1(
+      filePaths_.begin() + 10, filePaths_.end());
+  std::vector<std::vector<std::shared_ptr<TempFilePath>>> filePathsList = {
+      filePaths0, filePaths1};
+  std::vector<std::string> partialSortTaskIds;
+  RowTypePtr outputType;
+  std::vector<std::shared_ptr<TempDirectoryPath>> spillDirectories;
+  core::PlanNodeId partitionNodeId;
+  std::unordered_map<std::string, std::string> spillMergeConfigs{
+      {"spill_enabled", "true"},
+      {"local_merge_enabled", "true"},
+      {"local_merge_max_num_merge_sources", "3"}};
+  std::vector<core::PlanNodeId> localMergeNodeIds;
+  for (int i = 0; i < 2; ++i) {
+    auto sortTaskId = makeTaskId("orderby", tasks.size());
+    partialSortTaskIds.push_back(sortTaskId);
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    std::vector<std::shared_ptr<const core::PlanNode>> sources;
+    std::vector<std::string> scanNodeIds;
+    for (int j = 0; j < 5; ++j) {
+      core::PlanNodeId scanNodeId;
+      sources.push_back(PlanBuilder(planNodeIdGenerator)
+                            .tableScan(rowType_)
+                            .capturePlanNodeId(scanNodeId)
+                            .orderBy({"c0"}, true)
+                            .planNode());
+      scanNodeIds.push_back(scanNodeId);
+    }
+
+    core::PlanNodeId localMergeNodeId;
+    auto partialSortPlan =
+        PlanBuilder(planNodeIdGenerator)
+            .localMerge({"c0"}, std::move(sources))
+            .capturePlanNodeId(localMergeNodeId)
+            .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam().serdeKind)
+            .capturePlanNodeId(partitionNodeId)
+            .planNode();
+    localMergeNodeIds.push_back(localMergeNodeId);
+    auto sortTask =
+        makeTask(sortTaskId, partialSortPlan, spillMergeConfigs, tasks.size());
+    spillDirectories.push_back(TempDirectoryPath::create());
+    sortTask->setSpillDirectory(spillDirectories[i]->getPath());
+    tasks.push_back(sortTask);
+    sortTask->start(2);
+    addHiveSplits(sortTask, scanNodeIds, filePathsList[i]);
+    outputType = partialSortPlan->outputType();
+  }
+
+  auto finalSortTaskId = makeTaskId("orderby", tasks.size());
+  core::PlanNodeId mergeExchangeId;
+  auto finalSortPlan =
+      PlanBuilder()
+          .mergeExchange(outputType, {"c0"}, GetParam().serdeKind)
+          .capturePlanNodeId(mergeExchangeId)
+          .partitionedOutput({}, 1, /*outputLayout=*/{}, GetParam().serdeKind)
+          .planNode();
+
+  auto mergeTask = makeTask(finalSortTaskId, finalSortPlan, 0);
+  tasks.push_back(mergeTask);
+  mergeTask->start(1);
+  addRemoteSplits(mergeTask, partialSortTaskIds);
+
+  auto op = PlanBuilder().exchange(outputType, GetParam().serdeKind).planNode();
+
+  test::AssertQueryBuilder(op, duckDbQueryRunner_)
+      .split(remoteSplit(finalSortTaskId))
+      .config(
+          core::QueryConfig::kShuffleCompressionKind,
+          common::compressionKindToString(GetParam().compressionKind))
+      .assertResults(
+          "SELECT * FROM tmp ORDER BY 1 NULLS LAST", std::vector<uint32_t>{0});
+
+  for (auto& task : tasks) {
+    ASSERT_TRUE(waitForTaskCompletion(task.get())) << task->taskId();
+  }
+  for (auto i = 0; i < 2; ++i) {
+    auto taskStats = toPlanStats(tasks[i]->taskStats());
+    auto& planStats = taskStats.at(localMergeNodeIds[i]);
+    ASSERT_GT(planStats.spilledBytes, 0);
+    ASSERT_EQ(planStats.spilledPartitions, 3);
+    ASSERT_EQ(planStats.spilledFiles, 3);
+  }
+
+  const auto finalSortStats = toPlanStats(mergeTask->taskStats());
+  const auto& mergeExchangeStats = finalSortStats.at(mergeExchangeId);
+
+  EXPECT_EQ(20'000, mergeExchangeStats.inputRows);
+  EXPECT_EQ(20'000, mergeExchangeStats.rawInputRows);
+
+  EXPECT_LT(0, mergeExchangeStats.inputBytes);
+  EXPECT_LT(0, mergeExchangeStats.rawInputBytes);
+
+  const auto serdeKindRuntimsStats =
+      mergeExchangeStats.customStats.at(Operator::kShuffleSerdeKind);
+  ASSERT_EQ(serdeKindRuntimsStats.count, 1);
+  ASSERT_EQ(
+      serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+  ASSERT_EQ(
+      serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
 }
 
 TEST_P(MultiFragmentTest, noHashPartitionSkew) {

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1548,10 +1548,6 @@ std::shared_ptr<Task> assertQuery(
     DuckDbQueryRunner& duckDbQueryRunner,
     std::optional<std::vector<uint32_t>> sortingKeys) {
   auto [cursor, actualResults] = readCursor(params, addSplits);
-  for (const auto& actual : actualResults) {
-    std::cerr << "MACDUAN RESULTS: " << actual->toString(0, actual->size())
-              << std::endl;
-  }
 
   if (sortingKeys) {
     assertResultsOrdered(

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1548,6 +1548,10 @@ std::shared_ptr<Task> assertQuery(
     DuckDbQueryRunner& duckDbQueryRunner,
     std::optional<std::vector<uint32_t>> sortingKeys) {
   auto [cursor, actualResults] = readCursor(params, addSplits);
+  for (const auto& actual : actualResults) {
+    std::cerr << "MACDUAN RESULTS: " << actual->toString(0, actual->size())
+              << std::endl;
+  }
 
   if (sortingKeys) {
     assertResultsOrdered(


### PR DESCRIPTION
The `LocalMerge` operator may start only a subset of the sources at a time
to limit memory usage. Hence, it performs multiple partial sort-merge operations,
each handling a subset of the merge sources. It spills the results produced by each subset
and finishes the spill to ensure the order both within and across all spill files for each partial merge.
Finally, creates a `ConcatFilesSpillMergeStream` for each group of spill files of each partial merge ,
setup a `SpillMerger` using those  `ConcatFilesSpillMergeStream` to perform the final sort-merge
of the outputs.

Parts of #13260