### PR TITLE
fix: Fix RowNumber Fuzzer

### DIFF
--- a/velox/exec/fuzzer/RowNumberFuzzerBase.h
+++ b/velox/exec/fuzzer/RowNumberFuzzerBase.h
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "velox/common/fuzzer/Utils.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Split.h"
 #include "velox/exec/fuzzer/ReferenceQueryRunner.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -124,14 +125,14 @@ class RowNumberFuzzerBase {
       memory::memoryManager()->addRootPool(
           "rowNumberFuzzer",
           memory::kMaxMemory,
-          memory::MemoryReclaimer::create())};
+          exec::MemoryReclaimer::create())};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild(
       "rowNumberFuzzerLeaf",
       true,
-      memory::MemoryReclaimer::create())};
+      exec::MemoryReclaimer::create())};
   std::shared_ptr<memory::MemoryPool> writerPool_{rootPool_->addAggregateChild(
       "rowNumberFuzzerWriter",
-      memory::MemoryReclaimer::create())};
+      exec::MemoryReclaimer::create())};
   VectorFuzzer vectorFuzzer_;
   std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner_;
 };


### PR DESCRIPTION
Summary: RowNumber Fuzzer's source operator is a Values node which has an input that uses  an external memory pool (RowNumberFuzzerBase::pool_). This pool does not have proper reclaimer linked for driver execution, meaning when this pool triggers arbitration, it is unable to suspend the driver, making the following driver suspension check during arbitration process fail. The fix is to link the external memory pools with reclaimers having proper driver suspension mechanism, not the default memory reclaimer.

Differential Revision: D76602923
issue: https://github.com/facebookincubator/velox/issues/13737
