### PR TITLE
build(macos): Fix error numExternalMapped needs override

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -193,7 +193,7 @@ class TestStatsReportMmapAllocator : public memory::MmapAllocator {
     return numMallocBytes_;
   }
 
-  memory::MachinePageCount numExternalMapped() const {
+  memory::MachinePageCount numExternalMapped() const override {
     return numExternalMapped_;
   }
 


### PR DESCRIPTION
As part of this PR: https://github.com/facebookincubator/velox/pull/13531
Function needed to add the override to build on mac.