### PR TITLE
fix: Add missing Hive tests to TARGETS

### DIFF
--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -29,6 +29,10 @@ using namespace facebook::velox::dwio::catalog::fbhive;
 class HivePartitionUtilTest : public ::testing::Test,
                               public velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
   template <typename T>
   VectorPtr makeDictionary(const std::vector<T>& data) {
     auto base = makeFlatVector(data);


### PR DESCRIPTION
Differential Revision: D75499856

Found missing test files in TARGETS

## Test plan
`MergeTest.localMergeSpill` test is failed in Signals, but it's not related to my changes

new tests:
```
$ buck2 test fbcode//velox/connectors/hive/tests:hive_connector_test
Before:
Tests finished: Pass 79. Fail 0. Fatal 0. Skip 0. Build failure 0
After:
Tests finished: Pass 83. Fail 0. Fatal 0. Skip 0. Build failure 0
```
