### PR TITLE
feat(type): Add support for BIGINT noise scale

### DIFF
--- a/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
@@ -278,6 +278,12 @@ void registerNoisyCountIfGaussianAggregate(
           .argumentType("boolean")
           .argumentType("double")
           .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("boolean")
+          .argumentType("bigint") // support BIGINT noise scale
+          .build(),
   };
 
   auto name = prefix + kNoisyCountIfGaussian;

--- a/velox/functions/prestosql/aggregates/tests/NoisyCountIfGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyCountIfGaussianAggregationTest.cpp
@@ -175,4 +175,17 @@ TEST_F(
       "SELECT c0 % 11, SUM(if(c1, 1, 0)), SUM(if(c2, 1, 0)) FROM tmp WHERE c0 % 2 = 0 GROUP BY 1");
 }
 
+// Test that the aggregation works with zero rows, multiple groups and a
+// constant noise scale.
+TEST_F(NoisyCountIfGaussianAggregationTest, zeroRowsMultipleGroupsNoise) {
+  auto vectors = makeVectors(rowType_, 0, 5);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_count_if_gaussian(c1, 0.1)", "noisy_count_if_gaussian(c2, 0.1)"},
+      "SELECT c0, sum(if(c1, 1, 0)), sum(if(c2, 1, 0)) FROM tmp group by c0, c1");
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyCountIfGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyCountIfGaussianAggregationTest.cpp
@@ -188,4 +188,17 @@ TEST_F(NoisyCountIfGaussianAggregationTest, zeroRowsMultipleGroupsNoise) {
       "SELECT c0, sum(if(c1, 1, 0)), sum(if(c2, 1, 0)) FROM tmp group by c0, c1");
 }
 
+// Test that the aggregation supports BIGINT as a valid
+// noise scale.
+TEST_F(NoisyCountIfGaussianAggregationTest, bigIntNoiseScale) {
+  auto vectors = makeVectors(rowType_, 10, 4);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_count_if_gaussian(c1, 2)", "noisy_count_if_gaussian(c2, 2)"},
+      "SELECT sum(if(c1, 1, 0)), sum(if(c2, 1, 0)) FROM tmp");
+}
+
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
### Summary
Add another function signature to support BIGINT as a valid variable type for noiseScale in NOISY_COUNT_IF_GAUSSIAN(col, noise_scale) in Velox. Also provide unit test for this feature.

#### Changes
*   Modified `NoisyCountIfGaussianAggregate.cpp` to include BIGINT as a valid noise scale argument type.
*   Added test cases to `NoisyCountIfGaussianAggregationTest.cpp` for BIGINT noise scale support.

Differential Revision: D75258579
