### PR TITLE
feat: Add property for query memory reclaimer priority

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -638,6 +638,11 @@ class QueryConfig {
   /// a single output for each input batch.
   static constexpr const char* kUnnestSplitOutput = "unnest_split_output";
 
+  /// Priority of the query in the memory pool reclaimer. Lower value means
+  /// higher priority. This is used in global arbitration victim selection.
+  static constexpr const char* kQueryMemoryReclaimerPriority =
+      "query_memory_reclaimer_priority";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -1160,6 +1165,11 @@ class QueryConfig {
 
   bool unnestSplitOutput() const {
     return get<bool>(kUnnestSplitOutput, true);
+  }
+
+  int32_t queryMemoryReclaimerPriority() const {
+    return get<int32_t>(
+        kQueryMemoryReclaimerPriority, std::numeric_limits<int32_t>::max());
   }
 
   template <typename T>

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -100,8 +100,10 @@ void QueryCtx::updateTracedBytesAndCheckLimit(uint64_t bytes) {
 std::unique_ptr<memory::MemoryReclaimer> QueryCtx::MemoryReclaimer::create(
     QueryCtx* queryCtx,
     memory::MemoryPool* pool) {
-  return std::unique_ptr<memory::MemoryReclaimer>(
-      new QueryCtx::MemoryReclaimer(queryCtx->shared_from_this(), pool));
+  return std::unique_ptr<memory::MemoryReclaimer>(new QueryCtx::MemoryReclaimer(
+      queryCtx->shared_from_this(),
+      pool,
+      queryCtx->queryConfig().queryMemoryReclaimerPriority()));
 }
 
 uint64_t QueryCtx::MemoryReclaimer::reclaim(

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -264,6 +264,11 @@ Memory Management
        memory limit for partial aggregation is automatically doubled up to `max_extended_partial_aggregation_memory`.
        This adaptation is disabled by default, since the value of `max_extended_partial_aggregation_memory` equals the
        value of `max_partial_aggregation_memory`. Specify higher value for `max_extended_partial_aggregation_memory` to enable.
+   * - query_memory_reclaimer_priority
+     - integer
+     - 2147483647
+     - Priority of the query in the memory pool reclaimer. Lower value means higher priority. This is used in
+       global arbitration victim selection.
 
 Spilling
 --------


### PR DESCRIPTION
Summary:
Add property for query memory reclaimer priority. Lower value means higher priority.
This is used in global arbitration victim selection.

Differential Revision: D76368365
