### PR TITLE
feat(date): Add support for Teradata date function `to_char`

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -2184,9 +2184,10 @@ Expected<std::shared_ptr<DateTimeFormatter>> buildTeradataDateTimeFormatter(
             if (threadSkipErrorDetails()) {
               return folly::makeUnexpected(Status::UserError());
             }
-            return folly::makeUnexpected(Status::UserError(
-                "Specifier {} is not supported or number of digits is not supported.",
-                *startTokenPtr));
+            return folly::makeUnexpected(
+                Status::UserError(
+                    "Specifier {} is not supported or number of digits is not supported.",
+                    *startTokenPtr));
           } else {
             builder.appendLiteral(startTokenPtr, 1);
           }

--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -34,6 +34,7 @@ enum class DateTimeFormatterType {
   // Corresponding to java.text.SimpleDateFormat in strict(lenient=false) mode.
   // It is used by Spark 'cast date to string'.
   STRICT_SIMPLE,
+  TERADATA,
   UNKNOWN
 };
 
@@ -231,6 +232,9 @@ Expected<std::shared_ptr<DateTimeFormatter>> buildJodaDateTimeFormatter(
 Expected<std::shared_ptr<DateTimeFormatter>> buildSimpleDateTimeFormatter(
     const std::string_view& format,
     bool lenient);
+
+Expected<std::shared_ptr<DateTimeFormatter>> buildTeradataDateTimeFormatter(
+    const std::string_view& format);
 
 } // namespace facebook::velox::functions
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -251,11 +251,18 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "date_format"});
   registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
       {prefix + "format_datetime"});
+  registerFunction<TeradataDateToCharFunction, Varchar, Timestamp, Varchar>(
+      {prefix + "to_char"});
   registerFunction<
       FormatDateTimeFunction,
       Varchar,
       TimestampWithTimezone,
       Varchar>({prefix + "format_datetime"});
+  registerFunction<
+      TeradataDateToCharFunction,
+      Varchar,
+      TimestampWithTimezone ,
+      Varchar>({prefix + "to_char"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -261,7 +261,7 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<
       TeradataDateToCharFunction,
       Varchar,
-      TimestampWithTimezone ,
+      TimestampWithTimezone,
       Varchar>({prefix + "to_char"});
   registerFunction<
       ParseDateTimeFunction,

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3886,9 +3886,8 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
 
 TEST_F(DateTimeFunctionsTest, teradataDateToChar) {
   const auto toChar = [&](std::optional<Timestamp> timestamp,
-                                  std::optional<std::string> format) {
-    return evaluateOnce<std::string>(
-        "to_char(c0, c1)", timestamp, format);
+                          std::optional<std::string> format) {
+    return evaluateOnce<std::string>("to_char(c0, c1)", timestamp, format);
   };
 
   // Day of month test cases - 'dd'
@@ -3898,9 +3897,7 @@ TEST_F(DateTimeFunctionsTest, teradataDateToChar) {
   for (int i = 0; i < 24; i++) {
     std::string buildString = "2022-01-01 " + padNumber(i) + ":00:00";
     StringView date(buildString);
-    EXPECT_EQ(
-        padNumber((i + 11) % 12 + 1),
-        toChar(parseTimestamp(date), "hh"));
+    EXPECT_EQ(padNumber((i + 11) % 12 + 1), toChar(parseTimestamp(date), "hh"));
   }
 
   // Hour of day test cases - 'hh24'
@@ -3921,9 +3918,7 @@ TEST_F(DateTimeFunctionsTest, teradataDateToChar) {
   for (int i = 0; i < 12; i++) {
     auto month = i + 1;
     std::string date("2022-" + std::to_string(month) + "-01");
-    EXPECT_EQ(
-        padNumber(month),
-        toChar(parseTimestamp(StringView{date}), "mm"));
+    EXPECT_EQ(padNumber(month), toChar(parseTimestamp(StringView{date}), "mm"));
   }
 
   // Second of minute test cases - 's'
@@ -3938,15 +3933,19 @@ TEST_F(DateTimeFunctionsTest, teradataDateToChar) {
   EXPECT_EQ("2022", toChar(parseTimestamp("2022-06-20"), "yyyy"));
 
   // General test cases
-  EXPECT_EQ("2022-01-01", toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd"));
-  EXPECT_EQ("2022-01-01 00:00:00", toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd hh24:mi:ss"));
-  EXPECT_EQ("2022-01-01 12:00:00", toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd hh:mi:ss"));
+  EXPECT_EQ(
+      "2022-01-01",
+      toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd"));
+  EXPECT_EQ(
+      "2022-01-01 00:00:00",
+      toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd hh24:mi:ss"));
+  EXPECT_EQ(
+      "2022-01-01 12:00:00",
+      toChar(parseTimestamp("2022-01-01 00:00:00"), "yyyy-mm-dd hh:mi:ss"));
 
   // User format errors or unsupported errors.
-  EXPECT_THROW(
-      toChar(parseTimestamp("1970-01-01"), "q"), VeloxUserError);
-  EXPECT_THROW(
-      toChar(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
+  EXPECT_THROW(toChar(parseTimestamp("1970-01-01"), "q"), VeloxUserError);
+  EXPECT_THROW(toChar(parseTimestamp("1970-01-01"), "'abcd"), VeloxUserError);
   EXPECT_THROW(
       toChar(parseTimestamp("1970-01-01"), "yyyy-MM-dd"), VeloxUserError);
   EXPECT_THROW(


### PR DESCRIPTION
This PR is to address #13591 .

Basically I implement a `buildTeraDateTimeFormatter` to only handle the date specifiers listed in the [doc](https://prestodb.io/docs/current/functions/teradata.html). The reasons to implement a new formatter being:
1. Decouple with Joda's formatter, otherwise those Joda' syntax can be mixed with teradata date format and if user use Joda format in the teradata UDF like `to_char` it might have undefined behaviors.
2. Could be easier to extend in the future, for example when implement the other two Teradata date UDFs.