### PR TITLE
feat(fuzzer): Add support for BINGTILE to expression fuzzer using presto query runner

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -32,6 +32,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h"
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
@@ -307,7 +308,7 @@ bool PrestoQueryRunner::isConstantExprSupported(
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
-        !isTDigestType(type) && !isQDigestType(type);
+        !isTDigestType(type) && !isQDigestType(type) && !isBingTileType(type);
     ;
   }
   return true;
@@ -323,7 +324,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
   // special handling, because Presto requires literals of these types to be
   // valid, and doesn't allow creating HIVE columns of these types.
   return !(
-      usesTypeName(signature, "bingtile") ||
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
       usesInputTypeName(signature, "ipaddress") ||

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
@@ -50,7 +51,10 @@ intermediateTypeTransforms() {
           {QDIGEST(REAL()),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                QDIGEST(REAL()), VARBINARY())},
-          {JSON(), std::make_shared<JsonTransform>()}};
+          {JSON(), std::make_shared<JsonTransform>()},
+          {BINGTILE(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               BINGTILE(), BIGINT())}};
   return intermediateTypeTransforms;
 }
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -273,6 +273,8 @@ int main(int argc, char** argv) {
         "inverse_poisson_cdf", // https://github.com/facebookincubator/velox/issues/12982
         "inverse_f_cdf", // https://github.com/facebookincubator/velox/issues/13715
         "inverse_chi_squared_cdf", // https://github.com/facebookincubator/velox/issues/13788
+        "bing_tile_children", // Velox limits the max zoom shift
+                              // https://github.com/facebookincubator/velox/pull/13604
     });
 
     referenceQueryRunner = std::make_shared<PrestoQueryRunner>(

--- a/velox/functions/prestosql/BingTileFunctions.h
+++ b/velox/functions/prestosql/BingTileFunctions.h
@@ -149,6 +149,12 @@ struct BingTileParentFunction {
       out_type<BingTile>& result,
       const arg_type<BingTile>& tile,
       const arg_type<int32_t>& parentZoom) {
+    if (FOLLY_UNLIKELY(parentZoom > BingTileType::kBingTileMaxZoomLevel)) {
+      return Status::UserError(fmt::format(
+          "newZoom {} is greater than max zoom {}",
+          parentZoom,
+          BingTileType::kBingTileMaxZoomLevel));
+    }
     return call(result, tile, static_cast<int8_t>(parentZoom));
   }
 };

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -363,6 +363,14 @@ TEST_F(BingTileFunctionsTest, bingTileParentZoom) {
       testBingTileParent(0, 0, 0, 1), "Parent zoom 1 must be <= tile zoom 0");
   VELOX_ASSERT_USER_THROW(
       testBingTileParent(5, 17, 5, 8), "Parent zoom 8 must be <= tile zoom 5");
+  VELOX_ASSERT_USER_THROW(
+      evaluateOnce<int64_t>(
+          "CAST(bing_tile_parent(bing_tile(c0, c1, c2), c3) AS BIGINT)",
+          std::optional<int32_t>(0),
+          std::optional<int32_t>(0),
+          std::optional<int8_t>(0),
+          std::optional<int32_t>(99)),
+      "newZoom 99 is greater than max zoom 23");
 }
 
 TEST_F(BingTileFunctionsTest, bingTileChildren) {


### PR DESCRIPTION
Adds support for BINGTILE to expression fuzzer using presto query runner
and skips running bing_tile_children as Velox limits the max zoom shift
([https://github.com/facebookincubator/velox/pull/13604](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebookincubator%2Fvelox%2Fpull%2F13604&h=AT2GoUHARqZIq2XN_P87bSsvwA3JHe4M6Oe2v8uS3x3d8AGFGx-DUi97W_73x0_0YGdih2U6dMaGJD6UFCE6CNtzz3bsnx_h_fDcen9Ssui-BuOTZ9f-30aoGNsWgXzMGEA2PUj61UtMJHIFb4C2JwAHTzA))
This also uncovered a bug in bing_tile_parent where it accepts an integer
newZoom param. Here, values outside of the range of int8 were clipped
and accepted as valid resulting in incorrect result. This change also adds a
fix for that bug.

Differential Revision: D75492761


