### PR TITLE
refactor: Rename copyPreserveEncodings to testingCopyPreserveEncodings

### DIFF
--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/exec/Values.h"
 #include "velox/common/testutil/TestValue.h"
-
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
@@ -47,7 +46,7 @@ void Values::initialize() {
         // being shared across threads.  Note that the contract in ValuesNode is
         // that this should only be enabled for testing.
         values_.emplace_back(std::static_pointer_cast<RowVector>(
-            vector->copyPreserveEncodings()));
+            vector->testingCopyPreserveEncodings()));
       } else {
         values_.emplace_back(vector);
       }

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -1377,7 +1377,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, orderByWithLazyInput) {
 
   std::vector<RowVectorPtr> lazyInputCopy;
   lazyInputCopy.push_back(std::dynamic_pointer_cast<RowVector>(
-      nonLazyVector->copyPreserveEncodings()));
+      nonLazyVector->testingCopyPreserveEncodings()));
   createDuckDbTable(lazyInputCopy);
 
   std::atomic_bool nonReclaimableSectionEntered{false};

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -543,7 +543,7 @@ class BaseVector {
 
   /// This makes a deep copy of the Vector allocating new child Vectors and
   /// Buffers recursively.  Unlike copy, this preserves encodings recursively.
-  virtual VectorPtr copyPreserveEncodings(
+  virtual VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const = 0;
 
   /// Construct a zero-copy slice of the vector with the indicated offset and

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -163,7 +163,7 @@ class BiasVector : public SimpleVector<T> {
     VELOX_NYI();
   }
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : BaseVector::pool_;
     return std::make_shared<BiasVector<T>>(

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -164,12 +164,12 @@ class RowVector : public BaseVector {
       const BaseVector* source,
       const folly::Range<const CopyRange*>& ranges) override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     std::vector<VectorPtr> copiedChildren(children_.size());
 
     for (auto i = 0; i < children_.size(); ++i) {
-      copiedChildren[i] = children_[i]->copyPreserveEncodings(pool);
+      copiedChildren[i] = children_[i]->testingCopyPreserveEncodings(pool);
     }
 
     auto selfPool = pool ? pool : pool_;
@@ -493,7 +493,7 @@ class ArrayVector : public ArrayVectorBase {
       const BaseVector* source,
       const folly::Range<const CopyRange*>& ranges) override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : pool_;
     return std::make_shared<ArrayVector>(
@@ -503,7 +503,7 @@ class ArrayVector : public ArrayVectorBase {
         length_,
         AlignedBuffer::copy(selfPool, offsets_),
         AlignedBuffer::copy(selfPool, sizes_),
-        elements_->copyPreserveEncodings(pool),
+        elements_->testingCopyPreserveEncodings(pool),
         nullCount_);
   }
 
@@ -636,7 +636,7 @@ class MapVector : public ArrayVectorBase {
       const BaseVector* source,
       const folly::Range<const CopyRange*>& ranges) override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : pool_;
     return std::make_shared<MapVector>(
@@ -646,8 +646,8 @@ class MapVector : public ArrayVectorBase {
         length_,
         AlignedBuffer::copy(selfPool, offsets_),
         AlignedBuffer::copy(selfPool, sizes_),
-        keys_->copyPreserveEncodings(pool),
-        values_->copyPreserveEncodings(pool),
+        keys_->testingCopyPreserveEncodings(pool),
+        values_->testingCopyPreserveEncodings(pool),
         nullCount_,
         sortedKeys_);
   }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -373,7 +373,7 @@ class ConstantVector final : public SimpleVector<T> {
     }
   }
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : BaseVector::pool_;
     if (valueVector_) {
@@ -381,7 +381,7 @@ class ConstantVector final : public SimpleVector<T> {
           selfPool,
           BaseVector::length_,
           index_,
-          valueVector_->copyPreserveEncodings(pool),
+          valueVector_->testingCopyPreserveEncodings(pool),
           SimpleVector<T>::stats_);
     }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -233,14 +233,14 @@ class DictionaryVector : public SimpleVector<T> {
 
   void validate(const VectorValidateOptions& options) const override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : BaseVector::pool_;
     return std::make_shared<DictionaryVector<T>>(
         selfPool,
         AlignedBuffer::copy(selfPool, BaseVector::nulls_),
         BaseVector::length_,
-        dictionaryValues_->copyPreserveEncodings(),
+        dictionaryValues_->testingCopyPreserveEncodings(),
         AlignedBuffer::copy(selfPool, indices_),
         SimpleVector<T>::stats_,
         BaseVector::distinctValueCount_,

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -322,7 +322,7 @@ void FlatVector<StringView>::copy(
 // need to perform a deep copy and reconstruct the string views against the
 // updated stringBuffers.
 template <>
-VectorPtr FlatVector<StringView>::copyPreserveEncodings(
+VectorPtr FlatVector<StringView>::testingCopyPreserveEncodings(
     velox::memory::MemoryPool* pool) const {
   const auto allocPool = pool ? pool : BaseVector::pool_;
   // If the backing memory pool is the same as the vector pool

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -271,7 +271,7 @@ class FlatVector final : public SimpleVector<T> {
       const BaseVector* source,
       const folly::Range<const BaseVector::CopyRange*>& ranges) override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     const auto allocPool = pool ? pool : BaseVector::pool_;
     return std::make_shared<FlatVector<T>>(
@@ -652,7 +652,7 @@ template <>
 void FlatVector<StringView>::prepareForReuse();
 
 template <>
-VectorPtr FlatVector<StringView>::copyPreserveEncodings(
+VectorPtr FlatVector<StringView>::testingCopyPreserveEncodings(
     velox::memory::MemoryPool* pool) const;
 
 template <typename T>

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -196,9 +196,10 @@ class FunctionVector : public BaseVector {
     VELOX_NYI();
   }
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* /* pool */ = nullptr) const override {
-    VELOX_UNSUPPORTED("copyPreserveEncodings not defined for FunctionVector");
+    VELOX_UNSUPPORTED(
+        "testingCopyPreserveEncodings not defined for FunctionVector");
   }
 
  private:

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -364,10 +364,10 @@ class LazyVector : public BaseVector {
 
   void validate(const VectorValidateOptions& options) const override;
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     VELOX_CHECK(isLoaded());
-    return loadedVector()->copyPreserveEncodings(pool);
+    return loadedVector()->testingCopyPreserveEncodings(pool);
   }
 
  private:

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -194,13 +194,13 @@ class SequenceVector : public SimpleVector<T> {
     return false;
   }
 
-  VectorPtr copyPreserveEncodings(
+  VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const override {
     auto selfPool = pool ? pool : BaseVector::pool_;
     return std::make_shared<SequenceVector<T>>(
         selfPool,
         BaseVector::length_,
-        sequenceValues_->copyPreserveEncodings(),
+        sequenceValues_->testingCopyPreserveEncodings(),
         AlignedBuffer::copy(selfPool, sequenceLengths_),
         SimpleVector<T>::stats_,
         BaseVector::distinctValueCount_,

--- a/velox/vector/tests/CopyPreserveEncodingsTest.cpp
+++ b/velox/vector/tests/CopyPreserveEncodingsTest.cpp
@@ -204,7 +204,7 @@ class CopyPreserveEncodingsTest : public testing::Test {
 
 TEST_F(CopyPreserveEncodingsTest, biasHasNulls) {
   auto biasVector = vectorMaker_.biasVector(generateIntInputWithNulls());
-  auto copy = biasVector->copyPreserveEncodings();
+  auto copy = biasVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(biasVector, copy);
   validateCopyPreserveEncodings(biasVector, copy);
@@ -212,7 +212,7 @@ TEST_F(CopyPreserveEncodingsTest, biasHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, biasNoNulls) {
   auto biasVector = vectorMaker_.biasVector(generateIntInput());
-  auto copy = biasVector->copyPreserveEncodings();
+  auto copy = biasVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(biasVector, copy);
   validateCopyPreserveEncodings(biasVector, copy);
@@ -220,7 +220,7 @@ TEST_F(CopyPreserveEncodingsTest, biasNoNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, arrayHasNulls) {
   auto arrayVector = generateArrayVector({TestOptions::WITH_NULLS});
-  auto copy = arrayVector->copyPreserveEncodings();
+  auto copy = arrayVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(arrayVector, copy);
   validateCopyPreserveEncodings(arrayVector, copy);
@@ -228,7 +228,7 @@ TEST_F(CopyPreserveEncodingsTest, arrayHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, arrayNoNulls) {
   auto arrayVector = generateArrayVector();
-  auto copy = arrayVector->copyPreserveEncodings();
+  auto copy = arrayVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(arrayVector, copy);
   validateCopyPreserveEncodings(arrayVector, copy);
@@ -236,7 +236,7 @@ TEST_F(CopyPreserveEncodingsTest, arrayNoNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, mapHasNulls) {
   auto mapVector = generateMapVector({TestOptions::WITH_NULLS});
-  auto copy = mapVector->copyPreserveEncodings();
+  auto copy = mapVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(mapVector, copy);
   validateCopyPreserveEncodings(mapVector, copy);
@@ -244,7 +244,7 @@ TEST_F(CopyPreserveEncodingsTest, mapHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, mapNoNulls) {
   auto mapVector = generateMapVector();
-  auto copy = mapVector->copyPreserveEncodings();
+  auto copy = mapVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(mapVector, copy);
   validateCopyPreserveEncodings(mapVector, copy);
@@ -257,7 +257,7 @@ TEST_F(CopyPreserveEncodingsTest, rowHasNulls) {
        generateMapVector()});
 
   rowVector->setNull(3, true);
-  auto copy = rowVector->copyPreserveEncodings();
+  auto copy = rowVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(rowVector, copy);
   validateCopyPreserveEncodings(rowVector, copy);
@@ -268,7 +268,7 @@ TEST_F(CopyPreserveEncodingsTest, rowNoNulls) {
       {vectorMaker_.flatVectorNullable(generateIntInput()),
        generateArrayVector(),
        generateMapVector()});
-  auto copy = rowVector->copyPreserveEncodings();
+  auto copy = rowVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(rowVector, copy);
   validateCopyPreserveEncodings(rowVector, copy);
@@ -276,7 +276,7 @@ TEST_F(CopyPreserveEncodingsTest, rowNoNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, constantNull) {
   auto constantVector = vectorMaker_.constantVector<int32_t>({std::nullopt});
-  auto copy = constantVector->copyPreserveEncodings();
+  auto copy = constantVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(constantVector, copy);
   validateCopyPreserveEncodings(constantVector, copy);
@@ -284,7 +284,7 @@ TEST_F(CopyPreserveEncodingsTest, constantNull) {
 
 TEST_F(CopyPreserveEncodingsTest, constantNoNulls) {
   auto constantVector = vectorMaker_.constantVector<int32_t>({1});
-  auto copy = constantVector->copyPreserveEncodings();
+  auto copy = constantVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(constantVector, copy);
   validateCopyPreserveEncodings(constantVector, copy);
@@ -293,7 +293,7 @@ TEST_F(CopyPreserveEncodingsTest, constantNoNulls) {
 TEST_F(CopyPreserveEncodingsTest, dictionaryHasNulls) {
   auto dictionaryVector =
       vectorMaker_.dictionaryVector(generateIntInputWithNulls());
-  auto copy = dictionaryVector->copyPreserveEncodings();
+  auto copy = dictionaryVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(dictionaryVector, copy);
   validateCopyPreserveEncodings(dictionaryVector, copy);
@@ -301,7 +301,7 @@ TEST_F(CopyPreserveEncodingsTest, dictionaryHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, dictionaryNoNulls) {
   auto dictionaryVector = vectorMaker_.dictionaryVector(generateIntInput());
-  auto copy = dictionaryVector->copyPreserveEncodings();
+  auto copy = dictionaryVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(dictionaryVector, copy);
   validateCopyPreserveEncodings(dictionaryVector, copy);
@@ -310,7 +310,7 @@ TEST_F(CopyPreserveEncodingsTest, dictionaryNoNulls) {
 TEST_F(CopyPreserveEncodingsTest, flatHasNulls) {
   auto flatVector =
       vectorMaker_.flatVectorNullable(generateIntInputWithNulls());
-  auto copy = flatVector->copyPreserveEncodings();
+  auto copy = flatVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(flatVector, copy);
   validateCopyPreserveEncodings(flatVector, copy);
@@ -318,7 +318,7 @@ TEST_F(CopyPreserveEncodingsTest, flatHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, flatNoNulls) {
   auto flatVector = vectorMaker_.flatVectorNullable(generateIntInput());
-  auto copy = flatVector->copyPreserveEncodings();
+  auto copy = flatVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(flatVector, copy);
   validateCopyPreserveEncodings(flatVector, copy);
@@ -327,9 +327,9 @@ TEST_F(CopyPreserveEncodingsTest, flatNoNulls) {
 TEST_F(CopyPreserveEncodingsTest, lazyNoNulls) {
   auto lazyVector = vectorMaker_.lazyFlatVector<int32_t>(
       10, [](vector_size_t row) { return row; });
-  VELOX_ASSERT_THROW(lazyVector->copyPreserveEncodings(), "");
+  VELOX_ASSERT_THROW(lazyVector->testingCopyPreserveEncodings(), "");
 
-  auto copy = lazyVector->loadedVector()->copyPreserveEncodings();
+  auto copy = lazyVector->loadedVector()->testingCopyPreserveEncodings();
   assertEqualVectors(lazyVector, copy);
   ASSERT_EQ(copy->encoding(), VectorEncoding::Simple::FLAT);
   ASSERT_EQ(copy->nulls(), nullptr);
@@ -338,7 +338,7 @@ TEST_F(CopyPreserveEncodingsTest, lazyNoNulls) {
 TEST_F(CopyPreserveEncodingsTest, sequenceHasNulls) {
   auto sequenceVector =
       vectorMaker_.sequenceVector(generateIntInputWithNulls());
-  auto copy = sequenceVector->copyPreserveEncodings();
+  auto copy = sequenceVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(sequenceVector, copy);
   validateCopyPreserveEncodings(sequenceVector, copy);
@@ -346,7 +346,7 @@ TEST_F(CopyPreserveEncodingsTest, sequenceHasNulls) {
 
 TEST_F(CopyPreserveEncodingsTest, sequenceNoNulls) {
   auto sequenceVector = vectorMaker_.sequenceVector(generateIntInput());
-  auto copy = sequenceVector->copyPreserveEncodings();
+  auto copy = sequenceVector->testingCopyPreserveEncodings();
 
   assertEqualVectors(sequenceVector, copy);
   validateCopyPreserveEncodings(sequenceVector, copy);
@@ -360,7 +360,7 @@ TEST_F(CopyPreserveEncodingsTest, newMemoryPool) {
   auto preCopySrcMemory = sourcePool->usedBytes();
   ASSERT_EQ(0, targetPool->usedBytes());
 
-  auto copy = dictionaryVector->copyPreserveEncodings(targetPool.get());
+  auto copy = dictionaryVector->testingCopyPreserveEncodings(targetPool.get());
   assertEqualVectors(dictionaryVector, copy);
   validateCopyPreserveEncodings(dictionaryVector, copy);
 

--- a/velox/vector/tests/EncodedVectorCopyTest.cpp
+++ b/velox/vector/tests/EncodedVectorCopyTest.cpp
@@ -165,7 +165,7 @@ class EncodedVectorCopyTest : public testing::TestWithParam<TestParams::Type>,
       sourceCopy = source;
     } else {
       sourcePool = rootPool_->addLeafChild("SourcePool");
-      sourceCopy = source->copyPreserveEncodings(sourcePool.get());
+      sourceCopy = source->testingCopyPreserveEncodings(sourcePool.get());
     }
     f(sourceCopy);
   }


### PR DESCRIPTION
Summary: [T222142639] copyPreserveEncodings are only used in test file with the exception of facebook::velox::exec::Values::initialize. We also replaced the call in Values::initialize() as it was not called elsewhere in the codebase.

Differential Revision: D75084110


