### PR TITLE
feat: Make the max bucket count configurable

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -67,6 +67,11 @@ uint32_t HiveConfig::maxPartitionsPerWriters(
       config_->get<uint32_t>(kMaxPartitionsPerWriters, 128));
 }
 
+uint32_t HiveConfig::maxBucketCount(const config::ConfigBase* session) const {
+  return session->get<uint32_t>(
+      kMaxBucketCountSession, config_->get<uint32_t>(kMaxBucketCount, 100'000));
+}
+
 bool HiveConfig::immutablePartitions() const {
   return config_->get<bool>(kImmutablePartitions, false);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -49,6 +49,10 @@ class HiveConfig {
   static constexpr const char* kMaxPartitionsPerWritersSession =
       "max_partitions_per_writers";
 
+  /// Maximum number of bucketed count.
+  static constexpr const char* kMaxBucketCount = "max-bucket-count";
+  static constexpr const char* kMaxBucketCountSession = "max_bucket_count";
+
   /// Whether new data can be inserted into an unpartition table.
   /// Velox currently does not support appending data to existing partitions.
   static constexpr const char* kImmutablePartitions =
@@ -187,6 +191,8 @@ class HiveConfig {
       const config::ConfigBase* session) const;
 
   uint32_t maxPartitionsPerWriters(const config::ConfigBase* session) const;
+
+  uint32_t maxBucketCount(const config::ConfigBase* session) const;
 
   bool immutablePartitions() const;
 

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -200,6 +200,7 @@ class FileNameGenerator : public ISerializable {
 
   virtual std::pair<std::string, std::string> gen(
       std::optional<uint32_t> bucketId,
+      std::optional<uint32_t> maxBucketCount,
       const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx& connectorQueryCtx,
       bool commitRequired) const = 0;
@@ -213,6 +214,7 @@ class HiveInsertFileNameGenerator : public FileNameGenerator {
 
   std::pair<std::string, std::string> gen(
       std::optional<uint32_t> bucketId,
+      std::optional<uint32_t> maxBucketCount,
       const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx& connectorQueryCtx,
       bool commitRequired) const override;
@@ -525,11 +527,6 @@ class HiveDataSink : public DataSink {
       uint32_t bucketCount,
       std::unique_ptr<core::PartitionFunction> bucketFunction);
 
-  static uint32_t maxBucketCount() {
-    static const uint32_t kMaxBucketCount = 100'000;
-    return kMaxBucketCount;
-  }
-
   void appendData(RowVectorPtr input) override;
 
   bool finish() override;
@@ -665,6 +662,7 @@ class HiveDataSink : public DataSink {
   const std::shared_ptr<const HiveConfig> hiveConfig_;
   const HiveWriterParameters::UpdateMode updateMode_;
   const uint32_t maxOpenWriters_;
+  const uint32_t maxBucketCount_;
   const std::vector<column_index_t> partitionChannels_;
   const std::unique_ptr<PartitionIdGenerator> partitionIdGenerator_;
   // Indices of dataChannel are stored in ascending order

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -32,6 +32,7 @@ TEST(HiveConfigTest, defaultConfig) {
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kError);
   ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 128);
+  ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
   ASSERT_EQ(hiveConfig.immutablePartitions(), false);
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");
@@ -59,6 +60,7 @@ TEST(HiveConfigTest, overrideConfig) {
   std::unordered_map<std::string, std::string> configFromFile = {
       {HiveConfig::kInsertExistingPartitionsBehavior, "OVERWRITE"},
       {HiveConfig::kMaxPartitionsPerWriters, "120"},
+      {HiveConfig::kMaxBucketCount, "200"},
       {HiveConfig::kImmutablePartitions, "true"},
       {HiveConfig::kGcsEndpoint, "hey"},
       {HiveConfig::kGcsCredentialsPath, "hey"},
@@ -84,6 +86,7 @@ TEST(HiveConfigTest, overrideConfig) {
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
   ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(emptySession.get()), 120);
+  ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 200);
   ASSERT_TRUE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "hey");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "hey");
@@ -121,6 +124,7 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kAllowNullPartitionKeysSession, "false"},
       {HiveConfig::kIgnoreMissingFilesSession, "true"},
       {HiveConfig::kReadStatsBasedFilterReorderDisabledSession, "true"},
+      {HiveConfig::kMaxBucketCountSession, "200"},
       {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)}};
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -129,6 +133,7 @@ TEST(HiveConfigTest, overrideSession) {
       facebook::velox::connector::hive::HiveConfig::
           InsertExistingPartitionsBehavior::kOverwrite);
   ASSERT_EQ(hiveConfig.maxPartitionsPerWriters(session.get()), 128);
+  ASSERT_EQ(hiveConfig.maxBucketCount(session.get()), 200);
   ASSERT_FALSE(hiveConfig.immutablePartitions());
   ASSERT_EQ(hiveConfig.gcsEndpoint(), "");
   ASSERT_EQ(hiveConfig.gcsCredentialsPath(), "");

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -521,6 +521,11 @@ Each query can override the config by setting corresponding query session proper
      - integer
      - 100
      - Maximum number of (bucketed) partitions per a single table writer instance.
+   * - hive.max-bucket-count
+     -
+     - integer
+     - 100'000
+     - Maximum number of bucket count for table writer.
    * - insert-existing-partitions-behavior
      - insert_existing_partitions_behavior
      - string

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1557,6 +1557,14 @@ TEST_P(BucketedTableOnlyWriteTest, bucketCountLimit) {
   SCOPED_TRACE(testParam_.toString());
   auto input = makeVectors(1, 100);
   createDuckDbTable(input);
+
+  // Get the default maxBucketCount from config.
+  HiveConfig hiveConfig(std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>()));
+  const auto emptySession = std::make_unique<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>());
+  uint32_t maxBucketCount = hiveConfig.maxBucketCount(emptySession.get());
+
   struct {
     uint32_t bucketCount;
     bool expectedError;
@@ -1568,10 +1576,10 @@ TEST_P(BucketedTableOnlyWriteTest, bucketCountLimit) {
   } testSettings[] = {
       {1, false},
       {3, false},
-      {HiveDataSink::maxBucketCount() - 1, false},
-      {HiveDataSink::maxBucketCount(), true},
-      {HiveDataSink::maxBucketCount() + 1, true},
-      {HiveDataSink::maxBucketCount() * 2, true}};
+      {maxBucketCount - 1, false},
+      {maxBucketCount, true},
+      {maxBucketCount + 1, true},
+      {maxBucketCount * 2, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto outputDirectory = TempDirectoryPath::create();


### PR DESCRIPTION
We encountered an exception when enabling bucket writing for non-partitioned tables in Gluten https://github.com/apache/incubator-gluten/pull/9575. Upon investigation, we discovered that the `maxBucketCount `value is hard-coded and cannot be adjusted through configurations. This PR introduces the `kMaxBucketCount `parameter in `HiveConfig`, allowing it to be configurable.
```
Caused by: org.apache.gluten.exception.GlutenException: org.apache.gluten.exception.GlutenException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: (100001 vs. 100000) bucketCount exceeds the limit
Retriable: False
Expression: bucketCount_ < maxBucketCount()
Function: HiveDataSink
File: /work/ep/build-velox/build/velox_ep/velox/connectors/hive/HiveDataSink.cpp
Line: 426
Stack trace:
# 0  _ZN8facebook5velox7process10StackTraceC1Ei
# 1  _ZN8facebook5velox14VeloxExceptionC1EPKcmS3_St17basic_string_viewIcSt11char_traitsIcEES7_S7_S7_bNS1_4TypeES7_
# 2  _ZN8facebook5velox6detail14veloxCheckFailINS0_14VeloxUserErrorERKSsEEvRKNS1_18VeloxCheckFailArgsET0_
# 3  _ZN8facebook5velox9connector4hive12HiveDataSinkC2ESt10shared_ptrIKNS0_7RowTypeEES4_IKNS2_21HiveInsertTableHandleEEPKNS1_17ConnectorQueryCtxENS1_14CommitStrategyERKS4_IKNS2_10HiveConfigEEjSt10unique_ptrINS0_4core17PartitionFunctionESt14default_deleteISM_EE
# 4  _ZN8facebook5velox9connector4hive12HiveDataSinkC2ESt10shared_ptrIKNS0_7RowTypeEES4_IKNS2_21HiveInsertTableHandleEEPKNS1_17ConnectorQueryCtxENS1_14CommitStrategyERKS4_IKNS2_10HiveConfigEE
# 5  _ZN8facebook5velox9connector4hive13HiveConnector14createDataSinkESt10shared_ptrIKNS0_7RowTypeEES4_INS1_26ConnectorInsertTableHandleEEPNS1_17ConnectorQueryCtxENS1_14CommitStrategyE
# 6  _ZN8facebook5velox4exec11TableWriter14createDataSinkEv
# 7  _ZN8facebook5velox4exec11TableWriter10initializeEv
# 8  _ZN8facebook5velox4exec6Driver19initializeOperatorsEv
# 9  _ZN8facebook5velox4exec6Driver11runInternalERSt10shared_ptrIS2_ERS3_INS1_13BlockingStateEERS3_INS0_9RowVectorEE
# 10 _ZN8facebook5velox4exec6Driver4nextEPN5folly10SemiFutureINS3_4UnitEEERPNS1_8OperatorERNS1_14BlockingReasonE
# 11 _ZN8facebook5velox4exec4Task4nextEPN5folly10SemiFutureINS3_4UnitEEE
# 12 _ZN6gluten24WholeStageResultIterator4nextEv
# 13 Java_org_apache_gluten_vectorized_ColumnarBatchOutIterator_nativeHasNext
# 14 0x00007f351965dadb
```