### PR TITLE
refactor: Replace 'typedef' with 'using'

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -31,7 +31,7 @@ namespace facebook::velox::core {
 class PlanNodeVisitor;
 class PlanNodeVisitorContext;
 
-typedef std::string PlanNodeId;
+using PlanNodeId = std::string;
 
 /// Generic representation of InsertTable
 struct InsertTableHandle {
@@ -301,7 +301,7 @@ class PlanNode : public ISerializable {
       std::stringstream& stream,
       size_t indentationSize) const;
 
-  const std::string id_;
+  const PlanNodeId id_;
 };
 
 using PlanNodePtr = std::shared_ptr<const PlanNode>;


### PR DESCRIPTION
In modern C++, `using` is preferred over `typedef` for defining aliases.

There is also a " modernize-use-using " rule in clang-tidy, see [1].

No functional changes.

[1] https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html