### PR TITLE
feat: Add a method in GeometryDeserializer to efficiently get envelope from a geometry

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -618,7 +618,7 @@ struct StXMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -633,7 +633,7 @@ struct StYMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -648,7 +648,7 @@ struct StXMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -663,7 +663,7 @@ struct StYMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }

--- a/velox/functions/prestosql/geospatial/GeometrySerde.cpp
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.cpp
@@ -53,6 +53,50 @@ std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::deserialize(
   }
 }
 
+const std::unique_ptr<geos::geom::Envelope>
+GeometryDeserializer::deserializeEnvelope(const StringView& geometry) {
+  velox::common::InputByteStream inputStream(geometry.data());
+  auto geometryType = static_cast<GeometrySerializationType>(
+      inputStream.read<GeometrySerializationType>());
+
+  switch (geometryType) {
+    case GeometrySerializationType::POINT:
+      return std::make_unique<geos::geom::Envelope>(
+          *readPoint(inputStream)->getEnvelopeInternal());
+    case GeometrySerializationType::MULTI_POINT:
+    case GeometrySerializationType::LINE_STRING:
+    case GeometrySerializationType::MULTI_LINE_STRING:
+    case GeometrySerializationType::POLYGON:
+    case GeometrySerializationType::MULTI_POLYGON:
+      skipEsriType(inputStream);
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::ENVELOPE:
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::GEOMETRY_COLLECTION:
+      return std::make_unique<geos::geom::Envelope>(
+          *readGeometryCollection(inputStream, geometry.size())
+               ->getEnvelopeInternal());
+    default:
+      VELOX_FAIL(
+          "Unrecognized geometry type: {}", static_cast<uint8_t>(geometryType));
+  }
+}
+
+std::unique_ptr<geos::geom::Envelope> GeometryDeserializer::deserializeEnvelope(
+    velox::common::InputByteStream& input) {
+  auto xMin = input.read<double>();
+  auto yMin = input.read<double>();
+  auto xMax = input.read<double>();
+  auto yMax = input.read<double>();
+
+  if (isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMax) ||
+      isEsriNaN(yMax)) {
+    return std::make_unique<geos::geom::Envelope>();
+  }
+
+  return std::make_unique<geos::geom::Envelope>(xMin, xMax, yMin, yMax);
+}
+
 geos::geom::Coordinate GeometryDeserializer::readCoordinate(
     velox::common::InputByteStream& input) {
   auto x = input.read<double>();
@@ -250,14 +294,6 @@ GeometryDeserializer::readGeometryCollection(
 
   return std::unique_ptr<geos::geom::GeometryCollection>(
       getGeometryFactory()->createGeometryCollection(rawGeometries));
-}
-
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry) {
-  std::unique_ptr<geos::geom::Geometry> geosGeometry =
-      geospatial::GeometryDeserializer::deserialize(geometry);
-  return std::make_unique<geos::geom::Envelope>(
-      *geosGeometry->getEnvelopeInternal());
 }
 
 } // namespace facebook::velox::functions::geospatial

--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -311,6 +311,9 @@ class GeometryDeserializer {
     return deserialize(inputStream, geometryString.size());
   }
 
+  static const std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      const StringView& geometry);
+
  private:
   static std::unique_ptr<geos::geom::Geometry> deserialize(
       velox::common::InputByteStream& stream,
@@ -327,6 +330,9 @@ class GeometryDeserializer {
   static void skipEnvelope(velox::common::InputByteStream& input) {
     input.read<double>(4); // Envelopes are 4 doubles (minX, minY, maxX, maxY)
   }
+
+  static std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      velox::common::InputByteStream& input);
 
   static geos::geom::Coordinate readCoordinate(
       velox::common::InputByteStream& input);
@@ -356,9 +362,5 @@ class GeometryDeserializer {
       velox::common::InputByteStream& input,
       size_t size);
 };
-
-/// Deserialize Velox's internal format to a geometry and get the Envelope.
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry);
 
 } // namespace facebook::velox::functions::geospatial


### PR DESCRIPTION
Summary
In Presto's internal geometry representation, the envelope of a geometry is stored alongside most geometry types. As noted in #13674, it is unnecessary to fully deserialize a geometry to compute its envelope — the envelope can be read directly. This PR introduces a method in `GeometryDeserializer` that efficiently retrieves the envelope without requiring full deserialization.
