### PR TITLE
misc(fuzzer): Skip json_extract in expression fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -162,6 +162,7 @@ int main(int argc, char** argv) {
       "st_issimple",
       "geometry_invalid_reason",
       "simplify_geometry",
+      "json_extract", // https://github.com/facebookincubator/velox/issues/13682
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 


### PR DESCRIPTION
Summary: Skip json_extract in expression fuzzer due to a known bug https://github.com/facebookincubator/velox/issues/13682 while we fix this function.

Differential Revision: D76433805
