### PR TITLE
fix: Fix Expr::isDeterministic for lambda functions

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -836,9 +836,17 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
     std::vector<core::TypedExprPtr>&& source,
     core::ExecCtx* execCtx);
 
-/// Evaluates an expression that doesn't depend on any inputs and returns the
-/// result as single-row vector.
+/// Evaluates a deterministic expression that doesn't depend on any inputs and
+/// returns the result as single-row vector. Throws if expression is
+/// non-deterministic or has dependencies.
 VectorPtr evaluateConstantExpression(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* pool);
+
+/// Evaluates a deterministic expression that doesn't depend on any inputs and
+/// returns the result as single-row vector. Returns nullptr if the expression
+/// is non-deterministic or has dependencies.
+VectorPtr tryEvaluateConstantExpression(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool);
 

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -49,6 +49,10 @@ class LambdaExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
+  const ExprPtr& body() const {
+    return body_;
+  }
+
  protected:
   void computeDistinctFields() override;
 


### PR DESCRIPTION
Summary: 

An expression like "transform(c0, x -> x + rand())" is non-deterministic, but Expression engine used to consider it deterministic.

Fixes https://github.com/facebookincubator/velox/issues/13646

Differential Revision: D76041612


