### PR TITLE
feat: support namespace prefixes in cudf

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -30,6 +30,8 @@
 #include <cudf/stream_compaction.hpp>
 #include <cudf/unary.hpp>
 
+#include <boost/algorithm/string.hpp>
+
 namespace {
 
 using namespace facebook::velox;
@@ -394,19 +396,19 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
     bool isGlobal) {
   // Companion function may be count_merge_extract or count_partial or others,
   // so use this to map
-  if (kind.rfind("sum", 0) == 0) {
+  if (boost::algorithm::ends_with(kind, "sum")) {
     return std::make_unique<SumAggregator>(
         step, inputIndex, constant, isGlobal);
-  } else if (kind.rfind("count", 0) == 0) {
+  } else if (boost::algorithm::ends_with(kind, "count")) {
     return std::make_unique<CountAggregator>(
         step, inputIndex, constant, isGlobal);
-  } else if (kind.rfind("min", 0) == 0) {
+  } else if (boost::algorithm::ends_with(kind, "min")) {
     return std::make_unique<MinAggregator>(
         step, inputIndex, constant, isGlobal);
-  } else if (kind.rfind("max", 0) == 0) {
+  } else if (boost::algorithm::ends_with(kind, "max")) {
     return std::make_unique<MaxAggregator>(
         step, inputIndex, constant, isGlobal);
-  } else if (kind.rfind("avg", 0) == 0) {
+  } else if (boost::algorithm::ends_with(kind, "avg")) {
     return std::make_unique<MeanAggregator>(
         step, inputIndex, constant, isGlobal);
   } else {

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/experimental/cudf/exec/ExpressionEvaluator.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/FieldReference.h"
@@ -29,6 +30,8 @@
 #include <cudf/strings/slice.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/transform.hpp>
+
+#include <boost/algorithm/string.hpp>
 
 namespace facebook::velox::cudf_velox {
 namespace {
@@ -249,8 +252,18 @@ const std::unordered_set<std::string> supportedOps = {
 
 namespace detail {
 
+inline std::string strip_prefix(
+    const std::string& input,
+    const std::string& prefix) {
+  if (boost::algorithm::starts_with(input, prefix)) {
+    return input.substr(prefix.size());
+  }
+  return input;
+}
+
 bool canBeEvaluated(const std::shared_ptr<velox::exec::Expr>& expr) {
-  const auto& name = expr->name();
+  const auto& name =
+      strip_prefix(expr->name(), CudfOptions::getInstance().prefix());
   if (supportedOps.count(name) || binaryOps.count(name) ||
       unaryOps.count(name)) {
     return std::all_of(
@@ -334,7 +347,8 @@ cudf::ast::expression const& AstContext::multipleInputsToPairWise(
     const std::shared_ptr<velox::exec::Expr>& expr) {
   using Operation = cudf::ast::operation;
 
-  const auto& name = expr->name();
+  const auto& name =
+      detail::strip_prefix(expr->name(), CudfOptions::getInstance().prefix());
   auto len = expr->inputs().size();
   // Create a simple chain of operations
   auto result = &pushExprToTree(expr->inputs()[0]);
@@ -359,7 +373,8 @@ cudf::ast::expression const& AstContext::pushExprToTree(
   using velox::exec::ConstantExpr;
   using velox::exec::FieldReference;
 
-  auto& name = expr->name();
+  auto name =
+      detail::strip_prefix(expr->name(), CudfOptions::getInstance().prefix());
   auto len = expr->inputs().size();
 
   if (name == "literal") {

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -47,16 +47,36 @@ class CompileState {
   exec::Driver& driver_;
 };
 
-struct CudfOptions {
-  bool cudfEnabled = FLAGS_velox_cudf_enabled;
-  std::string cudfMemoryResource = FLAGS_velox_cudf_memory_resource;
-  static CudfOptions defaultOptions() {
-    return CudfOptions();
+class CudfOptions {
+ public:
+  static CudfOptions& getInstance() {
+    static CudfOptions instance;
+    return instance;
   }
+
+  const bool cudfEnabled;
+  const std::string cudfMemoryResource;
+
+  void setPrefix(const std::string& prefix) {
+    prefix_ = prefix;
+  }
+
+  std::string prefix() const {
+    return prefix_;
+  }
+
+ private:
+  CudfOptions()
+      : cudfEnabled(FLAGS_velox_cudf_enabled),
+        cudfMemoryResource(FLAGS_velox_cudf_memory_resource),
+        prefix_("") {}
+  CudfOptions(const CudfOptions&) = delete;
+  CudfOptions& operator=(const CudfOptions&) = delete;
+  std::string prefix_;
 };
 
 /// Registers adapter to add cuDF operators to Drivers.
-void registerCudf(const CudfOptions& options = CudfOptions::defaultOptions());
+void registerCudf(const CudfOptions& options = CudfOptions::getInstance());
 void unregisterCudf();
 
 /// Returns true if cuDF is registered.


### PR DESCRIPTION
Prestissimo uses a custom namespace prefix for its functions which is currently not understood by the cuDF code. this change enables Prestissimo (or other applications using Velox) to register the prefix.