### PR TITLE
fix: Selective flatmap column reader read offset not updated when all rows filtered out

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -302,6 +302,8 @@ void SelectiveFlatMapColumnReaderHelper<T, KeyNode, FormatData>::read(
       for (auto* child : reader_.children_) {
         child->addParentNulls(offset, mapNulls, rows);
       }
+      reader_.lazyVectorReadOffset_ = offset;
+      reader_.readOffset_ = offset + rows.back() + 1;
       return;
     }
     activeRows = reader_.outputRows_;


### PR DESCRIPTION
Summary:
When we have a filter on flatmap column that filtering all the rows
out, the read offset on the column is not updated.  This was triggering a sanity
check and throwing exception on next batch.

Differential Revision: D74774715


