### PR TITLE
feat: Remove query_id check in TraceReplayerRunner

### DIFF
--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -246,7 +246,6 @@ TraceReplayRunner::TraceReplayRunner()
 
 void TraceReplayRunner::init() {
   VELOX_USER_CHECK(!FLAGS_root_dir.empty(), "--root_dir must be provided");
-  VELOX_USER_CHECK(!FLAGS_query_id.empty(), "--query_id must be provided");
   VELOX_USER_CHECK(!FLAGS_node_id.empty(), "--node_id must be provided");
 
   if (!memory::MemoryManager::testInstance()) {


### PR DESCRIPTION
Summary: Dpp veloski has not setup queryid, so removing the check so that the loader_test replayer could pass

Differential Revision: D76328032


