### PR TITLE
feat(noisy_sum): Implement noisy_sum_gaussian(col, noise_scale, random_seed))

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -748,12 +748,12 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+.. function:: noisy_sum_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
 Miscellaneous
 -------------


### PR DESCRIPTION
Summary:
## This Diff

#### Overview

This diff updates the `noisy_sum_gaussian` aggregate function to include an optional `random_seed` parameter. The function now takes three arguments: `col`, `noise_scale`, and `random_seed`. The `random_seed` parameter allows users to specify a seed for the random number generator, enabling reproducibility.

#### Code Changes

The following files have been modified:

* `fbcode/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp`: Updated the function to accept the `random_seed` parameter and added logic to handle it.
* `fbcode/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp`: Added test cases to cover the new functionality.
* `fbcode/velox/docs/functions/presto/aggregate.rst`: Updated the documentation to reflect the changes to the function signature.
* `fbcode/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h`: Modified the `NoisySumAccumulator` class to accept the `random_seed` parameter.

#### Impact

This update enables users to specify a random seed for the `noisy_sum_gaussian` aggregate function, making it possible to reproduce the results. This is particularly useful for testing and debugging purposes. The updated function remains backward compatible, and existing use cases will not be affected.

Differential Revision: D75976973
