### PR TITLE
fix: Skip null map keys in delta reader

### DIFF
--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -137,7 +137,7 @@ const std::vector<ScanSpec*>& ScanSpec::stableChildren() {
 
 bool ScanSpec::hasFilter() const {
   if (filterDisabled_) {
-    return false;
+    return isMapKey_;
   }
   if (hasFilter_.has_value()) {
     return hasFilter_.value();
@@ -450,12 +450,14 @@ ScanSpec* ScanSpec::addFieldRecursively(
 
 ScanSpec* ScanSpec::addMapKeyField() {
   auto* child = addField(kMapKeysFieldName, kNoChannel);
+  child->isMapKey_ = true;
   child->isArrayElementOrMapEntry_ = true;
   return child;
 }
 
 ScanSpec* ScanSpec::addMapKeyFieldRecursively(const Type& type) {
   auto* child = addFieldRecursively(kMapKeysFieldName, type, kNoChannel);
+  child->isMapKey_ = true;
   child->isArrayElementOrMapEntry_ = true;
   return child;
 }

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -57,8 +57,16 @@ class ScanSpec {
   // Filter to apply. If 'this' corresponds to a struct/list/map, this
   // can only be isNull or isNotNull, other filtering is given by
   // 'children'.
-  common::Filter* filter() const {
-    return filterDisabled_ ? nullptr : filter_.get();
+  Filter* filter() const {
+    /* library-local */ static IsNotNull isNotNull;
+    if (filterDisabled_) {
+      return isMapKey_ ? &isNotNull : nullptr;
+    }
+    if (filter_) {
+      VELOX_DCHECK(!(isMapKey_ && filter_->testNull()));
+      return filter_.get();
+    }
+    return isMapKey_ ? &isNotNull : nullptr;
   }
 
   // Sets 'filter_'. May be used at initialization or when adding a
@@ -451,6 +459,10 @@ class ScanSpec {
   // If this node is map key/value or array element, filter will not be
   // propagated to parent.
   bool isArrayElementOrMapEntry_ = false;
+
+  // Whether this node is a map key.  When true, we should always filter out
+  // null values.
+  bool isMapKey_ = false;
 
   // Only take the first maxArrayElementsCount_ elements from each array.
   vector_size_t maxArrayElementsCount_ =


### PR DESCRIPTION
Summary:
In Presto we skip null map key entries (these are considered invalid)
when data coming out of reader.  In delta reader we missed this filter.  Add it
to be compatible with Presto.

Differential Revision: D76161405


