### PR TITLE
feat: Support single node tracing

### DIFF
--- a/velox/common/base/TraceConfig.cpp
+++ b/velox/common/base/TraceConfig.cpp
@@ -22,14 +22,14 @@
 namespace facebook::velox {
 
 TraceConfig::TraceConfig(
-    std::unordered_set<std::string> _queryNodeIds,
+    std::string _queryNodeId,
     std::string _queryTraceDir,
     UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
     std::string _taskRegExp)
-    : queryNodes(std::move(_queryNodeIds)),
+    : queryNodeId(std::move(_queryNodeId)),
       queryTraceDir(std::move(_queryTraceDir)),
       updateAndCheckTraceLimitCB(std::move(_updateAndCheckTraceLimitCB)),
       taskRegExp(std::move(_taskRegExp)) {
-  VELOX_CHECK(!queryNodes.empty(), "Query trace nodes cannot be empty");
+  VELOX_CHECK(!queryNodeId.empty(), "Query trace nodes cannot be empty");
 }
 } // namespace facebook::velox

--- a/velox/common/base/TraceConfig.h
+++ b/velox/common/base/TraceConfig.h
@@ -39,7 +39,7 @@ using UpdateAndCheckTraceLimitCB = std::function<void(uint64_t)>;
 
 struct TraceConfig {
   /// Target query trace nodes.
-  std::unordered_set<std::string> queryNodes;
+  std::string queryNodeId;
   /// Base dir of query trace.
   std::string queryTraceDir;
   UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB;
@@ -47,7 +47,7 @@ struct TraceConfig {
   std::string taskRegExp;
 
   TraceConfig(
-      std::unordered_set<std::string> _queryNodeIds,
+      std::string _queryNodeIds,
       std::string _queryTraceDir,
       UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
       std::string _taskRegExp);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -454,9 +454,14 @@ class QueryConfig {
   /// Base dir of a query to store tracing data.
   static constexpr const char* kQueryTraceDir = "query_trace_dir";
 
-  /// A comma-separated list of plan node ids whose input data will be traced.
+  /// @Deprecated. Do not use. Remove once existing call sites are updated.
+  /// The plan node id whose input data will be traced.
   /// Empty string if only want to trace the query metadata.
-  static constexpr const char* kQueryTraceNodeIds = "query_trace_node_ids";
+  static constexpr const char* kQueryTraceNodeIds = "query_trace_node_id";
+
+  /// The plan node id whose input data will be traced.
+  /// Empty string if only want to trace the query metadata.
+  static constexpr const char* kQueryTraceNodeId = "query_trace_node_id";
 
   /// The max trace bytes limit. Tracing is disabled if zero.
   static constexpr const char* kQueryTraceMaxBytes = "query_trace_max_bytes";
@@ -905,9 +910,15 @@ class QueryConfig {
     return get<std::string>(kQueryTraceDir, "");
   }
 
+  /// @Deprecated. Do not use. Remove once existing call sites are updated.
   std::string queryTraceNodeIds() const {
-    // The default query trace nodes, empty by default.
-    return get<std::string>(kQueryTraceNodeIds, "");
+    // Use the new config kQueryTraceNodeId.
+    return get<std::string>(kQueryTraceNodeId, "");
+  }
+
+  std::string queryTraceNodeId() const {
+    // The default query trace node ID, empty by default.
+    return get<std::string>(kQueryTraceNodeId, "");
   }
 
   uint64_t queryTraceMaxBytes() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -982,10 +982,10 @@ Tracing
      - string
      -
      - The root directory to store the tracing data and metadata for a query.
-   * - query_trace_node_ids
+   * - query_trace_node_id
      - string
      -
-     - A comma-separated list of plan node ids whose input data will be trace. If it is empty, then we only trace the
+     - The plan node id whose input data will be trace. If it is empty, then we only trace the
        query metadata which includes the query plan and configs etc.
    * - query_trace_task_reg_exp
      - string

--- a/velox/docs/develop/debugging/tracing.rst
+++ b/velox/docs/develop/debugging/tracing.rst
@@ -101,7 +101,7 @@ to the following simplified, pretty-printed JSON string (with some content remov
         "name":"HashJoinNode"
       },
       "connectorProperties":{...},
-      "queryConfig":{"query_trace_node_ids":"2", ...}
+      "queryConfig":{"query_trace_node_id":"2", ...}
     }
 
 **OperatorTraceInputWriter**
@@ -301,7 +301,7 @@ It would show something as the follows:
 
   ++++++Query configs++++++
   	query_trace_task_reg_exp: .*
-  	query_trace_node_ids: 2
+  	query_trace_node_id: 2
   	query_trace_max_bytes: 107374182400
   	query_trace_dir: /tmp/velox_test_aJqeFd/basic/traceRoot/
   	query_trace_enabled: 1

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -111,7 +111,7 @@ void Operator::maybeSetTracer() {
   }
 
   const auto nodeId = planNodeId();
-  if (traceConfig->queryNodes.count(nodeId) == 0) {
+  if (traceConfig->queryNodeId.empty() || traceConfig->queryNodeId != nodeId) {
     return;
   }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3339,40 +3339,23 @@ std::optional<TraceConfig> Task::maybeMakeTraceConfig() const {
     return std::nullopt;
   }
 
-  const auto traceNodes = queryConfig.queryTraceNodeIds();
-  VELOX_USER_CHECK(!traceNodes.empty(), "Query trace nodes are not set");
+  const auto traceNodeId = queryConfig.queryTraceNodeId();
+  VELOX_USER_CHECK(!traceNodeId.empty(), "Query trace node ID are not set");
 
   const auto traceDir = trace::getTaskTraceDirectory(
       queryConfig.queryTraceDir(), queryCtx_->queryId(), taskId_);
 
-  std::vector<std::string> traceNodeIds;
-  folly::split(',', traceNodes, traceNodeIds);
-  std::unordered_set<std::string> traceNodeIdSet(
-      traceNodeIds.begin(), traceNodeIds.end());
-  VELOX_USER_CHECK_EQ(
-      traceNodeIdSet.size(),
-      traceNodeIds.size(),
-      "Duplicate trace nodes found: {}",
-      folly::join(", ", traceNodeIds));
+  VELOX_USER_CHECK_NOT_NULL(
+      core::PlanNode::findFirstNode(
+          planFragment_.planNode.get(),
+          [traceNodeId](const core::PlanNode* node) -> bool {
+            return node->id() == traceNodeId;
+          }),
+      "Trace plan node ID = {} not found from task {}",
+      traceNodeId,
+      taskId_);
 
-  bool foundTraceNode{false};
-  for (const auto& traceNodeId : traceNodeIds) {
-    if (core::PlanNode::findFirstNode(
-            planFragment_.planNode.get(),
-            [traceNodeId](const core::PlanNode* node) -> bool {
-              return node->id() == traceNodeId;
-            })) {
-      foundTraceNode = true;
-      break;
-    }
-  }
-  VELOX_USER_CHECK(
-      foundTraceNode,
-      "Trace plan nodes not found from task {}: {}",
-      taskId_,
-      folly::join(",", traceNodeIdSet));
-
-  LOG(INFO) << "Trace input for plan nodes " << traceNodes << " from task "
+  LOG(INFO) << "Trace input for plan nodes " << traceNodeId << " from task "
             << taskId_;
 
   UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB =
@@ -3380,7 +3363,7 @@ std::optional<TraceConfig> Task::maybeMakeTraceConfig() const {
         queryCtx_->updateTracedBytesAndCheckLimit(bytes);
       };
   return TraceConfig(
-      std::move(traceNodeIdSet),
+      traceNodeId,
       traceDir,
       std::move(updateAndCheckTraceLimitCB),
       queryConfig.queryTraceTaskRegExp());
@@ -3394,7 +3377,9 @@ void Task::maybeInitTrace() {
   trace::createTraceDirectory(traceConfig_->queryTraceDir);
   const auto metadataWriter = std::make_unique<trace::TaskTraceMetadataWriter>(
       traceConfig_->queryTraceDir, memory::traceMemoryPool());
-  metadataWriter->write(queryCtx_, planFragment_.planNode);
+  auto traceNode =
+      trace::getTraceNode(planFragment_.planNode, traceConfig_->queryNodeId);
+  metadataWriter->write(queryCtx_, traceNode);
 }
 
 void Task::testingVisitDrivers(const std::function<void(Driver*)>& callback) {

--- a/velox/exec/TraceUtil.h
+++ b/velox/exec/TraceUtil.h
@@ -135,4 +135,12 @@ folly::dynamic getTaskMetadata(
 
 /// Checks whether the operator can be traced.
 bool canTrace(const std::string& operatorType);
+
+/// Gets the specified the trace node from 'plan'. In the returned trace node,
+/// we replace its source nodes with DummySourceNode for replay.
+core::PlanNodePtr getTraceNode(
+    const core::PlanNodePtr& plan,
+    core::PlanNodeId nodeId);
+
+void registerDummySourceSerDe();
 } // namespace facebook::velox::exec::trace

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -271,6 +271,7 @@ void TraceReplayRunner::init() {
 #endif
 
   core::PlanNode::registerSerDe();
+  velox::exec::trace::registerDummySourceSerDe();
   core::ITypedExpr::registerSerDe();
   common::Filter::registerSerDe();
   Type::registerSerDe();

--- a/velox/tool/trace/tests/AggregationReplayerTest.cpp
+++ b/velox/tool/trace/tests/AggregationReplayerTest.cpp
@@ -72,6 +72,7 @@ class AggregationReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertTableHandle::registerSerDe();
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -262,7 +263,7 @@ TEST_F(AggregationReplayerTest, hashAggregationTest) {
               .config(core::QueryConfig::kQueryTraceDir, traceRoot)
               .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
               .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-              .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+              .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
               .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
               .copyResults(pool(), task);
 
@@ -328,7 +329,7 @@ TEST_F(AggregationReplayerTest, streamingAggregateTest) {
               .config(core::QueryConfig::kQueryTraceDir, traceRoot)
               .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
               .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-              .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+              .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
               .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
               .copyResults(pool(), task);
 

--- a/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
+++ b/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
@@ -72,6 +72,7 @@ class FilterProjectReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     connector::hive::HiveConnectorSplit::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -179,9 +180,7 @@ TEST_F(FilterProjectReplayerTest, filterProject) {
         .config(core::QueryConfig::kQueryTraceDir, traceRoot)
         .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
         .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-        .config(
-            core::QueryConfig::kQueryTraceNodeIds,
-            fmt::format("{},{}", filterNodeId_, projectNodeId_));
+        .config(core::QueryConfig::kQueryTraceNodeId, projectNodeId_);
     auto traceResult = traceBuilder.splits(tracePlanWithSplits.splits)
                            .copyResults(pool(), task);
 
@@ -216,9 +215,7 @@ TEST_F(FilterProjectReplayerTest, filterOnly) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(
-          core::QueryConfig::kQueryTraceNodeIds,
-          fmt::format("{},{}", filterNodeId_, projectNodeId_));
+      .config(core::QueryConfig::kQueryTraceNodeId, filterNodeId_);
   auto traceResult =
       traceBuilder.splits(tracePlanWithSplits.splits).copyResults(pool(), task);
 
@@ -252,9 +249,7 @@ TEST_F(FilterProjectReplayerTest, projectOnly) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(
-          core::QueryConfig::kQueryTraceNodeIds,
-          fmt::format("{},{}", filterNodeId_, projectNodeId_));
+      .config(core::QueryConfig::kQueryTraceNodeId, projectNodeId_);
   auto traceResult =
       traceBuilder.splits(tracePlanWithSplits.splits).copyResults(pool(), task);
 

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -73,6 +73,7 @@ class HashJoinReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     connector::hive::HiveConnectorSplit::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -222,7 +223,7 @@ TEST_F(HashJoinReplayerTest, basic) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_);
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
   for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
     traceBuilder.splits(planNodeId, nodeSplits);
   }
@@ -278,7 +279,7 @@ TEST_F(HashJoinReplayerTest, partialDriverIds) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_);
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
   for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
     traceBuilder.splits(planNodeId, nodeSplits);
   }
@@ -344,7 +345,7 @@ TEST_F(HashJoinReplayerTest, runner) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_);
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
   for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
     traceBuilder.splits(planNodeId, nodeSplits);
   }
@@ -447,7 +448,7 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashBuildSpill) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
       .config(core::QueryConfig::kSpillEnabled, true)
       .config(core::QueryConfig::kJoinSpillEnabled, true)
       .spillDirectory(spillDir);
@@ -528,7 +529,7 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashProbeSpill) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
       .config(core::QueryConfig::kSpillEnabled, true)
       .config(core::QueryConfig::kJoinSpillEnabled, true)
       .spillDirectory(spillDir);

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -23,6 +23,7 @@
 
 #include "velox/common/file/tests/FaultyFileSystem.h"
 #include "velox/exec/PartitionFunction.h"
+#include "velox/exec/TraceUtil.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -62,6 +63,7 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     connector::hive::HiveConnectorSplit::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
     connector::registerConnectorFactory(
@@ -301,7 +303,7 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .splits(
               probeScanId,
               {Split(makeHiveConnectorSplit(sourceFilePath->getPath()))})

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -64,6 +64,7 @@ class PartitionedOutputReplayerTest
     connector::hive::HiveInsertTableHandle::registerSerDe();
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -111,7 +112,7 @@ class PartitionedOutputReplayerTest
              {core::QueryConfig::kQueryTraceMaxBytes,
               std::to_string(100UL << 30)},
              {core::QueryConfig::kQueryTraceTaskRegExp, ".*"},
-             {core::QueryConfig::kQueryTraceNodeIds, capturedPlanNodeId},
+             {core::QueryConfig::kQueryTraceNodeId, capturedPlanNodeId},
              {core::QueryConfig::kMaxPartitionedOutputBufferSize,
               std::to_string(8UL << 20)},
              {core::QueryConfig::kMaxOutputBufferSize,

--- a/velox/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableScanReplayerTest.cpp
@@ -67,6 +67,7 @@ class TableScanReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     connector::hive::HiveConnectorSplit::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -124,7 +125,7 @@ TEST_F(TableScanReplayerTest, runner) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .splits(makeHiveConnectorSplits(splitFiles))
           .copyResults(pool(), task);
 
@@ -196,7 +197,7 @@ TEST_F(TableScanReplayerTest, basic) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .splits(makeHiveConnectorSplits(splitFiles))
           .copyResults(pool(), task);
 
@@ -265,7 +266,7 @@ TEST_F(TableScanReplayerTest, columnPrunning) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .splits(makeHiveConnectorSplits(splitFiles))
           .copyResults(pool(), task);
 
@@ -328,7 +329,7 @@ TEST_F(TableScanReplayerTest, subfieldPrunning) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .split(split)
           .copyResults(pool(), task);
 
@@ -369,7 +370,7 @@ TEST_F(TableScanReplayerTest, concurrent) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
           .splits(makeHiveConnectorSplits(splitFiles))
           .copyResults(pool(), task);
 

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -66,6 +66,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertTableHandle::registerSerDe();
     connector::hive::HiveInsertFileNameGenerator::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -293,7 +294,7 @@ TEST_F(TableWriterReplayerTest, runner) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId)
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId)
           .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
           .copyResults(pool(), task);
 
@@ -364,7 +365,7 @@ TEST_F(TableWriterReplayerTest, basic) {
           .config(core::QueryConfig::kQueryTraceDir, traceRoot)
           .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
           .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-          .config(core::QueryConfig::kQueryTraceNodeIds, planNodeId)
+          .config(core::QueryConfig::kQueryTraceNodeId, planNodeId)
           .split(makeHiveConnectorSplit(sourceFilePath->getPath()))
           .copyResults(pool(), task);
   const auto traceOutputDir = TempDirectoryPath::create();
@@ -482,7 +483,7 @@ TEST_F(TableWriterReplayerTest, partitionWrite) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, tableWriteNodeId)
+      .config(core::QueryConfig::kQueryTraceNodeId, tableWriteNodeId)
       .splits(makeHiveConnectorSplits(inputFilePaths))
       .copyResults(pool(), task);
   actualPartitionDirectories =

--- a/velox/tool/trace/tests/TraceFileToolTest.cpp
+++ b/velox/tool/trace/tests/TraceFileToolTest.cpp
@@ -70,6 +70,7 @@ class TraceFileToolTest : public HiveConnectorTestBase {
     connector::hive::HiveInsertTableHandle::registerSerDe();
     connector::hive::HiveConnectorSplit::registerSerDe();
     core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
   }
@@ -213,7 +214,7 @@ TEST_F(TraceFileToolTest, basic) {
       .config(core::QueryConfig::kQueryTraceDir, traceRoot)
       .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
       .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
-      .config(core::QueryConfig::kQueryTraceNodeIds, traceNodeId_);
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
 
   for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
     traceBuilder.splits(planNodeId, nodeSplits);


### PR DESCRIPTION
The TaskTraceMetadataWriter serializes and writes the entire plan
fragment to the task metadata file. Then, the TaskTraceMetadataReader
deserializes the task metadata, extracts the target trace node, and constructs
a replay node by using it. During this process, there may be some plan nodes
that do not support serialization and deserialization in the whole plan fragment,
and it would break the tracing of the target tracing node. Hence, we need only
to trace the target node and replace its source nodes with DummySourceNode
to retain the trace node's input types.

