### PR TITLE
feat: Add dry run trace mode for crash debugging

### DIFF
--- a/velox/common/base/TraceConfig.cpp
+++ b/velox/common/base/TraceConfig.cpp
@@ -25,11 +25,13 @@ TraceConfig::TraceConfig(
     std::string _queryNodeId,
     std::string _queryTraceDir,
     UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
-    std::string _taskRegExp)
+    std::string _taskRegExp,
+    bool _dryRun)
     : queryNodeId(std::move(_queryNodeId)),
       queryTraceDir(std::move(_queryTraceDir)),
       updateAndCheckTraceLimitCB(std::move(_updateAndCheckTraceLimitCB)),
-      taskRegExp(std::move(_taskRegExp)) {
+      taskRegExp(std::move(_taskRegExp)),
+      dryRun(_dryRun) {
   VELOX_CHECK(!queryNodeId.empty(), "Query trace nodes cannot be empty");
 }
 } // namespace facebook::velox

--- a/velox/common/base/TraceConfig.h
+++ b/velox/common/base/TraceConfig.h
@@ -45,11 +45,16 @@ struct TraceConfig {
   UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB;
   /// The trace task regexp.
   std::string taskRegExp;
+  /// If true, we only collect operator input trace without the actual
+  /// execution. This is used by crash debugging so that we can collect the
+  /// input that triggers the crash.
+  bool dryRun{false};
 
   TraceConfig(
-      std::string _queryNodeIds,
-      std::string _queryTraceDir,
-      UpdateAndCheckTraceLimitCB _updateAndCheckTraceLimitCB,
-      std::string _taskRegExp);
+      std::string queryNodeIds,
+      std::string queryTraceDir,
+      UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB,
+      std::string taskRegExp,
+      bool dryRun);
 };
 } // namespace facebook::velox

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -173,4 +173,18 @@ folly::dynamic ConnectorTableHandle::serializeBase(
 folly::dynamic ConnectorTableHandle::serialize() const {
   return serializeBase("ConnectorTableHandle");
 }
+
+// static
+ConnectorTableHandlePtr ConnectorTableHandle::create(
+    const folly::dynamic& obj,
+    void* /*unused*/) {
+  const auto connectorId = obj["connectorId"].asString();
+  return std::make_shared<const ConnectorTableHandle>(connectorId);
+}
+
+// static
+void ConnectorTableHandle::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+  registry.Register("ConnectorTableHandle", create);
+}
 } // namespace facebook::velox::connector

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -104,6 +104,9 @@ class ColumnHandle : public ISerializable {
 
 using ColumnHandlePtr = std::shared_ptr<const ColumnHandle>;
 
+class ConnectorTableHandle;
+using ConnectorTableHandlePtr = std::shared_ptr<const ConnectorTableHandle>;
+
 class ConnectorTableHandle : public ISerializable {
  public:
   explicit ConnectorTableHandle(std::string connectorId)
@@ -133,14 +136,18 @@ class ConnectorTableHandle : public ISerializable {
 
   virtual folly::dynamic serialize() const override;
 
+  static ConnectorTableHandlePtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+  static void registerSerDe();
+
  protected:
   folly::dynamic serializeBase(std::string_view name) const;
 
  private:
   const std::string connectorId_;
 };
-
-using ConnectorTableHandlePtr = std::shared_ptr<const ConnectorTableHandle>;
 
 /// Represents a request for writing to connector
 class ConnectorInsertTableHandle : public ISerializable {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4036,8 +4036,16 @@ class UnnestNode : public PlanNode {
     return unnestVariables_;
   }
 
+  const std::vector<std::string>& unnestNames() const {
+    return unnestNames_;
+  }
+
   bool withOrdinality() const {
     return ordinalityName_.has_value();
+  }
+
+  const std::optional<std::string>& ordinalityName() const {
+    return ordinalityName_;
   }
 
   std::string_view name() const override {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -478,6 +478,10 @@ class QueryConfig {
   static constexpr const char* kQueryTraceTaskRegExp =
       "query_trace_task_reg_exp";
 
+  /// If true, we only collect the input trace for a given operator but without
+  /// the actual execution.
+  static constexpr const char* kQueryTraceDryRun = "query_trace_dry_run";
+
   /// Config used to create operator trace directory. This config is provided to
   /// underlying file system and the config is free form. The form should be
   /// defined by the underlying file system.
@@ -961,6 +965,10 @@ class QueryConfig {
   std::string queryTraceTaskRegExp() const {
     // The default query trace task regexp, empty by default.
     return get<std::string>(kQueryTraceTaskRegExp, "");
+  }
+
+  bool queryTraceDryRun() const {
+    return get<bool>(kQueryTraceDryRun, false);
   }
 
   std::string opTraceDirectoryCreateConfig() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1009,3 +1009,8 @@ Tracing
      - integer
      - 0
      - The max trace bytes limit. Tracing is disabled if zero.
+   * - query_trace_dry_run
+     - boolean
+     - false
+     - If true, we only collect the input trace for a given operator but without the actual
+       execution. This is used for crash debugging.

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -482,6 +482,12 @@ bool Driver::checkUnderArbitration(ContinueFuture* future) {
 }
 
 namespace {
+inline void addInput(Operator* op, const RowVectorPtr& input) {
+  if (FOLLY_LIKELY(!op->dryRun())) {
+    op->addInput(input);
+  }
+}
+
 inline void getOutput(Operator* op, RowVectorPtr& result) {
   result = op->getOutput();
   if (FOLLY_UNLIKELY(op->shouldDropOutput())) {
@@ -641,7 +647,7 @@ StopReason Driver::runInternal(
                         nextOp);
 
                     CALL_OPERATOR(
-                        nextOp->addInput(intermediateResult),
+                        addInput(nextOp, intermediateResult),
                         nextOp,
                         curOperatorId_ + 1,
                         kOpMethodAddInput);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -88,6 +88,9 @@ Operator::Operator(
           operatorType)),
       outputType_(std::move(outputType)),
       spillConfig_(std::move(spillConfig)),
+      dryRun_(
+          operatorCtx_->driverCtx()->traceConfig().has_value() &&
+          operatorCtx_->driverCtx()->traceConfig()->dryRun),
       stats_(OperatorStats{
           operatorId,
           driverCtx->pipelineId,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -283,6 +283,12 @@ class Operator : public BaseRuntimeStatWriter {
   /// build side is empty.
   virtual bool isFinished() = 0;
 
+  /// True if the operator is in dry run mode which is only used by input
+  /// trace collection for crash debugging.
+  bool dryRun() const {
+    return dryRun_;
+  }
+
   /// Traces input batch of the operator.
   virtual void traceInput(const RowVectorPtr&);
 
@@ -631,6 +637,8 @@ class Operator : public BaseRuntimeStatWriter {
   /// Contains the disk spilling related configs if spilling is enabled (e.g.
   /// the fs dir path to store spill files), otherwise null.
   const std::optional<common::SpillConfig> spillConfig_;
+
+  const bool dryRun_;
 
   bool initialized_{false};
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3434,7 +3434,8 @@ std::optional<TraceConfig> Task::maybeMakeTraceConfig() const {
       traceNodeId,
       traceDir,
       std::move(updateAndCheckTraceLimitCB),
-      queryConfig.queryTraceTaskRegExp());
+      queryConfig.queryTraceTaskRegExp(),
+      queryConfig.queryTraceDryRun());
 }
 
 void Task::maybeInitTrace() {

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -288,6 +288,8 @@ void TraceReplayRunner::init() {
   if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
+
+  connector::ConnectorTableHandle::registerSerDe();
   connector::hive::HiveTableHandle::registerSerDe();
   connector::hive::LocationHandle::registerSerDe();
   connector::hive::HiveColumnHandle::registerSerDe();


### PR DESCRIPTION
Summary: Add dry run mode for query trace collection for crash debugging so we are able to collect the input that triggers the crash

Differential Revision: D76019158


