### PR TITLE
[Presto] Add SerdeParameters to rowReaderOpts in velox open source

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -629,6 +629,7 @@ void configureRowReaderOptions(
         hiveConfig->readTimestampUnit(sessionProperties)));
   }
   rowReaderOptions.setStorageParameters(hiveSplit->storageParameters);
+  rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }
 
 namespace {

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -349,11 +349,11 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptions) {
   float_features->setFlatMapFeatureSelection({"1", "3"});
 }
 
-TEST_F(HiveConnectorUtilTest, configureStoragePamatersRowReaderOptions) {
+TEST_F(HiveConnectorUtilTest, configureSstRowReaderOptions) {
   dwio::common::RowReaderOptions rowReaderOpts;
   auto hiveSplit =
       std::make_shared<hive::HiveConnectorSplit>("", "", FileFormat::SST);
-  hiveSplit->storageParameters = {
+  hiveSplit->serdeParameters = {
       {"key_col_indices", "0,1,2"},
       {"value_col_indices", "4,5"},
   };
@@ -367,7 +367,7 @@ TEST_F(HiveConnectorUtilTest, configureStoragePamatersRowReaderOptions) {
       /*sessionProperties=*/nullptr,
       /*rowReaderOptions=*/rowReaderOpts);
 
-  EXPECT_EQ(rowReaderOpts.storageParameters(), hiveSplit->storageParameters);
+  EXPECT_EQ(rowReaderOpts.serdeParameters(), hiveSplit->serdeParameters);
 }
 
 } // namespace facebook::velox::connector

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -382,6 +382,15 @@ class RowReaderOptions {
     formatSpecificOptions_ = std::move(options);
   }
 
+  const std::unordered_map<std::string, std::string>& serdeParameters() const {
+    return serdeParameters_;
+  }
+
+  void setSerdeParameters(
+      std::unordered_map<std::string, std::string> serdeParameters) {
+    serdeParameters_ = std::move(serdeParameters);
+  }
+
   const std::unordered_map<std::string, std::string>& storageParameters()
       const {
     return storageParameters_;
@@ -413,7 +422,10 @@ class RowReaderOptions {
   size_t decodingParallelismFactor_{0};
   std::optional<RowNumberColumnInfo> rowNumberColumnInfo_{std::nullopt};
   // Parameters that are provided as the physical storage properties.
-  std::unordered_map<std::string, std::string> storageParameters_ = {};
+  std::unordered_map<std::string, std::string> storageParameters_{};
+  // Parameters that are provided as the serialization/deserialization
+  // properties.
+  std::unordered_map<std::string, std::string> serdeParameters_{};
 
   // Function to populate metrics related to feature projection stats
   // in Koski. This gets fired in FlatMapColumnReader.


### PR DESCRIPTION
Summary:
SST reader use storage parameters in hive split but writer use serde parameters. 
This diff first add serde parameters to open source. Since the tess will  all break. Will move the storage parameter in the code later diff.

Differential Revision: D74706322


