### PR TITLE
feat: Add lazy multi merge

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2169,6 +2169,10 @@ class LocalMergeNode : public PlanNode {
     return sortingKeys_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return !sortingKeys_.empty() && queryConfig.localMergeSpillEnabled();
+  }
+
   const std::vector<SortOrder>& sortingOrders() const {
     return sortingOrders_;
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -263,6 +263,13 @@ class QueryConfig {
   static constexpr const char* kTopNRowNumberSpillEnabled =
       "topn_row_number_spill_enabled";
 
+  /// LocalMerge spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kLocalMergeSpillEnabled = "local_merge_enabled";
+
+  /// Specify the max number of local sources to merge at a time.
+  static constexpr const char* kLocalMergeMaxNumMergeSources =
+      "local_merge_max_num_merge_sources";
+
   /// The max row numbers to fill and spill for each spill run. This is used to
   /// cap the memory used for spilling. If it is zero, then there is no limit
   /// and spilling might run out of memory.
@@ -837,6 +844,17 @@ class QueryConfig {
 
   bool topNRowNumberSpillEnabled() const {
     return get<bool>(kTopNRowNumberSpillEnabled, true);
+  }
+
+  bool localMergeSpillEnabled() const {
+    return get<bool>(kLocalMergeSpillEnabled, false);
+  }
+
+  uint32_t localMergeMaxNumMergeSources() const {
+    const auto maxNumMergeSources = get<uint32_t>(
+        kLocalMergeMaxNumMergeSources, std::numeric_limits<uint32_t>::max());
+    VELOX_CHECK_GT(maxNumMergeSources, 0);
+    return maxNumMergeSources;
   }
 
   int32_t maxSpillLevel() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -277,6 +277,10 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashBuild and HashProbe operators can spill to disk under memory pressure.
+   * - local_merge_enabled
+     - boolean
+     - false
+     - When `spill_enabled` is true, determines whether LocalMerge operators can spill to disk to cap memory usage.
    * - mixed_grouped_mode_hash_join_spill_enabled
      - boolean
      - false

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/Merge.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 
 using facebook::velox::common::testutil::TestValue;
@@ -43,48 +44,35 @@ Merge::Merge(
         sortingKeys,
     const std::vector<core::SortOrder>& sortingOrders,
     const std::string& planNodeId,
-    const std::string& operatorType)
+    const std::string& operatorType,
+    const std::optional<common::SpillConfig>& spillConfig)
     : SourceOperator(
           driverCtx,
           std::move(outputType),
           operatorId,
           planNodeId,
-          operatorType),
-      outputBatchSize_{outputBatchRows()} {
-  auto numKeys = sortingKeys.size();
-  sortingKeys_.reserve(numKeys);
-  for (int i = 0; i < numKeys; ++i) {
-    auto channel = exprToChannel(sortingKeys[i].get(), outputType_);
-    VELOX_CHECK_NE(
-        channel,
-        kConstantChannel,
-        "Merge doesn't allow constant grouping keys");
-    sortingKeys_.emplace_back(
-        channel,
-        CompareFlags{
-            sortingOrders[i].isNullsFirst(),
-            sortingOrders[i].isAscending(),
-            false});
-  }
-}
-
-void Merge::initializeTreeOfLosers() {
-  std::vector<std::unique_ptr<SourceStream>> sourceCursors;
-  sourceCursors.reserve(sources_.size());
-  for (auto& source : sources_) {
-    sourceCursors.push_back(std::make_unique<SourceStream>(
-        source.get(), sortingKeys_, outputBatchSize_));
-  }
-
-  // Save the pointers to cursors before moving these into the TreeOfLosers.
-  streams_.reserve(sources_.size());
-  for (auto& cursor : sourceCursors) {
-    streams_.push_back(cursor.get());
-  }
-
-  treeOfLosers_ =
-      std::make_unique<TreeOfLosers<SourceStream>>(std::move(sourceCursors));
-}
+          operatorType,
+          spillConfig),
+      outputBatchSize_{outputBatchRows()},
+      sortingKeys_([&]() {
+        auto numKeys = sortingKeys.size();
+        std::vector<SpillSortKey> keys;
+        keys.reserve(numKeys);
+        for (int i = 0; i < numKeys; ++i) {
+          auto channel = exprToChannel(sortingKeys[i].get(), outputType_);
+          VELOX_CHECK_NE(
+              channel,
+              kConstantChannel,
+              "Merge doesn't allow constant grouping keys");
+          keys.emplace_back(
+              channel,
+              CompareFlags{
+                  sortingOrders[i].isNullsFirst(),
+                  sortingOrders[i].isAscending(),
+                  false});
+        }
+        return keys;
+      }()) {}
 
 BlockingReason Merge::isBlocked(ContinueFuture* future) {
   TestValue::adjust("facebook::velox::exec::Merge::isBlocked", this);
@@ -101,18 +89,7 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
     return BlockingReason::kNotBlocked;
   }
 
-  startSources();
-
-  // No merging is needed if there is only one source.
-  if (streams_.empty() && sources_.size() > 1) {
-    initializeTreeOfLosers();
-  }
-
-  if (sourceBlockingFutures_.empty()) {
-    for (auto& cursor : streams_) {
-      cursor->isBlocked(sourceBlockingFutures_);
-    }
-  }
+  maybeStartNextMergeSourceGroup();
 
   if (sourceBlockingFutures_.empty()) {
     return BlockingReason::kNotBlocked;
@@ -123,25 +100,149 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
   return BlockingReason::kWaitForProducer;
 }
 
-void Merge::startSources() {
-  VELOX_CHECK_LE(numStartedSources_, sources_.size());
-  // Start the merge source once.
-  if (numStartedSources_ >= sources_.size()) {
-    return;
-  }
-  VELOX_CHECK_EQ(numStartedSources_, 0);
-  VELOX_CHECK(streams_.empty());
-  VELOX_CHECK(sourceBlockingFutures_.empty());
-  // TODO: support lazy start for local merge with a large number of sources
-  // to cap the memory usage.
-  for (auto& source : sources_) {
-    source->start();
-  }
-  numStartedSources_ = sources_.size();
-}
-
 bool Merge::isFinished() {
   return finished_;
+}
+
+void Merge::maybeSetupOutputSpiller() {
+  VELOX_CHECK(canSpill());
+  if (mergeOutputSpiller_ != nullptr) {
+    return;
+  }
+
+  mergeOutputSpiller_ = std::make_unique<MergeSpiller>(
+      outputType_,
+      std::nullopt,
+      HashBitRange{},
+      sortingKeys_,
+      &spillConfig_.value(),
+      &spillStats_);
+}
+
+void Merge::spill() {
+  if (output_ == nullptr) {
+    return;
+  }
+  maybeSetupOutputSpiller();
+  numSpilledRows_ += output_->size();
+  mergeOutputSpiller_->spill(SpillPartitionId{0}, output_);
+  output_ = nullptr;
+}
+
+void Merge::finishMergeSourceGroup() {
+  sourceMerger_ = nullptr;
+  if (mergeOutputSpiller_ == nullptr) {
+    return;
+  }
+  VELOX_CHECK(needSpill());
+  VELOX_CHECK_GT(numSpilledRows_, 0);
+  // Finishes spill if it has happened and setup spill merger if no more source
+  // to merge.
+  SpillPartitionSet spillPartitionSet;
+  mergeOutputSpiller_->finishSpill(spillPartitionSet);
+  mergeOutputSpiller_ = nullptr;
+  VELOX_CHECK_EQ(spillPartitionSet.size(), 1);
+  auto spillFiles = spillPartitionSet.begin()->second->files();
+  VELOX_CHECK(!spillFiles.empty());
+  spillFileGroups_.push_back(std::move(spillFiles));
+}
+
+void Merge::setupSpillMerger() {
+  VELOX_CHECK(!spillFileGroups_.empty());
+  VELOX_CHECK_NULL(spillMerger_);
+  std::vector<std::vector<std::unique_ptr<SpillReadFile>>> spillReadFilesGroups;
+  spillReadFilesGroups.reserve(spillFileGroups_.size());
+  for (const auto& spillFiles : spillFileGroups_) {
+    std::vector<std::unique_ptr<SpillReadFile>> spillReadFiles;
+    spillReadFiles.reserve(spillFiles.size());
+    for (const auto& spillFile : spillFiles) {
+      spillReadFiles.emplace_back(SpillReadFile::create(
+          spillFile, spillConfig_->readBufferSize, pool(), &spillStats_));
+    }
+    spillReadFilesGroups.push_back(std::move(spillReadFiles));
+  }
+  spillFileGroups_.clear();
+  spillMerger_ = std::make_unique<SpillMerger>(
+      outputType_, numSpilledRows_, std::move(spillReadFilesGroups), pool());
+}
+
+void Merge::maybeStartNextMergeSourceGroup() {
+  SCOPE_EXIT {
+    if (sourceMerger_ != nullptr) {
+      sourceMerger_->isBlocked(sourceBlockingFutures_);
+    }
+  };
+
+  if (sourceMerger_ != nullptr || numStartedSources_ >= sources_.size()) {
+    return;
+  }
+
+  // Gets the merge sources for the next partial merge run.
+  std::vector<MergeSource*> sources;
+  for (auto i = numStartedSources_; i <
+       (std::min(sources_.size(), numStartedSources_ + maxNumMergeSources_));
+       ++i) {
+    sources.push_back(sources_[i].get());
+  }
+
+  // Initializes the source merger.
+  std::vector<std::unique_ptr<SourceStream>> cursors;
+  cursors.reserve(sources.size());
+  for (auto* source : sources) {
+    cursors.push_back(
+        std::make_unique<SourceStream>(source, sortingKeys_, outputBatchSize_));
+  }
+
+  sourceMerger_ =
+      std::make_unique<SourceMerger>(outputType_, std::move(cursors), pool());
+  // Start sources.
+  for (const auto& source : sources) {
+    source->start();
+  }
+  numStartedSources_ += sources.size();
+}
+
+RowVectorPtr Merge::getOutputFromSpill() {
+  VELOX_CHECK_NOT_NULL(spillMerger_);
+  VELOX_CHECK_NULL(sourceMerger_);
+  output_ = spillMerger_->getOutput(outputBatchSize_);
+  if (output_ != nullptr) {
+    return std::move(output_);
+  }
+  spillMerger_.reset();
+  finished_ = true;
+  return nullptr;
+}
+
+RowVectorPtr Merge::getOutputFromSource() {
+  VELOX_CHECK_NULL(spillMerger_);
+  bool atEnd = false;
+  output_ =
+      sourceMerger_->getOutput(outputBatchSize_, sourceBlockingFutures_, atEnd);
+  SCOPE_EXIT {
+    if (!atEnd) {
+      return;
+    }
+
+    finishMergeSourceGroup();
+    if (numStartedSources_ < sources_.size()) {
+      return;
+    }
+
+    if (numSpilledRows_ > 0) {
+      setupSpillMerger();
+      return;
+    }
+    finished_ = true;
+  };
+
+  if (needSpill()) {
+    spill();
+    return nullptr;
+  }
+
+  VELOX_CHECK_EQ(numSpilledRows_, 0);
+  return std::move(output_);
 }
 
 RowVectorPtr Merge::getOutput() {
@@ -149,35 +250,64 @@ RowVectorPtr Merge::getOutput() {
     return nullptr;
   }
 
-  VELOX_CHECK_EQ(numStartedSources_, sources_.size());
-
-  // No merging is needed if there is only one source.
-  if (sources_.size() == 1) {
-    ContinueFuture future;
-    RowVectorPtr data;
-    auto reason = sources_[0]->next(data, &future);
-    if (reason != BlockingReason::kNotBlocked) {
-      sourceBlockingFutures_.emplace_back(std::move(future));
-      return nullptr;
-    }
-
-    finished_ = data == nullptr;
-    return data;
+  // Read from spill.
+  if (spillMerger_ != nullptr) {
+    return getOutputFromSpill();
   }
 
+  return getOutputFromSource();
+}
+
+void Merge::close() {
+  for (auto& source : sources_) {
+    source->close();
+  }
+  Operator::close();
+}
+
+SourceMerger::SourceMerger(
+    const RowTypePtr& type,
+    std::vector<std::unique_ptr<SourceStream>> sourceStreams,
+    velox::memory::MemoryPool* pool)
+    : type_(type),
+      streams_([&sourceStreams]() {
+        std::vector<SourceStream*> streams;
+        for (auto& cursor : sourceStreams) {
+          streams.push_back(cursor.get());
+        }
+        return streams;
+      }()),
+      merger_(std::make_unique<TreeOfLosers<SourceStream>>(
+          std::move(sourceStreams))),
+      pool_(pool) {}
+
+void SourceMerger::isBlocked(
+    std::vector<ContinueFuture>& sourceBlockingFutures) const {
+  if (sourceBlockingFutures.empty()) {
+    for (auto* stream : streams_) {
+      stream->isBlocked(sourceBlockingFutures);
+    }
+  }
+}
+
+RowVectorPtr SourceMerger::getOutput(
+    vector_size_t maxOutputRows,
+    std::vector<ContinueFuture>& sourceBlockingFutures,
+    bool& atEnd) {
+  VELOX_CHECK_NOT_NULL(merger_);
+  atEnd = false;
   if (!output_) {
-    output_ = BaseVector::create<RowVector>(
-        outputType_, outputBatchSize_, operatorCtx_->pool());
+    output_ = BaseVector::create<RowVector>(type_, maxOutputRows, pool_);
     for (auto& child : output_->children()) {
-      child->resize(outputBatchSize_);
+      child->resize(maxOutputRows);
     }
   }
 
   for (;;) {
-    auto stream = treeOfLosers_->next();
+    auto stream = merger_->next();
 
     if (!stream) {
-      finished_ = true;
+      atEnd = true;
 
       // Return nullptr if there is no data.
       if (outputSize_ == 0) {
@@ -192,14 +322,17 @@ RowVectorPtr Merge::getOutput() {
       // The stream is at end of input batch. Need to copy out the rows before
       // fetching next batch in 'pop'.
       stream->copyToOutput(output_);
+      TestValue::adjust(
+          "facebook::velox::exec::SourceMerger::getOutput",
+          &sourceBlockingFutures);
     }
 
     ++outputSize_;
 
     // Advance the stream.
-    stream->pop(sourceBlockingFutures_);
+    stream->pop(sourceBlockingFutures);
 
-    if (outputSize_ == outputBatchSize_) {
+    if (outputSize_ == maxOutputRows) {
       // Copy out data from all sources.
       for (auto& s : streams_) {
         s->copyToOutput(output_);
@@ -209,16 +342,115 @@ RowVectorPtr Merge::getOutput() {
       return std::move(output_);
     }
 
-    if (!sourceBlockingFutures_.empty()) {
+    if (!sourceBlockingFutures.empty()) {
       return nullptr;
     }
   }
 }
 
-void Merge::close() {
-  for (auto& source : sources_) {
-    source->close();
+std::unique_ptr<TreeOfLosers<SpillMergeStream>> SpillMerger::createSpillMerger(
+    std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
+        spillReadFilesGroups) {
+  std::vector<std::unique_ptr<SpillMergeStream>> streams;
+  streams.reserve(spillReadFilesGroups.size());
+  for (auto i = 0; i < spillReadFilesGroups.size(); ++i) {
+    streams.push_back(ConcatFilesSpillMergeStream::create(
+        i, std::move(spillReadFilesGroups[i])));
   }
+  return std::make_unique<TreeOfLosers<SpillMergeStream>>(std::move(streams));
+}
+
+SpillMerger::SpillMerger(
+    const RowTypePtr& type,
+    uint64_t numSpilledRows,
+    std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
+        spillReadFilesGroup,
+    velox::memory::MemoryPool* pool)
+    : type_(type),
+      numSpilledRows_(numSpilledRows),
+      merger_([&spillReadFilesGroup]() {
+        std::vector<std::unique_ptr<SpillMergeStream>> streams;
+        streams.reserve(spillReadFilesGroup.size());
+        for (auto i = 0; i < spillReadFilesGroup.size(); ++i) {
+          streams.push_back(ConcatFilesSpillMergeStream::create(
+              i, std::move(spillReadFilesGroup[i])));
+        }
+        return std::make_unique<TreeOfLosers<SpillMergeStream>>(
+            std::move(streams));
+      }()),
+      pool_(pool) {
+  VELOX_CHECK_NOT_NULL(merger_);
+}
+
+RowVectorPtr SpillMerger::getOutput(vector_size_t maxOutputRows) {
+  // Check if the spill merger has finished.
+  if (numOutputRows_ == numSpilledRows_) {
+    return nullptr;
+  }
+
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numSpilledRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numSpilledRows_ - numOutputRows_, maxOutputRows);
+  if (output_ != nullptr) {
+    VectorPtr output = std::move(output_);
+    BaseVector::prepareForReuse(output, batchSize);
+    output_ = std::static_pointer_cast<RowVector>(output);
+  } else {
+    output_ = std::static_pointer_cast<RowVector>(
+        BaseVector::create(type_, batchSize, pool_));
+  }
+
+  for (const auto& child : output_->children()) {
+    child->resize(batchSize);
+  }
+
+  spillSources_.resize(batchSize);
+  spillSourceRows_.resize(batchSize);
+
+  VELOX_CHECK_GT(output_->size(), 0);
+  VELOX_CHECK_LE(output_->size() + numOutputRows_, numSpilledRows_);
+
+  int32_t outputRow = 0;
+  int32_t outputSize = 0;
+  bool isEndOfBatch = false;
+  while (outputRow + outputSize < output_->size()) {
+    SpillMergeStream* stream = merger_->next();
+    VELOX_CHECK_NOT_NULL(stream);
+
+    spillSources_[outputSize] = &stream->current();
+    spillSourceRows_[outputSize] = stream->currentIndex(&isEndOfBatch);
+    ++outputSize;
+    if (FOLLY_UNLIKELY(isEndOfBatch)) {
+      // The stream is at end of input batch. Need to copy out the rows before
+      // fetching next batch in 'pop'.
+      gatherCopy(
+          output_.get(),
+          outputRow,
+          outputSize,
+          spillSources_,
+          spillSourceRows_,
+          {});
+      outputRow += outputSize;
+      outputSize = 0;
+    }
+    // Advance the stream.
+    stream->pop();
+  }
+  VELOX_CHECK_EQ(outputRow + outputSize, output_->size());
+
+  if (FOLLY_LIKELY(outputSize != 0)) {
+    gatherCopy(
+        output_.get(),
+        outputRow,
+        outputSize,
+        spillSources_,
+        spillSourceRows_,
+        {});
+  }
+
+  numOutputRows_ += output_->size();
+  return std::move(output_);
 }
 
 bool SourceStream::operator<(const MergeStream& other) const {
@@ -312,11 +544,18 @@ LocalMerge::LocalMerge(
           localMergeNode->sortingKeys(),
           localMergeNode->sortingOrders(),
           localMergeNode->id(),
-          "LocalMerge") {
+          "LocalMerge",
+          localMergeNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId)
+              : std::nullopt) {
   VELOX_CHECK_EQ(
       operatorCtx_->driverCtx()->driverId,
       0,
       "LocalMerge needs to run single-threaded");
+  maxNumMergeSources_ = operatorCtx_->task()
+                            ->queryCtx()
+                            ->queryConfig()
+                            .localMergeMaxNumMergeSources();
 }
 
 BlockingReason LocalMerge::addMergeSources(ContinueFuture* /* future */) {

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -120,18 +120,19 @@ class SourceMerger {
  public:
   SourceMerger(
       const RowTypePtr& type,
+      vector_size_t outputBatchSize,
       std::vector<std::unique_ptr<SourceStream>> sourceStreams,
       velox::memory::MemoryPool* pool);
 
   void isBlocked(std::vector<ContinueFuture>& sourceBlockingFutures) const;
 
   RowVectorPtr getOutput(
-      vector_size_t maxOutputRows,
       std::vector<ContinueFuture>& sourceBlockingFutures,
       bool& atEnd);
 
  private:
   const RowTypePtr type_;
+  const vector_size_t outputBatchSize_;
   const std::vector<SourceStream*> streams_;
   const std::unique_ptr<TreeOfLosers<SourceStream>> merger_;
   velox::memory::MemoryPool* const pool_;
@@ -155,10 +156,6 @@ class SpillMerger {
   RowVectorPtr getOutput(vector_size_t maxOutputRows);
 
  private:
-  static std::unique_ptr<TreeOfLosers<SpillMergeStream>> createSpillMerger(
-      std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
-          spillReadFilesGroups);
-
   const RowTypePtr type_;
   // The number of spilled input rows.
   const uint64_t numSpilledRows_;

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -18,11 +18,14 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/MergeSource.h"
 #include "velox/exec/Spill.h"
+#include "velox/exec/Spiller.h"
 #include "velox/exec/TreeOfLosers.h"
 
 namespace facebook::velox::exec {
 
 class SourceStream;
+class SourceMerger;
+class SpillMerger;
 
 // Merge operator Implementation: This implementation uses priority queue
 // to perform a k-way merge of its inputs. It stops merging if any one of
@@ -37,7 +40,8 @@ class Merge : public SourceOperator {
           sortingKeys,
       const std::vector<core::SortOrder>& sortingOrders,
       const std::string& planNodeId,
-      const std::string& operatorType);
+      const std::string& operatorType,
+      const std::optional<common::SpillConfig>& spillConfig = std::nullopt);
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
@@ -56,34 +60,119 @@ class Merge : public SourceOperator {
 
   std::vector<std::shared_ptr<MergeSource>> sources_;
   size_t numStartedSources_{0};
+  /// Maximum number of merge sources per run.
+  uint32_t maxNumMergeSources_{std::numeric_limits<uint32_t>::max()};
 
  private:
-  void startSources();
+  // Start sources for this merge run, it may start either all the sources at
+  // once or a portion of the sources at a time to cap the memory usage.
+  void maybeStartNextMergeSourceGroup();
 
-  void initializeTreeOfLosers();
+  // Returns true if needs to spill the merged source output if all sources can
+  // not be merged at once.
+  bool needSpill() const {
+    return maxNumMergeSources_ < sources_.size();
+  }
+
+  void maybeSetupOutputSpiller();
+
+  // Spill the output of a partial merge sources.
+  void spill();
+
+  // Invoked at the end for each partial merge run to ensure the order within
+  // each spill file.
+  void finishMergeSourceGroup();
+
+  // Create spillMerger_ exactly once if spill has happened.
+  void setupSpillMerger();
+
+  RowVectorPtr getOutputFromSpill();
+
+  RowVectorPtr getOutputFromSource();
 
   /// Maximum number of rows in the output batch.
   const vector_size_t outputBatchSize_;
-
-  std::vector<SpillSortKey> sortingKeys_;
-
-  /// A list of cursors over batches of ordered source data. One per source.
-  /// Aligned with 'sources'.
-  std::vector<SourceStream*> streams_;
-
-  /// Used to merge data from two or more sources.
-  std::unique_ptr<TreeOfLosers<SourceStream>> treeOfLosers_;
+  const std::vector<SpillSortKey> sortingKeys_;
 
   RowVectorPtr output_;
-
   /// Number of rows accumulated in 'output_' so far.
   vector_size_t outputSize_{0};
-
   bool finished_{false};
 
   /// A list of blocking futures for sources. These are populates when a given
   /// source is blocked waiting for the next batch of data.
   std::vector<ContinueFuture> sourceBlockingFutures_;
+
+  std::unique_ptr<SourceMerger> sourceMerger_;
+  std::unique_ptr<SpillMerger> spillMerger_;
+  std::unique_ptr<MergeSpiller> mergeOutputSpiller_;
+  // Number of total spilled rows, it must be equal to the input rows.
+  uint64_t numSpilledRows_{0};
+  // SpillFiles group for all the partial merge runs.
+  std::vector<SpillFiles> spillFileGroups_;
+};
+
+/// A utility class for sort-merging data from upstream sources of the
+/// `LocalMerge` operator. The `LocalMerge` operator may start only a portion of
+/// the sources at a time to cap the memory usage, hence it might perform
+/// multiple sort-merge operations with a subset of merge sources.
+class SourceMerger {
+ public:
+  SourceMerger(
+      const RowTypePtr& type,
+      std::vector<std::unique_ptr<SourceStream>> sourceStreams,
+      velox::memory::MemoryPool* pool);
+
+  void isBlocked(std::vector<ContinueFuture>& sourceBlockingFutures) const;
+
+  RowVectorPtr getOutput(
+      vector_size_t maxOutputRows,
+      std::vector<ContinueFuture>& sourceBlockingFutures,
+      bool& atEnd);
+
+ private:
+  const RowTypePtr type_;
+  const std::vector<SourceStream*> streams_;
+  const std::unique_ptr<TreeOfLosers<SourceStream>> merger_;
+  velox::memory::MemoryPool* const pool_;
+
+  // Reusable output vector.
+  RowVectorPtr output_;
+  uint64_t outputSize_{0};
+};
+
+/// A utility class for sort-merging data from data spilled by the `LocalMerge`
+/// operator.
+class SpillMerger {
+ public:
+  SpillMerger(
+      const RowTypePtr& type,
+      uint64_t numSpilledRows,
+      std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
+          spillReadFilesGroup,
+      velox::memory::MemoryPool* pool);
+
+  RowVectorPtr getOutput(vector_size_t maxOutputRows);
+
+ private:
+  static std::unique_ptr<TreeOfLosers<SpillMergeStream>> createSpillMerger(
+      std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
+          spillReadFilesGroups);
+
+  const RowTypePtr type_;
+  // The number of spilled input rows.
+  const uint64_t numSpilledRows_;
+  // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
+  const std::unique_ptr<TreeOfLosers<SpillMergeStream>> merger_;
+  velox::memory::MemoryPool* const pool_;
+
+  // Records the source rows to copy to 'output_' in order.
+  std::vector<const RowVector*> spillSources_;
+  std::vector<vector_size_t> spillSourceRows_;
+  // Reusable output vector.
+  RowVectorPtr output_;
+  // The number of output rows.
+  uint64_t numOutputRows_{0};
 };
 
 class SourceStream final : public MergeStream {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -698,13 +698,15 @@ class SourceOperator : public Operator {
       RowTypePtr outputType,
       int32_t operatorId,
       const std::string& planNodeId,
-      const std::string& operatorType)
+      const std::string& operatorType,
+      const std::optional<common::SpillConfig>& spillConfig = std::nullopt)
       : Operator(
             driverCtx,
             std::move(outputType),
             operatorId,
             planNodeId,
-            operatorType) {}
+            operatorType,
+            spillConfig) {}
 
   bool needsInput() const override {
     return false;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -386,6 +386,20 @@ NoRowContainerSpiller::NoRowContainerSpiller(
     RowTypePtr rowType,
     std::optional<SpillPartitionId> parentId,
     HashBitRange bits,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<common::SpillStats>* spillStats)
+    : NoRowContainerSpiller(
+          std::move(rowType),
+          parentId,
+          bits,
+          {},
+          spillConfig,
+          spillStats) {}
+
+NoRowContainerSpiller::NoRowContainerSpiller(
+    RowTypePtr rowType,
+    std::optional<SpillPartitionId> parentId,
+    HashBitRange bits,
     const std::vector<SpillSortKey>& sortingKeys,
     const common::SpillConfig* spillConfig,
     folly::Synchronized<common::SpillStats>* spillStats)
@@ -397,20 +411,6 @@ NoRowContainerSpiller::NoRowContainerSpiller(
           spillConfig->maxFileSize,
           0,
           parentId,
-          spillConfig,
-          spillStats) {}
-
-NoRowContainerSpiller::NoRowContainerSpiller(
-    RowTypePtr rowType,
-    std::optional<SpillPartitionId> parentId,
-    HashBitRange bits,
-    const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
-    : NoRowContainerSpiller(
-          std::move(rowType),
-          parentId,
-          bits,
-          {},
           spillConfig,
           spillStats) {}
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -206,14 +206,6 @@ class NoRowContainerSpiller : public SpillerBase {
       RowTypePtr rowType,
       std::optional<SpillPartitionId> parentId,
       HashBitRange bits,
-      const std::vector<SpillSortKey>& sortingKeys,
-      const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
-
-  NoRowContainerSpiller(
-      RowTypePtr rowType,
-      std::optional<SpillPartitionId> parentId,
-      HashBitRange bits,
       const common::SpillConfig* spillConfig,
       folly::Synchronized<common::SpillStats>* spillStats);
 
@@ -227,6 +219,15 @@ class NoRowContainerSpiller : public SpillerBase {
     }
   }
 
+ protected:
+  NoRowContainerSpiller(
+      RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
+      HashBitRange bits,
+      const std::vector<SpillSortKey>& sortingKeys,
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats);
+
  private:
   std::string type() const override {
     return std::string(kType);
@@ -235,6 +236,24 @@ class NoRowContainerSpiller : public SpillerBase {
   bool needSort() const override {
     return false;
   }
+};
+
+class MergeSpiller final : public NoRowContainerSpiller {
+ public:
+  MergeSpiller(
+      RowTypePtr rowType,
+      std::optional<SpillPartitionId> parentId,
+      HashBitRange bits,
+      const std::vector<SpillSortKey>& sortingKeys,
+      const common::SpillConfig* spillConfig,
+      folly::Synchronized<common::SpillStats>* spillStats)
+      : NoRowContainerSpiller(
+            std::move(rowType),
+            parentId,
+            bits,
+            sortingKeys,
+            spillConfig,
+            spillStats) {}
 };
 
 class SortInputSpiller : public SpillerBase {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
+  MergerTest.cpp
   MultiFragmentTest.cpp
   NestedLoopJoinTest.cpp
   OrderByTest.cpp

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -67,7 +67,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
 
   SpillFiles generateSortedSpillFiles(
       const std::vector<RowVectorPtr>& sortedVectors) {
-    const auto spiller = std::make_unique<NoRowContainerSpiller>(
+    const auto spiller = std::make_unique<MergeSpiller>(
         inputType_,
         std::nullopt,
         HashBitRange{},

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -25,6 +28,11 @@ using namespace facebook::velox::common::testutil;
 using namespace facebook::velox::exec::test;
 
 class MergeTest : public OperatorTestBase {
+ public:
+  MergeTest() {
+    filesystems::registerLocalFileSystem();
+  }
+
  protected:
   void testSingleKey(
       const std::vector<RowVectorPtr>& inputVectors,
@@ -33,7 +41,6 @@ class MergeTest : public OperatorTestBase {
 
     std::vector<std::string> sortOrderSqls = {
         "NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
-
     for (const auto& sortOrderSql : sortOrderSqls) {
       const auto orderByClause = fmt::format("{} {}", key, sortOrderSql);
       auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -41,18 +48,17 @@ class MergeTest : public OperatorTestBase {
                       .localMerge(
                           {orderByClause},
                           {PlanBuilder(planNodeIdGenerator)
-                               .values(inputVectors, true)
+                               .values(inputVectors)
                                .orderBy({orderByClause}, true)
                                .planNode()})
                       .planNode();
-
+      // Use single source for local merge.
       CursorParameters params;
       params.planNode = plan;
-      params.maxDrivers = 2;
+      params.maxDrivers = 1;
       assertQueryOrdered(
           params,
-          "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) ORDER BY " +
-              orderByClause,
+          "SELECT * FROM (SELECT * FROM tmp) ORDER BY " + orderByClause,
           {keyIndex});
 
       // Use multiple sources for local merge.
@@ -100,18 +106,17 @@ class MergeTest : public OperatorTestBase {
                         .localMerge(
                             orderByClauses,
                             {PlanBuilder(planNodeIdGenerator)
-                                 .values(inputVectors, true)
+                                 .values(inputVectors)
                                  .orderBy(orderByClauses, true)
                                  .planNode()})
                         .planNode();
-
+        // Use single source for local merge.
         CursorParameters params;
         params.planNode = plan;
-        params.maxDrivers = 2;
+        params.maxDrivers = 1;
         assertQueryOrdered(
             params,
-            "SELECT * FROM (SELECT * FROM tmp UNION ALL SELECT * FROM tmp) " +
-                orderBySql,
+            "SELECT * FROM (SELECT * FROM tmp) " + orderBySql,
             sortingKeys);
 
         // Use multiple sources for local merge.
@@ -131,12 +136,199 @@ class MergeTest : public OperatorTestBase {
       }
     }
   }
+
+  void testSingleKeyWithSpill(
+      const std::vector<RowVectorPtr>& inputVectors,
+      const std::string& key) {
+    auto keyIndex = inputVectors[0]->type()->asRow().getChildIdx(key);
+
+    std::vector<std::string> sortOrderSqls = {
+        "NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
+
+    for (const auto& sortOrderSql : sortOrderSqls) {
+      const auto orderByClause = fmt::format("{} {}", key, sortOrderSql);
+      const auto planNodeIdGenerator =
+          std::make_shared<core::PlanNodeIdGenerator>();
+      const std::shared_ptr<TempDirectoryPath> spillDirectory =
+          TempDirectoryPath::create();
+      std::vector<std::shared_ptr<const core::PlanNode>> sources;
+      for (const auto& input : inputVectors) {
+        sources.push_back(PlanBuilder(planNodeIdGenerator)
+                              .values({input})
+                              .orderBy({orderByClause}, true)
+                              .planNode());
+      }
+      core::PlanNodeId nodeId;
+      const auto plan = PlanBuilder(planNodeIdGenerator)
+                            .localMerge({orderByClause}, std::move(sources))
+                            .capturePlanNodeId(nodeId)
+                            .planNode();
+      CursorParameters params;
+      params.planNode = plan;
+      params.maxDrivers = 2;
+      params.queryConfigs = {
+          {"spill_enabled", "true"},
+          {"local_merge_enabled", "true"},
+          {"local_merge_max_num_merge_sources", "2"}};
+      params.spillDirectory = spillDirectory->getPath();
+      auto task = assertQueryOrdered(
+          params, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+      auto taskStats = toPlanStats(task->taskStats());
+      auto& planStats = taskStats.at(nodeId);
+      auto expectedNumSpillFiles = (inputVectors.size() + 2 - 1) / 2;
+      ASSERT_GT(planStats.spilledBytes, 0);
+      ASSERT_EQ(planStats.spilledPartitions, expectedNumSpillFiles);
+      ASSERT_EQ(planStats.spilledFiles, expectedNumSpillFiles);
+      ASSERT_EQ(
+          planStats.spilledRows, inputVectors.size() * inputVectors[0]->size());
+    }
+  }
+
+  void testTwoKeysWithSpill(
+      const std::vector<RowVectorPtr>& inputVectors,
+      const std::string& key1,
+      const std::string& key2) {
+    auto& rowType = inputVectors[0]->type()->asRow();
+    auto sortingKeys = {rowType.getChildIdx(key1), rowType.getChildIdx(key2)};
+
+    std::vector<core::SortOrder> sortOrders = {
+        core::kAscNullsLast,
+        core::kAscNullsFirst,
+        core::kDescNullsFirst,
+        core::kDescNullsLast};
+    std::vector<std::string> sortOrderSqls = {
+        "NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
+
+    for (auto i = 0; i < sortOrders.size(); ++i) {
+      for (auto j = 0; j < sortOrders.size(); ++j) {
+        const std::vector<std::string> orderByClauses = {
+            fmt::format("{} {}", key1, sortOrderSqls[i]),
+            fmt::format("{} {}", key2, sortOrderSqls[j])};
+        const auto orderBySql = fmt::format(
+            "ORDER BY {}, {}", orderByClauses[0], orderByClauses[1]);
+        const auto planNodeIdGenerator =
+            std::make_shared<core::PlanNodeIdGenerator>();
+        const std::shared_ptr<TempDirectoryPath> spillDirectory =
+            TempDirectoryPath::create();
+        std::vector<std::shared_ptr<const core::PlanNode>> sources;
+        for (const auto& input : inputVectors) {
+          sources.push_back(PlanBuilder(planNodeIdGenerator)
+                                .values({input})
+                                .orderBy(orderByClauses, true)
+                                .planNode());
+        }
+        core::PlanNodeId nodeId;
+        const auto plan = PlanBuilder(planNodeIdGenerator)
+                              .localMerge({orderByClauses}, std::move(sources))
+                              .capturePlanNodeId(nodeId)
+                              .planNode();
+        CursorParameters params;
+        params.planNode = plan;
+        params.maxDrivers = 2;
+        params.queryConfigs = {
+            {"spill_enabled", "true"},
+            {"local_merge_enabled", "true"},
+            {"local_merge_max_num_merge_sources", "2"}};
+        params.spillDirectory = spillDirectory->getPath();
+        auto task = assertQueryOrdered(
+            params, "SELECT * FROM tmp " + orderBySql, sortingKeys);
+        auto taskStats = toPlanStats(task->taskStats());
+        auto& planStats = taskStats.at(nodeId);
+        auto expectedNumSpillFiles = (inputVectors.size() + 2 - 1) / 2;
+        ASSERT_GT(planStats.spilledBytes, 0);
+        ASSERT_EQ(planStats.spilledPartitions, expectedNumSpillFiles);
+        ASSERT_EQ(planStats.spilledFiles, expectedNumSpillFiles);
+        ASSERT_EQ(
+            planStats.spilledRows,
+            inputVectors.size() * inputVectors[0]->size());
+      }
+    }
+  }
+
+  void testLocalMergeSpill(
+      const uint32_t batchSize,
+      const uint32_t numMaxMergeSources) {
+    std::vector<std::vector<RowVectorPtr>> inputVectors;
+    for (int32_t i = 0; i < 9; ++i) {
+      std::vector<RowVectorPtr> vectors;
+      for (int32_t i = 0; i < 3; ++i) {
+        auto c0 = makeFlatVector<int64_t>(
+            batchSize,
+            [&](auto row) { return batchSize * i + row; },
+            nullEvery(5));
+        auto c1 = makeFlatVector<int64_t>(
+            batchSize, [&](auto row) { return row; }, nullEvery(5));
+        auto c2 = makeFlatVector<double>(
+            batchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+        auto c3 = makeFlatVector<StringView>(batchSize, [](auto row) {
+          return StringView::makeInline(std::to_string(row));
+        });
+        vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+      }
+      inputVectors.push_back(std::move(vectors));
+    }
+    std::vector<RowVectorPtr> duckInputs;
+    for (const auto& input : inputVectors) {
+      for (const auto& vector : input) {
+        duckInputs.push_back(vector);
+      }
+    }
+    createDuckDbTable(duckInputs);
+    auto keyIndex = inputVectors[0][0]->type()->asRow().getChildIdx("c0");
+
+    const auto orderByClause = fmt::format("{}", "c0");
+    const auto planNodeIdGenerator =
+        std::make_shared<core::PlanNodeIdGenerator>();
+    const std::shared_ptr<TempDirectoryPath> spillDirectory =
+        TempDirectoryPath::create();
+    std::vector<std::shared_ptr<const core::PlanNode>> sources;
+    sources.reserve(inputVectors.size());
+    for (const auto& vectors : inputVectors) {
+      sources.push_back(PlanBuilder(planNodeIdGenerator)
+                            .values(vectors)
+                            .orderBy({orderByClause}, true)
+                            .planNode());
+    }
+    core::PlanNodeId nodeId;
+    const auto plan = PlanBuilder(planNodeIdGenerator)
+                          .localMerge({orderByClause}, std::move(sources))
+                          .capturePlanNodeId(nodeId)
+                          .planNode();
+    CursorParameters params;
+    params.planNode = plan;
+    params.maxDrivers = 2;
+    params.queryConfigs = {
+        {"spill_enabled", "true"},
+        {"local_merge_enabled", "true"},
+        {"local_merge_max_num_merge_sources",
+         std::to_string(numMaxMergeSources)}};
+    params.spillDirectory = spillDirectory->getPath();
+    auto task = assertQueryOrdered(
+        params, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+
+    auto taskStats = toPlanStats(task->taskStats());
+    auto& planStats = taskStats.at(nodeId);
+    if (batchSize == 0 || numMaxMergeSources >= inputVectors.size()) {
+      ASSERT_EQ(planStats.spilledBytes, 0);
+      ASSERT_EQ(planStats.spilledPartitions, 0);
+      ASSERT_EQ(planStats.spilledFiles, 0);
+      ASSERT_EQ(planStats.spilledRows, 0);
+    } else {
+      const auto expectedFiles =
+          (inputVectors.size() + numMaxMergeSources - 1) / numMaxMergeSources;
+      const auto expectedSpillRows = batchSize * duckInputs.size();
+      ASSERT_GT(planStats.spilledBytes, 0);
+      ASSERT_EQ(planStats.spilledPartitions, expectedFiles);
+      ASSERT_EQ(planStats.spilledFiles, expectedFiles);
+      ASSERT_EQ(planStats.spilledRows, expectedSpillRows);
+    }
+  }
 };
 
-TEST_F(MergeTest, localMerge) {
-  vector_size_t batchSize = 1000;
+TEST_F(MergeTest, localMergeSpillBasic) {
   std::vector<RowVectorPtr> vectors;
-  for (int32_t i = 0; i < 3; ++i) {
+  for (int32_t i = 0; i < 9; ++i) {
+    constexpr vector_size_t batchSize = 137;
     auto c0 = makeFlatVector<int64_t>(
         batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
     auto c1 = makeFlatVector<int64_t>(
@@ -144,6 +336,189 @@ TEST_F(MergeTest, localMerge) {
     auto c2 = makeFlatVector<double>(
         batchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
     auto c3 = makeFlatVector<StringView>(batchSize, [](auto row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+
+  testSingleKeyWithSpill(vectors, "c0");
+  testSingleKeyWithSpill(vectors, "c3");
+
+  testTwoKeysWithSpill(vectors, "c0", "c3");
+  testTwoKeysWithSpill(vectors, "c3", "c0");
+}
+
+TEST_F(MergeTest, localMergeSpill) {
+  struct TestParam {
+    uint32_t maxNumMergeSources;
+    uint32_t batchSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxNumMergeSources {}, batchSize {}", maxNumMergeSources, batchSize);
+    }
+  } testSettings[]{
+      {1, 0},
+      {10, 0},
+      {1, 30},
+      {3, 30},
+      {8, 30},
+      {9, 30},
+      {std::numeric_limits<uint32_t>::max(), 30}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    testLocalMergeSpill(testData.batchSize, testData.maxNumMergeSources);
+  }
+}
+
+TEST_F(MergeTest, localMergeSpillPartialEmpty) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 9; ++i) {
+    auto batchSize = 30;
+    if (i % 2 == 0) {
+      batchSize = 0;
+    }
+
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        batchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+    auto c3 = makeFlatVector<StringView>(batchSize, [](auto row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+  auto keyIndex = vectors[0]->type()->asRow().getChildIdx("c0");
+
+  const auto orderByClause = fmt::format("{}", "c0");
+  const auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  const std::shared_ptr<TempDirectoryPath> spillDirectory =
+      TempDirectoryPath::create();
+  std::vector<std::shared_ptr<const core::PlanNode>> sources;
+  sources.reserve(vectors.size());
+  for (const auto& vector : vectors) {
+    sources.push_back(PlanBuilder(planNodeIdGenerator)
+                          .values({vector})
+                          .orderBy({orderByClause}, true)
+                          .planNode());
+  }
+  core::PlanNodeId nodeId;
+  const auto plan = PlanBuilder(planNodeIdGenerator)
+                        .localMerge({orderByClause}, std::move(sources))
+                        .capturePlanNodeId(nodeId)
+                        .planNode();
+  CursorParameters params;
+  params.planNode = plan;
+  params.maxDrivers = 2;
+  params.queryConfigs = {
+      {"spill_enabled", "true"},
+      {"local_merge_enabled", "true"},
+      {"local_merge_max_num_merge_sources", "2"}};
+  params.spillDirectory = spillDirectory->getPath();
+  auto task = assertQueryOrdered(
+      params, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+
+  auto taskStats = toPlanStats(task->taskStats());
+  auto& planStats = taskStats.at(nodeId);
+  ASSERT_GT(planStats.spilledBytes, 0);
+  ASSERT_EQ(planStats.spilledPartitions, 4);
+  ASSERT_EQ(planStats.spilledFiles, 4);
+  ASSERT_EQ(planStats.spilledRows, 120);
+}
+
+DEBUG_ONLY_TEST_F(MergeTest, localMergeSmallBatch) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 9; ++i) {
+    auto batchSize = 30;
+    if (i != 0) {
+      batchSize = 0;
+    }
+
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return batchSize * i + row; }, nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        batchSize, [&](auto row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        batchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+    auto c3 = makeFlatVector<StringView>(batchSize, [](auto row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+  auto keyIndex = vectors[0]->type()->asRow().getChildIdx("c0");
+
+  const auto orderByClause = fmt::format("{}", "c0");
+  const auto planNodeIdGenerator =
+      std::make_shared<core::PlanNodeIdGenerator>();
+  const std::shared_ptr<TempDirectoryPath> spillDirectory =
+      TempDirectoryPath::create();
+  std::vector<std::shared_ptr<const core::PlanNode>> sources;
+  sources.reserve(vectors.size());
+  for (const auto& vector : vectors) {
+    sources.push_back(PlanBuilder(planNodeIdGenerator)
+                          .values({vector})
+                          .orderBy({orderByClause}, true)
+                          .planNode());
+  }
+  core::PlanNodeId nodeId;
+  const auto plan = PlanBuilder(planNodeIdGenerator)
+                        .localMerge({orderByClause}, std::move(sources))
+                        .capturePlanNodeId(nodeId)
+                        .planNode();
+
+  std::atomic_bool blockFlag{true};
+  folly::Promise<folly::Unit> promise;
+  folly::EventCount callWait;
+  std::atomic_bool callWaitFlag{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::SourceMerger::getOutput",
+      std::function<void(std::vector<ContinueFuture>*)>(
+          [&](std::vector<ContinueFuture>* sourceBlockingFutures) {
+            if (blockFlag) {
+              blockFlag = false;
+              auto [p, f] = folly::makePromiseContract<folly::Unit>();
+              sourceBlockingFutures->push_back(std::move(f));
+              promise = std::move(p);
+              callWaitFlag = false;
+              callWait.notifyAll();
+            }
+          }));
+
+  std::thread promiseThread([&]() {
+    callWait.await([&]() { return !callWaitFlag.load(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(1'000)); // NOLINT
+    promise.setValue();
+  });
+
+  CursorParameters params;
+  params.planNode = plan;
+  auto task = assertQueryOrdered(
+      params, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+  auto taskStats = toPlanStats(task->taskStats());
+  ASSERT_EQ(taskStats[nodeId].outputRows, 30);
+  ASSERT_EQ(taskStats[nodeId].outputVectors, 1);
+  promiseThread.join();
+}
+
+TEST_F(MergeTest, localMerge) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 3; ++i) {
+    static constexpr vector_size_t kBatchSize = 100;
+    auto c0 = makeFlatVector<int64_t>(
+        kBatchSize,
+        [&](auto row) { return kBatchSize * i + row; },
+        nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        kBatchSize, [&](auto row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        kBatchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+    auto c3 = makeFlatVector<StringView>(kBatchSize, [](auto row) {
       return StringView::makeInline(std::to_string(row));
     });
     vectors.push_back(makeRowVector({c0, c1, c2, c3}));

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/Merge.h"
+#include "velox/exec/MergeSource.h"
+#include "velox/exec/SortBuffer.h"
+#include "velox/exec/Spill.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::exec::test {
+
+class MergerTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+  }
+
+  std::vector<RowVectorPtr> generateSortedVectors(
+      const int32_t numVectors,
+      const size_t vectorSize) {
+    const VectorFuzzer::Options fuzzerOpts{.vectorSize = vectorSize};
+    const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
+    const auto sortBuffer = std::make_unique<SortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        common::PrefixSortConfig{},
+        nullptr,
+        nullptr);
+    for (const auto& vector : vectors) {
+      sortBuffer->addInput(vector);
+    }
+    sortBuffer->noMoreInput();
+    std::vector<RowVectorPtr> sortedVectors;
+    sortedVectors.reserve(numVectors);
+    for (auto i = 0; i < numVectors; ++i) {
+      sortedVectors.emplace_back(sortBuffer->getOutput(vectorSize));
+    }
+    return sortedVectors;
+  }
+
+  SpillFiles generateSortedSpillFiles(
+      const std::vector<RowVectorPtr>& sortedVectors) {
+    const auto spiller = std::make_unique<MergeSpiller>(
+        inputType_,
+        std::nullopt,
+        HashBitRange{},
+        sortingKeys_,
+        &spillConfig_,
+        &spillStats_);
+    for (const auto& vector : sortedVectors) {
+      spiller->spill(SpillPartitionId(0), vector);
+    }
+    SpillPartitionSet spillPartitionSet;
+    spiller->finishSpill(spillPartitionSet);
+    EXPECT_EQ(spillPartitionSet.size(), 1);
+    return spillPartitionSet.cbegin()->second->files();
+  }
+
+  std::pair<
+      std::vector<std::vector<RowVectorPtr>>,
+      std::vector<std::vector<std::unique_ptr<SpillReadFile>>>>
+  generateInputs(size_t numStreams, size_t vectorSize) {
+    std::vector<std::vector<RowVectorPtr>> totalVectors;
+    std::vector<std::vector<std::unique_ptr<SpillReadFile>>>
+        spillReadFilesGroups;
+    for (auto i = 1; i <= numStreams; ++i) {
+      const auto vectors = generateSortedVectors(i * 3 + 1, vectorSize);
+      totalVectors.push_back(vectors);
+      const auto spillFiles = generateSortedSpillFiles(vectors);
+      EXPECT_EQ(spillFiles.size(), vectors.size());
+      std::vector<std::unique_ptr<SpillReadFile>> spillReadFiles;
+      spillReadFiles.reserve(spillFiles.size());
+      for (const auto& spillFile : spillFiles) {
+        spillReadFiles.emplace_back(SpillReadFile::create(
+            spillFile, spillConfig_.readBufferSize, pool_.get(), &spillStats_));
+      }
+      spillReadFilesGroups.emplace_back(std::move(spillReadFiles));
+    }
+    return std::make_pair(
+        std::move(totalVectors), std::move(spillReadFilesGroups));
+  }
+
+  std::vector<RowVectorPtr> makeExpectedResults(
+      const std::vector<std::vector<RowVectorPtr>>& inputs,
+      size_t vectorSize) {
+    std::vector<RowVectorPtr> flatInputs;
+    for (const auto& vectors : inputs) {
+      for (const auto& vector : vectors) {
+        flatInputs.emplace_back(vector);
+      }
+    }
+    const auto sortBuffer = std::make_unique<SortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        common::PrefixSortConfig{},
+        nullptr,
+        nullptr);
+    for (const auto& vector : flatInputs) {
+      sortBuffer->addInput(vector);
+    }
+    sortBuffer->noMoreInput();
+    std::vector<RowVectorPtr> sortedVectors;
+    sortedVectors.reserve(flatInputs.size());
+    for (auto i = 0; i < flatInputs.size(); ++i) {
+      sortedVectors.emplace_back(sortBuffer->getOutput(vectorSize));
+    }
+    return sortedVectors;
+  }
+
+  std::unique_ptr<SourceMerger> createSourceMerger(
+      const std::vector<std::shared_ptr<MergeSource>>& sources,
+      uint64_t outputBatchSize) {
+    std::vector<std::unique_ptr<SourceStream>> sourceStreams;
+    for (const auto& source : sources) {
+      sourceStreams.push_back(std::make_unique<SourceStream>(
+          source.get(), sortingKeys_, outputBatchSize));
+    }
+    return std::make_unique<SourceMerger>(
+        inputType_, outputBatchSize, std::move(sourceStreams), pool());
+  }
+
+  static std::vector<std::shared_ptr<MergeSource>> createMergeSources(int num) {
+    std::vector<std::shared_ptr<MergeSource>> sources;
+    sources.reserve(num);
+    for (auto i = 0; i < num; ++i) {
+      sources.push_back(MergeSource::createLocalMergeSource());
+    }
+    for (const auto& source : sources) {
+      source->start();
+    }
+    return sources;
+  }
+
+  static void enqueueMergeSources(
+      MergeSource* mergeSource,
+      const RowVectorPtr& vector) {
+    ContinueFuture future;
+    auto blockingReason = mergeSource->enqueue(vector, &future);
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      future.wait();
+    }
+  }
+
+  static std::vector<std::thread> createProducers(
+      int num,
+      const std::vector<std::vector<RowVectorPtr>>& inputs,
+      const std::vector<std::shared_ptr<MergeSource>>& sources) {
+    std::vector<std::thread> producers;
+    producers.reserve(num);
+    for (auto i = 0; i < num; ++i) {
+      producers.emplace_back([&, i]() {
+        auto* mergeSource = sources[i].get();
+        const auto& vectors = inputs[i];
+        for (const auto& vector : vectors) {
+          enqueueMergeSources(mergeSource, vector);
+        }
+        // Enqueue an end signal.
+        enqueueMergeSources(mergeSource, nullptr);
+      });
+    }
+    return producers;
+  }
+
+  static std::vector<RowVectorPtr> getOutputFromSourceMerger(
+      SourceMerger* sourceMerger) {
+    std::vector<ContinueFuture> sourceBlockingFutures;
+    std::vector<RowVectorPtr> results;
+    for (;;) {
+      sourceMerger->isBlocked(sourceBlockingFutures);
+      if (!sourceBlockingFutures.empty()) {
+        auto future = std::move(sourceBlockingFutures.back());
+        sourceBlockingFutures.pop_back();
+        future.wait();
+        continue;
+      }
+
+      bool atEnd = false;
+      auto output = sourceMerger->getOutput(sourceBlockingFutures, atEnd);
+      if (output != nullptr) {
+        results.emplace_back(std::move(output));
+      }
+      if (atEnd) {
+        break;
+      }
+    }
+    return results;
+  }
+
+  std::unique_ptr<SpillMerger> createSpillMerger(
+      std::vector<std::vector<std::unique_ptr<SpillReadFile>>> filesGroup,
+      uint64_t numSpillRows) const {
+    return std::make_unique<SpillMerger>(
+        inputType_, numSpillRows, std::move(filesGroup), pool());
+  }
+
+  static std::vector<RowVectorPtr> getOutputFromSpillMerger(
+      SpillMerger* spillMerger,
+      uint64_t maxOutputRows) {
+    std::vector<RowVectorPtr> results;
+    for (;;) {
+      auto output = spillMerger->getOutput(maxOutputRows);
+      if (output == nullptr) {
+        break;
+      }
+      results.emplace_back(std::move(output));
+    }
+    return results;
+  }
+
+  static void checkResults(
+      std::vector<RowVectorPtr> expectedResults,
+      std::vector<RowVectorPtr> actualResults) {
+    ASSERT_TRUE(assertEqualResults(expectedResults, actualResults));
+    const auto& actual = actualResults[0];
+    std::for_each(
+        std::next(actualResults.begin()),
+        actualResults.end(),
+        [&](const auto& ele) { actual->append(ele.get()); });
+    const auto& expect = expectedResults[0];
+    std::for_each(
+        std::next(expectedResults.begin()),
+        expectedResults.end(),
+        [&](const auto& ele) { expect->append(ele.get()); });
+    facebook::velox::test::assertEqualVectors(expect, actual);
+  }
+
+ private:
+  const RowTypePtr inputType_ = ROW({{"c0", BIGINT()}, {"c1", SMALLINT()}});
+  const std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+  const std::vector<column_index_t> sortColumnIndices_{0, 1};
+  const std::vector<CompareFlags> sortCompareFlags_{
+      CompareFlags{.ascending = true},
+      CompareFlags{.ascending = false}};
+  const std::vector<SpillSortKey> sortingKeys_ =
+      SpillState::makeSortingKeys(sortColumnIndices_, sortCompareFlags_);
+  const std::shared_ptr<TempDirectoryPath> spillDirectory_ =
+      exec::test::TempDirectoryPath::create();
+  const common::SpillConfig spillConfig_{
+      [&]() -> const std::string& { return spillDirectory_->getPath(); },
+      [&](uint64_t) {},
+      "0.0.0",
+      10, // Force to create a file per spill to mock multiple files per stream
+      0,
+      1 << 20,
+      executor_.get(),
+      100,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0,
+      "none",
+      std::nullopt};
+
+  folly::Synchronized<common::SpillStats> spillStats_;
+  tsan_atomic<bool> nonReclaimableSection_{false};
+};
+} // namespace facebook::velox::exec::test
+
+TEST_F(MergerTest, sourceMerger) {
+  struct {
+    size_t maxOutputRows;
+    size_t numSources;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxOutputRows:{} numStreams:{}", maxOutputRows, numSources);
+    }
+  } testSettings[] = {
+      {1, 1},
+      {1, 3},
+      {1, 8},
+      {7, 1},
+      {7, 3},
+      {7, 8},
+      {16, 1},
+      {16, 3},
+      {16, 8},
+      {32, 3},
+      {1024, 8}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    std::vector<std::vector<RowVectorPtr>> inputs;
+    for (auto i = 1; i <= testData.numSources; ++i) {
+      inputs.emplace_back(generateSortedVectors(i, 16));
+    }
+    const auto sources = createMergeSources(testData.numSources);
+    auto producers = createProducers(testData.numSources, inputs, sources);
+    const auto sourceMerger =
+        createSourceMerger(sources, testData.maxOutputRows);
+    const auto results = getOutputFromSourceMerger(sourceMerger.get());
+    for (auto& producer : producers) {
+      producer.join();
+    }
+    const auto expectedResults = makeExpectedResults(inputs, 16);
+    checkResults(expectedResults, results);
+  }
+}
+
+TEST_F(MergerTest, sourceMergerWithEmptySources) {
+  std::vector<std::vector<RowVectorPtr>> inputs;
+  for (auto i = 0; i < 10; ++i) {
+    const auto numVectors = (i % 2 == 0) ? 0 : i;
+    inputs.emplace_back(generateSortedVectors(numVectors, 16));
+  }
+  const auto sources = createMergeSources(10);
+  auto producers = createProducers(10, inputs, sources);
+  const auto sourceMerger = createSourceMerger(sources, 32);
+  const auto results = getOutputFromSourceMerger(sourceMerger.get());
+  for (auto& producer : producers) {
+    producer.join();
+  }
+  const auto expectedResults = makeExpectedResults(inputs, 16);
+  checkResults(expectedResults, results);
+}
+
+TEST_F(MergerTest, spilMerger) {
+  struct {
+    size_t maxOutputRows;
+    size_t numSources;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxOutputRows:{} numStreams:{}", maxOutputRows, numSources);
+    }
+  } testSettings[] = {
+      {1, 1},
+      {1, 3},
+      {1, 8},
+      {7, 1},
+      {7, 3},
+      {7, 8},
+      {16, 1},
+      {16, 3},
+      {16, 8},
+      {32, 3},
+      {1024, 8}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto [inputs, filesGroup] = generateInputs(testData.numSources, 16);
+    uint64_t numSpillRows = 0;
+    for (const auto& vectors : inputs) {
+      for (const auto& vector : vectors) {
+        numSpillRows += vector->size();
+      }
+    }
+    const auto spillMerger =
+        createSpillMerger(std::move(filesGroup), numSpillRows);
+    const auto results =
+        getOutputFromSpillMerger(spillMerger.get(), testData.maxOutputRows);
+    const auto expectedResults = makeExpectedResults(inputs, 16);
+    checkResults(expectedResults, results);
+  }
+}


### PR DESCRIPTION
The `LocalMerge` operator may start only a subset of the sources at a time
to limit memory usage. Hence, it performs multiple partial sort-merge operations,
each handling a subset of the merge sources. It spills the results produced by each subset
and finishes the spill to ensure the order both within and across all spill files for each partial merge.
Finally, creates a `ConcatFilesSpillMergeStream` for each group of spill files of each partial merge ,
setup a `SpillMerger` using those  `ConcatFilesSpillMergeStream` to perform the final sort-merge
of the outputs.

Parts of #13260