### PR TITLE
feat: Support values in verax

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -322,6 +322,28 @@ class ValuesNode : public PlanNode {
         parallelizable_(parallelizable),
         repeatTimes_(repeatTimes) {}
 
+  ValuesNode(
+      const PlanNodeId& id,
+      std::vector<RowVectorPtr> values,
+      const RowTypePtr& outputType,
+      bool parallelizable = kDefaultParallelizable,
+      size_t repeatTimes = kDefaultRepeatTimes)
+      : PlanNode(id),
+        values_(std::move(values)),
+        outputType_(outputType),
+        parallelizable_(parallelizable),
+        repeatTimes_(repeatTimes) {
+    if (values_.empty()) {
+      VELOX_CHECK(ROW({})->equivalent(*outputType_));
+    } else {
+      for (const auto& rowVector : values_) {
+        const auto& valuesType =
+            std::dynamic_pointer_cast<const RowType>(rowVector->type());
+        VELOX_CHECK(valuesType->equivalent(*outputType_));
+      }
+    }
+  }
+
   class Builder {
    public:
     Builder() = default;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/verax/pull/16

Note: The diff just to get feedback, will address comments and clean up before landing. 

Introduce values node support which is modeled as a `ValuesTable`, `ValuesTable` is a child class of `BaseTable`.  When making the queryGraph, `velox::ValuesNode` is added to the `schema` with a an internedName that starts with `values_`.  Unlike traditional `BaseTables`, I omit adding the layout and leave the locus as nullptr.  Since I still need to remember what the `std::vector<RowVectorPtr>` is  in order to create `ValuesNode` when we construct the physical plan, I cache `std::vector<const RowVector*>` using the custom allocator. The `RowVectorPtr` themselves are registered and cached in the QueryOptimization such that future references to the `shared_ptr` will alway be accessed via a raw pointer similar to types. Note that there is no de-duplication since the odds of two different vectors with same value are low, and even if it happens, we we just pay the cost with more entries without needing to take on any of the complexity to de-dupe, recursively hash and do equality comparison.

A `RelType::kValues` is also added  to support constructing the `PlanPtr`.  If `from->type() == PlanType::kValuesTable`, we construct a `Values`, the RelationOp.  Note the construction is similar to a dummy table scan.

Differential Revision: D74134105


