### PR TITLE
test(noisy_count_if): Add fuzzer result verifier for noisy_count_if(col, noise_scale)

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -33,6 +33,8 @@
 #include "velox/functions/prestosql/fuzzer/MapUnionSumInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxByResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/MinMaxInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/NoisyCountIfInputGenerator.h"
+#include "velox/functions/prestosql/fuzzer/NoisyCountIfResultVerifier.h"
 #include "velox/functions/prestosql/fuzzer/QDigestAggInputGenerator.h"
 #include "velox/functions/prestosql/fuzzer/QDigestAggResultVerifier.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -82,6 +84,8 @@ getCustomInputGenerators() {
       {"approx_percentile", std::make_shared<ApproxPercentileInputGenerator>()},
       {"qdigest_agg", std::make_shared<QDigestAggInputGenerator>()},
       {"map_union_sum", std::make_shared<MapUnionSumInputGenerator>()},
+      {"noisy_count_if_gaussian",
+       std::make_shared<NoisyCountIfInputGenerator>()},
   };
 }
 
@@ -133,7 +137,6 @@ int main(int argc, char** argv) {
       "max_data_size_for_stats",
       "any_value",
       // Skip non-deterministic functions.
-      "noisy_count_if_gaussian",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };
@@ -148,6 +151,7 @@ int main(int argc, char** argv) {
   using facebook::velox::exec::test::ArbitraryResultVerifier;
   using facebook::velox::exec::test::AverageResultVerifier;
   using facebook::velox::exec::test::MinMaxByResultVerifier;
+  using facebook::velox::exec::test::NoisyCountIfResultVerifier;
   using facebook::velox::exec::test::QDigestAggResultVerifier;
   using facebook::velox::exec::test::setupReferenceQueryRunner;
   using facebook::velox::exec::test::TransformResultVerifier;
@@ -199,6 +203,8 @@ int main(int argc, char** argv) {
           // https://github.com/facebookincubator/velox/issues/6330
           {"max_data_size_for_stats", nullptr},
           {"sum_data_size_for_stats", nullptr},
+          {"noisy_count_if_gaussian",
+           std::make_shared<NoisyCountIfResultVerifier>()},
       };
 
   using Runner = facebook::velox::exec::test::AggregationFuzzerRunner;

--- a/velox/functions/prestosql/fuzzer/NoisyCountIfInputGenerator.h
+++ b/velox/functions/prestosql/fuzzer/NoisyCountIfInputGenerator.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <vector>
+#include "velox/exec/fuzzer/InputGenerator.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::exec::test {
+
+class NoisyCountIfInputGenerator : public InputGenerator {
+ public:
+  std::vector<VectorPtr> generate(
+      const std::vector<TypePtr>& types,
+      VectorFuzzer& fuzzer,
+      FuzzerGenerator& rng,
+      memory::MemoryPool* pool) override {
+    vector_size_t size = static_cast<int32_t>(fuzzer.getOptions().vectorSize);
+    std::vector<VectorPtr> result;
+
+    // Make sure to use the same value of 'noiseScale' for all batches inputs,
+    // so we only set it once.
+    if (!noiseScale_.has_value()) {
+      noiseScale_ =
+          boost::random::uniform_real_distribution<double>(0.0, 10.0)(rng);
+    }
+
+    // Process each type in the input.
+    // Types of parameters in noisy_count_if(col, noiseScale, randomSeed)
+    VELOX_CHECK(types.size() >= 2);
+    for (size_t i = 0; i < types.size(); ++i) {
+      const auto& type = types[i];
+
+      // For the first boolean argument(col)
+      if (i == 0 && type->isBoolean()) {
+        // Create a simple boolean vector with alternating true/false values
+        auto flatVector = std::static_pointer_cast<BaseVector>(
+            BaseVector::create<FlatVector<bool>>(BOOLEAN(), size, pool));
+
+        // Add some nulls
+        for (vector_size_t j = 0; j < size; j += 10) {
+          if (j < size) {
+            flatVector->setNull(j, true);
+          }
+        }
+
+        result.push_back(flatVector);
+      }
+      // For the second argument (noise scale)
+      else if (i == 1) {
+        if (type->isDouble()) {
+          result.push_back(
+              BaseVector::createConstant(DOUBLE(), *noiseScale_, size, pool));
+        } else if (type->isBigint()) {
+          // Create a variant with the correct integer value
+          variant intValue = static_cast<int64_t>(*noiseScale_);
+          result.push_back(
+              BaseVector::createConstant(BIGINT(), intValue, size, pool));
+        }
+      }
+    }
+
+    return result;
+  }
+  void reset() override {
+    noiseScale_.reset();
+  }
+
+ private:
+  std::optional<double> noiseScale_;
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/NoisyCountIfResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/NoisyCountIfResultVerifier.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/fuzzer/ResultVerifier.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec::test {
+
+class NoisyCountIfResultVerifier : public ResultVerifier {
+ public:
+  bool supportsCompare() override {
+    return false;
+  }
+
+  bool supportsVerify() override {
+    return true;
+  }
+
+  void initialize(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<core::ExprPtr>& projections,
+      const std::vector<std::string>& groupingKeys,
+      const core::AggregationNode::Aggregate& aggregate,
+      const std::string& aggregateName) override {
+    VELOX_CHECK(!input.empty());
+    // Extract the noise scale from the function call.
+    extractNoiseScale(input[0]);
+
+    // Extract the column name to aggregate on
+    const auto& args = aggregate.call->inputs();
+    VELOX_CHECK_GE(args.size(), 1);
+    auto field = core::TypedExprs::asFieldAccess(args[0]);
+    VELOX_CHECK_NOT_NULL(field);
+    aggregateColumn_ = field->name();
+
+    groupingKeys_ = groupingKeys;
+    name_ = aggregateName;
+
+    // Create a function to get the expected result without noise.
+    auto countIfCall =
+        fmt::format("noisy_count_if_gaussian({}, 0.0)", aggregateColumn_);
+
+    // Add filter if distinct mask exists
+    if (aggregate.mask != nullptr) {
+      countIfCall += fmt::format(" filter (where {})", aggregate.mask->name());
+    }
+
+    // Execute plan to get expected result without noise
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .projectExpressions(projections)
+                    .singleAggregation(groupingKeys, {countIfCall})
+                    .planNode();
+
+    expectedNoNoise_ = AssertQueryBuilder(plan).copyResults(input[0]->pool());
+  }
+
+  bool compare(
+      [[maybe_unused]] const RowVectorPtr& result,
+      [[maybe_unused]] const RowVectorPtr& otherResult) override {
+    VELOX_UNSUPPORTED();
+  }
+
+  bool verify(const RowVectorPtr& result) override {
+    // The expected result and actual result are grouped by the same keys,
+    // but the rows may be in different order. So we need to union the results.
+    // Create sources for expected and actual results
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto expectedSource = PlanBuilder(planNodeIdGenerator)
+                              .values({expectedNoNoise_})
+                              .appendColumns({"'expected' as label"})
+                              .planNode();
+    auto actualSource = PlanBuilder(planNodeIdGenerator)
+                            .values({result})
+                            .appendColumns({"'actual' as label"})
+                            .planNode();
+
+    // Combine expected and actual results by grouping keys using map_agg
+    auto mapAgg = fmt::format("map_agg(label, {}) as m", name_);
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .localPartition({}, {expectedSource, actualSource})
+                    .singleAggregation(groupingKeys_, {mapAgg})
+                    .project({"m['actual'] as a", "m['expected'] as e"})
+                    .planNode();
+    auto combined = AssertQueryBuilder(plan).copyResults(result->pool());
+
+    // Extract actual and expected values
+    auto* actual = combined->childAt(0)->as<SimpleVector<int64_t>>();
+    auto* expected = combined->childAt(1)->as<SimpleVector<int64_t>>();
+
+    const auto numGroups = result->size();
+    VELOX_CHECK_EQ(numGroups, combined->size());
+
+    // Calculate allowed difference based on noise scale
+    const int64_t deviationMultiple = 50;
+    const double allowedFailureRate = 0.001;
+    const auto allowedDifference =
+        static_cast<int64_t>(deviationMultiple * noiseScale_);
+    const auto lowerBound = -allowedDifference;
+    const auto upperBound = allowedDifference;
+
+    // Check each group's result
+    int failures = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      // Skip verification for null rows
+      if (expected->isNullAt(i) || actual->isNullAt(i)) {
+        continue;
+      }
+
+      const auto actualValue = actual->valueAt(i);
+      const auto expectedValue = expected->valueAt(i);
+      const auto difference = actualValue - expectedValue;
+
+      // Check if actual value is within expected +/- allowedDifference
+      if (difference < lowerBound || difference > upperBound) {
+        LOG(ERROR) << fmt::format(
+            "noisy_count_if_gaussian result is outside the expected range.\n"
+            "  Group: {}\n"
+            "  Actual: {}\n"
+            "  Expected: {}\n"
+            "  Difference: {}\n"
+            "  Allowed range: [{}, {}] (noise_scale = {})",
+            i,
+            actualValue,
+            expectedValue,
+            difference,
+            expectedValue + lowerBound,
+            expectedValue + upperBound,
+            noiseScale_);
+        failures++;
+      }
+    }
+
+    // Allow a very small percentage of failures for large result sets
+    if (numGroups >= 50) {
+      const auto maxFailures = static_cast<int>(allowedFailureRate * numGroups);
+      if (failures > maxFailures) {
+        LOG(ERROR) << fmt::format(
+            "Too many failures: {} out of {} groups (max allowed: {})",
+            failures,
+            numGroups,
+            maxFailures);
+        return false;
+      }
+      return true;
+    }
+
+    // For small result sets, require all groups to pass
+    return failures == 0;
+  }
+
+  void reset() override {
+    noiseScale_ = 0.0;
+    name_.clear();
+    groupingKeys_.clear();
+    aggregateColumn_.clear();
+    expectedNoNoise_.reset();
+  }
+
+ private:
+  void extractNoiseScale(const RowVectorPtr& input) {
+    auto secondArg = input->childAt(1);
+    if (secondArg->type()->isDouble()) {
+      noiseScale_ = secondArg->as<SimpleVector<double>>()->valueAt(0);
+      return;
+    } else if (secondArg->type()->isBigint()) {
+      noiseScale_ = static_cast<double>(
+          secondArg->as<SimpleVector<int64_t>>()->valueAt(0));
+      return;
+    }
+  }
+
+  double noiseScale_{0.0};
+  std::string name_;
+  std::vector<std::string> groupingKeys_;
+  std::string aggregateColumn_;
+  RowVectorPtr expectedNoNoise_;
+};
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
### Added Support for Fuzz Testing of Noisy Count If Aggregation Function

This diff introduces two new classes: `NoisyCountIfInputGenerator` and `NoisyCountIfResultVerifier`, which are used to fuzz test the `noisy_count_if` aggregation function.

**Input Generator**

The `NoisyCountIfInputGenerator` class generates input data for the `noisy_count_if` aggregation function. It produces a vector of rows, where each row contains a set of columns that are used as input for the aggregation function.

**Result Verifier**

The `NoisyCountIfResultVerifier` class verifies the result of the `noisy_count_if` aggregation function. It compares the actual result with the expected result, which is generated using a deterministic algorithm.

**Integration with Fuzzer Framework**

The new input generator and result verifier are integrated with the fuzzer framework, which is used to test the robustness and performance of the `noisy_count_if` aggregation function. The fuzzer framework generates random input data, executes the aggregation function, and verifies the result using the result verifier.

This will start the fuzzer, which will generate random input data, execute the `noisy_count_if` aggregation function, and verify the result using the result verifier.

Differential Revision: D76486031
