### PR TITLE
build: Add shellcheck and shfmt hooks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,6 +97,13 @@ repos:
       - id: shellcheck
         args: [-x, --severity=warning]
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.11.0-1
+    hooks:
+      - id: shfmt
+        # w: write changes, s: simplify, i set indent to 2 spaces
+        args: [-w, -s, -i, '2']
+
   # The following checks mostly target GitHub Actions workflows.
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.0

--- a/scripts/ci/presto/start-prestojava.sh
+++ b/scripts/ci/presto/start-prestojava.sh
@@ -15,4 +15,4 @@
 
 set -e
 
-"$PRESTO_HOME"/bin/launcher --pid-file=/tmp/pidfile  run
+"$PRESTO_HOME"/bin/launcher --pid-file=/tmp/pidfile run

--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -29,12 +29,12 @@ ext() {
 }
 
 print_info() {
-echo "$info" | grep -e "$1" | ext
+  echo "$info" | grep -e "$1" | ext
 }
 
 result="
 Velox System Info v${version}
-Commit: $(git rev-parse HEAD 2> /dev/null || echo "Not in a git repo.")
+Commit: $(git rev-parse HEAD 2>/dev/null || echo "Not in a git repo.")
 CMake Version: $(cmake --version | grep -oE '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+')
 System: $(print_info 'CMAKE_SYSTEM "')
 Arch: $(print_info 'CMAKE_SYSTEM_PROCESSOR')
@@ -61,7 +61,7 @@ all="$result  $conda"
 echo "$all"
 
 if [ -x "$(command -v xclip)" ]; then
- clip="xclip -selection c"
+  clip="xclip -selection c"
 elif [ -x "$(command -v pbcopy)" ]; then
   clip="pbcopy"
 else

--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -91,9 +91,9 @@ function install_cuda {
   arch="$(uname -m)"
   local repo_url
 
-  if [[ "$arch" == "x86_64" ]]; then
+  if [[ $arch == "x86_64" ]]; then
     repo_url="https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo"
-  elif [[ "$arch" == "aarch64" ]]; then
+  elif [[ $arch == "aarch64" ]]; then
     # Using SBSA (Server Base System Architecture) repository for ARM64 servers
     repo_url="https://developer.download.nvidia.com/compute/cuda/repos/rhel9/sbsa/cuda-rhel9.repo"
   else
@@ -175,7 +175,7 @@ function install_velox_deps {
   run_and_time install_faiss
 }
 
-(return 2> /dev/null) && return # If script was sourced, don't run commands.
+(return 2>/dev/null) && return # If script was sourced, don't run commands.
 
 (
   if [[ $# -ne 0 ]]; then

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -91,7 +91,7 @@ function install_fbthrift {
 }
 
 function install_duckdb {
-  if $BUILD_DUCKDB ; then
+  if $BUILD_DUCKDB; then
     wget_and_untar https://github.com/duckdb/duckdb/archive/refs/tags/"${DUCKDB_VERSION}".tar.gz duckdb
     cmake_install_dir duckdb -DBUILD_UNITTESTS=OFF -DENABLE_SANITIZER=OFF -DENABLE_UBSAN=OFF -DBUILD_SHELL=OFF -DEXPORT_DLL_SYMBOLS=OFF -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
   fi
@@ -186,31 +186,31 @@ function install_arrow {
 }
 
 function install_thrift {
-   wget_and_untar https://github.com/apache/thrift/archive/"${THRIFT_VERSION}".tar.gz thrift
+  wget_and_untar https://github.com/apache/thrift/archive/"${THRIFT_VERSION}".tar.gz thrift
 
-   EXTRA_CXXFLAGS="-O3 -fPIC"
-   # Clang will generate warnings and they need to be suppressed, otherwise the build will fail.
-   if [[ ${USE_CLANG} != "false" ]]; then
-     EXTRA_CXXFLAGS="-O3 -fPIC -Wno-inconsistent-missing-override -Wno-unused-but-set-variable"
-   fi
+  EXTRA_CXXFLAGS="-O3 -fPIC"
+  # Clang will generate warnings and they need to be suppressed, otherwise the build will fail.
+  if [[ ${USE_CLANG} != "false" ]]; then
+    EXTRA_CXXFLAGS="-O3 -fPIC -Wno-inconsistent-missing-override -Wno-unused-but-set-variable"
+  fi
 
-   CXX_FLAGS="$EXTRA_CXXFLAGS" cmake_install_dir thrift \
-     -DBUILD_SHARED_LIBS=OFF \
-     -DBUILD_COMPILER=ON \
-     -DBUILD_EXAMPLES=OFF \
-     -DBUILD_TUTORIALS=OFF \
-     -DCMAKE_DEBUG_POSTFIX= \
-     -DWITH_AS3=OFF \
-     -DWITH_CPP=ON \
-     -DWITH_C_GLIB=OFF \
-     -DWITH_JAVA=OFF \
-     -DWITH_JAVASCRIPT=OFF \
-     -DWITH_LIBEVENT=OFF \
-     -DWITH_NODEJS=OFF \
-     -DWITH_PYTHON=OFF \
-     -DWITH_QT5=OFF \
-     -DWITH_ZLIB=OFF \
-     "${EXTRA_ARROW_OPTIONS}"
+  CXX_FLAGS="$EXTRA_CXXFLAGS" cmake_install_dir thrift \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DBUILD_COMPILER=ON \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_TUTORIALS=OFF \
+    -DCMAKE_DEBUG_POSTFIX= \
+    -DWITH_AS3=OFF \
+    -DWITH_CPP=ON \
+    -DWITH_C_GLIB=OFF \
+    -DWITH_JAVA=OFF \
+    -DWITH_JAVASCRIPT=OFF \
+    -DWITH_LIBEVENT=OFF \
+    -DWITH_NODEJS=OFF \
+    -DWITH_PYTHON=OFF \
+    -DWITH_QT5=OFF \
+    -DWITH_ZLIB=OFF \
+    "${EXTRA_ARROW_OPTIONS}"
 }
 
 function install_stemmer {
@@ -225,7 +225,7 @@ function install_stemmer {
 }
 
 function install_geos {
-  if [[ "$BUILD_GEOS" == "true" ]]; then
+  if [[ $BUILD_GEOS == "true" ]]; then
     wget_and_untar https://github.com/libgeos/geos/archive/"${GEOS_VERSION}".tar.gz geos
     cmake_install_dir geos -DBUILD_TESTING=OFF
   fi
@@ -236,7 +236,7 @@ function install_faiss_deps {
 }
 
 function install_faiss {
-  if [[ "$BUILD_FAISS" == "true" ]]; then
+  if [[ $BUILD_FAISS == "true" ]]; then
     # Install OpenBLAS and libomp if not already installed
     install_faiss_deps
 
@@ -249,7 +249,6 @@ function install_faiss {
       -DFAISS_ENABLE_BENCHMARKS=OFF
   fi
 }
-
 
 # Adapters that can be installed.
 
@@ -338,7 +337,7 @@ function install_azure-storage-sdk-cpp {
   if ! grep -q "baseline" $azure_core_dir/vcpkg.json; then
     # build and install azure-core with the version compatible with system pre-installed openssl
     openssl_version=$(openssl version -v | awk '{print $2}')
-    if [[ "$openssl_version" == 1.1.1* ]]; then
+    if [[ $openssl_version == 1.1.1* ]]; then
       openssl_version="1.1.1n"
     fi
     sed -i "s/\"version-string\"/\"builtin-baseline\": \"$vcpkg_commit_id\",\"version-string\"/" $azure_core_dir/vcpkg.json
@@ -346,7 +345,7 @@ function install_azure-storage-sdk-cpp {
   fi
   (
     cd $azure_core_dir || exit
-    cmake_install  -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DBUILD_SHARED_LIBS=OFF
+    cmake_install -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DBUILD_SHARED_LIBS=OFF
   )
   # install azure-identity
   (

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -48,7 +48,7 @@ function github_checkout {
   shift
   local VERSION=$1
   shift
-  local GIT_CLONE_PARAMS=$*
+  local GIT_CLONE_PARAMS=( "$@" )
   local DIRNAME
   DIRNAME=$(basename "$REPO")
   SUDO="${SUDO:-""}"
@@ -61,7 +61,7 @@ function github_checkout {
     ${SUDO} rm -rf "${DIRNAME}"
   fi
   if [ ! -d "${DIRNAME}" ]; then
-    git clone -q -b "$VERSION" "$GIT_CLONE_PARAMS" "https://github.com/${REPO}.git"
+    git clone -q -b "$VERSION" "${GIT_CLONE_PARAMS[@]}" "https://github.com/${REPO}.git"
   fi
   cd "${DIRNAME}" || exit
 }

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -48,7 +48,7 @@ function github_checkout {
   shift
   local VERSION=$1
   shift
-  local GIT_CLONE_PARAMS=( "$@" )
+  local GIT_CLONE_PARAMS=$*
   local DIRNAME
   DIRNAME=$(basename "$REPO")
   SUDO="${SUDO:-""}"
@@ -61,7 +61,7 @@ function github_checkout {
     ${SUDO} rm -rf "${DIRNAME}"
   fi
   if [ ! -d "${DIRNAME}" ]; then
-    git clone -q -b "$VERSION" "${GIT_CLONE_PARAMS[@]}" "https://github.com/${REPO}.git"
+    git clone -q -b "$VERSION" "$GIT_CLONE_PARAMS" "https://github.com/${REPO}.git"
   fi
   cd "${DIRNAME}" || exit
 }

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -49,9 +49,8 @@ SUDO="${SUDO:-""}"
 
 function update_brew {
   DEFAULT_BREW_PATH=/usr/local/bin/brew
-  if [ "$(arch)" == "arm64" ] ;
-    then
-      DEFAULT_BREW_PATH=$(which brew) ;
+  if [ "$(arch)" == "arm64" ]; then
+    DEFAULT_BREW_PATH=$(which brew)
   fi
   BREW_PATH=${BREW_PATH:-$DEFAULT_BREW_PATH}
   $BREW_PATH update --auto-update --verbose
@@ -60,41 +59,45 @@ function update_brew {
 
 function install_from_brew {
   pkg=$1
-  if [[ "${pkg}" =~ ^([0-9a-z-]*):([0-9](\.[0-9\])*)$ ]];
-  then
+  if [[ ${pkg} =~ ^([0-9a-z-]*):([0-9](\.[0-9\])*)$ ]]; then
     pkg=${BASH_REMATCH[1]}
     ver=${BASH_REMATCH[2]}
     echo "Installing '${pkg}' at '${ver}'"
     tap="velox/local-${pkg}"
     brew tap-new "${tap}"
     brew extract "--version=${ver}" "${pkg}" "${tap}"
-    brew install "${tap}/${pkg}@${ver}" || ( echo "Failed to install ${tap}/${pkg}@${ver}" ; exit 1 )
+    brew install "${tap}/${pkg}@${ver}" || (
+      echo "Failed to install ${tap}/${pkg}@${ver}"
+      exit 1
+    )
   else
-    ( brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula "$pkg" ) || ( echo "Failed to install ${pkg}" ; exit 1 )
+    (brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula "$pkg") || (
+      echo "Failed to install ${pkg}"
+      exit 1
+    )
   fi
 }
 
 function install_build_prerequisites {
-  for pkg in ${MACOS_BUILD_DEPS}
-  do
+  for pkg in ${MACOS_BUILD_DEPS}; do
     install_from_brew "${pkg}"
   done
   if [ ! -f "${PYTHON_VENV}"/pyvenv.cfg ]; then
     echo "Creating Python Virtual Environment at ${PYTHON_VENV}"
     python3 -m venv "${PYTHON_VENV}"
   fi
-  source "${PYTHON_VENV}"/bin/activate; pip3 install cmake-format regex pyyaml
+  source "${PYTHON_VENV}"/bin/activate
+  pip3 install cmake-format regex pyyaml
 
   # Install ccache
-  curl -L https://github.com/ccache/ccache/releases/download/v"${CCACHE_VERSION}"/ccache-"${CCACHE_VERSION}"-darwin.tar.gz > ccache.tar.gz
+  curl -L https://github.com/ccache/ccache/releases/download/v"${CCACHE_VERSION}"/ccache-"${CCACHE_VERSION}"-darwin.tar.gz >ccache.tar.gz
   tar -xf ccache.tar.gz
   mv ccache-"${CCACHE_VERSION}"-darwin/ccache /usr/local/bin/
   rm -rf ccache-"${CCACHE_VERSION}"-darwin ccache.tar.gz
 }
 
 function install_velox_deps_from_brew {
-  for pkg in ${MACOS_VELOX_DEPS}
-  do
+  for pkg in ${MACOS_VELOX_DEPS}; do
     install_from_brew "${pkg}"
   done
 }
@@ -130,9 +133,9 @@ function install_duckdb_clang {
   clang_major_version=$(echo | clang -dM -E - | grep __clang_major__ | awk '{print $3}')
   # Clang17 requires this. See issue #13215.
   if [ "${clang_major_version}" -ge 17 ]; then
-     EXTRA_PKG_CXXFLAGS=" -Wno-missing-template-arg-list-after-template-kw" install_duckdb
+    EXTRA_PKG_CXXFLAGS=" -Wno-missing-template-arg-list-after-template-kw" install_duckdb
   else
-     install_duckdb
+    install_duckdb
   fi
 }
 
@@ -142,7 +145,7 @@ function install_faiss_deps {
 }
 
 function install_faiss {
-  if [[ "$BUILD_FAISS" == "true" ]]; then
+  if [[ $BUILD_FAISS == "true" ]]; then
     # Install OpenBLAS and libomp if not already installed
     install_faiss_deps
 
@@ -183,16 +186,16 @@ function install_velox_deps {
   run_and_time install_fbthrift
   run_and_time install_xsimd
   run_and_time install_stemmer
-# We allow arrow to bundle thrift on MacOS due to issues with bison and flex.
-# See https://github.com/facebook/fbthrift/pull/317 for an explanation.
-# run_and_time install_thrift
+  # We allow arrow to bundle thrift on MacOS due to issues with bison and flex.
+  # See https://github.com/facebook/fbthrift/pull/317 for an explanation.
+  # run_and_time install_thrift
   run_and_time install_arrow
   run_and_time install_duckdb_clang
   run_and_time install_geos
   run_and_time install_faiss
 }
 
-(return 2> /dev/null) && return # If script was sourced, don't run commands.
+(return 2>/dev/null) && return # If script was sourced, don't run commands.
 
 (
   update_brew
@@ -209,7 +212,7 @@ function install_velox_deps {
       echo "Skipping installation of build dependencies since INSTALL_PREREQUISITES is not set"
     fi
     install_velox_deps
-    echo "All deps for Velox installed! Now try \"make\""
+    echo 'All deps for Velox installed! Now try "make"'
   fi
 )
 

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -60,7 +60,6 @@ function install_build_prerequisites {
   dnf_install ninja-build cmake ccache gcc-toolset-12 git wget which
   dnf_install autoconf automake python3-devel pip libtool
 
-
   if [[ ${USE_CLANG} != "false" ]]; then
     install_clang15
   fi
@@ -91,9 +90,9 @@ function install_cuda {
   arch=$(uname -m)
   local repo_url
 
-  if [[ "$arch" == "x86_64" ]]; then
+  if [[ $arch == "x86_64" ]]; then
     repo_url="https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo"
-  elif [[ "$arch" == "aarch64" ]]; then
+  elif [[ $arch == "aarch64" ]]; then
     # Using SBSA (Server Base System Architecture) repository for ARM64 servers
     repo_url="https://developer.download.nvidia.com/compute/cuda/repos/rhel8/sbsa/cuda-rhel8.repo"
   else
@@ -127,7 +126,7 @@ function install_velox_deps {
   run_and_time install_arrow
 }
 
-(return 2> /dev/null) && return # If script was sourced, don't run commands.
+(return 2>/dev/null) && return # If script was sourced, don't run commands.
 
 (
   if [[ $# -ne 0 ]]; then

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -88,7 +88,7 @@ function install_build_prerequisites {
     echo "Creating Python Virtual Environment at ${PYTHON_VENV}"
     python3 -m venv "${PYTHON_VENV}"
   fi
-  source "${PYTHON_VENV}"/bin/activate;
+  source "${PYTHON_VENV}"/bin/activate
   # Install to /usr/local to make it available to all users.
   ${SUDO} pip3 install cmake==3.28.3
 
@@ -173,9 +173,9 @@ function install_cuda {
   fi
 
   local cuda_repo
-  if [[ "$arch" == "x86_64" ]]; then
+  if [[ $arch == "x86_64" ]]; then
     cuda_repo="${os_ver}/x86_64"
-  elif [[ "$arch" == "aarch64" ]]; then
+  elif [[ $arch == "aarch64" ]]; then
     cuda_repo="${os_ver}/sbsa"
   else
     echo "Unsupported architecture: $arch" >&2
@@ -264,7 +264,7 @@ function install_apt_deps {
   install_velox_deps_from_apt
 }
 
-(return 2> /dev/null) && return # If script was sourced, don't run commands.
+(return 2>/dev/null) && return # If script was sourced, don't run commands.
 
 (
   if [[ ${USE_CLANG} != "false" ]]; then

--- a/velox/dwio/dwrf/proto/fb_protobuf.sh
+++ b/velox/dwio/dwrf/proto/fb_protobuf.sh
@@ -16,6 +16,6 @@
 set -e
 
 (
-    "${PROTOC:-protoc}" dwrf_proto.proto --cpp_out="$INSTALL_DIR"
-    "${PROTOC:-protoc}" orc_proto.proto --cpp_out="$INSTALL_DIR"
+  "${PROTOC:-protoc}" dwrf_proto.proto --cpp_out="$INSTALL_DIR"
+  "${PROTOC:-protoc}" orc_proto.proto --cpp_out="$INSTALL_DIR"
 )

--- a/velox/experimental/breeze/test/generate.sh
+++ b/velox/experimental/breeze/test/generate.sh
@@ -19,13 +19,13 @@ SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 cd "$SCRIPTDIR"
 
 function generate {
-    BACKEND=$1
-    TYPE=$2
-    EXT=$3
-    DIR="$TYPE"s
-    mkdir -p generated/"$DIR"
-    ./kernel_generator.py --backend="$BACKEND" --template="$DIR"/"$TYPE"-kernels.template.h --out=generated/"$DIR"/kernels-"$BACKEND"."$EXT" ${LLVM_PATH:+-l "$LLVM_PATH"}
-    ./test_fixture_generator.py --backend="$BACKEND" --template="$DIR"/"$TYPE"_test.template.h --out=generated/"$DIR"/"$TYPE"_test-"$BACKEND"."$EXT" ${LLVM_PATH:+-l "$LLVM_PATH"}
+  BACKEND=$1
+  TYPE=$2
+  EXT=$3
+  DIR="$TYPE"s
+  mkdir -p generated/"$DIR"
+  ./kernel_generator.py --backend="$BACKEND" --template="$DIR"/"$TYPE"-kernels.template.h --out=generated/"$DIR"/kernels-"$BACKEND"."$EXT" ${LLVM_PATH:+-l "$LLVM_PATH"}
+  ./test_fixture_generator.py --backend="$BACKEND" --template="$DIR"/"$TYPE"_test.template.h --out=generated/"$DIR"/"$TYPE"_test-"$BACKEND"."$EXT" ${LLVM_PATH:+-l "$LLVM_PATH"}
 }
 
 generate openmp "algorithm" h

--- a/velox/experimental/wave/jit/make_headers.sh
+++ b/velox/experimental/wave/jit/make_headers.sh
@@ -13,44 +13,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 # Generates the inlined headers for Wave Jit.
 #
 # Run in the valox checkout root.
 
 JIT=velox/experimental/wave/jit
 if [ -z "$STRINGIFY" ]; then
-    STRINGIFY=stringify
+  STRINGIFY=stringify
 fi
 
-head --lines 16 velox/experimental/wave/common/Cuda.h > $JIT/Headers.h
-echo "namespace facebook::velox::wave {" >> $JIT/Headers.h
+head --lines 16 velox/experimental/wave/common/Cuda.h >$JIT/Headers.h
+echo "namespace facebook::velox::wave {" >>$JIT/Headers.h
 
-echo "bool registerHeader(const char* text);" >> $JIT/Headers.h
+echo "bool registerHeader(const char* text);" >>$JIT/Headers.h
 
-$STRINGIFY velox/experimental/wave/common/BitUtil.cuh >> $JIT/Headers.h
-$STRINGIFY velox/experimental/wave/common/Scan.cuh >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/vector/Operand.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/exec/ErrorCode.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/exec/WaveCore.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/exec/ExprKernel.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/exec/Accumulators.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/exec/Join.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/HashTable.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/HashTable.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/hash.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/StringView.cuh" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/StringView.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/Hash.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/CompilerDefines.h" >> $JIT/Headers.h
-$STRINGIFY "velox/experimental/wave/common/Atomic.cuh" >> $JIT/Headers.h
+$STRINGIFY velox/experimental/wave/common/BitUtil.cuh >>$JIT/Headers.h
+$STRINGIFY velox/experimental/wave/common/Scan.cuh >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/vector/Operand.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/exec/ErrorCode.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/exec/WaveCore.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/exec/ExprKernel.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/exec/Accumulators.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/exec/Join.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/HashTable.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/HashTable.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/hash.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/StringView.cuh" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/StringView.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/Hash.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/CompilerDefines.h" >>$JIT/Headers.h
+$STRINGIFY "velox/experimental/wave/common/Atomic.cuh" >>$JIT/Headers.h
 cd velox/experimental/breeze || exit
-$STRINGIFY "breeze/platforms/cuda.cuh" >> ../../../$JIT/Headers.h
-$STRINGIFY "breeze/platforms/specialization/cuda-ptx.cuh" >> ../../../$JIT/Headers.h
-$STRINGIFY "breeze/platforms/platform.h" >> ../../../$JIT/Headers.h
-$STRINGIFY "breeze/utils/types.h" >> ../../../$JIT/Headers.h
+$STRINGIFY "breeze/platforms/cuda.cuh" >>../../../$JIT/Headers.h
+$STRINGIFY "breeze/platforms/specialization/cuda-ptx.cuh" >>../../../$JIT/Headers.h
+$STRINGIFY "breeze/platforms/platform.h" >>../../../$JIT/Headers.h
+$STRINGIFY "breeze/utils/types.h" >>../../../$JIT/Headers.h
 cd - || exit
 
-echo "}" >> $JIT/Headers.h
+echo "}" >>$JIT/Headers.h
 
 clang-format -i $JIT/Headers.h


### PR DESCRIPTION
Shellcheck is a linter for shell scripts with a lot of good hints collected over the years. Let's benefit from that knowledge!

In addition Meta uses shellcheck in the [internal linter](https://github.com/facebookincubator/velox/pull/13554#issuecomment-2963693247), so properly mirroring that on the OSS side will make merges smoother!

I have also added shfmt to keep the formatting standardized as well.