### PR TITLE
fix: Set maxDrivers for final stage of LocalRunner

### DIFF
--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -115,6 +115,7 @@ RowVectorPtr LocalRunner::next() {
 void LocalRunner::start() {
   VELOX_CHECK_EQ(state_, State::kInitialized);
   auto lastStage = makeStages();
+  params_.maxDrivers = options_.numDrivers;
   params_.planNode = fragments_.back().fragment.planNode;
   auto cursor = exec::TaskCursor::create(params_);
   stages_.push_back({cursor->task()});

--- a/velox/runner/tests/LocalRunnerTest.cpp
+++ b/velox/runner/tests/LocalRunnerTest.cpp
@@ -119,6 +119,7 @@ class LocalRunnerTest : public LocalRunnerTestBase {
             "",
             {"c0", "b0"})
         .shufflePartitioned({}, 1, false)
+        .localPartition({})
         .finalAggregation({}, {"count(1)"}, {{BIGINT()}});
     return std::make_shared<MultiFragmentPlan>(
         rootBuilder.fragments(), std::move(options));

--- a/velox/runner/tests/PrestoQueryReplayRunnerTest.cpp
+++ b/velox/runner/tests/PrestoQueryReplayRunnerTest.cpp
@@ -139,7 +139,7 @@ TEST_F(PrestoQueryReplayRunnerTest, joinWithTableScan) {
 
   auto rootPool = memory::memoryManager()->addRootPool("testRootPool");
   auto pool = rootPool->addLeafChild("testLeafPool");
-  PrestoQueryReplayRunner runner{pool.get(), getTaskPrefix};
+  PrestoQueryReplayRunner runner{pool.get(), getTaskPrefix, 4, 1};
   auto result =
       runner.run(queryId, serializedPlanFragments, serializedConnectorSplits);
 


### PR DESCRIPTION
When running single stage plans with LocalRunner, we need to set the parallelism in the cursors parameters.  \

This is needed for interactive use of single stage plans in velox_sql.