### PR TITLE
test(noisy_sum): Add unit test to noisy_sum_gaussian(col, noise_scale, lower, upper, random_seed)

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -744,8 +744,17 @@ Noisy Aggregate Functions
     If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
     ::
+
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
+
+
+.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+
+    Calculates the sum over the input values in ``col`` and then adds a normally distributed
+    random double value with 0 mean and standard deviation of ``noise_scale``.
+
+
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -748,7 +748,6 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-
 .. function:: noisy_sum_gaussian(col, noise_scale) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -724,7 +724,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -741,7 +742,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -753,8 +755,17 @@ Noisy Aggregate Functions
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
+.. function:: noisy_sum_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+
+    Calculates the sum over the input values in ``col`` and then adds a normally distributed
+    random double value with 0 mean and standard deviation of ``noise_scale``.
+    Each value is clipped to the range of [``lower``, ``upper``] before adding to the sum.
+
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
 
 Miscellaneous

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -748,10 +748,12 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+.. function:: noisy_sum_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
+
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
 
 

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class NoisySumAccumulator {
+ public:
+  NoisySumAccumulator(double sum, double noiseScale)
+      : sum_{sum}, noiseScale_{noiseScale} {}
+
+  NoisySumAccumulator() = default;
+
+  void checkAndSetNoiseScale(double noiseScale) {
+    VELOX_USER_CHECK_GE(
+        noiseScale, 0.0, "Noise scale must be non-negative value.");
+    this->noiseScale_ = noiseScale;
+  }
+
+  // This function is used to update the sum
+  void update(double value) {
+    this->sum_ += value;
+  }
+
+  double getSum() const {
+    return this->sum_;
+  }
+
+  double getNoiseScale() const {
+    return this->noiseScale_;
+  }
+
+  static size_t serializedSize() {
+    return sizeof(double) + sizeof(double);
+  }
+
+  void serialize(char* buffer) {
+    common::OutputByteStream stream(buffer);
+    stream.appendOne(sum_);
+    stream.appendOne(noiseScale_);
+  }
+
+  static NoisySumAccumulator deserialize(const char* intermediate) {
+    common::InputByteStream stream(intermediate);
+    auto sum = stream.read<double>();
+    auto noiseScale = stream.read<double>();
+
+    return NoisySumAccumulator{sum, noiseScale};
+  }
+
+ private:
+  double sum_{0.0};
+  // Initial noise scale is an invalid noise scale,
+  // indicating that we have not updated it yet
+  double noiseScale_{-1.0};
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -59,6 +59,7 @@ const char* const kMinBy = "min_by";
 const char* const kMultiMapAgg = "multimap_agg";
 const char* const kNoisyCountIfGaussian = "noisy_count_if_gaussian";
 const char* const kNoisyCountGaussian = "noisy_count_gaussian";
+const char* const kNoisySumGaussian = "noisy_sum_gaussian";
 const char* const kReduceAgg = "reduce_agg";
 const char* const kRegrIntercept = "regr_intercept";
 const char* const kRegrSlop = "regr_slope";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -47,6 +47,7 @@ velox_add_library(
   RegisterAggregateFunctions.cpp
   NoisyCountIfGaussianAggregate.cpp
   NoisyCountGaussianAggregate.cpp
+  NoisySumGaussianAggregate.cpp
   SetAggregates.cpp
   SumAggregate.cpp
   SumDataSizeForStatsAggregate.cpp

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::functions::aggregate;
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+class NoisySumGaussianAggregate : public exec::Aggregate {
+ public:
+  explicit NoisySumGaussianAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  using AccumulatorType = NoisySumAccumulator;
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return static_cast<int32_t>(sizeof(AccumulatorType));
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+        return;
+      }
+
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+
+      // Update noise scale.
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        accumulator->checkAndSetNoiseScale(
+            decodedNoiseScale_.valueAt<double>(i));
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        accumulator->checkAndSetNoiseScale(
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+
+      // Update sum.
+      accumulator->update(decodedValue_.valueAt<double>(i));
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+        return;
+      }
+
+      // Update noise scale.
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        accumulator->checkAndSetNoiseScale(
+            decodedNoiseScale_.valueAt<double>(i));
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        accumulator->checkAndSetNoiseScale(
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+      // Update sum.
+      accumulator->update(decodedValue_.valueAt<double>(i));
+    });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+
+    int32_t numOfValidGroups = 0;
+    for (auto i = 0; i < numGroups; i++) {
+      numOfValidGroups += !isNull(groups[i]);
+    }
+    size_t totalSize = numOfValidGroups * AccumulatorType::serializedSize();
+
+    // Allocate buffer for serialized data.
+    auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    size_t offset = 0;
+    auto size = AccumulatorType::serializedSize();
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+        // Write to the pre-allocated buffer.
+        accumulator->serialize(rawBuffer + offset);
+        flatResult->setNoCopy(
+            i, StringView(rawBuffer + offset, static_cast<int32_t>(size)));
+        offset += size;
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<double>();
+    flatResult->resize(numGroups);
+
+    // Find the noise scale from group.
+    double noiseScale = -1.0;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        noiseScale = accumulator->getNoiseScale();
+        if (noiseScale >= 0) {
+          break;
+        }
+      }
+    }
+
+    // None of the groups have noise scale, return early.
+    if (noiseScale < 0) {
+      for (auto i = 0; i < numGroups; ++i) {
+        flatResult->setNull(i, true);
+      }
+      return;
+    }
+
+    // Initialize the random generator and seed with randomly generated seed.
+    folly::Random::DefaultGenerator rng;
+    rng.seed(folly::Random::secureRand32());
+
+    std::normal_distribution<double> dist;
+    bool addNoise = false;
+    if (noiseScale > 0) {
+      dist = std::normal_distribution<double>(0.0, noiseScale);
+      addNoise = true;
+    }
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+        // Return null for null values in the group.
+        if (accumulator->getNoiseScale() < 0) {
+          flatResult->setNull(i, true);
+          continue;
+        }
+        double noise = addNoise ? dist(rng) : 0;
+        flatResult->set(i, accumulator->getSum() + noise);
+      }
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decoded(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+
+      // Update sum from intermediate result.
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+      auto serialized = decoded.valueAt<StringView>(i);
+      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+      accumulator->update(otherAccumulator.getSum());
+
+      // Update noise scale.
+      if (otherAccumulator.getNoiseScale() >= 0) {
+        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decoded(*args[0], rows);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+
+      auto serialized = decoded.valueAt<StringView>(i);
+      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+      accumulator->update(otherAccumulator.getSum());
+
+      // Update noise scale.
+      if (otherAccumulator.getNoiseScale() >= 0) {
+        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    // Initialize the accumulator for each group
+    for (auto i : indices) {
+      *value<AccumulatorType>(groups[i]) = AccumulatorType();
+    }
+  }
+
+ private:
+  DecodedVector decodedValue_;
+  DecodedVector decodedNoiseScale_;
+
+  /// Helper function to process input data. Used in addRawInput and
+  /// addSingleGroupRawInput.
+  void decodeInputData(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    VELOX_CHECK(args.size() >= 2);
+    // Decode input values and noise scale
+    decodedValue_.decode(*args[0], rows);
+    decodedNoiseScale_.decode(*args[1], rows);
+  }
+};
+} // namespace
+
+void registerNoisySumGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+
+  // Generate signatures for simple data types
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("double")
+                           .intermediateType("varbinary")
+                           .argumentType("double") // input type
+                           .argumentType("double") // noise_scale type
+                           .build());
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("double")
+                           .intermediateType("varbinary")
+                           .argumentType("double") // input type
+                           .argumentType("bigint") // noise_scale type
+                           .build());
+
+  auto name = prefix + kNoisySumGaussian;
+  exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          [[maybe_unused]] const TypePtr& resultType,
+          [[maybe_unused]] const core::QueryConfig&)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(argTypes.size(), 2, "{} takes 2 arguments", name);
+
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<NoisySumGaussianAggregate>(VARBINARY());
+        }
+        return std::make_unique<NoisySumGaussianAggregate>(DOUBLE());
+      },
+      {false /*orderSensitive*/, false /*companionFunction*/},
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -44,13 +44,18 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
     decodeInputData(rows, args);
+    bool hasRandomSeed = args.size() == 3;
 
     rows.applyToSelected([&](vector_size_t i) {
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+      // Update random seed if provided.
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
+      }
+
       if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
         return;
       }
-
-      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
 
       // Update noise scale.
       auto noiseScaleType = args[1]->typeKind();
@@ -75,10 +80,16 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
     decodeInputData(rows, args);
+    bool hasRandomSeed = args.size() == 3;
 
     auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
 
     rows.applyToSelected([&](vector_size_t i) {
+      // Update random seed if provided.
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
+      }
+
       if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
         return;
       }
@@ -157,9 +168,23 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       return;
     }
 
-    // Initialize the random generator and seed with randomly generated seed.
+    // Initialize the random generator and seed with random_seed if provided.
     folly::Random::DefaultGenerator rng;
-    rng.seed(folly::Random::secureRand32());
+    bool hasRandomSeed = false;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        if (accumulator->getRandomSeed().has_value()) {
+          rng.seed(accumulator->getRandomSeed().value());
+          hasRandomSeed = true;
+          break;
+        }
+      }
+    }
+
+    if (!hasRandomSeed) {
+      rng.seed(folly::Random::secureRand32());
+    }
 
     std::normal_distribution<double> dist;
     bool addNoise = false;
@@ -207,6 +232,11 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       if (otherAccumulator.getNoiseScale() >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
       }
+
+      // Update random seed.
+      if (otherAccumulator.getRandomSeed().has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
+      }
     });
   }
 
@@ -231,6 +261,11 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       if (otherAccumulator.getNoiseScale() >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
       }
+
+      // Update random seed.
+      if (otherAccumulator.getRandomSeed().has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
+      }
     });
   }
 
@@ -247,6 +282,7 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
  private:
   DecodedVector decodedValue_;
   DecodedVector decodedNoiseScale_;
+  DecodedVector decodedRandomSeed_;
 
   /// Helper function to process input data. Used in addRawInput and
   /// addSingleGroupRawInput.
@@ -257,6 +293,10 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     // Decode input values and noise scale
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
+
+    if (args.size() == 3) {
+      decodedRandomSeed_.decode(*args[2], rows);
+    }
   }
 
   // Template helper function to update accumulator, can support all numeric
@@ -315,6 +355,7 @@ void registerNoisySumGaussianAggregate(
   const std::vector<std::string> simpleDataTypes = {
       "tinyint", "smallint", "integer", "bigint", "real", "double"};
   const std::vector<std::string> noiseScaleTypes = {"double", "bigint"};
+  const std::string randomSeedType = "bigint";
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
@@ -322,9 +363,16 @@ void registerNoisySumGaussianAggregate(
   for (const auto& noiseScaleType : noiseScaleTypes) {
     // Handle simple types.
     for (const auto& dataType : simpleDataTypes) {
+      // Signature 1: (col, noise_scale)
       signatures.push_back(createBuilder()
                                .argumentType(dataType)
                                .argumentType(noiseScaleType)
+                               .build());
+      // Signature 2: (col, noise_scale, random_seed)
+      signatures.push_back(createBuilder()
+                               .argumentType(dataType)
+                               .argumentType(noiseScaleType)
+                               .argumentType(randomSeedType)
                                .build());
     }
 
@@ -336,6 +384,15 @@ void registerNoisySumGaussianAggregate(
                              .intermediateType("varbinary")
                              .argumentType("DECIMAL(a_precision, a_scale)")
                              .argumentType(noiseScaleType)
+                             .build());
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("double")
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType(noiseScaleType)
+                             .argumentType(randomSeedType)
                              .build());
   }
 
@@ -349,7 +406,10 @@ void registerNoisySumGaussianAggregate(
           [[maybe_unused]] const TypePtr& resultType,
           [[maybe_unused]] const core::QueryConfig&)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(argTypes.size(), 2, "{} takes 2 arguments", name);
+        VELOX_CHECK_GE(
+            argTypes.size(), 2, "{} takes at least 2 arguments", name);
+        VELOX_CHECK_LE(
+            argTypes.size(), 3, "{} takes at most 3 arguments", name);
 
         if (exec::isPartialOutput(step)) {
           return std::make_unique<NoisySumGaussianAggregate>(VARBINARY());

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -44,18 +44,15 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
     decodeInputData(rows, args);
-    bool hasRandomSeed = args.size() == 3;
+    bool hasRandomSeed = (args.size() == 3 || args.size() == 5);
+    bool hasBounds = args.size() > 3;
 
     rows.applyToSelected([&](vector_size_t i) {
-      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
-      // Update random seed if provided.
-      if (hasRandomSeed) {
-        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
-      }
-
       if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
         return;
       }
+
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
 
       // Update noise scale.
       auto noiseScaleType = args[1]->typeKind();
@@ -65,6 +62,34 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       } else if (noiseScaleType == TypeKind::BIGINT) {
         accumulator->checkAndSetNoiseScale(
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+
+      // Update lower and upper bound if provided. support both double and
+      // bigint type.
+      if (hasBounds) {
+        auto lowerBoundType = args[2]->typeKind();
+        auto upperBoundType = args[3]->typeKind();
+        double lowerBound = 0.0;
+        double upperBound = 0.0;
+        if (lowerBoundType == TypeKind::DOUBLE) {
+          lowerBound = decodedLowerBound_.valueAt<double>(i);
+        } else if (lowerBoundType == TypeKind::BIGINT) {
+          lowerBound =
+              static_cast<double>(decodedLowerBound_.valueAt<int64_t>(i));
+        }
+
+        if (upperBoundType == TypeKind::DOUBLE) {
+          upperBound = decodedUpperBound_.valueAt<double>(i);
+        } else if (upperBoundType == TypeKind::BIGINT) {
+          upperBound =
+              static_cast<double>(decodedUpperBound_.valueAt<int64_t>(i));
+        }
+        accumulator->checkAndSetBounds(lowerBound, upperBound);
+      }
+
+      // Update random seed if provided.
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
       }
 
       // Update sum. check input value and dispatch to corresponding type.
@@ -80,7 +105,8 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
     decodeInputData(rows, args);
-    bool hasRandomSeed = args.size() == 3;
+    bool hasRandomSeed = (args.size() == 3 || args.size() == 5);
+    bool hasBounds = args.size() > 3;
 
     auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
 
@@ -102,6 +128,34 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       } else if (noiseScaleType == TypeKind::BIGINT) {
         accumulator->checkAndSetNoiseScale(
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+
+      // Update lower and upper bound if provided. support both double and
+      // bigint type.
+      if (hasBounds) {
+        auto lowerBoundType = args[2]->typeKind();
+        auto upperBoundType = args[3]->typeKind();
+        double lowerBound = 0.0;
+        double upperBound = 0.0;
+        if (lowerBoundType == TypeKind::DOUBLE) {
+          lowerBound = decodedLowerBound_.valueAt<double>(i);
+        } else if (lowerBoundType == TypeKind::BIGINT) {
+          lowerBound =
+              static_cast<double>(decodedLowerBound_.valueAt<int64_t>(i));
+        }
+
+        if (upperBoundType == TypeKind::DOUBLE) {
+          upperBound = decodedUpperBound_.valueAt<double>(i);
+        } else if (upperBoundType == TypeKind::BIGINT) {
+          upperBound =
+              static_cast<double>(decodedUpperBound_.valueAt<int64_t>(i));
+        }
+        accumulator->checkAndSetBounds(lowerBound, upperBound);
+      }
+
+      // Update random seed if provided.
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
       }
 
       // Update sum. check input value and dispatch to corresponding type.
@@ -205,7 +259,18 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
           continue;
         }
         double noise = addNoise ? dist(rng) : 0;
-        flatResult->set(i, accumulator->getSum() + noise);
+
+        // Check the sign of noisy sum is consistent with the bounds.
+        double nosiySum = accumulator->getSum() + noise;
+        if (accumulator->getLowerBound().has_value() &&
+            accumulator->getUpperBound().has_value()) {
+          if (accumulator->getLowerBound().value() >= 0) {
+            nosiySum = std::max(nosiySum, 0.0);
+          } else if (accumulator->getUpperBound().value() <= 0) {
+            nosiySum = std::min(nosiySum, 0.0);
+          }
+        }
+        flatResult->set(i, nosiySum);
       }
     }
   }
@@ -231,6 +296,14 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       // Update noise scale.
       if (otherAccumulator.getNoiseScale() >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+      }
+
+      // Update lower and upper bound.
+      if (otherAccumulator.getLowerBound().has_value() &&
+          otherAccumulator.getUpperBound().has_value()) {
+        accumulator->checkAndSetBounds(
+            *otherAccumulator.getLowerBound(),
+            *otherAccumulator.getUpperBound());
       }
 
       // Update random seed.
@@ -262,6 +335,14 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
         accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
       }
 
+      // Update lower and upper bound.
+      if (otherAccumulator.getLowerBound().has_value() &&
+          otherAccumulator.getUpperBound().has_value()) {
+        accumulator->checkAndSetBounds(
+            *otherAccumulator.getLowerBound(),
+            *otherAccumulator.getUpperBound());
+      }
+
       // Update random seed.
       if (otherAccumulator.getRandomSeed().has_value()) {
         accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
@@ -282,6 +363,8 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
  private:
   DecodedVector decodedValue_;
   DecodedVector decodedNoiseScale_;
+  DecodedVector decodedLowerBound_;
+  DecodedVector decodedUpperBound_;
   DecodedVector decodedRandomSeed_;
 
   /// Helper function to process input data. Used in addRawInput and
@@ -294,8 +377,19 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
 
+    // If intput has random seed, decode it
     if (args.size() == 3) {
       decodedRandomSeed_.decode(*args[2], rows);
+    }
+
+    if (args.size() == 5) {
+      decodedRandomSeed_.decode(*args[4], rows);
+    }
+
+    // If intput has lower and upper bounds, decode them
+    if (args.size() > 3) {
+      decodedLowerBound_.decode(*args[2], rows);
+      decodedUpperBound_.decode(*args[3], rows);
     }
   }
 
@@ -316,7 +410,7 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
                                             : type->asLongDecimal().scale();
         double doubleValue = static_cast<double>(value) / pow(10, scale);
 
-        accumulator->update(doubleValue);
+        accumulator->clipUpdate(doubleValue);
         return;
       }
     }
@@ -333,7 +427,7 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       if (std::isnan(decodedValue.valueAt<T>(i))) {
         return;
       }
-      accumulator->update(static_cast<double>(decodedValue.valueAt<T>(i)));
+      accumulator->clipUpdate(static_cast<double>(decodedValue.valueAt<T>(i)));
     }
   }
 };
@@ -356,6 +450,7 @@ void registerNoisySumGaussianAggregate(
       "tinyint", "smallint", "integer", "bigint", "real", "double"};
   const std::vector<std::string> noiseScaleTypes = {"double", "bigint"};
   const std::string randomSeedType = "bigint";
+  const std::vector<std::string> boundTypes = {"double", "bigint"};
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
@@ -374,9 +469,30 @@ void registerNoisySumGaussianAggregate(
                                .argumentType(noiseScaleType)
                                .argumentType(randomSeedType)
                                .build());
-    }
 
+      for (const auto& lowerBoundType : boundTypes) {
+        for (const auto& upperBoundType : boundTypes) {
+          // Signature 3: (col, noise_scale, lower_bound, upper_bound)
+          signatures.push_back(createBuilder()
+                                   .argumentType(dataType)
+                                   .argumentType(noiseScaleType)
+                                   .argumentType(lowerBoundType)
+                                   .argumentType(upperBoundType)
+                                   .build());
+          // Signature 4: (col, noise_scale, lower_bound, upper_bound,
+          // random_seed)
+          signatures.push_back(createBuilder()
+                                   .argumentType(dataType)
+                                   .argumentType(noiseScaleType)
+                                   .argumentType(lowerBoundType)
+                                   .argumentType(upperBoundType)
+                                   .argumentType(randomSeedType)
+                                   .build());
+        }
+      }
+    }
     // Handle decimal types separately.
+    // Signature 1: (col, noise_scale)
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .integerVariable("a_precision")
                              .integerVariable("a_scale")
@@ -385,6 +501,7 @@ void registerNoisySumGaussianAggregate(
                              .argumentType("DECIMAL(a_precision, a_scale)")
                              .argumentType(noiseScaleType)
                              .build());
+    // Signature 2: (col, noise_scale, random_seed)
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                              .integerVariable("a_precision")
                              .integerVariable("a_scale")
@@ -394,6 +511,35 @@ void registerNoisySumGaussianAggregate(
                              .argumentType(noiseScaleType)
                              .argumentType(randomSeedType)
                              .build());
+
+    for (const auto& lowerBoundType : boundTypes) {
+      for (const auto& upperBoundType : boundTypes) {
+        // Signature 3: (col, noise_scale, lower_bound, upper_bound)
+        signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                                 .integerVariable("a_precision")
+                                 .integerVariable("a_scale")
+                                 .returnType("double")
+                                 .intermediateType("varbinary")
+                                 .argumentType("DECIMAL(a_precision, a_scale)")
+                                 .argumentType(noiseScaleType)
+                                 .argumentType(lowerBoundType)
+                                 .argumentType(upperBoundType)
+                                 .build());
+        // Signature 4: (col, noise_scale, lower_bound, upper_bound,
+        // random_seed)
+        signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                                 .integerVariable("a_precision")
+                                 .integerVariable("a_scale")
+                                 .returnType("double")
+                                 .intermediateType("varbinary")
+                                 .argumentType("DECIMAL(a_precision, a_scale)")
+                                 .argumentType(noiseScaleType)
+                                 .argumentType(lowerBoundType)
+                                 .argumentType(upperBoundType)
+                                 .argumentType(randomSeedType)
+                                 .build());
+      }
+    }
   }
 
   auto name = prefix + kNoisySumGaussian;
@@ -409,7 +555,7 @@ void registerNoisySumGaussianAggregate(
         VELOX_CHECK_GE(
             argTypes.size(), 2, "{} takes at least 2 arguments", name);
         VELOX_CHECK_LE(
-            argTypes.size(), 3, "{} takes at most 3 arguments", name);
+            argTypes.size(), 5, "{} takes at most 5 arguments", name);
 
         if (exec::isPartialOutput(step)) {
           return std::make_unique<NoisySumGaussianAggregate>(VARBINARY());

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisySumGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -43,6 +43,7 @@
 #include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h"
+#include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/QDigestAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/ReduceAgg.h"
 #include "velox/functions/prestosql/aggregates/SetAggregates.h"
@@ -97,6 +98,7 @@ void registerAllAggregateFunctions(
       prefix, withCompanionFunctions, overwrite);
   registerNoisyCountGaussianAggregate(
       prefix, withCompanionFunctions, overwrite);
+  registerNoisySumGaussianAggregate(prefix, withCompanionFunctions, overwrite);
   registerReduceAgg(prefix, withCompanionFunctions, overwrite);
   registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
   registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   MultiMapAggTest.cpp
   NoisyCountGaussianAggregationTest.cpp
   NoisyCountIfGaussianAggregationTest.cpp
+  NoisySumGaussianAggregationTest.cpp
   PrestoHasherTest.cpp
   QDigestAggTest.cpp
   ReduceAggTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -30,6 +30,18 @@ class NoisySumGaussianAggregationTest
 
   RowTypePtr doubleRowType_{
       ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+  RowTypePtr bigintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), BIGINT()})};
+  RowTypePtr decimalRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DECIMAL(20, 5)})};
+  RowTypePtr realRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), REAL()})};
+  RowTypePtr integerRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()})};
+  RowTypePtr smallintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), SMALLINT()})};
+  RowTypePtr tinyintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), TINYINT()})};
 };
 
 TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
@@ -166,4 +178,63 @@ TEST_F(NoisySumGaussianAggregationTest, groupByNullTestNoNoise) {
       {vectors}, {"c0"}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult2});
 }
 
+TEST_F(NoisySumGaussianAggregationTest, inputTypeTestNoNoise) {
+  // Test that the function supports various input types.
+  auto doubleVector = makeVectors(doubleRowType_, 5, 3);
+  auto bigintVector = makeVectors(bigintRowType_, 5, 3);
+  auto decimalVector = makeVectors(decimalRowType_, 5, 3);
+  auto realVector = makeVectors(realRowType_, 5, 3);
+  auto integerVector = makeVectors(integerRowType_, 5, 3);
+  auto smallintVector = makeVectors(smallintRowType_, 5, 3);
+  auto tinyintVector = makeVectors(tinyintRowType_, 5, 3);
+
+  createDuckDbTable(doubleVector);
+  testAggregations(
+      doubleVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"}, // double noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(bigintVector);
+  testAggregations(
+      bigintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(decimalVector);
+  testAggregations(
+      decimalVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(realVector);
+  testAggregations(
+      realVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"}, // bigint noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(integerVector);
+  testAggregations(
+      integerVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(smallintVector);
+  testAggregations(
+      smallintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(tinyintVector);
+  testAggregations(
+      tinyintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+}
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+
+class NoisySumGaussianAggregationTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+
+  RowTypePtr doubleRowType_{
+      ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+};
+
+TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0})})};
+
+  // Expect the result to be 15.0
+  auto expectedResult = makeRowVector({makeConstant(15.0, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult});
+
+  // test nosie scale of bigint type.
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0)"}, {expectedResult});
+}
+
+// Test cases where the noise scale is invalid.
+TEST_F(NoisySumGaussianAggregationTest, inValidNoise) {
+  auto vectors = makeVectors(doubleRowType_, 10, 5);
+  createDuckDbTable(vectors);
+
+  // Test should fail and output expected error message.
+  testFailingAggregations(
+      vectors,
+      {},
+      {"noisy_sum_gaussian(c2, -1.0)"},
+      "Noise scale must be non-negative value.");
+}
+
+TEST_F(NoisySumGaussianAggregationTest, nullTestNoNoise) {
+  // Test non-null and null values mixed.
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1, 2, 3, 4, 5}),
+       makeNullableFlatVector<double>({std::nullopt, 2, std::nullopt, 4, 5})});
+
+  // Expect the result to be 11.0
+  auto expectedResult = makeRowVector({makeConstant(11.0, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult});
+
+  // Test all null values.
+  auto vectors2 = makeRowVector({makeAllNullFlatVector<double>(10)});
+
+  // Expect the result to be NULL
+  auto expectedResult2 = makeRowVector({makeNullConstant(TypeKind::DOUBLE, 1)});
+  testAggregations(
+      {vectors2}, {}, {"noisy_sum_gaussian(c0, 0.0)"}, {expectedResult2});
+}
+
+TEST_F(NoisySumGaussianAggregationTest, emptyTestNoNoise) {
+  // Test empty input.
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>({}),
+       makeFlatVector<int64_t>({}),
+       makeFlatVector<double>({})})};
+
+  // Expect the result to be NULL
+  auto expectedResult = makeRowVector({makeNullConstant(TypeKind::DOUBLE, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult});
+}
+
+TEST_F(
+    NoisySumGaussianAggregationTest,
+    singleGroupMultipleAggregationTestNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  // Single group by key, multiple aggregation functions.
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_sum_gaussian(c1, 0.0)", "noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT SUM(c1), SUM(c2) FROM tmp");
+}
+
+TEST_F(
+    NoisySumGaussianAggregationTest,
+    multipleGroupSingleAggregationTestNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  // Multiple group by keys, single aggregation functions.
+  testAggregations(
+      vectors,
+      {"c0", "c1"},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT c0, c1, SUM(c2) FROM tmp GROUP BY c0, c1");
+}
+
+TEST_F(
+    NoisySumGaussianAggregationTest,
+    multipleGroupMultipleAggregationTestNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  // Multiple group by keys, multiple aggregation functions.
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_sum_gaussian(c1, 0.0)", "noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT c0, SUM(c1), SUM(c2) FROM tmp GROUP BY c0");
+}
+
+TEST_F(NoisySumGaussianAggregationTest, groupByNullTestNoNoise) {
+  // Test group
+  auto vectors = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, 2, std::nullopt, 2, 2}),
+       makeFlatVector<double>({1, 1, 3, 3, 3}),
+       makeNullableFlatVector<double>({std::nullopt, 2, std::nullopt, 2, 2})});
+
+  // Group by c0, aggregate c1, expect the result:
+  // c0   | noisy_sum_gaussian(c1, 0.0)
+  // NULL | 4
+  // 2    | 7
+  auto expectedResult = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, 2}),
+       makeNullableFlatVector<double>({4, 7})});
+  testAggregations(
+      {vectors}, {"c0"}, {"noisy_sum_gaussian(c1, 0.0)"}, {expectedResult});
+
+  // Group by c0, aggregate c2, expect the result:
+  // c0   | noisy_sum_gaussian(c2, 0.0)
+  // NULL | NULL
+  // 2    | 6
+  auto expectedResult2 = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, 2}),
+       makeNullableFlatVector<double>({std::nullopt, 6})});
+
+  testAggregations(
+      {vectors}, {"c0"}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult2});
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -271,4 +271,85 @@ TEST_F(NoisySumGaussianAggregationTest, randomSeedTestWithNoise) {
         vectors, {}, {"noisy_sum_gaussian(c2, 20, 12345)"}, {expectedResult});
   }
 }
+
+TEST_F(NoisySumGaussianAggregationTest, boundsTestNoNoise) {
+  // Test easy case with lower and upper bounds.
+  auto vectors1 = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0})})};
+
+  // With lower bound = 3.0 and upper bound = 5.0
+  // Expect the result to be 18.0
+  auto expectedResult = makeRowVector({makeConstant(18.0, 1)});
+  testAggregations(
+      {vectors1},
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 3.0, 5.0)"},
+      {expectedResult});
+
+  // Test against DuckDB.
+  auto vectors2 = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors2);
+
+  // Test double lower bound and double upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 0.1, 0.8)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 0.8), 0.1) END) FROM tmp");
+
+  // Test double lower bound and bigint upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 0.1, 800)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 800), 0.1) END) FROM tmp");
+
+  // Test bigint lower bound and double upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 10, 50.8)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 50.8), 10) END) FROM tmp");
+
+  // Test bigint lower bound and bigint upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 100, 800)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 800), 100) END) FROM tmp");
+
+  // Test lower bound > upper bound.
+  testFailingAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 100, 80)"},
+      "Lower bound must be less than or equal to upper bound.");
+}
+
+TEST_F(NoisySumGaussianAggregationTest, boundsTestWithNoise) {
+  auto vectors = makeVectors(integerRowType_, 5, 3);
+  createDuckDbTable(vectors);
+  // Test that the noise is deterministic given the same noise_scale,
+  // random_seed. noisy_sum_gaussian(col, noise_scale, lower_bound, upper_bound,
+  // randon_seed)
+  auto expectedResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation(
+                  {}, {"noisy_sum_gaussian(c2, 20, 10, 100, 12345)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  for (int i = 0; i < 10; i++) {
+    testAggregations(
+        vectors,
+        {},
+        {"noisy_sum_gaussian(c2, 20, 10, 100, 12345)"},
+        {expectedResult});
+  }
+}
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -37,6 +37,8 @@
 #include "velox/functions/prestosql/fuzzer/NoisyCountIfResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/NoisyCountInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/NoisyCountResultVerifier.h"
+#include "velox/functions/prestosql/fuzzer/NoisySumInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/QDigestAggInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/QDigestAggResultVerifier.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -89,6 +91,7 @@ getCustomInputGenerators() {
       {"noisy_count_if_gaussian",
        std::make_shared<NoisyCountIfInputGenerator>()},
       {"noisy_count_gaussian", std::make_shared<NoisyCountInputGenerator>()},
+      {"noisy_sum_gaussian", std::make_shared<NoisySumInputGenerator>()},
   };
 }
 
@@ -156,6 +159,7 @@ int main(int argc, char** argv) {
   using facebook::velox::exec::test::MinMaxByResultVerifier;
   using facebook::velox::exec::test::NoisyCountIfResultVerifier;
   using facebook::velox::exec::test::NoisyCountResultVerifier;
+  using facebook::velox::exec::test::NoisySumResultVerifier;
   using facebook::velox::exec::test::QDigestAggResultVerifier;
   using facebook::velox::exec::test::setupReferenceQueryRunner;
   using facebook::velox::exec::test::TransformResultVerifier;
@@ -211,6 +215,7 @@ int main(int argc, char** argv) {
            std::make_shared<NoisyCountIfResultVerifier>()},
           {"noisy_count_gaussian",
            std::make_shared<NoisyCountResultVerifier>()},
+          {"noisy_sum_gaussian", std::make_shared<NoisySumResultVerifier>()},
       };
 
   using Runner = facebook::velox::exec::test::AggregationFuzzerRunner;

--- a/velox/functions/prestosql/fuzzer/NoisySumInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/NoisySumInputGenerator.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <vector>
+#include "velox/exec/fuzzer/InputGenerator.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::exec::test {
+
+class NoisySumInputGenerator : public InputGenerator {
+ public:
+  /// Generate input for the noisy_sum_gaussian function.
+  /// The signature takes 2-5 arguments.
+  /// noisy_sum_gaussian(col, noiseScale[[, lower, upper], randomSeed])
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) override {
+    vector_size_t size = static_cast<int32_t>(fuzzer.getOptions().vectorSize);
+    std::vector<VectorPtr> result;
+
+    // Make sure to use the same value of 'noiseScale' for all batches inputs,
+    // so we only set it once.
+    if (!noiseScale_.has_value()) {
+      noiseScale_ =
+          boost::random::uniform_real_distribution<double>(0.0, 100.0)(rng);
+    }
+
+    // Process each type in the input.
+    // Types of parameters in noisy_sum_gaussian(col, noiseScale, lower, upper,
+    // randomSeed)
+    VELOX_CHECK(types.size() >= 2);
+    VELOX_CHECK(types.size() <= 5);
+    for (size_t i = 0; i < types.size(); ++i) {
+      const auto& type = types[i];
+
+      // For the first argument which is a numeric column
+      if (i == 0) {
+        // Create a flat vector for sum aggregation. Signature only accept
+        // numeric type.
+        auto flatVector = fuzzer.fuzzFlat(type, size);
+        result.push_back(flatVector);
+      }
+      // For the second argument (noise scale)
+      else if (i == 1) {
+        if (type->isDouble()) {
+          result.push_back(
+              BaseVector::createConstant(DOUBLE(), *noiseScale_, size, pool));
+        } else if (type->isBigint()) {
+          // Create a variant with the correct integer value
+          variant intValue = static_cast<int64_t>(*noiseScale_);
+          result.push_back(
+              BaseVector::createConstant(BIGINT(), intValue, size, pool));
+        }
+      }
+      // For the third argument
+      else if (i == 2) {
+        // If the third arg is random seed
+        if (types.size() == 3) {
+          if (!randomSeed_.has_value()) {
+            randomSeed_ =
+                boost::random::uniform_int_distribution<int64_t>(0, 12345)(rng);
+          }
+          result.push_back(
+              BaseVector::createConstant(BIGINT(), *randomSeed_, size, pool));
+        }
+        // size >= 4 means it has lower and upper bound.
+        else {
+          // Generate lower and upper bound if they are not set.
+          if (!lowerBound_.has_value()) {
+            lowerBound_ = boost::random::uniform_real_distribution<double>(
+                -1000.0, 1000.0)(rng);
+            // Make sure lower bound is less than upper bound.
+            upperBound_ = boost::random::uniform_real_distribution<double>(
+                              100.0, 1000.0)(rng) +
+                *lowerBound_;
+          }
+
+          if (type->isDouble()) {
+            result.push_back(
+                BaseVector::createConstant(DOUBLE(), *lowerBound_, size, pool));
+          } else if (type->isBigint()) {
+            // Create a variant with the correct integer value
+            variant intValue = static_cast<int64_t>(*lowerBound_);
+            result.push_back(
+                BaseVector::createConstant(BIGINT(), intValue, size, pool));
+          }
+        }
+      }
+      // For the fourth argument(upper bound)
+      else if (i == 3) {
+        // When type size is GE 4, it is guaranteed to have lower and upper
+        // bound.
+        if (type->isDouble()) {
+          result.push_back(
+              BaseVector::createConstant(DOUBLE(), *upperBound_, size, pool));
+        } else if (type->isBigint()) {
+          // Create a variant with the correct integer value
+          variant intValue = static_cast<int64_t>(*upperBound_);
+          result.push_back(
+              BaseVector::createConstant(BIGINT(), intValue, size, pool));
+        }
+      }
+      // For the fifth argument(random seed)
+      else if (i == 4) {
+        VELOX_CHECK(type->isBigint());
+        if (!randomSeed_.has_value()) {
+          randomSeed_ =
+              boost::random::uniform_int_distribution<int64_t>(0, 12345)(rng);
+        }
+        result.push_back(
+            BaseVector::createConstant(BIGINT(), *randomSeed_, size, pool));
+      }
+    }
+
+    return result;
+  }
+  void reset() override {
+    noiseScale_.reset();
+    lowerBound_.reset();
+    upperBound_.reset();
+    randomSeed_.reset();
+  }
+
+ private:
+  std::optional<double> noiseScale_;
+  std::optional<double> lowerBound_;
+  std::optional<double> upperBound_;
+  std::optional<int64_t> randomSeed_;
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include "velox/core/PlanNode.h"
+#include "velox/exec/fuzzer/ResultVerifier.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec::test {
+
+/// Verifier for the noisy_sum_gaussian function.
+/// The function takes 2-5 arguments:
+/// If the signature takes 5 arguments, the function clips
+/// the input to the specified bounds, and then sums the clipped values.
+/// At the last step, it adds Gaussian noise to the sum with the specified
+/// noise scale. Random seed is used to generate a determined sequence of
+/// noises.
+/// The idea of this verifier is to create a benchmark plan that simulates the
+/// function without adding noise. Then we can compare the result of the actual
+/// function with the result of the benchmark plan. If the difference is within
+/// the expected range, we consider the result as correct.
+/// To create the benchmark, we cannot use noisy_sum_gaussian directly and we
+/// need to use a sequence of other functions to replicate the same behavior.
+/// Basically we need to:
+/// 1. Deduplicate the input with window function if distinct is true.
+/// 2. Clip the input to the specified bounds and convert the aggregate column
+///    to double to ensure the result is always double, keeping consistent with
+///    noisy_sum_gaussian. This process returns a new vector with clipped input.
+/// 3. Sum the clipped values.
+/// 4. Call noisy_sum_gaussian on the input.
+/// 5. Compare the result with the expected result.
+class NoisySumResultVerifier : public ResultVerifier {
+ public:
+  bool supportsCompare() override {
+    return false;
+  }
+
+  bool supportsVerify() override {
+    return true;
+  }
+
+  void initialize(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
+      const std::vector<std::string>& groupingKeys,
+      const core::AggregationNode::Aggregate& aggregate,
+      const std::string& aggregateName) override {
+    VELOX_CHECK(!input.empty());
+
+    groupingKeys_ = groupingKeys;
+    name_ = aggregateName;
+    // Extract the noise scale from the function call.
+    const auto& args = aggregate.call->inputs();
+    extractNoiseScaleAndBound(input[0], args);
+
+    // Extract aggregate column name before deduplication
+    auto field = core::TypedExprs::asFieldAccess(args[0]);
+    VELOX_CHECK_NOT_NULL(field);
+    aggregateColumn_ = field->name();
+
+    // When distinct is true, we should deduplicate the input before clipping.
+    // if mask is provided, mask should apply to the input before
+    // deduplication.
+    auto deduplicatedInput = input;
+    if (aggregate.distinct) {
+      deduplicatedInput = deduplicateInput(input, aggregate.mask);
+    }
+    // Clip the input to the specified bounds and convert to double. This is
+    // needed because the noisy_sum_gaussian function only return double
+    // outputs.
+    clipInput(deduplicatedInput);
+
+    auto sumCall = fmt::format("sum({})", aggregateColumn_);
+
+    // If distinct is false, mask has not been applied yet.
+    if (aggregate.mask != nullptr && !aggregate.distinct) {
+      sumCall += fmt::format(" filter (where {})", aggregate.mask->name());
+    }
+
+    core::PlanNodePtr plan = PlanBuilder()
+                                 .values(clippedInput_)
+                                 .projectExpressions(projections)
+                                 .singleAggregation(groupingKeys, {sumCall})
+                                 .planNode();
+
+    expectedNoNoise_ = AssertQueryBuilder(plan).copyResults(input[0]->pool());
+  }
+
+  bool compare(
+      [[maybe_unused]] const RowVectorPtr& result,
+      [[maybe_unused]] const RowVectorPtr& otherResult) override {
+    VELOX_UNSUPPORTED();
+  }
+
+  bool verify(const RowVectorPtr& result) override {
+    // The expected result and actual result are grouped by the same keys,
+    // but the rows may be in different order. So we need to union the results.
+    // Create sources for expected and actual results
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto expectedSource = PlanBuilder(planNodeIdGenerator)
+                              .values({expectedNoNoise_})
+                              .appendColumns({"'expected' as label"})
+                              .planNode();
+    auto actualSource = PlanBuilder(planNodeIdGenerator)
+                            .values({result})
+                            .appendColumns({"'actual' as label"})
+                            .planNode();
+
+    // Combine expected and actual results by grouping keys using map_agg
+    auto mapAgg = fmt::format("map_agg(label, {}) as m", name_);
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .localPartition({}, {expectedSource, actualSource})
+                    .singleAggregation(groupingKeys_, {mapAgg})
+                    .project({"m['actual'] as a", "m['expected'] as e"})
+                    .planNode();
+    auto combined = AssertQueryBuilder(plan).copyResults(result->pool());
+
+    // Extract actual and expected values, handling type differences
+    auto actualColumn = combined->childAt(0);
+    auto expectedColumn = combined->childAt(1);
+
+    const auto numGroups = result->size();
+    VELOX_CHECK_EQ(numGroups, combined->size());
+
+    // Calculate allowed difference based on noise scale
+    const int64_t deviationMultiple = 50;
+    const double allowedFailureRate = 0.001;
+    // When noise_scale is 0, we expect exact match.
+    // But type conversion may lose precision, especially for very large result.
+    // so we allow a small percentage of differences.
+    const double allowedDifferencePercent = 0.000000001;
+    const auto allowedDifference = deviationMultiple * noiseScale_;
+    auto lowerBound = -allowedDifference;
+    auto upperBound = allowedDifference;
+
+    // Check each group's result
+    int failures = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      // Skip verification for null rows
+      if (expectedColumn->isNullAt(i) || actualColumn->isNullAt(i)) {
+        continue;
+      }
+
+      const auto actualValue =
+          actualColumn->as<SimpleVector<double>>()->valueAt(i);
+      const auto expectedValue =
+          expectedColumn->as<SimpleVector<double>>()->valueAt(i);
+      const auto difference = actualValue - expectedValue;
+
+      // Allow a small percentage of difference for noise_scale = 0
+      lowerBound =
+          std::min(lowerBound, -allowedDifferencePercent * expectedValue);
+      upperBound =
+          std::max(upperBound, allowedDifferencePercent * expectedValue);
+
+      // Check if actual value is within expected +/- allowedDifference
+      if (difference < lowerBound || difference > upperBound) {
+        LOG(ERROR) << fmt::format(
+            "noisy_sum_gaussian result is outside the expected range.\n"
+            "  Group: {}\n"
+            "  Actual: {}\n"
+            "  Expected: {}\n"
+            "  Difference: {}\n"
+            "  Allowed range: [{}, {}] (noise_scale = {})",
+            i,
+            actualValue,
+            expectedValue,
+            difference,
+            expectedValue + lowerBound,
+            expectedValue + upperBound,
+            noiseScale_);
+        failures++;
+      }
+    }
+
+    // Allow a very small percentage of failures for large result sets
+    if (numGroups >= 50) {
+      const auto maxFailures = static_cast<int>(allowedFailureRate * numGroups);
+      if (failures > maxFailures) {
+        LOG(ERROR) << fmt::format(
+            "Too many failures: {} out of {} groups (max allowed: {})",
+            failures,
+            numGroups,
+            maxFailures);
+        return false;
+      }
+      return true;
+    }
+
+    // For small result sets, require all groups to pass
+    return failures == 0;
+  }
+
+  void reset() override {
+    noiseScale_ = 0.0;
+    lowerBound_.reset();
+    upperBound_.reset();
+    name_.clear();
+    groupingKeys_.clear();
+    aggregateColumn_.clear();
+    expectedNoNoise_.reset();
+    clippedInput_.clear();
+  }
+
+ private:
+  std::vector<RowVectorPtr> deduplicateInput(
+      const std::vector<RowVectorPtr>& input,
+      const core::FieldAccessTypedExprPtr& mask) {
+    // Deduplicate the input by using window functions to identify unique
+    // combinations of grouping keys and aggregate column, preserving the
+    // original row type.
+    VELOX_CHECK(!input.empty());
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+    // Create partition keys that include both the original grouping keys
+    // and the aggregate column to ensure proper deduplication for DISTINCT
+    // aggregation
+    auto partitionKeys = groupingKeys_;
+    partitionKeys.push_back(aggregateColumn_);
+
+    // Build partition by clause for window function
+    std::string partitionBy;
+    if (!partitionKeys.empty()) {
+      partitionBy =
+          fmt::format("partition by {}", fmt::join(partitionKeys, ", "));
+    }
+
+    // Use row_number() window function to identify first occurrence of each
+    // unique combination, then filter to keep only those rows(row number = 1)
+    auto windowExpr = fmt::format("row_number() over ({}) as rn", partitionBy);
+
+    auto builder = PlanBuilder(planNodeIdGenerator).values(input);
+
+    // Apply mask filter first if it exists
+    if (mask != nullptr) {
+      builder = builder.filter(mask->name());
+    }
+
+    auto source = builder.window({windowExpr})
+                      .filter("rn = 1")
+                      .project(asRowType(input[0]->type())->names())
+                      .planNode();
+    auto deduplicated =
+        AssertQueryBuilder(source).copyResults(input[0]->pool());
+    return {deduplicated};
+  }
+
+  void extractNoiseScaleAndBound(
+      const RowVectorPtr& input,
+      const std::vector<core::TypedExprPtr>& args) {
+    auto secondArg = input->childAt(1);
+    if (secondArg->type()->isDouble()) {
+      noiseScale_ = secondArg->as<SimpleVector<double>>()->valueAt(0);
+    } else if (secondArg->type()->isBigint()) {
+      noiseScale_ = static_cast<double>(
+          secondArg->as<SimpleVector<int64_t>>()->valueAt(0));
+    }
+
+    // Extract lower and upper bound if they exist
+    if (args.size() > 3) {
+      auto thirdArg = input->childAt(2);
+      if (thirdArg->type()->isDouble()) {
+        lowerBound_ = thirdArg->as<SimpleVector<double>>()->valueAt(0);
+      } else if (thirdArg->type()->isBigint()) {
+        lowerBound_ = static_cast<double>(
+            thirdArg->as<SimpleVector<int64_t>>()->valueAt(0));
+      }
+
+      auto fourthArg = input->childAt(3);
+      if (fourthArg->type()->isDouble()) {
+        upperBound_ = fourthArg->as<SimpleVector<double>>()->valueAt(0);
+      } else if (fourthArg->type()->isBigint()) {
+        upperBound_ = static_cast<double>(
+            fourthArg->as<SimpleVector<int64_t>>()->valueAt(0));
+      }
+    }
+  }
+
+  void clipInput(const std::vector<RowVectorPtr>& input) {
+    auto pool = input[0]->pool();
+    for (const auto& rowVector : input) {
+      std::vector<VectorPtr> clippedChildren;
+
+      for (auto i = 0; i < rowVector->childrenSize(); ++i) {
+        auto column = rowVector->childAt(i);
+
+        if (i == 0) {
+          // Clip first column values within bounds and convert to double
+          auto size = column->size();
+          auto clippedColumn = BaseVector::create(DOUBLE(), size, pool);
+
+          for (auto j = 0; j < size; ++j) {
+            if (column->isNullAt(j)) {
+              clippedColumn->setNull(j, true);
+            } else {
+              auto type = column->type()->kind();
+              VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+                  updateValueByType, type, column, clippedColumn, j);
+            }
+          }
+          clippedChildren.push_back(clippedColumn);
+        } else {
+          // For other columns, just copy them as-is
+          clippedChildren.push_back(column);
+        }
+      }
+
+      // Create a new RowType with first column changed to double
+      auto originalRowType = asRowType(rowVector->type());
+      std::vector<std::string> names = originalRowType->names();
+      std::vector<TypePtr> types = originalRowType->children();
+
+      // Change first column type to double
+      types[0] = DOUBLE();
+
+      auto newRowType = ROW(std::move(names), std::move(types));
+
+      auto clippedRowVector = std::make_shared<RowVector>(
+          pool, newRowType, nullptr, rowVector->size(), clippedChildren);
+
+      clippedInput_.push_back(clippedRowVector);
+    }
+  }
+
+  // Helper function to update the value in the clipped column based on the
+  // data type.
+  template <TypeKind TData>
+  void updateValueByType(
+      VectorPtr& column,
+      VectorPtr& clippedColumn,
+      vector_size_t i) {
+    using T = typename TypeTraits<TData>::NativeType;
+    // Skip testing decimal types.
+    // Skip non-numeric types.
+    if constexpr (
+        std::is_same_v<T, TypeTraits<TypeKind::TIMESTAMP>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARBINARY>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARCHAR>> ||
+        std::is_same_v<T, facebook::velox::StringView> ||
+        std::is_same_v<T, facebook::velox::Timestamp>) {
+      VELOX_FAIL("NoisySumGaussianAggregate does not support this data type.");
+    } else {
+      // Convert the value to double and set it in the clipped column
+      auto rawValue = column->asFlatVector<T>()->valueAt(i);
+      // Skip NaN.
+      if (std::isnan(rawValue)) {
+        clippedColumn->setNull(i, true);
+        return;
+      }
+
+      // Apply clipping if bounds are set
+      double clippedValue = static_cast<double>(rawValue);
+      if (lowerBound_.has_value() && upperBound_.has_value()) {
+        clippedValue =
+            std::min(*upperBound_, std::max(*lowerBound_, clippedValue));
+      }
+
+      clippedColumn->asFlatVector<double>()->set(i, clippedValue);
+    }
+  }
+
+  double noiseScale_{0.0};
+  std::optional<double> lowerBound_;
+  std::optional<double> upperBound_;
+  std::string name_;
+  std::vector<std::string> groupingKeys_;
+  std::string aggregateColumn_;
+  RowVectorPtr expectedNoNoise_;
+  std::vector<RowVectorPtr> clippedInput_;
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -122,9 +122,11 @@ int main(int argc, char** argv) {
       "array_agg",
       // Skip non-deterministic functions.
       "noisy_count_if_gaussian",
+      "noisy_count_gaussian",
+      "noisy_sum_gaussian",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
-      "noisy_count_gaussian",
+
   };
 
   if (!FLAGS_presto_url.empty()) {


### PR DESCRIPTION
Summary:
### Diff Summary

#### Test: Add Unit Test for `noisy_sum_gaussian` Function

This diff adds a unit test for the `noisy_sum_gaussian` function, specifically to test its behavior with no noise. The test is designed to randomly generate input vectors, noise scales, bounds, and random seeds, and then compare the results of the aggregation function with DuckDB.

#### Affected Files

* `fbcode/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp`

#### Notable Changes

* Added a new test `fuzzerTestNoNoise` to `NoisySumGaussianAggregationTest.cpp` to test the `noisy_sum_gaussian` function with no noise.
* The test uses randomly generated input vectors, noise scales, bounds, and random seeds to test the function's behavior.
* The results of the aggregation function are compared with DuckDB to ensure accuracy.

Differential Revision: D75988485
