### PR TITLE
fix: Crash when bucket conversion applied on batch reader last empty output

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -223,7 +223,7 @@ uint64_t SplitReader::next(uint64_t size, VectorPtr& output) {
     mutation.randomSkip = baseReaderOpts_.randomSkip().get();
     numScanned = baseRowReader_->next(size, output, &mutation);
   }
-  if (partitionFunction_) {
+  if (numScanned > 0 && partitionFunction_) {
     applyBucketConversion(
         output, bucketConversionRows(*output->asChecked<RowVector>()));
   }


### PR DESCRIPTION
Summary: When we apply bucket conversion on batch reader, and we already at end of the stripe, the reader returns nullptr as output, make sure we do not crash due to nullptr in this case.

Differential Revision: D75791777


