### PR TITLE
feat(noisy_sum): Add support for all numeric types in noisy_sum_gaussian(col, noise_scale)

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -748,7 +748,6 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-
 .. function:: noisy_sum_gaussian(col, noise_scale) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -30,6 +30,18 @@ class NoisySumGaussianAggregationTest
 
   RowTypePtr doubleRowType_{
       ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+  RowTypePtr bigintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), BIGINT()})};
+  RowTypePtr decimalRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DECIMAL(20, 5)})};
+  RowTypePtr realRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), REAL()})};
+  RowTypePtr integerRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()})};
+  RowTypePtr smallintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), SMALLINT()})};
+  RowTypePtr tinyintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), TINYINT()})};
 };
 
 TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
@@ -166,4 +178,63 @@ TEST_F(NoisySumGaussianAggregationTest, groupByNullTestNoNoise) {
       {vectors}, {"c0"}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult2});
 }
 
+TEST_F(NoisySumGaussianAggregationTest, inputTypeTestNoNoise) {
+  // Test that the function supports various input types.
+  auto doubleVector = makeVectors(doubleRowType_, 5, 3);
+  auto bigintVector = makeVectors(bigintRowType_, 5, 3);
+  auto decimalVector = makeVectors(decimalRowType_, 5, 3);
+  auto realVector = makeVectors(realRowType_, 5, 3);
+  auto integerVector = makeVectors(integerRowType_, 5, 3);
+  auto smallintVector = makeVectors(smallintRowType_, 5, 3);
+  auto tinyintVector = makeVectors(tinyintRowType_, 5, 3);
+
+  createDuckDbTable(doubleVector);
+  testAggregations(
+      doubleVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"}, // double noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(bigintVector);
+  testAggregations(
+      bigintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(decimalVector);
+  testAggregations(
+      decimalVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(realVector);
+  testAggregations(
+      realVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"}, // bigint noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(integerVector);
+  testAggregations(
+      integerVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(smallintVector);
+  testAggregations(
+      smallintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(tinyintVector);
+  testAggregations(
+      tinyintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+}
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
## This Diff

This diff adds support for all numeric types in the `noisy_sum_gaussian` function.

### Key changes

**Testing**
New test cases have been added to cover the additional numeric types.

**Implementation**
The implementation of the `noisy_sum_gaussian` function has been updated to handle the new numeric types. This includes dispatching to the corresponding type for the update sum operation.

**Impact**
This diff extends the functionality of the `noisy_sum_gaussian` function to support more numeric types, making it more versatile and useful in a wider range of applications.

Differential Revision: D75964171


