### PR TITLE
fix(vector)!: Add check for BaseVector::length_

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -55,6 +55,10 @@ BaseVector::BaseVector(
       representedByteCount_(representedByteCount),
       storageByteCount_(storageByteCount) {
   VELOX_CHECK_NOT_NULL(type_, "Vector creation requires a non-null type.");
+  VELOX_CHECK_LE(
+      length,
+      std::numeric_limits<vector_size_t>::max(),
+      "Length must be smaller or equal to max(vector_size_t).");
 
   if (nulls_) {
     int32_t bytes = byteSize<bool>(length_);
@@ -107,6 +111,7 @@ uint64_t BaseVector::byteSize<bool>(vector_size_t count) {
 }
 
 void BaseVector::resize(vector_size_t size, bool setNotNull) {
+  VELOX_CHECK_GE(size, 0, "Size must be non-negative.");
   if (nulls_) {
     const auto bytes = byteSize<bool>(size);
     if (length_ < size || nulls_->isView()) {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -272,6 +272,7 @@ class ConstantVector final : public SimpleVector<T> {
   }
 
   void resize(vector_size_t newSize, bool /*setNotNull*/ = true) override {
+    VELOX_CHECK_GE(newSize, 0, "Size must be non-negative.");
     BaseVector::length_ = newSize;
     if constexpr (std::is_same_v<T, StringView>) {
       SimpleVector<StringView>::resizeIsAsciiIfNotEmpty(

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -533,6 +533,7 @@ class FlatVector final : public SimpleVector<T> {
   }
 
   void unsafeSetSize(vector_size_t newSize) {
+    VELOX_CHECK_GE(newSize, 0, "Size must be non-negative.");
     this->length_ = newSize;
   }
 

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -242,6 +242,7 @@ class LazyVector : public BaseVector {
         vector_(std::move(vector)) {}
 
   void reset(std::unique_ptr<VectorLoader>&& loader, vector_size_t size) {
+    VELOX_CHECK_GE(size, 0, "Size must be non-negative.");
     BaseVector::length_ = size;
     loader_ = std::move(loader);
     allLoaded_ = false;


### PR DESCRIPTION
Summary:
Add a non-negative constraint for BaseVector::length_ to prevent it from being set to
negative values in case of int overflows and to expose places causing such overflows.

BREAKING CHANGE:
This change will break code that relies on ability to pass negative value as a length, and
later on updating it to a correct value. Such places should be fixed to not rely on passing
negative vector size.

Differential Revision: D75005693


