### PR TITLE
feat(noisy_avg): Add support for optional random_seed

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -748,12 +748,12 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+.. function:: noisy_sum_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -724,7 +724,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -741,7 +742,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -753,7 +755,18 @@ Noisy Aggregate Functions
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
+
+.. function:: noisy_sum_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+
+    Calculates the sum over the input values in ``col`` and then adds a normally distributed
+    random double value with 0 mean and standard deviation of ``noise_scale``.
+    Each value is clipped to the range of [``lower``, ``upper``] before adding to the sum.
+
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
+
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -773,6 +773,11 @@ Noisy Aggregate Functions
     normally distributed random double value with 0 mean and standard deviation of noise_scale.
 
 
+.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper) -> double
+    Calculates the average (arithmetic mean) of all the input values in ``col`` and then adds a
+    normally distributed random double value with 0 mean and standard deviation of ``noise_scale``.
+    Each value is clipped to the range of [``lower``, ``upper``] before averaging.
+
 Miscellaneous
 -------------
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -767,6 +767,11 @@ Noisy Aggregate Functions
     If provided, ``random_seed`` is used to seed the random number generator.
     Otherwise, noise is drawn from a secure random.
 
+.. function:: noisy_avg_gaussian(col, noise_scale) -> double
+
+    Calculates the average (arithmetic mean) of all the input values in col and then adds a
+    normally distributed random double value with 0 mean and standard deviation of noise_scale.
+
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -767,16 +767,22 @@ Noisy Aggregate Functions
     If provided, ``random_seed`` is used to seed the random number generator.
     Otherwise, noise is drawn from a secure random.
 
-.. function:: noisy_avg_gaussian(col, noise_scale) -> double
+.. function:: noisy_avg_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the average (arithmetic mean) of all the input values in col and then adds a
     normally distributed random double value with 0 mean and standard deviation of noise_scale.
 
+    If provided, random_seed is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
-.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper) -> double
+.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+
     Calculates the average (arithmetic mean) of all the input values in ``col`` and then adds a
     normally distributed random double value with 0 mean and standard deviation of ``noise_scale``.
     Each value is clipped to the range of [``lower``, ``upper``] before averaging.
+
+    If provided, random_seed is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
 Miscellaneous
 -------------

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
@@ -31,12 +31,14 @@ class NoisyAvgAccumulator {
       uint64_t count,
       double noiseScale,
       std::optional<double> lowerBound,
-      std::optional<double> upperBound)
+      std::optional<double> upperBound,
+      std::optional<int64_t> randomSeed)
       : sum_{sum},
         count_{count},
         noiseScale_{noiseScale},
         lowerBound_(lowerBound),
-        upperBound_(upperBound) {}
+        upperBound_(upperBound),
+        randomSeed_(randomSeed) {}
 
   void updateCount(uint64_t value) {
     count_ = facebook::velox::checkedPlus<uint64_t>(count_, value);
@@ -70,6 +72,10 @@ class NoisyAvgAccumulator {
     this->upperBound_ = upperBound;
   }
 
+  void setRandomSeed(int64_t randomSeed) {
+    this->randomSeed_ = randomSeed;
+  }
+
   double getSum() const {
     return sum_;
   }
@@ -90,15 +96,21 @@ class NoisyAvgAccumulator {
     return upperBound_;
   }
 
+  std::optional<int64_t> getRandomSeed() const {
+    return randomSeed_;
+  }
+
   // sizeof(double) for sum_
   // sizeof(uint64_t) for count_
   // sizeof(double) for noiseScale_
   // sizeof(bool) for has_bound flag
   // sizeof(double) for lowerBound_ value
   // sizeof(double) for upperBound_ value
+  // sizeof(bool) for randomSeed_ has_value flag
+  // sizeof(int32_t) for randomSeed_ value
   static size_t serializedSize() {
     return sizeof(double) + sizeof(uint64_t) + sizeof(double) + sizeof(bool) +
-        sizeof(double) + sizeof(double);
+        sizeof(double) + sizeof(double) + sizeof(bool) + sizeof(int64_t);
   }
 
   void serialize(char* buffer) const {
@@ -110,6 +122,10 @@ class NoisyAvgAccumulator {
     stream.appendOne(lowerBound_.has_value());
     stream.appendOne(lowerBound_.has_value() ? *lowerBound_ : 0.0);
     stream.appendOne(upperBound_.has_value() ? *upperBound_ : 0.0);
+
+    // Serialize randomSeed_(append 0 if has_value is false).
+    stream.appendOne(randomSeed_.has_value());
+    stream.appendOne(randomSeed_.has_value() ? *randomSeed_ : 0);
   }
 
   static NoisyAvgAccumulator deserialize(const char* buffer) {
@@ -120,12 +136,15 @@ class NoisyAvgAccumulator {
     bool hasBounds = stream.read<bool>();
     std::optional<double> lowerBound = stream.read<double>();
     std::optional<double> upperBound = stream.read<double>();
+    bool hasRandomSeed = stream.read<bool>();
+    std::optional<int32_t> randomSeed = stream.read<int64_t>();
     return NoisyAvgAccumulator(
         sum,
         count,
         noiseScale,
         hasBounds ? lowerBound : std::nullopt,
-        hasBounds ? upperBound : std::nullopt);
+        hasBounds ? upperBound : std::nullopt,
+        hasRandomSeed ? randomSeed : std::nullopt);
   }
 
  private:
@@ -134,6 +153,7 @@ class NoisyAvgAccumulator {
   double noiseScale_{-1};
   std::optional<double> lowerBound_{std::nullopt};
   std::optional<double> upperBound_{std::nullopt};
+  std::optional<int64_t> randomSeed_{std::nullopt};
 };
 
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class NoisyAvgAccumulator {
+ public:
+  NoisyAvgAccumulator() = default;
+  NoisyAvgAccumulator(double sum, uint64_t count, double noiseScale)
+      : sum_{sum}, count_{count}, noiseScale_{noiseScale} {}
+
+  void updateCount(uint64_t value) {
+    count_ = facebook::velox::checkedPlus<uint64_t>(count_, value);
+  }
+
+  void updateSum(double value) {
+    sum_ += value;
+  }
+
+  void checkAndSetNoiseScale(double newNoiseScale) {
+    VELOX_USER_CHECK_GE(
+        newNoiseScale, 0, "Noise scale must be a non-negative value.");
+    noiseScale_ = newNoiseScale;
+  }
+
+  double getSum() const {
+    return sum_;
+  }
+
+  uint64_t getCount() const {
+    return count_;
+  }
+
+  double getNoiseScale() const {
+    return noiseScale_;
+  }
+
+  static size_t serializedSize() {
+    return sizeof(double) + sizeof(uint64_t) + sizeof(double);
+  }
+
+  void serialize(char* buffer) const {
+    common::OutputByteStream stream(buffer);
+    stream.appendOne(sum_);
+    stream.appendOne(count_);
+    stream.appendOne(noiseScale_);
+  }
+
+  static NoisyAvgAccumulator deserialize(const char* buffer) {
+    common::InputByteStream stream(buffer);
+    double sum = stream.read<double>();
+    uint64_t count = stream.read<uint64_t>();
+    double noiseScale = stream.read<double>();
+    return NoisyAvgAccumulator(sum, count, noiseScale);
+  }
+
+ private:
+  double sum_{0};
+  uint64_t count_{0};
+  double noiseScale_{-1};
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -57,6 +57,7 @@ const char* const kMerge = "merge";
 const char* const kMin = "min";
 const char* const kMinBy = "min_by";
 const char* const kMultiMapAgg = "multimap_agg";
+const char* const kNoisyAvgGaussian = "noisy_avg_gaussian";
 const char* const kNoisyCountIfGaussian = "noisy_count_if_gaussian";
 const char* const kNoisyCountGaussian = "noisy_count_gaussian";
 const char* const kNoisySumGaussian = "noisy_sum_gaussian";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   QDigestAggAggregate.cpp
   ReduceAgg.cpp
   RegisterAggregateFunctions.cpp
+  NoisyAvgGaussianAggregate.cpp
   NoisyCountIfGaussianAggregate.cpp
   NoisyCountGaussianAggregate.cpp
   NoisySumGaussianAggregate.cpp

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -211,7 +211,14 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
     if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
       return;
     }
-    accumulator->checkAndSetNoiseScale(decodedNoiseScale_.valueAt<double>(i));
+    double noiseScale = 0;
+    auto noiseScaleType = args[1]->typeKind();
+    if (noiseScaleType == TypeKind::DOUBLE) {
+      noiseScale = decodedNoiseScale_.valueAt<double>(i);
+    } else if (noiseScaleType == TypeKind::BIGINT) {
+      noiseScale = static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
+    }
+    accumulator->checkAndSetNoiseScale(noiseScale);
     accumulator->updateCount(1);
     accumulator->updateSum(decodedValue_.valueAt<double>(i));
   }
@@ -245,6 +252,12 @@ void registerNoisyAvgGaussianAggregate(
           .intermediateType("varbinary")
           .argumentType("double") // input type
           .argumentType("double") // noise scale
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("varbinary")
+          .argumentType("double") // input type
+          .argumentType("bigint") // noise scale
           .build()};
 
   auto name = prefix + kNoisyAvgGaussian;

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+class NoisyAvgGaussianAggregate : public exec::Aggregate {
+ public:
+  explicit NoisyAvgGaussianAggregate(TypePtr resultType)
+      : exec::Aggregate(std::move(resultType)) {}
+
+  using AccumulatorType = functions::aggregate::NoisyAvgAccumulator;
+
+  bool isFixedSize() const override {
+    return true;
+  }
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return static_cast<int32_t>(sizeof(AccumulatorType));
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    // Process the args data and update the accumulator for each group.
+    rows.applyToSelected([&](vector_size_t i) {
+      auto* accumulator = value<AccumulatorType>(groups[i]);
+      updateAccumulatorFromInput(args, accumulator, i);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+    auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      updateAccumulatorFromInput(args, accumulator, i);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+      updateAccumulatorFromIntermediateResult(accumulator, decodedVector, i);
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      updateAccumulatorFromIntermediateResult(accumulator, decodedVector, i);
+    });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    VELOX_CHECK(flatResult);
+    flatResult->resize(numGroups);
+
+    int32_t numOfValidGroups = 0;
+    for (auto i = 0; i < numGroups; i++) {
+      numOfValidGroups += !isNull(groups[i]);
+    }
+    size_t totalSize = numOfValidGroups * AccumulatorType::serializedSize();
+
+    // Allocate buffer for serialized data.
+    auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    size_t offset = 0;
+    auto size = AccumulatorType::serializedSize();
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+        // Write to the pre-allocated buffer.
+        accumulator->serialize(rawBuffer + offset);
+        flatResult->setNoCopy(
+            i, StringView(rawBuffer + offset, static_cast<int32_t>(size)));
+        offset += size;
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<double>();
+    flatResult->resize(numGroups);
+
+    // Find the noise scale from group.
+    double noiseScale = -1.0;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        noiseScale = accumulator->getNoiseScale();
+        if (noiseScale >= 0) {
+          break;
+        }
+      }
+    }
+
+    // None of the groups have noise scale, return early.
+    if (noiseScale < 0) {
+      for (auto i = 0; i < numGroups; ++i) {
+        flatResult->setNull(i, true);
+      }
+      return;
+    }
+
+    // Initialize the random generator and seed with random_seed if provided.
+    folly::Random::DefaultGenerator rng;
+    rng.seed(folly::Random::secureRand32());
+
+    std::normal_distribution<double> dist;
+    bool addNoise = false;
+    if (noiseScale > 0) {
+      dist = std::normal_distribution<double>(0.0, noiseScale);
+      addNoise = true;
+    }
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+        // Return null for null values in the group.
+        if (accumulator->getNoiseScale() < 0) {
+          flatResult->setNull(i, true);
+          continue;
+        }
+        uint64_t trueCount = accumulator->getCount();
+        double trueSum = accumulator->getSum();
+        VELOX_CHECK_LE(trueCount, std::numeric_limits<double>::max());
+        double trueAvg = trueSum / static_cast<double>(trueCount);
+        double noise = addNoise ? dist(rng) : 0;
+        flatResult->set(i, trueAvg + noise);
+      }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    // Initialize the accumulator for each group
+    for (auto i : indices) {
+      *value<AccumulatorType>(groups[i]) = AccumulatorType();
+    }
+  }
+
+ private:
+  DecodedVector decodedValue_;
+  DecodedVector decodedNoiseScale_;
+
+  void decodeInputData(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    decodedValue_.decode(*args[0], rows);
+    decodedNoiseScale_.decode(*args[1], rows);
+  }
+
+  void updateAccumulatorFromInput(
+      const std::vector<VectorPtr>& args,
+      AccumulatorType* accumulator,
+      vector_size_t i) {
+    if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+      return;
+    }
+    accumulator->checkAndSetNoiseScale(decodedNoiseScale_.valueAt<double>(i));
+    accumulator->updateCount(1);
+    accumulator->updateSum(decodedValue_.valueAt<double>(i));
+  }
+
+  void updateAccumulatorFromIntermediateResult(
+      AccumulatorType* accumulator,
+      DecodedVector& decodedVector,
+      vector_size_t i) {
+    if (decodedVector.isNullAt(i)) {
+      return;
+    }
+
+    auto serialized = decodedVector.valueAt<StringView>(i);
+    auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+    accumulator->updateSum(otherAccumulator.getSum());
+    accumulator->updateCount(otherAccumulator.getCount());
+    if (otherAccumulator.getNoiseScale() >= 0) {
+      accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+    }
+  }
+};
+} // namespace
+
+void registerNoisyAvgGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("varbinary")
+          .argumentType("double") // input type
+          .argumentType("double") // noise scale
+          .build()};
+
+  auto name = prefix + kNoisyAvgGaussian;
+  exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& /*resultType*/,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 2, "{} takes exactly two arguments", name);
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<NoisyAvgGaussianAggregate>(VARBINARY());
+        }
+        return std::make_unique<NoisyAvgGaussianAggregate>(DOUBLE());
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisyAvgGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -41,6 +41,7 @@
 #include "velox/functions/prestosql/aggregates/MinByAggregate.h"
 #include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
 #include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
@@ -232,6 +233,7 @@ void registerAllAggregateFunctions(
   registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
   registerMaxByAggregates(prefix, withCompanionFunctions, overwrite);
   registerMinByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerNoisyAvgGaussianAggregate(prefix, withCompanionFunctions, overwrite);
   registerNoisyCountIfGaussianAggregate(
       prefix, withCompanionFunctions, overwrite);
   registerNoisyCountGaussianAggregate(

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -176,4 +176,12 @@ TEST_F(NoisyAvgGaussianAggregationTest, emptyInputTest) {
       vectors, {}, {"noisy_avg_gaussian(c2, 0.0)"}, "SELECT AVG(c2) FROM tmp");
 }
 
+TEST_F(NoisyAvgGaussianAggregationTest, bigintNoiseScaleType) {
+  auto vectors = makeVectors(doubleRowType_, 3, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors, {}, {"noisy_avg_gaussian(c2, 0)"}, "SELECT AVG(c2) FROM tmp");
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+class NoisyAvgGaussianAggregationTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+
+  RowTypePtr doubleRowType_{
+      ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+};
+
+TEST_F(NoisyAvgGaussianAggregationTest, basicNoNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+      makeFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      {vectors},
+      {},
+      {"noisy_avg_gaussian(c2, 0.0)"},
+      "SELECT AVG(c2) FROM tmp");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, basicWithNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  // Set the noise scale to 0.1, true average is 3.0.
+  // use +/- 50*SD and test the result is within range [-2.0, 8.0].
+
+  auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation({}, {"noisy_avg_gaussian(c0, 0.1)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  ASSERT_EQ(result->size(), 1);
+  ASSERT_TRUE(result->childAt(0)->asFlatVector<double>()->valueAt(0) >= -2.0);
+  ASSERT_TRUE(result->childAt(0)->asFlatVector<double>()->valueAt(0) <= 8.0);
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, invalidNoiseScale) {
+  auto vectors = makeVectors(doubleRowType_, 3, 3);
+  createDuckDbTable(vectors);
+
+  // Test invalid noise scale.
+  testFailingAggregations(
+      vectors,
+      {},
+      {"noisy_avg_gaussian(c2, -1.0)"},
+      "Noise scale must be a non-negative value.");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, groupbyNullsNoNoise) {
+  auto vectors = {makeRowVector({
+      makeNullableFlatVector<double>({std::nullopt, 1, 1, 1, std::nullopt}),
+      makeNullableFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  // Group by c0, aggregate c1. Expected result:
+  // c0   | noisy_avg_gaussian(c1, 0.0)
+  // NULL | 3.0
+  // 1    | 3.0
+  auto expectedResult = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, 1.0}),
+       makeFlatVector<double>({3.0, 3.0})});
+
+  testAggregations(
+      vectors, {"c0"}, {"noisy_avg_gaussian(c1, 0.0)"}, {expectedResult});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, aggregateNullsNoNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 2}),
+      makeNullableFlatVector<double>({std::nullopt, std::nullopt, 1, 1, 1}),
+  })};
+
+  // group by c0, aggregate c1. Expected result:
+  // c0   | noisy_avg_gaussian(c1, 0.1)
+  // 1    | NULL
+  // 2    | 1.0
+  auto expectedResult = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<double>({std::nullopt, 1.0})});
+
+  testAggregations(
+      vectors, {"c0"}, {"noisy_avg_gaussian(c1, 0.0)"}, {expectedResult});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, singleGroupSingleAggregateNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_avg_gaussian(c1, 0.0)"},
+      {"SELECT AVG(c1) FROM tmp"});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, singleGroupMultipleAggregationNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_avg_gaussian(c1, 0.0)", "noisy_avg_gaussian(c2, 0.0)"},
+      {"SELECT AVG(c1), AVG(c2) FROM tmp"});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, multipleGroupSingleAggregationNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_avg_gaussian(c2, 0.0)"},
+      {"SELECT c0, AVG(c2) FROM tmp GROUP BY c0"});
+}
+
+TEST_F(
+    NoisyAvgGaussianAggregationTest,
+    multipleGroupMultipleAggregationNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_avg_gaussian(c1, 0.0)", "noisy_avg_gaussian(c2, 0.0)"},
+      {"SELECT c0, AVG(c1), AVG(c2) FROM tmp GROUP BY c0"});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, emptyInputTest) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({}),
+      makeFlatVector<int32_t>({}),
+      makeFlatVector<double>({}),
+  })};
+
+  createDuckDbTable(vectors);
+  // Should return NULL for empty input. consistent with DuckDB.
+  testAggregations(
+      vectors, {}, {"noisy_avg_gaussian(c2, 0.0)"}, "SELECT AVG(c2) FROM tmp");
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -29,6 +29,18 @@ class NoisyAvgGaussianAggregationTest
 
   RowTypePtr doubleRowType_{
       ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+  RowTypePtr bigintRowType_{
+      ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()})};
+  RowTypePtr decimalRowType_{
+      ROW({"c0", "c1", "c2"},
+          {DECIMAL(20, 5), DECIMAL(20, 5), DECIMAL(20, 5)})};
+  RowTypePtr realRowType_{ROW({"c0", "c1", "c2"}, {REAL(), REAL(), REAL()})};
+  RowTypePtr integerRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()})};
+  RowTypePtr smallintRowType_{
+      ROW({"c0", "c1", "c2"}, {SMALLINT(), SMALLINT(), SMALLINT()})};
+  RowTypePtr tinyintRowType_{
+      ROW({"c0", "c1", "c2"}, {TINYINT(), TINYINT(), TINYINT()})};
 };
 
 TEST_F(NoisyAvgGaussianAggregationTest, basicNoNoise) {
@@ -182,6 +194,28 @@ TEST_F(NoisyAvgGaussianAggregationTest, bigintNoiseScaleType) {
 
   testAggregations(
       vectors, {}, {"noisy_avg_gaussian(c2, 0)"}, "SELECT AVG(c2) FROM tmp");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, numericInputTypeTestNoNoise) {
+  auto rowTypes = {
+      doubleRowType_,
+      bigintRowType_,
+      decimalRowType_,
+      realRowType_,
+      integerRowType_,
+      smallintRowType_,
+      tinyintRowType_};
+
+  for (const auto& rowType : rowTypes) {
+    auto vectors = makeVectors(rowType, 3, 3);
+    createDuckDbTable(vectors);
+
+    testAggregations(
+        vectors,
+        {},
+        {"noisy_avg_gaussian(c2, 0.0)"},
+        "SELECT AVG(c2) FROM tmp");
+  }
 }
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -33,6 +33,8 @@
 #include "velox/functions/prestosql/fuzzer/MapUnionSumInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/NoisyAvgInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/NoisyAvgResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/NoisyCountIfInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/NoisyCountIfResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/NoisyCountInputGenerator.h"
@@ -91,6 +93,7 @@ getCustomInputGenerators() {
       {"tdigest_agg", std::make_shared<TDigestAggregateInputGenerator>()},
       {"qdigest_agg", std::make_shared<QDigestAggInputGenerator>()},
       {"map_union_sum", std::make_shared<MapUnionSumInputGenerator>()},
+      {"noisy_avg_gaussian", std::make_shared<NoisyAvgInputGenerator>()},
       {"noisy_count_if_gaussian",
        std::make_shared<NoisyCountIfInputGenerator>()},
       {"noisy_count_gaussian", std::make_shared<NoisyCountInputGenerator>()},
@@ -160,6 +163,7 @@ int main(int argc, char** argv) {
   using facebook::velox::exec::test::ArbitraryResultVerifier;
   using facebook::velox::exec::test::AverageResultVerifier;
   using facebook::velox::exec::test::MinMaxByResultVerifier;
+  using facebook::velox::exec::test::NoisyAvgResultVerifier;
   using facebook::velox::exec::test::NoisyCountIfResultVerifier;
   using facebook::velox::exec::test::NoisyCountResultVerifier;
   using facebook::velox::exec::test::NoisySumResultVerifier;
@@ -216,6 +220,7 @@ int main(int argc, char** argv) {
           // https://github.com/facebookincubator/velox/issues/6330
           {"max_data_size_for_stats", nullptr},
           {"sum_data_size_for_stats", nullptr},
+          {"noisy_avg_gaussian", std::make_shared<NoisyAvgResultVerifier>()},
           {"noisy_count_if_gaussian",
            std::make_shared<NoisyCountIfResultVerifier>()},
           {"noisy_count_gaussian",

--- a/velox/functions/prestosql/fuzzer/NoisyAvgInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/NoisyAvgInputGenerator.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/prestosql/fuzzer/NoisySumInputGenerator.h"
+
+namespace facebook::velox::exec::test {
+class NoisyAvgInputGenerator : public NoisySumInputGenerator {};
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/NoisyAvgResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/NoisyAvgResultVerifier.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h"
+
+namespace facebook::velox::exec::test {
+class NoisyAvgResultVerifier : public NoisySumResultVerifier {
+ public:
+  void initialize(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
+      const std::vector<std::string>& groupingKeys,
+      const core::AggregationNode::Aggregate& aggregate,
+      const std::string& aggregateName) override {
+    groupingKeys_ = groupingKeys;
+    name_ = aggregateName;
+    // Extract the noise scale from the function call.
+    const auto& args = aggregate.call->inputs();
+    extractNoiseScaleAndBound(input[0], args);
+
+    // Extract aggregate column name before deduplication
+    auto field = core::TypedExprs::asFieldAccess(args[0]);
+    VELOX_CHECK_NOT_NULL(field);
+    aggregateColumn_ = field->name();
+
+    // When distinct is true, we should deduplicate the input before clipping.
+    // if mask is provided, mask should apply to the input before
+    // deduplication.
+    auto deduplicatedInput = input;
+    if (aggregate.distinct) {
+      deduplicatedInput = deduplicateInput(input, aggregate.mask);
+    }
+    // Clip the input to the specified bounds and convert to double. This is
+    // needed because the noisy_avg_gaussian function only return double
+    // outputs.
+    clipInput(deduplicatedInput);
+
+    auto sumCall = fmt::format("avg({})", aggregateColumn_);
+
+    // If distinct is false, mask has not been applied yet.
+    if (aggregate.mask != nullptr && !aggregate.distinct) {
+      sumCall += fmt::format(" filter (where {})", aggregate.mask->name());
+    }
+
+    core::PlanNodePtr plan = PlanBuilder()
+                                 .values(clippedInput_)
+                                 .projectExpressions(projections)
+                                 .singleAggregation(groupingKeys, {sumCall})
+                                 .planNode();
+
+    expectedNoNoise_ = AssertQueryBuilder(plan).copyResults(input[0]->pool());
+  }
+};
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/NoisySumResultVerifier.h
@@ -220,7 +220,7 @@ class NoisySumResultVerifier : public ResultVerifier {
     clippedInput_.clear();
   }
 
- private:
+ protected:
   std::vector<RowVectorPtr> deduplicateInput(
       const std::vector<RowVectorPtr>& input,
       const core::FieldAccessTypedExprPtr& mask) {

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -124,6 +124,7 @@ int main(int argc, char** argv) {
       // array_agg requires a flag controlling whether to ignore nulls.
       "array_agg",
       // Skip non-deterministic functions.
+      "noisy_avg_gaussian",
       "noisy_count_if_gaussian",
       "noisy_count_gaussian",
       "noisy_sum_gaussian",


### PR DESCRIPTION
Summary:
### Added Optional Random Seed to Noisy Avg Gaussian Aggregation

This diff adds support for an optional `random_seed` parameter to the `noisy_avg_gaussian` aggregation function. This allows users to specify a seed for the random number generator, enabling reproducibility in the results.

The changes include:

#### Updated Test Cases

New test cases were added to `NoisyAvgGaussianAggregationTest.cpp` to cover the `random_seed` parameter.

#### Documentation Update

The `aggregate.rst` file was updated to reflect the new `random_seed` parameter in the `noisy_avg_gaussian` function signature.

#### Code Changes

The `NoisyAvgAccumulator.h` file was updated to include the `randomSeed` parameter in the constructor, and the `NoisyAvgGaussianAggregate.cpp` file was updated to handle the `random_seed` parameter in the `decodeInputData` function.

These changes provide users with more control over the randomness in the `noisy_avg_gaussian` aggregation function, enabling use cases that require reproducibility.

Differential Revision: D76211847
