### PR TITLE
test: Exclude bing_tile functions from expression fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -153,6 +153,16 @@ int main(int argc, char** argv) {
       "st_issimple",
       "geometry_invalid_reason",
       "simplify_geometry",
+      // bing_tile functions:
+      // https://github.com/facebookincubator/velox/issues/13593
+      "bing_tile",
+      "bing_tile_zoom_level",
+      "bing_tile_coordinates",
+      "bing_tile_parent",
+      "bing_tile_children",
+      "bing_tile_quadkey"
+      "bing_tile_at",
+      "bing_tiles_around",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 


### PR DESCRIPTION
Summary: Some fuzzer tests are failing: https://github.com/facebookincubator/velox/actions/runs/15370535592/job/43249537201

Differential Revision: D75762689


