### PR TITLE
feat(bit_map): Implement BitMap for SfmSketch

### DIFF
--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.cpp
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.h"
+#include <cstdint>
+#include <vector>
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox::functions::aggregate {
+
+using Allocator = facebook::velox::StlAllocator<int8_t>;
+
+BitMap::BitMap(uint32_t length, HashStringAllocator* allocator)
+    : length_(length), bits_(Allocator(allocator)) {
+  bits_.resize(velox::bits::nbytes(length_));
+}
+
+BitMap::BitMap(const char* serialized, HashStringAllocator* allocator)
+    : bits_(Allocator(allocator)) {
+  common::InputByteStream stream(serialized);
+  length_ = stream.read<uint32_t>();
+
+  bits_.resize(velox::bits::nbytes(static_cast<uint64_t>(length_)));
+  stream.copyTo(bits_.data(), static_cast<int>(bits_.size()));
+}
+
+bool BitMap::bitAt(uint32_t position) const {
+  return bits::isBitSet(bits_.data(), static_cast<uint64_t>(position));
+}
+
+void BitMap::setBit(uint32_t position, bool value) {
+  bits::setBit(bits_.data(), static_cast<uint64_t>(position), value);
+}
+
+void BitMap::flipBit(uint32_t position) {
+  bits::setBit(
+      bits_.data(),
+      static_cast<uint64_t>(position),
+      !bits::isBitSet(bits_.data(), position));
+}
+
+uint32_t BitMap::countBits() const {
+  const uint64_t* wordBits = reinterpret_cast<const uint64_t*>(bits_.data());
+  return static_cast<uint32_t>(bits::countBits(wordBits, 0, length_));
+}
+
+std::vector<int8_t, Allocator> BitMap::toCompactIntVector() const {
+  if (bits_.empty()) {
+    return std::vector<int8_t, Allocator>(Allocator(bits_.get_allocator()));
+  }
+
+  // Find the last non-zero byte.
+  const uint64_t* wordBits = reinterpret_cast<const uint64_t*>(bits_.data());
+  int32_t lastSetBit = bits::findLastBit(wordBits, 0, length_);
+
+  if (lastSetBit < 0) {
+    // No bits are set
+    return std::vector<int8_t, Allocator>(Allocator(bits_.get_allocator()));
+  }
+
+  // Calculate the byte index that contains the last set bit
+  int64_t lastNonZeroIndex = lastSetBit / 8;
+
+  return std::vector<int8_t, Allocator>(
+      bits_.begin(),
+      bits_.begin() + lastNonZeroIndex + 1,
+      Allocator(bits_.get_allocator()));
+}
+
+size_t BitMap::serializedSize() const {
+  return sizeof(uint32_t) + sizeof(int8_t) * toCompactIntVector().size();
+}
+
+void BitMap::serialize(char* output) const {
+  common::OutputByteStream stream(output);
+  auto compactVector = toCompactIntVector();
+  uint32_t serializedLength =
+      static_cast<uint32_t>(compactVector.size() * sizeof(int8_t));
+  stream.appendOne(serializedLength);
+  stream.append(
+      reinterpret_cast<const char*>(compactVector.data()),
+      static_cast<int32_t>(compactVector.size()));
+}
+
+BitMap BitMap::deserialize(
+    const char* bytes,
+    uint32_t actualLength, // this is the serialized length after truncation
+    uint32_t expectedLength, // this length equal to buckets * precison
+    HashStringAllocator* allocator) {
+  BitMap bitmap(expectedLength, allocator);
+
+  if (actualLength > 0) {
+    // Java's BitSet.toByteArray() returns bytes in little-endian format
+    // and truncates trailing zeros. We need to copy these bytes and
+    // ensure the rest of the bitmap is zero-initialized.
+    uint32_t bytesToCopy = std::min(
+        actualLength,
+        static_cast<uint32_t>(velox::bits::nbytes(expectedLength)));
+
+    std::memcpy(bitmap.getMutableBits().data(), bytes, bytesToCopy);
+  }
+
+  return bitmap;
+}
+
+void BitMap::bitwiseOr(const BitMap& other) {
+  VELOX_CHECK_NOT_NULL(other.bits_.data(), "Can't combine with null bitmap.");
+  VELOX_CHECK_EQ(
+      length_, other.length_, "Can't OR two bitmaps of different lengths.");
+
+  uint64_t* target = reinterpret_cast<uint64_t*>(bits_.data());
+  const uint64_t* right = reinterpret_cast<const uint64_t*>(other.bits_.data());
+  bits::orBits(target, right, 0, length_);
+}
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox::functions::aggregate {
+
+/// A C++ implementation of the Bitmap class used in SfmSketch.
+/// This is a wrapper around std::vector<int8_t> which provides functionality
+/// similar to Java's BitSet. We can't use existing C++ implementations of
+/// bit_map using std::vector<int64_> because they are not compatible with
+/// Java's BitSet.toByteArray() which truncates trailing 0s in byte size.
+class BitMap {
+ public:
+  explicit BitMap(uint32_t length, HashStringAllocator* allocator);
+
+  // This is for deserializing the bitmap from the intermediate varbinary (C++
+  // format).
+  BitMap(const char* serialized, HashStringAllocator* allocator);
+
+  bool bitAt(uint32_t position) const;
+
+  void setBit(uint32_t position, bool value);
+
+  void flipBit(uint32_t position);
+
+  uint32_t length() const {
+    return length_;
+  }
+
+  // This method returns reference to the underlying vector of bytes.
+  // used for deserialization.
+  std::vector<int8_t, facebook::velox::StlAllocator<int8_t>>& getMutableBits() {
+    return bits_;
+  }
+
+  // Count the number of bits set to 1.
+  uint32_t countBits() const;
+
+  // This is for serializing and store the bitmap in the database.
+  // Strip trailing zeros in byte size and return the vector of integers.
+  std::vector<int8_t, facebook::velox::StlAllocator<int8_t>>
+  toCompactIntVector() const;
+
+  size_t serializedSize() const;
+
+  void serialize(char* output) const;
+
+  // Deserialize BitMap from truncated serialization,
+  // Simulate Java byte array (BitSet.toByteArray() format)
+  static BitMap deserialize(
+      const char* bytes,
+      uint32_t actualLength, // this is the serialized length after truncation
+      uint32_t expectedLength, // this length equal to buckets * precison
+      HashStringAllocator* allocator);
+
+  void bitwiseOr(const BitMap& other);
+
+  template <typename RandomizationStrategy>
+  void flipBit(
+      uint32_t position,
+      double probability,
+      RandomizationStrategy randomizationStrategy) {
+    if (randomizationStrategy.nextBoolean(probability)) {
+      flipBit(position);
+    }
+  }
+
+  template <typename RandomizationStrategy>
+  void flipAll(
+      double probability,
+      RandomizationStrategy randomizationStrategy) {
+    for (uint32_t i = 0; i < length_; ++i) {
+      if (randomizationStrategy.nextBoolean(probability)) {
+        flipBit(i);
+      }
+    }
+  }
+
+ private:
+  uint32_t length_;
+  std::vector<int8_t, facebook::velox::StlAllocator<int8_t>> bits_;
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_functions_aggregates_noisy_sketch BitMap.cpp)
+
+target_link_libraries(
+  velox_functions_aggregates_noisy_sketch
+  velox_common_base
+  velox_memory)
+
+target_include_directories(
+  velox_functions_aggregates_noisy_sketch
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../../..)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/RandomizationStrategy.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/RandomizationStrategy.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::functions::aggregate {
+
+class RandomizationStrategy {
+ public:
+  virtual bool nextBoolean(double probability) = 0;
+
+  virtual ~RandomizationStrategy() = default;
+
+  // Explicitly default copy constructor and copy assignment operator
+  RandomizationStrategy(const RandomizationStrategy&) = default;
+  RandomizationStrategy& operator=(const RandomizationStrategy&) = default;
+  RandomizationStrategy(RandomizationStrategy&&) = default;
+  RandomizationStrategy& operator=(RandomizationStrategy&&) = default;
+
+ protected:
+  // Allow default construction for derived classes
+  RandomizationStrategy() = default;
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/SecureRandomizationStrategy.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/SecureRandomizationStrategy.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Random.h>
+#include "velox/functions/lib/aggregates/noisy_aggregation/sketch/RandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class SecureRandomizationStrategy : public RandomizationStrategy {
+ public:
+  SecureRandomizationStrategy() = default;
+
+  bool nextBoolean(double probability) override {
+    // folly random generate random number in [0, 1)
+    return folly::Random::secureRandDouble01() < probability;
+  }
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/tests/BitMapTest.cpp
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/tests/BitMapTest.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/aggregates/noisy_aggregation/sketch/BitMap.h"
+#include "gtest/gtest.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/lib/aggregates/noisy_aggregation/sketch/RandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+// In tests, we use the default allocator (StlAllocator) which works with
+// HashStringAllocator.
+using Allocator = facebook::velox::StlAllocator<int8_t>;
+
+class BitMapTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+ protected:
+  BitMap CreateBitMap(uint32_t length) {
+    return BitMap(length, &allocator_);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+class RandomizationStrategyForTest : RandomizationStrategy {
+ public:
+  RandomizationStrategyForTest() : RandomizationStrategy() {}
+  bool nextBoolean(double p) override {
+    return p >= 0.5;
+  }
+};
+
+TEST_F(BitMapTest, basicBitMapTest) {
+  // Create a bit map with 983232 bits.
+  BitMap bitMap = CreateBitMap(983232);
+
+  for (uint32_t i = 0; i < bitMap.length(); i++) {
+    // All bits should be false initially.
+    ASSERT_TRUE(bitMap.bitAt(i) == false);
+  }
+
+  // Set the bits at indices vector to true.
+  std::vector<uint32_t> indices = {
+      1, 4, 6, 8, 32, 323, 873, 9887, 33778, 787666};
+
+  for (const auto& index : indices) {
+    bitMap.setBit(index, true);
+  }
+
+  // Verify that the bits at indices vector are set to true,
+  // and all other bits are set to false.
+  for (uint32_t i = 0; i < bitMap.length(); i++) {
+    if (std::find(indices.begin(), indices.end(), i) != indices.end()) {
+      ASSERT_TRUE(bitMap.bitAt(i) == true);
+    } else {
+      ASSERT_TRUE(bitMap.bitAt(i) == false);
+    }
+  }
+
+  // Count the number of bits set to true.
+  ASSERT_EQ(bitMap.countBits(), indices.size());
+
+  // Flip the bits back to false at the indices vector.
+  for (const auto& index : indices) {
+    bitMap.flipBit(index);
+  }
+
+  // Verify that the all bits are set to false,
+  for (uint32_t i = 0; i < bitMap.length(); i++) {
+    ASSERT_TRUE(bitMap.bitAt(i) == false);
+  }
+}
+
+TEST_F(BitMapTest, randomFlipTest) {
+  BitMap bitMap = CreateBitMap(24);
+
+  // Flip the bit if p >= 0.5.
+  RandomizationStrategyForTest randomizationStrategy;
+
+  bitMap.flipBit(0, 0.6, randomizationStrategy);
+  ASSERT_TRUE(bitMap.bitAt(0));
+
+  bitMap.flipBit(0, 0.6, randomizationStrategy);
+  ASSERT_FALSE(bitMap.bitAt(0));
+
+  bitMap.flipBit(0, 0.4, randomizationStrategy);
+  ASSERT_FALSE(bitMap.bitAt(0));
+
+  bitMap.flipAll(0.7, randomizationStrategy);
+  for (uint32_t i = 0; i < bitMap.length(); i++) {
+    ASSERT_TRUE(bitMap.bitAt(i));
+  }
+
+  bitMap.flipAll(0.3, randomizationStrategy);
+  for (uint32_t i = 0; i < bitMap.length(); i++) {
+    ASSERT_TRUE(bitMap.bitAt(i));
+  }
+}
+
+TEST_F(BitMapTest, bitwiseOrTest) {
+  std::vector<int8_t> bits1 = {1, 4, 6, 32, 21, 56, 99, 8, 32, 45};
+  std::vector<int8_t> bits2 = {33, 23, 11, 56, 99, 8, 32, 32, 87, 98};
+
+  BitMap bitMap1 = CreateBitMap(static_cast<uint32_t>(bits1.size()) * 8);
+  BitMap bitMap2 = CreateBitMap(static_cast<uint32_t>(bits2.size()) * 8);
+
+  // Initialize bitMap1 with bits1 data
+  for (auto i = 0; i < bits1.size(); ++i) {
+    for (auto bit = 0; bit < 8; ++bit) {
+      if (bits1[i] & (1 << bit)) {
+        bitMap1.setBit(static_cast<uint32_t>(i * 8 + bit), true);
+      }
+    }
+  }
+
+  // Initialize bitMap2 with bits2 data
+  for (auto i = 0; i < bits2.size(); ++i) {
+    for (auto bit = 0; bit < 8; ++bit) {
+      if (bits2[i] & (1 << bit)) {
+        bitMap2.setBit(static_cast<uint32_t>(i * 8 + bit), true);
+      }
+    }
+  }
+
+  BitMap bitMap3 = CreateBitMap(bitMap1.length());
+  // Copy bitMap1 to bitMap3
+  for (uint32_t i = 0; i < bitMap1.length(); ++i) {
+    bitMap3.setBit(i, bitMap1.bitAt(i));
+  }
+  bitMap1.bitwiseOr(bitMap2);
+
+  for (uint32_t i = 0; i < bitMap1.length(); i++) {
+    ASSERT_EQ(bitMap1.bitAt(i), bitMap3.bitAt(i) || bitMap2.bitAt(i));
+  }
+}
+
+// Test the serialization and deserialization of a bit map.
+// we can deserialize an integer vector to a bit map.
+// We can also serialize a bit map to an integer vector.
+// During the serialization, we drop the trailing zeros to save space.
+TEST_F(BitMapTest, truncateSerializeDeserializeTest) {
+  // Create a bit map from a bigint integer vector.
+  std::vector<int8_t> bits = {100, 4, 6, 33, 21, 56, 99, 8, 32, 32};
+  BitMap bitMap = CreateBitMap(static_cast<uint32_t>(bits.size()) * 8);
+
+  // Initialize bitMap with bits data
+  for (auto i = 0; i < bits.size(); ++i) {
+    for (auto bit = 0; bit < 8; ++bit) {
+      if (bits[i] & (1 << bit)) {
+        bitMap.setBit(static_cast<uint32_t>(i * 8 + bit), true);
+      }
+    }
+  }
+
+  // Intentionally set the last 40 bits to false.
+  for (uint32_t i = 0; i < 40; i++) {
+    bitMap.setBit(i + bitMap.length() - 40, false);
+  }
+
+  // Serialize the bit map. the expected behavior is that the trailing zeros
+  // will be dropped.
+  auto serialized = bitMap.toCompactIntVector();
+  ASSERT_EQ(serialized.size(), 5);
+
+  // Assert that the serialized vector is the same as the original vector.
+  for (uint32_t i = 0; i < 5; i++) {
+    ASSERT_EQ(serialized[i], bits[i]);
+  }
+}
+
+TEST_F(BitMapTest, fullLengthSerializeDeserializeTest) {
+  // Create a bitmap with 1024 bits
+  BitMap bitMap = CreateBitMap(1024);
+
+  // Set specific bits, make shure the last bit is not 0.
+  std::vector<uint32_t> indices = {1, 4, 6, 8, 32, 323, 1023};
+  for (const auto& index : indices) {
+    bitMap.setBit(index, true);
+  }
+
+  // Serialize the bitmap
+  auto serialized = bitMap.toCompactIntVector();
+
+  // Create new bitmap from serialized data
+  BitMap newBitMap = CreateBitMap(1024);
+
+  // Initialize newBitMap with serialized data
+  for (auto i = 0; i < serialized.size(); ++i) {
+    for (auto bit = 0; bit < 8; ++bit) {
+      if (serialized[i] & (1 << bit)) {
+        newBitMap.setBit(static_cast<uint32_t>(i * 8 + bit), true);
+      }
+    }
+  }
+
+  // Verify that only originally set bits are set in new bitmap
+  for (uint32_t i = 0; i < newBitMap.length(); i++) {
+    if (std::find(indices.begin(), indices.end(), i) != indices.end()) {
+      ASSERT_TRUE(newBitMap.bitAt(i));
+    } else {
+      ASSERT_FALSE(newBitMap.bitAt(i));
+    }
+  }
+}
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/noisy_aggregation/sketch/tests/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/noisy_aggregation/sketch/tests/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_functions_aggregates_noisy_sketch_test BitMapTest.cpp)
+
+add_test(NAME velox_functions_aggregates_noisy_sketch_test
+         COMMAND velox_functions_aggregates_noisy_sketch_test)
+
+target_link_libraries(
+  velox_functions_aggregates_noisy_sketch_test
+  velox_functions_aggregates_noisy_sketch
+  velox_core
+  Folly::folly
+  GTest::gtest
+  GTest::gtest_main
+  glog::glog)


### PR DESCRIPTION
Summary:
**New Implementation of BitMap for SfmSketch**
==============================================

This diff introduces a new implementation of the `BitMap` class, which is used in the `SfmSketch` aggregation function. The `BitMap` class is a wrapper around `std::vector<int64_t>` and provides functionality similar to Java's `BitSet`.

**Changes**
-----------

The following files have been added or modified:

* `BitMap.h`: New header file for the `BitMap` class.
* `CMakeLists.txt`: New file added to the `sketch` directory.
* `tests/BUCK`: New file added to the `tests` directory.
* `tests/BitMapTest.cpp`: New test file for the `BitMap` class.
* `RandomizationStrategy.h`: New header file for the `RandomizationStrategy` class.

**Functionality**
-----------------

The `BitMap` class provides the following functionality:

* Construction from an `int64_t` length parameter.
* Resizing of the underlying bit vector using `velox::bits::nwords`.

The `RandomizationStrategy` class is also introduced, which provides a virtual interface for generating random boolean values.

**Testing**
------------

A new test file `BitMapTest.cpp` has been added to verify the correctness of the `BitMap` class.

Differential Revision: D76522246
