### PR TITLE
fix(noisy_count_if): Fix potential issue with random_seed type

### DIFF
--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyCountAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyCountAccumulator.h
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
 #pragma once
 
@@ -31,9 +30,9 @@ struct NoisyCountAccumulator {
   double noiseScale{-1.0};
 
   // Add a field to store random seed
-  std::optional<int32_t> randomSeed{std::nullopt};
+  std::optional<int64_t> randomSeed{std::nullopt};
 
-  void setRandomSeed(int32_t seed) {
+  void setRandomSeed(int64_t seed) {
     randomSeed = seed;
   }
 
@@ -50,7 +49,7 @@ struct NoisyCountAccumulator {
 
   static size_t serializedSize() {
     return sizeof(uint64_t) + sizeof(double) +
-        sizeof(bool) /** has_random_seed flag */ + sizeof(int32_t);
+        sizeof(bool) /** has_random_seed flag */ + sizeof(int64_t);
   }
 
   void serialize(char* output) {
@@ -67,7 +66,7 @@ struct NoisyCountAccumulator {
     auto count = stream.read<uint64_t>();
     auto noiseScale = stream.read<double>();
     auto hasRandomSeed = stream.read<bool>();
-    auto randomSeed = stream.read<int32_t>();
+    auto randomSeed = stream.read<int64_t>();
     if (hasRandomSeed) {
       return NoisyCountAccumulator{count, noiseScale, randomSeed};
     }

--- a/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
@@ -213,7 +213,7 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
 
       if (args.size() == 3 && args[2]->isConstantEncoding() &&
           !decodedRandomSeed_.isNullAt(i)) {
-        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
       }
     });
   }
@@ -286,7 +286,7 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
 
       if (args.size() == 3 && args[2]->isConstantEncoding() &&
           !decodedRandomSeed_.isNullAt(i)) {
-        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int32_t>(i));
+        accumulator->setRandomSeed(decodedRandomSeed_.valueAt<int64_t>(i));
       }
     });
   }


### PR DESCRIPTION
Summary:
#### Fixed Potential Issue with Random Seed Type

The diff addresses a potential issue with the `randomSeed` type in the `NoisyCountAccumulator` class. The fix involves:

* Changing the type of `randomSeed` from `int32_t` to `int64_t` to ensure consistency.

These changes aim to prevent potential issues with the random seed value and ensure the correctness of the noisy count aggregation.

Differential Revision: D76485114
