### PR TITLE
build(ci): Fix broken yaml syntax in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,7 @@ jobs:
 
       # Folly is built with a new flag that the cache may not have. Ensure velox build and folly have
       # used the correct flags (disabled the coroutines)
-      - name: TEMP: Force folly rebuild and update cache
+      - name: 'TEMP: Force folly rebuild and update cache'
         run: |
             source velox/scripts/setup-ubuntu.sh
             run_and_time install_folly


### PR DESCRIPTION
The name is interpreted as invalid yaml, because it looks like a `KEY: <value>`, making the job silently fail. These kind of failures will finally be prevented by the new hooks added in #13361. 