### PR TITLE
fix: Ensure json_extract handles invalid json during parsing

### DIFF
--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -77,7 +77,8 @@ simdjson::error_code extractObject(
   for (auto field : jsonObj) {
     SIMDJSON_ASSIGN_OR_RAISE(auto currentKey, field.unescaped_key());
     if (currentKey == key) {
-      ret.emplace(field.value());
+      SIMDJSON_ASSIGN_OR_RAISE(auto value, field.value());
+      ret.emplace(value);
       return simdjson::SUCCESS;
     }
   }

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -1018,6 +1018,13 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
 
   EXPECT_EQ(std::nullopt, jsonExtract("INVALID_JSON", "$"));
   VELOX_ASSERT_THROW(jsonExtract("{\"\":\"\"}", ""), "Invalid JSON path");
+  // This is a special case where the input is only identified as invalid once
+  // jsonExtract starts to traverse the path.
+  EXPECT_EQ(
+      std::nullopt,
+      jsonExtract(
+          R"({3436654998315577471:-768009352,3684989847712002091:-317930923,5235625120989803984:1278962211,6359026774420146638:651644866,6614027999037539496:528067092})",
+          "$.*"));
 
   EXPECT_EQ(
       "[\"0-553-21311-3\",\"0-395-19395-8\"]",


### PR DESCRIPTION
Summary:
The current implementation of json_extract relies on simdjson's
document parsing API to detect invalid JSONs early in the process.
However, this API only catches some invalid conditions as per the
documentation.
To handle errors during processing, non-exception throwing APIs are
used, which return an error code instead of throwing an exception.
Unfortunately, not all calls utilize these APIs, resulting in
exceptions being thrown when trying to access invalid portions of the
JSON.
This combination of factors allowed a specific type of invalid JSON
to bypass the initial check and encounter the exception-throwing
accessor API during parsing. As a result, the UDF threw an error
instead of returning a null result as expected. This change addresses
and resolves this issue by updating those exception throwing
callsites to use the nonexcept versions instead.

Differential Revision: D76276107


