### PR TITLE
fix: Access after buffer boundary causing crash in selective reader

### DIFF
--- a/velox/dwio/common/DecoderUtil.h
+++ b/velox/dwio/common/DecoderUtil.h
@@ -105,7 +105,7 @@ inline void processFixedFilter(
     ; /* no values passed, no action*/
   } else if (word == simd::allSetBitMask<T>()) {
     loadIndices(0).store_unaligned(filterHits + numValues);
-    if (is16) {
+    if (is16 && width > kIndexLaneCount) {
       // If 16 values in 'values', copy the next 8x 32 bit indices.
       loadIndices(1).store_unaligned(filterHits + numValues + kIndexLaneCount);
     }


### PR DESCRIPTION
Summary:
In case we are filtering `int16_t` data, we read 16 of them at same
time.  However the row numbers are 32 bits long and we can only do them 8 at a
time.  In case that all 16 rows passing the filter, we read and write 2 SIMD
batches of indices without checking the end boundary.  This is ok for values (we
always ensure 1 SIMD batch padding) but not ok for indices (need 2 batches
padding in worst case), causing accessing over boundary and crashes.  This was
not generating incorrect results because the length of the output rows is set
correctly and extra rows at end are ignored.

Differential Revision: D74752697


