### PR TITLE
misc: Add QueryCtx::started_ member

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -113,6 +113,14 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     return queryId_;
   }
 
+  bool started() const {
+    return started_;
+  }
+
+  void setStarted() {
+    started_ = true;
+  }
+
   /// Checks if the associated query is under memory arbitration or not. The
   /// function returns true if it is and set future which is fulfilled when the
   /// memory arbitration finishes.
@@ -227,6 +235,9 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   // Indicates if this query is under memory arbitration or not.
   std::atomic_bool underArbitration_{false};
   std::vector<ContinuePromise> arbitrationPromises_;
+
+  // True if at least one task of this query is started.
+  std::atomic_bool started_{false};
 };
 
 // Represents the state of one thread of query execution.

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -857,6 +857,8 @@ void Task::recordBatchEndTime() {
 }
 
 void Task::start(uint32_t maxDrivers, uint32_t concurrentSplitGroups) {
+  queryCtx()->setStarted();
+
   facebook::velox::process::ThreadDebugInfo threadDebugInfo{
       queryCtx()->queryId(), taskId_, nullptr};
   facebook::velox::process::ScopedThreadDebugInfo scopedInfo(threadDebugInfo);


### PR DESCRIPTION
Summary:
This member will be used to avoid queuing tasks for a query that
already has tasks started.

Differential Revision: D76137271


