### PR TITLE
fix: unreachable-break issue in velox/common/base/RuntimeMetrics.cpp

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -80,7 +80,6 @@ std::string RuntimeMetric::toString() const {
           succinctNanos(min),
           succinctNanos(max),
           succinctNanos(count == 0 ? 0 : sum / count));
-      break;
     case RuntimeCounter::Unit::kBytes:
       return fmt::format(
           "sum:{}, count:{}, min:{}, max:{}, avg: {}",
@@ -89,7 +88,6 @@ std::string RuntimeMetric::toString() const {
           succinctBytes(min),
           succinctBytes(max),
           succinctBytes(count == 0 ? 0 : sum / count));
-      break;
     case RuntimeCounter::Unit::kNone:
       [[fallthrough]];
     default:


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: kletkavrubashku

Differential Revision: D76476286
