### PR TITLE
fix core dump issue while do tree-loop-vectorize optimize for lzoDeco…

### DIFF
--- a/velox/common/compression/LzoDecompressor.cpp
+++ b/velox/common/compression/LzoDecompressor.cpp
@@ -60,6 +60,8 @@ class MalformedInputException : public dwio::common::ParseError {
 };
 } // namespace
 
+#pragma GCC push_options
+#pragma GCC optimize ("no-tree-loop-vectorize")
 uint64_t lzoDecompress(
     const char* inputAddress,
     const char* inputLimit,
@@ -382,6 +384,7 @@ uint64_t lzoDecompress(
 
   return static_cast<uint64_t>(output - outputAddress);
 }
+#pragma GCC pop_options
 
 } // namespace compression
 } // namespace common


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/13452

this is not the final fix, temp commit for show the issue code bock and this change can prevent the core dump