### PR TITLE
build(geos): Patch the macOS setup install of geos

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -191,7 +191,14 @@ function install_stemmer {
 
 function install_geos {
   if [[ "$BUILD_GEOS" == "true" ]]; then
+    ABSOLUTE_SCRIPTDIR=$(realpath ${SCRIPTDIR})
     wget_and_untar https://github.com/libgeos/geos/archive/${GEOS_VERSION}.tar.gz geos
+    (
+      # Adopted from the bundled patching needed for macOS.
+      cd ${DEPENDENCY_DIR}/geos
+      git apply "${ABSOLUTE_SCRIPTDIR}/../CMake/resolve_dependency_modules/geos/geos-cmakelists.patch"
+      git apply "${ABSOLUTE_SCRIPTDIR}/../CMake/resolve_dependency_modules/geos/geos-build.patch"
+    )
     cmake_install_dir geos -DBUILD_TESTING=OFF
   fi
 }


### PR DESCRIPTION
The bundled version of geos fixes some issues that address build issues on macOS with unknown type size_t and other things.