### PR TITLE
fix(fuzzer): Skip non-deterministic noisy_count_if_gaussian in aggregation fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -132,6 +132,8 @@ int main(int argc, char** argv) {
       "reduce_agg",
       "max_data_size_for_stats",
       "any_value",
+      // Skip non-deterministic functions.
+      "noisy_count_if_gaussian",
   };
 
   static const std::unordered_set<std::string> functionsRequireSortedInput = {


### PR DESCRIPTION
Summary:
noisy_count_if_gaussian is a non-deterministic function that causes result mismatch failures in aggregation fuzzer. This diff adds this function to the skip-function list.

it's already being skipped in window fuzzer https://github.com/facebookincubator/velox/pull/13521

Differential Revision: D75694700


