### PR TITLE
feat: Making TableWriter commitStrategy configurable

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -384,7 +384,7 @@ core::PlanNodePtr PlanBuilder::TableWriterBuilder::build(core::PlanNodeId id) {
       insertHandle_,
       false,
       TableWriteTraits::outputType(aggregationNode),
-      connector::CommitStrategy::kNoCommit,
+      commitStrategy_,
       upstreamNode);
   VELOX_CHECK(!writeNode->supportsBarrier());
   return writeNode;
@@ -624,7 +624,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::string& outputFileName,
     const common::CompressionKind compressionKind,
     const RowTypePtr& schema,
-    const bool ensureFiles) {
+    const bool ensureFiles,
+    const connector::CommitStrategy commitStrategy) {
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)
       .outputFileName(outputFileName)
@@ -640,6 +641,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       .options(options)
       .compressionKind(compressionKind)
       .ensureFiles(ensureFiles)
+      .commitStrategy(commitStrategy)
       .endTableWriter();
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -471,6 +471,15 @@ class PlanBuilder {
       return *this;
     }
 
+    /// Specifies commitStrategy for writing to the connector.
+    /// @param commitStrategy The commit strategy to use for the table write
+    /// operation.
+    TableWriterBuilder& commitStrategy(
+        connector::CommitStrategy commitStrategy) {
+      commitStrategy_ = commitStrategy;
+      return *this;
+    }
+
     /// Stop the TableWriterBuilder.
     PlanBuilder& endTableWriter() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -502,6 +511,8 @@ class PlanBuilder {
     common::CompressionKind compressionKind_{common::CompressionKind_NONE};
 
     bool ensureFiles_{false};
+    connector::CommitStrategy commitStrategy_{
+        connector::CommitStrategy::kNoCommit};
   };
 
   /// Start a TableWriterBuilder.
@@ -720,7 +731,9 @@ class PlanBuilder {
       const std::string& outputFileName = "",
       const common::CompressionKind = common::CompressionKind_NONE,
       const RowTypePtr& schema = nullptr,
-      const bool ensureFiles = false);
+      const bool ensureFiles = false,
+      const connector::CommitStrategy commitStrategy =
+          connector::CommitStrategy::kNoCommit);
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(


### PR DESCRIPTION
Summary:
Currently we hard-code `kNoCommit` as the commit strategy, which directly writes to the final file instead of writing to a temporary file instead before "committing". 

With this option we will be able to set this to avoid inconsistent behavior when running velox in a distributed environment (Pyspark/Velox).

Differential Revision: D75159377


