### PR TITLE
feat: Optimize nested loop other join types with small build side

### DIFF
--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -305,6 +305,26 @@ Velox implements an optimization to finish the join early and return an empty
 set of results without waiting to receive all the probe side input. In this case
 all upstream operators are canceled to avoid unnecessary computation.
 
+Small Build Side Inputs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Nested loop join materializes the entire build side before producing output.
+When the build side is small enough to fit into a single row or a single
+vector, Velox uses specialized paths to avoid processing one probe row at a
+time.
+
+If the build side has a single row, build-side projections are wrapped as
+constants and evaluated against the whole probe batch at once. If the build
+side has a single vector, Velox wraps probe-side and build-side rows in
+dictionaries and evaluates the join condition over a batched cross product that
+covers as many probe rows as fit within ``outputBatchSize_``.
+
+These paths reduce repeated cross-product materialization and join-condition
+setup for small build inputs while preserving the usual nested loop join
+semantics, including probe-side output order for inner and left joins. If the
+build side spans multiple vectors, Velox falls back to processing one probe row
+against one build vector at a time.
+
 Skipping Duplicate Keys
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -328,7 +328,102 @@ void NestedLoopJoinProbe::handleLeftSemiProjectNoCondition() {
       ->asFlatVector<bool>()
       ->set(numOutputRows_ - 1, true);
   buildIndex_ = buildVectors_.value().size();
+  filterResultRow_ = 0;
+}
+
+bool NestedLoopJoinProbe::addSingleProbeRowOutput(
+    const RowVectorPtr& buildVector) {
+  for (size_t i = filterResultRow_; i < decodedFilterResult_.size(); ++i) {
+    buildRow_ = i;
+
+    if (!isJoinConditionMatch(i)) {
+      if (buildRow_ + 1 != buildVector->size() || !checkProbeMismatchRow()) {
+        continue;
+      }
+    } else {
+      if (needsBuildMismatch(joinType_)) {
+        buildMatched_[buildIndex_].setValid(buildRow_, true);
+      }
+      addOutputRow();
+      ++numOutputRows_;
+      probeRowHasMatch_ = true;
+
+      if (isLeftSemiProjectJoin(joinType_)) {
+        output_->childAt(outputType_->size() - 1)
+            ->asFlatVector<bool>()
+            ->set(numOutputRows_ - 1, true);
+        buildIndex_ = buildVectors_.value().size();
+        filterResultRow_ = 0;
+        buildRow_ = 0;
+        return true;
+      }
+    }
+
+    if (numOutputRows_ == outputBatchSize_) {
+      filterResultRow_ = i + 1;
+      copyBuildValues(buildVector);
+      return false;
+    }
+  }
+
+  copyBuildValues(buildVector);
+  ++buildIndex_;
+  filterResultRow_ = 0;
   buildRow_ = 0;
+  return true;
+}
+
+bool NestedLoopJoinProbe::addMultiProbeRowsOutput(
+    const RowVectorPtr& buildVector) {
+  const auto buildRowCount = buildVector->size();
+  probeRowHasMatch_ = buildRow_ == 0 ? false : probeRowHasMatch_;
+
+  for (size_t i = filterResultRow_; i < decodedFilterResult_.size(); ++i) {
+    if (!isJoinConditionMatch(i)) {
+      if (buildRow_ + 1 == buildRowCount) {
+        checkProbeMismatchRow();
+      }
+    } else {
+      if (needsBuildMismatch(joinType_)) {
+        buildMatched_[buildIndex_].setValid(buildRow_, true);
+      }
+      addOutputRow();
+      ++numOutputRows_;
+      probeRowHasMatch_ = true;
+
+      if (isLeftSemiProjectJoin(joinType_)) {
+        output_->childAt(outputType_->size() - 1)
+            ->asFlatVector<bool>()
+            ->set(numOutputRows_ - 1, true);
+        filterResultRow_ = i + (buildRowCount - buildRow_);
+        ++probeRow_;
+        buildRow_ = 0;
+        probeRowHasMatch_ = false;
+        return true;
+      }
+    }
+
+    ++buildRow_;
+    if (buildRow_ == buildRowCount) {
+      buildRow_ = 0;
+      ++probeRow_;
+      probeRowHasMatch_ = false;
+    }
+
+    if (numOutputRows_ == outputBatchSize_) {
+      filterResultRow_ = i + 1;
+      copyBuildValues(buildVector);
+      return false;
+    }
+  }
+
+  copyBuildValues(buildVector);
+  ++buildIndex_;
+  filterResultRow_ = 0;
+  probeRow_ = filterProbeRow_;
+  probeRowHasMatch_ = false;
+  buildRow_ = 0;
+  return true;
 }
 
 // Main join loop.
@@ -351,7 +446,7 @@ bool NestedLoopJoinProbe::addToOutput() {
     // Empty build vector; move to the next.
     if (currentBuild->size() == 0) {
       ++buildIndex_;
-      buildRow_ = 0;
+      filterResultRow_ = 0;
       continue;
     }
 
@@ -364,86 +459,41 @@ bool NestedLoopJoinProbe::addToOutput() {
       numOutputRows_ = output_->size();
       probeRowHasMatch_ = true;
       ++buildIndex_;
-      buildRow_ = 0;
+      filterResultRow_ = 0;
       return false;
     }
 
     // Handle LeftSemiProjectJoin with no join condition before evaluating the
-    // filter
+    // filter.
     if (isLeftSemiProjectNoCondition()) {
       handleLeftSemiProjectNoCondition();
       return true;
     }
 
     // Only re-calculate the filter if we have a new build vector.
-    if (buildRow_ == 0) {
+    if (filterResultRow_ == 0) {
+      buildRow_ = 0;
+      filterProbeRow_ = probeRow_;
       evaluateJoinFilter(currentBuild);
     }
 
-    // Iterate over the filter results. For each match, add an output record.
-    for (size_t i = buildRow_; i < decodedFilterResult_.size(); ++i) {
-      if (!isJoinConditionMatch(i)) {
-        continue;
-      }
-
-      addOutputRow(i);
-      ++numOutputRows_;
-      probeRowHasMatch_ = true;
-
-      // Left Semi Project Join within NestedLoopJoinProbe.
-      // The left join will ensure that exactly one row is
-      // produced for each probe row, along with a boolean "match" column
-      // which will indicate whether a matching build row exists on the
-      // build side.
-      //
-      // 1. At this point, the filter expressions are applied and we short
-      //    circuit the execution for a LeftSemiProject since we don't require
-      //    mismatch rows or build side projections. For each probe row, we
-      //    simply iterate through decoded filter results to determine if at
-      //    least one build side row satisfies the filter condition.
-      // 2. If match is found, the match column is marked as `true`, and
-      //    defaulted to false otherwise.
-      // 3. Ensures that only one row is produced in the output, handles
-      // mis-matched
-      //    probe side rows after evaluating the filter.
-      //
-      // Returns a `RowVectorPtr` representing the output row. For left semi
-      // project this basically contains probe row data with the match column.
-      //
-      if (isLeftSemiProjectJoin(joinType_)) {
-        output_->childAt(outputType_->size() - 1)
-            ->asFlatVector<bool>()
-            ->set(numOutputRows_ - 1, true);
-        buildIndex_ = buildVectors_.value().size();
-        buildRow_ = 0;
-        return true;
-      }
-
-      // If this is a right or full join, we need to keep track of the build
-      // records that got a hit (key match), so that at end we know which
-      // build records to add and which to skip.
-      if (needsBuildMismatch(joinType_)) {
-        buildMatched_[buildIndex_].setValid(i, true);
-      }
-
-      // If the buffer is full, save state and produce it as output.
-      if (numOutputRows_ == outputBatchSize_) {
-        buildRow_ = i + 1;
-        copyBuildValues(currentBuild);
+    if (probeRowCount_ == 1) {
+      if (!addSingleProbeRowOutput(currentBuild)) {
         return false;
       }
+      continue;
     }
 
-    // Before moving to the next build vector, copy the needed ranges.
-    copyBuildValues(currentBuild);
-    ++buildIndex_;
-    buildRow_ = 0;
+    if (!addMultiProbeRowsOutput(currentBuild)) {
+      return false;
+    }
   }
 
-  // Check if the current probed row needs to be added as a mismatch (for left
-  // and full outer joins).
-  checkProbeMismatchRow();
-
+  // If build side is empty, need to add mismatch row (for left, left semi and
+  // full outer joins)
+  if (isBuildSideEmpty()) {
+    checkProbeMismatchRow();
+  }
   // Signals that all input has been generated for the probeRow and build
   // vectors; safe to move to the next probe record.
   return true;
@@ -515,13 +565,11 @@ RowVectorPtr NestedLoopJoinProbe::getNextCrossProductBatch(
     const std::vector<IdentityProjection>& buildProjections) {
   VELOX_CHECK_GT(buildVector->size(), 0);
 
-  // TODO: For now we only enable the build optimizations in cross-joins, but we
-  // should allow it for other join types as well.
-  if (isCrossJoin() && isSingleBuildRow()) {
+  if (isSingleBuildRow()) {
     return genCrossProductSingleBuildRow(
         buildVector, outputType, probeProjections, buildProjections);
   }
-  if (isCrossJoin() && isSingleBuildVector()) {
+  if (isSingleBuildVector()) {
     return genCrossProductSingleBuildVector(
         buildVector, outputType, probeProjections, buildProjections);
   }
@@ -632,18 +680,22 @@ RowVectorPtr NestedLoopJoinProbe::genCrossProductMultipleBuildVectors(
       pool(), outputType, nullptr, numOutputRows, std::move(projectedChildren));
 }
 
-void NestedLoopJoinProbe::addOutputRow(vector_size_t buildRow) {
+void NestedLoopJoinProbe::addOutputRow() {
   // Probe side is always a dictionary; just populate the index.
   rawProbeOutputIndices_[numOutputRows_] = probeRow_;
 
   // For the build side, we accumulate the ranges to copy, then copy all of them
-  // at once. If records are consecutive and can have a single copy range run.
+  // at once. Merge adjacent ranges only when both the build source rows and the
+  // output target rows are contiguous; mismatch rows may create gaps in the
+  // target side even if buildRow_ stays consecutive.
   if (!buildCopyRanges_.empty() &&
+      (buildCopyRanges_.back().targetIndex + buildCopyRanges_.back().count) ==
+          numOutputRows_ &&
       (buildCopyRanges_.back().sourceIndex + buildCopyRanges_.back().count) ==
-          buildRow) {
+          buildRow_) {
     ++buildCopyRanges_.back().count;
   } else {
-    buildCopyRanges_.push_back({buildRow, numOutputRows_, 1});
+    buildCopyRanges_.push_back({buildRow_, numOutputRows_, 1});
   }
 }
 
@@ -677,15 +729,17 @@ void NestedLoopJoinProbe::addProbeMismatchRow() {
   }
 }
 
-void NestedLoopJoinProbe::checkProbeMismatchRow() {
+bool NestedLoopJoinProbe::checkProbeMismatchRow() {
   // If we are processing the last batch of the build side, check if we need
   // to add a probe mismatch record.
-  if (needsProbeMismatch(joinType_) && hasProbedAllBuildData() &&
-      !probeRowHasMatch_) {
+  if (needsProbeMismatch(joinType_) && !probeRowHasMatch_ &&
+      isLastBuildIndex()) {
     prepareOutput();
     addProbeMismatchRow();
     ++numOutputRows_;
+    return true;
   }
+  return false;
 }
 
 void NestedLoopJoinProbe::finishProbeInput() {

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -333,81 +333,47 @@ void NestedLoopJoinProbe::handleLeftSemiProjectNoCondition() {
 
 bool NestedLoopJoinProbe::addSingleProbeRowOutput(
     const RowVectorPtr& buildVector) {
-  for (size_t i = filterResultRow_; i < decodedFilterResult_.size(); ++i) {
-    buildRow_ = i;
-
-    if (!isJoinConditionMatch(i)) {
-      if (buildRow_ + 1 != buildVector->size() || !checkProbeMismatchRow()) {
-        continue;
-      }
-    } else {
-      if (needsBuildMismatch(joinType_)) {
-        buildMatched_[buildIndex_].setValid(buildRow_, true);
-      }
-      addOutputRow();
-      ++numOutputRows_;
-      probeRowHasMatch_ = true;
-
-      if (isLeftSemiProjectJoin(joinType_)) {
-        output_->childAt(outputType_->size() - 1)
-            ->asFlatVector<bool>()
-            ->set(numOutputRows_ - 1, true);
-        buildIndex_ = buildVectors_.value().size();
-        filterResultRow_ = 0;
-        buildRow_ = 0;
-        return true;
-      }
-    }
-
-    if (numOutputRows_ == outputBatchSize_) {
-      filterResultRow_ = i + 1;
-      copyBuildValues(buildVector);
-      return false;
-    }
-  }
-
-  copyBuildValues(buildVector);
-  ++buildIndex_;
-  filterResultRow_ = 0;
-  buildRow_ = 0;
-  return true;
+  return addFilteredOutput(buildVector, true);
 }
 
 bool NestedLoopJoinProbe::addMultiProbeRowsOutput(
     const RowVectorPtr& buildVector) {
+  return addFilteredOutput(buildVector, false);
+}
+
+bool NestedLoopJoinProbe::addFilteredOutput(
+    const RowVectorPtr& buildVector,
+    bool singleProbeRow) {
   const auto buildRowCount = buildVector->size();
-  probeRowHasMatch_ = buildRow_ == 0 ? false : probeRowHasMatch_;
+  if (!singleProbeRow && buildRow_ == 0) {
+    probeRowHasMatch_ = false;
+  }
 
   for (size_t i = filterResultRow_; i < decodedFilterResult_.size(); ++i) {
-    if (!isJoinConditionMatch(i)) {
-      if (buildRow_ + 1 == buildRowCount) {
-        checkProbeMismatchRow();
-      }
-    } else {
-      if (needsBuildMismatch(joinType_)) {
-        buildMatched_[buildIndex_].setValid(buildRow_, true);
-      }
-      addOutputRow();
-      ++numOutputRows_;
-      probeRowHasMatch_ = true;
-
-      if (isLeftSemiProjectJoin(joinType_)) {
-        output_->childAt(outputType_->size() - 1)
-            ->asFlatVector<bool>()
-            ->set(numOutputRows_ - 1, true);
-        filterResultRow_ = i + (buildRowCount - buildRow_);
-        ++probeRow_;
-        buildRow_ = 0;
-        probeRowHasMatch_ = false;
-        return true;
-      }
+    if (singleProbeRow) {
+      buildRow_ = i;
     }
 
-    ++buildRow_;
-    if (buildRow_ == buildRowCount) {
-      buildRow_ = 0;
-      ++probeRow_;
-      probeRowHasMatch_ = false;
+    if (!isJoinConditionMatch(i)) {
+      if (buildRow_ + 1 == buildRowCount) {
+        const auto addedMismatch = checkProbeMismatchRow();
+        if (singleProbeRow && !addedMismatch) {
+          continue;
+        }
+      } else if (singleProbeRow) {
+        continue;
+      }
+    } else if (handleMatchedFilterRow(i, buildRowCount, singleProbeRow)) {
+      return true;
+    }
+
+    if (!singleProbeRow) {
+      ++buildRow_;
+      if (buildRow_ == buildRowCount) {
+        buildRow_ = 0;
+        ++probeRow_;
+        probeRowHasMatch_ = false;
+      }
     }
 
     if (numOutputRows_ == outputBatchSize_) {
@@ -420,9 +386,43 @@ bool NestedLoopJoinProbe::addMultiProbeRowsOutput(
   copyBuildValues(buildVector);
   ++buildIndex_;
   filterResultRow_ = 0;
-  probeRow_ = filterProbeRow_;
-  probeRowHasMatch_ = false;
   buildRow_ = 0;
+  if (!singleProbeRow) {
+    probeRow_ = filterProbeRow_;
+    probeRowHasMatch_ = false;
+  }
+  return true;
+}
+
+bool NestedLoopJoinProbe::handleMatchedFilterRow(
+    vector_size_t filterResultRow,
+    vector_size_t buildRowCount,
+    bool singleProbeRow) {
+  if (needsBuildMismatch(joinType_)) {
+    buildMatched_[buildIndex_].setValid(buildRow_, true);
+  }
+  addOutputRow();
+  ++numOutputRows_;
+  probeRowHasMatch_ = true;
+
+  if (!isLeftSemiProjectJoin(joinType_)) {
+    return false;
+  }
+
+  output_->childAt(outputType_->size() - 1)
+      ->asFlatVector<bool>()
+      ->set(numOutputRows_ - 1, true);
+
+  if (singleProbeRow) {
+    buildIndex_ = buildVectors_.value().size();
+    filterResultRow_ = 0;
+    buildRow_ = 0;
+  } else {
+    filterResultRow_ = filterResultRow + (buildRowCount - buildRow_);
+    ++probeRow_;
+    buildRow_ = 0;
+    probeRowHasMatch_ = false;
+  }
   return true;
 }
 

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -166,6 +166,19 @@ class NestedLoopJoinProbe : public Operator {
   // filled up and must be produced immediately.
   bool addMultiProbeRowsOutput(const RowVectorPtr& buildVector);
 
+  // Shared implementation for processing filtered join output.
+  // `singleProbeRow` indicates whether decodedFilterResult_ covers one probe
+  // row or a batch of probe rows.
+  bool addFilteredOutput(const RowVectorPtr& buildVector, bool singleProbeRow);
+
+  // Handles output state for a matched filter row. Returns true if processing
+  // should stop immediately, e.g. left semi project found a match for the
+  // current probe row.
+  bool handleMatchedFilterRow(
+      vector_size_t filterResultRow,
+      vector_size_t buildRowCount,
+      bool singleProbeRow);
+
   // Generates the next batch of a cross product between probe and build. It
   // should be used as the entry point, and will internally delegate to one of
   // the three functions below.

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -153,6 +153,19 @@ class NestedLoopJoinProbe : public Operator {
         decodedFilterResult_.valueAt<bool>(i));
   }
 
+  // Processes a decoded filter batch that corresponds to a single probe row.
+  // Returns false if output_ filled up and must be produced immediately.
+  bool addSingleProbeRowOutput(const RowVectorPtr& buildVector);
+
+  // Processes a decoded filter batch that corresponds to multiple probe rows.
+  // This path is used only for small build-side fast paths where a single
+  // build row or build vector can be evaluated against multiple probe rows at
+  // once. filterResultRow_ is a linear offset within that decoded batch, while
+  // filterProbeRow_ stores the first probe row covered by the batch so that the
+  // operator can resume correctly after yielding. Returns false if output_
+  // filled up and must be produced immediately.
+  bool addMultiProbeRowsOutput(const RowVectorPtr& buildVector);
+
   // Generates the next batch of a cross product between probe and build. It
   // should be used as the entry point, and will internally delegate to one of
   // the three functions below.
@@ -195,12 +208,13 @@ class NestedLoopJoinProbe : public Operator {
   // zero-copy (dictionary indices), and build side projections are marked to be
   // copied using `buildCopyRanges_`; they will be copied later on by
   // `copyBuildValues()`.
-  void addOutputRow(vector_size_t buildRow);
+  void addOutputRow();
 
-  // Checks if it is required to add a probe mismatch row, and does it if
-  // needed. The caller needs to ensure there is available space in `output_`
-  // for the new record, which has nulled out build projections.
-  void checkProbeMismatchRow();
+  // Checks if it is required to add a probe mismatch row, does it and return
+  // true if needed, else return false. The caller needs to ensure there is
+  // available space in `output_` for the new record, which has nulled out build
+  // projections.
+  bool checkProbeMismatchRow();
 
   // Add a probe mismatch (only for left/full outer joins). The record is based
   // on the current probeRow and vector (input_) and build projections are null.
@@ -234,6 +248,12 @@ class NestedLoopJoinProbe : public Operator {
   // on buildIndex_'s value).
   bool hasProbedAllBuildData() const {
     return (buildIndex_ >= buildVectors_.value().size());
+  }
+
+  // Whether processing last batch of build data or processed all build data for
+  // the current probe row (based on buildIndex_'s value).
+  bool isLastBuildIndex() const {
+    return buildIndex_ + 1 >= buildVectors_.value().size();
   }
 
   // Cross joins are translated into NLJ's without a join conditition.
@@ -358,7 +378,19 @@ class NestedLoopJoinProbe : public Operator {
   // Index into `buildVectors_` for the build vector being currently processed.
   size_t buildIndex_{0};
 
-  // Row being currently processed from `buildVectors_[buildIndex_]`.
+  // Row being currently processed from `decodedFilterResult_`.
+  // For multi-probe fast paths this is a linear offset within one decoded
+  // batch, not a buildRow_ for the current probe row.
+  vector_size_t filterResultRow_{0};
+
+  // Probe row used to generate the current decodedFilterResult_. This stays
+  // fixed while resuming the same decoded filter batch across multiple calls to
+  // addToOutput(). probeRow_ advances while emitting rows from that batch, so
+  // it cannot be used as the stable batch origin for restoring filterResultRow_
+  // after yield.
+  vector_size_t filterProbeRow_{0};
+
+  // Row being currently processed from `buildVector_[buildIndex_]`.
   vector_size_t buildRow_{0};
 
   // Keep track of the build rows that had matches (only used for right or full

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -57,6 +57,62 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
     joinTypes_ = std::move(joinTypes);
   }
 
+  RowVectorPtr makeOutputOrderProbeVector() {
+    return makeRowVector(
+        {"probe_ordinal", "l1", "l2"},
+        {
+            makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5}),
+            makeNullableFlatVector<int64_t>({1, 8, 6, std::nullopt, 7, 4}),
+            makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}),
+        });
+  }
+
+  std::vector<RowVectorPtr> makeOutputOrderMultiVectorBuild() {
+    return {
+        makeRowVector(
+            {"build_ordinal", "r1", "r2"},
+            {
+                makeFlatVector<int64_t>({0, 1, 2}),
+                makeNullableFlatVector<int64_t>({4, 6, 1}),
+                makeFlatVector<StringView>({"z", "x", "y"}),
+            }),
+        makeRowVector(
+            {"build_ordinal", "r1", "r2"},
+            {
+                makeFlatVector<int64_t>({3, 4, 5}),
+                makeNullableFlatVector<int64_t>({10, std::nullopt, 6}),
+                makeFlatVector<StringView>({"z", "p", "u"}),
+            })};
+  }
+
+  RowVectorPtr makeOutputOrderSingleRowBuild() {
+    return makeRowVector(
+        {"build_ordinal", "r1", "r2"},
+        {
+            makeFlatVector<int64_t>({0}),
+            makeNullableFlatVector<int64_t>({8}),
+            makeFlatVector<StringView>({"c"}),
+        });
+  }
+
+  core::PlanNodePtr makeOutputOrderPlan(
+      const RowVectorPtr& probeVector,
+      const std::vector<RowVectorPtr>& buildVectors,
+      core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    return PlanBuilder(planNodeIdGenerator)
+        .values({probeVector})
+        .nestedLoopJoin(
+            PlanBuilder(planNodeIdGenerator)
+                .values(buildVectors)
+                .project({"build_ordinal", "r1", "r2"})
+                .planNode(),
+            "l1 < r1",
+            {"probe_ordinal", "l1", "l2", "build_ordinal", "r1", "r2"},
+            joinType)
+        .planNode();
+  }
+
   template <typename T>
   VectorPtr sequence(vector_size_t size, T start = 0) {
     return makeFlatVector<int32_t>(
@@ -509,35 +565,150 @@ TEST_F(NestedLoopJoinTest, allTypes) {
   runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
 
-// Ensures output order follows the probe input order for inner and left joins.
-TEST_F(NestedLoopJoinTest, outputOrder) {
-  auto probeVectors = makeRowVector(
+TEST_F(NestedLoopJoinTest, outputOrderWithSingleBuildVector) {
+  auto probeVector = makeOutputOrderProbeVector();
+  auto buildVectors = makeOutputOrderMultiVectorBuild();
+  const std::vector<uint32_t> sortingKeys = {0, 3};
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u_multi", buildVectors);
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(probeVector, buildVectors, core::JoinType::kInner),
+      duckDbQueryRunner_)
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t JOIN u_multi ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal",
+          sortingKeys);
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(probeVector, buildVectors, core::JoinType::kLeft),
+      duckDbQueryRunner_)
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t LEFT JOIN u_multi ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal NULLS LAST",
+          sortingKeys);
+}
+
+TEST_F(NestedLoopJoinTest, outputOrderWithSingleBuildRow) {
+  auto probeVector = makeOutputOrderProbeVector();
+  auto singleRowBuild = makeOutputOrderSingleRowBuild();
+  const std::vector<uint32_t> sortingKeys = {0, 3};
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u_single", {singleRowBuild});
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(
+          probeVector, {singleRowBuild}, core::JoinType::kInner),
+      duckDbQueryRunner_)
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t JOIN u_single ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal",
+          sortingKeys);
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(probeVector, {singleRowBuild}, core::JoinType::kLeft),
+      duckDbQueryRunner_)
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t LEFT JOIN u_single ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal NULLS LAST",
+          sortingKeys);
+}
+
+TEST_F(NestedLoopJoinTest, outputOrderWithMultipleBuildVectors) {
+  auto probeVector = makeOutputOrderProbeVector();
+  auto buildVectors = makeOutputOrderMultiVectorBuild();
+  const std::vector<uint32_t> sortingKeys = {0, 3};
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u_multi", buildVectors);
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(probeVector, buildVectors, core::JoinType::kInner),
+      duckDbQueryRunner_)
+      .config(core::QueryConfig::kMaxOutputBatchRows, "5")
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t JOIN u_multi ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal",
+          sortingKeys);
+
+  AssertQueryBuilder(
+      makeOutputOrderPlan(probeVector, buildVectors, core::JoinType::kLeft),
+      duckDbQueryRunner_)
+      .config(core::QueryConfig::kMaxOutputBatchRows, "5")
+      .assertResults(
+          "SELECT probe_ordinal, l1, l2, build_ordinal, r1, r2 "
+          "FROM t LEFT JOIN u_multi ON l1 < r1 "
+          "ORDER BY probe_ordinal, build_ordinal NULLS LAST",
+          sortingKeys);
+}
+
+TEST_F(NestedLoopJoinTest, addOutputRowWithContinuesBuildRow) {
+  auto probeVector = makeRowVector(
+      {"l1", "l2"},
+      {
+          makeNullableFlatVector<int64_t>({1, 8, 0}),
+          makeFlatVector<StringView>({"a", "b", "c"}),
+      });
+  auto buildVector = makeRowVector(
+      {"r1", "r2"},
+      {
+          makeNullableFlatVector<int64_t>({1, 1, 0}),
+          makeFlatVector<StringView>({"z", "x", "y"}),
+      });
+
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u", {buildVector});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto op =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVector})
+          .nestedLoopJoin(
+              PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+              "l1 = r1",
+              {"l1", "l2", "r1", "r2"},
+              core::JoinType::kLeft)
+          .planNode();
+
+  assertQuery(op, "SELECT l1, l2, r1, r2 FROM t LEFT JOIN u ON l1 = r1");
+}
+
+TEST_F(NestedLoopJoinTest, smallBuildSideOuterJoins) {
+  auto probeVector = makeRowVector(
       {"l1", "l2"},
       {
           makeNullableFlatVector<int64_t>({1, 8, 6, std::nullopt, 7, 4}),
           makeFlatVector<StringView>({"a", "b", "c", "d", "e", "f"}),
       });
-  auto buildVector1 = makeRowVector(
+  auto singleVectorBuild = makeRowVector(
       {"r1", "r2"},
       {
           makeNullableFlatVector<int64_t>({4, 6, 1}),
           makeFlatVector<StringView>({"z", "x", "y"}),
       });
-
-  auto buildVector2 = makeRowVector(
+  auto singleRowBuild = makeRowVector(
       {"r1", "r2"},
       {
-          makeNullableFlatVector<int64_t>({10, std::nullopt, 6}),
-          makeFlatVector<StringView>({"z", "p", "u"}),
+          makeNullableFlatVector<int64_t>({8}),
+          makeFlatVector<StringView>({"c"}),
       });
 
-  const auto createPlan = [&](core::JoinType joinType) {
+  createDuckDbTable("t", {probeVector});
+  createDuckDbTable("u_single_vector", {singleVectorBuild});
+  createDuckDbTable("u_single_row", {singleRowBuild});
+
+  const auto createPlan = [&](const RowVectorPtr& buildVector,
+                              core::JoinType joinType) {
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     return PlanBuilder(planNodeIdGenerator)
-        .values({probeVectors})
+        .values({probeVector})
         .nestedLoopJoin(
             PlanBuilder(planNodeIdGenerator)
-                .values({buildVector1, buildVector2})
+                .values({buildVector})
                 .project({"r1", "r2"})
                 .planNode(),
             "l1 < r1",
@@ -546,33 +717,18 @@ TEST_F(NestedLoopJoinTest, outputOrder) {
         .planNode();
   };
 
-  // Inner.
-  auto results = AssertQueryBuilder(createPlan(core::JoinType::kInner))
-                     .copyResults(pool());
-  auto expectedInner = makeRowVector({
-      makeNullableFlatVector<int64_t>({1, 1, 1, 1, 8, 6, 7, 4, 4, 4}),
-      makeFlatVector<StringView>(
-          {"a", "a", "a", "a", "b", "c", "e", "f", "f", "f"}),
-      makeNullableFlatVector<int64_t>({4, 6, 10, 6, 10, 10, 10, 6, 10, 6}),
-      makeFlatVector<StringView>(
-          {"z", "x", "z", "u", "z", "z", "z", "x", "z", "u"}),
-  });
-  assertEqualVectors(expectedInner, results);
-
-  // Left.
-  results =
-      AssertQueryBuilder(createPlan(core::JoinType::kLeft)).copyResults(pool());
-  auto expectedLeft = makeRowVector({
-      makeNullableFlatVector<int64_t>(
-          {1, 1, 1, 1, 8, 6, std::nullopt, 7, 4, 4, 4}),
-      makeNullableFlatVector<StringView>(
-          {"a", "a", "a", "a", "b", "c", "d", "e", "f", "f", "f"}),
-      makeNullableFlatVector<int64_t>(
-          {4, 6, 10, 6, 10, 10, std::nullopt, 10, 6, 10, 6}),
-      makeNullableFlatVector<StringView>(
-          {"z", "x", "z", "u", "z", "z", std::nullopt, "z", "x", "z", "u"}),
-  });
-  assertEqualVectors(expectedLeft, results);
+  assertQuery(
+      createPlan(singleVectorBuild, core::JoinType::kRight),
+      "SELECT l1, l2, r1, r2 FROM t RIGHT JOIN u_single_vector ON l1 < r1");
+  assertQuery(
+      createPlan(singleVectorBuild, core::JoinType::kFull),
+      "SELECT l1, l2, r1, r2 FROM t FULL JOIN u_single_vector ON l1 < r1");
+  assertQuery(
+      createPlan(singleRowBuild, core::JoinType::kRight),
+      "SELECT l1, l2, r1, r2 FROM t RIGHT JOIN u_single_row ON l1 < r1");
+  assertQuery(
+      createPlan(singleRowBuild, core::JoinType::kFull),
+      "SELECT l1, l2, r1, r2 FROM t FULL JOIN u_single_row ON l1 < r1");
 }
 
 TEST_F(NestedLoopJoinTest, mergeBuildVectors) {

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -677,7 +677,7 @@ TEST_F(NestedLoopJoinTest, addOutputRowWithContinuesBuildRow) {
   assertQuery(op, "SELECT l1, l2, r1, r2 FROM t LEFT JOIN u ON l1 = r1");
 }
 
-TEST_F(NestedLoopJoinTest, smallBuildSideOuterJoins) {
+TEST_F(NestedLoopJoinTest, smallBuildSideJoins) {
   auto probeVector = makeRowVector(
       {"l1", "l2"},
       {
@@ -702,6 +702,8 @@ TEST_F(NestedLoopJoinTest, smallBuildSideOuterJoins) {
   createDuckDbTable("u_single_row", {singleRowBuild});
 
   const auto createPlan = [&](const RowVectorPtr& buildVector,
+                              const std::string& condition,
+                              const std::vector<std::string>& outputLayout,
                               core::JoinType joinType) {
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     return PlanBuilder(planNodeIdGenerator)
@@ -711,24 +713,59 @@ TEST_F(NestedLoopJoinTest, smallBuildSideOuterJoins) {
                 .values({buildVector})
                 .project({"r1", "r2"})
                 .planNode(),
-            "l1 < r1",
-            {"l1", "l2", "r1", "r2"},
+            condition,
+            outputLayout,
             joinType)
         .planNode();
   };
 
+  const auto assertLeftSemiProject = [&](const RowVectorPtr& buildVector,
+                                         const std::string& tableName) {
+    AssertQueryBuilder(
+        createPlan(
+            buildVector,
+            "l1 = r1",
+            {"l1", "match"},
+            core::JoinType::kLeftSemiProject),
+        duckDbQueryRunner_)
+        .assertResults(
+            fmt::format(
+                "SELECT l1, EXISTS(SELECT 1 FROM {} WHERE l1 = r1) AS match "
+                "FROM t ORDER BY l1 NULLS LAST",
+                tableName));
+  };
+
   assertQuery(
-      createPlan(singleVectorBuild, core::JoinType::kRight),
+      createPlan(
+          singleVectorBuild,
+          "l1 < r1",
+          {"l1", "l2", "r1", "r2"},
+          core::JoinType::kRight),
       "SELECT l1, l2, r1, r2 FROM t RIGHT JOIN u_single_vector ON l1 < r1");
   assertQuery(
-      createPlan(singleVectorBuild, core::JoinType::kFull),
+      createPlan(
+          singleVectorBuild,
+          "l1 < r1",
+          {"l1", "l2", "r1", "r2"},
+          core::JoinType::kFull),
       "SELECT l1, l2, r1, r2 FROM t FULL JOIN u_single_vector ON l1 < r1");
   assertQuery(
-      createPlan(singleRowBuild, core::JoinType::kRight),
+      createPlan(
+          singleRowBuild,
+          "l1 < r1",
+          {"l1", "l2", "r1", "r2"},
+          core::JoinType::kRight),
       "SELECT l1, l2, r1, r2 FROM t RIGHT JOIN u_single_row ON l1 < r1");
   assertQuery(
-      createPlan(singleRowBuild, core::JoinType::kFull),
+      createPlan(
+          singleRowBuild,
+          "l1 < r1",
+          {"l1", "l2", "r1", "r2"},
+          core::JoinType::kFull),
       "SELECT l1, l2, r1, r2 FROM t FULL JOIN u_single_row ON l1 < r1");
+
+  assertLeftSemiProject(singleVectorBuild, "u_single_vector");
+  assertLeftSemiProject(singleRowBuild, "u_single_row");
 }
 
 TEST_F(NestedLoopJoinTest, mergeBuildVectors) {


### PR DESCRIPTION
follow #10726, optimize nested loop other join types with small build side, include inner, left, right, full outer and left semi join. 
Local test performance improved several times, in the following example, it takes 10 seconds before PR and 2 seconds after PR.
```
TEST_F(NestedLoopJoinTest, innerJoin) {
  auto probeVectors = {
    makeRowVector({sequence<int32_t>(1000000, 10)}),
    };

  auto buildVectors = {
    makeRowVector({sequence<int32_t>(10, 111)}),
    };

  createDuckDbTable("t", {probeVectors});
  createDuckDbTable("u", {buildVectors});

  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
  auto testOuterJoin = [&](core::JoinType joinType) {
    auto op = PlanBuilder(planNodeIdGenerator)
    .values({probeVectors})
    .nestedLoopJoin(
    PlanBuilder(planNodeIdGenerator)
    .values({buildVectors})
    .project({"c0 AS u_c0"})
    .planNode(),
    "c0 > u_c0",
    {"c0", "u_c0"},
    joinType)
    .singleAggregation({}, {"count(*)"})
    .planNode();
    assertQuery(
    op,
    fmt::format(
        "SELECT count(*) FROM t {} join u on t.c0>u.c0",
        core::joinTypeName(joinType)));
  };
  time_t start_time = time(NULL);
  testOuterJoin(core::JoinType::kInner);
  time_t end_time = time(NULL);
  double time_difference = difftime(end_time, start_time);
  std::cout << "Time difference: " << time_difference << " seconds" << std::endl;
}
```