### PR TITLE
feat: Validate the cudf plan

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -284,6 +284,10 @@ std::shared_ptr<Task> Task::create(
       std::move(onError)));
   task->initTaskPool();
   task->addToTaskList();
+  if (mode == Task::ExecutionMode::kSerial) {
+    task->initDriverFactory();
+  }
+
   return task;
 }
 
@@ -502,6 +506,45 @@ void Task::initTaskPool() {
       fmt::format("task.{}", taskId_.c_str()), createTaskReclaimer());
 }
 
+void Task::initDriverFactory() {
+  VELOX_CHECK_NULL(
+      consumerSupplier_,
+      "Serial execution mode doesn't support delivering results to a "
+      "callback");
+
+  taskStats_.executionStartTimeMs = getCurrentTimeMs();
+  LocalPlanner::plan(
+      planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
+  exchangeClients_.resize(driverFactories_.size());
+
+  // In Task::next() we always assume ungrouped execution.
+  for (const auto& factory : driverFactories_) {
+    VELOX_CHECK(factory->supportsSerialExecution());
+    numDriversUngrouped_ += factory->numDrivers;
+    numTotalDrivers_ += factory->numTotalDrivers;
+    taskStats_.pipelineStats.emplace_back(
+        factory->inputDriver, factory->outputDriver);
+  }
+
+  // Create drivers.
+  createSplitGroupStateLocked(kUngroupedGroupId);
+  std::vector<std::shared_ptr<Driver>> drivers =
+      createDriversLocked(kUngroupedGroupId);
+  if (pool_->reservedBytes() != 0) {
+    VELOX_FAIL(
+        "Unexpected memory pool allocations during task[{}] driver initialization: {}",
+        taskId_,
+        pool_->treeMemoryUsage());
+  }
+
+  drivers_ = std::move(drivers);
+  driverBlockingStates_.reserve(drivers_.size());
+  for (auto i = 0; i < drivers_.size(); ++i) {
+    driverBlockingStates_.emplace_back(
+        std::make_unique<DriverBlockingState>(drivers_[i].get()));
+  }
+}
+
 velox::memory::MemoryPool* Task::getOrAddNodePool(
     const core::PlanNodeId& planNodeId) {
   if (nodePools_.count(planNodeId) == 1) {
@@ -667,48 +710,7 @@ RowVectorPtr Task::next(ContinueFuture* future) {
     }
   }
 
-  // On first call, create the drivers.
-  if (driverFactories_.empty()) {
-    VELOX_CHECK_NULL(
-        consumerSupplier_,
-        "Serial execution mode doesn't support delivering results to a "
-        "callback");
-
-    taskStats_.executionStartTimeMs = getCurrentTimeMs();
-    LocalPlanner::plan(
-        planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
-    exchangeClients_.resize(driverFactories_.size());
-
-    // In Task::next() we always assume ungrouped execution.
-    for (const auto& factory : driverFactories_) {
-      VELOX_CHECK(factory->supportsSerialExecution());
-      numDriversUngrouped_ += factory->numDrivers;
-      numTotalDrivers_ += factory->numTotalDrivers;
-      taskStats_.pipelineStats.emplace_back(
-          factory->inputDriver, factory->outputDriver);
-    }
-
-    // Create drivers.
-    createSplitGroupStateLocked(kUngroupedGroupId);
-    std::vector<std::shared_ptr<Driver>> drivers =
-        createDriversLocked(kUngroupedGroupId);
-    if (pool_->reservedBytes() != 0) {
-      VELOX_FAIL(
-          "Unexpected memory pool allocations during task[{}] driver initialization: {}",
-          taskId_,
-          pool_->treeMemoryUsage());
-    }
-
-    drivers_ = std::move(drivers);
-    driverBlockingStates_.reserve(drivers_.size());
-    for (auto i = 0; i < drivers_.size(); ++i) {
-      driverBlockingStates_.emplace_back(
-          std::make_unique<DriverBlockingState>(drivers_[i].get()));
-    }
-    if (underBarrier()) {
-      startDriverBarriersLocked();
-    }
-  }
+  VELOX_CHECK(!driverFactories_.empty());
 
   // Run drivers one at a time. If a driver blocks, continue running the other
   // drivers. Running other drivers is expected to unblock some or all blocked

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -747,6 +747,9 @@ class Task : public std::enable_shared_from_this<Task> {
     return cancellationSource_.getToken();
   }
 
+  /// Returns the driver by driverIdx in drivers_.
+  std::shared_ptr<Driver> getDriver(uint32_t driverIdx) const;
+
   /// Returns the number of running tasks from velox runtime.
   static size_t numRunningTasks();
 
@@ -846,6 +849,8 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Invoked to initialize the memory pool for this task on creation.
   void initTaskPool();
+
+  void initDriverFactory();
 
   // Creates a scaled scan controller for a given table scan node.
   void addScaledScanControllerLocked(
@@ -954,7 +959,7 @@ class Task : public std::enable_shared_from_this<Task> {
   std::shared_ptr<TBridgeType> getJoinBridgeInternalLocked(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
-      MemberType SplitGroupState::*bridges_member);
+      MemberType SplitGroupState::* bridges_member);
 
   std::shared_ptr<JoinBridge> getCustomJoinBridgeInternal(
       uint32_t splitGroupId,
@@ -1109,8 +1114,6 @@ class Task : public std::enable_shared_from_this<Task> {
   // Create a 'QueryMetadtaWriter' to trace the query metadata if the query
   // trace enabled.
   void maybeInitTrace();
-
-  std::shared_ptr<Driver> getDriver(uint32_t driverId) const;
 
   // Invokes to record the start/end time of task output batch processing time
   // under serial execution mode.

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -174,6 +174,9 @@ struct CudfDriverAdapter {
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
+    if (!driver.driverCtx()->queryConfig().get<bool>(kCudfEnabled, "true")) {
+      return false;
+    }
     auto state = CompileState(factory, driver);
     auto res = state.compile();
     return res;
@@ -217,6 +220,10 @@ void unregisterCudf() {
 
 bool cudfIsRegistered() {
   return isCudfRegistered;
+}
+
+bool isCudfOperator(const exec::Operator* op) {
+  return isAnyOf<NvtxHelper>(op) || isAnyOf<CudfHashJoinBridgeTranslator>(op);
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -29,6 +29,9 @@ namespace facebook::velox::cudf_velox {
 
 static const std::string kCudfAdapterName = "cuDF";
 
+// QueryConfig key.
+static const std::string kCudfEnabled = "cudf.enabled";
+
 class CompileState {
  public:
   CompileState(const exec::DriverFactory& driverFactory, exec::Driver& driver)
@@ -61,4 +64,6 @@ void unregisterCudf();
 /// Returns true if cuDF is registered.
 bool cudfIsRegistered();
 
+/// Returns true if the operator is cudf operator.
+bool isCudfOperator(const exec::Operator* op);
 } // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
In Gluten, construct a Task to get the operators after DriverAdapter adapts, then validate the operators if it satisfies the offload condition, now only check it can be fully offloaded to cudf without extra data format conversion cost.
Futher more, we can compare the cost of the plan offload to cudf may with fallback and cpu operators.

The cudf and wave uses operators instead of PlanNode to validate the plan, it benefits Project validation which can be easily validated by FilterProject::exprsAndProjection.

This PR extracts the DriverFactory initialization from Task function `next` to Task constructor under mode Task::ExecutionMode::kSerial, then we can get the operators Driver after task is created.