### PR TITLE
build(ci): Fix failing benchmark and fuzzer jobs

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -37,8 +37,6 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/ccache"
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       GTest_SOURCE: BUNDLED
-      simdjson_SOURCE: BUNDLED
-      xsimd_SOURCE: BUNDLED
       cudf_SOURCE: BUNDLED
       CUDA_VERSION: "12.8"
       USE_CLANG: "${{ inputs.use-clang && 'true' || 'false' }}"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -170,8 +170,6 @@ jobs:
       - name: Build PyVelox
         if: ${{ github.event_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         working-directory: velox_main
-        env:
-          CXX_FLAGS: -DSIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
         run: |
           make python-build
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -170,6 +170,8 @@ jobs:
       - name: Build PyVelox
         if: ${{ github.event_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         working-directory: velox_main
+        env:
+          CXX_FLAGS: -DSIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
         run: |
           make python-build
 

--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -34,5 +34,3 @@ if(${VELOX_SIMDJSON_SKIPUTF8VALIDATION})
 endif()
 
 FetchContent_MakeAvailable(simdjson)
-target_compile_definitions(simdjson
-                           PUBLIC SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON)

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ benchmarks-build:
 					    -DVELOX_BUILD_RUNNER=OFF"
 
 benchmarks-basic-run:
-	scripts/benchmark-runner.py run \
+	scripts/ci/benchmark-runner.py run \
 			--bm_estimate_time \
 			--bm_max_secs 10 \
 			--bm_max_trials 10000 \

--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -22,8 +22,8 @@ velox_add_library(
 velox_link_libraries(velox_functions_json velox_functions_lib
                      simdjson::simdjson)
 
-velox_compile_definitions(velox_functions_json PRIVATE
-                           PUBLIC SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON)
+velox_compile_definitions(velox_functions_json
+                          PRIVATE SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -22,6 +22,9 @@ velox_add_library(
 velox_link_libraries(velox_functions_json velox_functions_lib
                      simdjson::simdjson)
 
+velox_compile_definitions(velox_functions_json PRIVATE
+                           PUBLIC SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON)
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
- I missed one line in the makefile in #13345 which causes the benchmark job to fail
- We used to build simdjson from source but #12321 changed that, this showed that we added the compile definition to turn on the experimental feature at the wrong place. 