### PR TITLE
fix: Fix TableWriterArbitrationTest.reclaimFromTableWriter

### DIFF
--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -2749,7 +2749,7 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromTableWriter) {
   const int batchSize = 1'000;
   options.vectorSize = batchSize;
   options.stringVariableLength = false;
-  options.stringLength = 1'000;
+  options.stringLength = 500;
   VectorFuzzer fuzzer(options, pool());
   const int numBatches = 20;
   std::vector<RowVectorPtr> vectors;


### PR DESCRIPTION
Summary:
The test was "broken" by D75535212 which changes folly's randomness generation. The test broke because with previous version of folly random, the generated data for table writer test is just under the size of memory capacity, not triggering cap exceed errors. Now with the new folly random, the size went above the capacity, triggering the cap exceed error.

The test is fixed by reducing the writer memory footprint by reducing the generated string size.

Differential Revision: D76387734


