### PR TITLE
feat: Reduce HashTable load factor from 0.875 to 0.7

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -127,6 +127,9 @@ class BaseHashTable {
 
   using MaskType = uint16_t;
 
+  /// The load factor of the hash table.
+  static constexpr double kHashTableLoadFactor = 0.7;
+
   /// 2M entries, i.e. 16MB is the largest array based hash table.
   static constexpr uint64_t kArrayHashMaxSize = 2L << 20;
 
@@ -742,8 +745,7 @@ class HashTable : public BaseHashTable {
 
   // Returns the number of entries after which the table gets rehashed.
   static uint64_t rehashSize(int64_t size) {
-    // This implements the F14 load factor: Resize if less than 1/8 unoccupied.
-    return size - (size / 8);
+    return size * kHashTableLoadFactor;
   }
 
   // Returns the number of entries with 'numNew' and existing 'numDistincts'


### PR DESCRIPTION
Summary:
Load factor of 7/8 is too high. When table is 7/8 full a significant performance
degradation is observed. Highly selective use cases (when value is not
present in the hash table) are impacted the most.

According to the simulation when table is 7/8 full a single probe operation has
to visit 2.88 buckets on average.

When double hashing algorithm is used the average number of bucket to visit is
reduced to 1.88 with the idential load.

The optimal load factor seems to be at 0.7. Past that point performance starts
to deteriorate fast. Performance deteriorates much faster for linear probing
algorithm.

Differential Revision: D76267085


