### PR TITLE
fix: Lazy reading on column with bucket conversion sometimes failing sanity check

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -223,7 +223,7 @@ uint64_t SplitReader::next(uint64_t size, VectorPtr& output) {
     mutation.randomSkip = baseReaderOpts_.randomSkip().get();
     numScanned = baseRowReader_->next(size, output, &mutation);
   }
-  if (numScanned > 0 && partitionFunction_) {
+  if (numScanned > 0 && output->size() > 0 && partitionFunction_) {
     applyBucketConversion(
         output, bucketConversionRows(*output->asChecked<RowVector>()));
   }


### PR DESCRIPTION
Summary:
There is a rare case in bucket conversion that would cause we access memory after free and most often manifest itself as a sanity check failure.  The conditions are:

1. The bucket column is not accessed in query.
2. First split requires bucket conversion.
3. The second split added to the same data source does not require bucket conversion, so we still read the bucket column but keep it lazy, and that column is not accessed for that split.
4. The third split requires bucket conversion, and the first batch is all filtered out.

In this case when we read the first batch in (4), we try to apply bucket conversion on the bucket column.  However since all rows are filtered out, the column vector is still pointing to the unloaded lazy vector from previous split. When we try to load the vector (this is done for the whole vector in `HivePartitionFunction::partition` regardless of the row set being empty), it tries to access the parent column reader of previous split and failing the sanity check.

The fix is to not do bucket conversion if the result vector is already empty.  In that case data source is also handing out a special empty vector instead of using the one with dangling pointer.

Differential Revision: D76292554


