### PR TITLE
fix(parquet): Reserve memory for thrift allocation

### DIFF
--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -251,6 +251,10 @@ class TestMemoryPool : public memory::MemoryPool {
     return nullptr;
   }
 
+  void reportAllocation(int64_t size) override {
+    return;
+  }
+
   void* allocateZeroFilled(int64_t /* unused */, int64_t /* unused */)
       override {
     return nullptr;
@@ -264,6 +268,8 @@ class TestMemoryPool : public memory::MemoryPool {
   }
 
   void free(void* /* unused */, int64_t /* unused */) override {}
+
+  void reportFree(int64_t /* unused */) override {}
 
   void allocateNonContiguous(
       memory::MachinePageCount /* unused */,

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -521,7 +521,6 @@ void* MemoryPoolImpl::allocate(
           alignment_);
     }
   }
-
   CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto alignedSize = sizeAlign(size);
   reserve(alignedSize);
@@ -537,6 +536,12 @@ void* MemoryPoolImpl::allocate(
   }
   DEBUG_RECORD_ALLOC(this, buffer, size);
   return buffer;
+}
+
+void MemoryPoolImpl::reportAllocation(int64_t size) {
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
+  const auto alignedSize = sizeAlign(size);
+  reserve(alignedSize);
 }
 
 void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
@@ -611,6 +616,12 @@ bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, uint64_t size) {
   release(alignedSize);
 
   return true;
+}
+
+void MemoryPoolImpl::reportFree(int64_t size) {
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
+  const auto alignedSize = sizeAlign(size);
+  release(alignedSize);
 }
 
 void MemoryPoolImpl::allocateNonContiguous(

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -241,6 +241,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       int64_t size,
       std::optional<uint32_t> alignment = std::nullopt) = 0;
 
+  virtual void reportAllocation(int64_t size) = 0;
+
   /// Allocates a zero-filled buffer with capacity that can store 'numEntries'
   /// entries with each size of 'sizeEach'.
   virtual void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) = 0;
@@ -258,6 +260,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   transferTo(MemoryPool* /*dest*/, void* /*buffer*/, uint64_t /*size*/) {
     return false;
   }
+  virtual void reportFree(int64_t size) = 0;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
@@ -617,6 +620,8 @@ class MemoryPoolImpl : public MemoryPool {
   void* allocate(int64_t size, std::optional<uint32_t> alignment = std::nullopt)
       override;
 
+  void reportAllocation(int64_t size) override;
+
   void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override;
 
   void* reallocate(void* p, int64_t size, int64_t newSize) override;
@@ -624,6 +629,8 @@ class MemoryPoolImpl : public MemoryPool {
   void free(void* p, int64_t size) override;
 
   bool transferTo(MemoryPool* dest, void* buffer, uint64_t size) override;
+
+  void reportFree(int64_t size) override;
 
   void allocateNonContiguous(
       MachinePageCount numPages,

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -216,6 +216,12 @@ uint64_t HiveConfig::footerEstimatedSize() const {
   return config_->get<uint64_t>(kFooterEstimatedSize, 256UL << 10);
 }
 
+uint64_t HiveConfig::parquetFooterTrackThriftMemoryThreshold() const {
+  return config_->get<uint64_t>(
+      kParquetFooterTrackThriftMemoryThreshold,
+      std::numeric_limits<uint64_t>::max());
+}
+
 uint64_t HiveConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -140,6 +140,12 @@ class HiveConfig {
   /// request
   static constexpr const char* kFooterEstimatedSize = "footer-estimated-size";
 
+  /// The byte size threshold beyond which the Parquet reader estimates and
+  /// reports the memory usage of deserialized Thrift objects to the memory
+  /// pool.
+  static constexpr const char* kParquetFooterTrackThriftMemoryThreshold =
+      "hive.parquet.track-footer-thrift-memory-threshold";
+
   /// The threshold of file size in bytes when the whole file is fetched with
   /// meta data together. Optimization to decrease the small IO requests
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
@@ -268,6 +274,8 @@ class HiveConfig {
       const config::ConfigBase* session) const;
 
   uint64_t footerEstimatedSize() const;
+
+  uint64_t parquetFooterTrackThriftMemoryThreshold() const;
 
   uint64_t filePreloadThreshold() const;
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -575,6 +575,8 @@ void configureReaderOptions(
       useColumnNamesForColumnMapping);
   readerOptions.setFileSchema(fileSchema);
   readerOptions.setFooterEstimatedSize(hiveConfig->footerEstimatedSize());
+  readerOptions.setParquetFooterTrackThriftMemoryThreshold(
+      hiveConfig->parquetFooterTrackThriftMemoryThreshold());
   readerOptions.setFilePreloadThreshold(hiveConfig->filePreloadThreshold());
   readerOptions.setPrefetchRowGroups(hiveConfig->prefetchRowGroups());
   readerOptions.setNoCacheRetention(!hiveSplit->cacheable);

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -235,6 +235,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       "true";
   customHiveConfigProps[hive::HiveConfig::kOrcUseColumnNames] = "true";
   customHiveConfigProps[hive::HiveConfig::kFooterEstimatedSize] = "1111";
+  customHiveConfigProps
+      [hive::HiveConfig::kParquetFooterTrackThriftMemoryThreshold] = "1111";
+
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
   hiveConfig = std::make_shared<hive::HiveConfig>(
@@ -253,6 +256,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       hiveConfig->isFileColumnNamesReadAsLowerCase(&sessionProperties));
   EXPECT_EQ(
       readerOptions.footerEstimatedSize(), hiveConfig->footerEstimatedSize());
+  EXPECT_EQ(
+      readerOptions.parquetFooterTrackThriftMemoryThreshold(),
+      hiveConfig->parquetFooterTrackThriftMemoryThreshold());
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -811,6 +811,11 @@ Each query can override the config by setting corresponding query session proper
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
+   * - hive.parquet.track-footer-thrift-memory-threshold
+     -
+     - string
+     - disabled (max uint64)
+     - Threshold for tracking thrift memory usage in Parquet file footers. When the footer size exceeds this threshold, memory usage is tracked and reported. By default, tracking is disabled.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -521,6 +521,9 @@ class ReaderOptions : public io::ReaderOptions {
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
 
+  static constexpr uint64_t kDefaultParquetFooterTrackThriftMemoryThreshold =
+      std::numeric_limits<uint64_t>::max(); // Disabled by default
+
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
       : io::ReaderOptions(pool),
         tailLocation_(std::numeric_limits<uint64_t>::max()),
@@ -564,6 +567,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   ReaderOptions& setFooterEstimatedSize(uint64_t size) {
     footerEstimatedSize_ = size;
+    return *this;
+  }
+  ReaderOptions& setParquetFooterTrackThriftMemoryThreshold(uint64_t size) {
+    parquetFooterTrackThriftMemoryThreshold_ = size;
     return *this;
   }
 
@@ -626,6 +633,10 @@ class ReaderOptions : public io::ReaderOptions {
 
   uint64_t footerEstimatedSize() const {
     return footerEstimatedSize_;
+  }
+
+  uint64_t parquetFooterTrackThriftMemoryThreshold() const {
+    return parquetFooterTrackThriftMemoryThreshold_;
   }
 
   uint64_t filePreloadThreshold() const {
@@ -709,6 +720,8 @@ class ReaderOptions : public io::ReaderOptions {
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
   bool allowEmptyFile_{false};
+  uint64_t parquetFooterTrackThriftMemoryThreshold_{
+      kDefaultParquetFooterTrackThriftMemoryThreshold};
 };
 
 struct WriterOptions {

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -100,6 +100,11 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     return allocator_->allocateBytes(size);
   }
 
+  void reportAllocation(int64_t size) override {
+    updateLocalMemoryUsage(size);
+    return;
+  }
+
   void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override {
     updateLocalMemoryUsage(numEntries * sizeEach);
     return allocator_->allocateZeroFilled(numEntries * sizeEach);
@@ -116,6 +121,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   void free(void* p, int64_t size) override {
     allocator_->freeBytes(p, size);
+    updateLocalMemoryUsage(-size);
+  }
+
+  void reportFree(int64_t size) override {
     updateLocalMemoryUsage(-size);
   }
 

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -397,26 +397,8 @@ size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column) {
   return size;
 }
 
-size_t analyzeFileMetadata(
-    const thrift::FileMetaData& metadata,
-    const std::string& filename,
-    uint64_t footerLength) {
+size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata) {
   size_t totalSize = sizeof(thrift::FileMetaData);
-
-  size_t numSchemaElements = metadata.schema.size();
-  size_t maxSchemaDepth = 0;
-  size_t currentDepth = 0;
-  size_t numLeafNodes = 0;
-  size_t numGroupNodes = 0;
-  size_t totalStringLength = 0;
-  size_t maxStringLength = 0;
-  size_t maxDepth = 0;
-  size_t maxDepthElementSize = 0;
-  std::string maxDepthElementName;
-  size_t maxElementSize = 0;
-  std::string maxElementName;
-  currentDepth = 0;
-
   for (const auto& schema : metadata.schema) {
     size_t elementSize = sizeof(schema) + schema.name.capacity() +
         sizeof(schema.type) + sizeof(schema.type_length) +
@@ -426,93 +408,24 @@ size_t analyzeFileMetadata(
     if (schema.__isset.logicalType) {
       elementSize += sizeof(schema.logicalType);
     }
-    if (elementSize > maxElementSize) {
-      maxElementSize = elementSize;
-      maxElementName = schema.name;
-    }
-    if (schema.__isset.num_children) {
-      currentDepth++;
-      if (currentDepth > maxDepth) {
-        maxDepth = currentDepth;
-        maxDepthElementName = schema.name;
-        maxDepthElementSize = elementSize;
-      }
-    }
+    totalSize += elementSize;
   }
-  size_t numRowGroups = metadata.row_groups.size();
-  size_t totalColumns = 0;
-  size_t totalEncodings = 0;
-  size_t totalPaths = 0;
-  size_t totalKeyValues = 0;
-
   totalSize += metadata.row_groups.size() * sizeof(thrift::RowGroup);
   for (const auto& rowGroup : metadata.row_groups) {
-    totalColumns += rowGroup.columns.size();
     totalSize += rowGroup.columns.size() * sizeof(thrift::ColumnChunk);
     for (const auto& column : rowGroup.columns) {
       totalSize += calculateColumnMetadataSize(column);
-      totalEncodings += column.meta_data.encodings.size();
-      totalPaths += column.meta_data.path_in_schema.size();
-      totalKeyValues += column.meta_data.key_value_metadata.size();
     }
   }
-
-  size_t numKeyValues = metadata.key_value_metadata.size();
   totalSize += metadata.key_value_metadata.size() * sizeof(thrift::KeyValue);
   for (const auto& kv : metadata.key_value_metadata) {
     totalSize += kv.key.capacity();
     totalSize += kv.value.capacity();
   }
-
   totalSize += metadata.created_by.capacity();
   totalSize += metadata.column_orders.size() * sizeof(thrift::ColumnOrder);
   totalSize += sizeof(thrift::EncryptionAlgorithm);
   totalSize += metadata.footer_signing_key_metadata.capacity();
-
-  auto encodingToString = [](thrift::Encoding::type encoding) -> std::string {
-    switch (encoding) {
-      case thrift::Encoding::PLAIN:
-        return "PLAIN";
-      case thrift::Encoding::PLAIN_DICTIONARY:
-        return "PLAIN_DICTIONARY";
-      case thrift::Encoding::RLE:
-        return "RLE";
-      case thrift::Encoding::BIT_PACKED:
-        return "BIT_PACKED";
-      case thrift::Encoding::DELTA_BINARY_PACKED:
-        return "DELTA_BINARY_PACKED";
-      case thrift::Encoding::DELTA_LENGTH_BYTE_ARRAY:
-        return "DELTA_LENGTH_BYTE_ARRAY";
-      case thrift::Encoding::DELTA_BYTE_ARRAY:
-        return "DELTA_BYTE_ARRAY";
-      case thrift::Encoding::RLE_DICTIONARY:
-        return "RLE_DICTIONARY";
-      case thrift::Encoding::BYTE_STREAM_SPLIT:
-        return "BYTE_STREAM_SPLIT";
-      default:
-        return "UNKNOWN";
-    }
-  };
-  std::set<thrift::Encoding::type> distinctEncodings;
-  std::map<thrift::Encoding::type, size_t> encodingCounts;
-
-  for (const auto& rowGroup : metadata.row_groups) {
-    for (const auto& column : rowGroup.columns) {
-      for (const auto& encoding : column.meta_data.encodings) {
-        distinctEncodings.insert(encoding);
-        encodingCounts[encoding]++;
-      }
-      totalEncodings += column.meta_data.encodings.size();
-      totalSize +=
-          column.meta_data.encodings.size() * sizeof(thrift::Encoding::type);
-    }
-  }
-
-  std::string encodingStats;
-  for (const auto& [encoding, count] : encodingCounts) {
-    encodingStats += fmt::format(
-        "      {}: {} occurrences\n", encodingToString(encoding), count);
-  }
   return totalSize;
 }
 

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 namespace facebook::velox::parquet {
 
@@ -159,5 +160,12 @@ class FileMetaDataPtr {
  private:
   const void* ptr_;
 };
+
+size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column);
+
+size_t analyzeFileMetadata(
+    const thrift::FileMetaData& metadata,
+    const std::string& filename,
+    uint64_t footerLength);
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/Metadata.h
+++ b/velox/dwio/parquet/reader/Metadata.h
@@ -163,9 +163,6 @@ class FileMetaDataPtr {
 
 size_t calculateColumnMetadataSize(const thrift::ColumnChunk& column);
 
-size_t analyzeFileMetadata(
-    const thrift::FileMetaData& metadata,
-    const std::string& filename,
-    uint64_t footerLength);
+size_t calculateFileMetadataSize(const thrift::FileMetaData& metadata);
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -249,8 +249,7 @@ void ReaderBase::loadFileMetaData() {
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
   if (footerLength > options().parquetFooterTrackThriftMemoryThreshold()) {
-    thriftSize_ = analyzeFileMetadata(
-        *fileMetaData_, input_->getReadFile()->getName(), footerLength);
+    thriftSize_ = calculateFileMetadataSize(*fileMetaData_);
   }
 }
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1790,16 +1790,10 @@ TEST_F(ParquetReaderTest, readerWithSchema) {
 }
 
 TEST_F(ParquetReaderTest, thriftMemoryTrackingTest) {
-  // Test the thrift memory tracking functionality added in the top commit.
-  // This test verifies that when footer size exceeds the threshold,
-  // memory is properly tracked, reported during row reader creation,
-  // and freed in the destructor.
-
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  // Test with a very low threshold to trigger memory tracking
   dwio::common::ReaderOptions readerOptions{leafPool_.get()};
-  readerOptions.setParquetFooterTrackThriftMemoryThreshold(1); // 1 byte threshold
+  readerOptions.setParquetFooterTrackThriftMemoryThreshold(1);
   auto initialUsage = leafPool_->usedBytes();
   size_t memoryAfterRowReader = 0;
   {
@@ -1809,21 +1803,16 @@ TEST_F(ParquetReaderTest, thriftMemoryTrackingTest) {
     auto scanSpec = makeScanSpec(sampleSchema());
     rowReaderOpts.setScanSpec(scanSpec);
     auto rowReader = reader->createRowReader(rowReaderOpts);
-
-    // After row reader creation, memory should be tracked (reportAllocation called)
     memoryAfterRowReader = leafPool_->usedBytes();
     EXPECT_GT(memoryAfterRowReader, initialUsage);
     auto result = BaseVector::create(sampleSchema(), 0, leafPool_.get());
     rowReader->next(10, result);
     EXPECT_EQ(result->size(), 10);
 
-    // Memory should still be tracked after reading
     auto memoryAfterReading = leafPool_->usedBytes();
     EXPECT_GE(memoryAfterReading, memoryAfterRowReader);
   }
 
-  // After reader destruction, memory should be properly cleaned up via ~ReaderBase()
   auto finalUsage = leafPool_->usedBytes();
-  // The destructor should call pool_.reportFree(thriftSize_) to free the tracked memory
   EXPECT_EQ(finalUsage, initialUsage);
 }


### PR DESCRIPTION
Fix #12252
```
 FileMetaData Statistics for 
  Footer length: 129.85MB):
  FileMetaData object size: 959.77MB
  Schema Statistics:
    Number of schema elements: 6879
    Maximum schema depth: 1 (Element: 'hive_schema', Size: 367B)
    Largest schema element:  (Size: 462B)
    Number of leaf nodes: 0
    Number of group nodes: 0
    Average string length: 0
    Maximum string length: 0
  Row Group Statistics:
    Number of row groups: 147
    Total columns: 1011066
    Average columns per row group: 6878
    Total encodings: 6066480
    Distinct encodings: 4
    Encoding distribution:
      PLAIN: 430661 occurrences
      PLAIN_DICTIONARY: 580447 occurrences
      RLE: 1011066 occurrences
      BIT_PACKED: 1011066 occurrences
    Total paths: 1011066
    Total key-value pairs: 0
```

We have a table with a large footer and queries on this cause OOMs as the thrift memory is not reported.

With this change it is reported and queries begin to fail

```
Top 10 leaf memory pool usages:
    op.4.0.6.Aggregation usage 23.74GB reserved 23.74GB peak 23.74GB
    op.0.0.6.TableScan usage 1.58GB reserved 1.59GB peak 2.81GB
    op.0.0.0.TableScan usage 1.18GB reserved 1.19GB peak 1.67GB
    op.0.0.1.TableScan usage 1.11GB reserved 1.12GB peak 4.86GB
    op.0.0.7.TableScan usage 1.10GB reserved 1.11GB peak 2.70GB
    op.0.0.5.TableScan usage 1.07GB reserved 1.07GB peak 2.22GB
    op.0.0.3.TableScan usage 1.02GB reserved 1.03GB peak 2.16GB
    op.0.0.4.TableScan usage 590.64MB reserved 592.00MB peak 1.65GB
    op.466.1.5.Exchange usage 39.19MB reserved 40.00MB peak 46.05MB
    exchangeClient.466.1 usage 32.25MB reserved 36.00MB peak 88.54MB
```
