### PR TITLE
feat: Add inverse_chi_squared_cdf

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -362,6 +362,12 @@ Probability Functions: inverse_cdf
     The mean must be a real value and the scale must be a positive real value (both of type DOUBLE).
     The probability ``p`` must lie on the interval [0, 1].
 
+.. function:: inverse_chi_squared_cdf(df, p) -> double
+
+    Compute the inverse of the Chi-square cdf with given ``df`` (degrees of freedom) parameter for the cumulative
+    probability (p): P(N < n). The df parameter must be positive real values.
+    The probability ``p`` must lie on the interval [0, 1].
+
 ====================================
 Statistical Functions
 ====================================

--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -266,6 +266,23 @@ struct InverseNormalCDFFunction {
 };
 
 template <typename T>
+struct InverseChiSquaredCDFFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(double& result, double df, double p) {
+    static constexpr double kInf = std::numeric_limits<double>::infinity();
+
+    VELOX_USER_CHECK(
+        (p >= 0) && (p <= 1) && (p != kInf),
+        "p must be in the interval [0, 1]");
+    VELOX_USER_CHECK_GT(df, 0, "df must be greater than 0");
+
+    boost::math::chi_squared_distribution<> dist(df);
+    result = boost::math::quantile(dist, p);
+  }
+};
+
+template <typename T>
 struct InverseWeibullCDFFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
@@ -52,6 +52,8 @@ void registerProbTrigFunctions(const std::string& prefix) {
       {prefix + "inverse_beta_cdf"});
   registerFunction<InverseNormalCDFFunction, double, double, double, double>(
       {prefix + "inverse_normal_cdf"});
+  registerFunction<InverseChiSquaredCDFFunction, double, double, double>(
+      {prefix + "inverse_chi_squared_cdf"});
   registerFunction<PoissonCDFFunction, double, double, int32_t>(
       {prefix + "poisson_cdf"});
   registerFunction<GammaCDFFunction, double, double, double, double>(

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -772,5 +772,59 @@ TEST_F(ProbabilityTest, invPoissonCDF) {
       "inversePoissonCdf Function: p must be in the interval [0, 1)");
 }
 
+TEST_F(ProbabilityTest, inverseChiSquaredCDF) {
+  const auto inverseChiSquaredCDF = [&](std::optional<double> df,
+                                        std::optional<double> p) {
+    return evaluateOnce<double>("inverse_chi_squared_cdf(c0, c1)", df, p);
+  };
+
+  EXPECT_EQ(0.0, inverseChiSquaredCDF(3, 0.0));
+  EXPECT_EQ(1.4236522430352796, inverseChiSquaredCDF(3, 0.3));
+  EXPECT_EQ(11.344866730144370, inverseChiSquaredCDF(3, 0.99));
+  EXPECT_EQ(2.80930085646724e-123, inverseChiSquaredCDF(5, kDoubleMin));
+  EXPECT_EQ(kInf, inverseChiSquaredCDF(kDoubleMax, 0.95));
+  EXPECT_EQ(std::nullopt, inverseChiSquaredCDF(std::nullopt, 0.94));
+  EXPECT_EQ(std::nullopt, inverseChiSquaredCDF(142.345, std::nullopt));
+  EXPECT_EQ(std::nullopt, inverseChiSquaredCDF(std::nullopt, std::nullopt));
+
+  // Test invalid inputs for df.
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(-3, 0.3), "df must be greater than 0");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kNan, 0.99), "df must be greater than 0");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kInf, 0.99),
+      "Error in function boost::math::chi_squared_distribution<double>::chi_squared_distribution: Degrees of freedom argument is inf, but must be > 0 !");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kBigIntMin, 0.15), "df must be greater than 0");
+
+  // Test invalid inputs for p.
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(3, 1.00001), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(40, kNan), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(40, kInf), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(11, kDoubleMax), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(500, kBigIntMin),
+      "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(234, kBigIntMax),
+      "p must be in the interval [0, 1]");
+
+  // Test invalid inputs for both params.
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(-3, -0.001), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kNan, kNan), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kInf, kInf), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseChiSquaredCDF(kBigIntMin, kBigIntMax),
+      "p must be in the interval [0, 1]");
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
feat: Add inverse_chi_squared_cdf

I am taking over the implementation of this function for @svm1.
Previous PR: https://github.com/facebookincubator/velox/pull/11278

I ran the fuzzer and got the following error:
```
I20250522 21:08:20.052790 32684429 ExpressionVerifier.cpp:293] Execute with reference DB.
I20250522 21:08:20.052894 32684429 PrestoQueryRunner.cpp:433] Execute presto sql: DROP TABLE IF EXISTS t_values
I20250522 21:08:20.145370 32684429 PrestoQueryRunner.cpp:433] Execute presto sql: CREATE TABLE t_values(c0, c1, c2, row_number) WITH (format = 'DWRF') AS SELECT cast(null as DOUBLE), cast(null as DOUBLE), cast(null as DOUBLE), cast(null as BIGINT)
I20250522 21:08:20.914126 32684429 PrestoQueryRunner.cpp:433] Execute presto sql: SELECT "$path" FROM t_values
I20250522 21:08:21.400630 32684429 PrestoQueryRunner.cpp:433] Execute presto sql: DELETE FROM t_values
I20250522 21:08:21.665546 32684429 Writer.cpp:660] Stripe 0: Flush overhead = 0, data length = 162, pre flush mem = 397056, post flush mem = 395200. Closing = true
I20250522 21:08:21.665978 32684429 FileSink.cpp:131] closing file: /Users/minhancao/oss_java_presto_only/data/tpch/t_values/t_values.dwrf,  total size: 1.16KB
I20250522 21:08:21.666232 32684429 PrestoQueryRunner.cpp:433] Execute presto sql: SELECT try(inverse_chi_squared_cdf(inverse_chi_squared_cdf(c0, inverse_chi_squared_cdf(c0, c1)), inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2)))) as p0, try(inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2))) as p1, try(row_number) as p2 FROM (t_values)
E20250522 21:08:22.336602 32684429 Exceptions.h:66] Line: /Users/minhancao/velox_2/velox/velox/expression/tests/ExpressionVerifier.cpp:355, Function:verify, Expression: exec::test::assertEqualResults( referenceEvalResult.value(), projectionPlan->outputType(), {commonEvalResultRow}) Velox and reference DB results don't match, Source: RUNTIME, ErrorCode: INVALID_STATE
/Users/minhancao/velox_2/velox/velox/exec/tests/utils/QueryAssertions.cpp:1171: Failure
I20250522 21:08:22.336664 32684429 ExpressionVerifier.cpp:503] Skipping persistence because repro path is empty.
Failed
libc++abi: terminating due to uncaught exception of type facebook::velox::VeloxRuntimeError: Exception: VeloxRuntimeError
Expected 6, got 6
1 extra rows, 1 missing rows
1 of extra rows:
	4.450147717014402E-308 | 0.2141695652193845 | 0
1 of missing rows:
        null | 0.2141695656849056 | 0
```

Presto:
```
presto:tpch> select * from t_values;
         c0          |         c1          |         c2         | row_number 
---------------------+---------------------+--------------------+------------
  0.3486450535710901 | 0.38828716264106333 | 0.7332146414555609 |          0 
    0.56940804165788 |  0.7552411798387766 | 0.2734761103056371 |          1 
 0.45837914594449103 |  0.8319215362425894 | 0.6007434276398271 |          2 
  0.8559019945096225 |  0.7783600026741624 | 0.7332146414555609 |          3 
  0.7875391452107579 | 0.11767953541129827 | 0.7332146414555609 |          4 
  0.9075035622809082 |   0.480198334204033 | 0.2734761103056371 |          5 
(6 rows)

Query 20250523_041216_00047_5sw5s, FINISHED, 1 node
Splits: 17 total, 17 done (100.00%)
[Latency: client-side: 0:01, server-side: 0:01] [6 rows, 1.16KB] [9 rows/s, 1.82KB/s]

presto:tpch> SELECT try(inverse_chi_squared_cdf(inverse_chi_squared_cdf(c0, inverse_chi_squared_cdf(c0, c1)), inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2)))) as p0, try(inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2))) as p1, try(row_number) as p2 FROM (t_values);
          p0          |          p1           | p2 
----------------------+-----------------------+----
 NULL                 |    0.2141695656849056 |  0 
                  0.0 | 1.2301016925762965E-6 |  1 
 6.535116587341145E-6 |  0.014051220914519935 |  2 
 NULL                 |    0.2141695656849056 |  3 
                  0.0 |    0.2141695656849056 |  4 
                  0.0 | 1.2301016925762965E-6 |  5 
(6 rows)
```

Velox:
```
presto:tpch> select * from t_values;
         c0          |         c1          |         c2         | row_number 
---------------------+---------------------+--------------------+------------
  0.3486450535710901 | 0.38828716264106333 | 0.7332146414555609 |          0 
    0.56940804165788 |  0.7552411798387766 | 0.2734761103056371 |          1 
 0.45837914594449103 |  0.8319215362425895 | 0.6007434276398271 |          2 
  0.8559019945096226 |  0.7783600026741624 | 0.7332146414555609 |          3 
   0.787539145210758 | 0.11767953541129827 | 0.7332146414555609 |          4 
  0.9075035622809081 | 0.48019833420403296 | 0.2734761103056371 |          5 
(6 rows)

Query 20250523_023627_00036_pbtbm, FINISHED, 1 node
Splits: 2 total, 2 done (100.00%)
[Latency: client-side: 463ms, server-side: 377ms] [6 rows, 1.67KB] [15 rows/s, 4.43KB/s]

presto:tpch> SELECT try(inverse_chi_squared_cdf(inverse_chi_squared_cdf(c0, inverse_chi_squared_cdf(c0, c1)), inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2)))) as p0, try(inverse_chi_squared_cdf(DOUBLE '0.638314887881279', inverse_chi_squared_cdf(DOUBLE '0.5433810562826693', c2))) as p1, try(row_number) as p2 FROM (t_values);
           p0           |          p1           | p2 
------------------------+-----------------------+----
 4.450147717014402E-308 |    0.2141695652193845 |  0 
 1.7456390478869658E-33 | 1.2301018605050523E-6 |  1 
   6.535124632618876E-6 |  0.014051220861414915 |  2 
 NULL                   |    0.2141695652193845 |  3 
 4.450147717014402E-308 |    0.2141695652193845 |  4 
    2.1334374645811E-79 | 1.2301018605050523E-6 |  5 
(6 rows)
```

There are similar GitHub issues created for CDF Precision error for other inverse CDF functions from fuzzer:
https://github.com/facebookincubator/velox/issues/12918
https://github.com/facebookincubator/velox/issues/12981
https://github.com/facebookincubator/velox/issues/12982