### PR TITLE
feat(fuzzer): Add input generators for IPAddress and IPPrefix types

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -424,7 +424,6 @@ class PhoneNumberInputGenerator : public AbstractInputGenerator {
 /// them:
 ///  - On strings, arrays, and objects: .length()
 ///  - On arrays: [begin:end:step]
-
 class JsonPathGenerator : public AbstractInputGenerator {
  public:
   JsonPathGenerator(

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -37,6 +37,7 @@
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
 #include "velox/serializers/PrestoSerializer.h"
@@ -304,7 +305,8 @@ bool PrestoQueryRunner::isConstantExprSupported(
     return type->isPrimitiveType() && !type->isTimestamp() &&
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
-        !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type);
+        !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
+        !isTDigestType(type);
   }
   return true;
 }
@@ -322,7 +324,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "bingtile") ||
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
-      usesTypeName(signature, "tdigest") ||
       usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -33,6 +33,7 @@
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
@@ -303,7 +304,7 @@ bool PrestoQueryRunner::isConstantExprSupported(
     return type->isPrimitiveType() && !type->isTimestamp() &&
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
-        !isTimestampWithTimeZoneType(type);
+        !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type);
   }
   return true;
 }
@@ -321,7 +322,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "bingtile") ||
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
-      usesTypeName(signature, "hyperloglog") ||
       usesTypeName(signature, "tdigest") ||
       usesInputTypeName(signature, "json") ||
       usesInputTypeName(signature, "ipaddress") ||

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -28,7 +29,10 @@ intermediateTypeTransforms() {
   static std::unordered_map<TypePtr, std::shared_ptr<IntermediateTypeTransform>>
       intermediateTypeTransforms{
           {TIMESTAMP_WITH_TIME_ZONE(),
-           std::make_shared<TimestampWithTimeZoneTransform>()}};
+           std::make_shared<TimestampWithTimeZoneTransform>()},
+          {HYPERLOGLOG(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               HYPERLOGLOG(), VARBINARY())}};
   return intermediateTypeTransforms;
 }
 

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
@@ -32,7 +33,10 @@ intermediateTypeTransforms() {
            std::make_shared<TimestampWithTimeZoneTransform>()},
           {HYPERLOGLOG(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
-               HYPERLOGLOG(), VARBINARY())}};
+               HYPERLOGLOG(), VARBINARY())},
+          {TDIGEST(DOUBLE()),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               TDIGEST(DOUBLE()), VARBINARY())}};
   return intermediateTypeTransforms;
 }
 

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -94,7 +94,7 @@ std::string toTypeSql(const TypePtr& type) {
     }
     default:
       if (type->isPrimitiveType()) {
-        return type->name();
+        return type->toString();
       }
       VELOX_UNSUPPORTED("Type is not supported: {}", type->toString());
   }

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::exec::test {
@@ -34,6 +35,7 @@ TEST(PrestoSqlTest, toTypeSql) {
   EXPECT_EQ(toTypeSql(DOUBLE()), "DOUBLE");
   EXPECT_EQ(toTypeSql(VARCHAR()), "VARCHAR");
   EXPECT_EQ(toTypeSql(VARBINARY()), "VARBINARY");
+  EXPECT_EQ(toTypeSql(TDIGEST(DOUBLE())), "TDIGEST(DOUBLE)");
   EXPECT_EQ(toTypeSql(TIMESTAMP()), "TIMESTAMP");
   EXPECT_EQ(toTypeSql(DATE()), "DATE");
   EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -72,7 +72,6 @@ add_executable(
   PlanNodeToStringTest.cpp
   PlanNodeToSummaryStringTest.cpp
   PrefixSortTest.cpp
-  PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp
   PrintPlanWithStatsTest.cpp
   ProbeOperatorStateTest.cpp
   TraceUtilTest.cpp
@@ -205,6 +204,24 @@ target_link_libraries(
   gflags::gflags
   glog::glog
   fmt::fmt)
+
+add_executable(
+  velox_exec_util_test
+  Main.cpp PrestoQueryRunnerHyperLogLogTransformTest.cpp
+  PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
+  PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp)
+
+add_test(velox_exec_util_test velox_exec_util_test)
+
+target_link_libraries(
+  velox_exec_util_test
+  velox_fuzzer_util
+  velox_exec_test_lib
+  velox_functions_test_lib
+  velox_presto_types
+  velox_presto_types_fuzzer_utils
+  GTest::gtest
+  GTest::gtest_main)
 
 add_executable(velox_in_10_min_demo VeloxIn10MinDemo.cpp)
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -207,8 +207,10 @@ target_link_libraries(
 
 add_executable(
   velox_exec_util_test
-  Main.cpp PrestoQueryRunnerHyperLogLogTransformTest.cpp
+  Main.cpp
+  PrestoQueryRunnerHyperLogLogTransformTest.cpp
   PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
+  PrestoQueryRunnerTDigestTransformTest.cpp
   PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp)
 
 add_test(velox_exec_util_test velox_exec_util_test)

--- a/velox/exec/tests/PrestoQueryRunnerHyperLogLogTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerHyperLogLogTransformTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class PrestoQueryRunnerHyperLogLogTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerHyperLogLogTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(HYPERLOGLOG()));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(HYPERLOGLOG())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(HYPERLOGLOG(), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), HYPERLOGLOG())));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({HYPERLOGLOG(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(), TIMESTAMP(), ARRAY(ROW({MAP(VARCHAR(), HYPERLOGLOG())}))})));
+}
+
+TEST_F(PrestoQueryRunnerHyperLogLogTransformTest, transform) {
+  test(HYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerHyperLogLogTransformTest, transformArray) {
+  testArray(HYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerHyperLogLogTransformTest, transformMap) {
+  testMap(HYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerHyperLogLogTransformTest, transformRow) {
+  testRow(HYPERLOGLOG());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+
+namespace facebook::velox::exec::test {
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::test(
+    const VectorPtr& vector) {
+  const auto colName = "col";
+  const auto input =
+      makeRowVector({colName}, {transformIntermediateTypes(vector)});
+
+  auto expr = getProjectionsToIntermediateTypes(
+      vector->type(),
+      std::make_shared<core::FieldAccessExpr>(
+          colName,
+          std::nullopt,
+          std::vector<core::ExprPtr>{std::make_shared<core::InputExpr>()}),
+      colName);
+
+  core::PlanNodePtr plan =
+      PlanBuilder().values({input}).projectExpressions({expr}).planNode();
+
+  AssertQueryBuilder(plan).assertResults(makeRowVector({colName}, {vector}));
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testDictionary(
+    const VectorPtr& base) {
+  // Wrap in a dictionary without nulls.
+  auto dict = BaseVector::wrapInDictionary(
+      nullptr, makeIndicesInReverse(100), 100, base);
+  test(dict);
+  // Wrap in a dictionary with some nulls.
+  dict = BaseVector::wrapInDictionary(
+      makeNulls(100, [](vector_size_t row) { return row % 10 == 0; }),
+      makeIndicesInReverse(100),
+      100,
+      base);
+  test(dict);
+  // Wrap in a dictionary with all nulls.
+  dict = BaseVector::wrapInDictionary(
+      makeNulls(100, [](vector_size_t) { return true; }),
+      makeIndicesInReverse(100),
+      100,
+      base);
+  test(dict);
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testConstant(
+    const VectorPtr& base) {
+  // Test a non-null constant.
+  test(BaseVector::wrapInConstant(100, 0, base));
+  // Test a null constant.
+  test(BaseVector::createNullConstant(ARRAY(base->type()), 100, pool_.get()));
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::test(
+    const TypePtr& type) {
+  // No nulls.
+  auto& opts = fuzzer_.getMutableOptions();
+  opts.nullRatio = 0;
+  auto vector = fuzzer_.fuzzFlat(type, kVectorSize);
+  test(vector);
+  // All nulls.
+  opts.nullRatio = 1;
+  vector = fuzzer_.fuzzFlat(type, kVectorSize);
+  test(vector);
+  // Some nulls.
+  opts.nullRatio = 0.1;
+  vector = fuzzer_.fuzzFlat(type, kVectorSize);
+  test(vector);
+
+  testDictionary(vector);
+  testConstant(vector);
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testArray(
+    const TypePtr& type) {
+  // Test array vector no nulls.
+  auto& opts = fuzzer_.getMutableOptions();
+  opts.nullRatio = 0;
+  auto array = fuzzer_.fuzzArray(type, kVectorSize);
+  test(array);
+
+  // Test array vector all nulls.
+  opts.nullRatio = 1;
+  array = fuzzer_.fuzzArray(type, kVectorSize);
+  test(array);
+
+  // Test array vector some nulls.
+  opts.nullRatio = 0.1;
+  array = fuzzer_.fuzzArray(type, kVectorSize);
+  test(array);
+
+  testDictionary(array);
+  testConstant(array);
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testMap(
+    const TypePtr& type) {
+  // Test map vector no nulls.
+  auto& opts = fuzzer_.getMutableOptions();
+  opts.nullRatio = 0.0;
+  auto map = fuzzer_.fuzzMap(type, type, kVectorSize);
+  test(map);
+
+  // Test map vector all nulls.
+  opts.nullRatio = 1;
+  map = fuzzer_.fuzzMap(type, type, kVectorSize);
+  test(map);
+
+  // Test map vector some nulls.
+  opts.nullRatio = 0.1;
+  map = fuzzer_.fuzzMap(type, type, kVectorSize);
+  test(map);
+
+  testDictionary(map);
+  testConstant(map);
+}
+
+void PrestoQueryRunnerIntermediateTypeTransformTestBase::testRow(
+    const TypePtr& type) {
+  const auto size = 100;
+  auto& opts = fuzzer_.getMutableOptions();
+  opts.nullRatio = 0;
+  auto field1 = fuzzer_.fuzz(type, size);
+  opts.nullRatio = 0.1;
+  auto field2 = fuzzer_.fuzz(type, size);
+  opts.nullRatio = 1;
+  auto field3 = fuzzer_.fuzz(type, size);
+  const auto rowType =
+      ROW({"c1", "c2", "c3"}, {field1->type(), field2->type(), field3->type()});
+  // Test map vector no nulls.
+  test(vectorMaker_.rowVector({field1, field2, field3}));
+
+  // Test row vector some nulls.
+  test(std::make_shared<RowVector>(
+      pool_.get(),
+      rowType,
+      makeNulls(size, [](vector_size_t row) { return row % 10 == 0; }),
+      size,
+      std::vector<VectorPtr>{field1, field2, field3}));
+
+  // Test row vector all nulls.
+  test(std::make_shared<RowVector>(
+      pool_.get(),
+      rowType,
+      makeNulls(size, [](vector_size_t) { return true; }),
+      size,
+      std::vector<VectorPtr>{field1, field2, field3}));
+
+  const auto base = vectorMaker_.rowVector({field1, field2, field3});
+  testDictionary(base);
+  testConstant(base);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h
+++ b/velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::exec::test {
+
+class PrestoQueryRunnerIntermediateTypeTransformTestBase
+    : public functions::test::FunctionBaseTest {
+ protected:
+  void test(const VectorPtr& vector);
+
+  void testDictionary(const VectorPtr& base);
+
+  void testConstant(const VectorPtr& base);
+
+  void test(const TypePtr& type);
+
+  void testArray(const TypePtr& type);
+
+  void testMap(const TypePtr& type);
+
+  void testRow(const TypePtr& type);
+
+ private:
+  const int32_t kVectorSize = 100;
+  VectorFuzzer fuzzer_{VectorFuzzer::Options{}, pool_.get(), 123};
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PrestoQueryRunnerTDigestTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerTDigestTransformTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+#include "velox/functions/prestosql/types/TDigestType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class PrestoQueryRunnerTDigestTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerTDigestTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(TDIGEST(DOUBLE())));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(TDIGEST(DOUBLE()))));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(TDIGEST(DOUBLE()), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), TDIGEST(DOUBLE()))));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({TDIGEST(DOUBLE()), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(),
+       TIMESTAMP(),
+       ARRAY(ROW({MAP(VARCHAR(), TDIGEST(DOUBLE()))}))})));
+}
+
+TEST_F(PrestoQueryRunnerTDigestTransformTest, transform) {
+  test(TDIGEST(DOUBLE()));
+}
+
+TEST_F(PrestoQueryRunnerTDigestTransformTest, transformArray) {
+  testArray(TDIGEST(DOUBLE()));
+}
+
+TEST_F(PrestoQueryRunnerTDigestTransformTest, transformMap) {
+  testMap(TDIGEST(DOUBLE()));
+}
+
+TEST_F(PrestoQueryRunnerTDigestTransformTest, transformRow) {
+  testRow(TDIGEST(DOUBLE()));
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -88,9 +88,10 @@ int main(int argc, char** argv) {
       // (since TDigest is a user defined type), and tries to pass a
       // VARBINARY (since TDigest's implementation uses an
       // alias to VARBINARY).
-      "values_at_quantiles",
       "merge_tdigest",
       "construct_tdigest",
+      // https://github.com/facebookincubator/velox/issues/13551
+      "values_at_quantiles",
       // Fuzzer cannot generate valid 'comparator' lambda.
       "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
       "split_to_map(varchar,varchar,varchar,function(varchar,varchar,varchar,varchar)) -> map(varchar,varchar)",

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -82,11 +82,6 @@ int main(int argc, char** argv) {
   // Use function name to exclude all signatures of a given function from
   // testing. Use function signature to exclude only a specific signature.
   std::unordered_set<std::string> skipFunctions = {
-      // Fuzzer and the underlying engine are confused about cardinality(HLL)
-      // (since HLL is a user defined type), and end up trying to use
-      // cardinality passing a VARBINARY (since HLL's implementation uses an
-      // alias to VARBINARY).
-      "cardinality",
       "element_at",
       "width_bucket",
       // Fuzzer and the underlying engine are confused about TDigest output

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -134,6 +134,8 @@ int main(int argc, char** argv) {
       "any_value",
       // Skip non-deterministic functions.
       "noisy_count_if_gaussian",
+      // https://github.com/facebookincubator/velox/issues/13547
+      "merge",
   };
 
   static const std::unordered_set<std::string> functionsRequireSortedInput = {

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -126,6 +126,8 @@ int main(int argc, char** argv) {
       "max_by",
       // Skip non-deterministic functions.
       "noisy_count_if_gaussian",
+      // https://github.com/facebookincubator/velox/issues/13547
+      "merge",
   };
 
   // Functions whose results verification should be skipped. These can be

--- a/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/HyperLogLogRegistration.h"
 
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -34,8 +35,9 @@ class HyperLogLogTypeFactories : public CustomTypeFactories {
   }
 
   AbstractInputGeneratorPtr getInputGenerator(
-      const InputGeneratorConfig& /*config*/) const override {
-    return nullptr;
+      const InputGeneratorConfig& config) const override {
+    return std::make_shared<fuzzer::HyperLogLogInputGenerator>(
+        config.seed_, config.nullRatio_, config.pool_);
   }
 };
 } // namespace

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/functions/prestosql/types/IPAddressRegistration.h"
 
+#include <limits>
+
+#include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
@@ -267,8 +270,13 @@ class IPAddressTypeFactories : public CustomTypeFactories {
   }
 
   AbstractInputGeneratorPtr getInputGenerator(
-      const InputGeneratorConfig& /*config*/) const override {
-    return nullptr;
+      const InputGeneratorConfig& config) const override {
+    return std::make_shared<fuzzer::RangeConstrainedGenerator<int128_t>>(
+        config.seed_,
+        IPADDRESS(),
+        config.nullRatio_,
+        0,
+        std::numeric_limits<int128_t>::max());
   }
 };
 } // namespace

--- a/velox/functions/prestosql/types/TDigestType.h
+++ b/velox/functions/prestosql/types/TDigestType.h
@@ -68,6 +68,11 @@ class TDigestType : public VarbinaryType {
   const std::vector<TypeParameter> parameters_;
 };
 
+inline bool isTDigestType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return TDigestType::get(DOUBLE()) == type;
+}
+
 inline std::shared_ptr<const TDigestType> TDIGEST(const TypePtr& dataType) {
   return TDigestType::get(dataType);
 }

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_presto_types_fuzzer_utils
-                  TimestampWithTimeZoneInputGenerator.cpp)
+velox_add_library(
+  velox_presto_types_fuzzer_utils TimestampWithTimeZoneInputGenerator.cpp
+  HyperLogLogInputGenerator.cpp)
 
 velox_link_libraries(
   velox_presto_types_fuzzer_utils

--- a/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h"
+
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer {
+
+HyperLogLogInputGenerator::HyperLogLogInputGenerator(
+    const size_t seed,
+    const double nullRatio,
+    memory::MemoryPool* pool)
+    : AbstractInputGenerator{seed, HYPERLOGLOG(), nullptr, nullRatio},
+      pool_{pool} {
+  static const std::vector<TypePtr> kBaseTypes{
+      BIGINT(), VARCHAR(), DOUBLE(), UNKNOWN()};
+  baseType_ = kBaseTypes[rand<int32_t>(rng_, 0, kBaseTypes.size() - 1)];
+  error_ = rand<double>(rng_, 0.0040625, 0.26000);
+}
+
+variant HyperLogLogInputGenerator::generate() {
+  if (coinToss(rng_, nullRatio_)) {
+    return variant::null(type_->kind());
+  }
+
+  if (baseType_->isBigint()) {
+    return generateTyped<int64_t>();
+  } else if (baseType_->isVarchar()) {
+    return generateTyped<std::string>();
+  } else if (baseType_->isDouble()) {
+    return generateTyped<double>();
+  } else {
+    return generateTyped<UnknownValue>();
+  }
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/functions/prestosql/aggregates/HyperLogLogAggregate.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::fuzzer {
+
+using facebook::velox::aggregate::prestosql::HllAccumulator;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+class HyperLogLogInputGenerator : public AbstractInputGenerator {
+ public:
+  HyperLogLogInputGenerator(
+      const size_t seed,
+      const double nullRatio,
+      memory::MemoryPool* pool);
+
+  variant generate() override;
+
+ private:
+  template <typename T>
+  variant generateTyped() {
+    HashStringAllocator allocator{pool_};
+    HllAccumulator<T, true> accumulator(&allocator);
+    accumulator.setIndexBitLength(common::hll::toIndexBitLength(error_));
+    static const std::vector<UTF8CharList> encodings{
+        UTF8CharList::ASCII,
+        UTF8CharList::UNICODE_CASE_SENSITIVE,
+        UTF8CharList::EXTENDED_UNICODE,
+        UTF8CharList::MATHEMATICAL_SYMBOLS};
+
+    auto numValues = rand<int32_t>(rng_, 1, 100);
+    for (auto i = 0; i < numValues; ++i) {
+      if constexpr (
+          std::is_same_v<T, std::string> || std::is_same_v<T, StringView>) {
+        std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
+        auto size = rand<int32_t>(rng_, 0, 100);
+        std::string result;
+        accumulator.append(
+            randString(rng_, size, encodings, result, converter));
+      } else if (std::is_same_v<T, UnknownValue>) {
+        // No-op since approx_set ignores input nulls.
+      } else {
+        accumulator.append(rand<T>(rng_));
+      }
+    }
+    auto size = accumulator.serializedSize();
+    std::string buff(size, '\0');
+    accumulator.serialize(buff.data());
+    return variant::create<TypeKind::VARBINARY>(buff);
+  }
+
+  TypePtr baseType_;
+  double error_;
+
+  memory::MemoryPool* pool_;
+};
+#pragma GCC diagnostic pop
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_presto_types_fuzzer_utils_test
-               TimestampWithTimeZoneInputGeneratorTest.cpp)
+add_executable(
+  velox_presto_types_fuzzer_utils_test
+  TimestampWithTimeZoneInputGeneratorTest.cpp HyperLogLogInputGeneratorTest.cpp)
 
 add_test(velox_presto_types_fuzzer_utils_test
          velox_presto_types_fuzzer_utils_test)
@@ -21,6 +22,7 @@ add_test(velox_presto_types_fuzzer_utils_test
 target_link_libraries(
   velox_presto_types_fuzzer_utils_test
   velox_presto_types_fuzzer_utils
+  velox_functions_test_lib
   velox_presto_types
   velox_type
   velox_type_tz

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/HyperLogLogInputGeneratorTest.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/HyperLogLogInputGeneratorTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer::test {
+
+class HyperLogLogInputGeneratorTest : public functions::test::FunctionBaseTest {
+};
+
+TEST_F(HyperLogLogInputGeneratorTest, generate) {
+  HyperLogLogInputGenerator generator(123, 0.1, pool());
+
+  size_t numTrials = 100;
+  for (size_t i = 0; i < numTrials; ++i) {
+    variant generated = generator.generate();
+
+    if (generated.isNull()) {
+      continue;
+    }
+
+    generated.checkIsKind(TypeKind::VARBINARY);
+    const auto& value = generated.value<TypeKind::VARBINARY>();
+    HashStringAllocator allocator{pool_.get()};
+
+    if (SparseHll::canDeserialize(value.data())) {
+      SparseHll hll(value.data(), &allocator);
+      hll.cardinality();
+    } else if (DenseHll::canDeserialize(value.data())) {
+      DenseHll hll(value.data(), &allocator);
+      hll.cardinality();
+    } else {
+      VELOX_FAIL("Invalid HLL value");
+    }
+  }
+}
+
+} // namespace facebook::velox::fuzzer::test

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2025,6 +2025,10 @@ using CastOperatorPtr = std::shared_ptr<const CastOperator>;
 class variant;
 class AbstractInputGenerator;
 
+namespace memory {
+class MemoryPool;
+} // namespace memory
+
 using AbstractInputGeneratorPtr = std::shared_ptr<AbstractInputGenerator>;
 using FuzzerGenerator = folly::detail::DefaultGenerator;
 
@@ -2032,6 +2036,7 @@ struct InputGeneratorConfig {
   // TODO: hook up the rest options in VectorFuzzer::Options.
   size_t seed_;
   double nullRatio_;
+  memory::MemoryPool* pool_;
 };
 
 /// Associates custom types with their custom operators to be the payload in

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -620,6 +620,17 @@ void VectorFuzzer::fuzzOffsetsAndSizes(
 }
 
 ArrayVectorPtr VectorFuzzer::fuzzArray(
+    const TypePtr& elementType,
+    vector_size_t size) {
+  auto length = getElementsVectorLength(opts_, size);
+
+  auto elements = opts_.containerHasNulls
+      ? fuzzFlat(elementType, length)
+      : fuzzFlatNotNull(elementType, length);
+  return fuzzArray(elements, size);
+}
+
+ArrayVectorPtr VectorFuzzer::fuzzArray(
     const VectorPtr& elements,
     vector_size_t size) {
   BufferPtr offsets, sizes;

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -244,6 +244,11 @@ class VectorFuzzer {
   /// `opts.containerVariableLength`).
   ArrayVectorPtr fuzzArray(const VectorPtr& elements, vector_size_t size);
 
+  /// Same as above, but fuzz the element vector. The length of the element
+  /// vector is based on opts.containerLength and does not exceed
+  /// opts.complexElementsMaxSize.
+  ArrayVectorPtr fuzzArray(const TypePtr& elementType, vector_size_t size);
+
   /// Uses `keys` and `values` as the internal elements vectors, wrapping them
   /// into a MapVector of `size` rows.
   ///

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -414,6 +414,24 @@ TEST_F(VectorFuzzerTest, array) {
   ASSERT_EQ(arraySize, vector->size());
   ASSERT_GE(
       100, vector->offsetAt(arraySize - 1) + vector->sizeAt(arraySize - 1));
+
+  // Test fuzzArray with given element type. Check that element size doesn't
+  // exceed opts.complexElementsMaxSize.
+  const auto kElementMaxSize = 100;
+  opts.complexElementsMaxSize = kElementMaxSize;
+  fuzzer.setOptions(opts);
+
+  auto checkElementSize = [&](size_t arraySize) {
+    vector = fuzzer.fuzzArray(BIGINT(), arraySize);
+    ASSERT_TRUE(vector->type()->childAt(0)->isBigint());
+    ASSERT_EQ(arraySize, vector->size());
+    ASSERT_LE(
+        vector->offsetAt(arraySize - 1) + vector->sizeAt(arraySize - 1),
+        kElementMaxSize);
+  };
+  checkElementSize(kElementMaxSize);
+  checkElementSize(kElementMaxSize - 70);
+  checkElementSize(kElementMaxSize + 50);
 }
 
 TEST_F(VectorFuzzerTest, map) {


### PR DESCRIPTION
Summary:
IPAddress and IPPrefix are custom data types and have specific valid range of values. Specifically,
* IPAddress is represented as a HUGEINT. The valid values are all positive integers that can fit within 2^128.
* IPPrefix is represented as a ROW<IPADDRESS, TINYINT>. The valid values of ipprefix are all the valid values of IPAddress. For the prefix, it shall be within [0, 128).

This diff adds the input generators for these two data types to increase the fuzzer coverage.

Differential Revision: D75797801
