### PR TITLE
fix: Enable constant folding for lambda functions

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -836,9 +836,17 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<core::TypedExprPtr>&& source,
     core::ExecCtx* execCtx);
 
-/// Evaluates an expression that doesn't depend on any inputs and returns the
-/// result as single-row vector.
+/// Evaluates a deterministic expression that doesn't depend on any inputs and
+/// returns the result as single-row vector. Throws if expression is
+/// non-deterministic or has dependencies.
 VectorPtr evaluateConstantExpression(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* pool);
+
+/// Evaluates a deterministic expression that doesn't depend on any inputs and
+/// returns the result as single-row vector. Returns nullptr if the expression
+/// is non-deterministic or has dependencies.
+VectorPtr tryEvaluateConstantExpression(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool);
 


### PR DESCRIPTION
Summary:
ExprCompiler used to not constant fold lambda functions. transform(array[1, 2, 3], x -> x * 2) would not be constant folded.

This was due to Expr::isConstant returning false for such an expression. Expr::isConstant returned true iff expression is deterministic and all input are ConstantExpr.

A fix is to modify Expr::isConstant to return true iff expression is deterministic and has no dependencies (distinctFields_ is empty).

Also, added convenience API tryEvaluateConstantExpression to compliment existing evaluateConstantExpression. The new API can be safely called on any expression without ensuring the expression is constant-foldable.

Differential Revision: D76004362


