### PR TITLE
feat: Clean up error reporting for Geometry functions

### DIFF
--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -21,9 +21,13 @@
 
 namespace facebook::velox::functions::geospatial {
 
+/// Deserialize Velox's internal format to a geometry.  Do not call this within
+/// GEOS_TRY macro: it will catch the exceptions that need to bubble up.
 std::unique_ptr<geos::geom::Geometry> deserializeGeometry(
     const StringView& geometryString);
 
+/// Serialize geometry into Velox's internal format.  Do not call this within
+/// GEOS_TRY macro: it will catch the exceptions that need to bubble up.
 std::string serializeGeometry(const geos::geom::Geometry& geosGeometry);
 
 } // namespace facebook::velox::functions::geospatial

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <geos/util/AssertionFailedException.h>
+#include <geos/util/UnsupportedOperationException.h>
+
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox::functions::geospatial {
+
+/// Utility macro used to wrap GEOS library calls in a try-catch block,
+/// returning a velox::Status with error message if an exception is caught.
+#define GEOS_TRY(func, user_error_message)                       \
+  try {                                                          \
+    func                                                         \
+  } catch (const geos::util::UnsupportedOperationException& e) { \
+    return Status::UnknownError(                                 \
+        fmt::format("Internal geometry error: {}", e.what()));   \
+  } catch (const geos::util::AssertionFailedException& e) {      \
+    return Status::UnknownError(                                 \
+        fmt::format("Internal geometry error: {}", e.what()));   \
+  } catch (const geos::util::GEOSException& e) {                 \
+    return Status::UserError(                                    \
+        fmt::format("{}: {}", user_error_message, e.what()));    \
+  }
+
+} // namespace facebook::velox::functions::geospatial


### PR DESCRIPTION
Summary:
This cleans up the error handling for the Geometry serde functions,
to establish the pattern for later geometry functions.  In this, we catch
all exceptions from GEOS and raise them as a UserError, so users can bypass
them with TRY as desired.

Certain GEOS exceptions are returned as internal errors, like
AssertionFailedException and UnsupportedOperationException, because they
indicate bugs in either Geos code or our code.

We also let errors from the internal de/serialization bubble up, since those
are bugs in our code.

Differential Revision: D74761810


