### PR TITLE
fix: Do not do timecheck after reclaim

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -812,7 +812,6 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
   }
 
   checkIfAborted(op);
-  checkIfTimeout(op);
 
   RETURN_IF_TRUE(maybeGrowFromSelf(op));
 
@@ -832,6 +831,9 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
               succinctBytes(participantConfig_.minReclaimBytes)),
           op.participant()->pool());
     }
+
+    checkIfTimeout(op);
+
     // After failing to acquire enough free capacity to fulfil this capacity
     // growth request, we will try to reclaim from the participant itself before
     // failing this operation. We only do this if global memory arbitration is

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -3122,7 +3122,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationTimeout) {
   op->allocate(memoryCapacity / 2);
 
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::ArbitrationParticipant::reclaim",
+      "facebook::velox::memory::SharedArbitrator::growCapacity",
       std::function<void(const ArbitrationParticipant*)>(
           ([&](const ArbitrationParticipant* /*unused*/) {
             std::this_thread::sleep_for(std::chrono::seconds(2)); // NOLINT
@@ -3136,8 +3136,8 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationTimeout) {
         testing::HasSubstr("Memory arbitration timed out on memory pool"));
   }
 
-  // Reclaim happened before timeout check.
-  ASSERT_EQ(task->capacity(), 0);
+  // Timeout check happened before reclaim.
+  ASSERT_EQ(task->capacity(), memoryCapacity / 2);
 }
 
 DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, reclaimLockTimeout) {


### PR DESCRIPTION
Summary: We shall not do time check after reclaim. Otherwise we wasted the just-now done reclaim.

Reviewed By: skyelves

Differential Revision: D76172342


