### PR TITLE
fix: Fix the unnest output child column size in case of identity mapping

### DIFF
--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -35,11 +35,12 @@ Unnest::Unnest(
   const auto& unnestVariables = unnestNode->unnestVariables();
   for (const auto& variable : unnestVariables) {
     if (!variable->type()->isArray() && !variable->type()->isMap()) {
-      VELOX_UNSUPPORTED("Unnest operator supports only ARRAY and MAP types");
+      VELOX_UNSUPPORTED(
+          "Unnest operator supports only ARRAY and MAP types, the actual type is {}",
+          variable->type()->toString());
     }
     unnestChannels_.push_back(inputType->getChildIdx(variable->name()));
   }
-
   unnestDecoded_.resize(unnestVariables.size());
 
   if (withOrdinality_) {
@@ -83,11 +84,13 @@ void Unnest::addInput(RowVectorPtr input) {
 
     if (unnestVector->typeKind() == TypeKind::ARRAY) {
       const auto* unnestBaseArray = currentDecoded.base()->as<ArrayVector>();
+      VELOX_CHECK_NOT_NULL(unnestBaseArray);
       rawSizes_[channel] = unnestBaseArray->rawSizes();
       rawOffsets_[channel] = unnestBaseArray->rawOffsets();
     } else {
-      VELOX_CHECK(unnestVector->typeKind() == TypeKind::MAP);
+      VELOX_CHECK_EQ(unnestVector->typeKind(), TypeKind::MAP);
       const auto* unnestBaseMap = currentDecoded.base()->as<MapVector>();
+      VELOX_CHECK_NOT_NULL(unnestBaseMap);
       rawSizes_[channel] = unnestBaseMap->rawSizes();
       rawOffsets_[channel] = unnestBaseMap->rawOffsets();
     }
@@ -98,9 +101,7 @@ void Unnest::addInput(RowVectorPtr input) {
     for (auto row = 0; row < size; ++row) {
       if (!currentDecoded.isNullAt(row)) {
         const auto unnestSize = currentSizes[currentIndices[row]];
-        if (rawMaxSizes_[row] < unnestSize) {
-          rawMaxSizes_[row] = unnestSize;
-        }
+        rawMaxSizes_[row] = std::max(rawMaxSizes_[row], unnestSize);
       }
     }
   }
@@ -118,15 +119,15 @@ RowVectorPtr Unnest::getOutput() {
     return nullptr;
   }
 
-  const auto size = input_->size();
-  VELOX_DCHECK_LT(nextInputRow_, size);
+  const auto numInputRows = input_->size();
+  VELOX_DCHECK_LT(nextInputRow_, numInputRows);
 
   // Limit the number of input rows to keep output batch size within
   // 'maxOutputSize_'. When the output size is 'maxOutputSize_', the
   // first and last row might not be processed completely, and their output
   // might be split into multiple batches.
-  auto rowRange = extractRowRange(size);
-  if (rowRange.numElements == 0) {
+  const auto rowRange = extractRowRange(numInputRows);
+  if (rowRange.numInnerRows == 0) {
     // All arrays/maps are null or empty.
     input_ = nullptr;
     nextInputRow_ = 0;
@@ -136,52 +137,53 @@ RowVectorPtr Unnest::getOutput() {
 
   const auto output = generateOutput(rowRange);
   VELOX_CHECK_NOT_NULL(output);
-  if (rowRange.lastRowEnd.has_value()) {
+  if (rowRange.lastInnerRowEnd.has_value()) {
     // The last row is not processed completely.
-    firstRowStart_ = rowRange.lastRowEnd.value();
-    nextInputRow_ += rowRange.size - 1;
+    firstInnerRowStart_ = rowRange.lastInnerRowEnd.value();
+    nextInputRow_ += rowRange.numInputRows - 1;
   } else {
-    firstRowStart_ = 0;
-    nextInputRow_ += rowRange.size;
+    firstInnerRowStart_ = 0;
+    nextInputRow_ += rowRange.numInputRows;
   }
 
-  if (nextInputRow_ >= size) {
+  if (nextInputRow_ >= numInputRows) {
     input_ = nullptr;
     nextInputRow_ = 0;
   }
   return output;
 }
 
-Unnest::RowRange Unnest::extractRowRange(vector_size_t size) const {
-  vector_size_t numInput = 0;
-  vector_size_t numElements = 0;
-  std::optional<vector_size_t> lastRowEnd;
-  for (auto row = nextInputRow_; row < size; ++row) {
-    const bool isFirstRow = (row == nextInputRow_);
-    const vector_size_t remainingSize =
-        isFirstRow ? rawMaxSizes_[row] - firstRowStart_ : rawMaxSizes_[row];
-    ++numInput;
-    if (numElements + remainingSize > maxOutputSize_) {
+Unnest::RowRange Unnest::extractRowRange(vector_size_t inputSize) const {
+  vector_size_t numInputRows{0};
+  vector_size_t numInnerRows{0};
+  std::optional<vector_size_t> lastInnerRowEnd;
+  for (auto inputRow = nextInputRow_; inputRow < inputSize; ++inputRow) {
+    const bool isFirstRow = (inputRow == nextInputRow_);
+    const vector_size_t remainingInnerRows = isFirstRow
+        ? rawMaxSizes_[inputRow] - firstInnerRowStart_
+        : rawMaxSizes_[inputRow];
+    ++numInputRows;
+    if (numInnerRows + remainingInnerRows > maxOutputSize_) {
       // A single row's output needs to be split into multiple batches.
       // Determines the range to process the first and last rows partially,
       // rather than processing from 0 to 'rawMaxSizes_[row]'.
       if (isFirstRow) {
-        lastRowEnd = firstRowStart_ + maxOutputSize_ - numElements;
+        lastInnerRowEnd = firstInnerRowStart_ + maxOutputSize_ - numInnerRows;
       } else {
-        lastRowEnd = maxOutputSize_ - numElements;
+        lastInnerRowEnd = maxOutputSize_ - numInnerRows;
       }
       // Process maxOutputSize_ in this getOutput.
-      numElements = maxOutputSize_;
+      numInnerRows = maxOutputSize_;
       break;
     }
     // Process this row completely.
-    numElements += remainingSize;
-    if (numElements == maxOutputSize_) {
+    numInnerRows += remainingInnerRows;
+    if (numInnerRows == maxOutputSize_) {
       break;
     }
   }
-  VELOX_DCHECK_LE(numElements, maxOutputSize_);
-  return {nextInputRow_, numInput, lastRowEnd, numElements};
+  VELOX_DCHECK_LE(numInnerRows, maxOutputSize_);
+  return {nextInputRow_, numInputRows, lastInnerRowEnd, numInnerRows};
 };
 
 void Unnest::generateRepeatedColumns(
@@ -189,10 +191,10 @@ void Unnest::generateRepeatedColumns(
     std::vector<VectorPtr>& outputs) {
   // Create "indices" buffer to repeat rows as many times as there are elements
   // in the array (or map) in unnestDecoded.
-  auto repeatedIndices = allocateIndices(range.numElements, pool());
+  auto repeatedIndices = allocateIndices(range.numInnerRows, pool());
   auto* rawRepeatedIndices = repeatedIndices->asMutable<vector_size_t>();
   vector_size_t index = 0;
-  VELOX_DCHECK_GT(range.size, 0);
+  VELOX_DCHECK_GT(range.numInputRows, 0);
   // Record the row number to process.
   range.forEachRow(
       [&](vector_size_t row, vector_size_t /*start*/, vector_size_t size) {
@@ -201,14 +203,14 @@ void Unnest::generateRepeatedColumns(
         index += size;
       },
       rawMaxSizes_,
-      firstRowStart_);
+      firstInnerRowStart_);
 
   // Wrap "replicated" columns in a dictionary using 'repeatedIndices'.
   for (const auto& projection : identityProjections_) {
     outputs.at(projection.outputChannel) = BaseVector::wrapInDictionary(
-        nullptr /*nulls*/,
+        /*nulls=*/nullptr,
         repeatedIndices,
-        range.numElements,
+        range.numInnerRows,
         input_->childAt(projection.inputChannel));
   }
 }
@@ -216,11 +218,11 @@ void Unnest::generateRepeatedColumns(
 const Unnest::UnnestChannelEncoding Unnest::generateEncodingForChannel(
     column_index_t channel,
     const RowRange& range) {
-  BufferPtr elementIndices = allocateIndices(range.numElements, pool());
-  auto* rawElementIndices = elementIndices->asMutable<vector_size_t>();
+  BufferPtr innerRowIndices = allocateIndices(range.numInnerRows, pool());
+  auto* rawInnerRowIndices = innerRowIndices->asMutable<vector_size_t>();
 
-  auto nulls = allocateNulls(range.numElements, pool());
-  auto rawNulls = nulls->asMutable<uint64_t>();
+  auto nulls = allocateNulls(range.numInnerRows, pool());
+  auto* rawNulls = nulls->asMutable<uint64_t>();
 
   auto& currentDecoded = unnestDecoded_[channel];
   auto* currentSizes = rawSizes_[channel];
@@ -230,7 +232,7 @@ const Unnest::UnnestChannelEncoding Unnest::generateEncodingForChannel(
   // Make dictionary index for elements column since they may be out of order.
   vector_size_t index = 0;
   bool identityMapping = true;
-  VELOX_DCHECK_GT(range.size, 0);
+  VELOX_DCHECK_GT(range.numInputRows, 0);
 
   range.forEachRow(
       [&](vector_size_t row, vector_size_t start, vector_size_t size) {
@@ -244,37 +246,37 @@ const Unnest::UnnestChannelEncoding Unnest::generateEncodingForChannel(
               unnestSize < end) {
             identityMapping = false;
           }
-          auto currentUnnestSize = std::min(end, unnestSize);
-          for (auto i = start; i < currentUnnestSize; i++) {
-            rawElementIndices[index++] = offset + i;
+          const auto currentUnnestSize = std::min(end, unnestSize);
+          for (auto i = start; i < currentUnnestSize; ++i) {
+            rawInnerRowIndices[index++] = offset + i;
           }
 
           for (auto i = std::max(start, currentUnnestSize); i < end; ++i) {
-            bits::setNull(rawNulls, index++, true);
+            bits::setNull(rawNulls, index++, bits::kNotNull);
           }
         } else if (size > 0) {
           identityMapping = false;
 
           for (auto i = start; i < end; ++i) {
-            bits::setNull(rawNulls, index++, true);
+            bits::setNull(rawNulls, index++, bits::kNotNull);
           }
         }
       },
       rawMaxSizes_,
-      firstRowStart_);
+      firstInnerRowStart_);
 
-  return {elementIndices, nulls, identityMapping};
+  return {innerRowIndices, nulls, identityMapping};
 }
 
 VectorPtr Unnest::generateOrdinalityVector(const RowRange& range) {
   auto ordinalityVector = BaseVector::create<FlatVector<int64_t>>(
-      BIGINT(), range.numElements, pool());
+      BIGINT(), range.numInnerRows, pool());
 
   // Set the ordinality at each result row to be the index of the element in
   // the original array (or map) plus one.
   auto* rawOrdinality = ordinalityVector->mutableRawValues();
 
-  VELOX_DCHECK_GT(range.size, 0);
+  VELOX_DCHECK_GT(range.numInputRows, 0);
 
   range.forEachRow(
       [&](vector_size_t /*row*/, vector_size_t start, vector_size_t size) {
@@ -282,7 +284,7 @@ VectorPtr Unnest::generateOrdinalityVector(const RowRange& range) {
         rawOrdinality += size;
       },
       rawMaxSizes_,
-      firstRowStart_);
+      firstInnerRowStart_);
 
   return ordinalityVector;
 }
@@ -292,26 +294,26 @@ RowVectorPtr Unnest::generateOutput(const RowRange& range) {
   generateRepeatedColumns(range, outputs);
 
   // Create unnest columns.
-  vector_size_t outputsIndex = identityProjections_.size();
+  vector_size_t outputColumnIndex = identityProjections_.size();
   for (auto channel = 0; channel < unnestChannels_.size(); ++channel) {
     const auto unnestChannelEncoding =
         generateEncodingForChannel(channel, range);
 
-    auto& currentDecoded = unnestDecoded_[channel];
+    const auto& currentDecoded = unnestDecoded_[channel];
     if (currentDecoded.base()->typeKind() == TypeKind::ARRAY) {
       // Construct unnest column using Array elements wrapped using above
       // created dictionary.
       const auto* unnestBaseArray = currentDecoded.base()->as<ArrayVector>();
-      outputs[outputsIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseArray->elements(), range.numElements);
+      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
+          unnestBaseArray->elements(), range.numInnerRows);
     } else {
       // Construct two unnest columns for Map keys and values vectors wrapped
       // using above created dictionary.
       const auto* unnestBaseMap = currentDecoded.base()->as<MapVector>();
-      outputs[outputsIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseMap->mapKeys(), range.numElements);
-      outputs[outputsIndex++] = unnestChannelEncoding.wrap(
-          unnestBaseMap->mapValues(), range.numElements);
+      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
+          unnestBaseMap->mapKeys(), range.numInnerRows);
+      outputs[outputColumnIndex++] = unnestChannelEncoding.wrap(
+          unnestBaseMap->mapValues(), range.numInnerRows);
     }
   }
 
@@ -323,8 +325,8 @@ RowVectorPtr Unnest::generateOutput(const RowRange& range) {
   return std::make_shared<RowVector>(
       pool(),
       outputType_,
-      BufferPtr(nullptr),
-      range.numElements,
+      /*nulls=*/nullptr,
+      range.numInnerRows,
       std::move(outputs));
 }
 
@@ -365,24 +367,26 @@ void Unnest::RowRange::forEachRow(
         vector_size_t /*start*/,
         vector_size_t /*size*/)> func,
     const vector_size_t* const rawMaxSizes,
-    vector_size_t firstRowStart) const {
+    vector_size_t firstInnerRowStart) const {
   // Process the first row.
-  const auto firstRowEnd = size == 1 && lastRowEnd.has_value()
-      ? lastRowEnd.value()
-      : rawMaxSizes[start];
-  func(start, firstRowStart, firstRowEnd - firstRowStart);
+  const auto firstInnerRowEnd = numInputRows == 1 && lastInnerRowEnd.has_value()
+      ? lastInnerRowEnd.value()
+      : rawMaxSizes[startInputRow];
+  func(
+      startInputRow, firstInnerRowStart, firstInnerRowEnd - firstInnerRowStart);
 
+  const auto lastInputRow = startInputRow + numInputRows - 1;
   // Process the middle rows.
-  for (auto row = start + 1; row < start + size - 1; ++row) {
-    func(row, 0, rawMaxSizes[row]);
+  for (auto inputRow = startInputRow + 1; inputRow < lastInputRow; ++inputRow) {
+    func(inputRow, 0, rawMaxSizes[inputRow]);
   }
 
   // Process the last row if exists.
-  if (size > 1) {
-    if (lastRowEnd.has_value()) {
-      func(start + size - 1, 0, lastRowEnd.value());
+  if (numInputRows > 1) {
+    if (lastInnerRowEnd.has_value()) {
+      func(lastInputRow, 0, lastInnerRowEnd.value());
     } else {
-      func(start + size - 1, 0, rawMaxSizes[start + size - 1]);
+      func(lastInputRow, 0, rawMaxSizes[lastInputRow]);
     }
   }
 }

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -46,8 +46,7 @@ class Unnest : public Operator {
   void maybeFinishDrain();
 
   // Represents the range of rows to process and indicates that the first and
-  // last
-  // rows may need to be processed partially to match the configured output
+  // last rows may need to be processed partially to match the configured output
   // batch size. When processing a single row, the range is from
   // 'firstRowStart_' to 'lastRowEnd'. For multiple rows, the range for the
   // first row is from 'firstRowStart_' to 'rawMaxSizes_[firstRow]', and for the
@@ -81,26 +80,27 @@ class Unnest : public Operator {
             vector_size_t /*start*/,
             vector_size_t /*size*/)> func,
         const vector_size_t* const rawMaxSizes,
-        vector_size_t firstRowStart) const;
+        vector_size_t firstInnerRowStart) const;
 
-    // First input row to be included in the output.
-    const vector_size_t start;
+    // First input row in 'input_' to be included in the output.
+    const vector_size_t startInputRow;
 
-    // Number of input rows to be included in the output.
-    const vector_size_t size;
+    // Number of input rows to be included in the output starting from
+    // 'startInputRow'.
+    const vector_size_t numInputRows;
 
     // The processing of the last input row starts at index 'firstRowStart_' or
     // 0, depending on whether it is the first row being processed, and ends at
     // 'lastRowEnd'. It is nullopt when the last row is processed completely.
-    const std::optional<vector_size_t> lastRowEnd;
+    const std::optional<vector_size_t> lastInnerRowEnd;
 
     // Total number of inner rows in the range.
-    const vector_size_t numElements;
+    const vector_size_t numInnerRows;
   };
 
   // Extract the range of rows to process.
   // @param size The size of input RowVector.
-  RowRange extractRowRange(vector_size_t size) const;
+  RowRange extractRowRange(vector_size_t inputSize) const;
 
   // Generate output for 'rowRange' represented rows.
   // @param rowRange Range of rows to process.
@@ -140,7 +140,7 @@ class Unnest : public Operator {
   vector_size_t* rawMaxSizes_{nullptr};
 
   // The index to start processing the first row.
-  vector_size_t firstRowStart_ = 0;
+  vector_size_t firstInnerRowStart_ = 0;
 
   std::vector<const vector_size_t*> rawSizes_;
   std::vector<const vector_size_t*> rawOffsets_;


### PR DESCRIPTION
Summary: Unnest operator produce the wrong child column vector size in case of identity map. It simply output the entire base vector in that case. This might cause problem if we only output a subset of unnest inner rows because of output batch size control. The unnest column size might not match the replicated column vector size. This PR fixes this by returning a slice of base vector in that case.

Differential Revision: D75748329


