### PR TITLE
build: Support build on macos-15 with cmake 4

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,7 +54,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       # The arm runners have only 7GB RAM
-      BUILD_TYPE: ${{ matrix.os == 'macos-15' && 'Release' || 'Debug' }}
+      BUILD_TYPE: ${{ (matrix.os == 'macos-14' || matrix.os == 'macos-15') && 'Release' || 'Debug' }}
       INSTALL_PREFIX: /tmp/deps-install
     steps:
       - name: Checkout

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -48,13 +48,13 @@ jobs:
       fail-fast: false
       matrix:
         # macos-13 = x86_64 Mac
-        # macos-14 = arm64 Mac
-        os: [macos-13, macos-14]
+        # macos-15 = arm64 Mac and cmake 4.0
+        os: [macos-13, macos-15]
     runs-on: ${{ matrix.os }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       # The arm runners have only 7GB RAM
-      BUILD_TYPE: ${{ matrix.os ==  'macos-14' && 'Release' || 'Debug' }}
+      BUILD_TYPE: ${{ matrix.os == 'macos-15' && 'Release' || 'Debug' }}
       INSTALL_PREFIX: /tmp/deps-install
     steps:
       - name: Checkout
@@ -75,9 +75,11 @@ jobs:
           install_double_conversion
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
-          brew link --force protobuf@21
-          brew uninstall cmake
-          pipx install --force cmake==3.31
+          majorVersion=$(sw_vers -productVersion | awk -F '.' '{print $1}')
+          if (( majorVersion == 13 || majorVersion == 14 )); then
+            brew uninstall cmake
+            pipx install --force cmake==3.31
+          fi
 
       - name: Cache ccache
         uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -54,7 +54,7 @@ jobs:
     env:
       CCACHE_DIR: ${{ github.workspace }}/ccache
       # The arm runners have only 7GB RAM
-      BUILD_TYPE: ${{ (matrix.os == 'macos-14' || matrix.os == 'macos-15') && 'Release' || 'Debug' }}
+      BUILD_TYPE: ${{ matrix.os == 'macos-15' && 'Release' || 'Debug' }}
       INSTALL_PREFIX: /tmp/deps-install
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
 
           echo "NJOBS=`sysctl -n hw.ncpu`" >> $GITHUB_ENV
           majorVersion=$(sw_vers -productVersion | awk -F '.' '{print $1}')
-          if (( majorVersion == 13 || majorVersion == 14 )); then
+          if (( majorVersion == 13 )); then
             brew uninstall cmake
             pipx install --force cmake==3.31
           fi

--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -75,8 +75,8 @@ if(VELOX_ENABLE_ARROW)
     CMAKE_ARGS ${ARROW_CMAKE_ARGS}
     BUILD_BYPRODUCTS ${ARROW_LIBDIR}/libarrow.a
                      ${ARROW_LIBDIR}/libarrow_testing.a ${THRIFT_LIB}
-    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/thrift-download.patch
-                  && git apply ${CMAKE_CURRENT_LIST_DIR}/cmake-compatibility.patch)
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/thrift-download.patch &&
+                  git apply ${CMAKE_CURRENT_LIST_DIR}/cmake-compatibility.patch)
 
   add_library(arrow STATIC IMPORTED GLOBAL)
   add_library(arrow_testing STATIC IMPORTED GLOBAL)

--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -75,7 +75,8 @@ if(VELOX_ENABLE_ARROW)
     CMAKE_ARGS ${ARROW_CMAKE_ARGS}
     BUILD_BYPRODUCTS ${ARROW_LIBDIR}/libarrow.a
                      ${ARROW_LIBDIR}/libarrow_testing.a ${THRIFT_LIB}
-    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/thrift-download.patch)
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/thrift-download.patch
+                  && git apply ${CMAKE_CURRENT_LIST_DIR}/cmake-compatibility.patch)
 
   add_library(arrow STATIC IMPORTED GLOBAL)
   add_library(arrow_testing STATIC IMPORTED GLOBAL)

--- a/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
+++ b/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
@@ -1,0 +1,38 @@
+
+Original file line number	Original file line	Diff line number	Diff line change
+@@ -0,0 +1,34 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
++++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
+@@ -971,7 +971,8 @@
+     -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=${CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY}
+     -DCMAKE_INSTALL_LIBDIR=lib
+     -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT}
+-    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE})
++    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE}
++    -DCMAKE_POLICY_VERSION_MINIMUM=3.5)
+
+ # Enable s/ccache if set by parent.
+ if(CMAKE_C_COMPILER_LAUNCHER AND CMAKE_CXX_COMPILER_LAUNCHER)
+@@ -1026,6 +1027,7 @@
+   set(CMAKE_COMPILE_WARNING_AS_ERROR FALSE)
+   set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY TRUE)
+   set(CMAKE_MACOSX_RPATH ${ARROW_INSTALL_NAME_RPATH})
++  set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
+   if(MSVC)
+     string(REPLACE "/WX" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+     string(REPLACE "/WX" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+

--- a/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
+++ b/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
@@ -1,6 +1,3 @@
-
-Original file line number	Original file line	Diff line number	Diff line change
-@@ -0,0 +1,34 @@
 # Copyright (c) Facebook, Inc. and its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,4 +32,3 @@ Original file line number	Original file line	Diff line number	Diff line change
    if(MSVC)
      string(REPLACE "/WX" "" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
      string(REPLACE "/WX" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
-

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -211,7 +211,7 @@ function cmake_install_dir {
   pushd "${DEPENDENCY_DIR}/$1" || exit
   # remove the directory argument
   shift
-  cmake_install "$@"
+  cmake_install "$@" -DCMAKE_POLICY_VERSION_MINIMUM=3.5
   popd || exit
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Updated CMake/resolve_dependency_modules/arrow/CMakeLists.txt to include `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for Arrow dependencies.
2. Updated the call to cmake_install by appending `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the arguments.

Specifying `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` ensures compatibility with CMake policies introduced in version 3.5 and above. This can help avoid policy-related warnings or errors when building dependencies, especially in environments using newer CMake releases. e.g.: macos-15 with cmake 4.

### How was this patch tested?

Verified the build process on macOS runners (macos-13, macos-14, macos-15): https://github.com/wangyum/velox/actions/runs/15344032933/job/43176222446