### PR TITLE
misc: Add External error source in VeloxException

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -53,6 +53,10 @@ inline constexpr auto kErrorSourceRuntime = "RUNTIME"_fs;
 /// Errors where the root cause of the problem is some unreliable aspect of the
 /// system are classified with source SYSTEM.
 inline constexpr auto kErrorSourceSystem = "SYSTEM"_fs;
+
+/// Errors where the root cause of the problem is some external dependency (e.g.
+/// storage)
+inline constexpr auto kErrorSourceExternal = "EXTERNAL"_fs;
 } // namespace error_source
 
 namespace error_code {

--- a/velox/dwio/common/exception/Exception.h
+++ b/velox/dwio/common/exception/Exception.h
@@ -52,7 +52,7 @@ class LoggedException : public velox::VeloxException {
   explicit LoggedException(
       const std::string& errorMessage,
       const std::string& errorSource =
-          ::facebook::velox::error_source::kErrorSourceRuntime,
+          ::facebook::velox::error_source::kErrorSourceExternal,
       const std::string& errorCode = ::facebook::velox::error_code::kUnknown,
       const bool isRetriable = false)
       : VeloxException(
@@ -181,7 +181,7 @@ containing information about the file, line, and function where it happened.
 #define DWIO_RAISE(...)                                          \
   DWIO_EXCEPTION_CUSTOM(                                         \
       facebook::velox::dwio::common::exception::LoggedException, \
-      ::facebook::velox::error_source::kErrorSourceRuntime,      \
+      ::facebook::velox::error_source::kErrorSourceExternal,     \
       ::facebook::velox::error_code::kUnknown,                   \
       ##__VA_ARGS__)
 
@@ -189,7 +189,7 @@ containing information about the file, line, and function where it happened.
   DWIO_ENFORCE_CUSTOM(                                           \
       facebook::velox::dwio::common::exception::LoggedException, \
       expr,                                                      \
-      ::facebook::velox::error_source::kErrorSourceRuntime,      \
+      ::facebook::velox::error_source::kErrorSourceExternal,     \
       ::facebook::velox::error_code::kUnknown,                   \
       ##__VA_ARGS__)
 


### PR DESCRIPTION
Summary:
Adding External error source category. These category of errors come from external systems (e.g. storage connectors, third party libraries). There are two cases:
- External sources may have unique error codes. For example: In Meta internal distributed storage systems, there are error codes like FATAL_ERROR, LOCAL_THROTTLED, GLOBAL_THROTTLED)
- External sources may have common error codes (e.g. user error or [unknown error code](https://github.com/facebookincubator/velox/blob/main/velox/dwio/common/exception/Exception.h#L185) that is common with Runtime errors.

For service like Presto, external errors needs to identified by monitoring tools and customers to better classify system specific errors and inform external systems about there errors. Presto has [external error source](https://github.com/prestodb/presto/tree/6a455ac192c38f24b61d4c97f51ad36886ddec36/presto-common/src/main/java/com/facebook/presto/common#L22-L25) to uniquely idenitfy exteranl error codes. Adding `External` source to velox and using it from DWIO. It will also be used extensively for Meta internal uses cases to group storage specific error codes together and reporting to services like Presto.

Differential Revision: D75491192


