### PR TITLE
feat(cudf): Add cudf based HashAggregation operator

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(
   velox_cudf_exec
   CudfConversion.cpp
+  CudfHashAggregation.cpp
   CudfOrderBy.cpp
   ToCudf.cpp
   Utilities.cpp

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -75,7 +75,10 @@ CudfFromVelox::CudfFromVelox(
           operatorId,
           planNodeId,
           "CudfFromVelox"),
-      NvtxHelper(nvtx3::rgb{255, 140, 0}, operatorId) {} // Orange
+      NvtxHelper(
+          nvtx3::rgb{255, 140, 0}, // Orange
+          operatorId,
+          fmt::format("[{}]", planNodeId)) {}
 
 void CudfFromVelox::addInput(RowVectorPtr input) {
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
@@ -164,7 +167,10 @@ CudfToVelox::CudfToVelox(
           operatorId,
           planNodeId,
           "CudfToVelox"),
-      NvtxHelper(nvtx3::rgb{148, 0, 211}, operatorId) {} // Purple
+      NvtxHelper(
+          nvtx3::rgb{148, 0, 211}, // Purple
+          operatorId,
+          fmt::format("[{}]", planNodeId)) {}
 
 void CudfToVelox::addInput(RowVectorPtr input) {
   // Accumulate inputs

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1,0 +1,858 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfHashAggregation.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/exec/Task.h"
+#include "velox/expression/Expr.h"
+
+#include <cudf/binaryop.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/concatenate.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/stream_compaction.hpp>
+#include <cudf/unary.hpp>
+
+namespace {
+
+using namespace facebook::velox;
+
+#define DEFINE_SIMPLE_AGGREGATOR(Name, name, KIND)                            \
+  struct Name##Aggregator : cudf_velox::CudfHashAggregation::Aggregator {     \
+    Name##Aggregator(                                                         \
+        core::AggregationNode::Step step,                                     \
+        uint32_t inputIndex,                                                  \
+        VectorPtr constant,                                                   \
+        bool is_global)                                                       \
+        : Aggregator(                                                         \
+              step,                                                           \
+              cudf::aggregation::KIND,                                        \
+              inputIndex,                                                     \
+              constant,                                                       \
+              is_global) {}                                                   \
+                                                                              \
+    void addGroupbyRequest(                                                   \
+        cudf::table_view const& tbl,                                          \
+        std::vector<cudf::groupby::aggregation_request>& requests) override { \
+      VELOX_CHECK(                                                            \
+          constant == nullptr,                                                \
+          #Name "Aggregator does not yet support constant input");            \
+      auto& request = requests.emplace_back();                                \
+      output_idx = requests.size() - 1;                                       \
+      request.values = tbl.column(inputIndex);                                \
+      request.aggregations.push_back(                                         \
+          cudf::make_##name##_aggregation<cudf::groupby_aggregation>());      \
+    }                                                                         \
+                                                                              \
+    std::unique_ptr<cudf::column> makeOutputColumn(                           \
+        std::vector<cudf::groupby::aggregation_result>& results,              \
+        rmm::cuda_stream_view stream) override {                              \
+      return std::move(results[output_idx].results[0]);                       \
+    }                                                                         \
+                                                                              \
+    std::unique_ptr<cudf::column> doReduce(                                   \
+        cudf::table_view const& input,                                        \
+        TypePtr const& outputType,                                            \
+        rmm::cuda_stream_view stream) override {                              \
+      auto const aggRequest =                                                 \
+          cudf::make_##name##_aggregation<cudf::reduce_aggregation>();        \
+      auto const cudfOutputType =                                             \
+          cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));         \
+      auto const resultScalar = cudf::reduce(                                 \
+          input.column(inputIndex), *aggRequest, cudfOutputType, stream);     \
+      return cudf::make_column_from_scalar(*resultScalar, 1, stream);         \
+    }                                                                         \
+                                                                              \
+   private:                                                                   \
+    uint32_t output_idx;                                                      \
+  };
+
+DEFINE_SIMPLE_AGGREGATOR(Sum, sum, SUM)
+DEFINE_SIMPLE_AGGREGATOR(Min, min, MIN)
+DEFINE_SIMPLE_AGGREGATOR(Max, max, MAX)
+
+struct CountAggregator : cudf_velox::CudfHashAggregation::Aggregator {
+  CountAggregator(
+      core::AggregationNode::Step step,
+      uint32_t inputIndex,
+      VectorPtr constant,
+      bool isGlobal)
+      : Aggregator(
+            step,
+            cudf::aggregation::COUNT_VALID,
+            inputIndex,
+            constant,
+            isGlobal) {}
+
+  void addGroupbyRequest(
+      cudf::table_view const& tbl,
+      std::vector<cudf::groupby::aggregation_request>& requests) override {
+    auto& request = requests.emplace_back();
+    outputIdx_ = requests.size() - 1;
+    request.values = tbl.column(constant == nullptr ? inputIndex : 0);
+    std::unique_ptr<cudf::groupby_aggregation> aggRequest =
+        exec::isRawInput(step)
+        ? cudf::make_count_aggregation<cudf::groupby_aggregation>(
+              constant == nullptr ? cudf::null_policy::EXCLUDE
+                                  : cudf::null_policy::INCLUDE)
+        : cudf::make_sum_aggregation<cudf::groupby_aggregation>();
+    request.aggregations.push_back(std::move(aggRequest));
+  }
+
+  std::unique_ptr<cudf::column> doReduce(
+      cudf::table_view const& input,
+      TypePtr const& outputType,
+      rmm::cuda_stream_view stream) override {
+    if (exec::isRawInput(step)) {
+      // For raw input, implement count using size + null count
+      auto inputCol = input.column(constant == nullptr ? inputIndex : 0);
+
+      // count_valid: size - null_count, count_all: just the size
+      int64_t count = constant == nullptr
+          ? inputCol.size() - inputCol.null_count()
+          : inputCol.size();
+
+      auto resultScalar = cudf::numeric_scalar<int64_t>(count);
+
+      return cudf::make_column_from_scalar(resultScalar, 1, stream);
+    } else {
+      // For non-raw input (intermediate/final), use sum aggregation
+      auto const aggRequest =
+          cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+      auto const cudfOutputType = cudf::data_type(cudf::type_id::INT64);
+      auto const resultScalar = cudf::reduce(
+          input.column(inputIndex), *aggRequest, cudfOutputType, stream);
+      return cudf::make_column_from_scalar(*resultScalar, 1, stream);
+    }
+    return nullptr;
+  }
+
+  std::unique_ptr<cudf::column> makeOutputColumn(
+      std::vector<cudf::groupby::aggregation_result>& results,
+      rmm::cuda_stream_view stream) override {
+    // cudf produces int32 for count(0) but velox expects int64
+    auto col = std::move(results[outputIdx_].results[0]);
+    if (col->type() == cudf::data_type(cudf::type_id::INT32)) {
+      col = cudf::cast(*col, cudf::data_type(cudf::type_id::INT64), stream);
+    }
+    return col;
+  }
+
+ private:
+  uint32_t outputIdx_;
+};
+
+struct MeanAggregator : cudf_velox::CudfHashAggregation::Aggregator {
+  MeanAggregator(
+      core::AggregationNode::Step step,
+      uint32_t inputIndex,
+      VectorPtr constant,
+      bool isGlobal)
+      : Aggregator(
+            step,
+            cudf::aggregation::MEAN,
+            inputIndex,
+            constant,
+            isGlobal) {}
+
+  void addGroupbyRequest(
+      cudf::table_view const& tbl,
+      std::vector<cudf::groupby::aggregation_request>& requests) override {
+    switch (step) {
+      case core::AggregationNode::Step::kSingle: {
+        auto& request = requests.emplace_back();
+        meanIdx_ = requests.size() - 1;
+        request.values = tbl.column(inputIndex);
+        request.aggregations.push_back(
+            cudf::make_mean_aggregation<cudf::groupby_aggregation>());
+        break;
+      }
+      case core::AggregationNode::Step::kPartial: {
+        auto& request = requests.emplace_back();
+        sumIdx_ = requests.size() - 1;
+        request.values = tbl.column(inputIndex);
+        request.aggregations.push_back(
+            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+        request.aggregations.push_back(
+            cudf::make_count_aggregation<cudf::groupby_aggregation>(
+                cudf::null_policy::EXCLUDE));
+        break;
+      }
+      case core::AggregationNode::Step::kIntermediate:
+      case core::AggregationNode::Step::kFinal: {
+        // In intermediate and final aggregation, the previously computed sum
+        // and count are in the child columns of the input column.
+        auto& request = requests.emplace_back();
+        sumIdx_ = requests.size() - 1;
+        request.values = tbl.column(inputIndex).child(0);
+        request.aggregations.push_back(
+            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+
+        auto& request2 = requests.emplace_back();
+        countIdx_ = requests.size() - 1;
+        request2.values = tbl.column(inputIndex).child(1);
+        // The counts are already computed in partial aggregation, so we just
+        // need to sum them up again.
+        request2.aggregations.push_back(
+            cudf::make_sum_aggregation<cudf::groupby_aggregation>());
+        break;
+      }
+      default:
+        // We don't know how to handle kIntermediate step for mean
+        VELOX_NYI("Unsupported aggregation step for mean");
+    }
+  }
+
+  std::unique_ptr<cudf::column> makeOutputColumn(
+      std::vector<cudf::groupby::aggregation_result>& results,
+      rmm::cuda_stream_view stream) override {
+    switch (step) {
+      case core::AggregationNode::Step::kSingle:
+        return std::move(results[meanIdx_].results[0]);
+      case core::AggregationNode::Step::kPartial: {
+        auto sum = std::move(results[sumIdx_].results[0]);
+        auto count = std::move(results[sumIdx_].results[1]);
+
+        auto const size = sum->size();
+
+        auto countInt64 =
+            cudf::cast(*count, cudf::data_type(cudf::type_id::INT64), stream);
+
+        auto children = std::vector<std::unique_ptr<cudf::column>>();
+        children.push_back(std::move(sum));
+        children.push_back(std::move(countInt64));
+
+        // TODO: Handle nulls. This can happen if all values are null in a
+        // group.
+        return std::make_unique<cudf::column>(
+            cudf::data_type(cudf::type_id::STRUCT),
+            size,
+            rmm::device_buffer{},
+            rmm::device_buffer{},
+            0,
+            std::move(children));
+      }
+      case core::AggregationNode::Step::kIntermediate: {
+        // The difference between intermediate and partial is in where the
+        // sum and count are coming from. In partial, since the input column is
+        // the same, the sum and count are in the same agg result. In
+        // intermediate, the input columns are different (it's the child
+        // columns of the input column) and so the sum and count are in
+        // different agg results.
+        auto sum = std::move(results[sumIdx_].results[0]);
+        auto count = std::move(results[countIdx_].results[0]);
+
+        auto size = sum->size();
+
+        auto children = std::vector<std::unique_ptr<cudf::column>>();
+        children.push_back(std::move(sum));
+        children.push_back(std::move(count));
+
+        return std::make_unique<cudf::column>(
+            cudf::data_type(cudf::type_id::STRUCT),
+            size,
+            rmm::device_buffer{},
+            rmm::device_buffer{},
+            0,
+            std::move(children));
+      }
+      case core::AggregationNode::Step::kFinal: {
+        auto sum = std::move(results[sumIdx_].results[0]);
+        auto count = std::move(results[countIdx_].results[0]);
+        auto avg = cudf::binary_operation(
+            *sum,
+            *count,
+            cudf::binary_operator::DIV,
+            // TODO: Change the output type to be dependent on the input type
+            // like in the cudf groupby implementation.
+            cudf::data_type(cudf::type_id::FLOAT64),
+            stream);
+        return avg;
+      }
+      default:
+        VELOX_NYI("Unsupported aggregation step for mean");
+    }
+  }
+
+  std::unique_ptr<cudf::column> doReduce(
+      cudf::table_view const& input,
+      TypePtr const& outputType,
+      rmm::cuda_stream_view stream) override {
+    switch (step) {
+      case core::AggregationNode::Step::kSingle: {
+        auto const aggRequest =
+            cudf::make_mean_aggregation<cudf::reduce_aggregation>();
+        auto const cudfOutputType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));
+        auto const resultScalar = cudf::reduce(
+            input.column(inputIndex), *aggRequest, cudfOutputType, stream);
+        return cudf::make_column_from_scalar(*resultScalar, 1, stream);
+      }
+      case core::AggregationNode::Step::kPartial: {
+        VELOX_CHECK(outputType->isRow());
+        auto const& rowType = outputType->asRow();
+        auto const sumType = rowType.childAt(0);
+        auto const countType = rowType.childAt(1);
+        auto const cudfSumType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(sumType));
+        auto const cudfCountType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(countType));
+
+        // sum
+        auto const aggRequest =
+            cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto const sumResultScalar = cudf::reduce(
+            input.column(inputIndex), *aggRequest, cudfSumType, stream);
+        auto sumCol =
+            cudf::make_column_from_scalar(*sumResultScalar, 1, stream);
+
+        // libcudf doesn't have a count agg for reduce. What we want is to
+        // count the number of valid rows.
+        auto countCol = cudf::make_column_from_scalar(
+            cudf::numeric_scalar<int64_t>(
+                input.column(inputIndex).size() -
+                input.column(inputIndex).null_count()),
+            1,
+            stream);
+
+        // Assemble into struct as expected by velox.
+        auto children = std::vector<std::unique_ptr<cudf::column>>();
+        children.push_back(std::move(sumCol));
+        children.push_back(std::move(countCol));
+        return std::make_unique<cudf::column>(
+            cudf::data_type(cudf::type_id::STRUCT),
+            1,
+            rmm::device_buffer{},
+            rmm::device_buffer{},
+            0,
+            std::move(children));
+      }
+      case core::AggregationNode::Step::kFinal: {
+        // Input column has two children: sum and count
+        auto const sumCol = input.column(inputIndex).child(0);
+        auto const countCol = input.column(inputIndex).child(1);
+
+        // sum the sums
+        auto const sumAggRequest =
+            cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto const sumResultScalar =
+            cudf::reduce(sumCol, *sumAggRequest, sumCol.type(), stream);
+        auto sumResultCol =
+            cudf::make_column_from_scalar(*sumResultScalar, 1, stream);
+
+        // sum the counts
+        auto const countAggRequest =
+            cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto const countResultScalar =
+            cudf::reduce(countCol, *countAggRequest, countCol.type(), stream);
+
+        // divide the sums by the counts
+        auto const cudfOutputType =
+            cudf::data_type(cudf_velox::veloxToCudfTypeId(outputType));
+        return cudf::binary_operation(
+            *sumResultCol,
+            *countResultScalar,
+            cudf::binary_operator::DIV,
+            cudfOutputType,
+            stream);
+      }
+      default:
+        VELOX_NYI("Unsupported aggregation step for mean");
+    }
+  }
+
+ private:
+  // These indices are used to track where the desired result columns
+  // (mean/<sum, count>) are in the output of cudf::groupby::aggregate().
+  uint32_t meanIdx_;
+  uint32_t sumIdx_;
+  uint32_t countIdx_;
+};
+
+std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
+    core::AggregationNode::Step step,
+    std::string const& kind,
+    uint32_t inputIndex,
+    VectorPtr constant,
+    bool isGlobal) {
+  // Companion function may be count_merge_extract or count_partial or others,
+  // so use this to map
+  if (kind.rfind("sum", 0) == 0) {
+    return std::make_unique<SumAggregator>(
+        step, inputIndex, constant, isGlobal);
+  } else if (kind.rfind("count", 0) == 0) {
+    return std::make_unique<CountAggregator>(
+        step, inputIndex, constant, isGlobal);
+  } else if (kind.rfind("min", 0) == 0) {
+    return std::make_unique<MinAggregator>(
+        step, inputIndex, constant, isGlobal);
+  } else if (kind.rfind("max", 0) == 0) {
+    return std::make_unique<MaxAggregator>(
+        step, inputIndex, constant, isGlobal);
+  } else if (kind.rfind("avg", 0) == 0) {
+    return std::make_unique<MeanAggregator>(
+        step, inputIndex, constant, isGlobal);
+  } else {
+    VELOX_NYI("Aggregation not yet supported");
+  }
+}
+
+auto toAggregators(
+    core::AggregationNode const& aggregationNode,
+    exec::OperatorCtx const& operatorCtx) {
+  auto const step = aggregationNode.step();
+  bool const isGlobal = aggregationNode.groupingKeys().empty();
+  auto const& inputRowSchema = aggregationNode.sources()[0]->outputType();
+
+  std::vector<std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator>>
+      aggregators;
+  for (auto const& aggregate : aggregationNode.aggregates()) {
+    std::vector<column_index_t> aggInputs;
+    std::vector<VectorPtr> aggConstants;
+    for (auto const& arg : aggregate.call->inputs()) {
+      if (auto const field =
+              dynamic_cast<core::FieldAccessTypedExpr const*>(arg.get())) {
+        aggInputs.push_back(inputRowSchema->getChildIdx(field->name()));
+      } else if (
+          auto constant =
+              dynamic_cast<const core::ConstantTypedExpr*>(arg.get())) {
+        aggInputs.push_back(kConstantChannel);
+        aggConstants.push_back(constant->toConstantVector(operatorCtx.pool()));
+      } else {
+        VELOX_NYI("Constants and lambdas not yet supported");
+      }
+    }
+    // The loop on aggregate.call->inputs() is taken from
+    // AggregateInfo.cpp::toAggregateInfo(). It seems to suggest that there can
+    // be multiple inputs to an aggregate.
+    // We're postponing properly supporting this for now because the currently
+    // supported aggregation functions in cudf_velox don't use it.
+    VELOX_CHECK(aggInputs.size() == 1);
+
+    if (aggregate.distinct) {
+      VELOX_NYI("De-dup before aggregation is not yet supported");
+    }
+
+    auto const kind = aggregate.call->name();
+    auto const inputIndex = aggInputs[0];
+    auto const constant = aggConstants.empty() ? nullptr : aggConstants[0];
+    aggregators.push_back(
+        createAggregator(step, kind, inputIndex, constant, isGlobal));
+  }
+  return aggregators;
+}
+
+auto toIntermediateAggregators(
+    core::AggregationNode const& aggregationNode,
+    exec::OperatorCtx const& operatorCtx) {
+  auto const step = core::AggregationNode::Step::kIntermediate;
+  bool const isGlobal = aggregationNode.groupingKeys().empty();
+  auto const& inputRowSchema = aggregationNode.outputType();
+
+  std::vector<std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator>>
+      aggregators;
+  for (size_t i = 0; i < aggregationNode.aggregates().size(); i++) {
+    // Intermediate aggregation has a 1:1 mapping between input and output.
+    // We don't need to figure out input from the aggregate function.
+    auto const& aggregate = aggregationNode.aggregates()[i];
+    auto const inputIndex = aggregationNode.groupingKeys().size() + i;
+    auto const kind = aggregate.call->name();
+    auto const constant = nullptr;
+    aggregators.push_back(
+        createAggregator(step, kind, inputIndex, constant, isGlobal));
+  }
+  return aggregators;
+}
+
+} // namespace
+
+namespace facebook::velox::cudf_velox {
+
+CudfHashAggregation::CudfHashAggregation(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<core::AggregationNode const> const& aggregationNode)
+    : Operator(
+          driverCtx,
+          aggregationNode->outputType(),
+          operatorId,
+          aggregationNode->id(),
+          aggregationNode->step() == core::AggregationNode::Step::kPartial
+              ? "CudfPartialAggregation"
+              : "CudfAggregation",
+          aggregationNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId)
+              : std::nullopt),
+      NvtxHelper(
+          nvtx3::rgb{34, 139, 34}, // Forest Green
+          operatorId,
+          fmt::format("[{}]", aggregationNode->id())),
+      aggregationNode_(aggregationNode),
+      isPartialOutput_(exec::isPartialOutput(aggregationNode->step())),
+      isGlobal_(aggregationNode->groupingKeys().empty()),
+      isDistinct_(!isGlobal_ && aggregationNode->aggregates().empty()),
+      maxPartialAggregationMemoryUsage_(
+          driverCtx->queryConfig().maxPartialAggregationMemoryUsage()) {}
+
+void CudfHashAggregation::initialize() {
+  Operator::initialize();
+
+  auto const& inputType = aggregationNode_->sources()[0]->outputType();
+  ignoreNullKeys_ = aggregationNode_->ignoreNullKeys();
+  setupGroupingKeyChannelProjections(
+      groupingKeyInputChannels_, groupingKeyOutputChannels_);
+
+  auto const numGroupingKeys = groupingKeyOutputChannels_.size();
+
+  // Velox CPU does optimizations related to pre-grouped keys. This can be
+  // done in cudf by passing sort information to cudf::groupby() constructor.
+  // We're postponing this for now.
+
+  numAggregates_ = aggregationNode_->aggregates().size();
+  aggregators_ = toAggregators(*aggregationNode_, *operatorCtx_);
+  intermediateAggregators_ =
+      toIntermediateAggregators(*aggregationNode_, *operatorCtx_);
+
+  // Check that aggregate result type match the output type.
+  // TODO: This is output schema validation. In velox CPU, it's done using
+  // output types reported by aggregation functions. We can't do that in cudf
+  // groupby.
+
+  // TODO: Set identity projections used by HashProbe to pushdown dynamic
+  // filters to table scan.
+
+  // TODO: Add support for grouping sets and group ids.
+
+  aggregationNode_.reset();
+}
+
+void CudfHashAggregation::setupGroupingKeyChannelProjections(
+    std::vector<column_index_t>& groupingKeyInputChannels,
+    std::vector<column_index_t>& groupingKeyOutputChannels) const {
+  VELOX_CHECK(groupingKeyInputChannels.empty());
+  VELOX_CHECK(groupingKeyOutputChannels.empty());
+
+  auto const& inputType = aggregationNode_->sources()[0]->outputType();
+  auto const& groupingKeys = aggregationNode_->groupingKeys();
+  // The map from the grouping key output channel to the input channel.
+  //
+  // NOTE: grouping key output order is specified as 'groupingKeys' in
+  // 'aggregationNode_'.
+  std::vector<exec::IdentityProjection> groupingKeyProjections;
+  groupingKeyProjections.reserve(groupingKeys.size());
+  for (auto i = 0; i < groupingKeys.size(); ++i) {
+    groupingKeyProjections.emplace_back(
+        exec::exprToChannel(groupingKeys[i].get(), inputType), i);
+  }
+
+  groupingKeyInputChannels.reserve(groupingKeys.size());
+  for (auto i = 0; i < groupingKeys.size(); ++i) {
+    groupingKeyInputChannels.push_back(groupingKeyProjections[i].inputChannel);
+  }
+
+  groupingKeyOutputChannels.resize(groupingKeys.size());
+
+  std::iota(
+      groupingKeyOutputChannels.begin(), groupingKeyOutputChannels.end(), 0);
+}
+
+void CudfHashAggregation::computeIntermediateGroupbyPartial(CudfVectorPtr tbl) {
+  // For every input, we'll do a groupby and compact results with the existing
+  // intermediate groupby results.
+
+  auto inputTableStream = tbl->stream();
+  auto groupbyOnInput = doGroupByAggregation(
+      tbl->release(),
+      groupingKeyInputChannels_,
+      aggregators_,
+      inputTableStream);
+
+  // If we already have partial output, concatenate the new results with it.
+  if (partialOutput_) {
+    // Create a vector of tables to concatenate
+    std::vector<cudf::table_view> tablesToConcat;
+    tablesToConcat.push_back(partialOutput_->getTableView());
+    tablesToConcat.push_back(groupbyOnInput->getTableView());
+
+    auto partialOutputStream = partialOutput_->stream();
+    // We need to join the input table stream on the partial output stream to
+    // make sure the intermediate results are available when we do the concat.
+    cudf::detail::join_streams(
+        std::vector<rmm::cuda_stream_view>{inputTableStream},
+        partialOutputStream);
+
+    // Concatenate the tables
+    auto concatenatedTable =
+        cudf::concatenate(tablesToConcat, partialOutputStream);
+
+    // Now we have to groupby again but this time with intermediate aggregators.
+    auto compactedOutput = doGroupByAggregation(
+        std::move(concatenatedTable),
+        groupingKeyOutputChannels_,
+        intermediateAggregators_,
+        partialOutputStream);
+    partialOutput_ = compactedOutput;
+  } else {
+    // First time processing, just store the result of the input batch's groupby
+    // This means we're storing the stream from the first batch.
+    partialOutput_ = groupbyOnInput;
+  }
+}
+
+void CudfHashAggregation::computeIntermediateDistinctPartial(
+    CudfVectorPtr tbl) {
+  // For every input, we'll concat with existing distinct results and then do a
+  // distinct on the concatenated results.
+
+  auto inputTableStream = tbl->stream();
+
+  if (partialOutput_) {
+    // Concatenate the input table with the existing distinct results.
+    std::vector<cudf::table_view> tablesToConcat;
+    tablesToConcat.push_back(partialOutput_->getTableView());
+    tablesToConcat.push_back(tbl->getTableView().select(
+        groupingKeyInputChannels_.begin(), groupingKeyInputChannels_.end()));
+
+    auto partialOutputStream = partialOutput_->stream();
+    // We need to join the input table stream on the partial output stream to
+    // make sure the input table is available when we do the concat.
+    cudf::detail::join_streams(
+        std::vector<rmm::cuda_stream_view>{inputTableStream},
+        partialOutputStream);
+
+    auto concatenatedTable =
+        cudf::concatenate(tablesToConcat, partialOutputStream);
+
+    // Do a distinct on the concatenated results.
+    auto distinctOutput = getDistinctKeys(
+        std::move(concatenatedTable),
+        groupingKeyOutputChannels_,
+        inputTableStream);
+    partialOutput_ = distinctOutput;
+  } else {
+    // First time processing, just store the result of the input batch's
+    // distinct.
+    partialOutput_ = getDistinctKeys(
+        tbl->release(), groupingKeyInputChannels_, inputTableStream);
+  }
+}
+
+void CudfHashAggregation::addInput(RowVectorPtr input) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  if (input->size() == 0) {
+    return;
+  }
+  numInputRows_ += input->size();
+
+  auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input);
+  VELOX_CHECK_NOT_NULL(cudfInput);
+
+  if (isPartialOutput_ && !isGlobal_) {
+    if (isDistinct_) {
+      // Handle partial distinct aggregation.
+      computeIntermediateDistinctPartial(cudfInput);
+    } else {
+      // Handle partial groupby aggregation.
+      computeIntermediateGroupbyPartial(cudfInput);
+    }
+    return;
+  }
+
+  // Handle final aggregation or global cases.
+  inputs_.push_back(std::move(cudfInput));
+}
+
+CudfVectorPtr CudfHashAggregation::doGroupByAggregation(
+    std::unique_ptr<cudf::table> tbl,
+    std::vector<column_index_t> const& groupByKeys,
+    std::vector<std::unique_ptr<Aggregator>>& aggregators,
+    rmm::cuda_stream_view stream) {
+  auto groupbyKeyView = tbl->select(groupByKeys.begin(), groupByKeys.end());
+
+  size_t const numGroupingKeys = groupbyKeyView.num_columns();
+
+  // TODO: All other args to groupby are related to sort groupby. We don't
+  // support optimizations related to it yet.
+  cudf::groupby::groupby groupByOwner(
+      groupbyKeyView,
+      ignoreNullKeys_ ? cudf::null_policy::EXCLUDE
+                      : cudf::null_policy::INCLUDE);
+
+  std::vector<cudf::groupby::aggregation_request> requests;
+  for (auto& aggregator : aggregators) {
+    aggregator->addGroupbyRequest(tbl->view(), requests);
+  }
+
+  auto [groupKeys, results] = groupByOwner.aggregate(requests, stream);
+  // flatten the results
+  std::vector<std::unique_ptr<cudf::column>> resultColumns;
+
+  // first fill the grouping keys
+  auto groupKeysColumns = groupKeys->release();
+  resultColumns.insert(
+      resultColumns.begin(),
+      std::make_move_iterator(groupKeysColumns.begin()),
+      std::make_move_iterator(groupKeysColumns.end()));
+
+  // then fill the aggregation results
+  for (auto& aggregator : aggregators) {
+    resultColumns.push_back(aggregator->makeOutputColumn(results, stream));
+  }
+
+  // make a cudf table out of columns
+  auto resultTable = std::make_unique<cudf::table>(std::move(resultColumns));
+
+  // velox expects nullptr instead of a table with 0 rows
+  if (resultTable->num_rows() == 0) {
+    return nullptr;
+  }
+
+  auto numRows = resultTable->num_rows();
+
+  return std::make_shared<cudf_velox::CudfVector>(
+      pool(), outputType_, numRows, std::move(resultTable), stream);
+}
+
+CudfVectorPtr CudfHashAggregation::doGlobalAggregation(
+    std::unique_ptr<cudf::table> tbl,
+    rmm::cuda_stream_view stream) {
+  std::vector<std::unique_ptr<cudf::column>> resultColumns;
+  resultColumns.reserve(aggregators_.size());
+  for (auto i = 0; i < aggregators_.size(); i++) {
+    resultColumns.push_back(aggregators_[i]->doReduce(
+        tbl->view(), outputType_->childAt(i), stream));
+  }
+
+  return std::make_shared<cudf_velox::CudfVector>(
+      pool(),
+      outputType_,
+      1,
+      std::make_unique<cudf::table>(std::move(resultColumns)),
+      stream);
+}
+
+CudfVectorPtr CudfHashAggregation::getDistinctKeys(
+    std::unique_ptr<cudf::table> tbl,
+    std::vector<column_index_t> const& groupByKeys,
+    rmm::cuda_stream_view stream) {
+  auto result = cudf::distinct(
+      tbl->view().select(groupByKeys.begin(), groupByKeys.end()),
+      {groupingKeyOutputChannels_.begin(), groupingKeyOutputChannels_.end()},
+      cudf::duplicate_keep_option::KEEP_FIRST,
+      cudf::null_equality::EQUAL,
+      cudf::nan_equality::ALL_EQUAL,
+      stream);
+
+  auto numRows = result->num_rows();
+
+  return std::make_shared<cudf_velox::CudfVector>(
+      pool(), outputType_, numRows, std::move(result), stream);
+}
+
+CudfVectorPtr CudfHashAggregation::releaseAndResetPartialOutput() {
+  VELOX_DCHECK(!isGlobal_);
+  auto numOutputRows = partialOutput_->size();
+  const double aggregationPct =
+      numOutputRows == 0 ? 0 : (numOutputRows * 1.0) / numInputRows_ * 100;
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat("flushRowCount", RuntimeCounter(numOutputRows));
+    lockedStats->addRuntimeStat("flushTimes", RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        "partialAggregationPct", RuntimeCounter(aggregationPct));
+  }
+
+  numInputRows_ = 0;
+  // We're moving partialOutput_ to the caller because we want it to be null
+  // after this call.
+  return std::move(partialOutput_);
+}
+
+RowVectorPtr CudfHashAggregation::getOutput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+
+  // Handle partial groupby.
+  if (isPartialOutput_ && !isGlobal_) {
+    if (partialOutput_ &&
+        partialOutput_->estimateFlatSize() >
+            maxPartialAggregationMemoryUsage_) {
+      // This is basically a flush of the partial output.
+      return releaseAndResetPartialOutput();
+    }
+    if (not noMoreInput_) {
+      // Don't produce output if the partial output hasn't reached memory limit
+      // and there's more batches to come.
+      return nullptr;
+    }
+    if (!partialOutput_ && finished_) {
+      return nullptr;
+    }
+    return releaseAndResetPartialOutput();
+  }
+
+  if (finished_) {
+    return nullptr;
+  }
+
+  if (!isPartialOutput_ && !noMoreInput_) {
+    // Final aggregation has to wait for all batches to arrive so we cannot
+    // return any results here.
+    return nullptr;
+  }
+
+  if (inputs_.empty()) {
+    return nullptr;
+  }
+
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto tbl = getConcatenatedTable(inputs_, stream);
+
+  // Release input data after synchronizing.
+  stream.synchronize();
+  inputs_.clear();
+
+  if (noMoreInput_) {
+    finished_ = true;
+  }
+
+  VELOX_CHECK_NOT_NULL(tbl);
+
+  if (isDistinct_) {
+    return getDistinctKeys(std::move(tbl), groupingKeyInputChannels_, stream);
+  } else if (isGlobal_) {
+    return doGlobalAggregation(std::move(tbl), stream);
+  } else {
+    return doGroupByAggregation(
+        std::move(tbl), groupingKeyInputChannels_, aggregators_, stream);
+  }
+}
+
+void CudfHashAggregation::noMoreInput() {
+  Operator::noMoreInput();
+  if (isPartialOutput_ && inputs_.empty()) {
+    finished_ = true;
+  }
+}
+
+bool CudfHashAggregation::isFinished() {
+  return finished_;
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/exec/Operator.h"
+
+#include <cudf/groupby.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+class CudfHashAggregation : public exec::Operator, public NvtxHelper {
+ public:
+  struct Aggregator {
+    core::AggregationNode::Step step;
+    bool is_global;
+    cudf::aggregation::Kind kind;
+    uint32_t inputIndex;
+    VectorPtr constant;
+
+    virtual void addGroupbyRequest(
+        cudf::table_view const& tbl,
+        std::vector<cudf::groupby::aggregation_request>& requests) = 0;
+
+    virtual std::unique_ptr<cudf::column> doReduce(
+        cudf::table_view const& input,
+        TypePtr const& outputType,
+        rmm::cuda_stream_view stream) = 0;
+
+    virtual std::unique_ptr<cudf::column> makeOutputColumn(
+        std::vector<cudf::groupby::aggregation_result>& results,
+        rmm::cuda_stream_view stream) = 0;
+
+   protected:
+    Aggregator(
+        core::AggregationNode::Step step,
+        cudf::aggregation::Kind kind,
+        uint32_t inputIndex,
+        VectorPtr constant,
+        bool isGlobal)
+        : step(step),
+          is_global(isGlobal),
+          kind(kind),
+          inputIndex(inputIndex),
+          constant(constant) {}
+  };
+
+  CudfHashAggregation(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::AggregationNode> const& aggregationNode);
+
+  void initialize() override;
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void noMoreInput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* /* unused */) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  // Setups the projections for accessing grouping keys stored in grouping
+  // set.
+  // For 'groupingKeyInputChannels', the index is the key column index from
+  // the grouping set, and the value is the key column channel from the input.
+  // For 'outputChannelProjections', the index is the key column channel from
+  // the output, and the value is the key column index from the grouping set.
+  void setupGroupingKeyChannelProjections(
+      std::vector<column_index_t>& groupingKeyInputChannels,
+      std::vector<column_index_t>& groupingKeyOutputChannels) const;
+
+  CudfVectorPtr doGroupByAggregation(
+      std::unique_ptr<cudf::table> tbl,
+      std::vector<column_index_t> const& groupByKeys,
+      std::vector<std::unique_ptr<Aggregator>>& aggregators,
+      rmm::cuda_stream_view stream);
+  CudfVectorPtr doGlobalAggregation(
+      std::unique_ptr<cudf::table> tbl,
+      rmm::cuda_stream_view stream);
+  CudfVectorPtr getDistinctKeys(
+      std::unique_ptr<cudf::table> tbl,
+      std::vector<column_index_t> const& groupByKeys,
+      rmm::cuda_stream_view stream);
+
+  CudfVectorPtr releaseAndResetPartialOutput();
+
+  std::vector<column_index_t> groupingKeyInputChannels_;
+  std::vector<column_index_t> groupingKeyOutputChannels_;
+
+  std::shared_ptr<const core::AggregationNode> aggregationNode_;
+  std::vector<std::unique_ptr<Aggregator>> aggregators_;
+  std::vector<std::unique_ptr<Aggregator>> intermediateAggregators_;
+
+  // Partial aggregation is the first phase of aggregation. e.g. count(*) when
+  // in partial phase will do a count_agg but in the final phase will do a sum
+  // of the previous calculated counts
+  const bool isPartialOutput_;
+  // Global means it's an aggregation without groupby. Like cudf::reduce
+  const bool isGlobal_;
+  // Distinct means it's a count distinct on the groupby keys, without any
+  // aggregations
+  const bool isDistinct_;
+
+  // Maximum memory usage for partial aggregation.
+  const int64_t maxPartialAggregationMemoryUsage_;
+  // Number of rows received in the input so far.
+  int64_t numInputRows_ = 0;
+
+  bool finished_ = false;
+
+  size_t numAggregates_;
+  bool ignoreNullKeys_;
+
+  std::vector<cudf_velox::CudfVectorPtr> inputs_;
+
+  // This is for partial aggregation to keep reducing the amount of memory it
+  // has to hold on to.
+  void computeIntermediateGroupbyPartial(CudfVectorPtr tbl);
+
+  void computeIntermediateDistinctPartial(CudfVectorPtr tbl);
+
+  CudfVectorPtr partialOutput_;
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOrderBy.cpp
+++ b/velox/experimental/cudf/exec/CudfOrderBy.cpp
@@ -17,12 +17,8 @@
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
-#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
-#include <cudf/concatenate.hpp>
 #include <cudf/sorting.hpp>
-#include <cudf/table/table.hpp>
-#include <cudf/utilities/default_stream.hpp>
 
 namespace facebook::velox::cudf_velox {
 
@@ -36,7 +32,10 @@ CudfOrderBy::CudfOrderBy(
           operatorId,
           orderByNode->id(),
           "CudfOrderBy"),
-      NvtxHelper(nvtx3::rgb{64, 224, 208}, operatorId), // Turquoise
+      NvtxHelper(
+          nvtx3::rgb{64, 224, 208}, // Turquoise
+          operatorId,
+          fmt::format("[{}]", orderByNode->id())),
       orderByNode_(orderByNode) {
   sortKeys_.reserve(orderByNode->sortingKeys().size());
   columnOrder_.reserve(orderByNode->sortingKeys().size());

--- a/velox/experimental/cudf/exec/CudfOrderBy.h
+++ b/velox/experimental/cudf/exec/CudfOrderBy.h
@@ -22,7 +22,7 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
 
-#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
 
 namespace facebook::velox::cudf_velox {
 

--- a/velox/experimental/cudf/exec/NvtxHelper.h
+++ b/velox/experimental/cudf/exec/NvtxHelper.h
@@ -25,11 +25,15 @@ namespace facebook::velox::cudf_velox {
 class NvtxHelper {
  public:
   NvtxHelper();
-  NvtxHelper(nvtx3::color color, std::optional<int64_t> payload = std::nullopt)
-      : color_(color), payload_(payload) {}
+  NvtxHelper(
+      nvtx3::color color,
+      std::optional<int64_t> payload = std::nullopt,
+      std::optional<std::string> extraInfo = std::nullopt)
+      : color_(color), payload_(payload), extraInfo_(extraInfo) {}
 
   nvtx3::color color_{nvtx3::rgb{125, 125, 125}}; // Gray
   std::optional<int64_t> payload_{};
+  std::optional<std::string> extraInfo_{};
 };
 
 /**
@@ -41,19 +45,55 @@ struct VeloxDomain {
 
 using NvtxRegisteredStringT = nvtx3::registered_string_in<VeloxDomain>;
 
+/**
+ * @brief Extracts class and function name from a pretty function string.
+ *
+ * This function parses a string like:
+ * "virtual facebook::velox::RowVectorPtr
+ * facebook::velox::cudf_velox::CudfHashAggregation::getOutput()" and returns
+ * "CudfHashAggregation::getOutput"
+ *
+ * @param prettyFunction The string from __PRETTY_FUNCTION__
+ * @return A simplified string in the format "classname::function"
+ */
+constexpr std::string_view extractClassAndFunction(
+    std::string_view prettyFunction) {
+  // Find the last occurrence of "::" before the opening parenthesis
+  auto parenPos = prettyFunction.find('(');
+  if (parenPos == std::string_view::npos) {
+    parenPos = prettyFunction.size();
+  }
+
+  auto lastColonPos = prettyFunction.rfind("::", parenPos);
+  if (lastColonPos == std::string_view::npos) {
+    return prettyFunction.substr(0, parenPos); // No class name found
+  }
+
+  // Find the previous "::" to get the start of the class name
+  auto prevColonPos = prettyFunction.rfind("::", lastColonPos - 1);
+  if (prevColonPos == std::string_view::npos) {
+    return prettyFunction.substr(0, parenPos); // No namespace found
+  }
+
+  // Return the class and function name
+  return prettyFunction.substr(prevColonPos + 2, parenPos - prevColonPos - 2);
+}
+
 #define VELOX_NVTX_OPERATOR_FUNC_RANGE()                                         \
   static_assert(                                                                 \
       std::is_base_of<NvtxHelper, std::remove_pointer<decltype(this)>::type>::   \
           value,                                                                 \
       "VELOX_NVTX_OPERATOR_FUNC_RANGE can only be used"                          \
       " in Operators derived from NvtxHelper");                                  \
-  static NvtxRegisteredStringT const nvtx3_func_name__{                          \
-      std::string(__func__) + " " + std::string(__PRETTY_FUNCTION__)};           \
-  static ::nvtx3::event_attributes const nvtx3_func_attr__{                    \
+  static std::string const nvtx3_func_name__{                                    \
+      std::string(extractClassAndFunction(__PRETTY_FUNCTION__))};                \
+  std::string const nvtx3_func_extra_info__{                                     \
+      nvtx3_func_name__ + " " + this->extraInfo_.value_or("")};                  \
+  ::nvtx3::event_attributes const nvtx3_func_attr__{                           \
       this->payload_.has_value() ?                                             \
-          ::nvtx3::event_attributes{nvtx3_func_name__, this->color_,           \
+          ::nvtx3::event_attributes{nvtx3_func_extra_info__, this->color_,     \
                                    nvtx3::payload{this->payload_.value()}} :   \
-          ::nvtx3::event_attributes{nvtx3_func_name__, this->color_}}; \
+          ::nvtx3::event_attributes{nvtx3_func_extra_info__, this->color_}}; \
   ::nvtx3::scoped_range_in<VeloxDomain> const nvtx3_range__{nvtx3_func_attr__};
 
 #define VELOX_NVTX_PRETTY_FUNC_RANGE()                                         \

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -17,14 +17,19 @@
 #pragma once
 
 #include "velox/common/memory/Memory.h"
-#include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 
-#include <cudf/column/column.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 
-namespace facebook::velox::cudf_velox::with_arrow {
+#include <rmm/cuda_stream_view.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+cudf::type_id veloxToCudfTypeId(const TypePtr& type);
+
+namespace with_arrow {
+
 std::unique_ptr<cudf::table> toCudfTable(
     const facebook::velox::RowVectorPtr& veloxTable,
     facebook::velox::memory::MemoryPool* pool,
@@ -42,4 +47,6 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     const std::vector<std::string>& columnNames,
     rmm::cuda_stream_view stream);
 
-} // namespace facebook::velox::cudf_velox::with_arrow
+} // namespace with_arrow
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+using core::QueryConfig;
+using facebook::velox::test::BatchMaker;
+using namespace common::testutil;
+
+class AggregationTest : public OperatorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+    TestValue::enable();
+  }
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+
+  std::vector<RowVectorPtr>
+  makeVectors(const RowTypePtr& rowType, size_t size, int numVectors) {
+    std::vector<RowVectorPtr> vectors;
+    VectorFuzzer fuzzer({.vectorSize = size}, pool());
+    for (int32_t i = 0; i < numVectors; ++i) {
+      vectors.push_back(fuzzer.fuzzInputRow(rowType));
+    }
+    return vectors;
+  }
+
+  template <typename T>
+  void testSingleKey(
+      const std::vector<RowVectorPtr>& vectors,
+      const std::string& keyName,
+      bool ignoreNullKeys,
+      bool distinct) {
+    std::vector<std::string> aggregates;
+    if (!distinct) {
+      // TODO (dm): "sum(15)", "sum(0.1)",  "min(15)",  "min(0.1)", "max(15)",
+      // "max(0.1)",
+      aggregates = {
+          "sum(c1)",
+          "sum(c2)",
+          "sum(c4)",
+          "sum(c5)",
+          "min(c1)",
+          "min(c2)",
+          "min(c3)",
+          "min(c4)",
+          "min(c5)",
+          "max(c1)",
+          "max(c2)",
+          "max(c3)",
+          "max(c4)",
+          "max(c5)"};
+    }
+
+    auto op = PlanBuilder()
+                  .values(vectors)
+                  .aggregation(
+                      {keyName},
+                      aggregates,
+                      {},
+                      core::AggregationNode::Step::kPartial,
+                      ignoreNullKeys)
+                  .planNode();
+
+    std::string fromClause = "FROM tmp";
+    if (ignoreNullKeys) {
+      fromClause += " WHERE " + keyName + " IS NOT NULL";
+    }
+    if (distinct) {
+      assertQuery(op, "SELECT distinct " + keyName + " " + fromClause);
+    } else {
+      // TODO (dm): sum(15), sum(cast(0.1 as double)), min(15), min(0.1),
+      // max(15), max(0.1),
+      assertQuery(
+          op,
+          "SELECT " + keyName +
+              ", sum(c1), sum(c2), sum(c4), sum(c5) , min(c1), min(c2), min(c3), min(c4), min(c5), max(c1), max(c2), max(c3), max(c4), max(c5) " +
+              fromClause + " GROUP BY " + keyName);
+    }
+  }
+
+  void testMultiKey(
+      const std::vector<RowVectorPtr>& vectors,
+      bool ignoreNullKeys,
+      bool distinct) {
+    std::vector<std::string> aggregates;
+    // TODO (dm): "sum(15)", "sum(0.1)",  "min(15)",  "min(0.1)", "max(15)",
+    // "max(0.1)"
+    if (!distinct) {
+      aggregates = {
+          "sum(c4)",
+          "sum(c5)",
+          "min(c3)",
+          "min(c4)",
+          "min(c5)",
+          "max(c3)",
+          "max(c4)",
+          "max(c5)"};
+    }
+    auto op = PlanBuilder()
+                  .values(vectors)
+                  .aggregation(
+                      {"c0", "c1", "c6"},
+                      aggregates,
+                      {},
+                      core::AggregationNode::Step::kPartial,
+                      ignoreNullKeys)
+                  .planNode();
+
+    std::string fromClause = "FROM tmp";
+    if (ignoreNullKeys) {
+      fromClause +=
+          " WHERE c0 IS NOT NULL AND c1 IS NOT NULL AND c6 IS NOT NULL";
+    }
+    if (distinct) {
+      assertQuery(op, "SELECT distinct c0, c1, c6 " + fromClause);
+    } else {
+      // TODO (dm): sum(15), sum(cast(0.1 as double)), min(15), min(0.1),
+      // max(15), max(0.1),, sum(1)
+      assertQuery(
+          op,
+          "SELECT c0, c1, c6, sum(c4), sum(c5), min(c3), min(c4), min(c5),  max(c3), max(c4), max(c5) " +
+              fromClause + " GROUP BY c0, c1, c6");
+    }
+  }
+
+  RowTypePtr rowType_{
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
+          {BIGINT(),
+           SMALLINT(),
+           INTEGER(),
+           BIGINT(),
+           DOUBLE(), // DM: This used to be REAL() but we don't support that
+           DOUBLE(),
+           VARCHAR()})};
+};
+
+TEST_F(AggregationTest, global) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  // DM: removed "sum(15)","min(15)","max(15)",
+  auto op = PlanBuilder()
+                .values(vectors)
+                .aggregation(
+                    {},
+                    {"sum(c1)",
+                     "sum(c2)",
+                     "sum(c4)",
+                     "sum(c5)",
+
+                     "min(c1)",
+                     "min(c2)",
+                     "min(c3)",
+                     "min(c4)",
+                     "min(c5)",
+
+                     "max(c1)",
+                     "max(c2)",
+                     "max(c3)",
+                     "max(c4)",
+                     "max(c5)"},
+                    {},
+                    core::AggregationNode::Step::kPartial,
+                    false)
+                .planNode();
+
+  // DM: removed sum(15), min(15), max(15),
+  assertQuery(
+      op,
+      "SELECT sum(c1), sum(c2), sum(c4), sum(c5), "
+      "min(c1), min(c2), min(c3), min(c4), min(c5), "
+      "max(c1), max(c2), max(c3), max(c4), max(c5) FROM tmp");
+}
+
+TEST_F(AggregationTest, singleBigintKey) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testSingleKey<int64_t>(vectors, "c0", false, false);
+  testSingleKey<int64_t>(vectors, "c0", true, false);
+}
+
+TEST_F(AggregationTest, singleBigintKeyDistinct) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testSingleKey<int64_t>(vectors, "c0", false, true);
+  testSingleKey<int64_t>(vectors, "c0", true, true);
+}
+
+TEST_F(AggregationTest, singleStringKey) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testSingleKey<StringView>(vectors, "c6", false, false);
+  testSingleKey<StringView>(vectors, "c6", true, false);
+}
+
+TEST_F(AggregationTest, singleStringKeyDistinct) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testSingleKey<StringView>(vectors, "c6", false, true);
+  testSingleKey<StringView>(vectors, "c6", true, true);
+}
+
+TEST_F(AggregationTest, multiKey) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testMultiKey(vectors, false, false);
+  testMultiKey(vectors, true, false);
+}
+
+TEST_F(AggregationTest, multiKeyDistinct) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+  testMultiKey(vectors, false, true);
+  testMultiKey(vectors, true, true);
+}
+
+TEST_F(AggregationTest, aggregateOfNulls) {
+  auto rowVector = makeRowVector({
+      BatchMaker::createVector<TypeKind::BIGINT>(
+          rowType_->childAt(0), 100, *pool_),
+      makeNullConstant(TypeKind::SMALLINT, 100),
+  });
+
+  auto vectors = {rowVector};
+  createDuckDbTable(vectors);
+
+  auto op = PlanBuilder()
+                .values(vectors)
+                .aggregation(
+                    {"c0"},
+                    {"sum(c1)", "min(c1)", "max(c1)"},
+                    {},
+                    core::AggregationNode::Step::kPartial,
+                    false)
+                .planNode();
+
+  assertQuery(op, "SELECT c0, sum(c1), min(c1), max(c1) FROM tmp GROUP BY c0");
+
+  // global aggregation
+  op = PlanBuilder()
+           .values(vectors)
+           .aggregation(
+               {},
+               {"sum(c1)", "min(c1)", "max(c1)"},
+               {},
+               core::AggregationNode::Step::kPartial,
+               false)
+           .planNode();
+
+  assertQuery(op, "SELECT sum(c1), min(c1), max(c1) FROM tmp");
+}
+
+TEST_F(AggregationTest, allKeyTypes) {
+  // Covers different key types. Unlike the integer/string tests, the
+  // hash table begins life in the generic mode, not array or
+  // normalized key. Add types here as they become supported.
+  auto rowType = ROW(
+      {"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
+      {DOUBLE(), REAL(), BIGINT(), INTEGER(), BOOLEAN(), VARCHAR(), DOUBLE()});
+
+  std::vector<RowVectorPtr> batches;
+  for (auto i = 0; i < 10; ++i) {
+    batches.push_back(std::static_pointer_cast<RowVector>(
+        BatchMaker::createBatch(rowType, 100, *pool_)));
+  }
+  createDuckDbTable(batches);
+  auto op =
+      PlanBuilder()
+          .values(batches)
+          .singleAggregation({"c0", "c1", "c2", "c3", "c4", "c5"}, {"sum(c6)"})
+          .planNode();
+
+  // DM: Instead of sum(c6), this was sum(1) but we don't yet support constants
+  assertQuery(
+      op,
+      "SELECT c0, c1, c2, c3, c4, c5, sum(c6) FROM tmp "
+      " GROUP BY c0, c1, c2, c3, c4, c5");
+}
+
+TEST_F(AggregationTest, ignoreNullKeys) {
+  // Some keys are null.
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {std::nullopt, 1, std::nullopt, 2, std::nullopt, 1, 2}),
+      makeFlatVector<int32_t>({-1, 1, -2, 2, -3, 3, 4}),
+  });
+
+  auto makePlan = [&](bool ignoreNullKeys) {
+    return PlanBuilder()
+        .values({data})
+        .aggregation(
+            {"c0"},
+            {"sum(c1)"},
+            {},
+            core::AggregationNode::Step::kPartial,
+            ignoreNullKeys)
+        .planNode();
+  };
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<int64_t>({4, 6}),
+  });
+  AssertQueryBuilder(makePlan(true)).assertResults(expected);
+
+  expected = makeRowVector({
+      makeNullableFlatVector<int32_t>({std::nullopt, 1, 2}),
+      makeFlatVector<int64_t>({-6, 4, 6}),
+  });
+  AssertQueryBuilder(makePlan(false)).assertResults(expected);
+
+  // All keys are null.
+  data = makeRowVector({
+      makeAllNullFlatVector<int32_t>(3),
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+
+  AssertQueryBuilder(makePlan(true)).assertEmptyResults();
+}
+
+TEST_F(AggregationTest, avgSingleGrouped) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  // DM: removed avg(c3). We're having overflow issues with int64_t.
+  std::vector<std::string> aggregates = {
+      "avg(c1)", "avg(c2)", "avg(c4)", "avg(c5)"};
+
+  std::string keyName = "c0";
+  auto op = PlanBuilder()
+                .values(vectors)
+                .singleAggregation({keyName}, aggregates)
+                .planNode();
+
+  assertQuery(
+      op,
+      "SELECT " + keyName + ", avg(c1), avg(c2), avg(c4), avg(c5) " +
+          "FROM tmp GROUP BY " + keyName);
+}
+
+TEST_F(AggregationTest, avgPartialFinalGrouped) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  // DM: removed avg(c3). We're having overflow issues with int64_t.
+  std::vector<std::string> aggregates = {
+      "avg(c1)", "avg(c2)", "avg(c4)", "avg(c5)"};
+
+  std::string keyName = "c0";
+  auto op = PlanBuilder()
+                .values(vectors)
+                .partialAggregation({keyName}, aggregates)
+                .finalAggregation()
+                .planNode();
+
+  assertQuery(
+      op,
+      "SELECT " + keyName + ", avg(c1), avg(c2), avg(c4), avg(c5) " +
+          "FROM tmp GROUP BY " + keyName);
+}
+
+TEST_F(AggregationTest, avgSingleGlobal) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::vector<std::string> aggregates = {
+      "avg(c1)", "avg(c2)", "avg(c4)", "avg(c5)"};
+  auto op = PlanBuilder()
+                .values(vectors)
+                .singleAggregation({}, aggregates)
+                .planNode();
+
+  assertQuery(op, "SELECT avg(c1), avg(c2), avg(c4), avg(c5) FROM tmp");
+}
+
+TEST_F(AggregationTest, avgPartialFinalGlobal) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::vector<std::string> aggregates = {
+      "avg(c1)", "avg(c2)", "avg(c4)", "avg(c5)"};
+
+  auto op = PlanBuilder()
+                .values(vectors)
+                .partialAggregation({}, aggregates)
+                .finalAggregation()
+                .planNode();
+
+  assertQuery(op, "SELECT avg(c1), avg(c2), avg(c4), avg(c5) FROM tmp");
+}
+
+TEST_F(AggregationTest, countSingleGroupBy) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::string keyName = "c0";
+  std::vector<std::string> aggregates = {"count(0)"};
+  auto op = PlanBuilder()
+                .values(vectors)
+                .singleAggregation({keyName}, aggregates)
+                .planNode();
+
+  assertQuery(
+      op, "SELECT " + keyName + ", count(*) FROM tmp GROUP BY " + keyName);
+}
+
+TEST_F(AggregationTest, countPartialFinalGroupBy) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::string keyName = "c0";
+  std::vector<std::string> aggregates = {"count(0)"};
+  auto op = PlanBuilder()
+                .values(vectors)
+                .partialAggregation({keyName}, aggregates)
+                .finalAggregation()
+                .planNode();
+
+  assertQuery(
+      op, "SELECT " + keyName + ", count(*) FROM tmp GROUP BY " + keyName);
+}
+
+TEST_F(AggregationTest, countSingleGlobal) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::vector<std::string> aggregates = {"count(0)"};
+  auto op = PlanBuilder()
+                .values(vectors)
+                .singleAggregation({}, aggregates)
+                .planNode();
+
+  assertQuery(op, "SELECT count(*) FROM tmp");
+}
+
+TEST_F(AggregationTest, countPartialFinalGlobal) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  std::vector<std::string> aggregates = {"count(0)"};
+  auto op = PlanBuilder()
+                .values(vectors)
+                .partialAggregation({}, aggregates)
+                .finalAggregation()
+                .planNode();
+
+  assertQuery(op, "SELECT count(*) FROM tmp");
+}
+
+TEST_F(AggregationTest, partialAggregationMemoryLimit) {
+  auto vectors = {
+      makeRowVector({makeFlatVector<int32_t>(
+          100, [](auto row) { return row; }, nullEvery(5))}),
+      makeRowVector({makeFlatVector<int32_t>(
+          110, [](auto row) { return row + 29; }, nullEvery(7))}),
+      makeRowVector({makeFlatVector<int32_t>(
+          90, [](auto row) { return row - 71; }, nullEvery(7))}),
+  };
+
+  createDuckDbTable(vectors);
+
+  // Set an artificially low limit on the amount of data to accumulate in
+  // the partial aggregation.
+
+  // Distinct aggregation.
+  core::PlanNodeId aggNodeId;
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .config(QueryConfig::kMaxPartialAggregationMemory, 100)
+                  .plan(PlanBuilder()
+                            .values(vectors)
+                            .partialAggregation({"c0"}, {})
+                            .capturePlanNodeId(aggNodeId)
+                            .finalAggregation()
+                            .planNode())
+                  .assertResults("SELECT distinct c0 FROM tmp");
+
+  auto rowFlushStats = toPlanStats(task->taskStats())
+                           .at(aggNodeId)
+                           .customStats.at("flushRowCount");
+  EXPECT_GT(rowFlushStats.sum, 0);
+  EXPECT_GT(rowFlushStats.max, 0);
+
+  // Count aggregation.
+  task = AssertQueryBuilder(duckDbQueryRunner_)
+             .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+             .plan(PlanBuilder()
+                       .values(vectors)
+                       .partialAggregation({"c0"}, {"count(1)"})
+                       .capturePlanNodeId(aggNodeId)
+                       .finalAggregation()
+                       .planNode())
+             .assertResults("SELECT c0, count(1) FROM tmp GROUP BY 1");
+
+  rowFlushStats = toPlanStats(task->taskStats())
+                      .at(aggNodeId)
+                      .customStats.at("flushRowCount");
+  EXPECT_GT(rowFlushStats.sum, 0);
+  EXPECT_GT(rowFlushStats.max, 0);
+
+  // Global aggregation.
+  task = AssertQueryBuilder(duckDbQueryRunner_)
+             .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+             .plan(PlanBuilder()
+                       .values(vectors)
+                       .partialAggregation({}, {"sum(c0)"})
+                       .capturePlanNodeId(aggNodeId)
+                       .finalAggregation()
+                       .planNode())
+             .assertResults("SELECT sum(c0) FROM tmp");
+  EXPECT_EQ(
+      0,
+      toPlanStats(task->taskStats())
+          .at(aggNodeId)
+          .customStats.count("flushRowCount"));
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -13,14 +13,22 @@
 # limitations under the License.
 
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)
+add_executable(velox_cudf_aggregation_test Main.cpp AggregationTest.cpp)
 
 add_test(
   NAME velox_cudf_order_by_test
   COMMAND velox_cudf_order_by_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+add_test(
+  NAME velox_cudf_aggregation_test
+  COMMAND velox_cudf_aggregation_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver
                                                          TIMEOUT 3000)
+set_tests_properties(velox_cudf_aggregation_test PROPERTIES LABELS cuda_driver
+                                                            TIMEOUT 3000)
 
 target_link_libraries(
   velox_cudf_order_by_test
@@ -28,6 +36,17 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_test_util
+  gtest
+  gtest_main
+  fmt::fmt)
+
+target_link_libraries(
+  velox_cudf_aggregation_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  velox_vector_fuzzer
   gtest
   gtest_main
   fmt::fmt)


### PR DESCRIPTION
This PR adds a cuDF based HashAggregation operator with limited in-built aggregation support. The supported aggregations are: sum, min, max, count, avg.

This PR also updates the nvtx utility to produce more descriptive labels when profiling.