### PR TITLE
fix(parquet): Flatten complex-type vectors when writing

### DIFF
--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -711,7 +711,7 @@ TEST_F(E2EFilterTest, writeDecimalAsInteger) {
   auto rowVector = makeRowVector(
       {makeFlatVector<int64_t>({1, 2}, DECIMAL(8, 2)),
        makeFlatVector<int64_t>({1, 2}, DECIMAL(10, 2)),
-       makeFlatVector<int64_t>({1, 2}, DECIMAL(19, 2))});
+       makeFlatVector<int128_t>({1, 2}, DECIMAL(19, 2))});
   writeToMemory(rowVector->type(), {rowVector}, false);
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto input = std::make_unique<BufferedInput>(

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -196,6 +196,11 @@ class Writer : public dwio::common::Writer {
   // Sets the memory reclaimers for all the memory pools used by this writer.
   void setMemoryReclaimers();
 
+  // Checks if the input data contains a nested wrapped vector or complex
+  // vector. If so, flatten the input to make it compatible with
+  // 'exportFlattenedVector' in Arrow export.
+  bool needFlatten(const VectorPtr& data) const;
+
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> generalPool_;


### PR DESCRIPTION
Parquet write relies on Bridge to convert Velox vector as Arrow array. In 
https://github.com/facebookincubator/velox/commit/98308143adc593fabbbf23f1b9a12c02d462fed6, 'flattenDictionary' and 'flattenConstant' are set as true for Parquet 
write, while Bridge export cannot handle the flattening of dictionary-encoded 
complex-type vectors. To fix this issue, this PR flattens the input vector
before exporting it as Arrow array in Parquet write.

https://github.com/facebookincubator/velox/issues/10397