### PR TITLE
fix: Avoid decompress data when estimate row size

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -117,6 +117,12 @@ RowVectorPtr TableScan::getOutput() {
       return nullptr;
     }
 
+    ExceptionContextSetter exceptionContext(
+        {[](VeloxException::Type /*exceptionType*/, auto* debugString) {
+           return *static_cast<std::string*>(debugString);
+         },
+         &debugString_});
+
     if (needNewSplit_) {
       const auto hasNewSplit = getSplit();
       if (!hasNewSplit) {
@@ -134,12 +140,6 @@ RowVectorPtr TableScan::getOutput() {
     }
     VELOX_CHECK(!needNewSplit_);
     VELOX_CHECK(!hasDrained());
-
-    ExceptionContextSetter exceptionContext(
-        {[](VeloxException::Type /*exceptionType*/, auto* debugString) {
-           return *static_cast<std::string*>(debugString);
-         },
-         &debugString_});
 
     int32_t readBatchSize = readBatchSize_;
     if (maxFilteringRatio_ > 0) {


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/168

With some very low selectivity queries (more stripes than output rows),
Nimble still needs to load and decompress the data in order to do the row size
estimation.  The shall be addressed once we have column statistics metadata; in
the meantime we can avoid the decompression cost by just get the row count and decompressed
size instead of actual decompressing the data.  This brings us on par with same
query on DWRF.

Differential Revision: D74884140


