### PR TITLE
fix: Handle empty matches in regexp_split

### DIFF
--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -114,3 +114,8 @@ limited to 20 different expressions per instance and thread of execution.
     array. Trailing empty strings are preserved::
 
         SELECT regexp_split('1a 2b 14m', '\s*[a-z]+\s*'); -- [1, 2, 14, ]
+
+    Note: Similar with Presto's implementation, When the pattern matches an empty string,
+    the function advances by one character and includes the skipped character in the result::
+
+        SELECT regexp_split('1a 2b 14m', ''); -- [, 1, 'a', ' ', 2, 'b', ' ', 1, 4, 'm', ]

--- a/velox/docs/functions/presto/regexp.rst
+++ b/velox/docs/functions/presto/regexp.rst
@@ -115,7 +115,7 @@ limited to 20 different expressions per instance and thread of execution.
 
         SELECT regexp_split('1a 2b 14m', '\s*[a-z]+\s*'); -- [1, 2, 14, ]
 
-    Note: Similar with Presto's implementation, When the pattern matches an empty string,
-    the function advances by one character and includes the skipped character in the result::
+    Note: When the regular expression ``pattern`` matches an empty string, the result array contains an
+    empty string, a single-character string for each character in the input string, and another empty string::
 
         SELECT regexp_split('1a 2b 14m', ''); -- [, 1, 'a', ' ', 2, 'b', ' ', 1, 4, 'm', ]

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -409,6 +409,7 @@ struct Re2RegexpSplit {
     const auto re2String = re2::StringPiece(string.data(), string.size());
 
     size_t pos = 0;
+    size_t lastEnd = 0;
     const char* start = string.data();
 
     re2::StringPiece subMatches[1];
@@ -423,18 +424,24 @@ struct Re2RegexpSplit {
       const auto offset = fullMatch.data() - start;
       const auto size = fullMatch.size();
 
-      out.add_item().setNoCopy(StringView(string.data() + pos, offset - pos));
+      out.add_item().setNoCopy(
+          StringView(string.data() + lastEnd, offset - lastEnd));
 
-      pos = offset + size;
+      lastEnd = offset + size;
       if (UNLIKELY(size == 0)) {
-        ++pos;
+        pos = lastEnd + 1;
+      } else {
+        pos = lastEnd;
       }
     }
 
-    auto lastSlice = LIKELY(pos <= string.size())
-        ? StringView(string.data() + pos, string.size() - pos)
-        : StringView(nullptr, 0);
-    out.add_item().setNoCopy(lastSlice);
+    if (LIKELY(pos <= string.size())) {
+      out.add_item().setNoCopy(
+          StringView(string.data() + pos, string.size() - pos));
+    } else {
+      static const StringView kEmptyString(nullptr, 0);
+      out.add_item().setNoCopy(kEmptyString);
+    }
   }
 
  private:

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -431,8 +431,10 @@ struct Re2RegexpSplit {
       }
     }
 
-    out.add_item().setNoCopy(
-        StringView(string.data() + pos, string.size() - pos));
+    auto lastSlice = LIKELY(pos <= string.size())
+        ? StringView(string.data() + pos, string.size() - pos)
+        : StringView(nullptr, 0);
+    out.add_item().setNoCopy(lastSlice);
   }
 
  private:

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -21,6 +21,7 @@
 #include <functional>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -1560,6 +1561,14 @@ TEST_F(Re2FunctionsTest, split) {
       {"", "a", "b", ""},
       {""},
       {"a", "b"},
+  });
+  assertEqualVectors(expected, result);
+  result = evaluate("regexp_split(c0, '\\s*[a-z]*\\s*')", input);
+  expected = makeArrayVector<std::string>({
+      std::vector<std::string>(9, ""),
+      std::vector<std::string>(8, ""),
+      std::vector<std::string>(2, ""),
+      std::vector<std::string>(7, ""),
   });
   assertEqualVectors(expected, result);
 }

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1563,12 +1563,22 @@ TEST_F(Re2FunctionsTest, split) {
       {"a", "b"},
   });
   assertEqualVectors(expected, result);
+
+  result = evaluate("regexp_split(c0, '')", input);
+  expected = makeArrayVector<std::string>({
+      {"", "1", "a", " ", "2", "b", " ", "1", "4", "m", ""},
+      {"", "1", "a", " ", "2", "b", " ", "1", "4", ""},
+      {"", ""},
+      {"", "a", "1", "2", "3", "b", ""},
+  });
+  assertEqualVectors(expected, result);
+
   result = evaluate("regexp_split(c0, '\\s*[a-z]*\\s*')", input);
   expected = makeArrayVector<std::string>({
-      std::vector<std::string>(9, ""),
-      std::vector<std::string>(8, ""),
-      std::vector<std::string>(2, ""),
-      std::vector<std::string>(7, ""),
+      {"", "1", "", "2", "", "1", "4", "", ""},
+      {"", "1", "", "2", "", "1", "4", ""},
+      {"", ""},
+      {"", "", "1", "2", "3", "", ""},
   });
   assertEqualVectors(expected, result);
 }

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -1564,6 +1564,7 @@ TEST_F(Re2FunctionsTest, split) {
   });
   assertEqualVectors(expected, result);
 
+  // Test for empty matches
   result = evaluate("regexp_split(c0, '')", input);
   expected = makeArrayVector<std::string>({
       {"", "1", "a", " ", "2", "b", " ", "1", "4", "m", ""},
@@ -1573,6 +1574,7 @@ TEST_F(Re2FunctionsTest, split) {
   });
   assertEqualVectors(expected, result);
 
+  // Test for another case of empty matches
   result = evaluate("regexp_split(c0, '\\s*[a-z]*\\s*')", input);
   expected = makeArrayVector<std::string>({
       {"", "1", "", "2", "", "1", "4", "", ""},


### PR DESCRIPTION
### Summary
This PR addresses a critical bug in the `regexp_split` function that causes a crash when the regex pattern matches empty slices at the end of input strings. The issue stems from an invalid `StringView` construction when position pointer exceeds the string length.

### Problem
When executing queries like:
```sql
SELECT regexp_split(c0, '\s*[a-z]*\s*') 
FROM (VALUES ('1a 2b 14m')) t(c0);
```

The following error occurs:
```
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (-1 vs. 0)
Retriable: False
Expression: len >= 0
Context: Top-level Expression: regexp_split(c0, \s*[a-z]*\s*:VARCHAR)
Function: StringView
File: /Users/xxx/velox/./velox/type/StringView.h
```

**Root Cause:** When empty slices are matched at the end of input strings, the position pointer (`pos`) gets incremented beyond the string's size before constructing a `StringView`, leading to invalid memory access in:
```cpp
StringView(string.data() + pos, string.size() - pos)
```

### Solution
1. **Bounds Check before StringView Construction**: Added validation before creating `StringView` instances to prevent invalid memory access.
2. **Align Behavior with Presto for Empty Matches**: Introduced a `lastEnd` pointer to track the end of the last match. This matches Presto's logic and produces more intuitive results.
3. **Update Documentation**: Clarified the function's behavior in the documentation.  