### PR TITLE
fix: Allow NestedLoopJoin to output rows not preserving input order if optimizer does not require it

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -208,6 +208,11 @@ class QueryConfig {
   static constexpr const char* kPreferredOutputBatchRows =
       "preferred_output_batch_rows";
 
+  /// Preferred produce output same order with probe data at NestedLoopJoin
+  /// operator
+  static constexpr const char* kPreferredNLJOutputProbeOrder =
+      "preferred_nlj_output_probe_order";
+
   /// Max number of rows that could be return by operators from
   /// Operator::getOutput. It is used when an estimate of average row size is
   /// known and kPreferredOutputBatchBytes is used to compute the number of
@@ -744,6 +749,11 @@ class QueryConfig {
     const uint32_t batchRows = get<uint32_t>(kPreferredOutputBatchRows, 1024);
     VELOX_USER_CHECK_LE(batchRows, std::numeric_limits<vector_size_t>::max());
     return batchRows;
+  }
+
+  bool preferredNLJOutputProbeOrder() const {
+    const bool probeOrder = get<bool>(kPreferredNLJOutputProbeOrder, true);
+    return probeOrder;
   }
 
   vector_size_t maxOutputBatchRows() const {


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/12294

optimize NestedLoopJoin with conditions by build vector size, do not  always do probe one by one
new execute time is still long than vanilla spark, but has been speed 10x+ compare with before

add config kPreferredNLJOutputProbeOrder, default is true, deal with probe one by one, but for  scenarios where preserving the order of the probe side is not required, we can set kPreferredNLJOutputProbeOrder to false for speed up

i have add some unit tests for new optimize, which is join with condition for one build row, join with condition for one build vector, join with condition for multi build vector

execute time before optimize (use from spark+gluten)
![image](https://github.com/user-attachments/assets/b3006c4b-56ba-48aa-a036-409038343569)

execute time after optimize (use from spark+gluten)
![image](https://github.com/user-attachments/assets/66059070-b720-4d56-a903-bff5451e28d8)

execute time use vanilla spark
![image](https://github.com/user-attachments/assets/9af670a0-27e7-456a-829e-10492fd70937)
