### PR TITLE
refactor: Refactor ST_Point to reuse GeometryFactory instance

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -115,6 +115,10 @@ struct StAsBinaryFunction {
 
 template <typename T>
 struct StPointFunction {
+  StPointFunction() {
+    factory_ = geos::geom::GeometryFactory::create();
+  }
+
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE Status call(
@@ -127,16 +131,16 @@ struct StPointFunction {
     }
     GEOS_TRY(
         {
-          geos::geom::GeometryFactory::Ptr factory =
-              geos::geom::GeometryFactory::create();
-          geos::geom::Point* point =
-              factory->createPoint(geos::geom::Coordinate(x, y));
+          auto point = std::unique_ptr<geos::geom::Point>(
+              factory_->createPoint(geos::geom::Coordinate(x, y)));
           result = geospatial::serializeGeometry(*point);
-          factory->destroyGeometry(point);
         },
         "Failed to create point geometry");
     return Status::OK();
   }
+
+ private:
+  geos::geom::GeometryFactory::Ptr factory_;
 };
 
 // Predicates


### PR DESCRIPTION
Summary: 
Previously, a new GeometryFactory was created and destroyed for each call. This change moves the factory to a member variable initialized once per function instance.