### PR TITLE
misc: Use contains() to replace in-list index join condition to ease SQL parsing

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3151,6 +3151,7 @@ struct IndexLookupCondition : public ISerializable {
 };
 using IndexLookupConditionPtr = std::shared_ptr<IndexLookupCondition>;
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 /// Represents IN-LIST index lookup condition: contains('list', 'key'). 'list'
 /// can be either a probe input column or a constant list with type of
 /// ARRAY(typeof('key')).
@@ -3177,6 +3178,35 @@ struct InIndexLookupCondition : public IndexLookupCondition {
   void validate() const;
 };
 using InIndexLookupConditionPtr = std::shared_ptr<InIndexLookupCondition>;
+#endif
+
+/// Represents CONTAINS index lookup condition: contains('list', 'key'). 'list'
+/// can be either a probe input column or a constant list with type of
+/// ARRAY(typeof('key')).
+struct ContainsIndexLookupCondition : public IndexLookupCondition {
+  /// References to either a probe input column or a constant list.
+  TypedExprPtr list;
+
+  ContainsIndexLookupCondition(FieldAccessTypedExprPtr _key, TypedExprPtr _list)
+      : IndexLookupCondition(std::move(_key)), list(std::move(_list)) {
+    validate();
+  }
+
+  bool isFilter() const override;
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+
+  static IndexLookupConditionPtr create(
+      const folly::dynamic& obj,
+      void* context);
+
+ private:
+  void validate() const;
+};
+using ContainsIndexLookupConditionPtr =
+    std::shared_ptr<ContainsIndexLookupCondition>;
 
 /// Represents BETWEEN index lookup condition: 'key' between 'lower' and
 /// 'upper'. 'lower' and 'upper' have the same type of 'key'.

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -259,10 +259,10 @@ void IndexLookupJoin::initLookupInput() {
     lookupIndexColumnSet.insert(indexKeyName);
     const auto indexKeyType = lookupType_->findChild(indexKeyName);
 
-    if (const auto inCondition =
-            std::dynamic_pointer_cast<const core::InIndexLookupCondition>(
+    if (const auto containsCondition =
+            std::dynamic_pointer_cast<const core::ContainsIndexLookupCondition>(
                 lookupCondition)) {
-      const auto conditionInputName = getColumnName(inCondition->list);
+      const auto conditionInputName = getColumnName(containsCondition->list);
       const auto conditionInputChannel =
           probeType_->getChildIdx(conditionInputName);
       const auto conditionInputType =

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1871,7 +1871,7 @@ core::IndexLookupConditionPtr PlanBuilder::parseIndexJoinCondition(
             removeCastTypedExpr(typedCallExpr->inputs()[1]));
     VELOX_CHECK_NOT_NULL(
         keyColumnExpr, "{}", typedCallExpr->inputs()[1]->toString());
-    return std::make_shared<core::InIndexLookupCondition>(
+    return std::make_shared<core::ContainsIndexLookupCondition>(
         keyColumnExpr,
         castIndexConditionInputExpr(
             typedCallExpr->inputs()[0], keyColumnExpr->type()));

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -43,13 +43,13 @@ core::TypedExprPtr toJoinConditionExpr(
   for (const auto& condition : joinConditions) {
     auto indexColumnExpr = std::make_shared<core::FieldAccessTypedExpr>(
         keyType->findChild(condition->key->name()), condition->key->name());
-    if (auto inCondition =
-            std::dynamic_pointer_cast<core::InIndexLookupCondition>(
+    if (auto containsCondition =
+            std::dynamic_pointer_cast<core::ContainsIndexLookupCondition>(
                 condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
           BOOLEAN(),
           std::vector<core::TypedExprPtr>{
-              inCondition->list, std::move(indexColumnExpr)},
+              containsCondition->list, std::move(indexColumnExpr)},
           "contains"));
       continue;
     }


### PR DESCRIPTION
Summary: Use contains() syntax for contains (or previously in-list) index join condition

Differential Revision: D76112220


