### PR TITLE
fix: Join condition should be not-exists for TPCH 22

### DIFF
--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -2447,7 +2447,7 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
               "",
               {"c_acctbal", "c_phone"},
               core::JoinType::kAnti,
-              true /*nullAware*/)
+              false /*nullAware*/)
           .project({"substr(c_phone, 1, 2) AS country_code", "c_acctbal"})
           .partialAggregation(
               {"country_code"},


### PR DESCRIPTION
Summary: TPCH - 22's join should be an anti join that is not null-aware to support "NOT EXISTS" semantics. We need to `nullAware=false`

Differential Revision: D74550644


