### PR TITLE
build(ci): Fix dependency install in macOS Wheel build

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
             export INSTALL_PREFIX="$GITHUB_WORKSPACE/dependencies"
             echo "CMAKE_PREFIX_PATH=$INSTALL_PREFIX" >> $GITHUB_ENV
+            echo "INSTALL_PREFIX=$INSTALL_PREFIX" >> $GITHUB_ENV
             echo "DYLD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$DYLD_LIBRARY_PATH" >> $GITHUB_ENV
 
             source scripts/setup-macos.sh

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -39,7 +39,7 @@ export OS_CXXFLAGS=" -isystem $(brew --prefix)/include "
 export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 simdjson snappy xz zstd"
+MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4 lzo openssl protobuf@21 simdjson snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"


### PR DESCRIPTION
Fixes #13607 

The macos jobs fail because the dependency install_prefix wasn't set in the second step and xxhash is missing from the setup script.