### PR TITLE
feat: Add Hive intermediate support for Interval

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -21,10 +21,10 @@ add_library(
   PrestoQueryRunnerIntermediateTypeTransforms.cpp
   PrestoQueryRunnerTimestampWithTimeZoneTransform.cpp
   PrestoQueryRunnerJsonTransform.cpp
+  PrestoQueryRunnerIntervalTransform.cpp
   PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
   FuzzerUtil.cpp
-  PrestoSql.cpp
-  PrestoQueryRunnerIntermediateTypeTransforms.cpp)
+  PrestoSql.cpp)
 
 target_link_libraries(
   velox_fuzzer_util

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::exec::test {
+
+core::ExprPtr IntervalDayTimeTransform::projectToTargetType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CallExpr>(
+      "try",
+      std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+          "to_milliseconds",
+          std::vector<core::ExprPtr>{inputExpr},
+          std::nullopt)},
+      columnAlias);
+}
+
+// The below transform executes the following Presto SQL:
+// try(parse_duration(concat(CAST(inputExpr AS VARCHAR), 'ms')))
+//
+// This casts the inputted bigint as a string and concatenates it with 'ms'
+// to generate a valid millisecond duration as a string, which will be parsed
+// as a valid interval and easily re-converted using to_milliseconds.
+core::ExprPtr IntervalDayTimeTransform::projectToIntermediateType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  return std::make_shared<core::CallExpr>(
+      "try",
+      std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+          "parse_duration",
+          std::vector<core::ExprPtr>{std::make_shared<core::CallExpr>(
+              "concat",
+              std::vector<core::ExprPtr>{
+                  std::make_shared<core::CastExpr>(
+                      VARCHAR(), inputExpr, false, columnAlias),
+                  std::make_shared<core::ConstantExpr>(
+                      VARCHAR(),
+                      variant::create<TypeKind::VARCHAR>("ms"),
+                      std::nullopt)},
+              std::nullopt)},
+          std::nullopt)},
+      columnAlias);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+
+namespace facebook::velox::exec::test {
+
+// This transform converts negative interval values to NULL due to the
+// constraints in parse_duration. Although constants and inputs to
+// to_milliseconds allow for negatives, parse_duration does not, the try
+// will capture this error and NULL the output. The behavior is the same
+// in Presto Java and Prestissimo.
+class IntervalDayTimeTransform : public IntermediateTypeTransform {
+ public:
+  IntervalDayTimeTransform()
+      : IntermediateTypeTransform(INTERVAL_DAY_TIME(), BIGINT()) {}
+
+  core::ExprPtr projectToTargetType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+
+  core::ExprPtr projectToIntermediateType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -393,6 +393,10 @@ std::string toConstantSql(const core::ConstantTypedExpr& constant) {
       sql << typeSql << " ";
     }
     sql << std::quoted(getConstantValue<std::string>(constant), '\'', '\'');
+  } else if (type->isIntervalYearMonth()) {
+    sql << fmt::format("INTERVAL '{}' YEAR TO MONTH", constant.toString());
+  } else if (type->isIntervalDayTime()) {
+    sql << fmt::format("INTERVAL '{}' DAY TO SECOND", constant.toString());
   } else if (type->isBigint()) {
     sql << getConstantValue<int64_t>(constant);
   } else if (type->isPrimitiveType()) {

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -411,5 +411,14 @@ TEST(PrestoSqlTest, toCallInputsSql) {
   EXPECT_EQ(sql.str(), "c0.field0");
 }
 
+TEST(PrestoSqlTest, toConstantSql) {
+  EXPECT_EQ(
+      toConstantSql(core::ConstantTypedExpr(INTERVAL_YEAR_MONTH(), 123)),
+      "INTERVAL '123' YEAR TO MONTH");
+  EXPECT_EQ(
+      toConstantSql(core::ConstantTypedExpr(INTERVAL_DAY_TIME(), int64_t(123))),
+      "INTERVAL '123' DAY TO SECOND");
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -213,6 +213,7 @@ add_executable(
   PrestoQueryRunnerTDigestTransformTest.cpp
   PrestoQueryRunnerQDigestTransformTest.cpp
   PrestoQueryRunnerJsonTransformTest.cpp
+  PrestoQueryRunnerIntervalTransformTest.cpp
   PrestoQueryRunnerTimestampWithTimeZoneTransformTest.cpp)
 
 add_test(velox_exec_util_test velox_exec_util_test)

--- a/velox/exec/tests/PrestoQueryRunnerIntervalTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerIntervalTransformTest.cpp
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class PrestoQueryRunnerIntervalTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(INTERVAL_DAY_TIME()));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(INTERVAL_DAY_TIME())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(INTERVAL_DAY_TIME(), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), INTERVAL_DAY_TIME())));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({INTERVAL_DAY_TIME(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(),
+       TIMESTAMP(),
+       ARRAY(ROW({MAP(VARCHAR(), INTERVAL_DAY_TIME())}))})));
+}
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, roundTrip) {
+  std::vector<std::optional<int64_t>> no_nulls{0, 1, 2, 3};
+  test(makeNullableFlatVector(no_nulls, INTERVAL_DAY_TIME()));
+
+  std::vector<std::optional<int64_t>> some_nulls{0, 1, std::nullopt, 3};
+  test(makeNullableFlatVector(some_nulls, INTERVAL_DAY_TIME()));
+
+  std::vector<std::optional<int64_t>> all_nulls{
+      std::nullopt, std::nullopt, std::nullopt};
+  test(makeNullableFlatVector(all_nulls, INTERVAL_DAY_TIME()));
+}
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, negative) {
+  auto vector = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          -1,
+          -2,
+          -3,
+          -4,
+          -5,
+      },
+      INTERVAL_DAY_TIME());
+  const auto colName = "col";
+  const auto input =
+      makeRowVector({colName}, {transformIntermediateTypes(vector)});
+
+  auto expr = getProjectionsToIntermediateTypes(
+      vector->type(),
+      std::make_shared<core::FieldAccessExpr>(
+          colName,
+          std::nullopt,
+          std::vector<core::ExprPtr>{std::make_shared<core::InputExpr>()}),
+      colName);
+
+  core::PlanNodePtr plan =
+      PlanBuilder().values({input}).projectExpressions({expr}).planNode();
+
+  AssertQueryBuilder(plan).assertResults(makeRowVector(
+      {colName},
+      {makeNullableFlatVector(
+          std::vector<std::optional<int64_t>>{
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
+              std::nullopt,
+          },
+          INTERVAL_DAY_TIME())}));
+}
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, transformArray) {
+  auto input = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          0,
+          1,
+          12,
+          123,
+          1234,
+          12345,
+          123456,
+          1234567,
+          12345678,
+          123456789,
+          1234567890,
+          12345678901,
+          123456789012,
+          1234567890123,
+          12345678901234,
+          123456789012345,
+          1234567890123456,
+          12345678901234567,
+          123456789012345678,
+          1234567890123456789,
+      },
+      INTERVAL_DAY_TIME());
+  testArray(input);
+
+  input = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          993296205767471,
+          101271764434518,
+          166587109740908,
+          210274651317771,
+          276381323443199,
+          283617048324990,
+          519099922518052,
+          530020098439118,
+          604149362180160,
+          622016152847258},
+      INTERVAL_DAY_TIME());
+  testArray(input);
+}
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, transformMap) {
+  auto keys = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          1,
+          12,
+          123,
+          1234,
+          12345,
+          123456,
+          1234567,
+          12345678,
+          123456789,
+          1234567890,
+      },
+      INTERVAL_DAY_TIME());
+
+  auto values = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          993296205767471,
+          101271764434518,
+          166587109740908,
+          210274651317771,
+          276381323443199,
+          283617048324990,
+          519099922518052,
+          530020098439118,
+          604149362180160,
+          622016152847258},
+      INTERVAL_DAY_TIME());
+
+  testMap(keys, values);
+}
+
+TEST_F(PrestoQueryRunnerIntervalTransformTest, transformRow) {
+  auto input = makeNullableFlatVector(
+      std::vector<std::optional<int64_t>>{
+          993296205767471,
+          101271764434518,
+          166587109740908,
+          210274651317771,
+          276381323443199,
+          283617048324990,
+          519099922518052,
+          530020098439118,
+          604149362180160,
+          622016152847258},
+      INTERVAL_DAY_TIME());
+  testRow({input}, {"row"});
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -162,7 +162,14 @@ void fuzzFlatPrimitiveImpl(
     } else if constexpr (std::is_same_v<TCpp, Timestamp>) {
       flatVector->set(i, randTimestamp(rng, opts.timestampPrecision));
     } else if constexpr (std::is_same_v<TCpp, int64_t>) {
-      if (vector->type()->isShortDecimal()) {
+      if (vector->type()->isIntervalDayTime()) {
+        flatVector->set(
+            i,
+            rand<TCpp>(
+                rng,
+                -VectorFuzzer::kMaxAllowedIntervalDayTime,
+                VectorFuzzer::kMaxAllowedIntervalDayTime));
+      } else if (vector->type()->isShortDecimal()) {
         flatVector->set(i, randShortDecimal(vector->type(), rng));
       } else {
         flatVector->set(i, rand<TCpp>(rng, opts.dataSpec));
@@ -176,7 +183,14 @@ void fuzzFlatPrimitiveImpl(
         VELOX_NYI();
       }
     } else if constexpr (std::is_same_v<TCpp, int32_t>) {
-      if (vector->type()->isDate()) {
+      if (vector->type()->isIntervalYearMonth()) {
+        flatVector->set(
+            i,
+            rand<TCpp>(
+                rng,
+                -VectorFuzzer::kMaxAllowedIntervalYearMonth,
+                VectorFuzzer::kMaxAllowedIntervalYearMonth));
+      } else if (vector->type()->isDate()) {
         flatVector->set(i, randDate(rng));
       } else {
         flatVector->set(i, rand<TCpp>(rng));

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -388,6 +388,10 @@ class VectorFuzzer {
     opaqueTypeGenerators_[std::type_index(typeid(Class))] = generator;
   }
 
+  // Maximum values allowed values by Presto for interval types.
+  static const int64_t kMaxAllowedIntervalDayTime = 2147483647;
+  static const int32_t kMaxAllowedIntervalYearMonth = 178956970;
+
  private:
   // Generates a flat vector for primitive types.
   VectorPtr fuzzFlatPrimitive(const TypePtr& type, vector_size_t size);


### PR DESCRIPTION
Summary: Add support for intermediate type INTERVAL type in expression fuzzer.

Differential Revision: D75998213
