### PR TITLE
misc: Add toString() to ColumnHandle

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -96,6 +96,10 @@ class ColumnHandle : public ISerializable {
     VELOX_UNSUPPORTED();
   }
 
+  virtual std::string toString() const {
+    VELOX_NYI();
+  }
+
   folly::dynamic serialize() const override;
 
  protected:

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -110,7 +110,7 @@ class HiveColumnHandle : public ColumnHandle {
         ColumnParseParameters::kDaysSinceEpoch;
   }
 
-  std::string toString() const;
+  std::string toString() const override;
 
   folly::dynamic serialize() const override;
 


### PR DESCRIPTION
We will need to add IcebergColumnHandle in the near future. To be consistent with other objects like ConnectorTableHandle, this commit adds toString as a virtual function in ColumnHandle.