### PR TITLE
fix: Fix binomial_cdf disparity

### DIFF
--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -97,6 +97,11 @@ struct BinomialCDFFunction {
       return;
     }
 
+    if (value >= numOfTrials) {
+      result = 1.0;
+      return;
+    }
+
     boost::math::binomial_distribution<> dist(numOfTrials, successProb);
     result = boost::math::cdf(dist, value);
   }

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -102,6 +102,7 @@ class ProbabilityTest : public functions::test::FunctionBaseTest {
         0.0);
     EXPECT_EQ(binomialCDF<ValueType>(10, 0.1, -2), 0.0);
     EXPECT_EQ(binomialCDF<ValueType>(25, 0.5, -100), 0.0);
+    EXPECT_EQ(binomialCDF<ValueType>(2, 0.1, 3), 1.0);
 
     // Invalid inputs
     VELOX_ASSERT_THROW(


### PR DESCRIPTION
Summary:
Fix binomial_cdf disparity

T226113911

In java, if value >= numberOfTrials, directly return 1.0
```
public double cumulativeProbability(int x) {
        double ret;
        if (x < 0) {
            ret = (double)0.0F;
        } else if (x >= this.numberOfTrials) {
            ret = (double)1.0F;
        } else {
            ret = (double)1.0F - Beta.regularizedBeta(this.probabilityOfSuccess, (double)x + (double)1.0F, (double)(this.numberOfTrials - x));
        }

        return ret;
    } 
```

In cpp, it throws an error in boost lib

``` 
if(k > N)
{
       *result = policies::raise_domain_error<RealType>(
          function,
          "Number of Successes argument is %1%, but must be <= Number of Trials !", k, pol);
       return false;
}
```

Differential Revision: D76301965


