### PR TITLE
test: Add Hive intermediate support for Json

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
   PrestoQueryRunner.cpp
   PrestoQueryRunnerIntermediateTypeTransforms.cpp
   PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
+  PrestoQueryRunnerJsonTransform.cpp
   PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
   FuzzerUtil.cpp
   PrestoSql.cpp

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -326,7 +326,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "bingtile") ||
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
-      usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -15,9 +15,11 @@
  */
 
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -47,7 +49,8 @@ intermediateTypeTransforms() {
                QDIGEST(BIGINT()), VARBINARY())},
           {QDIGEST(REAL()),
            std::make_shared<IntermediateTypeTransformUsingCast>(
-               QDIGEST(REAL()), VARBINARY())}};
+               QDIGEST(REAL()), VARBINARY())},
+          {JSON(), std::make_shared<JsonTransform>()}};
   return intermediateTypeTransforms;
 }
 

--- a/velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::exec::test {
+
+core::ExprPtr JsonTransform::projectToTargetType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CallExpr>(
+      "try",
+      std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+          "json_format", std::vector<core::ExprPtr>{inputExpr}, std::nullopt)},
+      columnAlias);
+}
+
+core::ExprPtr JsonTransform::projectToIntermediateType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CallExpr>(
+      "try",
+      std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+          "json_parse", std::vector<core::ExprPtr>{inputExpr}, std::nullopt)},
+      columnAlias);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::exec::test {
+class JsonTransform : public IntermediateTypeTransform {
+ public:
+  JsonTransform() : IntermediateTypeTransform(JSON(), VARCHAR()) {}
+
+  core::ExprPtr projectToTargetType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+
+  core::ExprPtr projectToIntermediateType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+};
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -212,6 +212,7 @@ add_executable(
   PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
   PrestoQueryRunnerTDigestTransformTest.cpp
   PrestoQueryRunnerQDigestTransformTest.cpp
+  PrestoQueryRunnerJsonTransformTest.cpp
   PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp)
 
 add_test(velox_exec_util_test velox_exec_util_test)

--- a/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
@@ -168,4 +168,24 @@ void PrestoQueryRunnerIntermediateTypeTransformTestBase::testRow(
   testConstant(base);
 }
 
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testArray(
+    const VectorPtr& vector) {
+  test(fuzzer_.fuzzArray(vector, vector->size()));
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testMap(
+    const VectorPtr& keys,
+    const VectorPtr& values) {
+  VELOX_DCHECK_EQ(keys->size(), values->size());
+  test(fuzzer_.fuzzMap(keys, values, keys->size()));
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testRow(
+    std::vector<VectorPtr>&& vectors,
+    std::vector<std::string> names) {
+  auto vector_size = vectors.size();
+  VELOX_DCHECK_EQ(vector_size, names.size());
+  test(fuzzer_.fuzzRow(std::move(vectors), names, vector_size));
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h
+++ b/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h
@@ -41,6 +41,14 @@ class PrestoQueryRunnerIntermediateTypeTransformTestBase
 
   void testRow(const TypePtr& type);
 
+  void testArray(const VectorPtr& vector);
+
+  void testMap(const VectorPtr& keys, const VectorPtr& values);
+
+  void testRow(
+      std::vector<VectorPtr>&& vectors,
+      std::vector<std::string> names);
+
  private:
   const int32_t kVectorSize = 100;
   VectorFuzzer fuzzer_{VectorFuzzer::Options{}, pool_.get(), 123};

--- a/velox/exec/tests/PrestoQueryRunnerJsonTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerJsonTransformTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+class PrestoQueryRunnerJsonTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, verifyTransformExpression) {
+  core::PlanNodePtr plan =
+      PlanBuilder()
+          .values({makeRowVector(
+              {"c0"},
+              {transformIntermediateTypes(makeNullableFlatVector(
+                  std::vector<std::optional<StringView>>{}, JSON()))})})
+          .projectExpressions({getProjectionsToIntermediateTypes(
+              JSON(),
+              std::make_shared<core::FieldAccessExpr>(
+                  "c0",
+                  std::nullopt,
+                  std::vector<core::ExprPtr>{
+                      std::make_shared<core::InputExpr>()}),
+              "c0")})
+          .planNode();
+
+  VELOX_CHECK_EQ(
+      plan->toString(true, false),
+      "-- Project[1][expressions: (c0:JSON, try(json_parse(ROW[\"c0\"])))] -> c0:JSON\n");
+  AssertQueryBuilder(plan).assertTypeAndNumRows(JSON(), 0);
+}
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, roundTrip) {
+  std::vector<std::optional<StringView>> no_nulls{"1", "2", "3"};
+  test(makeNullableFlatVector(no_nulls, JSON()));
+
+  std::vector<std::optional<StringView>> some_nulls{"1", std::nullopt, "3"};
+  test(makeNullableFlatVector(some_nulls, JSON()));
+
+  std::vector<std::optional<StringView>> all_nulls{
+      std::nullopt, std::nullopt, std::nullopt};
+  test(makeNullableFlatVector(all_nulls, JSON()));
+}
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(JSON()));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(JSON())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(JSON(), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), JSON())));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({JSON(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({BOOLEAN(), ARRAY(JSON())})));
+  ASSERT_TRUE(isIntermediateOnlyType(
+      ROW({SMALLINT(), TIMESTAMP(), ARRAY(ROW({MAP(VARCHAR(), JSON())}))})));
+}
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, transformArray) {
+  std::vector<std::optional<StringView>> valid_json{
+      "1",
+      "2",
+      "3",
+      "\"{}\"",
+      "[1,2,3]",
+      "{\"name\":\"John\"}",
+      "{\"product\":\"laptop\"}",
+      "{\"temperature\":23.5}",
+      "{\"isActive\":true}",
+      "{\"coordinates\":{\"latitude\":40.7128}}",
+      "{\"colors\":[\"red\"]}",
+      "{\"user\":{\"id\":123}}",
+      "{\"order\":{\"id\":456}}",
+      "{\"event\":\"concert\"}",
+      "{\"settings\":{\"volume\":75}}",
+      "{\"company\":{\"name\":\"TechCorp\"}}",
+      "{\"university\":{\"departments\":[{\"name\":\"ComputerScience\"}]}}",
+      "{\"library\":{\"books\":[{\"title\":\"1984\"}]}}",
+      "{\"restaurant\":{\"menu\":{\"appetizers\":[\"salad\"]}}}",
+      "{\"project\":{\"name\":\"Apollo\"}}",
+  };
+  auto input = makeNullableFlatVector(valid_json, JSON());
+  testArray(input);
+}
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, transformMap) {
+  std::vector<std::optional<StringView>> valid_json_keys{
+      "\"key1\"",
+      "\"key2\"",
+      "\"key3\"",
+      "{\"address\":{\"city\":\"New York\"}}",
+      "{\"company\":{\"name\":\"TechCorp\"}}",
+      "{\"product\":\"Laptop\"}",
+      "\"key7\"",
+      "\"key8\"",
+      "\"key9\"",
+      "\"key10\""};
+  auto keys = makeNullableFlatVector(valid_json_keys, JSON());
+  std::vector<std::optional<StringView>> valid_json_values{
+      "{\"name\":\"Alice\"}",
+      "{\"age\":30}",
+      "{\"address\":{\"city\":\"New York\"}}",
+      "{\"company\":{\"name\":\"TechCorp\"}}",
+      "{\"product\":\"Laptop\"}",
+      "{\"price\":999.99}",
+      "{\"user\":{\"id\":123}}",
+      "{\"order\":{\"id\":456}}",
+      "{\"event\":{\"name\":\"Conference\"}}",
+      "{\"library\":{\"books\":[{\"title\":\"1984\"}]}}"};
+  auto values = makeNullableFlatVector(valid_json_values, JSON());
+  testMap(keys, values);
+}
+
+TEST_F(PrestoQueryRunnerJsonTransformTest, transformRow) {
+  std::vector<std::optional<StringView>> valid_json{
+      "1",
+      "2",
+      "3",
+      "\"{}\"",
+      "[1,2,3]",
+      "{\"name\":\"John\"}",
+      "{\"product\":\"laptop\"}",
+      "{\"temperature\":23.5}",
+      "{\"isActive\":true}",
+      "{\"coordinates\":{\"latitude\":40.7128}}",
+      "{\"colors\":[\"red\"]}",
+      "{\"user\":{\"id\":123}}",
+      "{\"order\":{\"id\":456}}",
+      "{\"event\":\"concert\"}",
+      "{\"settings\":{\"volume\":75}}",
+      "{\"company\":{\"name\":\"TechCorp\"}}",
+      "{\"university\":{\"departments\":[{\"name\":\"ComputerScience\"}]}}",
+      "{\"library\":{\"books\":[{\"title\":\"1984\"}]}}",
+      "{\"restaurant\":{\"menu\":{\"appetizers\":[\"salad\"]}}}",
+      "{\"project\":{\"name\":\"Apollo\"}}",
+  };
+  auto input = makeNullableFlatVector(valid_json, JSON());
+  testRow({input}, {"row"});
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary: Adds support for writing Json as an intermediate type to Hive by building off of the added intermediate support here: D71585451.

Differential Revision: D74750619
