### PR TITLE
build: Control geometric functions registration with VELOX_ENABLE_GEO

### DIFF
--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -25,7 +25,6 @@ velox_add_library(
   DateTimeFunctionsRegistration.cpp
   DataSizeFunctionsRegistration.cpp
   GeneralFunctionsRegistration.cpp
-  GeometryFunctionsRegistration.cpp
   HyperLogFunctionsRegistration.cpp
   IntegerFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp
@@ -37,6 +36,10 @@ velox_add_library(
   StringFunctionsRegistration.cpp
   TDigestFunctionsRegistration.cpp
   URLFunctionsRegistration.cpp)
+
+if(VELOX_ENABLE_GEO)
+  velox_add_library(velox_functions_prestosql GeometryFunctionsRegistration.cpp)
+endif()
 
 # GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
 # up failing compilation in an openssl header included by a hash-related

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -41,7 +41,9 @@ extern void registerMapAllowingDuplicates(
     const std::string& name,
     const std::string& prefix);
 extern void registerBingTileFunctions(const std::string& prefix);
+#ifdef VELOX_ENABLE_GEO
 extern void registerGeometryFunctions(const std::string& prefix);
+#endif
 extern void registerInternalArrayFunctions();
 
 namespace prestosql {
@@ -87,9 +89,11 @@ void registerBingTileFunctions(const std::string& prefix) {
   functions::registerBingTileFunctions(prefix);
 }
 
+#ifdef VELOX_ENABLE_GEO
 void registerGeometryFunctions(const std::string& prefix) {
   functions::registerGeometryFunctions(prefix);
 }
+#endif
 
 void registerGeneralFunctions(const std::string& prefix) {
   functions::registerGeneralFunctions(prefix);
@@ -126,7 +130,9 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerTDigestFunctions(prefix);
   registerIntegerFunctions(prefix);
   registerBingTileFunctions(prefix);
+#ifdef VELOX_ENABLE_GEO
   registerGeometryFunctions(prefix);
+#endif
   registerGeneralFunctions(prefix);
   registerDateTimeFunctions(prefix);
   registerURLFunctions(prefix);


### PR DESCRIPTION
Register geometric functions when CMake flag `VELOX_ENABLE_GEO` is set.

Motivation:
Prevent error seen when building Prestissimo with `VELOX_ENABLE_GEO` enabled:
```
In file included from /root/presto/presto-native-execution/velox/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp:19:
In file included from /root/presto/presto-native-execution/velox/velox/functions/prestosql/GeometryFunctions.h:22:
In file included from /root/velox_dependency_install/include/geos/io/WKTReader.h:25:
In file included from /root/velox_dependency_install/include/geos/geom/GeometryFactory.h:23:
/root/velox_dependency_install/include/geos/geom/Geometry.h:26:3: error: "The GEOS C++ API is unstable, please use the C API instead" [-Werror,-W#warnings]
   26 | # warning "The GEOS C++ API is unstable, please use the C API instead"
      |   ^
/root/velox_dependency_install/include/geos/geom/Geometry.h:27:3: error: "HINT: #include geos_c.h" [-Werror,-W#warnings]
   27 | # warning "HINT: #include geos_c.h"
      |   ^
2 errors generated.
```