### PR TITLE
build(CUDA): Install GPUDirect Storage dependency

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -93,7 +93,8 @@ function install_cuda {
     cuda-driver-devel-$dashed \
     cuda-minimal-build-$dashed \
     cuda-nvrtc-devel-$dashed \
-    libcufile-devel-$dashed
+    libcufile-devel-$dashed \
+    numactl-libs
 }
 
 function install_s3 {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -168,7 +168,8 @@ function install_cuda {
     cuda-driver-dev-$dashed \
     cuda-minimal-build-$dashed \
     cuda-nvrtc-dev-$dashed \
-    libcufile-dev-$dashed
+    libcufile-dev-$dashed \
+    libnuma1
 }
 
 function install_s3 {


### PR DESCRIPTION
we need to install libcufile in order for GDS-enabled libraries (such as kvikio used by cudf) to pick up GDS support during compile time