### PR TITLE
refactor(Task): Add '#undef' after using 'CLEAR' marco

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -431,6 +431,7 @@ Task::~Task() {
 #define CLEAR(_action_)   \
   clearStage = #_action_; \
   _action_;
+
   CLEAR(threadFinishPromises_.clear());
   CLEAR(splitGroupStates_.clear());
   CLEAR(taskStats_ = TaskStats());
@@ -448,6 +449,9 @@ Task::~Task() {
   CLEAR(pool_.reset());
   CLEAR(planFragment_ = core::PlanFragment());
   CLEAR(queryCtx_.reset());
+
+#undef CLEAR
+
   clearStage = "exiting ~Task()";
 
   // Ful-fill the task deletion promises at the end.


### PR DESCRIPTION
As a best practice, we should explicitly '#undef' a macro after we 
no longer use it.

No functional changes.