### PR TITLE
feat(noise): Implement NOISY_COUNT_IF_GAUSSIAN(col, noise_scale, random_seed) (#13545)

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -709,11 +709,13 @@ Statistical Aggregate Functions
 Noisy Aggregate Functions
 -------------------------
 
-.. function:: noisy_count_if_gaussian(col, noise_scale) -> bigint
+.. function:: noisy_count_if_gaussian(col, noise_scale[, random_seed]) -> bigint
 
     Counts the ``TRUE`` values in ``col`` and then adds a normally distributed random double
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
+
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -723,6 +725,7 @@ Noisy Aggregate Functions
     .. note::
 
         Unlike :func:`!count_if`, this function returns ``NULL`` when the (true) count is 0.
+
 
 Miscellaneous
 -------------

--- a/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
@@ -74,7 +74,8 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
 
         // Write to the pre-allocated buffer
         accumulator->serialize(rawBuffer + offset);
-        flatResult->setNoCopy(i, StringView(rawBuffer + offset, size));
+        flatResult->setNoCopy(
+            i, StringView(rawBuffer + offset, static_cast<int32_t>(size)));
         offset += size;
       }
     }
@@ -108,10 +109,26 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
       return;
     }
 
-    // Generate a cryptographically secure random byte string as the seed for
-    // random generator
     folly::Random::DefaultGenerator rng;
-    rng.seed(folly::Random::secureRand32());
+
+    // Check if random seed is provided. If so, use it to seed the random
+    bool seedFound = false;
+    for (auto i = 0; i < numGroups && !seedFound; i++) {
+      auto group = groups[i];
+      if (!isNull(group)) {
+        auto* accumulator = value<AccumulatorType>(group);
+        if (accumulator->randomSeed.has_value()) {
+          rng.seed(*accumulator->randomSeed);
+          seedFound = true;
+        }
+      }
+    }
+
+    // Otherwise, generate a cryptographically secure random byte string as the
+    // seed for random generator
+    if (!seedFound) {
+      rng.seed(folly::Random::secureRand32());
+    }
 
     // This is to deal with the case when noiseScale == 0, which means we do not
     // need to add noise. We assume noiseScale = 0, thus no need to add noise,
@@ -135,9 +152,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
 
         int64_t noise = 0;
         if (addNoise) {
+          double rawNoise = dist(rng);
+
           noise = static_cast<int64_t>(
-              std::round(dist(rng))); // Need to round back to int64_t because
-                                      // we want to return int64_t
+              std::round(rawNoise)); // Need to round back to int64_t because
+                                     // we want to return int64_t
         }
 
         // Check and make sure the count is within int64_t range
@@ -164,6 +183,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
 
+    // If intput has random seed, decode it
+    if (args.size() == 3 && args[2]->isConstantEncoding()) {
+      decodedRandomSeed_.decode(*args[2], rows);
+    }
+
     rows.applyToSelected([&](vector_size_t i) {
       if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
         return;
@@ -185,6 +209,10 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
       }
       accumulator->checkAndSetNoiseScale(noiseScaleValue);
+
+      if (args.size() == 3 && !decodedRandomSeed_.isNullAt(i)) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+      }
     });
   }
 
@@ -211,6 +239,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
           otherAccumulator.noiseScale >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.noiseScale);
       }
+
+      if (otherAccumulator.randomSeed.has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.randomSeed);
+      }
+
       accumulator->increaseCount(otherAccumulator.count);
     });
   }
@@ -224,6 +257,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
 
+    // Check if input has random seed and make sure it's constant for each row.
+    if (args.size() == 3 && args[2]->isConstantEncoding()) {
+      decodedRandomSeed_.decode(*args[2], rows);
+    }
+
     auto* accumulator = value<AccumulatorType>(group);
 
     rows.applyToSelected([&](vector_size_t i) {
@@ -233,6 +271,7 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
       if (decodedValue_.valueAt<bool>(i)) {
         accumulator->increaseCount(1);
       }
+
       double noiseScaleValue = 0.0;
       auto noiseScaleType = args[1]->typeKind();
       if (noiseScaleType == TypeKind::DOUBLE) {
@@ -241,8 +280,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
         noiseScaleValue =
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
       }
-
       accumulator->checkAndSetNoiseScale(noiseScaleValue);
+
+      if (args.size() == 3 && !decodedRandomSeed_.isNullAt(i)) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+      }
     });
   }
 
@@ -264,6 +306,11 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
           otherAccumulator.noiseScale >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.noiseScale);
       }
+
+      if (otherAccumulator.randomSeed.has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.randomSeed);
+      }
+
       accumulator->increaseCount(otherAccumulator.count);
     });
   }
@@ -281,6 +328,7 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
  private:
   DecodedVector decodedValue_;
   DecodedVector decodedNoiseScale_;
+  DecodedVector decodedRandomSeed_;
 };
 
 } // namespace
@@ -302,6 +350,20 @@ void registerNoisyCountIfGaussianAggregate(
           .argumentType("boolean")
           .argumentType("bigint") // support BIGINT noise scale
           .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("boolean")
+          .argumentType("double")
+          .argumentType("bigint") // support random seed
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("boolean")
+          .argumentType("bigint")
+          .argumentType("bigint") // support random seed
+          .build(),
   };
 
   auto name = prefix + kNoisyCountIfGaussian;
@@ -314,7 +376,8 @@ void registerNoisyCountIfGaussianAggregate(
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(argTypes.size(), 2, "{} takes 2 arguments", name);
+        VELOX_CHECK_LE(argTypes.size(), 3, "{} takes 2 or 3 arguments", name);
+        VELOX_CHECK_GE(argTypes.size(), 2, "{} takes 2 or 3 arguments", name);
 
         if (exec::isPartialOutput(step)) {
           VELOX_CHECK_EQ(


### PR DESCRIPTION
Summary:

## This Diff

**feat(noise): Implement NOISY_COUNT_IF_GAUSSIAN(col, noise_scale, random_seed)**

This diff implements the `NOISY_COUNT_IF_GAUSSIAN` aggregation function, which takes three parameters: `col`, `noise_scale`, and `random_seed`. The function is designed to provide a noisy count of rows that satisfy a given condition, using a Gaussian distribution to generate the noise.

**Key Changes:**

*   **Added random seed support**: The diff introduces a new `random_seed` parameter to the `NOISY_COUNT_IF_GAUSSIAN` function. This allows users to specify a random seed for the noise generation process, enabling reproducibility and predictability in the results.
*   **Updated test cases**: New test cases have been added to verify the correctness of the `random_seed` parameter. These tests cover different scenarios, including cases where the random seed is provided and where it is not.
*   **Modified noisy aggregation logic**: The underlying logic for generating the noise has been updated to incorporate the random seed. If a random seed is provided, it is used to seed the random number generator; otherwise, a cryptographically secure random byte string is generated as the seed.

**Impact:**

The introduction of the `random_seed` parameter provides greater control and flexibility in the noisy aggregation process. It enables users to reproduce the same results with the same input data, which is essential for testing, validation, and auditing purposes.

**Code Changes:**

The diff includes changes to the following files:

*   `fbcode/velox/functions/prestosql/aggregates/tests/NoisyCountIfGaussianAggregationTest.cpp`
*   `fbcode/velox/functions/lib/aggregates/noisy_aggregation/NoisyCountAccumulator.h`
*   `fbcode/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp`

These changes implement the new `random_seed` parameter, update the test cases, and modify the noisy aggregation logic to incorporate the random seed.

Differential Revision: D75716299


