### PR TITLE
fix: Remove incorrect check in ArbitrationParticipant::abortLocked()

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -356,14 +356,14 @@ uint64_t ArbitrationParticipant::abort(
 
 uint64_t ArbitrationParticipant::abortLocked(
     const std::exception_ptr& error) noexcept {
-  TestValue::adjust(
-      "facebook::velox::memory::ArbitrationParticipant::abortLocked", this);
   {
     std::lock_guard<std::mutex> l(stateLock_);
     if (aborted_) {
       return 0;
     }
   }
+  TestValue::adjust(
+      "facebook::velox::memory::ArbitrationParticipant::abortLocked", this);
   try {
     VELOX_MEM_LOG(WARNING) << "Memory pool " << pool_->name()
                            << " is being aborted";
@@ -378,7 +378,6 @@ uint64_t ArbitrationParticipant::abortLocked(
   VELOX_CHECK(pool_->aborted());
 
   std::lock_guard<std::mutex> l(stateLock_);
-  VELOX_CHECK(!aborted_);
   aborted_ = true;
   return shrinkLocked(/*reclaimAll=*/true);
 }


### PR DESCRIPTION
Summary: The check is incorrect because it could be possible that a driver thread and global arbitration thread is aborting at the same time. Driver thread could be faster and could already have set the aborted_ to true, making the check on global arbitration thread throw.

Differential Revision: D75500404


