### PR TITLE
fix(geos): Add support for bing_tile_parent(bing_tile, integer) signature

### DIFF
--- a/velox/functions/prestosql/BingTileFunctions.h
+++ b/velox/functions/prestosql/BingTileFunctions.h
@@ -143,6 +143,13 @@ struct BingTileParentFunction {
     result = parent.value();
     return Status::OK();
   }
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<BingTile>& result,
+      const arg_type<BingTile>& tile,
+      const arg_type<int32_t>& parentZoom) {
+    return call(result, tile, static_cast<int8_t>(parentZoom));
+  }
 };
 
 template <typename T>

--- a/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
@@ -44,6 +44,8 @@ void registerSimpleBingTileFunctions(const std::string& prefix) {
       {prefix + "bing_tile_parent"});
   registerFunction<BingTileParentFunction, BingTile, BingTile, int8_t>(
       {prefix + "bing_tile_parent"});
+  registerFunction<BingTileParentFunction, BingTile, BingTile, int32_t>(
+      {prefix + "bing_tile_parent"});
   registerFunction<BingTileChildrenFunction, Array<BingTile>, BingTile>(
       {prefix + "bing_tile_children"});
   registerFunction<BingTileChildrenFunction, Array<BingTile>, BingTile, int8_t>(

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -315,19 +315,31 @@ TEST_F(BingTileFunctionsTest, bingTileParentZoom) {
         y,
         zoom,
         parentZoom);
-    if (x.has_value() && y.has_value() && zoom.has_value() &&
-        parentZoom.has_value()) {
-      ASSERT_TRUE(tile.has_value());
-      int32_t shift = *zoom - *parentZoom;
-      ASSERT_EQ(
-          BingTileType::bingTileCoordsToInt(
-              static_cast<uint32_t>(*x) >> shift,
-              static_cast<uint32_t>(*y) >> shift,
-              *parentZoom),
-          *tile);
-    } else {
-      ASSERT_FALSE(tile.has_value());
-    }
+    auto validate = [&]() {
+      if (x.has_value() && y.has_value() && zoom.has_value() &&
+          parentZoom.has_value()) {
+        ASSERT_TRUE(tile.has_value());
+        int32_t shift = *zoom - *parentZoom;
+        ASSERT_EQ(
+            BingTileType::bingTileCoordsToInt(
+                static_cast<uint32_t>(*x) >> shift,
+                static_cast<uint32_t>(*y) >> shift,
+                *parentZoom),
+            *tile);
+      } else {
+        ASSERT_FALSE(tile.has_value());
+      }
+    };
+
+    validate();
+
+    tile = evaluateOnce<int64_t>(
+        "CAST(bing_tile_parent(bing_tile(c0, c1, c2), cast(c3 as integer)) AS BIGINT)",
+        x,
+        y,
+        zoom,
+        parentZoom);
+    validate();
   };
 
   testBingTileParent(0, 0, 0, 0);


### PR DESCRIPTION
Summary: Added  bing_tile_parent(bing_tile, integer)  which is the signature used by Presto when calling bing_tile_parent.

Differential Revision: D75481392


