### PR TITLE
fix: Handle extreme float-point values in Spark from_json by mapping the value to INF

### DIFF
--- a/velox/functions/sparksql/specialforms/FromJson.cpp
+++ b/velox/functions/sparksql/specialforms/FromJson.cpp
@@ -454,8 +454,28 @@ struct ExtractJsonTypeImpl {
     SIMDJSON_ASSIGN_OR_RAISE(auto type, value.type());
     switch (type) {
       case simdjson::ondemand::json_type::number: {
-        SIMDJSON_ASSIGN_OR_RAISE(auto num, value.get_double());
-        return convertIfInRange<T>(num, writer);
+        auto result = value.get_double();
+        if (result.error() == simdjson::SUCCESS) {
+          auto num = result.value_unsafe();
+          writer.castTo<T>() = num;
+        } else if (result.error() == simdjson::NUMBER_ERROR) {
+          // simdjson parses floating point numbers in the range
+          // [std::numeric_limits<double>::lowest(),
+          // std::numeric_limits<double>::max()], i.e., from approximately
+          // -1.7976e308 to 1.7975e308. Values outside this range
+          // (<= -1e308 or >= 1e308) are rejected and simdjson returns
+          // NUMBER_ERROR. However, our expected behavior is to convert such
+          // extreme values to -INF or +INF, so we add extra logic here to
+          // handle NUMBER_ERROR and perform the conversion.
+          auto castResult = util::Converter<TypeKind::DOUBLE>::tryCast(
+              value.raw_json_token());
+          if (!castResult.hasError()) {
+            writer.castTo<T>() = castResult.value();
+            return simdjson::SUCCESS;
+          }
+        }
+
+        return result.error();
       }
       case simdjson::ondemand::json_type::string: {
         SIMDJSON_ASSIGN_OR_RAISE(auto s, value.get_string());

--- a/velox/functions/sparksql/tests/FromJsonTest.cpp
+++ b/velox/functions/sparksql/tests/FromJsonTest.cpp
@@ -121,19 +121,11 @@ TEST_F(FromJsonTest, basicBigInt) {
 
 TEST_F(FromJsonTest, basicFloat) {
   auto expected = makeNullableFlatVector<float>(
-      {1.0,
-       2.0,
-       -3.4028235E38,
-       3.4028235E38,
-       -kInfFloat,
-       kInfFloat,
-       std::nullopt,
-       kNaNFloat,
-       -kInfFloat,
-       -kInfFloat,
-       kInfFloat,
-       kInfFloat,
-       kInfFloat});
+      {1.0,          2.0,          -3.4028235E38, 3.4028235E38, -kInfFloat,
+       kInfFloat,    0.0,          0.0,           std::nullopt, std::nullopt,
+       std::nullopt, std::nullopt, std::nullopt,  std::nullopt, std::nullopt,
+       std::nullopt, kNaNFloat,    -kInfFloat,    -kInfFloat,   kInfFloat,
+       kInfFloat,    kInfFloat});
   auto input = makeFlatVector<std::string>(
       {R"({"a": 1})",
        R"({"a": 2.0})",
@@ -141,7 +133,16 @@ TEST_F(FromJsonTest, basicFloat) {
        R"({"a": 3.4028235E38})", // Max float value
        R"({"a": -3.4028235E39})",
        R"({"a": 3.4028235E39})",
+       R"({"a": 0})",
+       R"({"a": 1.0e-200})",
        R"({"a": "3"})",
+       R"({"a": 1.1.0})", // Multiple decimal points.
+       R"({"a": 1.})", // Missing fraction digits after a decimal point.
+       R"({"a": 01})", // Leading zero.
+       R"({"a": 1e})", // Missing exponent digits after ‘e’ or ‘E’.
+       R"({"a": 1e+})", // Missing exponent digits after ‘e’ or ‘E’.
+       R"({"a": .e10})", // Missing digits.
+       R"({"a": -.})", // Missing digits entirely.
        R"({"a": "NaN"})",
        R"({"a": "-Infinity"})",
        R"({"a": "-INF"})",
@@ -159,6 +160,15 @@ TEST_F(FromJsonTest, basicDouble) {
        1.7976931348623158e+308,
        -kInfDouble,
        kInfDouble,
+       0.0,
+       0.0,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
+       std::nullopt,
        std::nullopt,
        kNaNDouble,
        -kInfDouble,
@@ -173,7 +183,16 @@ TEST_F(FromJsonTest, basicDouble) {
        R"({"a": 1.7976931348623158e+308})", // Max double value
        R"({"a": -1.7976931348623158e+309})",
        R"({"a": 1.7976931348623158e+309})",
+       R"({"a": 0})",
+       R"({"a": 1.0e-2000})",
        R"({"a": "3"})",
+       R"({"a": 1.1.0})", // Multiple decimal points.
+       R"({"a": 1.})", // Missing fraction digits after a decimal point.
+       R"({"a": 01})", // Leading zero.
+       R"({"a": 1e})", // Missing exponent digits after ‘e’ or ‘E’.
+       R"({"a": 1e+})", // Missing exponent digits after ‘e’ or ‘E’.
+       R"({"a": .e10})", // Missing digits.
+       R"({"a": -.})", // Missing digits entirely.
        R"({"a": "NaN"})",
        R"({"a": "-Infinity"})",
        R"({"a": "-INF"})",

--- a/velox/functions/sparksql/tests/FromJsonTest.cpp
+++ b/velox/functions/sparksql/tests/FromJsonTest.cpp
@@ -123,6 +123,10 @@ TEST_F(FromJsonTest, basicFloat) {
   auto expected = makeNullableFlatVector<float>(
       {1.0,
        2.0,
+       -3.4028235E38,
+       3.4028235E38,
+       -kInfFloat,
+       kInfFloat,
        std::nullopt,
        kNaNFloat,
        -kInfFloat,
@@ -133,6 +137,10 @@ TEST_F(FromJsonTest, basicFloat) {
   auto input = makeFlatVector<std::string>(
       {R"({"a": 1})",
        R"({"a": 2.0})",
+       R"({"a": -3.4028235E38})", // Min float value
+       R"({"a": 3.4028235E38})", // Max float value
+       R"({"a": -3.4028235E39})",
+       R"({"a": 3.4028235E39})",
        R"({"a": "3"})",
        R"({"a": "NaN"})",
        R"({"a": "-Infinity"})",
@@ -147,6 +155,10 @@ TEST_F(FromJsonTest, basicDouble) {
   auto expected = makeNullableFlatVector<double>(
       {1.0,
        2.0,
+       -1.7976931348623158e+308,
+       1.7976931348623158e+308,
+       -kInfDouble,
+       kInfDouble,
        std::nullopt,
        kNaNDouble,
        -kInfDouble,
@@ -157,6 +169,10 @@ TEST_F(FromJsonTest, basicDouble) {
   auto input = makeFlatVector<std::string>(
       {R"({"a": 1})",
        R"({"a": 2.0})",
+       R"({"a": -1.7976931348623158e+308})", // Min double value
+       R"({"a": 1.7976931348623158e+308})", // Max double value
+       R"({"a": -1.7976931348623158e+309})",
+       R"({"a": 1.7976931348623158e+309})",
        R"({"a": "3"})",
        R"({"a": "NaN"})",
        R"({"a": "-Infinity"})",


### PR DESCRIPTION
When handling double and float values, the current Velox implementation checks 
whether the values fall within the range [minValue, maxValue]. This behavior is 
inconsistent with Spark's implementation and may lead to the following 
mismatches. This PR fixes this issue.

Spark
```
scala> spark.conf.set("spark.gluten.enabled","false")

scala> spark.sql("""select from_json('{"a": 3.4028235E39}', 'a FLOAT')""").collect
res10: Array[org.apache.spark.sql.Row] = Array([[Infinity]])

scala> spark.sql("""select from_json('{"a": 1.7976931348623158e+309}', 'a DOUBLE')""").collect
res11: Array[org.apache.spark.sql.Row] = Array([[Infinity]])
```
Velox
```
scala> spark.conf.set("spark.gluten.enabled","true")

scala> spark.sql("""select from_json('{"a": 3.4028235E39}', 'a FLOAT')""").collect
25/06/04 17:13:00 WARN IndicatorVectorPool: There are still unreleased native columnar batches during ending the task. Will close them automatically however the batches should be better released manually to minimize memory pressure.
res13: Array[org.apache.spark.sql.Row] = Array([[null]])

scala> spark.sql("""select from_json('{"a": 1.7976931348623158e+309}', 'a DOUBLE')""").collect
25/06/04 17:13:03 WARN IndicatorVectorPool: There are still unreleased native columnar batches during ending the task. Will close them automatically however the batches should be better released manually to minimize memory pressure.
res14: Array[org.apache.spark.sql.Row] = Array([[null]])
```