### PR TITLE
fix: Fix resource release for memoizing constant folding expression

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1970,8 +1970,7 @@ void ExprSet::clear() {
   for (auto* memo : memoizingExprs_) {
     memo->clearMemo();
   }
-  distinctFields_.clear();
-  multiplyReferencedFields_.clear();
+  memoizingExprs_.clear();
 }
 
 void ExprSet::clearCache() {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -220,9 +220,9 @@ class Expr {
 
   void clearMemo() {
     baseOfDictionaryRepeats_ = 0;
-    baseOfDictionary_.reset();
-    baseOfDictionaryWeakPtr_.reset();
     baseOfDictionaryRawPtr_ = nullptr;
+    baseOfDictionaryWeakPtr_.reset();
+    baseOfDictionary_.reset();
     dictionaryCache_ = nullptr;
     cachedDictionaryIndices_ = nullptr;
   }


### PR DESCRIPTION
The `memoizingExprs_` of ExprSet is used to  track expressions that have been 
evaluated with dictionary memoization. This ensures that when the ExprSet is 
cleared, it can call `clearMemo` on each memoizing expression to release cached 
resources.

However, the constant folding uses an uninitialized ExprSet for eval. This 
breaks the invariant that `memoizingExprs_` relies on, which is that the Expr 
pointers will be alive for the lifetime of the ExprSet.

To fix this issue, this PR clears the execution state, including the
`memoizingExprs_`, of the ExprSet to avoid dangling Expr pointers being cached.

For reference, the stack was:

```
C  [libvelox.dylib+0x19350]  long std::__1::__libcpp_atomic_refcount_decrement[abi:ne180100]<long>(long&)+0x18
C  [libvelox.dylib+0x1929c]  std::__1::__shared_weak_count::__release_shared[abi:ne180100]()+0x1c
C  [libvelox.dylib+0x301b8]  std::__1::shared_ptr<facebook::velox::BaseVector>::~shared_ptr[abi:ne180100]()+0x40
C  [libvelox.dylib+0x30168]  std::__1::shared_ptr<facebook::velox::BaseVector>::~shared_ptr[abi:ne180100]()+0x1c
C  [libvelox.dylib+0xe7edc]  std::__1::shared_ptr<facebook::velox::BaseVector>::operator=[abi:ne180100](std::__1::shared_ptr<facebook::velox::BaseVector>&&)+0x40
C  [libvelox.dylib+0xf1c4f4]  facebook::velox::exec::Expr::clearMemo()+0x5c
C  [libvelox.dylib+0xfc032c]  facebook::velox::exec::ExprSet::clear()+0x70
C  [libvelox.dylib+0x8bb0fc0]  facebook::velox::exec::FilterProject::close()+0x44
C  [libvelox.dylib+0x8b5616c]  facebook::velox::exec::Driver::closeOperators()+0x84
C  [libvelox.dylib+0x8b557b0]  facebook::velox::exec::Driver::close()+0xac
```