### PR TITLE
feat: Add skeleton code for TextReaderImpl class

### DIFF
--- a/velox/dwio/text/reader/ReaderBase.cpp
+++ b/velox/dwio/text/reader/ReaderBase.cpp
@@ -68,4 +68,54 @@ uint64_t ReaderBase::getMemoryUse() {
   return 0;
 }
 
+/// TODO: Add implementation
+TextReaderImpl::TextReaderImpl(
+    std::unique_ptr<velox::dwio::common::ReadFileInputStream> /*stream*/,
+    const ReaderOptions& options)
+    : options_(options) {}
+
+/// TODO: Add implementation
+common::CompressionKind TextReaderImpl::getCompression() const {
+  return common::CompressionKind::CompressionKind_NONE;
+}
+
+/// TODO: Add implementation
+uint64_t TextReaderImpl::getNumberOfRows() const {
+  return 0;
+}
+
+/// TODO: Add implementation
+std::unique_ptr<RowReader> TextReaderImpl::createRowReader() const {
+  return nullptr;
+}
+
+/// TODO: Add implementation
+std::unique_ptr<RowReader> TextReaderImpl::createRowReader(
+    const RowReaderOptions& /*options*/) const {
+  return nullptr;
+}
+
+/// TODO: Add implementation
+std::unique_ptr<RowReader> TextReaderImpl::createRowReader(
+    const RowReaderOptions& /*options*/,
+    bool /*prestoTextReader*/) const {
+  return nullptr;
+}
+
+/// TODO: Add implementation
+uint64_t TextReaderImpl::getFileLength() const {
+  return 0;
+}
+
+/// TODO: Add implementation
+const std::shared_ptr<const RowType>& TextReaderImpl::getType() const {
+  static std::shared_ptr<const RowType> dummy;
+  return dummy;
+}
+
+/// TODO: Add implementation
+uint64_t TextReaderImpl::getMemoryUse() {
+  return 0;
+}
+
 } // namespace facebook::velox::text

--- a/velox/dwio/text/reader/ReaderBase.h
+++ b/velox/dwio/text/reader/ReaderBase.h
@@ -76,4 +76,39 @@ class ReaderBase {
   uint64_t getMemoryUse();
 };
 
+class TextReaderImpl : public RowReader {
+ private:
+  const ReaderOptions& options_;
+
+  std::shared_ptr<FileContents> contents_;
+  std::shared_ptr<const TypeWithId> schemaWithId_;
+
+  // Usable only for testing.
+  std::shared_ptr<const RowType> internalSchema_;
+
+ public:
+  TextReaderImpl(
+      std::unique_ptr<velox::dwio::common::ReadFileInputStream> stream,
+      const ReaderOptions& options);
+
+  common::CompressionKind getCompression() const;
+
+  uint64_t getNumberOfRows() const;
+
+  std::unique_ptr<RowReader> createRowReader() const;
+
+  std::unique_ptr<RowReader> createRowReader(
+      const RowReaderOptions& options) const;
+
+  std::unique_ptr<RowReader> createRowReader(
+      const RowReaderOptions& options,
+      bool prestoTextReader) const;
+
+  uint64_t getFileLength() const;
+
+  const std::shared_ptr<const RowType>& getType() const;
+
+  uint64_t getMemoryUse();
+};
+
 } // namespace facebook::velox::text


### PR DESCRIPTION
Summary: TextReaderImpl is used as the reader member in TextReader class. It is a layer on top of both BufferedInput and ReadFileInputStream for IO performance optimization.

Differential Revision: D75833825


