### PR TITLE
fix: Update corrupted file handling from GENERIC_INTERNAL_ERROR to USER ERROR

### DIFF
--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -329,7 +329,7 @@ std::shared_ptr<const Type> ReaderBase::convertType(
     const FooterWrapper& footer,
     uint32_t index,
     bool fileColumnNamesReadAsLowerCase) {
-  VELOX_CHECK_LT(
+  VELOX_USER_CHECK_LT(
       index,
       folly::to<uint32_t>(footer.typesSize()),
       "Corrupted file, invalid types");


### PR DESCRIPTION
Summary:
For partitioned tables, when some partitions are  in RCFile format, Velox is unable to read them. Since we are deprecating RCFile formats, it's necessary to update the error category for this type of error from internal error to user error. This change will prevent unnecessary panic or mis calculated UER.

link: https://fburl.com/scuba/presto_queries/hvnkoz74

Reviewed By: amitkdutta

Differential Revision: D75488333


