### PR TITLE
feat: Add support for memory pool priority

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -109,7 +109,8 @@ ArbitrationParticipant::ArbitrationParticipant(
       pool_(pool.get()),
       config_(config),
       maxCapacity_(pool_->maxCapacity()),
-      createTimeNs_(getCurrentTimeNano()) {
+      createTimeNs_(getCurrentTimeNano()),
+      poolPriority_(pool_->poolPriority()) {
   VELOX_CHECK_LE(
       config_->minCapacity,
       maxCapacity_,

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -173,6 +173,11 @@ class ArbitrationParticipant
     return config_->minCapacity;
   }
 
+  /// Returns the priority of the underlying query memory pool.
+  uint32_t poolPriority() const {
+    return poolPriority_;
+  }
+
   /// Returns the duration of this arbitration participant since its creation.
   uint64_t durationNs() const {
     const auto now = getCurrentTimeNano();
@@ -344,6 +349,7 @@ class ArbitrationParticipant
   const Config* const config_;
   const uint64_t maxCapacity_;
   const uint64_t createTimeNs_;
+  const uint32_t poolPriority_;
 
   mutable std::mutex stateLock_;
   bool aborted_{false};

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -331,7 +331,8 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
     const std::string& name,
     int64_t maxCapacity,
     std::unique_ptr<MemoryReclaimer> reclaimer,
-    const std::optional<MemoryPool::DebugOptions>& poolDebugOpts) {
+    const std::optional<MemoryPool::DebugOptions>& poolDebugOpts,
+    uint32_t poolPriority) {
   std::string poolName = name;
   if (poolName.empty()) {
     static std::atomic<int64_t> poolId{0};
@@ -345,6 +346,7 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
   options.coreOnAllocationFailureEnabled = coreOnAllocationFailureEnabled_;
   options.getPreferredSize = getPreferredSize_;
   options.debugOptions = poolDebugOpts;
+  options.poolPriority = poolPriority;
 
   auto pool = createRootPool(poolName, reclaimer, options);
   if (!disableMemoryPoolTracking_) {

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -337,7 +337,8 @@ class MemoryManager {
       int64_t maxCapacity = kMaxMemory,
       std::unique_ptr<MemoryReclaimer> reclaimer = nullptr,
       const std::optional<MemoryPool::DebugOptions>& poolDebugOpts =
-          std::nullopt);
+          std::nullopt,
+      uint32_t poolPriority = 0);
 
   /// Creates a leaf memory pool for direct memory allocation use with specified
   /// 'name'. If 'name' is missing, the memory manager generates a default name

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -227,6 +227,7 @@ MemoryPool::MemoryPool(
       trackUsage_(options.trackUsage),
       threadSafe_(options.threadSafe),
       debugOptions_(options.debugOptions),
+      poolPriority_(options.poolPriority),
       coreOnAllocationFailureEnabled_(options.coreOnAllocationFailureEnabled),
       getPreferredSize_(
           options.getPreferredSize == nullptr

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -152,6 +152,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
     /// If non-empty, enables debug mode for the created memory pool.
     std::optional<DebugOptions> debugOptions{std::nullopt};
+
+    /// Sets the priority of the memory pool. The priority is used for
+    /// determining which pools to abort when the system is out of memory.
+    /// higher poolPriority value respresents higher priority and vice-versa.
+    uint32_t poolPriority{0};
   };
 
   /// Constructs a named memory pool with specified 'name', 'parent' and 'kind'.
@@ -295,6 +300,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// memory pool object.  Must be a power of two.
   virtual uint16_t alignment() const {
     return alignment_;
+  }
+
+  /// Returns the priority of this pool.
+  uint32_t poolPriority() const {
+    return poolPriority_;
   }
 
   /// Resource governing methods used to track and limit the memory usage
@@ -546,6 +556,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const bool trackUsage_;
   const bool threadSafe_;
   const std::optional<DebugOptions> debugOptions_;
+  const uint32_t poolPriority_;
   const bool coreOnAllocationFailureEnabled_;
   std::function<size_t(size_t)> getPreferredSize_;
 

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -113,11 +113,16 @@ class MockTask : public std::enable_shared_from_this<MockTask> {
     std::weak_ptr<MockTask> task_;
   };
 
-  void initTaskPool(MemoryManager* manager, uint64_t capacity) {
+  void initTaskPool(
+      MemoryManager* manager,
+      uint64_t capacity,
+      uint32_t taskPriority = 0) {
     root_ = manager->addRootPool(
         fmt::format("RootPool-{}", poolId_++),
         capacity,
-        MemoryReclaimer::create(shared_from_this()));
+        MemoryReclaimer::create(shared_from_this()),
+        std::nullopt,
+        taskPriority);
   }
 
   MemoryPool* pool() const {
@@ -509,9 +514,11 @@ class MockSharedArbitrationTest : public testing::Test {
     arbitrator_ = static_cast<SharedArbitrator*>(manager_->arbitrator());
   }
 
-  std::shared_ptr<MockTask> addTask(int64_t capacity = kMaxMemory) {
+  std::shared_ptr<MockTask> addTask(
+      int64_t capacity = kMaxMemory,
+      uint32_t taskPriority = 0) {
     auto task = std::make_shared<MockTask>();
-    task->initTaskPool(manager_.get(), capacity);
+    task->initTaskPool(manager_.get(), capacity, taskPriority);
     return task;
   }
 
@@ -2041,6 +2048,76 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationSmallParticipantLargeGrow) {
   ASSERT_TRUE(task0->error() != nullptr);
   VELOX_ASSERT_THROW(
       std::rethrow_exception(task0->error()),
+      "Memory pool aborted to reclaim used memory");
+}
+
+TEST_F(MockSharedArbitrationTest, globalArbitrationWithMemoryPoolPriority) {
+  // This test tests global arbitration takes into consideration query priority
+  // attempting to grow capacity when selecting abort partitipants.
+  const int64_t memoryCapacity = 512 << 20;
+  const uint64_t memoryPoolInitCapacity = memoryCapacity / 2;
+  setupMemory(
+      memoryCapacity,
+      0,
+      memoryPoolInitCapacity,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      memoryCapacity, // Set abort capacity limit to differenciate capacity.
+      0,
+      kMemoryReclaimThreadsHwMultiplier,
+      nullptr,
+      true,
+      5 * 60 * 1'000'000'000UL,
+      true);
+
+  // task0 is normal priority with 256MB capacity with initial allocation of
+  // 256MB
+  auto task0 = addTask(memoryCapacity / 2, 100);
+  auto* op0 = task0->addMemoryOp(false);
+  op0->allocate(memoryCapacity / 2);
+
+  // task1 is low priority with 256MB capacity with initial allocation of 256MB
+  auto task1 = addTask(memoryCapacity / 2, 10);
+  auto* op1 = task1->addMemoryOp(true);
+  op1->allocate(memoryCapacity / 2);
+
+  // task2 is normal priority in lower bucket has 256MB capacity with 0
+  // allocation
+  auto task2 = addTask(memoryCapacity / 2, 999);
+  auto* op2 = task2->addMemoryOp(true);
+
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats;
+  auto statsWriter = std::make_unique<TestRuntimeStatWriter>(runtimeStats);
+  setThreadLocalRunTimeStatWriter(statsWriter.get());
+
+  // At this point, memory pool is full
+  ASSERT_EQ(manager_->capacity(), manager_->getTotalBytes());
+
+  // Next allocation should succeed with side effect of lowest priority
+  // query getting killed.
+  op2->allocate(memoryCapacity / 2);
+
+  ASSERT_EQ(
+      runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+  ASSERT_GT(runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+  ASSERT_EQ(
+      runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
+  ASSERT_EQ(runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
+  ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+
+  // task1 gets aborted since its lowest priority compared to task0
+  // task2 is younger in same bucket but survives due to priority.
+  ASSERT_TRUE(task0->error() == nullptr);
+  ASSERT_TRUE(task1->error() != nullptr);
+  ASSERT_TRUE(task2->error() == nullptr);
+
+  VELOX_ASSERT_THROW(
+      std::rethrow_exception(task1->error()),
       "Memory pool aborted to reclaim used memory");
 }
 


### PR DESCRIPTION
Summary:
Current memory arbitration process doesn't know(hence consider) priority of a query. This results into high priority queries getting killed.
Add support for killing low priority queries in same memory bucket first.
Followup presto PRs will add the functionality of computing the priority and passing it down to workers.

Differential Revision: D74895697


