### PR TITLE
misc: Enhance transient type support in presto query runner

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -222,10 +222,10 @@ PrestoQueryRunner::inputProjections(
     // unchanged and the projection is just an identity mapping.
     if (isIntermediateOnlyType(childType)) {
       for (int batchIndex = 0; batchIndex < input.size(); batchIndex++) {
-        children[batchIndex].push_back(transformIntermediateOnlyType(
-            input[batchIndex]->childAt(childIndex)));
+        children[batchIndex].push_back(
+            transformIntermediateTypes(input[batchIndex]->childAt(childIndex)));
       }
-      projections.push_back(getIntermediateOnlyTypeProjectionExpr(
+      projections.push_back(getProjectionsToIntermediateTypes(
           childType,
           std::make_shared<core::FieldAccessExpr>(
               names[childIndex], names[childIndex]),

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -16,52 +16,13 @@
 
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
-#include "velox/expression/VectorWriters.h"
+#include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
-#include "velox/vector/ComplexVector.h"
-#include "velox/vector/DecodedVector.h"
-#include "velox/vector/fuzzer/Utils.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::exec::test {
 namespace {
-class ArrayTransform {
- public:
-  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
-      const;
-
-  core::ExprPtr projectionExpr(
-      const TypePtr& type,
-      const core::ExprPtr& inputExpr,
-      const std::string& columnAlias) const;
-};
-
-class MapTransform {
- public:
-  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
-      const;
-
-  core::ExprPtr projectionExpr(
-      const TypePtr& type,
-      const core::ExprPtr& inputExpr,
-      const std::string& columnAlias) const;
-};
-
-class RowTransform {
- public:
-  VectorPtr transform(const VectorPtr& vector, const SelectivityVector& rows)
-      const;
-
-  core::ExprPtr projectionExpr(
-      const TypePtr& type,
-      const core::ExprPtr& inputExpr,
-      const std::string& columnAlias) const;
-};
-
-const ArrayTransform kArrayTransform;
-const MapTransform kMapTransform;
-const RowTransform kRowTransform;
-
 const std::unordered_map<TypePtr, std::shared_ptr<IntermediateTypeTransform>>&
 intermediateTypeTransforms() {
   static std::unordered_map<TypePtr, std::shared_ptr<IntermediateTypeTransform>>
@@ -84,129 +45,43 @@ const std::shared_ptr<IntermediateTypeTransform>& getIntermediateTypeTransform(
   return it->second;
 }
 
-VectorPtr transformIntermediateOnlyType(
-    const VectorPtr& vector,
+VectorPtr evaluateExpression(
+    core::ExprPtr& expression,
+    const VectorPtr& input,
     const SelectivityVector& rows) {
-  const auto& type = vector->type();
-  if (type->isArray()) {
-    return kArrayTransform.transform(vector, rows);
-  } else if (type->isMap()) {
-    return kMapTransform.transform(vector, rows);
-  } else if (type->isRow()) {
-    return kRowTransform.transform(vector, rows);
-  } else {
-    const auto& transform = getIntermediateTypeTransform(type);
-    DecodedVector decoded(*vector);
-    const auto* base = decoded.base();
-
-    VectorPtr result;
-    const auto& transformedType = transform->transformedType();
-    BaseVector::ensureWritable(
-        SelectivityVector(base->size()), transformedType, base->pool(), result);
-    VectorWriter<Any> writer;
-    writer.init(*result);
-
-    if (base->isConstantEncoding()) {
-      if (rows.countSelected() > 0) {
-        if (base->isNullAt(0)) {
-          result = BaseVector::createNullConstant(
-              transformedType, base->size(), base->pool());
-        } else {
-          const auto value = transform->transform(base, 0);
-
-          if (value.isNull()) {
-            result = BaseVector::createNullConstant(
-                transformedType, base->size(), base->pool());
-          } else {
-            writer.setOffset(0);
-            VELOX_DYNAMIC_TYPE_DISPATCH(
-                fuzzer::writeOne,
-                transformedType->kind(),
-                value,
-                writer.current());
-            writer.commit(true);
-            result = BaseVector::wrapInConstant(base->size(), 0, result);
-          }
-        }
-      }
-    } else {
-      rows.applyToSelected([&](vector_size_t row) {
-        auto index = decoded.index(row);
-        writer.setOffset(index);
-
-        if (base->isNullAt(index)) {
-          writer.commitNull();
-        } else {
-          const auto value = transform->transform(base, index);
-
-          if (value.isNull()) {
-            writer.commitNull();
-          } else {
-            VELOX_DYNAMIC_TYPE_DISPATCH(
-                fuzzer::writeOne,
-                transformedType->kind(),
-                value,
-                writer.current());
-            writer.commit(true);
-          }
-        }
-      });
-    }
-
-    if (!decoded.isIdentityMapping()) {
-      result = decoded.wrap(result, *vector, vector->size());
-    }
-
-    return result;
-  }
+  std::shared_ptr<core::QueryCtx> queryCtx_{velox::core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx{
+      std::make_unique<core::ExecCtx>(input->pool(), queryCtx_.get())};
+  velox::test::VectorMaker vectorMaker(input->pool());
+  auto rowVector = vectorMaker.rowVector({input});
+  core::TypedExprPtr typedExpr = core::Expressions::inferTypes(
+      expression, rowVector->type(), input->pool());
+  exec::ExprSet exprSet(
+      std::vector<core::TypedExprPtr>{typedExpr}, execCtx.get());
+  exec::EvalCtx evalCtx(execCtx.get(), &exprSet, rowVector.get());
+  std::vector<VectorPtr> result;
+  exprSet.eval(rows, evalCtx, result);
+  VELOX_CHECK_EQ(result.size(), 1);
+  VELOX_CHECK_NOT_NULL(result[0]);
+  return result[0];
 }
 
-// Converts an ArrayVector so that any intermediate only types in the elements
-// are transformed.
-VectorPtr ArrayTransform::transform(
-    const VectorPtr& vector,
-    const SelectivityVector& rows) const {
-  VELOX_CHECK(vector->type()->isArray());
-  DecodedVector decoded(*vector);
-  const auto* base = decoded.base()->as<ArrayVector>();
+enum class TransformDirection { TO_INTERMEDIATE, TO_TARGET };
 
-  SelectivityVector elementRows(base->elements()->size(), false);
-  rows.applyToSelected([&](vector_size_t row) {
-    if (!decoded.isNullAt(row)) {
-      auto index = decoded.index(row);
-      elementRows.setValidRange(
-          base->offsetAt(index),
-          base->offsetAt(index) + base->sizeAt(index),
-          true);
-    }
-  });
-  elementRows.updateBounds();
-
-  VectorPtr elementsVector =
-      transformIntermediateOnlyType(base->elements(), elementRows);
-
-  VectorPtr array = std::make_shared<ArrayVector>(
-      base->pool(),
-      ARRAY(elementsVector->type()),
-      base->nulls(),
-      base->size(),
-      base->offsets(),
-      base->sizes(),
-      elementsVector);
-
-  if (!decoded.isIdentityMapping()) {
-    array = decoded.wrap(array, *vector, vector->size());
-  }
-
-  return array;
-}
-
-// Applies a lambda transform to the elements of an array to convert input
-// types to intermediate only types where necessary.
-core::ExprPtr ArrayTransform::projectionExpr(
+core::ExprPtr getProjection(
     const TypePtr& type,
     const core::ExprPtr& inputExpr,
-    const std::string& columnAlias) const {
+    const std::string& columnAlias,
+    const TransformDirection transformDirection);
+
+// Applies a lambda transform to the elements of an array to convert input
+// types <=> intermediate types (where necessary) depending on
+// 'transformDirection'.
+core::ExprPtr getProjectionForArray(
+    const TypePtr& type,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias,
+    const TransformDirection transformDirection) {
   VELOX_CHECK(type->isArray());
 
   return std::make_shared<core::CallExpr>(
@@ -215,70 +90,22 @@ core::ExprPtr ArrayTransform::projectionExpr(
           inputExpr,
           std::make_shared<core::LambdaExpr>(
               std::vector<std::string>{"x"},
-              getIntermediateOnlyTypeProjectionExpr(
+              getProjection(
                   type->asArray().elementType(),
                   std::make_shared<core::FieldAccessExpr>("x", "x"),
-                  "x"))},
+                  "x",
+                  transformDirection))},
       columnAlias);
 }
 
-// Converts an MapVector so that any intermediate only types in the keys and
-// values are transformed.
-VectorPtr MapTransform::transform(
-    const VectorPtr& vector,
-    const SelectivityVector& rows) const {
-  VELOX_CHECK(vector->type()->isMap());
-  DecodedVector decoded(*vector);
-  const auto* base = decoded.base()->as<MapVector>();
-
-  VectorPtr keysVector = base->mapKeys();
-  VectorPtr valuesVector = base->mapValues();
-  const auto& keysType = keysVector->type();
-  const auto& valuesType = valuesVector->type();
-
-  SelectivityVector elementRows(keysVector->size(), false);
-  rows.applyToSelected([&](vector_size_t row) {
-    if (!decoded.isNullAt(row)) {
-      auto index = decoded.index(row);
-      elementRows.setValidRange(
-          base->offsetAt(index),
-          base->offsetAt(index) + base->sizeAt(index),
-          true);
-    }
-  });
-  elementRows.updateBounds();
-
-  if (isIntermediateOnlyType(keysType)) {
-    keysVector = transformIntermediateOnlyType(keysVector, elementRows);
-  }
-
-  if (isIntermediateOnlyType(valuesType)) {
-    valuesVector = transformIntermediateOnlyType(valuesVector, elementRows);
-  }
-
-  VectorPtr map = std::make_shared<MapVector>(
-      base->pool(),
-      MAP(keysVector->type(), valuesVector->type()),
-      base->nulls(),
-      base->size(),
-      base->offsets(),
-      base->sizes(),
-      keysVector,
-      valuesVector);
-
-  if (!decoded.isIdentityMapping()) {
-    map = decoded.wrap(map, *vector, vector->size());
-  }
-
-  return map;
-}
-
 // Applies a lambda transform to the keys and values of a map to convert input
-// types to intermediate only types where necessary.
-core::ExprPtr MapTransform::projectionExpr(
+// types <=> intermediate types (where necessary) depending on
+// 'transformDirection'.
+core::ExprPtr getProjectionForMap(
     const TypePtr& type,
     const core::ExprPtr& inputExpr,
-    const std::string& columnAlias) const {
+    const std::string& columnAlias,
+    const TransformDirection transformDirection) {
   VELOX_CHECK(type->isMap());
   const auto& mapType = type->asMap();
   const auto& keysType = mapType.keyType();
@@ -293,10 +120,11 @@ core::ExprPtr MapTransform::projectionExpr(
             expr,
             std::make_shared<core::LambdaExpr>(
                 std::vector<std::string>{"k", "v"},
-                getIntermediateOnlyTypeProjectionExpr(
+                getProjection(
                     keysType,
                     std::make_shared<core::FieldAccessExpr>("k", "k"),
-                    "k"))},
+                    "k",
+                    transformDirection))},
         columnAlias);
   }
 
@@ -307,80 +135,65 @@ core::ExprPtr MapTransform::projectionExpr(
             expr,
             std::make_shared<core::LambdaExpr>(
                 std::vector<std::string>{"k", "v"},
-                getIntermediateOnlyTypeProjectionExpr(
+                getProjection(
                     valuesType,
                     std::make_shared<core::FieldAccessExpr>("v", "v"),
-                    "v"))},
+                    "v",
+                    transformDirection))},
         columnAlias);
   }
 
   return expr;
 }
 
-// Converts an RowVector so that any intermediate only types in the children
-// are transformed.
-VectorPtr RowTransform::transform(
-    const VectorPtr& vector,
-    const SelectivityVector& rows) const {
-  VELOX_CHECK(vector->type()->isRow());
-  DecodedVector decoded(*vector);
-  const auto* base = decoded.base()->as<RowVector>();
-
-  SelectivityVector childRows(base->size(), false);
-  rows.applyToSelected([&](vector_size_t row) {
-    if (!decoded.isNullAt(row)) {
-      childRows.setValid(decoded.index(row), true);
+TypePtr replaceIntermediateWithTargetType(TypePtr type) {
+  if (type->isArray()) {
+    const auto& arrayType = type->asArray();
+    return ARRAY(replaceIntermediateWithTargetType(arrayType.elementType()));
+  } else if (type->isMap()) {
+    const auto& mapType = type->asMap();
+    return MAP(
+        replaceIntermediateWithTargetType(mapType.keyType()),
+        replaceIntermediateWithTargetType(mapType.valueType()));
+  } else if (type->isRow()) {
+    const auto& rowType = type->asRow();
+    std::vector<std::string> names;
+    std::vector<TypePtr> children;
+    for (int i = 0; i < rowType.size(); i++) {
+      names.push_back(rowType.nameOf(i));
+      children.push_back(replaceIntermediateWithTargetType(rowType.childAt(i)));
     }
-  });
-  childRows.updateBounds();
-
-  std::vector<VectorPtr> children;
-  std::vector<TypePtr> childrenTypes;
-  std::vector<std::string> childrenNames = base->type()->asRow().names();
-  for (const auto& child : base->children()) {
-    if (isIntermediateOnlyType(child->type())) {
-      children.push_back(transformIntermediateOnlyType(child, childRows));
-      childrenTypes.push_back(children.back()->type());
-    } else {
-      children.push_back(child);
-      childrenTypes.push_back(child->type());
-    }
+    return ROW(std::move(names), std::move(children));
   }
-
-  VectorPtr row = std::make_shared<RowVector>(
-      base->pool(),
-      ROW(std::move(childrenNames), std::move(childrenTypes)),
-      base->nulls(),
-      base->size(),
-      std::move(children));
-
-  if (!decoded.isIdentityMapping()) {
-    row = decoded.wrap(row, *vector, vector->size());
+  if (isIntermediateOnlyType(type)) {
+    const auto& transform = getIntermediateTypeTransform(type);
+    return transform->targetType();
   }
-
-  return row;
+  return type;
 }
 
-// Applies transforms to the children of a row to convert input types to
-// intermediate only types where necessary, and reconstructs the row via
-// row_constructor.
-core::ExprPtr RowTransform::projectionExpr(
+// Applies transforms to the children of a row to convert input
+// types <=> intermediate types (where necessary) depending on
+// 'transformDirection', and reconstructs the row via row_constructor.
+core::ExprPtr getProjectionForRow(
     const TypePtr& type,
     const core::ExprPtr& inputExpr,
-    const std::string& columnAlias) const {
+    const std::string& columnAlias,
+    const TransformDirection transformDirection) {
   VELOX_CHECK(type->isRow());
   const auto& rowType = type->asRow();
 
   std::vector<core::ExprPtr> children;
   for (int i = 0; i < rowType.size(); i++) {
     if (isIntermediateOnlyType(rowType.childAt(i))) {
-      children.push_back(getIntermediateOnlyTypeProjectionExpr(
+      children.push_back(getProjection(
           rowType.childAt(i),
           std::make_shared<core::FieldAccessExpr>(
               rowType.nameOf(i),
               rowType.nameOf(i),
               std::vector<core::ExprPtr>{inputExpr}),
-          rowType.nameOf(i)));
+          rowType.nameOf(i),
+          transformDirection));
     } else {
       children.push_back(std::make_shared<core::FieldAccessExpr>(
           rowType.nameOf(i),
@@ -389,21 +202,64 @@ core::ExprPtr RowTransform::projectionExpr(
     }
   }
 
+  TypePtr outputRowType;
+  if (transformDirection == TransformDirection::TO_TARGET) {
+    outputRowType = replaceIntermediateWithTargetType(type);
+  } else {
+    outputRowType = type;
+  }
+
   return std::make_shared<core::CallExpr>(
       "switch",
       std::vector<core::ExprPtr>{
           std::make_shared<core::CallExpr>(
               "is_null", std::vector<core::ExprPtr>{inputExpr}, std::nullopt),
           std::make_shared<core::ConstantExpr>(
-              type, variant::null(TypeKind::ROW), std::nullopt),
+              outputRowType, variant::null(TypeKind::ROW), std::nullopt),
           std::make_shared<core::CastExpr>(
-              type,
+              outputRowType,
               std::make_shared<core::CallExpr>(
                   "row_constructor", std::move(children), std::nullopt),
               false,
               std::nullopt)},
       columnAlias);
 }
+
+core::ExprPtr getProjection(
+    const TypePtr& originaltype,
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias,
+    const TransformDirection transformDirection) {
+  if (originaltype->isArray()) {
+    return getProjectionForArray(
+        originaltype, inputExpr, columnAlias, transformDirection);
+  } else if (originaltype->isMap()) {
+    return getProjectionForMap(
+        originaltype, inputExpr, columnAlias, transformDirection);
+  } else if (originaltype->isRow()) {
+    return getProjectionForRow(
+        originaltype, inputExpr, columnAlias, transformDirection);
+  }
+  const auto& transform = getIntermediateTypeTransform(originaltype);
+  if (transformDirection == TransformDirection::TO_TARGET) {
+    return transform->projectToTargetType(inputExpr, columnAlias);
+  }
+  return transform->projectToIntermediateType(inputExpr, columnAlias);
+}
+
+VectorPtr transformIntermediateTypes(
+    const VectorPtr& vector,
+    const SelectivityVector& rows) {
+  const auto& type = vector->type();
+  auto expression = getProjection(
+      type,
+      std::make_shared<core::FieldAccessExpr>("c0", "c0"),
+      "c0",
+      TransformDirection::TO_TARGET);
+
+  return evaluateExpression(expression, vector, rows);
+}
+
 } // namespace
 
 bool isIntermediateOnlyType(const TypePtr& type) {
@@ -421,24 +277,30 @@ bool isIntermediateOnlyType(const TypePtr& type) {
   return false;
 }
 
-VectorPtr transformIntermediateOnlyType(const VectorPtr& vector) {
-  return transformIntermediateOnlyType(
+VectorPtr transformIntermediateTypes(const VectorPtr& vector) {
+  return transformIntermediateTypes(
       vector, SelectivityVector(vector->size(), true));
 }
 
-core::ExprPtr getIntermediateOnlyTypeProjectionExpr(
+core::ExprPtr getProjectionsToIntermediateTypes(
     const TypePtr& type,
     const core::ExprPtr& inputExpr,
     const std::string& columnAlias) {
-  if (type->isArray()) {
-    return kArrayTransform.projectionExpr(type, inputExpr, columnAlias);
-  } else if (type->isMap()) {
-    return kMapTransform.projectionExpr(type, inputExpr, columnAlias);
-  } else if (type->isRow()) {
-    return kRowTransform.projectionExpr(type, inputExpr, columnAlias);
-  } else {
-    return getIntermediateTypeTransform(type)->projectionExpr(
-        inputExpr, columnAlias);
-  }
+  return getProjection(
+      type, inputExpr, columnAlias, TransformDirection::TO_INTERMEDIATE);
+}
+
+core::ExprPtr IntermediateTypeTransformUsingCast::projectToTargetType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CastExpr>(
+      targetType_, inputExpr, false, columnAlias);
+}
+
+core::ExprPtr IntermediateTypeTransformUsingCast::projectToIntermediateType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CastExpr>(
+      intermediateType_, inputExpr, false, columnAlias);
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
@@ -15,51 +15,17 @@
  */
 
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
-#include "velox/functions/lib/DateTimeFormatter.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
-#include "velox/type/tz/TimeZoneMap.h"
-#include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::exec::test {
 namespace {
 const std::string kFormat = "yyyy-MM-dd HH:mm:ss.SSS ZZZ";
 const std::string kBackupFormat = "yyyy-MM-dd HH:mm:ss.SSS ZZ";
-
-std::string format(const int64_t timestampWithTimeZone) {
-  static const std::shared_ptr<functions::DateTimeFormatter> kJodaDateTime =
-      functions::buildJodaDateTimeFormatter(kFormat).value();
-
-  const auto timestamp = unpackTimestampUtc(timestampWithTimeZone);
-  const auto timeZoneId = unpackZoneKeyId(timestampWithTimeZone);
-  auto* timezonePtr = tz::locateZone(tz::getTimeZoneName(timeZoneId));
-
-  const auto maxResultSize = kJodaDateTime->maxResultSize(timezonePtr);
-  std::string str;
-  str.resize(maxResultSize);
-  const auto resultSize =
-      kJodaDateTime->format(timestamp, timezonePtr, maxResultSize, str.data());
-  str.resize(resultSize);
-
-  return str;
-}
 } // namespace
-
-// Convert a TimestampWithTimeZone into a Varchar using DatetimeFormatter, so
-// that we can get the TimestampWithTimeZone back by calling parse_datetime.
-variant TimestampWithTimeZoneTransform::transform(
-    const BaseVector* const vector,
-    vector_size_t row) const {
-  VELOX_CHECK(isTimestampWithTimeZoneType(vector->type()));
-  VELOX_CHECK(!vector->isNullAt(row));
-
-  return variant::create<TypeKind::VARCHAR>(
-      format(vector->asChecked<SimpleVector<int64_t>>()->valueAt(row)));
-}
 
 // Applies parse_datetime to a Vector of VARCHAR (formatted timestamps with time
 // zone) to produce values of type TimestampWithTimeZone.
-core::ExprPtr TimestampWithTimeZoneTransform::projectionExpr(
+core::ExprPtr TimestampWithTimeZoneTransform::projectToIntermediateType(
     const core::ExprPtr& inputExpr,
     const std::string& columnAlias) const {
   // format_datetime with the ZZZ pattern produces time zones that need to be

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h
@@ -17,18 +17,18 @@
 #pragma once
 
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::exec::test {
-class TimestampWithTimeZoneTransform : public IntermediateTypeTransform {
+class TimestampWithTimeZoneTransform
+    : public IntermediateTypeTransformUsingCast {
  public:
-  TypePtr transformedType() const override {
-    return VARCHAR();
-  }
+  TimestampWithTimeZoneTransform()
+      : IntermediateTypeTransformUsingCast(
+            TIMESTAMP_WITH_TIME_ZONE(),
+            VARCHAR()) {}
 
-  variant transform(const BaseVector* const vector, vector_size_t row)
-      const override;
-
-  core::ExprPtr projectionExpr(
+  core::ExprPtr projectToIntermediateType(
       const core::ExprPtr& inputExpr,
       const std::string& columnAlias) const override;
 };

--- a/velox/exec/tests/PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
@@ -48,9 +48,9 @@ class PrestoQueryRunnerTimestampWithTimeZoneTransformTest
   void test(const VectorPtr& vector) {
     const auto colName = "col";
     const auto input =
-        makeRowVector({colName}, {transformIntermediateOnlyType(vector)});
+        makeRowVector({colName}, {transformIntermediateTypes(vector)});
 
-    auto expr = getIntermediateOnlyTypeProjectionExpr(
+    auto expr = getProjectionsToIntermediateTypes(
         vector->type(),
         std::make_shared<core::FieldAccessExpr>(
             colName,
@@ -66,8 +66,9 @@ class PrestoQueryRunnerTimestampWithTimeZoneTransformTest
 
   void testDictionary(const VectorPtr& base) {
     // Wrap in a dictionary without nulls.
-    test(BaseVector::wrapInDictionary(
-        nullptr, makeIndicesInReverse(100), 100, base));
+    auto dict = BaseVector::wrapInDictionary(
+        nullptr, makeIndicesInReverse(100), 100, base);
+    test(dict);
     // Wrap in a dictionary with some nulls.
     test(BaseVector::wrapInDictionary(
         makeNulls(100, [](vector_size_t row) { return row % 10 == 0; }),
@@ -145,8 +146,8 @@ TEST_F(
     transformIntermediateOnlyTypeTimestampWithTimeZoneArray) {
   auto elements = fuzzTimestampWithTimeZone(0, 0.1, 1000);
   auto size = 100;
-  std::vector<vector_size_t> offsets(size + 1);
-  for (int i = 0; i < size + 1; i++) {
+  std::vector<vector_size_t> offsets;
+  for (int i = 0; i < size; i++) {
     offsets.push_back(i * 10);
   }
   // Test array vector no nulls.
@@ -177,8 +178,8 @@ TEST_F(
   auto keys = fuzzTimestampWithTimeZone(0, 0, 1000);
   auto values = fuzzTimestampWithTimeZone(1, 0.1, 1000);
   auto size = 100;
-  std::vector<vector_size_t> offsets(size + 1);
-  for (int i = 0; i < size + 1; i++) {
+  std::vector<vector_size_t> offsets;
+  for (int i = 0; i < size; i++) {
     offsets.push_back(i * 10);
   }
   // Test map vector no nulls.

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -693,16 +693,6 @@ TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsUnevenKeysValues) {
   EXPECT_THROW(maker_.mapVector({0, 2, 4}, keys, values), VeloxRuntimeError);
 }
 
-TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsNullsInvalidIndices) {
-  auto keys = maker_.flatVector<int32_t>({0, 1, 2, 3, 4, 5});
-  auto values = maker_.flatVector<int64_t>({6, 7, 8, 9, 10, 11});
-
-  // The middle map is NULL, but according to the offsets it has size 2, this
-  // should fail.
-  EXPECT_THROW(
-      maker_.mapVector({0, 2, 4}, keys, values, {1}), VeloxRuntimeError);
-}
-
 TEST_F(VectorMakerTest, mapVectorStringString) {
   auto mapVector = maker_.mapVector<std::string, std::string>({
       {{"a", "1"}, {"b", "2"}},

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -226,7 +226,6 @@ ArrayVectorPtr VectorMaker::arrayVector(
     auto rawNulls = nullsBuffer->asMutable<uint64_t>();
 
     for (int i = 0; i < nulls.size(); i++) {
-      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0);
       bits::setNull(rawNulls, nulls[i]);
     }
   }
@@ -267,7 +266,6 @@ MapVectorPtr VectorMaker::mapVector(
     auto rawNulls = nullsBuffer->asMutable<uint64_t>();
 
     for (int i = 0; i < nulls.size(); i++) {
-      VELOX_CHECK_EQ(rawSizes[nulls[i]], 0);
       bits::setNull(rawNulls, nulls[i]);
     }
   }


### PR DESCRIPTION
Summary:
This update improves the existing support for transient types, such
as "timestamp with timezone," in the Presto query runner. The
enhancement aims to simplify the process of adding support for
additional transient types in the future.
For types that do not require special handling during conversion
to/from their target types, this change introduces a default
implementation. This implementation leverages the CAST expression
to facilitate the conversion process.

Differential Revision: D75232290


