### PR TITLE
fix: Fix DecimalUtil::computeAverage rounding in overflow cases

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -31,11 +31,20 @@ General Aggregate Functions
     inputs if :doc:`presto.array_agg.ignore_nulls <../../configs>` is set
     to false.
 
-.. function:: avg(x) -> double|real
+.. function:: avg(x) -> double|real|decimal
 
     Returns the average (arithmetic mean) of all non-null input values.
     When x is of type REAL, the result type is REAL.
-    For all other input types, the result type is DOUBLE.
+    When x is an integer or a DOUBLE, the result is DOUBLE.
+    When x is of type DECIMAL(p, s), the result type is DECIMAL(p, s).
+    Note: For the overflow cases, Velox returns a result when Presto throws "Decimal overflow". ::
+        SELECT AVG(col)
+        FROM ( VALUES
+        	  (CAST(9999999999999999999999999999999.9999999 AS DECIMAL(38,7))),
+              (CAST(9999999999999999999999999999999.9999999 AS DECIMAL(38,7)))
+             ) AS t(col);
+        -- Velox: 9999999999999999999999999999999.9999999
+        -- Presto: Decimal overflow
 
 .. function:: bool_and(boolean) -> boolean
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -482,6 +482,24 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {makeRowVector(
           {makeFlatVector(std::vector<int64_t>{337}, DECIMAL(3, 2))})});
 
+  // Round-up average when sum overflows the max int128_t limit.
+  testAggregations(
+      {makeRowVector({makeFlatVector<int128_t>(
+          {HugeInt::parse("99999999999999999999999999999999999999"),
+           HugeInt::parse("99999999999999999999999999999999999998"),
+           HugeInt::parse("99999999999999999999999999999999999997"),
+           HugeInt::parse("99999999999999999999999999999999999995"),
+           HugeInt::parse("99999999999999999999999999999999999995"),
+           HugeInt::parse("99999999999999999999999999999999999995")},
+          DECIMAL(38, 7))})},
+      {},
+      {"avg(c0)"},
+      {},
+      {makeRowVector({makeFlatVector(
+          std::vector<int128_t>{
+              HugeInt::parse("99999999999999999999999999999999999997")},
+          DECIMAL(38, 7))})});
+
   // The total sum overflows the max int128_t limit.
   std::vector<int128_t> rawVector;
   for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
In DecimalUtil::computeAverage(), the calculation of remTotal does not round up, but it should theoretically round up to avoid accuracy issues in the results.

Fixes https://github.com/facebookincubator/velox/issues/13731