### PR TITLE
fix: Add config for requested type check in ReaderBase::convertType

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -235,6 +235,13 @@ bool HiveConfig::readStatsBasedFilterReorderDisabled(
       config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
 }
 
+bool HiveConfig::isRequestedTypeCheckEnabled(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kEnableRequestedTypeCheckSession,
+      config_->get<bool>(kEnableRequestedTypeCheck, true));
+}
+
 std::string HiveConfig::hiveLocalDataPath() const {
   return config_->get<std::string>(kLocalDataPath, "");
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -197,6 +197,11 @@ class HiveConfig {
   static constexpr const char* kPreserveFlatMapsInMemorySession =
       "hive.preserve_flat_maps_in_memory";
 
+  static constexpr const char* kEnableRequestedTypeCheck =
+      "enable-requested-type-check";
+  static constexpr const char* kEnableRequestedTypeCheckSession =
+      "enable_requested_type_check";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const config::ConfigBase* session) const;
 
@@ -269,6 +274,10 @@ class HiveConfig {
   /// Returns true if the stats based filter reorder for read is disabled.
   bool readStatsBasedFilterReorderDisabled(
       const config::ConfigBase* session) const;
+
+  /// Whether to enable requested type check in the ReaderBase::convertType.
+  /// Returns true by default.
+  bool isRequestedTypeCheckEnabled(const config::ConfigBase* session) const;
 
   /// Returns the file system path containing local data. If non-empty,
   /// initializes LocalHiveConnectorMetadata to provide metadata for the tables

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -604,6 +604,8 @@ void configureReaderOptions(
     }
 
     readerOptions.setFileFormat(hiveSplit->fileFormat);
+    readerOptions.setEnableRequestedTypeCheck(
+        hiveConfig->isRequestedTypeCheckEnabled(sessionProperties));
   }
 }
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -685,7 +685,11 @@ Each query can override the config by setting corresponding query session proper
      - bool
      - false
      - Whether to preserve flat maps in memory as FlatMapVectors instead of converting them to MapVectors. This is only applied during data reading inside the DWRF and Nimble readers, not during downstream processing like expression evaluation etc.
-
+   * - enable-requested-type-check
+     - enable_requested_type_check
+     - bool
+     - true
+     - Whether to enable requested type check in the `ReaderBase::convertType`. True by default.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -638,6 +638,10 @@ class ReaderOptions : public io::ReaderOptions {
     return randomSkip_;
   }
 
+  bool enableRequestedTypeCheck() const {
+    return enableRequestedTypeCheck_;
+  }
+
   void setRandomSkip(std::shared_ptr<random::RandomSkipTracker> randomSkip) {
     randomSkip_ = std::move(randomSkip);
   }
@@ -674,6 +678,10 @@ class ReaderOptions : public io::ReaderOptions {
     allowEmptyFile_ = value;
   }
 
+  void setEnableRequestedTypeCheck(bool enableRequestedTypeCheck) {
+    enableRequestedTypeCheck_ = enableRequestedTypeCheck;
+  }
+
  private:
   uint64_t tailLocation_;
   FileFormat fileFormat_;
@@ -691,6 +699,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
   bool allowEmptyFile_{false};
+  bool enableRequestedTypeCheck_{true};
 };
 
 struct WriterOptions {

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -722,6 +722,7 @@ TypePtr ReaderBase::convertType(
 
   static std::string_view kTypeMappingErrorFmtStr =
       "Converted type {} is not allowed for requested type {}";
+  const bool enableRequestedTypeCheck = options_.enableRequestedTypeCheck();
   if (schemaElement.__isset.converted_type) {
     switch (schemaElement.converted_type) {
       case thrift::ConvertedType::INT_8:
@@ -731,14 +732,16 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TINYINT ||
-                requestedType->kind() == TypeKind::SMALLINT ||
-                requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "TINYINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::TINYINT ||
+                  requestedType->kind() == TypeKind::SMALLINT ||
+                  requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "TINYINT",
+              requestedType->toString());
+        }
         return TINYINT();
 
       case thrift::ConvertedType::INT_16:
@@ -748,13 +751,15 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::SMALLINT ||
-                requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "SMALLINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::SMALLINT ||
+                  requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "SMALLINT",
+              requestedType->toString());
+        }
         return SMALLINT();
 
       case thrift::ConvertedType::INT_32:
@@ -764,12 +769,14 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "INTEGER",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "INTEGER",
+              requestedType->toString());
+        }
         return INTEGER();
 
       case thrift::ConvertedType::INT_64:
@@ -779,11 +786,13 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT64,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "BIGINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "BIGINT",
+              requestedType->toString());
+        }
         return BIGINT();
 
       case thrift::ConvertedType::DATE:
@@ -791,11 +800,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "DATE converted type can only be set for value of thrift::Type::INT32");
-        VELOX_CHECK(
-            !requestedType || requestedType->isDate(),
-            kTypeMappingErrorFmtStr,
-            "DATE",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->isDate(),
+              kTypeMappingErrorFmtStr,
+              "DATE",
+              requestedType->toString());
+        }
         return DATE();
 
       case thrift::ConvertedType::TIMESTAMP_MICROS:
@@ -804,11 +815,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "TIMESTAMP_MICROS or TIMESTAMP_MILLIS converted type can only be set for value of thrift::Type::INT64");
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
-            kTypeMappingErrorFmtStr,
-            "TIMESTAMP",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
+              kTypeMappingErrorFmtStr,
+              "TIMESTAMP",
+              requestedType->toString());
+        }
         return TIMESTAMP();
 
       case thrift::ConvertedType::DECIMAL: {
@@ -817,20 +830,20 @@ TypePtr ReaderBase::convertType(
             "DECIMAL requires a length and scale specifier!");
         const auto schemaElementPrecision = schemaElement.precision;
         const auto schemaElementScale = schemaElement.scale;
-        // A long decimal requested type cannot read a value of a short decimal.
-        // As a result, the mapping from short to long decimal is currently
-        // restricted.
+        // A long decimal requested type cannot read a value of a short
+        // decimal. As a result, the mapping from short to long decimal is
+        // currently restricted.
         auto type = DECIMAL(schemaElementPrecision, schemaElementScale);
-        if (requestedType) {
+        if (enableRequestedTypeCheck && requestedType) {
           VELOX_CHECK(
               requestedType->isDecimal(),
               kTypeMappingErrorFmtStr,
               "DECIMAL",
               requestedType->toString());
-          // Reading short decimals with a long decimal requested type is not
-          // yet possible. To allow for correct interpretation of the values,
-          // the scale of the file type and requested type must match while
-          // precision may be larger.
+          // Reading short decimals with a long decimal requested type is
+          // not yet possible. To allow for correct interpretation of the
+          // values, the scale of the file type and requested type must
+          // match while precision may be larger.
           if (requestedType->isShortDecimal()) {
             const auto& shortDecimalType = requestedType->asShortDecimal();
             VELOX_CHECK(
@@ -858,11 +871,13 @@ TypePtr ReaderBase::convertType(
         switch (schemaElement.type) {
           case thrift::Type::BYTE_ARRAY:
           case thrift::Type::FIXED_LEN_BYTE_ARRAY:
-            VELOX_CHECK(
-                !requestedType || requestedType->kind() == TypeKind::VARCHAR,
-                kTypeMappingErrorFmtStr,
-                "VARCHAR",
-                requestedType->toString());
+            if (enableRequestedTypeCheck) {
+              VELOX_CHECK(
+                  !requestedType || requestedType->kind() == TypeKind::VARCHAR,
+                  kTypeMappingErrorFmtStr,
+                  "VARCHAR",
+                  requestedType->toString());
+            }
             return VARCHAR();
           default:
             VELOX_FAIL(
@@ -873,11 +888,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::BYTE_ARRAY,
             "ENUM converted type can only be set for value of thrift::Type::BYTE_ARRAY");
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::VARCHAR,
-            kTypeMappingErrorFmtStr,
-            "VARCHAR",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::VARCHAR,
+              kTypeMappingErrorFmtStr,
+              "VARCHAR",
+              requestedType->toString());
+        }
         return VARCHAR();
       }
       case thrift::ConvertedType::MAP:
@@ -896,69 +913,85 @@ TypePtr ReaderBase::convertType(
   } else {
     switch (schemaElement.type) {
       case thrift::Type::type::BOOLEAN:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BOOLEAN,
-            kTypeMappingErrorFmtStr,
-            "BOOLEAN",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BOOLEAN,
+              kTypeMappingErrorFmtStr,
+              "BOOLEAN",
+              requestedType->toString());
+        }
         return BOOLEAN();
       case thrift::Type::type::INT32:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "INTEGER",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "INTEGER",
+              requestedType->toString());
+        }
         return INTEGER();
       case thrift::Type::type::INT64:
         // For Int64 Timestamp in nano precision
         if (schemaElement.__isset.logicalType &&
             schemaElement.logicalType.__isset.TIMESTAMP) {
+          if (enableRequestedTypeCheck) {
+            VELOX_CHECK(
+                !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
+                kTypeMappingErrorFmtStr,
+                "TIMESTAMP",
+                requestedType->toString());
+          }
+          return TIMESTAMP();
+        }
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "BIGINT",
+              requestedType->toString());
+        }
+        return BIGINT();
+      case thrift::Type::type::INT96:
+        if (enableRequestedTypeCheck) {
           VELOX_CHECK(
               !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
               kTypeMappingErrorFmtStr,
               "TIMESTAMP",
               requestedType->toString());
-          return TIMESTAMP();
         }
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "BIGINT",
-            requestedType->toString());
-        return BIGINT();
-      case thrift::Type::type::INT96:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
-            kTypeMappingErrorFmtStr,
-            "TIMESTAMP",
-            requestedType->toString());
         return TIMESTAMP(); // INT96 only maps to a timestamp
       case thrift::Type::type::FLOAT:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::REAL ||
-                requestedType->kind() == TypeKind::DOUBLE,
-            kTypeMappingErrorFmtStr,
-            "REAL",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::REAL ||
+                  requestedType->kind() == TypeKind::DOUBLE,
+              kTypeMappingErrorFmtStr,
+              "REAL",
+              requestedType->toString());
+        }
         return REAL();
       case thrift::Type::type::DOUBLE:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::DOUBLE,
-            kTypeMappingErrorFmtStr,
-            "DOUBLE",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::DOUBLE,
+              kTypeMappingErrorFmtStr,
+              "DOUBLE",
+              requestedType->toString());
+        }
         return DOUBLE();
       case thrift::Type::type::BYTE_ARRAY:
       case thrift::Type::type::FIXED_LEN_BYTE_ARRAY:
         if (requestedType && requestedType->isVarchar()) {
           return VARCHAR();
         } else {
-          VELOX_CHECK(
-              !requestedType || requestedType->isVarbinary(),
-              kTypeMappingErrorFmtStr,
-              "VARBINARY",
-              requestedType->toString());
+          if (enableRequestedTypeCheck) {
+            VELOX_CHECK(
+                !requestedType || requestedType->isVarbinary(),
+                kTypeMappingErrorFmtStr,
+                "VARBINARY",
+                requestedType->toString());
+          }
           return VARBINARY();
         }
 


### PR DESCRIPTION
A check on the requested type against the element converted type has been 
introduced in https://github.com/facebookincubator/velox/commit/5ad65e4a487ea4a43dc808802726a479b017b1b8.  However, some check failures are acceptable in Spark
scan. For example:
- The bigint data could be read as integer type in Spark.
- When the element converted type in scalar type, the check requires the
requested type must not be array. However, an unannotated array in Parquet
is a repeated field that is not explicitly marked as a LIST logical type, and it
depends on the reader to decide whether the data should be interpreted as
scalar values or array.

To avoid the type check failures and allow more compatibility with engines like
Spark, this PR adds a configuration to enable or disable the type check.