### PR TITLE
build: Add compile flags for stemmer

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -209,7 +209,8 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-${STEMMER_VERSION}.tar.gz stemmer
   (
     cd ${DEPENDENCY_DIR}/stemmer
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    COMPILER_FLAGS=$(get_cxx_flags)
+    sed -i "s/CPPFLAGS=-Iinclude/CPPFLAGS=-Iinclude -fPIC ${COMPILER_FLAGS}/" Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a ${INSTALL_PREFIX}/lib/
     ${SUDO} cp include/libstemmer.h ${INSTALL_PREFIX}/include/

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -193,7 +193,8 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-${STEMMER_VERSION}.tar.gz stemmer
   (
     cd ${DEPENDENCY_DIR}/stemmer
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    COMPILER_FLAGS=$(get_cxx_flags)
+    sed -i '' "s/CPPFLAGS=-Iinclude/CPPFLAGS=-Iinclude -fPIC ${COMPILER_FLAGS}/" Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a ${INSTALL_PREFIX}/lib/
     ${SUDO} cp include/libstemmer.h ${INSTALL_PREFIX}/include/

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -206,7 +206,8 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-${STEMMER_VERSION}.tar.gz stemmer
   (
     cd ${DEPENDENCY_DIR}/stemmer
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    COMPILER_FLAGS=$(get_cxx_flags)
+    sed -i "s/CPPFLAGS=-Iinclude/CPPFLAGS=-Iinclude -fPIC ${COMPILER_FLAGS}/" Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a ${INSTALL_PREFIX}/lib/
     ${SUDO} cp include/libstemmer.h ${INSTALL_PREFIX}/include/

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -258,7 +258,8 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-${STEMMER_VERSION}.tar.gz stemmer
   (
     cd ${DEPENDENCY_DIR}/stemmer
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    COMPILER_FLAGS=$(get_cxx_flags)
+    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC "${COMPILER_FLAGS}"/' Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a ${INSTALL_PREFIX}/lib/
     ${SUDO} cp include/libstemmer.h ${INSTALL_PREFIX}/include/


### PR DESCRIPTION
This PR adds the compiler flags from `get_cxx_flags` to stemmer.