### PR TITLE
fix: Increase abbreviation length for DateTimeFormatter maxLength function

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1221,17 +1221,16 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         break;
       case DateTimeFormatSpecifier::TIMEZONE:
         if (token.pattern.minRepresentDigits <= 3) {
-          // The longest abbreviation according to here is 5, e.g. some time
-          // zones use the offset as the abbreviation, like +0530.
+          // The longest timezone abbreviation is 6 in the case of negative or
+          // explicitly positive numeric representations (e.g., +01:00, -08:00)
           // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-          size += 5;
+          size += 6;
         } else {
           // The longest time zone long name is 40, Australian Central Western
           // Standard Time.
           // https://www.timeanddate.com/time/zones/
           size += 50;
         }
-
         break;
       case DateTimeFormatSpecifier::TIMEZONE_OFFSET_ID:
         if (token.pattern.minRepresentDigits == 1) {

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1345,6 +1345,15 @@ TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
   EXPECT_EQ(getJodaDateTimeFormatter("C")->maxResultSize(timezone), 8);
   // Needs to pad to make result contain 9 digits.
   EXPECT_EQ(getJodaDateTimeFormatter("CCCCCCCCC")->maxResultSize(timezone), 9);
+
+  EXPECT_EQ(
+      getJodaDateTimeFormatter("yyyy-MM-dd z")->maxResultSize(timezone), 23);
+  EXPECT_EQ(
+      getJodaDateTimeFormatter("yyyy-MM-dd Z")->maxResultSize(timezone), 25);
+  EXPECT_EQ(
+      getJodaDateTimeFormatter("yyyy-MM-dd zzzz")->maxResultSize(timezone), 67);
+  EXPECT_EQ(
+      getJodaDateTimeFormatter("yyyy-MM-dd ZZZZ")->maxResultSize(timezone), 49);
 }
 
 TEST_F(JodaDateTimeFormatterTest, betterErrorMessaging) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3709,6 +3709,10 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       formatDatetime(parseTimestamp("-292275054-01-01 00:00:00.000"), "yyyy"));
 
   // Time zone test cases - 'Z'
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ("-08:00", formatDatetime(parseTimestamp("1970-01-01"), "ZZ"));
+  EXPECT_EQ("-0800", formatDatetime(parseTimestamp("1970-01-01"), "Z"));
+
   setQueryTimeZone("Asia/Kolkata");
   EXPECT_EQ(
       "Asia/Kolkata",


### PR DESCRIPTION
Summary:
Increase maximum length of abbreviations in maxLength function. This function estimates the absolute maximum length of a timestamp with timezone, but incorrectly assumes maximum abbreviation length (i.e. PST or -08:00) is 5, when it should actually be 6 (in the case of positive or negative numeric timezones).

Increasing this value to 6 fixes "off-by-one" allocation error found in expression fuzzer runs:

https://www.internalfb.com/servicelab/experiment/5301127199/trial/5301676062/twlogs?logHandle=tsp_atn%2Ftwindtunnel%2Fcogwheel_velox_expression_fuzzer.cogwheel_test.5301676062.a&taskHandle=0&file=stderr

Differential Revision: D75105347


