### PR TITLE
feat: Add Spark trunc function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -310,6 +310,26 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT to_utc_timestamp('2015-07-24 00:00:00', 'America/Los_Angeles'); -- '2015-07-24 07:00:00'
 
+.. spark:function:: trunc(date, fmt) -> date
+
+    Returns date ``date`` truncated to the unit specified by the format model ``fmt``.
+    Returns NULL if ``fmt`` is invalid.
+
+    ``fmt`` is case insensitive and must be one of the following:
+        * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``date``` falls in
+        * "QUARTER" - truncate to the first date of the quarter that the ``date`` falls in
+        * "MONTH", "MM", "MON" - truncate to the first date of the month that the ``date`` falls in
+        * "WEEK" - truncate to the Monday of the week that the ``date`` falls in
+
+    ::
+
+        SELECT trunc('2019-08-04', 'week'); -- 2019-07-29
+        SELECT trunc('2019-08-04', 'quarter'); -- 2019-07-01
+        SELECT trunc('2009-02-12', 'MM'); -- 2009-02-01
+        SELECT trunc('2015-10-27', 'YEAR'); -- 2015-01-01
+        SELECT trunc('2015-10-27', ''); -- NULL
+        SELECT trunc('2015-10-27', 'day'); -- NULL
+
 .. spark:function:: unix_date(date) -> integer
 
     Returns the number of days since 1970-01-01. ::

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -312,11 +312,11 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: trunc(date, fmt) -> date
 
-    Returns date ``date`` truncated to the unit specified by the format model ``fmt``.
+    Returns ``date`` truncated to the unit specified by the format model ``fmt``.
     Returns NULL if ``fmt`` is invalid.
 
     ``fmt`` is case insensitive and must be one of the following:
-        * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``date``` falls in
+        * "YEAR", "YYYY", "YY" - truncate to the first date of the year that the ``date`` falls in
         * "QUARTER" - truncate to the first date of the quarter that the ``date`` falls in
         * "MONTH", "MM", "MON" - truncate to the first date of the month that the ``date`` falls in
         * "WEEK" - truncate to the Monday of the week that the ``date`` falls in

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -586,8 +586,6 @@ template <typename T>
 struct TruncFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  std::optional<DateTimeUnit> unit_;
-
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
@@ -612,7 +610,7 @@ struct TruncFunction {
                                                     /*throwIfInvalid=*/false,
                                                     /*allowMicro=*/false,
                                                     /*allowAbbreviated=*/true);
-    // Return null if unit is illegal, unit less than week is also illegal.
+    // Return NULL if unit is illegal or unit is less than week.
     if (!unitOption.has_value() || unitOption.value() < DateTimeUnit::kWeek) {
       return false;
     }
@@ -622,6 +620,9 @@ struct TruncFunction {
     result = Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
     return true;
   }
+
+ private:
+  std::optional<DateTimeUnit> unit_;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -580,6 +580,33 @@ struct DateTruncFunction {
   const tz::TimeZone* timeZone_ = nullptr;
 };
 
+/// Truncates a date to a specified time unit. Return NULL if the format is
+/// invalid. Format as abbreviated unit string is allowed.
+template <typename T>
+struct TruncFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Date>& result,
+      const arg_type<Date>& date,
+      const arg_type<Varchar>& format) {
+    std::optional<DateTimeUnit> unitOption = fromDateTimeUnitString(
+        format,
+        /*throwIfInvalid=*/false,
+        /*allowMicro=*/false,
+        /*allowAbbreviated=*/true);
+    // Return null if unit is illegal, unit less than week is also illegal.
+    if (!unitOption.has_value() || unitOption.value() < DateTimeUnit::kWeek) {
+      return false;
+    }
+    auto dateTime = getDateTime(date);
+    adjustDateTime(dateTime, unitOption.value());
+
+    result = Timestamp::calendarUtcToEpoch(dateTime) / kSecondsInDay;
+    return true;
+  }
+};
+
 template <typename T>
 struct DateAddFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -94,6 +94,7 @@ void registerDatetimeFunctions(const std::string& prefix) {
       {prefix + "timestamp_millis"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
       {prefix + "date_trunc"});
+  registerFunction<TruncFunction, Date, Date, Varchar>({prefix + "trunc"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1261,5 +1261,31 @@ TEST_F(DateTimeFunctionsTest, dateTrunc) {
       Timestamp(978336000, 0),
       dateTrunc("year", Timestamp(998'474'645, 321'001'234)));
 }
+
+TEST_F(DateTimeFunctionsTest, trunc) {
+  const auto trunc = [&](std::optional<int32_t> date,
+                         const std::string& format) {
+    return evaluateOnce<int32_t>(
+        fmt::format("trunc(c0, '{}')", format), DATE(), date);
+  };
+
+  // Date(0) is 1970-01-01.
+  EXPECT_EQ(std::nullopt, trunc(0, ""));
+  EXPECT_EQ(std::nullopt, trunc(0, "day"));
+  EXPECT_EQ(std::nullopt, trunc(0, "hour"));
+  EXPECT_EQ(std::nullopt, trunc(0, "minute"));
+  EXPECT_EQ(std::nullopt, trunc(0, "second"));
+  EXPECT_EQ(std::nullopt, trunc(0, "millisecond"));
+  EXPECT_EQ(std::nullopt, trunc(0, "microsecond"));
+
+  // Date(19576) is 2023-08-07, which is Monday, should return Monday.
+  EXPECT_EQ(19576, trunc(19576, "week"));
+  // Date(19579) is 2023-08-10, Thur, should return Monday.
+  EXPECT_EQ(19576, trunc(19579, "week"));
+  // Date(18297) is 2020-02-05.
+  EXPECT_EQ(18293, trunc(18297, "month"));
+  EXPECT_EQ(18262, trunc(18297, "quarter"));
+  EXPECT_EQ(18262, trunc(18297, "year"));
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Adds Spark trunc function.
Arguments:

date - date value or valid date string
fmt - the format representing the unit to be truncated to
"YEAR", "YYYY", "YY" - truncate to the first date of the year that the date falls in
"QUARTER" - truncate to the first date of the quarter that the date falls in
"MONTH", "MM", "MON" - truncate to the first date of the month that the date falls in
"WEEK" - truncate to the Monday of the week that the date falls in

https://spark.apache.org/docs/latest/api/sql/#trunc