### PR TITLE
feat: Add support for names with parentheses in parseTypeSignature

### DIFF
--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -34,7 +34,7 @@ Y   [Y|y]
 Z   [Z|z]
 
 WORD              ([[:alnum:]_]*)
-QUOTED_ID         (['"'][[:alnum:][:space:]_]*['"'])
+QUOTED_ID         (['"'][[:alnum:][:space:]_()]*['"'])
 ROW               (ROW|STRUCT)
 
 %%

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -230,6 +230,15 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(rowfield.rowFieldName(), "bla");
     ASSERT_EQ(rowfield.parameters().size(), 0);
   }
+
+  {
+    auto signature = parseTypeSignature("row(\"a (b)\" INTEGER)");
+    ASSERT_EQ(signature.baseName(), "row");
+    ASSERT_EQ(signature.parameters().size(), 1);
+    auto field0 = signature.parameters()[0];
+    ASSERT_EQ(field0.baseName(), "INTEGER");
+    ASSERT_EQ(field0.rowFieldName(), "a (b)");
+  }
 }
 
 TEST_F(ParseTypeSignatureTest, tdigest) {


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/13648