### PR TITLE
feat: Enable prefetch and barrier feature for indexLookupJoin barrier test

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -415,9 +415,11 @@ void IndexLookupJoin::addInput(RowVectorPtr input) {
   auto& batch = nextInputBatch();
   VELOX_CHECK_LE(numInputBatches(), maxNumInputBatches_);
   batch.input = std::move(input);
-  ensureInputLoaded(batch);
-  prepareLookup(batch);
-  startLookup(batch);
+  if (numInputBatches() > 0) {
+    ensureInputLoaded(batch);
+    prepareLookup(batch);
+    startLookup(batch);
+  }
 }
 
 RowVectorPtr IndexLookupJoin::getOutput() {

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -1916,7 +1916,7 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
 }
 
 TEST_P(IndexLookupJoinTest, barrier) {
-  if (!GetParam().serialExecution || GetParam().numPrefetches > 0) {
+  if (!GetParam().serialExecution) {
     GTEST_SKIP();
   }
   SequenceTableData tableData;


### PR DESCRIPTION
Summary: Enable prefetch and barrier for indexLookupJoinTest.barrier and disable the pre-materialization if prefetch is not enabled

Differential Revision: D75016998


