### PR TITLE
fix(fuzzer): Skip non-deterministic noisy_count_if_gaussian in window fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -121,6 +121,8 @@ int main(int argc, char** argv) {
       // https://github.com/prestodb/presto/pull/21793
       "min_by",
       "max_by",
+      // Skip non-deterministic functions.
+      "noisy_count_if_gaussian",
   };
 
   // Functions whose results verification should be skipped. These can be


### PR DESCRIPTION
Summary: noisy_count_if_gaussian is a non-detemrinistic function that causes result mismatch failures in window fuzzer. This diff adds this function to the skip-function list.

Differential Revision: D75542085


