### PR TITLE
fix: Update copyright for Sphinx in conf.py so it's always the correct year

### DIFF
--- a/velox/docs/conf.py
+++ b/velox/docs/conf.py
@@ -38,7 +38,7 @@ sys.path.insert(0, os.path.abspath("ext"))
 # -- Project information -----------------------------------------------------
 
 project = "Velox"
-copyright = "TBD"
+copyright = '%Y' # this will make sure the copyright year is always correct.
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
This updates the copyright to always be the correct year: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-copyright