### PR TITLE
misc: Add external mapped bytes metrics to common allocator interface

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -75,6 +75,14 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricMemoryAllocatorMappedBytes, facebook::velox::StatType::AVG);
 
+  // Number of bytes allocated and explicitly mmap'd by the application via
+  // allocateContiguous, outside of 'sizeClasses'. These pages are counted in
+  // 'kMetricMemoryAllocatorAllocatedBytes' and
+  // 'kMetricMemoryAllocatorMappedBytes'.
+  DEFINE_METRIC(
+      kMetricMemoryAllocatorExternalMappedBytes,
+      facebook::velox::StatType::AVG);
+
   // Number of bytes currently allocated (used) from MemoryAllocator in the form
   // of 'Allocation' or 'ContiguousAllocation'.
   DEFINE_METRIC(
@@ -83,13 +91,6 @@ void registerVeloxMetrics() {
   // Total number of bytes currently allocated from MemoryAllocator.
   DEFINE_METRIC(
       kMetricMemoryAllocatorTotalUsedBytes, facebook::velox::StatType::AVG);
-
-  // Number of bytes currently mapped in MmapAllocator, in the form of
-  // 'ContiguousAllocation'.
-  //
-  // NOTE: This applies only to MmapAllocator
-  DEFINE_METRIC(
-      kMetricMmapAllocatorExternalMappedBytes, facebook::velox::StatType::AVG);
 
   // Number of bytes currently allocated from MmapAllocator directly from raw
   // allocateBytes() interface, and internally allocated by malloc. Only small

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -181,14 +181,14 @@ constexpr folly::StringPiece kMetricArbitratorRequestsCount{
 constexpr folly::StringPiece kMetricMemoryAllocatorMappedBytes{
     "velox.memory_allocator_mapped_bytes"};
 
+constexpr folly::StringPiece kMetricMemoryAllocatorExternalMappedBytes{
+    "velox.memory_allocator_external_mapped_bytes"};
+
 constexpr folly::StringPiece kMetricMemoryAllocatorAllocatedBytes{
     "velox.memory_allocator_allocated_bytes"};
 
 constexpr folly::StringPiece kMetricMemoryAllocatorTotalUsedBytes{
     "velox.memory_allocator_total_used_bytes"};
-
-constexpr folly::StringPiece kMetricMmapAllocatorExternalMappedBytes{
-    "velox.mmap_allocator_external_mapped_bytes"};
 
 constexpr folly::StringPiece kMetricMmapAllocatorDelegatedAllocatedBytes{
     "velox.mmap_allocator_delegated_allocated_bytes"};

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -113,20 +113,21 @@ void PeriodicStatsReporter::reportAllocatorStats() {
       kMetricMemoryAllocatorMappedBytes,
       (velox::memory::AllocationTraits::pageBytes(allocator_->numMapped())));
   RECORD_METRIC_VALUE(
+      kMetricMemoryAllocatorExternalMappedBytes,
+      (velox::memory::AllocationTraits::pageBytes(
+          allocator_->numExternalMapped())));
+  RECORD_METRIC_VALUE(
       kMetricMemoryAllocatorAllocatedBytes,
       (velox::memory::AllocationTraits::pageBytes(allocator_->numAllocated())));
   RECORD_METRIC_VALUE(
       kMetricMemoryAllocatorTotalUsedBytes, (allocator_->totalUsedBytes()));
+
   // TODO(jtan6): Remove condition after T150019700 is done
   if (auto* mmapAllocator =
           dynamic_cast<const velox::memory::MmapAllocator*>(allocator_)) {
     RECORD_METRIC_VALUE(
         kMetricMmapAllocatorDelegatedAllocatedBytes,
         (mmapAllocator->numMallocBytes()));
-    RECORD_METRIC_VALUE(
-        kMetricMmapAllocatorExternalMappedBytes,
-        velox::memory::AllocationTraits::pageBytes(
-            (mmapAllocator->numExternalMapped())));
   }
   // TODO(xiaoxmeng): add memory allocation size stats.
 }

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -468,7 +468,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(
         counterMap.count(kMetricMmapAllocatorDelegatedAllocatedBytes.str()), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricMmapAllocatorExternalMappedBytes.str()), 1);
+        counterMap.count(kMetricMemoryAllocatorExternalMappedBytes.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSpillMemoryBytes.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricSpillPeakMemoryBytes.str()), 1);
     ASSERT_EQ(counterMap.count(kMetricMemoryAllocatorTotalUsedBytes.str()), 1);

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -150,6 +150,7 @@ bool MallocAllocator::allocateContiguousImpl(
     }
     numMapped_.fetch_sub(numContiguousCollateralPages);
     numAllocated_.fetch_sub(numContiguousCollateralPages);
+    numExternalMapped_.fetch_sub(numContiguousCollateralPages);
     decrementUsage(AllocationTraits::pageBytes(numContiguousCollateralPages));
     allocation.clear();
   }
@@ -171,6 +172,7 @@ bool MallocAllocator::allocateContiguousImpl(
   }
   numAllocated_.fetch_add(numPages);
   numMapped_.fetch_add(numPages);
+  numExternalMapped_.fetch_add(numPages);
   void* data = ::mmap(
       nullptr,
       AllocationTraits::pageBytes(maxPages),
@@ -228,6 +230,7 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   }
   numMapped_.fetch_sub(numPages);
   numAllocated_.fetch_sub(numPages);
+  numExternalMapped_.fetch_sub(numPages);
   decrementUsage(bytes);
   allocation.clear();
 }
@@ -248,6 +251,7 @@ bool MallocAllocator::growContiguousWithoutRetry(
   }
   numAllocated_ += increment;
   numMapped_ += increment;
+  numExternalMapped_ += increment;
   allocation.set(
       allocation.data(),
       allocation.size() + AllocationTraits::kPageSize * increment,

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -77,6 +77,10 @@ class MallocAllocator : public MemoryAllocator {
     return numMapped_;
   }
 
+  MachinePageCount numExternalMapped() const override {
+    return numExternalMapped_;
+  }
+
   bool checkConsistency() const override;
 
   std::string toString() const override;

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -341,6 +341,8 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
 
   virtual MachinePageCount numMapped() const = 0;
 
+  virtual MachinePageCount numExternalMapped() const = 0;
+
   virtual Stats stats() const {
     return stats_;
   }
@@ -501,6 +503,14 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   // (used) and freed in the past but haven't been returned to the operating
   // system by 'this' (via madvise calls).
   std::atomic<MachinePageCount> numMapped_{0};
+
+  // Number of pages allocated and explicitly mmap'd by the
+  // application via allocateContiguous, outside of
+  // 'sizeClasses'. These pages are counted in 'numAllocated_' and
+  // 'numMapped_'. Allocation requests are decided against
+  // 'numAllocated_' and 'numMapped_'. This counter is informational
+  // only.
+  std::atomic<MachinePageCount> numExternalMapped_{0};
 
   // Indicates if the failure injection is persistent or transient.
   //

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -145,7 +145,7 @@ class MmapAllocator : public MemoryAllocator {
     return numMapped_;
   }
 
-  MachinePageCount numExternalMapped() const {
+  MachinePageCount numExternalMapped() const override {
     return numExternalMapped_;
   }
 
@@ -381,14 +381,6 @@ class MmapAllocator : public MemoryAllocator {
 
   // Serializes moving capacity between size classes
   std::mutex sizeClassBalanceMutex_;
-
-  // Number of pages allocated and explicitly mmap'd by the
-  // application via allocateContiguous, outside of
-  // 'sizeClasses'. These pages are counted in 'numAllocated_' and
-  // 'numMapped_'. Allocation requests are decided against
-  // 'numAllocated_' and 'numMapped_'. This counter is informational
-  // only.
-  std::atomic<MachinePageCount> numExternalMapped_{0};
 
   // Allocations smaller than 'maxMallocBytes' will be delegated to
   // std::malloc().

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -243,15 +243,14 @@ Memory Management
        the bytes that are either currently being allocated or were in the past
        allocated, not yet been returned back to the operating system, in the
        form of 'Allocation' or 'ContiguousAllocation'.
-   * - memory_allocator_alloc_bytes
+   * - memory_allocator_allocated_bytes
      - Avg
      - Number of bytes currently allocated (used) from MemoryAllocator in the form
        of 'Allocation' or 'ContiguousAllocation'.
-   * - mmap_allocator_external_mapped_bytes
+   * - memory_allocator_external_mapped_bytes
      - Avg
-     - Number of bytes currently mapped in MmapAllocator, in the form of
+     - Number of bytes currently mapped in MemoryAllocator, in the form of
        'ContiguousAllocation'.
-       NOTE: This applies only to MmapAllocator
    * - mmap_allocator_delegated_alloc_bytes
      - Avg
      - Number of bytes currently allocated from MmapAllocator directly from raw


### PR DESCRIPTION
Summary: Since MallocAllocator perform external mmap directly as well, we can unify the API to make this external mapped pages common across allocators. When using MallocAllocator, this can help us understand the extra memory allocated not through malloc.

Reviewed By: xiaoxmeng

Differential Revision: D75568654


