### PR TITLE
build: Fix CMAKE_CXX_FLAGS being overridden

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -52,10 +52,6 @@ DUCKDB_VERSION="v0.8.1"
 GEOS_VERSION="3.10.2"
 FAST_FLOAT_VERSION="v8.0.2"
 
-# Folly Portability.h being used to decide whether or not support coroutines
-# causes issues (build, lin) if the selection is not consistent across users of folly.
-EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
-
 function dnf_install {
   dnf install -y -q --setopt=install_weak_deps=False "$@"
 }
@@ -157,8 +153,11 @@ function install_protobuf {
 }
 
 function install_fizz {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
 }
 
 function install_fast_float {
@@ -167,23 +166,35 @@ function install_fast_float {
 }
 
 function install_folly {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_wangle {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
 }
 
 function install_fbthrift {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_mvfst {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF
 }
 
 function install_duckdb {

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -17,7 +17,8 @@
 # specified repo, checking out the requested version.
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
-OS_CXXFLAGS=""
+OS_CXXFLAGS=${OS_CXXFLAGS:-""}
+EXTRA_PKG_CXXFLAGS=${EXTRA_PKG_CXXFLAGS:-""}
 NPROC=${BUILD_THREADS:-$(getconf _NPROCESSORS_ONLN)}
 
 CURL_OPTIONS=${CURL_OPTIONS:-""}
@@ -209,6 +210,7 @@ function cmake_install {
   COMPILER_FLAGS=$(get_cxx_flags)
   # Add platform specific CXX flags if any
   COMPILER_FLAGS+=${OS_CXXFLAGS}
+  COMPILER_FLAGS+=${EXTRA_PKG_CXXFLAGS}
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev ${CMAKE_OPTIONS} -B"${BINARY_DIR}" \

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -45,10 +45,6 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
-# Folly Portability.h being used to decide whether or not support coroutines
-# causes issues (build, lin) if the selection is not consistent across users of folly.
-EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
-
 FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
@@ -129,28 +125,43 @@ function install_fast_float {
 }
 
 function install_folly {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_fizz {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
 }
 
 function install_wangle {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
 }
 
 function install_mvfst {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF
 }
 
 function install_fbthrift {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_double_conversion {

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -40,10 +40,6 @@ USE_CLANG="${USE_CLANG:-false}"
 export INSTALL_PREFIX=${INSTALL_PREFIX:-"/usr/local"}
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)/deps-download}
 
-# Folly Portability.h being used to decide whether or not support coroutines
-# causes issues (build, lin) if the selection is not consistent across users of folly.
-EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
-
 FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
@@ -154,8 +150,11 @@ function install_protobuf {
 }
 
 function install_fizz {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
 }
 
 function install_fast_float {
@@ -164,23 +163,35 @@ function install_fast_float {
 }
 
 function install_folly {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_wangle {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
 }
 
 function install_fbthrift {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_mvfst {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, lin) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF
 }
 
 function install_duckdb {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -73,10 +73,6 @@ function install_gcc11_if_needed {
   fi
 }
 
-# Folly Portability.h being used to decide whether or not support coroutines
-# causes issues (build, lin) if the selection is not consistent across users of folly.
-EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"
-
 FB_OS_VERSION="v2025.04.28.00"
 FMT_VERSION="10.1.1"
 BOOST_VERSION="boost-1.84.0"
@@ -193,28 +189,43 @@ function install_fast_float {
 }
 
 function install_folly {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/${FB_OS_VERSION}.tar.gz folly
-  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir folly -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_fizz {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz
-  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
 }
 
 function install_wangle {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/${FB_OS_VERSION}.tar.gz wangle
-  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
 }
 
 function install_mvfst {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/${FB_OS_VERSION}.tar.gz mvfst
-  cmake_install_dir mvfst -DBUILD_TESTS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir mvfst -DBUILD_TESTS=OFF
 }
 
 function install_fbthrift {
+  # Folly Portability.h being used to decide whether or not support coroutines
+  # causes issues (build, link) if the selection is not consistent across users of folly.
+  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/${FB_OS_VERSION}.tar.gz fbthrift
-  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF ${EXTRA_FBOS_FLAGS}
+  cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }
 
 function install_conda {


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/13206 overrode the CMAKE_CXX_FLAGS, causing the compiler options to be ignored.
The override happens as we set ` -DCMAKE_CXX_FLAGS="$COMPILER_FLAGS"` inside `setup-helper-functions.sh`
 before the `EXTRA_FBOS_FLAGS=" -DCMAKE_CXX_FLAGS=-DFOLLY_CFG_NO_COROUTINES"`