### PR TITLE
feat: Add inverse_f_cdf

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -345,6 +345,12 @@ Probability Functions: inverse_cdf
     probability (p): P(N < n). The a, b parameters must be positive real values (all of type DOUBLE).
     The probability p must lie on the interval [0, 1].
 
+.. function:: inverse_f_cdf(df1, df2, p) -> double
+
+    Compute the inverse of the F cdf with a given ``df1`` (numerator degrees of freedom) and ``df2`` (denominator degrees of freedom) parameters 
+    for the cumulative probability (p): P(N < n). The numerator and denominator df parameters must be positive real numbers.
+    The probability ``p`` must lie on the interval [0, 1].
+
 .. function:: inverse_weibull_cdf(a, b, p) -> double
 
     Compute the inverse of the Weibull cdf with given parameters ``a``, ``b`` for the probability ``p``.

--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -187,6 +187,21 @@ struct InverseBetaCDFFunction {
 };
 
 template <typename T>
+struct InverseFCDFFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void
+  call(double& result, double df1, double df2, double p) {
+    VELOX_USER_CHECK((p >= 0) && (p <= 1), "p must be in the interval [0, 1]");
+    VELOX_USER_CHECK_GT(df1, 0, "numerator df must be greater than 0");
+    VELOX_USER_CHECK_GT(df2, 0, "denominator df must be greater than 0");
+
+    boost::math::fisher_f_distribution<> dist(df1, df2);
+    result = boost::math::quantile(dist, p);
+  }
+};
+
+template <typename T>
 struct ChiSquaredCDFFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ProbabilityTrigonometricFunctionsRegistration.cpp
@@ -50,6 +50,8 @@ void registerProbTrigFunctions(const std::string& prefix) {
       {prefix + "f_cdf"});
   registerFunction<InverseBetaCDFFunction, double, double, double, double>(
       {prefix + "inverse_beta_cdf"});
+  registerFunction<InverseFCDFFunction, double, double, double, double>(
+      {prefix + "inverse_f_cdf"});
   registerFunction<InverseNormalCDFFunction, double, double, double, double>(
       {prefix + "inverse_normal_cdf"});
   registerFunction<PoissonCDFFunction, double, double, int32_t>(

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -268,6 +268,57 @@ TEST_F(ProbabilityTest, invBetaCDF) {
   VELOX_ASSERT_THROW(invBetaCDF(3, 5, 1.1), "p must be in the interval [0, 1]");
 }
 
+TEST_F(ProbabilityTest, inverseFCDF) {
+  const auto inverseFCDF = [&](std::optional<double> df1,
+                               std::optional<double> df2,
+                               std::optional<double> p) {
+    return evaluateOnce<double>("inverse_f_cdf(c0, c1, c2)", df1, df2, p);
+  };
+
+  EXPECT_EQ(inverseFCDF(2.0, 5.0, 0.0), 0.0);
+  EXPECT_EQ(inverseFCDF(2.0, 5.0, 0.5), 0.79876977693223561);
+  EXPECT_EQ(inverseFCDF(2.0, 5.0, 0.9), 3.779716078773951);
+
+  EXPECT_EQ(inverseFCDF(2.0, 5.0, std::nullopt), std::nullopt);
+  EXPECT_EQ(inverseFCDF(2.0, std::nullopt, 3.7797), std::nullopt);
+  EXPECT_EQ(inverseFCDF(std::nullopt, 5.0, 3.7797), std::nullopt);
+
+  EXPECT_EQ(inverseFCDF(kDoubleMax, 5.0, 1), kInf);
+  EXPECT_EQ(inverseFCDF(1, kDoubleMax, 1), kInf);
+  EXPECT_EQ(inverseFCDF(82.6, 901.10, 1), kInf);
+  EXPECT_EQ(inverseFCDF(kDoubleMin, 50.620, 1), kInf);
+  EXPECT_EQ(
+      inverseFCDF(kBigIntMax, 5.0, 0.93256230095450132), 3.7797000000000009);
+  EXPECT_EQ(inverseFCDF(76.901, kBigIntMax, 1), kInf);
+  EXPECT_EQ(inverseFCDF(2.0, 5.0, 1), kInf);
+
+  // Test invalid inputs for df1.
+  VELOX_ASSERT_THROW(
+      inverseFCDF(0, 3, 0.5), "numerator df must be greater than 0");
+  VELOX_ASSERT_THROW(
+      inverseFCDF(kBigIntMin, 5.0, 0.999),
+      "numerator df must be greater than 0");
+
+  // Test invalid inputs for df2.
+  VELOX_ASSERT_THROW(
+      inverseFCDF(3, 0, 0.5), "denominator df must be greater than 0");
+  VELOX_ASSERT_THROW(
+      inverseFCDF(2.0, kBigIntMin, 0.0001),
+      "denominator df must be greater than 0");
+
+  // Test invalid inputs for p.
+  VELOX_ASSERT_THROW(
+      inverseFCDF(3, 5, -0.1), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseFCDF(2.0, 5.0, kBigIntMin), "p must be in the interval [0, 1]");
+
+  // Test a combination of invalid inputs.
+  VELOX_ASSERT_THROW(
+      inverseFCDF(-1.2, 0, -0.1), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseFCDF(1, -kInf, -0.1), "p must be in the interval [0, 1]");
+}
+
 TEST_F(ProbabilityTest, chiSquaredCDF) {
   const auto chiSquaredCDF = [&](std::optional<double> df,
                                  std::optional<double> value) {


### PR DESCRIPTION
feat: Add inverse_f_cdf

I am taking over the implementation of this function for @svm1.
Previous PR: https://github.com/facebookincubator/velox/pull/11281

I found fuzzer mismatch when running the fuzzer. I believe the difference is due to boost being more precise in its calculations compared to Apache common math. Which means that Velox's output is more precise/correct. So perhaps the fuzzer needs to be changed for this function to accommodate for this..

Similar situation to my [inverse_chi_squared_cdf() PR](https://github.com/facebookincubator/velox/pull/13449).

Fuzzer mismatch:
Repro:
```
velox_expression_fuzzer_test
--enable_variadic_signatures
--velox_fuzzer_enable_complex_types
--lazy_vector_generation_ratio=0.2
--velox_fuzzer_enable_column_reuse
--velox_fuzzer_enable_expression_reuse
--special_forms="cast,coalesce,if,switch"
--retry_with_try
--max_expression_trees_per_step=2
--velox_fuzzer_max_level_of_nesting=3
--batch_size=6
--duration_sec=1800
--logtostderr=1
--minloglevel=0
--presto_url=http://127.0.0.1:8080
-v=1
--only=inverse_f_cdf
--seed=2758082291
```
Output:
```
I20250528 15:39:12.787109 34067965 PrestoQueryRunner.cpp:433] Execute presto sql: SELECT try(inverse_f_cdf(inverse_f_cdf(c0, DOUBLE '0.3845435369294137', inverse_f_cdf(c1, DOUBLE '0.19255185569636524', DOUBLE '0.22899188683368266')), DOUBLE '0.8911417820490897', inverse_f_cdf(DOUBLE '0.06621671561151743', c2, inverse_f_cdf(DOUBLE '0.7039323435164988', c2, c3)))) as p0, try(row_number) as p1 FROM (t_values)
E20250528 15:39:12.944725 34067965 Exceptions.h:66] Line: /Users/minhancao/velox_2/velox/velox/expression/tests/ExpressionVerifier.cpp:355, Function:verify, Expression: exec::test::assertEqualResults( referenceEvalResult.value(), projectionPlan->outputType(), {commonEvalResultRow}) Velox and reference DB results don't match, Source: RUNTIME, ErrorCode: INVALID_STATE
I20250528 15:39:12.944821 34067965 ExpressionVerifier.cpp:503] Skipping persistence because repro path is empty.
/Users/minhancao/velox_2/velox/velox/exec/tests/utils/QueryAssertions.cpp:1171: Failure
Failed
Expected 6, got 6
1 extra rows, 1 missing rows
1 of extra rows:
	0.0030578571702443674 | 1

1 of missing rows:
	0 | 1

Unexpected results
```

There are similar GitHub issues created for CDF Precision error for other inverse CDF functions from fuzzer:
https://github.com/facebookincubator/velox/issues/13450
https://github.com/facebookincubator/velox/issues/12918
https://github.com/facebookincubator/velox/issues/12981
https://github.com/facebookincubator/velox/issues/12982