### PR TITLE
feat(python): Install signal handler for stack traces

### DIFF
--- a/velox/python/init/PyInit.cpp
+++ b/velox/python/init/PyInit.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/python/init/PyInit.h"
+
+#include <folly/debugging/symbolizer/SignalHandler.h>
+
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
@@ -71,6 +74,10 @@ void initializeVeloxMemory() {
     FLAGS_velox_exception_user_stacktrace_enabled = true;
     velox::memory::initializeMemoryManager(
         velox::memory::MemoryManager::Options{});
+
+    // Installs folly's signal handler to print a stack trace on crashes.
+    folly::symbolizer::installFatalSignalHandler(
+        folly::symbolizer::kAllFatalSignals);
   }
 }
 


### PR DESCRIPTION
Summary:
Installing folly's signal handler to print stack traces when Python
processes crashes.

Differential Revision: D75116260


