### PR TITLE
feat(functions): Support named rows as return type

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -21,8 +21,8 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox::exec {
-
 namespace {
+
 bool isAny(const TypeSignature& typeSignature) {
   return typeSignature.baseName() == "any";
 }
@@ -254,6 +254,7 @@ TypePtr SignatureBinder::tryResolveType(
 
   const auto& params = typeSignature.parameters();
   std::vector<TypeParameter> typeParameters;
+
   for (auto& param : params) {
     auto literal =
         tryResolveLongLiteral(param, variables, integerVariablesBindings);
@@ -267,7 +268,7 @@ TypePtr SignatureBinder::tryResolveType(
     if (!type) {
       return nullptr;
     }
-    typeParameters.push_back(TypeParameter(type));
+    typeParameters.push_back(TypeParameter(type, param.rowFieldName()));
   }
 
   try {

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -34,7 +34,7 @@ void testSignatureBinder(
 
   auto returnType = binder.tryResolveReturnType();
   ASSERT_TRUE(returnType != nullptr);
-  ASSERT_TRUE(expectedReturnType->equivalent(*returnType));
+  ASSERT_EQ(*expectedReturnType, *returnType);
 }
 
 void assertCannotResolve(
@@ -971,6 +971,15 @@ TEST(SignatureBinderTest, namedRows) {
         signature,
         {ROW({{"my_map", MAP(BIGINT(), ROW({{"bla", VARCHAR()}}))}})},
         VARCHAR());
+  }
+
+  // Return named row.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("row(foo bigint)")
+                         .argumentType("varchar")
+                         .build();
+    testSignatureBinder(signature, {VARCHAR()}, ROW({{"foo", BIGINT()}}));
   }
 }
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1305,12 +1305,16 @@ class RowParametricType {
     }
 
     std::vector<TypePtr> argumentTypes;
+    std::vector<std::string> argumentNames;
+
     argumentTypes.reserve(parameters.size());
+    argumentNames.reserve(parameters.size());
+
     for (const auto& parameter : parameters) {
       argumentTypes.push_back(parameter.type);
+      argumentNames.push_back(parameter.rowFieldName.value_or(""));
     }
-
-    return ROW(std::move(argumentTypes));
+    return ROW(std::move(argumentNames), std::move(argumentTypes));
   }
 };
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -397,7 +397,7 @@ class Type;
 using TypePtr = std::shared_ptr<const Type>;
 
 enum class TypeParameterKind {
-  /// Type. For example, element type in the array type.
+  /// Type. For example, element type in the array, map, or row children type.
   kType,
   /// Integer. For example, precision in a decimal type.
   kLongLiteral,
@@ -407,24 +407,32 @@ struct TypeParameter {
   const TypeParameterKind kind;
 
   /// Must be not not null when kind is kType. All other properties should be
-  /// null or unset.
+  /// null or unset (other than rowFieldName).
   const TypePtr type;
 
   /// Must be set when kind is kLongLiteral. All other properties should be null
   /// or unset.
   const std::optional<int64_t> longLiteral;
 
+  /// If this parameter is a child of another parent row type, it can optionally
+  /// have a name, e.g, "id" for `row(id bigint)`. Only set when kind is kType
+  const std::optional<std::string> rowFieldName;
+
   /// Creates kType parameter.
-  explicit TypeParameter(TypePtr _type)
+  explicit TypeParameter(
+      TypePtr _type,
+      std::optional<std::string> _rowFieldName = std::nullopt)
       : kind{TypeParameterKind::kType},
         type{std::move(_type)},
-        longLiteral{std::nullopt} {}
+        longLiteral{std::nullopt},
+        rowFieldName(_rowFieldName) {}
 
   /// Creates kLongLiteral parameter.
   explicit TypeParameter(int64_t _longLiteral)
       : kind{TypeParameterKind::kLongLiteral},
         type{nullptr},
-        longLiteral{_longLiteral} {}
+        longLiteral{_longLiteral},
+        rowFieldName{std::nullopt} {}
 };
 
 /// Abstract class hierarchy. Instances of these classes carry full


### PR DESCRIPTION
Summary:
Changing signature binder to carry the name of row children while
binding types, so that users can use functions that return rows with named
children, e.g `row(id bigint)`.

Differential Revision: D75146919


