### PR TITLE
test(noisy_avg): Add fuzzer test to cover all possible edge cases

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -738,10 +738,12 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+.. function:: noisy_sum_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
+
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
 
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -715,7 +715,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
 
@@ -732,7 +733,8 @@ Noisy Aggregate Functions
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
     ::
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
@@ -743,8 +745,17 @@ Noisy Aggregate Functions
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
+.. function:: noisy_sum_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
+
+    Calculates the sum over the input values in ``col`` and then adds a normally distributed
+    random double value with 0 mean and standard deviation of ``noise_scale``.
+    Each value is clipped to the range of [``lower``, ``upper``] before adding to the sum.
+
+    If provided, ``random_seed`` is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
 
 
 Miscellaneous

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -726,11 +726,13 @@ Noisy Aggregate Functions
 
         Unlike :func:`!count_if`, this function returns ``NULL`` when the (true) count is 0.
 
-.. function:: noisy_count_gaussian(col, noise_scale) -> bigint
+.. function:: noisy_count_gaussian(col, noise_scale[, random_seed]) -> bigint
 
     Counts the non-null values in ``col`` and then adds a normally distributed random double
     value with 0 mean and standard deviation of ``noise_scale`` to the true count.
     The noisy count is post-processed to be non-negative and rounded to bigint.
+
+    If provided, ``random_seed`` is used to seed the random number generator. Otherwise, noise is drawn from a secure random.
 
     ::
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -762,7 +762,11 @@ Noisy Aggregate Functions
     Calculates the average (arithmetic mean) of all the input values in col and then adds a
     normally distributed random double value with 0 mean and standard deviation of noise_scale.
 
-    
+.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper) -> double
+    Calculates the average (arithmetic mean) of all the input values in ``col`` and then adds a
+    normally distributed random double value with 0 mean and standard deviation of ``noise_scale``.
+    Each value is clipped to the range of [``lower``, ``upper``] before averaging.
+
 Miscellaneous
 -------------
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -757,7 +757,12 @@ Noisy Aggregate Functions
     If provided, ``random_seed`` is used to seed the random number generator.
     Otherwise, noise is drawn from a secure random.
 
+.. function:: noisy_avg_gaussian(col, noise_scale) -> double
 
+    Calculates the average (arithmetic mean) of all the input values in col and then adds a
+    normally distributed random double value with 0 mean and standard deviation of noise_scale.
+
+    
 Miscellaneous
 -------------
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -738,13 +738,12 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
-
 .. function:: noisy_sum_gaussian(col, noise_scale) -> double
 
     Calculates the sum over the input values in ``col`` and then adds a normally distributed
     random double value with 0 mean and standard deviation of ``noise_scale``.
 
-    
+
 
 Miscellaneous
 -------------

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -738,6 +738,14 @@ Noisy Aggregate Functions
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem; -- 60181 (1 row)
         SELECT noisy_count_gaussian(orderkey, 20.0) FROM tpch.tiny.lineitem WHERE false; -- NULL (1 row)
 
+
+.. function:: noisy_sum_gaussian(col, noise_scale) -> double
+
+    Calculates the sum over the input values in ``col`` and then adds a normally distributed
+    random double value with 0 mean and standard deviation of ``noise_scale``.
+
+    
+
 Miscellaneous
 -------------
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -757,16 +757,22 @@ Noisy Aggregate Functions
     If provided, ``random_seed`` is used to seed the random number generator.
     Otherwise, noise is drawn from a secure random.
 
-.. function:: noisy_avg_gaussian(col, noise_scale) -> double
+.. function:: noisy_avg_gaussian(col, noise_scale[, random_seed]) -> double
 
     Calculates the average (arithmetic mean) of all the input values in col and then adds a
     normally distributed random double value with 0 mean and standard deviation of noise_scale.
 
-.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper) -> double
+    If provided, random_seed is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
+
+.. function:: noisy_avg_gaussian(col, noise_scale, lower, upper[, random_seed]) -> double
     Calculates the average (arithmetic mean) of all the input values in ``col`` and then adds a
     normally distributed random double value with 0 mean and standard deviation of ``noise_scale``.
     Each value is clipped to the range of [``lower``, ``upper``] before averaging.
 
+    If provided, random_seed is used to seed the random number generator.
+    Otherwise, noise is drawn from a secure random.
+    
 Miscellaneous
 -------------
 

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
@@ -1,0 +1,69 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class NoisyAvgAccumulator {
+ public:
+  NoisyAvgAccumulator() = default;
+  NoisyAvgAccumulator(double sum, uint64_t count, double noiseScale)
+      : sum_{sum}, count_{count}, noiseScale_{noiseScale} {}
+
+  void updateCount(uint64_t value) {
+    count_ = facebook::velox::checkedPlus<uint64_t>(count_, value);
+  }
+
+  void updateSum(double value) {
+    sum_ += value;
+  }
+
+  void checkAndSetNoiseScale(double newNoiseScale) {
+    VELOX_USER_CHECK_GE(
+        newNoiseScale, 0, "Noise scale must be a non-negative value");
+    noiseScale_ = newNoiseScale;
+  }
+
+  double getSum() const {
+    return sum_;
+  }
+
+  uint64_t getCount() const {
+    return count_;
+  }
+
+  double getNoiseScale() const {
+    return noiseScale_;
+  }
+
+  static size_t serializedSize() {
+    return sizeof(double) + sizeof(uint64_t) + sizeof(double);
+  }
+
+  void serialize(char* buffer) const {
+    common::OutputByteStream stream(buffer);
+    stream.appendOne(sum_);
+    stream.appendOne(count_);
+    stream.appendOne(noiseScale_);
+  }
+
+  static NoisyAvgAccumulator deserialize(const char* buffer) {
+    common::InputByteStream stream(buffer);
+    double sum = stream.read<double>();
+    uint64_t count = stream.read<uint64_t>();
+    double noiseScale = stream.read<double>();
+    return NoisyAvgAccumulator(sum, count, noiseScale);
+  }
+
+ private:
+  double sum_{0};
+  uint64_t count_{0};
+  double noiseScale_{-1};
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
@@ -25,7 +25,7 @@ class NoisyAvgAccumulator {
 
   void checkAndSetNoiseScale(double newNoiseScale) {
     VELOX_USER_CHECK_GE(
-        newNoiseScale, 0, "Noise scale must be a non-negative value");
+        newNoiseScale, 0, "Noise scale must be a non-negative value.");
     noiseScale_ = newNoiseScale;
   }
 

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h
@@ -12,8 +12,17 @@ namespace facebook::velox::functions::aggregate {
 class NoisyAvgAccumulator {
  public:
   NoisyAvgAccumulator() = default;
-  NoisyAvgAccumulator(double sum, uint64_t count, double noiseScale)
-      : sum_{sum}, count_{count}, noiseScale_{noiseScale} {}
+  NoisyAvgAccumulator(
+      double sum,
+      uint64_t count,
+      double noiseScale,
+      std::optional<double> lowerBound,
+      std::optional<double> upperBound)
+      : sum_{sum},
+        count_{count},
+        noiseScale_{noiseScale},
+        lowerBound_(lowerBound),
+        upperBound_(upperBound) {}
 
   void updateCount(uint64_t value) {
     count_ = facebook::velox::checkedPlus<uint64_t>(count_, value);
@@ -23,10 +32,28 @@ class NoisyAvgAccumulator {
     sum_ += value;
   }
 
+  void clipUpdateSum(double value) {
+    if (lowerBound_.has_value() && upperBound_.has_value()) {
+      auto clippedValue = std::max(*lowerBound_, std::min(*upperBound_, value));
+      this->sum_ += clippedValue;
+    } else {
+      this->sum_ += value;
+    }
+  }
+
   void checkAndSetNoiseScale(double newNoiseScale) {
     VELOX_USER_CHECK_GE(
         newNoiseScale, 0, "Noise scale must be a non-negative value.");
     noiseScale_ = newNoiseScale;
+  }
+
+  void checkAndSetBounds(double lowerBound, double upperBound) {
+    VELOX_USER_CHECK_LE(
+        lowerBound,
+        upperBound,
+        "Lower bound must be less than or equal to upper bound.");
+    this->lowerBound_ = lowerBound;
+    this->upperBound_ = upperBound;
   }
 
   double getSum() const {
@@ -41,8 +68,23 @@ class NoisyAvgAccumulator {
     return noiseScale_;
   }
 
+  std::optional<double> getLowerBound() const {
+    return lowerBound_;
+  }
+
+  std::optional<double> getUpperBound() const {
+    return upperBound_;
+  }
+
+  // sizeof(double) for sum_
+  // sizeof(uint64_t) for count_
+  // sizeof(double) for noiseScale_
+  // sizeof(bool) for has_bound flag
+  // sizeof(double) for lowerBound_ value
+  // sizeof(double) for upperBound_ value
   static size_t serializedSize() {
-    return sizeof(double) + sizeof(uint64_t) + sizeof(double);
+    return sizeof(double) + sizeof(uint64_t) + sizeof(double) + sizeof(bool) +
+        sizeof(double) + sizeof(double);
   }
 
   void serialize(char* buffer) const {
@@ -50,6 +92,10 @@ class NoisyAvgAccumulator {
     stream.appendOne(sum_);
     stream.appendOne(count_);
     stream.appendOne(noiseScale_);
+    // Serialize lowerBound_ and upperBound_(append 0 if has_value is false).
+    stream.appendOne(lowerBound_.has_value());
+    stream.appendOne(lowerBound_.has_value() ? *lowerBound_ : 0.0);
+    stream.appendOne(upperBound_.has_value() ? *upperBound_ : 0.0);
   }
 
   static NoisyAvgAccumulator deserialize(const char* buffer) {
@@ -57,13 +103,23 @@ class NoisyAvgAccumulator {
     double sum = stream.read<double>();
     uint64_t count = stream.read<uint64_t>();
     double noiseScale = stream.read<double>();
-    return NoisyAvgAccumulator(sum, count, noiseScale);
+    bool hasBounds = stream.read<bool>();
+    std::optional<double> lowerBound = stream.read<double>();
+    std::optional<double> upperBound = stream.read<double>();
+    return NoisyAvgAccumulator(
+        sum,
+        count,
+        noiseScale,
+        hasBounds ? lowerBound : std::nullopt,
+        hasBounds ? upperBound : std::nullopt);
   }
 
  private:
   double sum_{0};
   uint64_t count_{0};
   double noiseScale_{-1};
+  std::optional<double> lowerBound_{std::nullopt};
+  std::optional<double> upperBound_{std::nullopt};
 };
 
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
@@ -1,0 +1,62 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class NoisySumAccumulator {
+ public:
+  NoisySumAccumulator(double sum, double noiseScale)
+      : sum_{sum}, noiseScale_{noiseScale} {}
+
+  NoisySumAccumulator() = default;
+
+  void checkAndSetNoiseScale(double noiseScale) {
+    VELOX_USER_CHECK_GE(
+        noiseScale, 0.0, "Noise scale must be non-negative value.");
+    this->noiseScale_ = noiseScale;
+  }
+
+  // This function is used to update the sum
+  void update(double value) {
+    this->sum_ += value;
+  }
+
+  double getSum() const {
+    return this->sum_;
+  }
+
+  double getNoiseScale() const {
+    return this->noiseScale_;
+  }
+
+  static size_t serializedSize() {
+    return sizeof(double) + sizeof(double);
+  }
+
+  void serialize(char* buffer) {
+    common::OutputByteStream stream(buffer);
+    stream.appendOne(sum_);
+    stream.appendOne(noiseScale_);
+  }
+
+  static NoisySumAccumulator deserialize(const char* intermediate) {
+    common::InputByteStream stream(intermediate);
+    auto sum = stream.read<double>();
+    auto noiseScale = stream.read<double>();
+
+    return NoisySumAccumulator{sum, noiseScale};
+  }
+
+ private:
+  double sum_{0.0};
+  // Initial noise scale is an invalid noise scale,
+  // indicating that we have not updated it yet
+  double noiseScale_{-1.0};
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
@@ -13,8 +13,14 @@ class NoisySumAccumulator {
   NoisySumAccumulator(
       double sum,
       double noiseScale,
+      std::optional<double> lowerBound,
+      std::optional<double> upperBound,
       std::optional<int32_t> randomSeed)
-      : sum_{sum}, noiseScale_{noiseScale}, randomSeed_{randomSeed} {}
+      : sum_{sum},
+        noiseScale_{noiseScale},
+        lowerBound_{lowerBound},
+        upperBound_{upperBound},
+        randomSeed_{randomSeed} {}
 
   NoisySumAccumulator() = default;
 
@@ -24,11 +30,30 @@ class NoisySumAccumulator {
     this->noiseScale_ = noiseScale;
   }
 
+  void checkAndSetBounds(double lowerBound, double upperBound) {
+    VELOX_USER_CHECK_LE(
+        lowerBound,
+        upperBound,
+        "Lower bound must be less than or equal to upper bound.");
+    this->lowerBound_ = lowerBound;
+    this->upperBound_ = upperBound;
+  }
+
   void setRandomSeed(int32_t randomSeed) {
     this->randomSeed_ = randomSeed;
   }
 
-  // This function is used to update the sum
+  // This function is used to update the sum with a new input value.
+  void clipUpdate(double value) {
+    if (lowerBound_.has_value() && upperBound_.has_value()) {
+      auto clippedValue = std::max(*lowerBound_, std::min(*upperBound_, value));
+      this->sum_ += clippedValue;
+    } else {
+      this->sum_ += value;
+    }
+  }
+
+  // This function is used to update the sum with intermediate accumulator.
   void update(double value) {
     this->sum_ += value;
   }
@@ -45,13 +70,25 @@ class NoisySumAccumulator {
     return this->randomSeed_;
   }
 
+  std::optional<double> getLowerBound() const {
+    return this->lowerBound_;
+  }
+
+  std::optional<double> getUpperBound() const {
+    return this->upperBound_;
+  }
+
   static size_t serializedSize() {
     // The serialized size should be the sum of:
     // - sizeof(double) for sum_
     // - sizeof(double) for noiseScale_
+    // - sizeof(bool) for has_bound flag
+    // - sizeof(double) for lowerBound_ value
+    // - sizeof(double) for upperBound_ value
     // - sizeof(bool) for randomSeed_ has_value flag
     // - sizeof(int32_t) for randomSeed_ value
-    return sizeof(double) + sizeof(double) + sizeof(bool) + sizeof(int32_t);
+    return sizeof(double) + sizeof(double) + sizeof(bool) + sizeof(double) +
+        sizeof(double) + sizeof(bool) + sizeof(int32_t);
   }
 
   void serialize(char* buffer) {
@@ -59,7 +96,13 @@ class NoisySumAccumulator {
     stream.appendOne(sum_);
     stream.appendOne(noiseScale_);
 
-    // Serialize randomSeed_.(append 0 if has_value is false)
+    // Serialize lowerBound_ and upperBound_(append 0 if has_value is false).
+    bool hasBounds = lowerBound_.has_value() && upperBound_.has_value();
+    stream.appendOne(hasBounds);
+    stream.appendOne(hasBounds ? *lowerBound_ : 0.0);
+    stream.appendOne(hasBounds ? *upperBound_ : 0.0);
+
+    // Serialize randomSeed_(append 0 if has_value is false).
     stream.appendOne(randomSeed_.has_value());
     stream.appendOne(randomSeed_.has_value() ? randomSeed_.value() : 0);
   }
@@ -69,12 +112,21 @@ class NoisySumAccumulator {
     auto sum = stream.read<double>();
     auto noiseScale = stream.read<double>();
 
+    // Deserialize lowerBound_ and upperBound_.
+    bool hasBounds = stream.read<bool>();
+    std::optional<double> lowerBound = stream.read<double>();
+    std::optional<double> upperBound = stream.read<double>();
+
     // Deserialize randomSeed_
     bool hasRandomSeed = stream.read<bool>();
-    int32_t randomSeed = stream.read<int32_t>();
+    std::optional<int32_t> randomSeed = stream.read<int32_t>();
 
-    return hasRandomSeed ? NoisySumAccumulator{sum, noiseScale, randomSeed}
-                         : NoisySumAccumulator{sum, noiseScale, std::nullopt};
+    return NoisySumAccumulator(
+        sum,
+        noiseScale,
+        hasBounds ? lowerBound : std::nullopt,
+        hasBounds ? upperBound : std::nullopt,
+        hasRandomSeed ? randomSeed : std::nullopt);
   }
 
  private:
@@ -82,6 +134,8 @@ class NoisySumAccumulator {
   // Initial noise scale is an invalid noise scale,
   // indicating that we have not updated it yet
   double noiseScale_{-1.0};
+  std::optional<double> lowerBound_{std::nullopt};
+  std::optional<double> upperBound_{std::nullopt};
   std::optional<int32_t> randomSeed_{std::nullopt};
 };
 

--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h
@@ -10,8 +10,11 @@ namespace facebook::velox::functions::aggregate {
 
 class NoisySumAccumulator {
  public:
-  NoisySumAccumulator(double sum, double noiseScale)
-      : sum_{sum}, noiseScale_{noiseScale} {}
+  NoisySumAccumulator(
+      double sum,
+      double noiseScale,
+      std::optional<int32_t> randomSeed)
+      : sum_{sum}, noiseScale_{noiseScale}, randomSeed_{randomSeed} {}
 
   NoisySumAccumulator() = default;
 
@@ -19,6 +22,10 @@ class NoisySumAccumulator {
     VELOX_USER_CHECK_GE(
         noiseScale, 0.0, "Noise scale must be non-negative value.");
     this->noiseScale_ = noiseScale;
+  }
+
+  void setRandomSeed(int32_t randomSeed) {
+    this->randomSeed_ = randomSeed;
   }
 
   // This function is used to update the sum
@@ -34,14 +41,27 @@ class NoisySumAccumulator {
     return this->noiseScale_;
   }
 
+  std::optional<int32_t> getRandomSeed() const {
+    return this->randomSeed_;
+  }
+
   static size_t serializedSize() {
-    return sizeof(double) + sizeof(double);
+    // The serialized size should be the sum of:
+    // - sizeof(double) for sum_
+    // - sizeof(double) for noiseScale_
+    // - sizeof(bool) for randomSeed_ has_value flag
+    // - sizeof(int32_t) for randomSeed_ value
+    return sizeof(double) + sizeof(double) + sizeof(bool) + sizeof(int32_t);
   }
 
   void serialize(char* buffer) {
     common::OutputByteStream stream(buffer);
     stream.appendOne(sum_);
     stream.appendOne(noiseScale_);
+
+    // Serialize randomSeed_.(append 0 if has_value is false)
+    stream.appendOne(randomSeed_.has_value());
+    stream.appendOne(randomSeed_.has_value() ? randomSeed_.value() : 0);
   }
 
   static NoisySumAccumulator deserialize(const char* intermediate) {
@@ -49,7 +69,12 @@ class NoisySumAccumulator {
     auto sum = stream.read<double>();
     auto noiseScale = stream.read<double>();
 
-    return NoisySumAccumulator{sum, noiseScale};
+    // Deserialize randomSeed_
+    bool hasRandomSeed = stream.read<bool>();
+    int32_t randomSeed = stream.read<int32_t>();
+
+    return hasRandomSeed ? NoisySumAccumulator{sum, noiseScale, randomSeed}
+                         : NoisySumAccumulator{sum, noiseScale, std::nullopt};
   }
 
  private:
@@ -57,6 +82,7 @@ class NoisySumAccumulator {
   // Initial noise scale is an invalid noise scale,
   // indicating that we have not updated it yet
   double noiseScale_{-1.0};
+  std::optional<int32_t> randomSeed_{std::nullopt};
 };
 
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -59,6 +59,7 @@ const char* const kMinBy = "min_by";
 const char* const kMultiMapAgg = "multimap_agg";
 const char* const kNoisyCountIfGaussian = "noisy_count_if_gaussian";
 const char* const kNoisyCountGaussian = "noisy_count_gaussian";
+const char* const kNoisySumGaussian = "noisy_sum_gaussian";
 const char* const kReduceAgg = "reduce_agg";
 const char* const kRegrIntercept = "regr_intercept";
 const char* const kRegrSlop = "regr_slope";

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -57,6 +57,7 @@ const char* const kMerge = "merge";
 const char* const kMin = "min";
 const char* const kMinBy = "min_by";
 const char* const kMultiMapAgg = "multimap_agg";
+const char* const kNoisyAvgGaussian = "noisy_avg_gaussian";
 const char* const kNoisyCountIfGaussian = "noisy_count_if_gaussian";
 const char* const kNoisyCountGaussian = "noisy_count_gaussian";
 const char* const kNoisySumGaussian = "noisy_sum_gaussian";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   QDigestAggAggregate.cpp
   ReduceAgg.cpp
   RegisterAggregateFunctions.cpp
+  NoisyAvgGaussianAggregate.cpp
   NoisyCountIfGaussianAggregate.cpp
   NoisyCountGaussianAggregate.cpp
   NoisySumGaussianAggregate.cpp

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -47,6 +47,7 @@ velox_add_library(
   RegisterAggregateFunctions.cpp
   NoisyCountIfGaussianAggregate.cpp
   NoisyCountGaussianAggregate.cpp
+  NoisySumGaussianAggregate.cpp
   SetAggregates.cpp
   SumAggregate.cpp
   SumDataSizeForStatsAggregate.cpp

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -1,0 +1,254 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/aggregates/noisy_aggregation/NoisyAvgAccumulator.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+class NoisyAvgGaussianAggregate : public exec::Aggregate {
+ public:
+  explicit NoisyAvgGaussianAggregate(TypePtr resultType)
+      : exec::Aggregate(std::move(resultType)) {}
+
+  using AccumulatorType = functions::aggregate::NoisyAvgAccumulator;
+
+  bool isFixedSize() const override {
+    return true;
+  }
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return static_cast<int32_t>(sizeof(AccumulatorType));
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    // Process the args data and update the accumulator for each group.
+    rows.applyToSelected([&](vector_size_t i) {
+      auto* accumulator = value<AccumulatorType>(groups[i]);
+      updateAccumulatorFromInput(args, accumulator, i);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+    auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      updateAccumulatorFromInput(args, accumulator, i);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+      updateAccumulatorFromIntermediateResult(accumulator, decodedVector, i);
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      updateAccumulatorFromIntermediateResult(accumulator, decodedVector, i);
+    });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    VELOX_CHECK(flatResult);
+    flatResult->resize(numGroups);
+
+    int32_t numOfValidGroups = 0;
+    for (auto i = 0; i < numGroups; i++) {
+      numOfValidGroups += !isNull(groups[i]);
+    }
+    size_t totalSize = numOfValidGroups * AccumulatorType::serializedSize();
+
+    // Allocate buffer for serialized data.
+    auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    size_t offset = 0;
+    auto size = AccumulatorType::serializedSize();
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+        // Write to the pre-allocated buffer.
+        accumulator->serialize(rawBuffer + offset);
+        flatResult->setNoCopy(
+            i, StringView(rawBuffer + offset, static_cast<int32_t>(size)));
+        offset += size;
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<double>();
+    flatResult->resize(numGroups);
+
+    // Find the noise scale from group.
+    double noiseScale = -1.0;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        noiseScale = accumulator->getNoiseScale();
+        if (noiseScale >= 0) {
+          break;
+        }
+      }
+    }
+
+    // None of the groups have noise scale, return early.
+    if (noiseScale < 0) {
+      for (auto i = 0; i < numGroups; ++i) {
+        flatResult->setNull(i, true);
+      }
+      return;
+    }
+
+    // Initialize the random generator and seed with random_seed if provided.
+    folly::Random::DefaultGenerator rng;
+    rng.seed(folly::Random::secureRand32());
+
+    std::normal_distribution<double> dist;
+    bool addNoise = false;
+    if (noiseScale > 0) {
+      dist = std::normal_distribution<double>(0.0, noiseScale);
+      addNoise = true;
+    }
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+        // Return null for null values in the group.
+        if (accumulator->getNoiseScale() < 0) {
+          flatResult->setNull(i, true);
+          continue;
+        }
+        uint64_t trueCount = accumulator->getCount();
+        double trueSum = accumulator->getSum();
+        double trueAvg = trueSum / trueCount;
+        double noise = addNoise ? dist(rng) : 0;
+        flatResult->set(i, trueAvg + noise);
+      }
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    // Initialize the accumulator for each group
+    for (auto i : indices) {
+      *value<AccumulatorType>(groups[i]) = AccumulatorType();
+    }
+  }
+
+ private:
+  DecodedVector decodedValue_;
+  DecodedVector decodedNoiseScale_;
+
+  void decodeInputData(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    decodedValue_.decode(*args[0], rows);
+    decodedNoiseScale_.decode(*args[1], rows);
+  }
+
+  void updateAccumulatorFromInput(
+      const std::vector<VectorPtr>& args,
+      AccumulatorType* accumulator,
+      vector_size_t i) {
+    if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+      return;
+    }
+    accumulator->checkAndSetNoiseScale(decodedNoiseScale_.valueAt<double>(i));
+    accumulator->updateCount(1);
+    accumulator->updateSum(decodedValue_.valueAt<double>(i));
+  }
+
+  void updateAccumulatorFromIntermediateResult(
+      AccumulatorType* accumulator,
+      DecodedVector& decodedVector,
+      vector_size_t i) {
+    if (decodedVector.isNullAt(i)) {
+      return;
+    }
+
+    auto serialized = decodedVector.valueAt<StringView>(i);
+    auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+    accumulator->updateSum(otherAccumulator.getSum());
+    accumulator->updateCount(otherAccumulator.getCount());
+    accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+  }
+};
+} // namespace
+
+void registerNoisyAvgGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("varbinary")
+          .argumentType("double") // input type
+          .argumentType("double") // noise scale
+          .build()};
+
+  auto name = prefix + kNoisyAvgGaussian;
+  exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& /*resultType*/,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 2, "{} takes exactly two arguments", name);
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<NoisyAvgGaussianAggregate>(VARBINARY());
+        }
+        return std::make_unique<NoisyAvgGaussianAggregate>(DOUBLE());
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -204,8 +204,12 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
       noiseScale = static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
     }
     accumulator->checkAndSetNoiseScale(noiseScale);
-    accumulator->updateCount(1);
-    accumulator->updateSum(decodedValue_.valueAt<double>(i));
+
+    // Update sum and count. check input value and dispatch to corresponding
+    // type.
+    auto inputType = args[0]->typeKind();
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        updateTemplate, inputType, accumulator, decodedValue_, i);
   }
 
   void updateAccumulatorFromIntermediateResult(
@@ -224,6 +228,42 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
       accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
     }
   }
+
+  // Template helper function to update accumulator, can support all numeric
+  // data types. Only used in this class.
+  template <TypeKind TData>
+  void updateTemplate(
+      AccumulatorType* accumulator,
+      const DecodedVector& decodedValue,
+      vector_size_t i) {
+    using T = typename TypeTraits<TData>::NativeType;
+    // Handle decimal types separately.
+    if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
+      const auto& type = decodedValue.base()->type();
+      if (type->isDecimal()) {
+        auto value = decodedValue.valueAt<T>(i);
+        auto scale = type->isShortDecimal() ? type->asShortDecimal().scale()
+                                            : type->asLongDecimal().scale();
+        double doubleValue = static_cast<double>(value) / pow(10, scale);
+
+        accumulator->updateSum(doubleValue);
+        accumulator->updateCount(1);
+        return;
+      }
+    }
+    // Handle other types.
+    if constexpr (
+        std::is_same_v<T, TypeTraits<TypeKind::TIMESTAMP>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARBINARY>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARCHAR>> ||
+        std::is_same_v<T, facebook::velox::StringView> ||
+        std::is_same_v<T, facebook::velox::Timestamp>) {
+      VELOX_FAIL("NoisySumGaussianAggregate does not support this data type.");
+    } else {
+      accumulator->updateSum(static_cast<double>(decodedValue.valueAt<T>(i)));
+      accumulator->updateCount(1);
+    }
+  }
 };
 } // namespace
 
@@ -231,19 +271,41 @@ void registerNoisyAvgGaussianAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
-      exec::AggregateFunctionSignatureBuilder()
-          .returnType("double")
-          .intermediateType("varbinary")
-          .argumentType("double") // input type
-          .argumentType("double") // noise scale
-          .build(),
-      exec::AggregateFunctionSignatureBuilder()
-          .returnType("double")
-          .intermediateType("varbinary")
-          .argumentType("double") // input type
-          .argumentType("bigint") // noise scale
-          .build()};
+  // Helper function to create a signature builder with return and
+  // intermediate types
+  auto createBuilder = []() {
+    return exec::AggregateFunctionSignatureBuilder()
+        .returnType("double")
+        .intermediateType("varbinary");
+  };
+
+  // List of possible argument types.
+  const std::vector<std::string> simpleDataTypes = {
+      "tinyint", "smallint", "integer", "bigint", "real", "double"};
+  const std::vector<std::string> noiseScaleTypes = {"double", "bigint"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+
+  // Generate signatures for all type combinations.
+  for (const auto& noiseScaleType : noiseScaleTypes) {
+    // Handle simple types.
+    for (const auto& dataType : simpleDataTypes) {
+      signatures.push_back(createBuilder()
+                               .argumentType(dataType)
+                               .argumentType(noiseScaleType)
+                               .build());
+    }
+
+    // Handle decimal types separately.
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("double")
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType(noiseScaleType)
+                             .build());
+  }
 
   auto name = prefix + kNoisyAvgGaussian;
   exec::registerAggregateFunction(

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -220,7 +220,9 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
     auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
     accumulator->updateSum(otherAccumulator.getSum());
     accumulator->updateCount(otherAccumulator.getCount());
-    accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+    if (otherAccumulator.getNoiseScale() >= 0) {
+      accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+    }
   }
 };
 } // namespace
@@ -253,8 +255,6 @@ void registerNoisyAvgGaussianAggregate(
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(
-            argTypes.size(), 2, "{} takes exactly two arguments", name);
         if (exec::isPartialOutput(step)) {
           return std::make_unique<NoisyAvgGaussianAggregate>(VARBINARY());
         }

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -30,12 +30,15 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
-    bool hasBounds = decodeInputData(rows, args);
+    auto flags = decodeInputData(rows, args);
+    bool hasBounds = flags.first;
+    bool hasRandomSeed = flags.second;
 
     // Process the args data and update the accumulator for each group.
     rows.applyToSelected([&](vector_size_t i) {
       auto* accumulator = value<AccumulatorType>(groups[i]);
-      updateAccumulatorFromInput(args, accumulator, i, hasBounds);
+      updateAccumulatorFromInput(
+          args, accumulator, i, hasBounds, hasRandomSeed);
     });
   }
 
@@ -44,11 +47,14 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
-    bool hasBounds = decodeInputData(rows, args);
+    auto flags = decodeInputData(rows, args);
+    bool hasBounds = flags.first;
+    bool hasRandomSeed = flags.second;
     auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
 
     rows.applyToSelected([&](vector_size_t i) {
-      updateAccumulatorFromInput(args, accumulator, i, hasBounds);
+      updateAccumulatorFromInput(
+          args, accumulator, i, hasBounds, hasRandomSeed);
     });
   }
 
@@ -139,7 +145,21 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
 
     // Initialize the random generator and seed with random_seed if provided.
     folly::Random::DefaultGenerator rng;
-    rng.seed(folly::Random::secureRand32());
+    bool hasRandomSeed = false;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        if (accumulator->getRandomSeed().has_value()) {
+          rng.seed(accumulator->getRandomSeed().value());
+          hasRandomSeed = true;
+          break;
+        }
+      }
+    }
+
+    if (!hasRandomSeed) {
+      rng.seed(folly::Random::secureRand32());
+    }
 
     std::normal_distribution<double> dist;
     bool addNoise = false;
@@ -183,28 +203,44 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
   DecodedVector decodedNoiseScale_;
   DecodedVector decodedLowerBound_;
   DecodedVector decodedUpperBound_;
+  DecodedVector decodedRandomSeed_;
 
-  bool decodeInputData(
+  // Helper function to decode the input data. And return has_bounds and
+  // has_random_seed flags.
+  std::pair<bool, bool> decodeInputData(
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args) {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
 
     // Decode lower and upper bounds if provided.
+    bool hasBounds = false;
     if (args.size() > 3 && args[2]->isConstantEncoding() &&
         args[3]->isConstantEncoding()) {
       decodedLowerBound_.decode(*args[2], rows);
       decodedUpperBound_.decode(*args[3], rows);
-      return true;
+      hasBounds = true;
     }
-    return false;
+
+    // Decode random seed if provided.
+    bool hasRandomSeed = false;
+    if (args.size() == 5 && args[4]->isConstantEncoding()) {
+      decodedRandomSeed_.decode(*args[4], rows);
+      hasRandomSeed = true;
+    }
+    if (args.size() == 3 && args[2]->isConstantEncoding()) {
+      decodedRandomSeed_.decode(*args[2], rows);
+      hasRandomSeed = true;
+    }
+    return std::make_pair(hasBounds, hasRandomSeed);
   }
 
   void updateAccumulatorFromInput(
       const std::vector<VectorPtr>& args,
       AccumulatorType* accumulator,
       vector_size_t i,
-      bool hasBounds) {
+      bool hasBounds,
+      bool hasRandomSeed) {
     if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
       return;
     }
@@ -239,6 +275,11 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
       accumulator->checkAndSetBounds(lowerBound, upperBound);
     }
 
+    // Update random seed if provided.
+    if (hasRandomSeed) {
+      accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+    }
+
     // Update sum and count. check input value and dispatch to corresponding
     // type.
     auto inputType = args[0]->typeKind();
@@ -265,6 +306,9 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
         otherAccumulator.getUpperBound().has_value()) {
       accumulator->checkAndSetBounds(
           *otherAccumulator.getLowerBound(), *otherAccumulator.getUpperBound());
+    }
+    if (otherAccumulator.getRandomSeed().has_value()) {
+      accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
     }
   }
 
@@ -324,6 +368,7 @@ void registerNoisyAvgGaussianAggregate(
       "tinyint", "smallint", "integer", "bigint", "real", "double"};
   const std::vector<std::string> noiseScaleTypes = {"double", "bigint"};
   const std::vector<std::string> boundTypes = {"double", "bigint"};
+  const std::string randomSeedType = "bigint";
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
@@ -336,20 +381,34 @@ void registerNoisyAvgGaussianAggregate(
                                .argumentType(dataType)
                                .argumentType(noiseScaleType)
                                .build());
+      // Signature 2: (col, noise_scale, random_seed)
+      signatures.push_back(createBuilder()
+                               .argumentType(dataType)
+                               .argumentType(noiseScaleType)
+                               .argumentType(randomSeedType)
+                               .build());
 
-      // Signature 2: (col, noise_scale, lower_bound, upper_bound)
       for (const auto& lowerBoundType : boundTypes) {
         for (const auto& upperBoundType : boundTypes) {
+          // Signature 3: (col, noise_scale, lower_bound, upper_bound)
           signatures.push_back(createBuilder()
                                    .argumentType(dataType)
                                    .argumentType(noiseScaleType)
                                    .argumentType(lowerBoundType)
                                    .argumentType(upperBoundType)
                                    .build());
+          // Signature 4: (col, noise_scale, lower_bound, upper_bound,
+          // random_seed)
+          signatures.push_back(createBuilder()
+                                   .argumentType(dataType)
+                                   .argumentType(noiseScaleType)
+                                   .argumentType(lowerBoundType)
+                                   .argumentType(upperBoundType)
+                                   .argumentType(randomSeedType)
+                                   .build());
         }
       }
     }
-
     // Handle decimal types separately.
     // Signature 1: (col, noise_scale)
     signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -360,10 +419,20 @@ void registerNoisyAvgGaussianAggregate(
                              .argumentType("DECIMAL(a_precision, a_scale)")
                              .argumentType(noiseScaleType)
                              .build());
+    // Signature 2: (col, noise_scale, random_seed)
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("double")
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType(noiseScaleType)
+                             .argumentType(randomSeedType)
+                             .build());
 
-    // Signature 2: (col, noise_scale, lower_bound, upper_bound)
     for (const auto& lowerBoundType : boundTypes) {
       for (const auto& upperBoundType : boundTypes) {
+        // Signature 3: (col, noise_scale, lower_bound, upper_bound)
         signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                                  .integerVariable("a_precision")
                                  .integerVariable("a_scale")
@@ -373,6 +442,19 @@ void registerNoisyAvgGaussianAggregate(
                                  .argumentType(noiseScaleType)
                                  .argumentType(lowerBoundType)
                                  .argumentType(upperBoundType)
+                                 .build());
+        // Signature 4: (col, noise_scale, lower_bound, upper_bound,
+        // random_seed)
+        signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                                 .integerVariable("a_precision")
+                                 .integerVariable("a_scale")
+                                 .returnType("double")
+                                 .intermediateType("varbinary")
+                                 .argumentType("DECIMAL(a_precision, a_scale)")
+                                 .argumentType(noiseScaleType)
+                                 .argumentType(lowerBoundType)
+                                 .argumentType(upperBoundType)
+                                 .argumentType(randomSeedType)
                                  .build());
       }
     }

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisyAvgGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
@@ -48,7 +48,7 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
-    decodeInputData(rows, args);
+    bool hasRandomSeed = decodeInputData(rows, args);
 
     // Process the args data and update the accumulator for each group.
     rows.applyToSelected([&](vector_size_t i) {
@@ -70,6 +70,11 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
       }
       accumulator->checkAndSetNoiseScale(noiseScale);
+
+      // If intput has random seed, set it.
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+      }
     });
   }
 
@@ -130,6 +135,10 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
           otherAccumulator.noiseScale >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.noiseScale);
       }
+
+      if (otherAccumulator.randomSeed.has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.randomSeed);
+      }
     });
   }
 
@@ -166,6 +175,23 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
     }
 
     folly::Random::DefaultGenerator rng;
+
+    // If intput has random seed, set it.
+    bool hasRandomSeed = false;
+    for (auto i = 0; i < numGroups && !hasRandomSeed; i++) {
+      auto group = groups[i];
+      if (!isNull(group)) {
+        auto* accumulator = value<AccumulatorType>(group);
+        if (accumulator->randomSeed.has_value()) {
+          rng.seed(*accumulator->randomSeed);
+          hasRandomSeed = true;
+        }
+      }
+    }
+
+    if (!hasRandomSeed) {
+      rng.seed(folly::Random::secureRand32());
+    }
 
     // Create a normal distribution with mean 0 and standard deviation noise.
     std::normal_distribution<double> distribution{0.0, 1.0};
@@ -223,6 +249,10 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
           otherAccumulator.noiseScale >= 0) {
         accumulator->checkAndSetNoiseScale(otherAccumulator.noiseScale);
       }
+
+      if (otherAccumulator.randomSeed.has_value()) {
+        accumulator->setRandomSeed(*otherAccumulator.randomSeed);
+      }
     });
   }
 
@@ -231,7 +261,7 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       [[maybe_unused]] bool mayPushdown) override {
-    decodeInputData(rows, args);
+    bool hasRandomSeed = decodeInputData(rows, args);
     auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
 
     rows.applyToSelected([&](vector_size_t i) {
@@ -249,6 +279,10 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
       }
       accumulator->checkAndSetNoiseScale(noiseScale);
+
+      if (hasRandomSeed) {
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+      }
     });
   }
 
@@ -262,17 +296,26 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
     }
   }
 
-  // Helper function to decode the input data.
-  void decodeInputData(
+  // Helper function to decode the input data. And return a has_random_seed
+  // flag.
+  bool decodeInputData(
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args) {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
+
+    // If intput has random seed, decode it.
+    if (args.size() == 3 && args[2]->isConstantEncoding()) {
+      decodedRandomSeed_.decode(*args[2], rows);
+      return true;
+    }
+    return false;
   }
 
  private:
   DecodedVector decodedValue_;
   DecodedVector decodedNoiseScale_;
+  DecodedVector decodedRandomSeed_;
 };
 } // namespace
 
@@ -295,6 +338,22 @@ void registerNoisyCountGaussianAggregate(
           .argumentType("T")
           .argumentType("bigint") // support BIGINT noise scale
           .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("T")
+          .argumentType("double") // support DOUBLE noise scale
+          .argumentType("bigint") // support BIGINT random seed
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("T")
+          .argumentType("bigint") // support BIGINT noise scale
+          .argumentType("bigint") // support BIGINT random seed
+          .build(),
   };
 
   auto name = prefix + kNoisyCountGaussian;
@@ -308,8 +367,10 @@ void registerNoisyCountGaussianAggregate(
           [[maybe_unused]] const TypePtr& resultType,
           [[maybe_unused]] const core::QueryConfig& config)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_USER_CHECK_EQ(
-            argTypes.size(), 2, "{} takes exactly 2 arguments", name);
+        VELOX_CHECK_LE(
+            argTypes.size(), 3, "{} takes at most 3 arguments", name);
+        VELOX_CHECK_GE(
+            argTypes.size(), 2, "{} takes at least 2 arguments", name);
 
         if (exec::isPartialOutput(step)) {
           return std::make_unique<NoisyCountGaussianAggregate>(VARBINARY());

--- a/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
@@ -61,7 +61,14 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
       auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
       accumulator->increaseCount(1);
 
-      double noiseScale = decodedNoiseScale_.valueAt<double>(i);
+      double noiseScale = 0.0;
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        noiseScale = decodedNoiseScale_.valueAt<double>(i);
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        noiseScale =
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
+      }
       accumulator->checkAndSetNoiseScale(noiseScale);
     });
   }
@@ -231,9 +238,16 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
       if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
         return;
       }
-
       accumulator->increaseCount(1);
-      double noiseScale = decodedNoiseScale_.valueAt<double>(i);
+
+      double noiseScale = 0.0;
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        noiseScale = decodedNoiseScale_.valueAt<double>(i);
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        noiseScale =
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i));
+      }
       accumulator->checkAndSetNoiseScale(noiseScale);
     });
   }
@@ -273,6 +287,13 @@ void registerNoisyCountGaussianAggregate(
           .intermediateType("varbinary")
           .argumentType("T")
           .argumentType("double") // support DOUBLE noise scale
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("bigint")
+          .intermediateType("varbinary")
+          .argumentType("T")
+          .argumentType("bigint") // support BIGINT noise scale
           .build(),
   };
 

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -34,54 +34,9 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     bool hasBounds = flag.second;
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
-        return;
-      }
-
       auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
-
-      // Update noise scale.
-      auto noiseScaleType = args[1]->typeKind();
-      if (noiseScaleType == TypeKind::DOUBLE) {
-        accumulator->checkAndSetNoiseScale(
-            decodedNoiseScale_.valueAt<double>(i));
-      } else if (noiseScaleType == TypeKind::BIGINT) {
-        accumulator->checkAndSetNoiseScale(
-            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
-      }
-
-      // Update lower and upper bound if provided. support both double and
-      // bigint type.
-      if (hasBounds) {
-        auto lowerBoundType = args[2]->typeKind();
-        auto upperBoundType = args[3]->typeKind();
-        double lowerBound = 0.0;
-        double upperBound = 0.0;
-        if (lowerBoundType == TypeKind::DOUBLE) {
-          lowerBound = decodedLowerBound_.valueAt<double>(i);
-        } else if (lowerBoundType == TypeKind::BIGINT) {
-          lowerBound =
-              static_cast<double>(decodedLowerBound_.valueAt<int64_t>(i));
-        }
-
-        if (upperBoundType == TypeKind::DOUBLE) {
-          upperBound = decodedUpperBound_.valueAt<double>(i);
-        } else if (upperBoundType == TypeKind::BIGINT) {
-          upperBound =
-              static_cast<double>(decodedUpperBound_.valueAt<int64_t>(i));
-        }
-        accumulator->checkAndSetBounds(lowerBound, upperBound);
-      }
-
-      // Update random seed if provided.
-      if (hasRandomSeed) {
-        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
-      }
-
-      // Update sum. check input value and dispatch to corresponding type.
-      auto inputType = args[0]->typeKind();
-      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          updateSumTemplate, inputType, accumulator, decodedValue_, i);
+      updateAccumulatorFromInput(
+          args, accumulator, i, hasRandomSeed, hasBounds);
     });
   }
 
@@ -97,52 +52,8 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
-        return;
-      }
-
-      // Update noise scale.
-      auto noiseScaleType = args[1]->typeKind();
-      if (noiseScaleType == TypeKind::DOUBLE) {
-        accumulator->checkAndSetNoiseScale(
-            decodedNoiseScale_.valueAt<double>(i));
-      } else if (noiseScaleType == TypeKind::BIGINT) {
-        accumulator->checkAndSetNoiseScale(
-            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
-      }
-
-      // Update lower and upper bound if provided. support both double and
-      // bigint type.
-      if (hasBounds) {
-        auto lowerBoundType = args[2]->typeKind();
-        auto upperBoundType = args[3]->typeKind();
-        double lowerBound = 0.0;
-        double upperBound = 0.0;
-        if (lowerBoundType == TypeKind::DOUBLE) {
-          lowerBound = decodedLowerBound_.valueAt<double>(i);
-        } else if (lowerBoundType == TypeKind::BIGINT) {
-          lowerBound =
-              static_cast<double>(decodedLowerBound_.valueAt<int64_t>(i));
-        }
-
-        if (upperBoundType == TypeKind::DOUBLE) {
-          upperBound = decodedUpperBound_.valueAt<double>(i);
-        } else if (upperBoundType == TypeKind::BIGINT) {
-          upperBound =
-              static_cast<double>(decodedUpperBound_.valueAt<int64_t>(i));
-        }
-        accumulator->checkAndSetBounds(lowerBound, upperBound);
-      }
-
-      // Update random seed if provided.
-      if (hasRandomSeed) {
-        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
-      }
-
-      // Update sum. check input value and dispatch to corresponding type.
-      auto inputType = args[0]->typeKind();
-      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          updateSumTemplate, inputType, accumulator, decodedValue_, i);
+      updateAccumulatorFromInput(
+          args, accumulator, i, hasRandomSeed, hasBounds);
     });
   }
 
@@ -253,33 +164,9 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     DecodedVector decoded(*args[0], rows);
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decoded.isNullAt(i)) {
-        return;
-      }
-
       // Update sum from intermediate result.
       auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
-      auto serialized = decoded.valueAt<StringView>(i);
-      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
-      accumulator->update(otherAccumulator.getSum());
-
-      // Update noise scale.
-      if (otherAccumulator.getNoiseScale() >= 0) {
-        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
-      }
-
-      // Update lower and upper bound.
-      if (otherAccumulator.getLowerBound().has_value() &&
-          otherAccumulator.getUpperBound().has_value()) {
-        accumulator->checkAndSetBounds(
-            *otherAccumulator.getLowerBound(),
-            *otherAccumulator.getUpperBound());
-      }
-
-      // Update random seed.
-      if (otherAccumulator.getRandomSeed().has_value()) {
-        accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
-      }
+      updateAccumulatorFromIntermediateResult(accumulator, decoded, i);
     });
   }
 
@@ -292,31 +179,7 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
 
     auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
     rows.applyToSelected([&](vector_size_t i) {
-      if (decoded.isNullAt(i)) {
-        return;
-      }
-
-      auto serialized = decoded.valueAt<StringView>(i);
-      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
-      accumulator->update(otherAccumulator.getSum());
-
-      // Update noise scale.
-      if (otherAccumulator.getNoiseScale() >= 0) {
-        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
-      }
-
-      // Update lower and upper bound.
-      if (otherAccumulator.getLowerBound().has_value() &&
-          otherAccumulator.getUpperBound().has_value()) {
-        accumulator->checkAndSetBounds(
-            *otherAccumulator.getLowerBound(),
-            *otherAccumulator.getUpperBound());
-      }
-
-      // Update random seed.
-      if (otherAccumulator.getRandomSeed().has_value()) {
-        accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
-      }
+      updateAccumulatorFromIntermediateResult(accumulator, decoded, i);
     });
   }
 
@@ -401,6 +264,92 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
       VELOX_FAIL("NoisySumGaussianAggregate does not support this data type.");
     } else {
       accumulator->clipUpdate(static_cast<double>(decodedValue.valueAt<T>(i)));
+    }
+  }
+
+  // Helper function toupdate the accumulator from input.
+  void updateAccumulatorFromInput(
+      const std::vector<VectorPtr>& args,
+      AccumulatorType* accumulator,
+      vector_size_t i,
+      bool hasRandomSeed,
+      bool hasBounds) {
+    // If value is null, we do not want to update the accumulator.
+    if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+      return;
+    }
+
+    // Update noise scale.
+    auto noiseScaleType = args[1]->typeKind();
+    if (noiseScaleType == TypeKind::DOUBLE) {
+      accumulator->checkAndSetNoiseScale(decodedNoiseScale_.valueAt<double>(i));
+    } else if (noiseScaleType == TypeKind::BIGINT) {
+      accumulator->checkAndSetNoiseScale(
+          static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+    }
+
+    // Update lower and upper bound if provided. support both double and
+    // bigint type.
+    if (hasBounds) {
+      auto lowerBoundType = args[2]->typeKind();
+      auto upperBoundType = args[3]->typeKind();
+      double lowerBound = 0.0;
+      double upperBound = 0.0;
+      if (lowerBoundType == TypeKind::DOUBLE) {
+        lowerBound = decodedLowerBound_.valueAt<double>(i);
+      } else if (lowerBoundType == TypeKind::BIGINT) {
+        lowerBound =
+            static_cast<double>(decodedLowerBound_.valueAt<int64_t>(i));
+      }
+
+      if (upperBoundType == TypeKind::DOUBLE) {
+        upperBound = decodedUpperBound_.valueAt<double>(i);
+      } else if (upperBoundType == TypeKind::BIGINT) {
+        upperBound =
+            static_cast<double>(decodedUpperBound_.valueAt<int64_t>(i));
+      }
+      accumulator->checkAndSetBounds(lowerBound, upperBound);
+    }
+
+    // Update random seed if provided.
+    if (hasRandomSeed) {
+      accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+    }
+
+    // Update sum. check input value and dispatch to corresponding type.
+    auto inputType = args[0]->typeKind();
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        updateSumTemplate, inputType, accumulator, decodedValue_, i);
+  }
+
+  // Helper function to update the accumulator from intermediate result.
+  void updateAccumulatorFromIntermediateResult(
+      AccumulatorType* accumulator,
+      DecodedVector& decodedVector,
+      vector_size_t i) {
+    if (decodedVector.isNullAt(i)) {
+      return;
+    }
+
+    auto serialized = decodedVector.valueAt<StringView>(i);
+    auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+    accumulator->update(otherAccumulator.getSum());
+
+    // Update noise scale.
+    if (otherAccumulator.getNoiseScale() >= 0) {
+      accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+    }
+
+    // Update lower and upper bound.
+    if (otherAccumulator.getLowerBound().has_value() &&
+        otherAccumulator.getUpperBound().has_value()) {
+      accumulator->checkAndSetBounds(
+          *otherAccumulator.getLowerBound(), *otherAccumulator.getUpperBound());
+    }
+
+    // Update random seed.
+    if (otherAccumulator.getRandomSeed().has_value()) {
+      accumulator->setRandomSeed(*otherAccumulator.getRandomSeed());
     }
   }
 };

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -48,8 +48,10 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
       }
 
-      // Update sum.
-      accumulator->update(decodedValue_.valueAt<double>(i));
+      // Update sum. check input value and dispatch to corresponding type.
+      auto inputType = args[0]->typeKind();
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          updateSumTemplate, inputType, accumulator, decodedValue_, i);
     });
   }
 
@@ -76,8 +78,11 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
         accumulator->checkAndSetNoiseScale(
             static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
       }
-      // Update sum.
-      accumulator->update(decodedValue_.valueAt<double>(i));
+
+      // Update sum. check input value and dispatch to corresponding type.
+      auto inputType = args[0]->typeKind();
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          updateSumTemplate, inputType, accumulator, decodedValue_, i);
     });
   }
 
@@ -238,6 +243,40 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
     decodedValue_.decode(*args[0], rows);
     decodedNoiseScale_.decode(*args[1], rows);
   }
+
+  // Template helper function to update accumulator, can support all numeric
+  // data types. Only used in this class.
+  template <TypeKind TData>
+  void updateSumTemplate(
+      AccumulatorType* accumulator,
+      const DecodedVector& decodedValue,
+      vector_size_t i) {
+    using T = typename TypeTraits<TData>::NativeType;
+    // Handle decimal types separately.
+    if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
+      const auto& type = decodedValue.base()->type();
+      if (type->isDecimal()) {
+        auto value = decodedValue.valueAt<T>(i);
+        auto scale = type->isShortDecimal() ? type->asShortDecimal().scale()
+                                            : type->asLongDecimal().scale();
+        double doubleValue = static_cast<double>(value) / pow(10, scale);
+
+        accumulator->update(doubleValue);
+        return;
+      }
+    }
+    // Handle other types.
+    if constexpr (
+        std::is_same_v<T, TypeTraits<TypeKind::TIMESTAMP>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARBINARY>> ||
+        std::is_same_v<T, TypeTraits<TypeKind::VARCHAR>> ||
+        std::is_same_v<T, facebook::velox::StringView> ||
+        std::is_same_v<T, facebook::velox::Timestamp>) {
+      VELOX_FAIL("NoisySumGaussianAggregate does not support this data type.");
+    } else {
+      accumulator->update(static_cast<double>(decodedValue.valueAt<T>(i)));
+    }
+  }
 };
 } // namespace
 
@@ -245,21 +284,41 @@ void registerNoisySumGaussianAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite) {
+  // Helper function to create a signature builder with return and
+  // intermediate types
+  auto createBuilder = []() {
+    return exec::AggregateFunctionSignatureBuilder()
+        .returnType("double") // noisy_sum_guassian always returns double
+        .intermediateType("varbinary");
+  };
+
+  // List of possible argument types.
+  const std::vector<std::string> simpleDataTypes = {
+      "tinyint", "smallint", "integer", "bigint", "real", "double"};
+  const std::vector<std::string> noiseScaleTypes = {"double", "bigint"};
+
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
-  // Generate signatures for simple data types
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .returnType("double")
-                           .intermediateType("varbinary")
-                           .argumentType("double") // input type
-                           .argumentType("double") // noise_scale type
-                           .build());
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .returnType("double")
-                           .intermediateType("varbinary")
-                           .argumentType("double") // input type
-                           .argumentType("bigint") // noise_scale type
-                           .build());
+  // Generate signatures for all type combinations.
+  for (const auto& noiseScaleType : noiseScaleTypes) {
+    // Handle simple types.
+    for (const auto& dataType : simpleDataTypes) {
+      signatures.push_back(createBuilder()
+                               .argumentType(dataType)
+                               .argumentType(noiseScaleType)
+                               .build());
+    }
+
+    // Handle decimal types separately.
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .integerVariable("a_precision")
+                             .integerVariable("a_scale")
+                             .returnType("double")
+                             .intermediateType("varbinary")
+                             .argumentType("DECIMAL(a_precision, a_scale)")
+                             .argumentType(noiseScaleType)
+                             .build());
+  }
 
   auto name = prefix + kNoisySumGaussian;
   exec::registerAggregateFunction(

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -1,0 +1,286 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/aggregates/noisy_aggregation/NoisySumAccumulator.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::functions::aggregate;
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+class NoisySumGaussianAggregate : public exec::Aggregate {
+ public:
+  explicit NoisySumGaussianAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  using AccumulatorType = NoisySumAccumulator;
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return static_cast<int32_t>(sizeof(AccumulatorType));
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+        return;
+      }
+
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+
+      // Update noise scale.
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        accumulator->checkAndSetNoiseScale(
+            decodedNoiseScale_.valueAt<double>(i));
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        accumulator->checkAndSetNoiseScale(
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+
+      // Update sum.
+      accumulator->update(decodedValue_.valueAt<double>(i));
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInputData(rows, args);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decodedValue_.isNullAt(i) || decodedNoiseScale_.isNullAt(i)) {
+        return;
+      }
+
+      // Update noise scale.
+      auto noiseScaleType = args[1]->typeKind();
+      if (noiseScaleType == TypeKind::DOUBLE) {
+        accumulator->checkAndSetNoiseScale(
+            decodedNoiseScale_.valueAt<double>(i));
+      } else if (noiseScaleType == TypeKind::BIGINT) {
+        accumulator->checkAndSetNoiseScale(
+            static_cast<double>(decodedNoiseScale_.valueAt<uint64_t>(i)));
+      }
+      // Update sum.
+      accumulator->update(decodedValue_.valueAt<double>(i));
+    });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+
+    int32_t numOfValidGroups = 0;
+    for (auto i = 0; i < numGroups; i++) {
+      numOfValidGroups += !isNull(groups[i]);
+    }
+    size_t totalSize = numOfValidGroups * AccumulatorType::serializedSize();
+
+    // Allocate buffer for serialized data.
+    auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    size_t offset = 0;
+    auto size = AccumulatorType::serializedSize();
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+
+        // Write to the pre-allocated buffer.
+        accumulator->serialize(rawBuffer + offset);
+        flatResult->setNoCopy(
+            i, StringView(rawBuffer + offset, static_cast<int32_t>(size)));
+        offset += size;
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto flatResult = (*result)->asFlatVector<double>();
+    flatResult->resize(numGroups);
+
+    // Find the noise scale from group.
+    double noiseScale = -1.0;
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+        noiseScale = accumulator->getNoiseScale();
+        if (noiseScale >= 0) {
+          break;
+        }
+      }
+    }
+
+    // None of the groups have noise scale, return early.
+    if (noiseScale < 0) {
+      for (auto i = 0; i < numGroups; ++i) {
+        flatResult->setNull(i, true);
+      }
+      return;
+    }
+
+    // Initialize the random generator and seed with randomly generated seed.
+    folly::Random::DefaultGenerator rng;
+    rng.seed(folly::Random::secureRand32());
+
+    std::normal_distribution<double> dist;
+    bool addNoise = false;
+    if (noiseScale > 0) {
+      dist = std::normal_distribution<double>(0.0, noiseScale);
+      addNoise = true;
+    }
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = exec::Aggregate::value<AccumulatorType>(group);
+        // Return null for null values in the group.
+        if (accumulator->getNoiseScale() < 0) {
+          flatResult->setNull(i, true);
+          continue;
+        }
+        double noise = addNoise ? dist(rng) : 0;
+        flatResult->set(i, accumulator->getSum() + noise);
+      }
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decoded(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+
+      // Update sum from intermediate result.
+      auto* accumulator = exec::Aggregate::value<AccumulatorType>(groups[i]);
+      auto serialized = decoded.valueAt<StringView>(i);
+      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+      accumulator->update(otherAccumulator.getSum());
+
+      // Update noise scale.
+      if (otherAccumulator.getNoiseScale() >= 0) {
+        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decoded(*args[0], rows);
+
+    auto* accumulator = exec::Aggregate::value<AccumulatorType>(group);
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decoded.isNullAt(i)) {
+        return;
+      }
+
+      auto serialized = decoded.valueAt<StringView>(i);
+      auto otherAccumulator = AccumulatorType::deserialize(serialized.data());
+      accumulator->update(otherAccumulator.getSum());
+
+      // Update noise scale.
+      if (otherAccumulator.getNoiseScale() >= 0) {
+        accumulator->checkAndSetNoiseScale(otherAccumulator.getNoiseScale());
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    // Initialize the accumulator for each group
+    for (auto i : indices) {
+      *value<AccumulatorType>(groups[i]) = AccumulatorType();
+    }
+  }
+
+ private:
+  DecodedVector decodedValue_;
+  DecodedVector decodedNoiseScale_;
+
+  /// Helper function to process input data. Used in addRawInput and
+  /// addSingleGroupRawInput.
+  void decodeInputData(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    // Decode input values and noise scale
+    decodedValue_.decode(*args[0], rows);
+    decodedNoiseScale_.decode(*args[1], rows);
+  }
+};
+} // namespace
+
+void registerNoisySumGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+
+  // Generate signatures for simple data types
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("double")
+                           .intermediateType("varbinary")
+                           .argumentType("double") // input type
+                           .argumentType("double") // noise_scale type
+                           .build());
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .returnType("double")
+                           .intermediateType("varbinary")
+                           .argumentType("double") // input type
+                           .argumentType("bigint") // noise_scale type
+                           .build());
+
+  auto name = prefix + kNoisySumGaussian;
+  exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          [[maybe_unused]] const TypePtr& resultType,
+          [[maybe_unused]] const core::QueryConfig&)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(argTypes.size(), 2, "{} takes 2 arguments", name);
+
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<NoisySumGaussianAggregate>(VARBINARY());
+        }
+        return std::make_unique<NoisySumGaussianAggregate>(DOUBLE());
+      },
+      {false /*orderSensitive*/, false /*companionFunction*/},
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
@@ -1,0 +1,14 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisySumGaussianAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -43,6 +43,7 @@
 #include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h"
+#include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/QDigestAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/ReduceAgg.h"
 #include "velox/functions/prestosql/aggregates/SetAggregates.h"
@@ -97,6 +98,7 @@ void registerAllAggregateFunctions(
       prefix, withCompanionFunctions, overwrite);
   registerNoisyCountGaussianAggregate(
       prefix, withCompanionFunctions, overwrite);
+  registerNoisySumGaussianAggregate(prefix, withCompanionFunctions, overwrite);
   registerReduceAgg(prefix, withCompanionFunctions, overwrite);
   registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
   registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -41,6 +41,7 @@
 #include "velox/functions/prestosql/aggregates/MinByAggregate.h"
 #include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
 #include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h"
@@ -94,6 +95,7 @@ void registerAllAggregateFunctions(
   registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
   registerMaxByAggregates(prefix, withCompanionFunctions, overwrite);
   registerMinByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerNoisyAvgGaussianAggregate(prefix, withCompanionFunctions, overwrite);
   registerNoisyCountIfGaussianAggregate(
       prefix, withCompanionFunctions, overwrite);
   registerNoisyCountGaussianAggregate(

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
   MultiMapAggTest.cpp
   NoisyCountGaussianAggregationTest.cpp
   NoisyCountIfGaussianAggregationTest.cpp
+  NoisySumGaussianAggregationTest.cpp
   PrestoHasherTest.cpp
   QDigestAggTest.cpp
   ReduceAggTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   MinMaxByAggregationTest.cpp
   MinMaxTest.cpp
   MultiMapAggTest.cpp
+  NoisyAvgGaussianAggregationTest.cpp
   NoisyCountGaussianAggregationTest.cpp
   NoisyCountIfGaussianAggregationTest.cpp
   NoisySumGaussianAggregationTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -234,4 +234,109 @@ TEST_F(NoisyAvgGaussianAggregationTest, randomSeedDeterminismTestWithNoise) {
   }
 }
 
+TEST_F(NoisyAvgGaussianAggregationTest, emptyInputNoNoise) {
+  auto vectors = makeVectors(bigintRowType_, 0, 3);
+
+  auto expectedResult = makeRowVector({makeAllNullFlatVector<double>(1)});
+
+  testAggregations(
+      vectors, {}, {"noisy_avg_gaussian(c2, 0.0)"}, {expectedResult});
+}
+
+TEST_F(
+    NoisyAvgGaussianAggregationTest,
+    multipleGroupMultipleAggregationTestNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_avg_gaussian(c1, 0.0)", "noisy_avg_gaussian(c2, 0.0)"},
+      "SELECT c0, AVG(c1), AVG(c2) FROM tmp GROUP BY c0");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, multipleGroupSingleAggregationTest) {
+  auto vectors = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0", "c1"},
+      {"noisy_avg_gaussian(c2, 0.0)"},
+      "SELECT c0, c1, AVG(c2) FROM tmp GROUP BY c0, c1");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, fuzzerTestNoNoise) {
+  // This test randomly picks input vectors, noise_scale, bounds, and
+  // random_seed. It runs the aggregation function on the input vectors and
+  // compare the result with DuckDB.
+  std::vector<RowTypePtr> rowTypes = {
+      doubleRowType_,
+      bigintRowType_,
+      realRowType_,
+      integerRowType_,
+      smallintRowType_,
+      tinyintRowType_,
+      decimalRowType_};
+
+  std::vector<std::string> aggregationFunctions = {
+      "noisy_avg_gaussian(c2, 0.0)",
+      "noisy_avg_gaussian(c2, 0.0, 12345)",
+      "noisy_avg_gaussian(c2, 0.0, 1.0, 10.0)",
+      "noisy_avg_gaussian(c2, 0.0, 1, 10)",
+      "noisy_avg_gaussian(c2, 0.0, 1.0, 10)",
+      "noisy_avg_gaussian(c2, 0.0, 1, 10.0)",
+      "noisy_avg_gaussian(c2, 0.0, 1.0, 10.0, 12345)",
+      "noisy_avg_gaussian(c2, 0.0, 1, 10, 12345)",
+      "noisy_avg_gaussian(c2, 0.0, 1.0, 10, 12345)",
+      "noisy_avg_gaussian(c2, 0.0, 1, 10.0, 12345)"};
+
+  std::vector<std::string> groupByKeys = {"c0", "c1"};
+
+  int numRuns = 5;
+  for (int i = 0; i < numRuns; i++) {
+    auto rowType = rowTypes[folly::Random::rand32() % rowTypes.size()];
+    auto vectors = makeVectors(rowType, 5, 3);
+    createDuckDbTable({vectors});
+
+    auto aggregationFunctionIndex =
+        folly::Random::rand32() % aggregationFunctions.size();
+    auto aggregationFunction = aggregationFunctions[aggregationFunctionIndex];
+
+    auto groupByKeysSize = folly::Random::rand32() % groupByKeys.size();
+    std::vector<std::string> groupByKeysVector;
+    groupByKeysVector.reserve(groupByKeysSize);
+    for (int j = 0; j < groupByKeysSize; j++) {
+      groupByKeysVector.push_back(
+          groupByKeys[folly::Random::rand32() % groupByKeys.size()]);
+    }
+
+    std::string duckDBQuery = "SELECT ";
+    for (int j = 0; j < groupByKeysVector.size(); j++) {
+      duckDBQuery += groupByKeysVector[j];
+      duckDBQuery += ", ";
+    }
+    if (aggregationFunctionIndex < 2) {
+      duckDBQuery += "AVG(c2) FROM tmp ";
+    } else {
+      duckDBQuery +=
+          "AVG(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 10), 1) ELSE c2 END) FROM tmp ";
+    }
+    for (int j = 0; j < groupByKeysVector.size(); j++) {
+      if (j == 0) {
+        duckDBQuery += "GROUP BY ";
+      }
+
+      duckDBQuery += groupByKeysVector[j];
+      if (j != groupByKeysVector.size() - 1) {
+        duckDBQuery += ", ";
+      }
+    }
+
+    testAggregations(
+        {vectors}, groupByKeysVector, {aggregationFunction}, duckDBQuery);
+  }
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -1,0 +1,114 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+class NoisyAvgGaussianAggregationTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+
+  RowTypePtr doubleRowType_{
+      ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+};
+
+TEST_F(NoisyAvgGaussianAggregationTest, basicNoNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+      makeFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      {vectors},
+      {},
+      {"noisy_avg_gaussian(c2, 0.0)"},
+      "SELECT AVG(c2) FROM tmp");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, basicWithNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  // Set the noise scale to 0.1, true average is 3.0.
+  // use +/- 50*SD and test the result is within range [-2.0, 8.0].
+
+  auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation({}, {"noisy_avg_gaussian(c0, 0.1)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  ASSERT_EQ(result->size(), 1);
+  ASSERT_TRUE(result->childAt(0)->asFlatVector<double>()->valueAt(0) >= -2.0);
+  ASSERT_TRUE(result->childAt(0)->asFlatVector<double>()->valueAt(0) <= 8.0);
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, invalidNoiseScale) {
+  auto vectors = makeVectors(doubleRowType_, 3, 3);
+  createDuckDbTable(vectors);
+
+  // Test invalid noise scale.
+  testFailingAggregations(
+      vectors,
+      {},
+      {"noisy_avg_gaussian(c2, -1.0)"},
+      "Noise scale must be a non-negative value.");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, bigintNoiseScaleType) {
+  auto vectors = makeVectors(doubleRowType_, 3, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors, {}, {"noisy_avg_gaussian(c2, 0)"}, "SELECT AVG(c2) FROM tmp");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, groupbyNullsNoNoise) {
+  auto vectors = {makeRowVector({
+      makeNullableFlatVector<double>({std::nullopt, 1, 1, 1, std::nullopt}),
+      makeNullableFlatVector<double>({1, 2, 3, 4, 5}),
+  })};
+
+  // Group by c0, aggregate c1. Expected result:
+  // c0   | noisy_avg_gaussian(c1, 0.0)
+  // NULL | 3.0
+  // 1    | 3.0
+  auto expectedResult = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, 1.0}),
+       makeFlatVector<double>({3.0, 3.0})});
+
+  testAggregations(
+      vectors, {"c0"}, {"noisy_avg_gaussian(c1, 0.0)"}, {expectedResult});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, aggregateNullsNoNoise) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 2}),
+      makeNullableFlatVector<double>({std::nullopt, std::nullopt, 1, 1, 1}),
+  })};
+
+  // group by c0, aggregate c1. Expected result:
+  // c0   | noisy_avg_gaussian(c1, 0.1)
+  // 1    | NULL
+  // 2    | 1.0
+  auto expectedResult = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<double>({std::nullopt, 1.0})});
+
+  testAggregations(
+      vectors, {"c0"}, {"noisy_avg_gaussian(c1, 0.0)"}, {expectedResult});
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -203,4 +203,35 @@ TEST_F(NoisyAvgGaussianAggregationTest, boundsClipTestNoNoise) {
   ASSERT_EQ(result->childAt(0)->asFlatVector<double>()->valueAt(0), 4);
 }
 
+TEST_F(NoisyAvgGaussianAggregationTest, randomSeedNoNoise) {
+  auto vectors = makeVectors(doubleRowType_, 3, 2);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_avg_gaussian(c2, 0.0, 12345)"},
+      "SELECT AVG(c2) FROM tmp");
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, randomSeedDeterminismTestWithNoise) {
+  auto vectors = makeVectors(doubleRowType_, 10, 5);
+
+  auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation({}, {"noisy_avg_gaussian(c2, 0.5, 12345)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  // Test that the noise is deterministic given the same noise_scale,
+  // random_seed.
+  for (int i = 0; i < 10; i++) {
+    testAggregations(
+        vectors, {}, {"noisy_avg_gaussian(c2, 0.5, 12345)"}, {result});
+  }
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyAvgGaussianAggregationTest.cpp
@@ -15,6 +15,18 @@ class NoisyAvgGaussianAggregationTest
 
   RowTypePtr doubleRowType_{
       ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()})};
+  RowTypePtr bigintRowType_{
+      ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()})};
+  RowTypePtr decimalRowType_{
+      ROW({"c0", "c1", "c2"},
+          {DECIMAL(20, 5), DECIMAL(20, 5), DECIMAL(20, 5)})};
+  RowTypePtr realRowType_{ROW({"c0", "c1", "c2"}, {REAL(), REAL(), REAL()})};
+  RowTypePtr integerRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()})};
+  RowTypePtr smallintRowType_{
+      ROW({"c0", "c1", "c2"}, {SMALLINT(), SMALLINT(), SMALLINT()})};
+  RowTypePtr tinyintRowType_{
+      ROW({"c0", "c1", "c2"}, {TINYINT(), TINYINT(), TINYINT()})};
 };
 
 TEST_F(NoisyAvgGaussianAggregationTest, basicNoNoise) {
@@ -109,6 +121,28 @@ TEST_F(NoisyAvgGaussianAggregationTest, aggregateNullsNoNoise) {
 
   testAggregations(
       vectors, {"c0"}, {"noisy_avg_gaussian(c1, 0.0)"}, {expectedResult});
+}
+
+TEST_F(NoisyAvgGaussianAggregationTest, numericInputTypeTestNoNoise) {
+  auto rowTypes = {
+      doubleRowType_,
+      bigintRowType_,
+      decimalRowType_,
+      realRowType_,
+      integerRowType_,
+      smallintRowType_,
+      tinyintRowType_};
+
+  for (const auto& rowType : rowTypes) {
+    auto vectors = makeVectors(rowType, 3, 3);
+    createDuckDbTable(vectors);
+
+    testAggregations(
+        vectors,
+        {},
+        {"noisy_avg_gaussian(c2, 0.0)"},
+        "SELECT AVG(c2) FROM tmp");
+  }
 }
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
@@ -274,4 +274,16 @@ TEST_F(NoisyCountGaussianAggregationTest, nonScalarInputNoNoise) {
       "SELECT count(c2) FROM tmp");
 }
 
+// Test cases where the noise_scale is BIGINT.
+TEST_F(NoisyCountGaussianAggregationTest, noiseScaleBigintNoNoise) {
+  auto vectors = makeVectors(rowType1_, 10, 3);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_count_gaussian(c0, 0)"},
+      "SELECT count(c0) FROM tmp");
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
@@ -30,6 +30,9 @@ class NoisyCountGaussianAggregationTest
       ROW({"c0", "c1", "c2"}, {INTEGER(), BOOLEAN(), VARCHAR()})};
   RowTypePtr rowType2_{
       ROW({"c0", "c1", "c2"}, {DOUBLE(), TIMESTAMP(), BIGINT()})};
+  RowTypePtr rowType3_{
+      ROW({"c0", "c1", "c2"},
+          {REAL(), ARRAY(BIGINT()), MAP(BIGINT(), BIGINT())})};
 };
 
 // Test normal count(*)
@@ -166,6 +169,17 @@ TEST_F(NoisyCountGaussianAggregationTest, groupByNullNoNoise) {
       {expectedResult});
 }
 
+// Test cases where the input vector is empty. Return null.
+TEST_F(NoisyCountGaussianAggregationTest, emptyInputNoNoise) {
+  auto vectors = makeVectors(rowType1_, 0, 1);
+
+  // Test against the expected result, will return NULL.
+  auto expectedResult = makeRowVector({makeAllNullFlatVector<int64_t>(1)});
+
+  testAggregations(
+      vectors, {}, {"noisy_count_gaussian(c0, 0.0)"}, {expectedResult});
+}
+
 TEST_F(NoisyCountGaussianAggregationTest, oneAggregateSingleGroupNoNoise) {
   // Make two batches of rows: one with nulls; another without.
   auto vectors = makeVectors(rowType1_, 10, 2);
@@ -238,6 +252,26 @@ TEST_F(NoisyCountGaussianAggregationTest, twoAggregatesSingleGroupNoNoise) {
   ASSERT_TRUE(result->size() == 1);
   ASSERT_TRUE(result->childAt(0)->asFlatVector<int64_t>()->valueAt(0) >= 50);
   ASSERT_TRUE(result->childAt(0)->asFlatVector<int64_t>()->valueAt(0) <= 150);
+}
+
+// Test non-scalar input types.
+TEST_F(NoisyCountGaussianAggregationTest, nonScalarInputNoNoise) {
+  auto vectors = makeVectors(rowType3_, 10, 3);
+  createDuckDbTable(vectors);
+
+  // Aggregate on column c1 which contains array values.
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_count_gaussian(c1, 0.0)"},
+      "SELECT count(c1) FROM tmp");
+
+  // Aggregate on column c2 which contains map values.
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_count_gaussian(c2, 0.0)"},
+      "SELECT count(c2) FROM tmp");
 }
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyCountGaussianAggregationTest.cpp
@@ -286,4 +286,112 @@ TEST_F(NoisyCountGaussianAggregationTest, noiseScaleBigintNoNoise) {
       "SELECT count(c0) FROM tmp");
 }
 
+TEST_F(NoisyCountGaussianAggregationTest, twoAggregatesMultipleGroupsNoNoise) {
+  // Test case that do not contain nulls.
+  auto vectors = {
+      makeRowVector({
+          makeFlatVector<int>(1'000, [](auto row) { return row % 5; }), // c0
+          makeFlatVector<int>(1'000, [](auto row) { return row % 2; }), // c1
+          makeFlatVector<std::string>(
+              1'000, [](auto row) { return std::to_string(row) + "foo"; }) // c2
+      }),
+  };
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {"c0"},
+      {"noisy_count_gaussian(c1, 0.0, 1234)", "noisy_count_gaussian(c2, 0.0)"},
+      "SELECT c0, count(c1), count(c2) FROM tmp GROUP BY c0");
+
+  // Test case that contains nulls.
+  auto vectors2 = {
+      // This test case is designed to test the senario where the aggregated
+      // column has null values for one of the groupby keys.
+      // c0: null,  1,  0,   1,  0,  null,  0,   1,  0,   1
+      // c1: null,  1, null, 1, null,  1,  null, 1, null, 1
+      // c2: null, "foo", ... "foo", "foo"
+      makeRowVector({
+          makeFlatVector<int>(
+              10, [](auto row) { return row % 2; }, nullEvery(5)), // c0
+          makeFlatVector<int>(
+              10, [](auto row) { return row % 2; }, nullEvery(2)), // c1
+          makeFlatVector<std::string>(
+              10,
+              [](auto row) { return std::to_string(row) + "foo"; },
+              nullEvery(10)) // c2
+      }),
+  };
+
+  // EXPECTED RESULT:
+  // C0   | noisy_count_gaussian(c1, 0.0) | noisy_count_gaussian(c2, 0.0)
+  // NULL | 1                             | 1
+  // 0    | NULL                          | 4
+  // 1    | 4                             | 4
+  auto expectedResult = makeRowVector(
+      {makeNullableFlatVector<int>({std::nullopt, 0, 1}),
+       makeNullableFlatVector<int64_t>({1, std::nullopt, 4}),
+       makeNullableFlatVector<int64_t>({1, 4, 4})});
+
+  testAggregations(
+      vectors2,
+      {"c0"},
+      {"noisy_count_gaussian(c1, 0.0, 1234)",
+       "noisy_count_gaussian(c2, 0.0, 5678)"},
+      {expectedResult});
+}
+
+TEST_F(
+    NoisyCountGaussianAggregationTest,
+    twoAggregatesMultipleGroupsWrappedNoNoise) {
+  auto vectors = makeVectors(rowType1_, 10, 4);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      [&](auto& builder) {
+        builder.values(vectors)
+            .filter("c0 % 2 = 0")
+            .project({"c0 % 11 AS c0_mod_11", "c1", "c2"});
+      },
+      {"c0_mod_11"},
+      {"noisy_count_gaussian(c1, 0.0, 000)",
+       "noisy_count_gaussian(c2, 0.0, 000)"},
+      "SELECT c0 % 11, count(c1), count(c2) FROM tmp WHERE c0 % 2 = 0 GROUP BY 1");
+}
+
+// Test that the aggregation random seed as input
+TEST_F(NoisyCountGaussianAggregationTest, randomSeedNoNoise) {
+  auto vectors = makeVectors(rowType2_, 10, 4);
+  createDuckDbTable(vectors);
+
+  testAggregations(
+      vectors,
+      {},
+      {"noisy_count_gaussian(c1, 0.0, 456)",
+       "noisy_count_gaussian(c2, 0.0, 456)"},
+      "SELECT count(c1), count(c2) FROM tmp");
+}
+
+// Test that given a random seed, the aggregation is deterministic.
+TEST_F(NoisyCountGaussianAggregationTest, randomSeedDeterminism) {
+  auto vectors = makeVectors(rowType1_, 10, 4);
+
+  // Now run the aggregation with the given random seed and extract the result
+  auto expectedResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation({}, {"noisy_count_gaussian(c1, 3.0, 456)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  // The result should be the same for the same input, noise scale, and seed
+  int numRuns = 10;
+  for (int i = 0; i < numRuns; i++) {
+    testAggregations(
+        vectors, {}, {"noisy_count_gaussian(c1, 3, 456)"}, {expectedResult});
+  }
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -16,6 +16,18 @@ class NoisySumGaussianAggregationTest
 
   RowTypePtr doubleRowType_{
       ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DOUBLE()})};
+  RowTypePtr bigintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), BIGINT()})};
+  RowTypePtr decimalRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DECIMAL(20, 5)})};
+  RowTypePtr realRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), REAL()})};
+  RowTypePtr integerRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()})};
+  RowTypePtr smallintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), SMALLINT()})};
+  RowTypePtr tinyintRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), TINYINT()})};
 };
 
 TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
@@ -32,5 +44,65 @@ TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
   // test nosie scale of bigint type.
   testAggregations(
       {vectors}, {}, {"noisy_sum_gaussian(c2, 0)"}, {expectedResult});
+}
+
+TEST_F(NoisySumGaussianAggregationTest, inputTypeTestNoNoise) {
+  // Test that the function supports various input types.
+  auto doubleVector = makeVectors(doubleRowType_, 5, 3);
+  auto bigintVector = makeVectors(bigintRowType_, 5, 3);
+  auto decimalVector = makeVectors(decimalRowType_, 5, 3);
+  auto realVector = makeVectors(realRowType_, 5, 3);
+  auto integerVector = makeVectors(integerRowType_, 5, 3);
+  auto smallintVector = makeVectors(smallintRowType_, 5, 3);
+  auto tinyintVector = makeVectors(tinyintRowType_, 5, 3);
+
+  createDuckDbTable(doubleVector);
+  testAggregations(
+      doubleVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"}, // double noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(bigintVector);
+  testAggregations(
+      bigintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(decimalVector);
+  testAggregations(
+      decimalVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(realVector);
+  testAggregations(
+      realVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"}, // bigint noise_scale
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(integerVector);
+  testAggregations(
+      integerVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(smallintVector);
+  testAggregations(
+      smallintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
+
+  createDuckDbTable(tinyintVector);
+  testAggregations(
+      tinyintVector,
+      {},
+      {"noisy_sum_gaussian(c2, 0)"},
+      "SELECT sum(c2) FROM tmp");
 }
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -150,6 +150,14 @@ TEST_F(NoisySumGaussianAggregationTest, randomSeedTest) {
       {"noisy_sum_gaussian(c2, 0.0, 12345)"},
       "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN c2 END) FROM tmp");
 
+  testAggregations(
+      vectors,
+      {},
+      // noisy_sum_gaussian(col, noise_scale, lower_bound, upper_bound,
+      // randon_seed)
+      {"noisy_sum_gaussian(c2, 0.0, 10, 100, 12345)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 100), 10) END) FROM tmp");
+
   // Test that the noise is deterministic given the same noise_scale,
   // random_seed. noisy_sum_gaussian(col, noise_scale, randon_seed)
   auto expectedResult =
@@ -165,6 +173,27 @@ TEST_F(NoisySumGaussianAggregationTest, randomSeedTest) {
   for (int i = 0; i < numRuns; i++) {
     testAggregations(
         vectors, {}, {"noisy_sum_gaussian(c2, 20, 12345)"}, {expectedResult});
+  }
+
+  // Test that the noise is deterministic given the same noise_scale,
+  // random_seed. noisy_sum_gaussian(col, noise_scale, lower_bound, upper_bound,
+  // randon_seed)
+  expectedResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values(vectors)
+              .singleAggregation(
+                  {}, {"noisy_sum_gaussian(c2, 20, 10, 100, 12345)"}, {})
+              .planNode(),
+          duckDbQueryRunner_)
+          .copyResults(pool());
+
+  for (int i = 0; i < numRuns; i++) {
+    testAggregations(
+        vectors,
+        {},
+        {"noisy_sum_gaussian(c2, 20, 10, 100, 12345)"},
+        {expectedResult});
   }
 }
 
@@ -223,6 +252,62 @@ TEST_F(NoisySumGaussianAggregationTest, groupByNullTestNoNoise) {
 
   testAggregations(
       {vectors}, {"c0"}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult2});
+}
+
+TEST_F(NoisySumGaussianAggregationTest, boundsTestNoNoise) {
+  // Test easy case with lower and upper bounds.
+  auto vectors1 = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0})})};
+
+  // With lower bound = 3.0 and upper bound = 5.0
+  // Expect the result to be 18.0
+  auto expectedResult = makeRowVector({makeConstant(18.0, 1)});
+  testAggregations(
+      {vectors1},
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 3.0, 5.0)"},
+      {expectedResult});
+
+  // Test against DuckDB.
+  auto vectors2 = makeVectors(doubleRowType_, 5, 3);
+  createDuckDbTable(vectors2);
+
+  // Test double lower bound and double upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 0.1, 0.8)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 0.8), 0.1) END) FROM tmp");
+
+  // Test double lower bound and bigint upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 0.1, 800)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 800), 0.1) END) FROM tmp");
+
+  // Test bigint lower bound and double upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 10, 50.8)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 50.8), 10) END) FROM tmp");
+
+  // Test bigint lower bound and bigint upper bound.
+  testAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 100, 800)"},
+      "SELECT SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 800), 100) END) FROM tmp");
+
+  // Test lower bound > upper bound.
+  testFailingAggregations(
+      vectors2,
+      {},
+      {"noisy_sum_gaussian(c2, 0.0, 100, 80)"},
+      "Lower bound must be less than or equal to upper bound.");
 }
 
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -310,4 +310,75 @@ TEST_F(NoisySumGaussianAggregationTest, boundsTestNoNoise) {
       "Lower bound must be less than or equal to upper bound.");
 }
 
+TEST_F(NoisySumGaussianAggregationTest, fuzzerTestNoNoise) {
+  // This test randomly picks input vectors, noise_scale, bounds, and
+  // random_seed. It runs the aggregation function on the input vectors and
+  // compare the result with DuckDB.
+  std::vector<RowTypePtr> rowTypes = {
+      doubleRowType_,
+      bigintRowType_,
+      realRowType_,
+      integerRowType_,
+      smallintRowType_,
+      tinyintRowType_,
+      decimalRowType_};
+
+  std::vector<std::string> aggregationFunctions = {
+      "noisy_sum_gaussian(c2, 0.0)",
+      "noisy_sum_gaussian(c2, 0.0, 12345)",
+      "noisy_sum_gaussian(c2, 0.0, 1.0, 10.0)",
+      "noisy_sum_gaussian(c2, 0.0, 1, 10)",
+      "noisy_sum_gaussian(c2, 0.0, 1.0, 10)",
+      "noisy_sum_gaussian(c2, 0.0, 1, 10.0)",
+      "noisy_sum_gaussian(c2, 0.0, 1.0, 10.0, 12345)",
+      "noisy_sum_gaussian(c2, 0.0, 1, 10, 12345)",
+      "noisy_sum_gaussian(c2, 0.0, 1.0, 10, 12345)",
+      "noisy_sum_gaussian(c2, 0.0, 1, 10.0, 12345)"};
+
+  std::vector<std::string> groupByKeys = {"c0", "c1"};
+
+  int numRuns = 100;
+  for (int i = 0; i < numRuns; i++) {
+    auto rowType = rowTypes[folly::Random::rand32() % rowTypes.size()];
+    auto vectors = makeVectors(rowType, 5, 3);
+    createDuckDbTable(vectors);
+
+    auto aggregationFunctionIndex =
+        folly::Random::rand32() % aggregationFunctions.size();
+    auto aggregationFunction = aggregationFunctions[aggregationFunctionIndex];
+
+    auto groupByKeysSize = folly::Random::rand32() % groupByKeys.size();
+    std::vector<std::string> groupByKeysVector;
+    groupByKeysVector.reserve(groupByKeysSize);
+    for (int j = 0; j < groupByKeysSize; j++) {
+      groupByKeysVector.push_back(
+          groupByKeys[folly::Random::rand32() % groupByKeys.size()]);
+    }
+
+    std::string duckDBQuery = "SELECT ";
+    for (int j = 0; j < groupByKeysVector.size(); j++) {
+      duckDBQuery += groupByKeysVector[j];
+      duckDBQuery += ", ";
+    }
+    if (aggregationFunctionIndex < 2) {
+      duckDBQuery += "SUM(c2) FROM tmp ";
+    } else {
+      duckDBQuery +=
+          "SUM(CASE WHEN c2 IS NOT NULL THEN GREATEST(LEAST(c2, 10), 1) END) FROM tmp ";
+    }
+    for (int j = 0; j < groupByKeysVector.size(); j++) {
+      if (j == 0) {
+        duckDBQuery += "GROUP BY ";
+      }
+
+      duckDBQuery += groupByKeysVector[j];
+      if (j != groupByKeysVector.size() - 1) {
+        duckDBQuery += ", ";
+      }
+    }
+    testAggregations(
+        vectors, groupByKeysVector, {aggregationFunction}, duckDBQuery);
+  }
+}
+
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisySumGaussianAggregationTest.cpp
@@ -1,0 +1,36 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <gtest/gtest.h>
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::aggregate::test {
+
+class NoisySumGaussianAggregationTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+
+  RowTypePtr doubleRowType_{
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), DOUBLE()})};
+};
+
+TEST_F(NoisySumGaussianAggregationTest, simpleTestNoNoise) {
+  auto vectors = {makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0})})};
+
+  // Expect the result to be 15.0
+  auto expectedResult = makeRowVector({makeConstant(15.0, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0.0)"}, {expectedResult});
+
+  // test nosie scale of bigint type.
+  testAggregations(
+      {vectors}, {}, {"noisy_sum_gaussian(c2, 0)"}, {expectedResult});
+}
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -127,6 +127,7 @@ int main(int argc, char** argv) {
       // Skip non-deterministic functions.
       "noisy_count_if_gaussian",
       "noisy_count_gaussian",
+      "noisy_sum_gaussian",
   };
 
   // Functions whose results verification should be skipped. These can be

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -128,6 +128,7 @@ int main(int argc, char** argv) {
       "noisy_count_if_gaussian",
       "noisy_count_gaussian",
       "noisy_sum_gaussian",
+      "noisy_avg_gaussian",
   };
 
   // Functions whose results verification should be skipped. These can be

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -126,6 +126,7 @@ int main(int argc, char** argv) {
       "max_by",
       // Skip non-deterministic functions.
       "noisy_count_if_gaussian",
+      "noisy_count_gaussian",
   };
 
   // Functions whose results verification should be skipped. These can be


### PR DESCRIPTION
Summary:
1. Added Fuzzer Test to Cover Edge Cases in `NoisyAvgGaussianAggregationTest`

1. `emptyInputNoNoise`: Tests the aggregation function with an empty input and no noise.
2. `multipleGroupMultipleAggregationTestNoNoise`: Tests the aggregation function with multiple groups and aggregations without noise. This test case currently contains an incomplete implementation and may be a work in progress.

Differential Revision: D76232407
