### PR TITLE
fix: Apply query config to constant folding

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2040,8 +2040,8 @@ core::ExecCtx* SimpleExpressionEvaluator::ensureExecCtx() {
 VectorPtr tryEvaluateConstantExpression(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool,
+    const std::shared_ptr<core::QueryCtx>& queryCtx,
     bool suppressEvaluationFailures) {
-  auto queryCtx = velox::core::QueryCtx::create();
   velox::core::ExecCtx execCtx{pool, queryCtx.get()};
   velox::exec::ExprSet exprSet({expr}, &execCtx);
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -816,6 +816,7 @@ std::unique_ptr<ExprSet> makeExprSetFromFlag(
 VectorPtr tryEvaluateConstantExpression(
     const core::TypedExprPtr& expr,
     memory::MemoryPool* pool,
+    const std::shared_ptr<core::QueryCtx>& queryCtx,
     bool suppressEvaluationFailures = false);
 
 /// Returns a string representation of the expression trees annotated with


### PR DESCRIPTION
Summary: Modify velox::exec::tryEvaluateConstantExpression to require the user to pass velox::core::QueryCtx. Using 'default' query context is incorrect as some functions may depend on configs for execution. These functions may either produce wrong results and fail outright with default query context.

Differential Revision: D76423739
