### PR TITLE
feat: Add bulk string buffer method to StringViewBufferholder

### DIFF
--- a/velox/buffer/StringViewBufferHolder.h
+++ b/velox/buffer/StringViewBufferHolder.h
@@ -72,6 +72,17 @@ class StringViewBufferHolder {
     return stringBuffers_;
   }
 
+  /// Add a buffer to the list of buffers. This is used to allow bulk addition
+  /// of values with fewer overall buffers vs adding a value at a time via
+  /// getOwnedValue. The buffer must be allocated on the same underlying memory
+  /// pool.
+  void addOwnedBuffer(BufferPtr&& inBuffer) {
+    VELOX_CHECK(
+        inBuffer->pool() == pool_,
+        "Buffer must be allocated on same memory pool");
+    stringBuffers_.push_back(std::move(inBuffer));
+  }
+
  private:
   StringView getOwnedStringView(StringView stringView);
   StringView getOwnedStringView(const char* data, int32_t size);

--- a/velox/buffer/tests/StringViewBufferHolderTest.cpp
+++ b/velox/buffer/tests/StringViewBufferHolderTest.cpp
@@ -208,4 +208,25 @@ TEST_F(StringViewBufferHolderTest, buffersCopy) {
   EXPECT_NE(&buffers, &firstMoved);
 }
 
+TEST_F(StringViewBufferHolderTest, addOwnedBuffer) {
+  auto holder = makeHolder();
+  ASSERT_EQ(0, holder.buffers().size());
+  auto buffer = AlignedBuffer::allocate<char>(10, pool_.get());
+  holder.addOwnedBuffer(std::move(buffer));
+  ASSERT_EQ(1, holder.buffers().size());
+  ASSERT_EQ(1, holder.moveBuffers().size());
+}
+
+TEST_F(StringViewBufferHolderTest, addOwnedBufferThrowsForWrongPool) {
+  auto holder = makeHolder();
+  ASSERT_EQ(0, holder.buffers().size());
+  auto buffer = AlignedBuffer::allocate<char>(10, pool_.get());
+  holder.addOwnedBuffer(std::move(buffer));
+
+  auto newPool = memory::memoryManager()->addLeafPool();
+  ASSERT_THROW(
+      holder.addOwnedBuffer(AlignedBuffer::allocate<char>(10, newPool.get())),
+      VeloxException);
+}
+
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: add a addOwnedBuffer method to StringViewBufferHolder to allow addition of larger owned buffer. When compared to adding a value at a time via getOwnedValue we can allocate significantly fewer buffers when constructing large vectors ( kInitialStringReservation is 8kb).

Differential Revision: D75619581


