### PR TITLE
fix: Support constant value for lead/lag function

### DIFF
--- a/velox/docs/functions/presto/window.rst
+++ b/velox/docs/functions/presto/window.rst
@@ -128,41 +128,41 @@ null for all rows, the ``default_value`` is returned, or if it is not specified,
 
 Returns the first value of the window.
 
+.. function:: lag(x[, offset[, default_value]]) -> [same as input]
+
+Returns the value at ``offset`` rows before the current row in the window partition.
+The input ``x`` can be a constant value or a column reference. Offsets start at ``0``,
+which is the current row. The default ``offset`` is ``1``. The offset can be a constant
+value or a column reference. If the offset is ``null``, ``null`` is returned. If the
+offset refers to a row that is not within the partition, the ``default_value`` is returned,
+or if ``default_value`` is not specified ``null`` is returned.
+
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
+
 .. function:: last_value(x) -> [same as input]
 
 Returns the last value of the window.
+
+.. function:: lead(x[, offset[, default_value]]) -> [same as input]
+
+Returns the value at ``offset`` rows after the current row in the window partition.
+The input ``x`` can be a constant value or a column reference. Offsets start at ``0``,
+which is the current row. The default ``offset`` is ``1``. The offset can be a constant
+value or a column reference. If the offset is ``null``, ``null`` is returned. If the
+offset refers to a row that is not within the partition, the ``default_value`` is returned,
+or if ``default_value`` is not specified ``null`` is returned.
+
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
 
 .. function:: nth_value(x, offset) -> [same as input]
 
 Returns the value at the specified offset from the beginning of the window. Offsets start at 1. The offset
 can be any scalar expression. If the offset is null or greater than the number of values in the window, null is
 returned. It is an error for the offset to be zero or negative.
-
-.. function:: lag(x[, offset[, default_value]]) -> [same as input]
-
-Returns the value at ``offset`` rows before the current row in the window partition.
-Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
-The offset can be a constant value or a column reference. If the offset is ``null``, ``null`` is
-returned. If the offset refers to a row that is not within the partition, the
-``default_value`` is returned, or if ``default_value`` is not specified ``null``
-is returned.
-
-If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
-If not enough non-null values are found during offset counting, ``default_value``
-is returned.
-
-.. function:: lead(x[, offset[, default_value]]) -> [same as input]
-
-Returns the value at ``offset`` rows after the current row in the window partition.
-Offsets start at ``0``, which is the current row. The default ``offset`` is ``1``.
-The offset can be a constant value or a column reference. If the offset is ``null``, ``null`` is
-returned. If the offset refers to a row that is not within the partition, the
-``default_value`` is returned, or if ``default_value`` is not specified ``null``
-is returned.
-
-If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
-If not enough non-null values are found during offset counting, ``default_value``
-is returned.
 
 Aggregate functions
 ___________________

--- a/velox/docs/functions/spark/window.rst
+++ b/velox/docs/functions/spark/window.rst
@@ -8,6 +8,32 @@ More details about window functions can be found at :doc:`/develop/window`.
 Value functions
 ---------------
 
+.. function:: lag(x[, offset[, default_value]]) -> [same as input]
+
+Returns the value at ``offset`` rows before the current row in the window partition.
+The input ``x`` can be a constant value or a column reference. Offsets start at ``0``,
+which is the current row. The default ``offset`` is ``1``.  The offset can be a constant
+value or a column reference. If the offset is ``null``, ``null`` is returned. If the
+offset refers to a row that is not within the partition, the ``default_value`` is returned,
+or if ``default_value`` is not specified ``null`` is returned.
+
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
+
+.. function:: lead(x[, offset[, default_value]]) -> [same as input]
+
+Returns the value at ``offset`` rows after the current row in the window partition.
+The input ``x`` can be a constant value or a column reference. Offsets start at ``0``,
+which is the current row. The default ``offset`` is ``1``. The offset can be a constant
+value or a column reference. If the offset is ``null``, ``null`` is returned. If the
+offset refers to a row that is not within the partition, the ``default_value`` is returned,
+or if ``default_value`` is not specified ``null`` is returned.
+
+If ``IGNORE NULLS`` is specified, ``null`` values are ignored during offset counting.
+If not enough non-null values are found during offset counting, ``default_value``
+is returned.
+
 .. function:: nth_value(x, offset) -> [same as input]
    :noindex:
 

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -441,6 +441,17 @@ void WindowFuzzer::go() {
     std::vector<TypePtr> argTypes = signature.args;
     std::vector<std::string> argNames = makeNames(argTypes.size());
 
+    // Test constant input for lead/lag.
+    if (signature.name == "lead" || signature.name == "lag") {
+      if (randInt(0, 10) == 0) {
+        if (randInt(0, 1) == 0) {
+          argNames[0] = "NULL::" + argTypes[0]->toString();
+        } else {
+          argNames[0] = "0::" + argTypes[0]->toString();
+        }
+      }
+    }
+
     const bool ignoreNulls =
         supportIgnoreNulls(signature.name) && vectorFuzzer_.coinToss(0.5);
     const auto call =

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -748,6 +748,8 @@ bool WindowFuzzer::verifyWindow(
                   .capturePlanNodeId(windowNodeId)
                   .planNode();
 
+  LOG(INFO) << "Testing plan: " << plan->toString(true, true);
+
   if (persistAndRunOnce_) {
     persistReproInfo({{plan, {}}}, reproPersistPath_);
   }


### PR DESCRIPTION
Example: `lag(100, c1, c2)`, where the first arg is not column reference.