### PR TITLE
feat(dwio): Allow DWRF selective readers to generate FlatMapVector

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -53,6 +53,7 @@ velox_add_library(
   SeekableInputStream.cpp
   SelectiveByteRleColumnReader.cpp
   SelectiveColumnReader.cpp
+  SelectiveFlatMapColumnReader.cpp
   SelectiveRepeatedColumnReader.cpp
   SelectiveStructColumnReader.cpp
   SortingWriter.cpp

--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -39,6 +39,14 @@ void resetIfNotWritable(VectorPtr& vector, const T&... buffer) {
 
 } // namespace detail
 
+// Output type of flat map column reader, indicates the in memory representation
+// the flat map should be read into.
+enum class FlatMapOutput : uint8_t {
+  kMap = 0, // MapVector
+  kStruct = 1, // RowVector
+  kFlatMap = 2, // FlatMapVector
+};
+
 // Struct for keeping track flatmap key stream metrics.
 // Used by keySelectionCallback_ in FlatMapColumnReader
 struct FlatMapKeySelectionStats {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -308,7 +308,7 @@ class RowReaderOptions {
     return flatmapNodeIdAsStruct_;
   }
 
-  void setPreserveFlatMapsInMemory(uint64_t preserveFlatMapsInMemory) {
+  void setPreserveFlatMapsInMemory(bool preserveFlatMapsInMemory) {
     preserveFlatMapsInMemory_ = preserveFlatMapsInMemory;
   }
 

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -21,6 +21,21 @@
 
 namespace facebook::velox::common {
 
+// static
+std::string_view ScanSpec::columnTypeString(ScanSpec::ColumnType columnType) {
+  switch (columnType) {
+    case ScanSpec::ColumnType::kRegular:
+      return "REGULAR";
+    case ScanSpec::ColumnType::kRowIndex:
+      return "ROW_INDEX";
+    case ScanSpec::ColumnType::kComposite:
+      return "COMPOSITE";
+    default:
+      VELOX_UNREACHABLE(
+          "Unrecognized ColumnType: {}", static_cast<int8_t>(columnType));
+  }
+}
+
 ScanSpec* ScanSpec::getOrCreateChild(const std::string& name) {
   if (auto it = this->childByFieldName_.find(name);
       it != this->childByFieldName_.end()) {

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -47,6 +47,9 @@ class ScanSpec {
     kComposite, // A struct with all children not read from file
   };
 
+  // Convert ColumnType to its string name representation.
+  static std::string_view columnTypeString(ColumnType columnType);
+
   static constexpr column_index_t kNoChannel = ~0;
   static constexpr const char* kMapKeysFieldName = "keys";
   static constexpr const char* kMapValuesFieldName = "values";
@@ -509,3 +512,14 @@ bool testFilter(
 } // namespace common
 } // namespace velox
 } // namespace facebook
+
+template <>
+struct fmt::formatter<facebook::velox::common::ScanSpec::ColumnType>
+    : formatter<std::string_view> {
+  auto format(
+      facebook::velox::common::ScanSpec::ColumnType columnType,
+      format_context& ctx) const {
+    return formatter<std::string_view>::format(
+        facebook::velox::common::ScanSpec::columnTypeString(columnType), ctx);
+  }
+};

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -223,6 +223,74 @@ uint64_t SelectiveStructColumnReaderBase::skip(uint64_t numValues) {
   return numValues;
 }
 
+void SelectiveStructColumnReaderBase::seekToPropagateNullsToChildren(
+    int64_t offset) {
+  if (offset == readOffset_) {
+    return;
+  }
+  if (readOffset_ < offset) {
+    if (numParentNulls_) {
+      VELOX_CHECK_LE(
+          parentNullsRecordedTo_,
+          offset,
+          "Must not seek to before parentNullsRecordedTo_");
+    }
+    auto distance = offset - readOffset_ - numParentNulls_;
+    auto numNonNulls = formatData_->skipNulls(distance);
+    // We inform children how many nulls there were between original position
+    // and destination. The children will seek this many less. The
+    // nulls include the nulls found here as well as the enclosing
+    // level nulls reported to this by parents.
+    for (auto& child : children_) {
+      if (child) {
+        child->addSkippedParentNulls(
+            readOffset_, offset, numParentNulls_ + distance - numNonNulls);
+      }
+    }
+    numParentNulls_ = 0;
+    parentNullsRecordedTo_ = 0;
+    readOffset_ = offset;
+  } else {
+    VELOX_FAIL("Seeking backward on a ColumnReader");
+  }
+}
+
+void SelectiveStructColumnReaderBase::seekToRowGroupFixedRowsPerRowGroup(
+    const int64_t index,
+    const int32_t rowsPerRowGroup) {
+  dwio::common::SelectiveStructColumnReaderBase::seekToRowGroup(index);
+  if (isTopLevel_ && !formatData_->hasNulls()) {
+    readOffset_ = index * rowsPerRowGroup;
+    return;
+  }
+
+  // There may be a nulls stream but no other streams for the struct.
+  formatData_->seekToRowGroup(index);
+  // Set the read offset recursively. Do this before seeking the children
+  // because list/map children will reset the offsets for their children.
+  setReadOffsetRecursive(index * rowsPerRowGroup);
+  for (auto& child : children_) {
+    child->seekToRowGroup(index);
+  }
+}
+
+/// Advance field reader to the row group closest to specified offset by
+/// calling seekToRowGroup.
+void SelectiveStructColumnReaderBase::advanceFieldReaderFixedRowsPerRowGroup(
+    dwio::common::SelectiveColumnReader* reader,
+    const int64_t offset,
+    const int32_t rowsPerRowGroup) {
+  if (!reader->isTopLevel()) {
+    return;
+  }
+  const auto rowGroup = reader->readOffset() / rowsPerRowGroup;
+  const auto nextRowGroup = offset / rowsPerRowGroup;
+  if (nextRowGroup > rowGroup) {
+    reader->seekToRowGroup(nextRowGroup);
+    reader->setReadOffset(nextRowGroup * rowsPerRowGroup);
+  }
+}
+
 void SelectiveStructColumnReaderBase::fillOutputRowsFromMutation(
     vector_size_t size) {
   if (mutation_->deletedRows) {

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -144,6 +144,23 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   /// forward within the row group.
   void recordParentNullsInChildren(int64_t offset, const RowSet& rows);
 
+  /// An implementation of seekTo that calls addSkippedParentNulls on each
+  /// child. Available as a helper function to formats that need it.
+  void seekToPropagateNullsToChildren(const int64_t offset);
+
+  /// A helper function that implements seekToRowGroup for formats that support
+  /// a fixed number of rows per row group.
+  void seekToRowGroupFixedRowsPerRowGroup(
+      const int64_t index,
+      const int32_t rowsPerRowGroup);
+
+  /// A helper function that implements advanceFieldReader for formats that
+  /// support a fixed number of rows per row group
+  void advanceFieldReaderFixedRowsPerRowGroup(
+      SelectiveColumnReader* reader,
+      const int64_t offset,
+      const int32_t rowsPerRowGroup);
+
   std::vector<SelectiveColumnReader*> children_;
 
  private:

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -72,6 +72,10 @@ class DwrfData : public dwio::common::FormatData {
     return flatMapContext_.inMapDecoder ? inMap_->as<uint64_t>() : nullptr;
   }
 
+  const velox::BufferPtr& inMapBuffer() {
+    return inMap_;
+  }
+
   /// Seeks possible flat map in map streams and nulls to the row group
   /// and returns a PositionsProvider for the other streams.
   dwio::common::PositionProvider seekToRowGroup(int64_t index) override;


### PR DESCRIPTION
Summary:
Extending support for the SelectiveFlatMapColumnReader to DWRF files to enable storage
flat maps to be read and preserved as FlatMapVectors.

Differential Revision: D75970378


