### PR TITLE
fix: Build should pass without folly dependency error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,6 +541,7 @@ endif()
 velox_set_source(simdjson)
 velox_resolve_dependency(simdjson 3.9.3)
 
+set(folly_SOURCE "BUNDLED")
 velox_set_source(folly)
 velox_resolve_dependency(folly 2025.04.28.00)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -542,7 +542,7 @@ velox_set_source(simdjson)
 velox_resolve_dependency(simdjson 3.9.3)
 
 velox_set_source(folly)
-velox_resolve_dependency(folly)
+velox_resolve_dependency(folly 2025.04.28.00)
 
 if(${VELOX_BUILD_TESTING})
   # Spark query runner depends on absl, gRPC.


### PR DESCRIPTION
The current build error is because there is a mismatch between Velox's functions dependent on Folly. 

The recent PR #13206 sets Folly version to 2025-04-28.

As a fix for the moment, Folly version has been set to the 2025-04-28 one in CMakeLists

### Relevant issues

Fixes #13349 