### PR TITLE
feat: Add Unnest Operator Tracing

### DIFF
--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -279,6 +279,7 @@ bool canTrace(const std::string& operatorType) {
       "HashBuild",
       "HashProbe",
       "IndexLookupJoin",
+      "Unnest",
       "PartialAggregation",
       "PartitionedOutput",
       "TableScan",

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -1128,6 +1128,7 @@ TEST_F(OperatorTraceTest, canTrace) {
       {"HashBuild", true},
       {"HashProbe", true},
       {"IndexLookupJoin", true},
+      {"Unnest", true},
       {"RowNumber", false},
       {"OrderBy", false},
       {"PartialAggregation", true},


### PR DESCRIPTION
Summary:
Add Unnest into canTrace operator types.

bypass-github-export-checks

Differential Revision: D76099130


