### PR TITLE
fix: Abort should not be marked noexcept

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -348,14 +348,12 @@ uint64_t ArbitrationParticipant::shrinkLocked(bool reclaimAll) {
   return reclaimedBytes;
 }
 
-uint64_t ArbitrationParticipant::abort(
-    const std::exception_ptr& error) noexcept {
+uint64_t ArbitrationParticipant::abort(const std::exception_ptr& error) {
   std::lock_guard<std::timed_mutex> l(reclaimMutex_);
   return abortLocked(error);
 }
 
-uint64_t ArbitrationParticipant::abortLocked(
-    const std::exception_ptr& error) noexcept {
+uint64_t ArbitrationParticipant::abortLocked(const std::exception_ptr& error) {
   TestValue::adjust(
       "facebook::velox::memory::ArbitrationParticipant::abortLocked", this);
   {

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -250,7 +250,7 @@ class ArbitrationParticipant
 
   /// Invoked to abort the query memory pool and returns the reclaimed bytes
   /// after abort.
-  uint64_t abort(const std::exception_ptr& error) noexcept;
+  uint64_t abort(const std::exception_ptr& error);
 
   /// Returns true if the query memory pool has been aborted.
   bool aborted() const {
@@ -339,7 +339,7 @@ class ArbitrationParticipant
   uint64_t minGrowCapacity() const;
 
   // Aborts the query memory pool and returns the reclaimed bytes after abort.
-  uint64_t abortLocked(const std::exception_ptr& error) noexcept;
+  uint64_t abortLocked(const std::exception_ptr& error);
 
   uint64_t shrinkLocked(bool reclaimAll);
 


### PR DESCRIPTION
Summary:
Functions in ArbitrationParticipant are labeled as noexcept; however, we have VELOX_CHECKS which may throw. If a function is throw and it is marked as noexcept, terminate will be called. 

see: https://en.cppreference.com/w/cpp/language/noexcept_spec

Instead of marking this function as noexcept, just let the top layers handle the exception.

Example trace:
```
E0515 22:45:50.661041  1048 [MemoryCheckerTh] ExceptionTracer.cpp:221] Exception type: facebook::velox::VeloxRuntimeError (13 frames)
    @ 0000000016150a98 (anonymous namespace)::Initializer::Initializer()::{lambda(void*, std::type_info*, void (**)(void*))#1}::__invoke(void*, std::type_info*, void (**)(void*)) [clone .__uniq.124032082404211820093816836866866025288]
                       ./fbcode/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp:85
    @ 000000000e8faa19 __cxa_throw
                       ./fbcode/folly/debugging/exception_tracer/ExceptionTracerLib.cpp:82
    @ 000000000e8c1073 void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, facebook::velox::detail::CompileTimeEmptyString>(facebook::velox::detail::VeloxCheckFailArgs const&, facebook::velox::detail::CompileTimeEmptyString)
                       fbcode/velox/common/base/Exceptions.h:74
    @ 000000001f84257c facebook::velox::memory::ArbitrationParticipant::abortLocked(std::__exception_ptr::exception_ptr const&)
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/x86_64-facebook-linux/bits/gthr-default.h:0
    @ 000000001f84278b facebook::velox::memory::ArbitrationParticipant::abort(std::__exception_ptr::exception_ptr const&)
                       ./fbcode/velox/common/memory/ArbitrationParticipant.cpp:353
    @ 000000001f83fada facebook::velox::memory::SharedArbitrator::abort(facebook::velox::memory::ScopedArbitrationParticipant const&, std::__exception_ptr::exception_ptr const&)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:1299
    @ 000000001f83abd2 facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryByAbort(bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:1222
    @ 000000001f835ed9 facebook::velox::memory::SharedArbitrator::shrinkCapacity(unsigned long, bool, bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:700
    @ 000000000f78a598 facebook::presto::FacebookPeriodicMemoryChecker::pushbackMemory()
                       fbcode/velox/common/memory/Memory.cpp:288
    @ 0000000025f15507 folly::FunctionScheduler::run() [clone .cold.0]
                       fbcode/folly/Function.h:370
    @ 00000000000df5b4 execute_native_thread_routine
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82
    @ 000000000009abc8 start_thread
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434
    @ 000000000012ce4b __clone3
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
E0515 22:45:50.962651  1048 [MemoryCheckerTh] ExceptionTracer.cpp:221] Exception type: facebook::velox::VeloxRuntimeError (10 frames)
    @ 0000000016150a98 (anonymous namespace)::Initializer::Initializer()::{lambda(void*, std::type_info*, void (**)(void*))#1}::__invoke(void*, std::type_info*, void (**)(void*)) [clone .__uniq.124032082404211820093816836866866025288]
                       ./fbcode/folly/debugging/exception_tracer/ExceptionStackTraceLib.cpp:85
    @ 000000000e8faa19 __cxa_throw
                       ./fbcode/folly/debugging/exception_tracer/ExceptionTracerLib.cpp:82
    @ 000000000e7ae7f7 void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
                       fbcode/velox/common/base/Exceptions.h:74
    @ 000000001f83add9 facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryByAbort(bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:1213
    @ 000000001f835ed9 facebook::velox::memory::SharedArbitrator::shrinkCapacity(unsigned long, bool, bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:700
    @ 000000000f78a598 facebook::presto::FacebookPeriodicMemoryChecker::pushbackMemory()
                       fbcode/velox/common/memory/Memory.cpp:288
    @ 0000000025f15507 folly::FunctionScheduler::run() [clone .cold.0]
                       fbcode/folly/Function.h:370
    @ 00000000000df5b4 execute_native_thread_routine
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82
    @ 000000000009abc8 start_thread
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434
    @ 000000000012ce4b __clone3
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
E0515 22:45:51.061182  1048 [MemoryCheckerTh] ExceptionTracer.cpp:223] exception stack complete
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Retriable: False
Expression: !aborted_
Function: abortLocked
File: fbcode/velox/common/memory/ArbitrationParticipant.cpp
Line: 380
Stack trace:
# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >) [clone .cold.0]
# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, facebook::velox::detail::CompileTimeEmptyString>(facebook::velox::detail::VeloxCheckFailArgs const&, facebook::velox::detail::CompileTimeEmptyString)
# 2  facebook::velox::memory::ArbitrationParticipant::abortLocked(std::__exception_ptr::exception_ptr const&)
# 3  facebook::velox::memory::ArbitrationParticipant::abort(std::__exception_ptr::exception_ptr const&)
# 4  facebook::velox::memory::SharedArbitrator::abort(facebook::velox::memory::ScopedArbitrationParticipant const&, std::__exception_ptr::exception_ptr const&)
# 5  facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryByAbort(bool)
# 6  facebook::velox::memory::SharedArbitrator::shrinkCapacity(unsigned long, bool, bool)
# 7  facebook::presto::FacebookPeriodicMemoryChecker::pushbackMemory()
# 8  folly::FunctionScheduler::run() [clone .cold.0]
# 9  execute_native_thread_routine
# 10 start_thread
# 11 __clone3
*** Aborted at 1747374351 (Unix time, try 'date -d 1747374351') ***
W0515 22:45:51.201150  1031 [populate_mem_cp] PrestoServer.cpp:1445] Server memory is overloaded. Currently used: 224.52GB, threshold: 170.00GB
W0515 22:45:51.201475  1031 [populate_mem_cp] PrestoServer.cpp:1466] Server CPU is overloaded. Currently used: 75.3153%, threshold: 75%
*** Signal 6 (SIGABRT) (0x75830000006f) received by PID 111 (pthread TID 0x7f931f200640) (linux TID 1048) (maybe from PID 111, UID 30083) (code: -6), stack trace: ***
I0515 22:45:51.273849 46738 [HTTPSrvCpu7306] TaskManager.cpp:653] Starting task 20250516_051934_01567_hh35x.2.0.160.0 with 16 max drivers.
I0515 22:45:51.317305 45108 [HTTPSrvCpu6942] TaskManager.cpp:653] Starting task 20250516_051934_01567_hh35x.4.0.160.0 with 16 max drivers.
I0515 22:45:51.366698 47243 [HTTPSrvCpu7399] TaskManager.cpp:610] No more splits for 20250516_051934_01567_hh35x.2.0.160.0 for node 1819
I0515 22:45:51.385264 47500 [HTTPSrvCpu7430] TaskManager.cpp:653] Starting task 20250516_051934_01567_hh35x.6.0.160.0 with 16 max drivers.
I0515 22:45:51.466087 45378 [HTTPSrvCpu7044] TaskManager.cpp:610] No more splits for 20250516_051934_01567_hh35x.4.0.160.0 for node 1817
I0515 22:45:51.848141 46880 [HTTPSrvCpu7323] TaskManager.cpp:610] No more splits for 20250516_051934_01567_hh35x.6.0.160.0 for node 1980
I0515 22:45:51.949023 47509 [HTTPSrvCpu7436] TaskManager.cpp:653] Starting task 20250516_051934_01567_hh35x.5.0.260.0 with 16 max drivers.
I0515 22:45:52.062893 47261 [HTTPSrvCpu7417] TaskManager.cpp:653] Starting task 20250516_052702_01593_hh35x.2.0.253.0 with 16 max drivers.
I0515 22:45:52.070972 47259 [HTTPSrvCpu7415] TaskManager.cpp:610] No more splits for 20250516_052702_01593_hh35x.2.0.253.0 for node 1863
I0515 22:45:52.173496 46874 [HTTPSrvCpu7317] TaskManager.cpp:653] Starting task 20250516_052702_01593_hh35x.3.0.280.0 with 16 max drivers.
W0515 22:45:52.204783  1031 [populate_mem_cp] PrestoServer.cpp:1445] Server memory is overloaded. Currently used: 224.52GB, threshold: 170.00GB
W0515 22:45:52.204957  1031 [populate_mem_cp] PrestoServer.cpp:1466] Server CPU is overloaded. Currently used: 87.3257%, threshold: 75%
I0515 22:45:52.380334  1920 ServiceClient.h:942] Couldn't get connected host and port from service router
    @ 000000001222a758 folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:453
    @ 0000000012229fae folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111] [clone .llvm.10910733530735293773]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:474
    @ 000000000004455f (unknown)
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/libc_sigaction.c:8
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c
    @ 000000000009c993 __GI___pthread_kill
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_kill.c:46
    @ 00000000000444ac __GI_raise
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/posix/raise.c:26
    @ 000000000002c432 __GI_abort
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/stdlib/abort.c:79
    @ 00000000000a3fc4 __gnu_cxx::__verbose_terminate_handler()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/vterminate.cc:95
    @ 00000000000a1b29 __cxxabiv1::__terminate(void (*)())
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:48
    @ 00000000000a1b94 std::terminate()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:58
    @ 000000000e6ca7dd __clang_call_terminate
    @ 000000001f842589 facebook::velox::memory::ArbitrationParticipant::abortLocked(std::__exception_ptr::exception_ptr const&)
                       ./fbcode/velox/common/memory/ArbitrationParticipant.cpp:0
    @ 000000001f84278b facebook::velox::memory::ArbitrationParticipant::abort(std::__exception_ptr::exception_ptr const&)
                       ./fbcode/velox/common/memory/ArbitrationParticipant.cpp:353
    @ 000000001f83fada facebook::velox::memory::SharedArbitrator::abort(facebook::velox::memory::ScopedArbitrationParticipant const&, std::__exception_ptr::exception_ptr const&)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:1299
    @ 000000001f83abd2 facebook::velox::memory::SharedArbitrator::reclaimUsedMemoryByAbort(bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:1222
    @ 000000001f835ed9 facebook::velox::memory::SharedArbitrator::shrinkCapacity(unsigned long, bool, bool)
                       ./fbcode/velox/common/memory/SharedArbitrator.cpp:700
    @ 000000000f78a598 facebook::presto::FacebookPeriodicMemoryChecker::pushbackMemory()
                       fbcode/velox/common/memory/Memory.cpp:288
    @ 0000000025f15507 folly::FunctionScheduler::run() [clone .cold.0]
                       fbcode/folly/Function.h:370
    @ 00000000000df5b4 execute_native_thread_routine
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82
    @ 000000000009abc8 start_thread
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434
    @ 000000000012ce4b __clone3
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
Fatal signal handler. ThreadDebugInfo object not found.
```

This happens when there seem to be > 1 participant which have the same underlying memory pool and abort is called.

Differential Revision: D75466000


