### PR TITLE
feat: Allow access to expression stats via operator stats

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -622,6 +622,13 @@ class QueryConfig {
   static constexpr const char* kFieldNamesInJsonCastEnabled =
       "field_names_in_json_cast_enabled";
 
+  /// If this is true, then operators that evaluate expressions will track their
+  /// stats and return them as part of their operator stats. Tracking these
+  /// stats can be expensive (especially if operator stats are retrieved
+  /// frequently) and this allows the user to explicitly enable it.
+  static constexpr const char* kOperatorTrackExpressionStats =
+      "operator_track_expression_stats";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -1132,6 +1139,10 @@ class QueryConfig {
 
   bool isFieldNamesInJsonCastEnabled() const {
     return get<bool>(kFieldNamesInJsonCastEnabled, false);
+  }
+
+  bool operatorTrackExpressionStats() const {
+    return get<bool>(kOperatorTrackExpressionStats, false);
   }
 
   template <typename T>

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -78,6 +78,10 @@ class FilterProject : public Operator {
 
   void initialize() override;
 
+  /// Ensures that expression stats are added to the operator stats if their
+  /// tracking is enabled via query config.
+  OperatorStats stats(bool clear) override;
+
  private:
   // Tests if 'numProcessedRows_' equals to the length of input_ and clears
   // outstanding references to input_ if done. Returns true if getOutput

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -589,6 +589,14 @@ void OperatorStats::add(const OperatorStats& other) {
     }
   }
 
+  for (const auto& [name, exprStats] : other.expressionStats) {
+    if (UNLIKELY(expressionStats.count(name) == 0)) {
+      expressionStats.insert(std::make_pair(name, exprStats));
+    } else {
+      expressionStats.at(name).add(exprStats);
+    }
+  }
+
   numDrivers += other.numDrivers;
   spilledInputBytes += other.spilledInputBytes;
   spilledBytes += other.spilledBytes;
@@ -625,6 +633,7 @@ void OperatorStats::clear() {
   memoryStats.clear();
 
   runtimeStats.clear();
+  expressionStats.clear();
 
   numDrivers = 0;
   spilledInputBytes = 0;

--- a/velox/exec/OperatorStats.h
+++ b/velox/exec/OperatorStats.h
@@ -17,6 +17,7 @@
 
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/expression/ExprStats.h"
 
 namespace facebook::velox::exec {
 
@@ -180,6 +181,11 @@ struct OperatorStats {
   int64_t numNullKeys{0};
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
+
+  // A map of expression name to its respective stats.
+  // These are only populated when a copy of the stats is returned via
+  // Operator::stats(bool) API.
+  std::unordered_map<std::string, ExprStats> expressionStats;
 
   int numDrivers = 0;
 

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -131,6 +131,14 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
     }
   }
 
+  for (const auto& [name, exprStats] : stats.expressionStats) {
+    if (UNLIKELY(this->expressionStats.count(name) == 0)) {
+      this->expressionStats.insert(std::make_pair(name, exprStats));
+    } else {
+      this->expressionStats.at(name).add(exprStats);
+    }
+  }
+
   // Populating number of drivers for plan nodes with multiple operators is not
   // useful. Each operator could have been executed in different pipelines with
   // different number of drivers.

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -18,6 +18,7 @@
 #include <folly/dynamic.h>
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/exec/Operator.h"
+#include "velox/expression/ExprStats.h"
 
 namespace facebook::velox::exec {
 struct TaskStats;
@@ -141,6 +142,9 @@ struct PlanNodeStats {
 
   /// Total spilled files.
   uint32_t spilledFiles{0};
+
+  /// A map of expression name to its respective stats.
+  std::unordered_map<std::string, ExprStats> expressionStats;
 
   /// Add stats for a single operator instance.
   void add(const OperatorStats& stats);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -25,6 +25,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
+#include "velox/expression/ExprStats.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
@@ -34,38 +35,6 @@ namespace facebook::velox::exec {
 class ExprSet;
 class FieldReference;
 class VectorFunction;
-
-struct ExprStats {
-  /// Requires QueryConfig.exprTrackCpuUsage() to be 'true'.
-  CpuWallTiming timing;
-
-  /// Number of processed rows.
-  uint64_t numProcessedRows{0};
-
-  /// Number of processed vectors / batches. Allows to compute average batch
-  /// size.
-  uint64_t numProcessedVectors{0};
-
-  /// Whether default-null behavior of an expression resulted in skipping
-  /// evaluation of rows.
-  bool defaultNullRowsSkipped{false};
-
-  void add(const ExprStats& other) {
-    timing.add(other.timing);
-    numProcessedRows += other.numProcessedRows;
-    numProcessedVectors += other.numProcessedVectors;
-    defaultNullRowsSkipped |= other.defaultNullRowsSkipped;
-  }
-
-  std::string toString() const {
-    return fmt::format(
-        "timing: {}, numProcessedRows: {}, numProcessedVectors: {}, defaultNullRowsSkipped: {}",
-        timing.toString(),
-        numProcessedRows,
-        numProcessedVectors,
-        defaultNullRowsSkipped ? "true" : "false");
-  }
-};
 
 /// Maintains a set of rows for evaluation and removes rows with
 /// nulls or errors as needed. Helps to avoid copying SelectivityVector in cases

--- a/velox/expression/ExprStats.h
+++ b/velox/expression/ExprStats.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/time/CpuWallTimer.h"
+
+namespace facebook::velox::exec {
+
+struct ExprStats {
+  /// Requires QueryConfig.exprTrackCpuUsage() to be 'true'.
+  CpuWallTiming timing;
+
+  /// Number of processed rows.
+  uint64_t numProcessedRows{0};
+
+  /// Number of processed vectors / batches. Allows to compute average batch
+  /// size.
+  uint64_t numProcessedVectors{0};
+
+  /// Whether default-null behavior of an expression resulted in skipping
+  /// evaluation of rows.
+  bool defaultNullRowsSkipped{false};
+
+  void add(const ExprStats& other) {
+    timing.add(other.timing);
+    numProcessedRows += other.numProcessedRows;
+    numProcessedVectors += other.numProcessedVectors;
+    defaultNullRowsSkipped |= other.defaultNullRowsSkipped;
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "timing: {}, numProcessedRows: {}, numProcessedVectors: {}, defaultNullRowsSkipped: {}",
+        timing.toString(),
+        numProcessedRows,
+        numProcessedVectors,
+        defaultNullRowsSkipped ? "true" : "false");
+  }
+};
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
The current Task abstraction has a limitation when it comes to
operators that evaluate expressions - their expression statistics
are not directly accessible. The only way to access those is through
the ExpressionListner API. This change allows access to those
expressions stats via the operator stats. Since fetching these stats
can be expensive (especially if they are fetched often) a query
option `operator_track_expression_stats` is added to allows the user
to explicitly enable them.

Differential Revision: D75997924


