### PR TITLE
fix: Temporarily disable intermediate and output type validations

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -321,22 +321,24 @@ std::unique_ptr<Aggregate> Aggregate::create(
     const std::vector<TypePtr>& argTypes,
     const TypePtr& resultType,
     const core::QueryConfig& config) {
-  // Validate the result type.
-  if (isPartialOutput(step)) {
-    auto intermediateType = Aggregate::intermediateType(name, argTypes);
-    VELOX_CHECK(
-        resultType->equivalent(*intermediateType),
-        "Intermediate type mismatch. Expected: {}, actual: {}",
-        intermediateType->toString(),
-        resultType->toString());
-  } else {
-    auto finalType = Aggregate::finalType(name, argTypes);
-    VELOX_CHECK(
-        resultType->equivalent(*finalType),
-        "Final type mismatch. Expected: {}, actual: {}",
-        finalType->toString(),
-        resultType->toString());
-  }
+  // TODO(timaou, kletkavrubashku): Reneable the validation once "regr_slope"
+  // signature is fixed
+  //
+  // Validate the result type. if (isPartialOutput(step)) {
+  //   auto intermediateType = Aggregate::intermediateType(name, argTypes);
+  //   VELOX_CHECK(
+  //       resultType->equivalent(*intermediateType),
+  //       "Intermediate type mismatch. Expected: {}, actual: {}",
+  //       intermediateType->toString(),
+  //       resultType->toString());
+  // } else {
+  //   auto finalType = Aggregate::finalType(name, argTypes);
+  //   VELOX_CHECK(
+  //       resultType->equivalent(*finalType),
+  //       "Final type mismatch. Expected: {}, actual: {}",
+  //       finalType->toString(),
+  //       resultType->toString());
+  // }
   // Lookup the function in the new registry first.
   if (auto func = getAggregateFunctionEntry(name)) {
     return func->factory(step, argTypes, resultType, config);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -549,7 +549,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
       readCursor(params), "Aggregate function not registered: missing-lambda");
 }
 
-TEST_F(AggregationTest, resultTypeMismatch) {
+TEST_F(AggregationTest, DISABLED_resultTypeMismatch) {
   using Step = core::AggregationNode::Step;
 
   registerAggregateFunction(


### PR DESCRIPTION
Summary:
The validation was added here: D74435817. But it fails for "regr_slope" function.
For "regr_slope" function:
- In Java intermediate type is row(double,bigint,double,double,double,double)
- In C++ intermediate type  it's row(double,bigint,double,double,double)
https://www.internalfb.com/intern/presto/query/?query_id=20250526_170301_05814_an5sc#sql

Temporarily disabling it to unblock the release

Differential Revision: D75480556


