### PR TITLE
Simplify Split

### DIFF
--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -123,8 +123,8 @@ class TpchSpeedTest {
     for (size_t i = 0; i < numSplits; ++i) {
       task.addSplit(
           scanId,
-          exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(
-              kTpchConnectorId_, /*cacheable=*/true, numSplits, i)));
+          exec::Split{std::make_shared<connector::tpch::TpchConnectorSplit>(
+              kTpchConnectorId_, /*cacheable=*/true, numSplits, i)});
     }
 
     task.noMoreSplits(scanId);

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -60,8 +60,8 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
 
   exec::Split makeTpchSplit(size_t totalParts = 1, size_t partNumber = 0)
       const {
-    return exec::Split(std::make_shared<TpchConnectorSplit>(
-        kTpchConnectorId, /*cacheable=*/true, totalParts, partNumber));
+    return exec::Split{std::make_shared<TpchConnectorSplit>(
+        kTpchConnectorId, /*cacheable=*/true, totalParts, partNumber)};
   }
 
   RowVectorPtr getResults(

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -106,8 +106,8 @@ class ParquetTpchTest : public testing::Test {
                       .tpchTableScan(table, std::move(columnNames), 0.01)
                       .planNode();
       auto split =
-          exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(
-              kTpchConnectorId, /*cacheable=*/true, 1, 0));
+          exec::Split{std::make_shared<connector::tpch::TpchConnectorSplit>(
+              kTpchConnectorId, /*cacheable=*/true, 1, 0)};
 
       auto rows =
           AssertQueryBuilder(plan).splits({split}).copyResults(pool.get());

--- a/velox/exec/Split.h
+++ b/velox/exec/Split.h
@@ -28,24 +28,12 @@ struct Split {
   /// to signal the output drain processing.
   bool barrier{false};
 
-  Split() = default;
-
-  explicit Split(
-      std::shared_ptr<velox::connector::ConnectorSplit>&& connectorSplit,
-      int32_t groupId = -1)
-      : connectorSplit(std::move(connectorSplit)), groupId(groupId) {}
-
   /// Called by the task barrier to create a special barrier split.
   static Split createBarrier() {
     static Split barrierSplit;
     barrierSplit.barrier = true;
     return barrierSplit;
   }
-
-  Split(Split&& other) = default;
-  Split(const Split& other) = default;
-  Split& operator=(Split&& other) = default;
-  Split& operator=(const Split& other) = default;
 
   bool isBarrier() const {
     return barrier;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -172,7 +172,7 @@ class ExchangeBenchmark : public VectorTestBase {
       for (int i = 0; i < width; i++) {
         auto taskId = makeTaskId(iteration, "final-agg", i);
         finalAggSplits.push_back(
-            exec::Split(std::make_shared<exec::RemoteConnectorSplit>(taskId)));
+            exec::Split{std::make_shared<exec::RemoteConnectorSplit>(taskId)});
         auto finalAggTask = makeTask(taskId, finalAggPlan, i);
         finalAggTasks.push_back(finalAggTask);
         finalAggTask->start(taskWidth);
@@ -358,9 +358,8 @@ class ExchangeBenchmark : public VectorTestBase {
       std::shared_ptr<Task> task,
       const std::vector<std::string>& remoteTaskIds) {
     for (const auto& taskId : remoteTaskIds) {
-      auto split =
-          exec::Split(std::make_shared<RemoteConnectorSplit>(taskId), -1);
-      task->addSplit("0", std::move(split));
+      task->addSplit(
+          "0", exec::Split{std::make_shared<RemoteConnectorSplit>(taskId), -1});
     }
     task->noMoreSplits("0");
   }

--- a/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
@@ -156,7 +156,7 @@ class WindowPrefixSortBenchmark : public HiveConnectorTestBase {
     auto task = makeTask(plan, prefixSort);
     task->addSplit(
         tableScanPlanId,
-        exec::Split(makeHiveConnectorSplit(sourceFilePath_->getPath())));
+        exec::Split{makeHiveConnectorSplit(sourceFilePath_->getPath())});
     task->noMoreSplits(tableScanPlanId);
     suspender1.dismiss();
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -47,11 +47,11 @@ class GroupedExecutionTest : public virtual HiveConnectorTestBase {
   }
 
   exec::Split makeHiveSplitWithGroup(std::string path, int32_t group) {
-    return exec::Split(makeHiveConnectorSplit(std::move(path)), group);
+    return exec::Split{makeHiveConnectorSplit(std::move(path)), group};
   }
 
   exec::Split makeHiveSplit(std::string path) {
-    return exec::Split(makeHiveConnectorSplit(std::move(path)));
+    return exec::Split{makeHiveConnectorSplit(std::move(path))};
   }
 
   static core::PlanNodePtr tableScanNode(const RowTypePtr& outputType) {

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -94,7 +94,7 @@ TEST_F(LimitTest, limitOverLocalExchange) {
 
   auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit(
-      scanNodeId, exec::Split(makeHiveConnectorSplit(file->getPath())));
+      scanNodeId, exec::Split{makeHiveConnectorSplit(file->getPath())});
 
   int32_t numRead = 0;
   while (cursor->moveNext()) {

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -132,12 +132,12 @@ class MultiFragmentTest : public HiveConnectorTestBase,
       std::shared_ptr<Task> task,
       const std::vector<std::shared_ptr<TempFilePath>>& filePaths) {
     for (auto& filePath : filePaths) {
-      auto split = exec::Split(
+      auto split = exec::Split{
           std::make_shared<connector::hive::HiveConnectorSplit>(
               kHiveConnectorId,
               "file:" + filePath->getPath(),
               facebook::velox::dwio::common::FileFormat::DWRF),
-          -1);
+          -1};
       task->addSplit("0", std::move(split));
       VLOG(1) << filePath->getPath() << "\n";
     }
@@ -145,7 +145,7 @@ class MultiFragmentTest : public HiveConnectorTestBase,
   }
 
   exec::Split remoteSplit(const std::string& taskId) {
-    return exec::Split(std::make_shared<RemoteConnectorSplit>(taskId));
+    return exec::Split{std::make_shared<RemoteConnectorSplit>(taskId)};
   }
 
   void addRemoteSplits(
@@ -1347,7 +1347,7 @@ TEST_P(MultiFragmentTest, limit) {
   leafTask->start(1);
 
   leafTask.get()->addSplit(
-      "0", exec::Split(makeHiveConnectorSplit(file->getPath())));
+      "0", exec::Split{makeHiveConnectorSplit(file->getPath())});
 
   // Make final task: Exchange -> FinalLimit(10).
   auto plan = PlanBuilder()

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1644,7 +1644,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
   // Manage remote exchange splits.
   task->addSplit(
       exchangeNodeId,
-      exec::Split(std::make_shared<RemoteConnectorSplit>(leafTaskId)));
+      exec::Split{std::make_shared<RemoteConnectorSplit>(leafTaskId)});
   task->noMoreSplits(exchangeNodeId);
 
   // Check the task stats.
@@ -3483,7 +3483,7 @@ TEST_F(TableScanTest, remainingFilterLazyWithMultiReferences) {
           .planNode();
   auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit(
-      "0", exec::Split(makeHiveConnectorSplit(file->getPath())));
+      "0", exec::Split{makeHiveConnectorSplit(file->getPath())});
   cursor->task()->noMoreSplits("0");
   int i = 0;
   while (cursor->moveNext()) {
@@ -3526,7 +3526,7 @@ TEST_F(TableScanTest, sharedNullBufferFromComplexResult) {
 
   auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit(
-      "0", exec::Split(makeHiveConnectorSplit(file->getPath())));
+      "0", exec::Split{makeHiveConnectorSplit(file->getPath())});
   cursor->task()->noMoreSplits("0");
   int i = 0;
   BufferPtr nullBufferHolder;
@@ -3564,7 +3564,7 @@ TEST_F(
                         .planNode();
   auto cursor = TaskCursor::create(params);
   cursor->task()->addSplit(
-      "0", exec::Split(makeHiveConnectorSplit(file->getPath())));
+      "0", exec::Split{makeHiveConnectorSplit(file->getPath())});
   cursor->task()->noMoreSplits("0");
   ASSERT_TRUE(cursor->moveNext());
   auto* result = cursor->current()->asUnchecked<RowVector>();

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -99,8 +99,9 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
   /// Make TPC-H split to add to TableScan node.
   exec::Split makeTpchSplit() const {
-    return exec::Split(std::make_shared<connector::tpch::TpchConnectorSplit>(
-        kTpchConnectorId, /*cacheable=*/true, 1, 0));
+    return exec::Split{
+        .connectorSplit = std::make_shared<connector::tpch::TpchConnectorSplit>(
+            kTpchConnectorId, /*cacheable=*/true, 1, 0)};
   }
 
   /// Run the demo.

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -155,7 +155,7 @@ AssertQueryBuilder& AssertQueryBuilder::split(
     const core::PlanNodeId& planNodeId,
     const std::shared_ptr<connector::ConnectorSplit>& connectorSplit) {
   splits_[planNodeId].emplace_back(
-      exec::Split(folly::copy(connectorSplit), -1));
+      exec::Split{folly::copy(connectorSplit), -1});
   return *this;
 }
 
@@ -172,7 +172,7 @@ AssertQueryBuilder& AssertQueryBuilder::splits(
         connectorSplits) {
   std::vector<Split> splits;
   for (auto& connectorSplit : connectorSplits) {
-    splits.emplace_back(exec::Split(folly::copy(connectorSplit), -1));
+    splits.emplace_back(exec::Split{folly::copy(connectorSplit), -1});
   }
   splits_[planNodeId] = std::move(splits);
   return *this;

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -800,7 +800,7 @@ class HashJoinTestBase : public HiveConnectorTestBase {
       std::vector<exec::Split> splits;
       splits.reserve(files[i].size());
       for (const auto& file : files[i]) {
-        splits.push_back(exec::Split(makeHiveConnectorSplit(file->getPath())));
+        splits.push_back(exec::Split{makeHiveConnectorSplit(file->getPath())});
       }
       splitInput.emplace(nodeIds[i], std::move(splits));
     }
@@ -857,9 +857,9 @@ class HashJoinTestBase : public HiveConnectorTestBase {
                   .planNode();
     SplitInput splitInput = {
         {probeScanId,
-         {exec::Split(makeHiveConnectorSplit(probeFile->getPath()))}},
+         {exec::Split{makeHiveConnectorSplit(probeFile->getPath())}}},
         {buildScanId,
-         {exec::Split(makeHiveConnectorSplit(buildFile->getPath()))}},
+         {exec::Split{makeHiveConnectorSplit(buildFile->getPath())}}},
     };
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .planNode(std::move(op))

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -172,7 +172,7 @@ std::shared_ptr<Task> OperatorTestBase::assertQuery(
   std::vector<exec::Split> splits;
   splits.reserve(connectorSplits.size());
   for (const auto& connectorSplit : connectorSplits) {
-    splits.emplace_back(exec::Split(folly::copy(connectorSplit), -1));
+    splits.emplace_back(exec::Split{folly::copy(connectorSplit), -1});
   }
 
   return assertQuery(plan, std::move(splits), duckDbSql, sortingKeys);

--- a/velox/exec/tests/utils/TableScanTestBase.cpp
+++ b/velox/exec/tests/utils/TableScanTestBase.cpp
@@ -39,8 +39,8 @@ std::vector<RowVectorPtr> TableScanTestBase::makeVectors(
 exec::Split TableScanTestBase::makeHiveSplit(
     const std::string& path,
     int64_t splitWeight) {
-  return exec::Split(makeHiveConnectorSplit(
-      path, 0, std::numeric_limits<uint64_t>::max(), splitWeight));
+  return exec::Split{makeHiveConnectorSplit(
+      path, 0, std::numeric_limits<uint64_t>::max(), splitWeight)};
 }
 
 std::shared_ptr<Task> TableScanTestBase::assertQuery(

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -218,7 +218,7 @@ std::shared_ptr<Task> TableWriterTestBase::assertQueryWithWriterConfigs(
     bool spillEnabled) {
   std::vector<Split> splits;
   for (const auto& filePath : filePaths) {
-    splits.push_back(Split(makeHiveConnectorSplit(filePath->getPath())));
+    splits.push_back(Split{makeHiveConnectorSplit(filePath->getPath())});
   }
   if (!spillEnabled) {
     return AssertQueryBuilder(plan, duckDbQueryRunner_)

--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -36,7 +36,7 @@ std::vector<exec::Split> listAllSplits(std::shared_ptr<SplitSource> source) {
         return result;
         break;
       }
-      result.push_back(exec::Split(std::move(split.split)));
+      result.push_back(exec::Split{std::move(split.split)});
     }
   }
   VELOX_UNREACHABLE();
@@ -133,7 +133,7 @@ void LocalRunner::start() {
     const auto finalStageConsumer =
         fragments_.back().inputStages[0].consumerNodeId;
     for (auto& remote : lastStage) {
-      cursor->task()->addSplit(finalStageConsumer, exec::Split(remote));
+      cursor->task()->addSplit(finalStageConsumer, exec::Split{remote});
     }
     cursor->task()->noMoreSplits(finalStageConsumer);
   }
@@ -262,11 +262,11 @@ LocalRunner::makeStages() {
       int32_t splitIdx = 0;
       auto getNextSplit = [&]() {
         if (splitIdx < splits.size()) {
-          return exec::Split(std::move(splits[splitIdx++].split));
+          return exec::Split{std::move(splits[splitIdx++].split)};
         }
         splits = source->getSplits(std::numeric_limits<int64_t>::max());
         splitIdx = 1;
-        return exec::Split(std::move(splits[0].split));
+        return exec::Split{std::move(splits[0].split)};
       };
 
       bool allDone = false;
@@ -295,7 +295,7 @@ LocalRunner::makeStages() {
       }
       for (auto& task : stages_[fragmentIndex]) {
         for (auto& remote : sourceSplits) {
-          task->addSplit(input.consumerNodeId, exec::Split(remote));
+          task->addSplit(input.consumerNodeId, exec::Split{remote});
         }
         task->noMoreSplits(input.consumerNodeId);
       }


### PR DESCRIPTION
Summary:
`Split` is a POD, and unnecessarily have constructors and all assignment operators.

We can simply delete them all to do the same thing.

Differential Revision: D75712160


