### PR TITLE
fix: Minor cleanups for spill partition bits

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -323,7 +323,7 @@ class QueryConfig {
       "spill_file_create_config";
 
   /// Default offset spill start partition bit. It is used with
-  /// 'kJoinSpillPartitionBits' or 'kAggregationSpillPartitionBits' together to
+  /// 'kSpillNumPartitionBits' together to
   /// calculate the spilling partition number for join spill or aggregation
   /// spill.
   static constexpr const char* kSpillStartPartitionBit =

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -420,7 +420,7 @@ Spilling
    * - spiller_start_partition_bit
      - integer
      - 29
-     - The start partition bit which is used with `spiller_partition_bits` together to calculate the spilling partition number.
+     - The start partition bit which is used with `spiller_num_partition_bits` together to calculate the spilling partition number.
    * - spiller_num_partition_bits
      - integer
      - 3

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1574,7 +1574,10 @@ void HashTable<ignoreNullKeys>::checkHashBitsOverlap(
     int8_t spillInputStartPartitionBit) {
   if (spillInputStartPartitionBit != kNoSpillInputStartPartitionBit &&
       hashMode() != HashMode::kArray) {
-    VELOX_CHECK_LT(sizeBits_ - 1, spillInputStartPartitionBit);
+    VELOX_CHECK_LT(
+        sizeBits_ - 1,
+        spillInputStartPartitionBit,
+        "The size bits of the hash table must be lower than the spilling partition bits to avoid overlap");
   }
 }
 


### PR DESCRIPTION
1. Fix out-of-date documentations for option `spiller_num_partition_bits`
2. Add a meaningful error message when the spill partition bits and hash bits are overlapping in hash table