### PR TITLE
fix: Loose mixed grouped mode join condition

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1058,7 +1058,7 @@ bool HashBuild::canSpill() const {
   if (!Operator::canSpill()) {
     return false;
   }
-  if (operatorCtx_->task()->hasMixedExecutionGroup()) {
+  if (operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get())) {
     return operatorCtx_->driverCtx()
                ->queryConfig()
                .mixedGroupedModeHashJoinSpillEnabled() &&

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -942,7 +942,7 @@ bool HashProbe::canSpill() const {
   if (!Operator::canSpill()) {
     return false;
   }
-  if (operatorCtx_->task()->hasMixedExecutionGroup()) {
+  if (operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get())) {
     return operatorCtx_->driverCtx()
                ->queryConfig()
                .mixedGroupedModeHashJoinSpillEnabled() &&
@@ -1049,7 +1049,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       asyncWaitForHashTable();
     } else {
       if (lastProber_ && canSpill()) {
-        if (operatorCtx_->task()->hasMixedExecutionGroup()) {
+        if (operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get())) {
           const bool isLastGroup = allProbeGroupFinished();
           if (isSpillInput()) {
             // Mixed group mode has triggered spilling, based on if current
@@ -1741,7 +1741,8 @@ bool HashProbe::isWaitingForPeers() const {
 }
 
 bool HashProbe::allProbeGroupFinished() const {
-  VELOX_CHECK(operatorCtx_->task()->hasMixedExecutionGroup());
+  VELOX_CHECK(
+      operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get()));
   VELOX_CHECK_EQ(operatorCtx_->task()->concurrentSplitGroups(), 1);
   return operatorCtx_->task()->allSplitsConsumed(joinNode_.get());
 }

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -155,7 +155,7 @@ OperatorSupplier makeOperatorSupplier(
   if (auto join =
           std::dynamic_pointer_cast<const core::HashJoinNode>(planNode)) {
     return [join](int32_t operatorId, DriverCtx* ctx) {
-      if (ctx->task->hasMixedExecutionGroup() &&
+      if (ctx->task->hasMixedExecutionGroupJoin(join.get()) &&
           needRightSideJoin(join->joinType())) {
         VELOX_UNSUPPORTED(
             "Hash join currently does not support mixed grouped execution for join "

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -176,12 +176,12 @@ class Task : public std::enable_shared_from_this<Task> {
 
   bool isUngroupedExecution() const;
 
-  /// Returns true if this task has ungrouped execution split under grouped
-  /// execution mode.
+  /// Returns true if the provided 'joinNode' has probe side as grouped
+  /// execution mode and build side as ungrouped execution mode.
   ///
   /// NOTE: calls this function after task has been started as the number of
   /// ungrouped drivers is set during task startup.
-  bool hasMixedExecutionGroup() const;
+  bool hasMixedExecutionGroupJoin(const core::HashJoinNode* joinNode) const;
 
   /// If 'planNode' is a source node, returns true if all splits for 'planNode'
   /// are consumed and no more splits are expected. Otherwise, returns true if


### PR DESCRIPTION
Summary: Today we tell if a join is in mixed grouped mode by telling if the entire task is mixed grouped mode. Telling based on the task is a stricter condition than the join node itself because a task can be mixed mode but the a join node inside the task can be non-mixed mode. This disallows some supported queries to run. This change looses the condition by replacing the task scope mixed mode method with a more specific method that tells the mode of a particular join node.

Differential Revision: D74839716


