### PR TITLE
misc: Remove unused dwrf writer reference from HiveDataSink

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -25,10 +25,6 @@
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/exec/MemoryReclaimer.h"
 
-namespace facebook::velox::dwrf {
-class Writer;
-}
-
 namespace facebook::velox::connector::hive {
 
 class LocationHandle;


### PR DESCRIPTION
Remove unused dwrf writer reference from HiveDataSink