### PR TITLE
feat: Extract subfield filters using FiltersAsNode in TableEvolutionFuzzer

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -418,10 +418,10 @@ void TableEvolutionFuzzer::run() {
 
   std::vector<std::unique_ptr<TaskCursor>> scanTasks(2);
 
-  scanTasks[0] =
-      makeScanTask(rowType, std::move(actualSplits), subfieldFilterConfig);
-  scanTasks[1] =
-      makeScanTask(rowType, std::move(expectedSplits), subfieldFilterConfig);
+  scanTasks[0] = makeScanTask(
+      rowType, std::move(actualSplits), subfieldFilterConfig, false);
+  scanTasks[1] = makeScanTask(
+      rowType, std::move(expectedSplits), subfieldFilterConfig, true);
 
   auto scanResults = runTaskCursors(scanTasks, *executor);
 
@@ -594,11 +594,13 @@ VectorPtr TableEvolutionFuzzer::liftToPrimitiveType(
 std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
     const RowTypePtr& tableSchema,
     std::vector<Split> splits,
-    const PushdownConfig& pushdownConfig) {
+    const PushdownConfig& pushdownConfig,
+    bool useFiltersAsNode) {
   CursorParameters params;
   params.serialExecution = true;
   // TODO: Mix in filter and aggregate pushdowns.
   params.planNode = PlanBuilder()
+                        .filtersAsNode(useFiltersAsNode)
                         .tableScanWithPushDown(
                             tableSchema,
                             /*pushdownConfig=*/pushdownConfig,

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -103,7 +103,8 @@ class TableEvolutionFuzzer {
   std::unique_ptr<TaskCursor> makeScanTask(
       const RowTypePtr& tableSchema,
       std::vector<Split> splits,
-      const PushdownConfig& pushdownConfig);
+      const PushdownConfig& pushdownConfig,
+      bool useFiltersAsNode);
 
   const Config config_;
   VectorFuzzer vectorFuzzer_;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -236,7 +236,6 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
     auto queryCtx = core::QueryCtx::create();
     exec::SimpleExpressionEvaluator evaluator(
         queryCtx.get(), planBuilder_.pool_);
-
     for (const auto& filter : subfieldFilters_) {
       auto filterExpr =
           core::Expressions::inferTypes(filter, parseType, planBuilder_.pool_);
@@ -259,6 +258,10 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
         filters[std::move(subfield)] = std::move(subfieldFilter);
       }
     }
+  }
+
+  if (filtersAsNode_) {
+    VELOX_CHECK(filters.empty());
   }
 
   core::TypedExprPtr remainingFilterExpr;


### PR DESCRIPTION
Summary: Extract expected path using FiltersAsNode path in TableEvolutionFuzzer.

Differential Revision: D75842056


