### PR TITLE
fix: Add config to cap max zoom level difference in bing_tile_children

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -515,6 +515,17 @@ class QueryConfig {
   static constexpr const char* kDebugLambdaFunctionEvaluationBatchSize =
       "debug_lambda_function_evaluation_batch_size";
 
+  /// The UDF `bing_tile_children` generates the children of a Bing tile based
+  /// on a specified target zoom level. The number of children produced is
+  /// determined by the difference between the target zoom level and the zoom
+  /// level of the input tile. This configuration limits the number of children
+  /// by capping the maximum zoom level difference, with a default value set
+  /// to 5. This cap is necessary to prevent excessively large array outputs,
+  /// which can exceed the size limits of the elements vector in the Velox array
+  /// vector.
+  static constexpr const char* kDebugBingTileChildrenMaxZoomShift =
+      "debug_bing_tile_children_max_zoom_shift";
+
   /// Temporary flag to control whether selective Nimble reader should be used
   /// in this query or not.  Will be removed after the selective Nimble reader
   /// is fully rolled out.
@@ -630,6 +641,10 @@ class QueryConfig {
 
   int32_t debugLambdaFunctionEvaluationBatchSize() const {
     return get<int32_t>(kDebugLambdaFunctionEvaluationBatchSize, 10'000);
+  }
+
+  uint8_t debugBingTileChildrenMaxZoomShift() const {
+    return get<uint8_t>(kDebugBingTileChildrenMaxZoomShift, 5);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -226,6 +226,11 @@ Expression Evaluation Configuration
      - integer
      - 10000
      - Some lambda functions over arrays and maps are evaluated in batches of the underlying elements that comprise the arrays/maps. This is done to make the batch size managable as array vectors can have thousands of elements each and hit scaling limits as implementations typically expect BaseVectors to a couple of thousand entries. This lets up tune those batch sizes. Setting this to zero is setting unlimited batch size.
+   * - debug_bing_tile_children_max_zoom_shift
+     - integer
+     - 5
+     - The UDF `bing_tile_children` generates the children of a Bing tile based on a specified target zoom level. The number of children produced is determined by the difference between the target zoom level and the zoom level of the input tile. This configuration limits the number of children by capping the maximum zoom level difference, with a default value set to 5. This cap is necessary to prevent excessively large array outputs, which can exceed the size limits of the elements vector in the Velox array vector.
+
 
 Memory Management
 -----------------

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -154,16 +154,6 @@ int main(int argc, char** argv) {
       "st_issimple",
       "geometry_invalid_reason",
       "simplify_geometry",
-      // bing_tile functions:
-      // https://github.com/facebookincubator/velox/issues/13593
-      "bing_tile",
-      "bing_tile_zoom_level",
-      "bing_tile_coordinates",
-      "bing_tile_parent",
-      "bing_tile_children",
-      "bing_tile_quadkey"
-      "bing_tile_at",
-      "bing_tiles_around",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -90,7 +90,8 @@ class BingTileFunctionsTest : public functions::test::FunctionBaseTest {
     uint64_t tileInt = BingTileType::bingTileCoordsToInt(x, y, tileZoom);
     // Making children is tested in BingTileTypeTest; this test is for whether
     // we call it correctly.
-    auto childrenRes = BingTileType::bingTileChildren(tileInt, childZoom);
+    auto childrenRes = BingTileType::bingTileChildren(
+        tileInt, childZoom, childZoom - tileZoom);
     if (childrenRes.hasError()) {
       return folly::makeUnexpected(childrenRes.error());
     }
@@ -446,6 +447,23 @@ TEST_F(BingTileFunctionsTest, bingTileChildrenZoom) {
       "Cannot call bing_tile_children with negative zoom");
   VELOX_ASSERT_USER_THROW(
       testBingTileChildren(0, 0, 2, 1), "Child zoom 1 must be >= tile zoom 2");
+  VELOX_ASSERT_USER_THROW(
+      testBingTileChildren(0, 0, 1, 7),
+      "Difference between parent zoom (1) and child zoom (7) must be <= 5");
+
+  {
+    RowVectorPtr input = makeSingleXYZoomZoomRow(0, 0, 1, 7);
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kDebugBingTileChildrenMaxZoomShift, "10"}});
+    evaluate("bing_tile_children(bing_tile(c0, c1, c2), c3)", input);
+
+    input = makeSingleXYZoomZoomRow(0, 0, 1, 15);
+    VELOX_ASSERT_USER_THROW(
+        evaluate("bing_tile_children(bing_tile(c0, c1, c2), c3)", input),
+        "Difference between parent zoom (1) and child zoom (15) must be <= 10");
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kDebugBingTileChildrenMaxZoomShift, "5"}});
+  }
 }
 
 TEST_F(BingTileFunctionsTest, bingTileAt) {

--- a/velox/functions/prestosql/types/BingTileType.cpp
+++ b/velox/functions/prestosql/types/BingTileType.cpp
@@ -271,7 +271,10 @@ folly::Expected<uint64_t, std::string> BingTileType::bingTileParent(
 }
 
 folly::Expected<std::vector<uint64_t>, std::string>
-BingTileType::bingTileChildren(uint64_t tile, uint8_t childZoom) {
+BingTileType::bingTileChildren(
+    uint64_t tile,
+    uint8_t childZoom,
+    uint8_t maxZoomShift) {
   uint8_t tileZoom = bingTileZoom(tile);
   if (FOLLY_UNLIKELY(tileZoom == childZoom)) {
     return std::vector<uint64_t>{tile};
@@ -291,6 +294,13 @@ BingTileType::bingTileChildren(uint64_t tile, uint8_t childZoom) {
   }
 
   uint8_t shift = childZoom - tileZoom;
+  if (shift > maxZoomShift) {
+    return folly::makeUnexpected(fmt::format(
+        "Difference between parent zoom ({}) and child zoom ({}) must be <= {}",
+        tileZoom,
+        childZoom,
+        maxZoomShift));
+  }
   uint32_t xBase = (x << shift);
   uint32_t yBase = (y << shift);
   uint32_t numChildrenPerOrdinate = 1 << shift;

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -142,9 +142,8 @@ class BingTileType : public BigintType {
       uint64_t tile,
       uint8_t parentZoom);
 
-  static folly::Expected<std::vector<uint64_t>, std::string> bingTileChildren(
-      uint64_t tile,
-      uint8_t childZoom);
+  static folly::Expected<std::vector<uint64_t>, std::string>
+  bingTileChildren(uint64_t tile, uint8_t childZoom, uint8_t maxZoomShift);
 
   static folly::Expected<uint64_t, std::string> bingTileFromQuadKey(
       const std::string_view& quadKey);

--- a/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
@@ -134,10 +134,12 @@ TEST_F(BingTileTypeTest, bingTileChildren) {
                                         uint32_t y,
                                         uint8_t zoom,
                                         uint8_t childZoom,
+                                        uint8_t maxZoomShift,
                                         std::optional<std::string> errorMsg) {
     uint64_t tile = BingTileType::bingTileCoordsToInt(x, y, zoom);
     int32_t shift = childZoom - zoom;
-    auto childrenResult = BingTileType::bingTileChildren(tile, childZoom);
+    auto childrenResult =
+        BingTileType::bingTileChildren(tile, childZoom, maxZoomShift);
     if (errorMsg.has_value()) {
       ASSERT_TRUE(childrenResult.hasError());
       ASSERT_EQ(errorMsg.value(), childrenResult.error());
@@ -167,17 +169,25 @@ TEST_F(BingTileTypeTest, bingTileChildren) {
     }
   };
 
-  testBingTileChildren(0, 0, 0, 0, std::nullopt);
-  testBingTileChildren(0, 0, 0, 1, std::nullopt);
-  testBingTileChildren(0, 0, 0, 2, std::nullopt);
-  testBingTileChildren(1, 1, 1, 2, std::nullopt);
-  testBingTileChildren(0, 127, 8, 12, std::nullopt);
-  testBingTileChildren(0, 127, 8, 8, std::nullopt);
-  testBingTileChildren((1 << 21) - 1, 1 << 20, 21, 23, std::nullopt);
-  testBingTileChildren((1 << 18) - 1, 1 << 17, 18, 23, std::nullopt);
+  testBingTileChildren(0, 0, 0, 0, 23, std::nullopt);
+  testBingTileChildren(0, 0, 0, 1, 23, std::nullopt);
+  testBingTileChildren(0, 0, 0, 2, 23, std::nullopt);
+  testBingTileChildren(1, 1, 1, 2, 23, std::nullopt);
+  testBingTileChildren(0, 127, 8, 12, 23, std::nullopt);
+  testBingTileChildren(0, 127, 8, 8, 23, std::nullopt);
+  testBingTileChildren((1 << 21) - 1, 1 << 20, 21, 23, 23, std::nullopt);
+  testBingTileChildren((1 << 18) - 1, 1 << 17, 18, 23, 23, std::nullopt);
 
-  testBingTileChildren(0, 0, 2, 1, "Child zoom 1 must be >= tile zoom 2");
-  testBingTileChildren(0, 0, 23, 24, "Child zoom 24 must be <= max zoom 23");
+  testBingTileChildren(0, 0, 2, 1, 23, "Child zoom 1 must be >= tile zoom 2");
+  testBingTileChildren(
+      0, 0, 23, 24, 23, "Child zoom 24 must be <= max zoom 23");
+  testBingTileChildren(
+      0,
+      0,
+      0,
+      6,
+      5,
+      "Difference between parent zoom (0) and child zoom (6) must be <= 5");
 }
 
 TEST_F(BingTileTypeTest, bingTileToQuadKey) {


### PR DESCRIPTION
Summary:
Added a new query configuration that applies to the
bing_tile_children UDF to cap the maximum zoom level difference
between the parent and the child, with a default value set to 5. This
configuration helps control the number of children generated by the
function, preventing excessively large array outputs that could exceed
the size limits of the elements vector in the Velox array vector.

Differential Revision: D75820054


