### PR TITLE
feat: Reuse thread-local GeometryFactory instead of creating local instances

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -115,10 +115,6 @@ struct StAsBinaryFunction {
 
 template <typename T>
 struct StPointFunction {
-  StPointFunction() {
-    factory_ = geos::geom::GeometryFactory::create();
-  }
-
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE Status call(
@@ -132,15 +128,13 @@ struct StPointFunction {
     GEOS_TRY(
         {
           auto point = std::unique_ptr<geos::geom::Point>(
-              factory_->createPoint(geos::geom::Coordinate(x, y)));
+              geospatial::getGeometryFactory()->createPoint(
+                  geos::geom::Coordinate(x, y)));
           geospatial::GeometrySerializer::serialize(*point, result);
         },
         "Failed to create point geometry");
     return Status::OK();
   }
-
- private:
-  geos::geom::GeometryFactory::Ptr factory_;
 };
 
 // Predicates
@@ -548,11 +542,9 @@ struct StCentroidFunction {
     if (geosGeometry->getNumPoints() == 0) {
       GEOS_TRY(
           {
-            geos::geom::GeometryFactory::Ptr factory =
-                geos::geom::GeometryFactory::create();
-            std::unique_ptr<geos::geom::Point> point = factory->createPoint();
+            std::unique_ptr<geos::geom::Point> point =
+                geospatial::getGeometryFactory()->createPoint();
             geospatial::GeometrySerializer::serialize(*point, result);
-            factory->destroyGeometry(point.release());
           },
           "Failed to create point geometry");
       return Status::OK();

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -61,8 +61,7 @@ geos::geom::GeometryFactory* getGeometryFactory();
 FOLLY_ALWAYS_INLINE const
     std::unordered_map<geos::geom::GeometryTypeId, std::string>&
     getGeosTypeToStringIdentifier() {
-  static const geos::geom::GeometryFactory::Ptr factory =
-      geos::geom::GeometryFactory::create();
+  geos::geom::GeometryFactory* factory = getGeometryFactory();
 
   static const std::unordered_map<geos::geom::GeometryTypeId, std::string>
       geosTypeToStringIdentifier{


### PR DESCRIPTION
Summary
Currently, some functions create a new local instance of `GeometryFactory` on each call. This change replaces local instances by thread-local instances using function `getGeometryFactory()`.