### PR TITLE
feat: Add IndexLookupJoin Tracing

### DIFF
--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -235,6 +235,7 @@ bool canTrace(const std::string& operatorType) {
       "FilterProject",
       "HashBuild",
       "HashProbe",
+      "IndexLookupJoin",
       "PartialAggregation",
       "PartitionedOutput",
       "TableScan",

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -1135,6 +1135,7 @@ TEST_F(OperatorTraceTest, canTrace) {
       {"PartitionedOutput", true},
       {"HashBuild", true},
       {"HashProbe", true},
+      {"IndexLookupJoin", true},
       {"RowNumber", false},
       {"OrderBy", false},
       {"PartialAggregation", true},


### PR DESCRIPTION
Summary:
Add IndexLookupJoin into canTrace operator types.



bypass-github-export-checks

Differential Revision: D75576410


