### PR TITLE
fix: Provide SQL generation support for type INTERVAL

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -393,6 +393,10 @@ std::string toConstantSql(const core::ConstantTypedExpr& constant) {
       sql << typeSql << " ";
     }
     sql << std::quoted(getConstantValue<std::string>(constant), '\'', '\'');
+  } else if (type->isIntervalYearMonth()) {
+    sql << fmt::format("INTERVAL '{}' YEAR TO MONTH", constant.toString());
+  } else if (type->isIntervalDayTime()) {
+    sql << fmt::format("INTERVAL '{}' DAY TO SECOND", constant.toString());
   } else if (type->isBigint()) {
     sql << getConstantValue<int64_t>(constant);
   } else if (type->isPrimitiveType()) {

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -411,5 +411,14 @@ TEST(PrestoSqlTest, toCallInputsSql) {
   EXPECT_EQ(sql.str(), "c0.field0");
 }
 
+TEST(PrestoSqlTest, toConstantSql) {
+  EXPECT_EQ(
+      toConstantSql(core::ConstantTypedExpr(INTERVAL_YEAR_MONTH(), 123)),
+      "INTERVAL '123' YEAR TO MONTH");
+  EXPECT_EQ(
+      toConstantSql(core::ConstantTypedExpr(INTERVAL_DAY_TIME(), int64_t(123))),
+      "INTERVAL '123' DAY TO SECOND");
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
There is no tailored support for INTERVAL type SQL generation; it is treated as all other types, so, during casts, PrestoSql outputs `INTERVAL YEAR TO MONTH some_value`, which is invalid.

This diff adds a case for INTERVAL type in PrestoSql's constantSql generation function and properly outputs `INTERVAL some_value YEAR TO MONTH` (and `... DAY TO SECOND`)

Differential Revision: D75644402


