### PR TITLE
feat: Support timestamp as hive PartitionId

### DIFF
--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -28,6 +28,7 @@ namespace facebook::velox::connector::hive {
       case TypeKind::BIGINT:                                                \
       case TypeKind::VARCHAR:                                               \
       case TypeKind::VARBINARY:                                             \
+      case TypeKind::TIMESTAMP:                                             \
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                          \
             TEMPLATE_FUNC, typeKind, __VA_ARGS__);                          \
       default:                                                              \
@@ -45,6 +46,18 @@ inline std::string makePartitionValueString(T value) {
 template <>
 inline std::string makePartitionValueString(bool value) {
   return value ? "true" : "false";
+}
+
+template <>
+inline std::string makePartitionValueString(Timestamp value) {
+  value.toTimezone(Timestamp::defaultTimezone());
+  TimestampToStringOptions options;
+  options.dateTimeSeparator = ' ';
+  // Set the precision to milliseconds, and enable the skipTrailingZeros match
+  // the timestamp precision and truncation behavior of Presto.
+  options.precision = TimestampPrecision::kMilliseconds;
+  options.skipTrailingZeros = true;
+  return value.toString(options);
 }
 
 template <TypeKind Kind>

--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -73,14 +73,17 @@ TEST_F(HivePartitionUtilTest, partitionName) {
          "flat_int_col",
          "flat_bigint_col",
          "dict_string_col",
-         "const_date_col"},
+         "const_date_col",
+         "flat_timestamp_col"},
         {makeFlatVector<bool>(std::vector<bool>{false}),
          makeFlatVector<int8_t>(std::vector<int8_t>{10}),
          makeFlatVector<int16_t>(std::vector<int16_t>{100}),
          makeFlatVector<int32_t>(std::vector<int32_t>{1000}),
          makeFlatVector<int64_t>(std::vector<int64_t>{10000}),
          makeDictionary<StringView>(std::vector<StringView>{"str1000"}),
-         makeConstant<int32_t>(10000, 1, DATE())});
+         makeConstant<int32_t>(10000, 1, DATE()),
+         makeFlatVector<Timestamp>(
+             std::vector<Timestamp>{Timestamp::fromMillis(1577836800000)})});
 
     std::vector<std::string> expectedPartitionKeyValues{
         "flat_bool_col=false",
@@ -89,7 +92,8 @@ TEST_F(HivePartitionUtilTest, partitionName) {
         "flat_int_col=1000",
         "flat_bigint_col=10000",
         "dict_string_col=str1000",
-        "const_date_col=1997-05-19"};
+        "const_date_col=1997-05-19",
+        "flat_timestamp_col=2019-12-31 16%3A00%3A00"};
 
     std::vector<column_index_t> partitionChannels;
     for (auto i = 1; i <= expectedPartitionKeyValues.size(); i++) {
@@ -135,7 +139,8 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
       "flat_int_col",
       "flat_bigint_col",
       "flat_string_col",
-      "const_date_col"};
+      "const_date_col",
+      "flat_timestamp_col"};
 
   RowVectorPtr input = makeRowVector(
       partitionColumnNames,
@@ -145,7 +150,8 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
        makeNullableFlatVector<int32_t>({std::nullopt}),
        makeNullableFlatVector<int64_t>({std::nullopt}),
        makeNullableFlatVector<StringView>({std::nullopt}),
-       makeConstant<int32_t>(std::nullopt, 1, DATE())});
+       makeConstant<int32_t>(std::nullopt, 1, DATE()),
+       makeNullableFlatVector<Timestamp>({std::nullopt})});
 
   for (auto i = 0; i < partitionColumnNames.size(); i++) {
     std::vector<column_index_t> partitionChannels = {(column_index_t)i};

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -45,6 +45,9 @@ namespace facebook::velox::exec {
       case TypeKind::VARBINARY: {                                        \
         return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);            \
       }                                                                  \
+      case TypeKind::TIMESTAMP: {                                        \
+        return TEMPLATE_FUNC<TypeKind::TIMESTAMP>(__VA_ARGS__);          \
+      }                                                                  \
       default:                                                           \
         VELOX_UNREACHABLE(                                               \
             "Unsupported value ID type: ", mapTypeKindToName(typeKind)); \
@@ -735,6 +738,7 @@ void extendRange(
     case TypeKind::BIGINT:
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
+    case TypeKind::TIMESTAMP:
       extendRange<int64_t>(reserve, min, max);
       break;
 

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -256,6 +256,10 @@ class MemoryArbitrationFuzzer {
 
 MemoryArbitrationFuzzer::MemoryArbitrationFuzzer(size_t initialSeed)
     : vectorFuzzer_{getFuzzerOptions(), pool_.get()} {
+  // Set timestamp precision as milliseconds, as timestamp may be used as
+  // paritition key, and presto doesn't supports nanosecond precision.
+  vectorFuzzer_.getMutableOptions().timestampPrecision =
+      fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
   if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -68,7 +68,12 @@ class RowNumberFuzzer : public RowNumberFuzzerBase {
 RowNumberFuzzer::RowNumberFuzzer(
     size_t initialSeed,
     std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
-    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {}
+    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
+  // Set timestamp precision as milliseconds, as timestamp may be used as
+  // paritition key, and presto doesn't supports nanosecond precision.
+  vectorFuzzer_.getMutableOptions().timestampPrecision =
+      fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
+}
 
 std::pair<std::vector<std::string>, std::vector<TypePtr>>
 RowNumberFuzzer::generatePartitionKeys() {

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -255,7 +255,8 @@ class WriterFuzzer {
       SMALLINT(),
       INTEGER(),
       BIGINT(),
-      VARCHAR()};
+      VARCHAR(),
+      TIMESTAMP()};
 
   const std::shared_ptr<FaultyFileSystem> faultyFs_ =
       std::dynamic_pointer_cast<FaultyFileSystem>(

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -134,8 +134,10 @@ int main(int argc, char** argv) {
   options.skipFunctions = skipFunctions;
   options.customVerificationFunctions = customVerificationFunctions;
   options.orderableGroupKeys = true;
+  // Set timestamp precision as milliseconds, as timestamp may be used as
+  // paritition key, and presto doesn't supports nanosecond precision
   options.timestampPrecision =
-      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
+      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
   options.hiveConfigs = {
       {facebook::velox::connector::hive::HiveConfig::kReadTimestampUnit, "6"}};
   return Runner::run(initialSeed, std::move(sparkQueryRunner), options);


### PR DESCRIPTION
Summary:
https://fburl.com/scuba/presto_queries/c8e9g59t
We need to support queries failing for timestamp partition exec::VectorHasher::typeKindSupportsValueIds( inputType->childAt(channel)->kind()) Unsupported partition type: TIMESTAMP.

Differential Revision: D75156810


