### PR TITLE
feat: Add envelope-based short-circuit optimizations for geometry functions

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -618,7 +618,7 @@ struct StXMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -633,7 +633,7 @@ struct StYMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -648,7 +648,7 @@ struct StXMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -663,7 +663,7 @@ struct StYMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <geos/geom/Coordinate.h>
+#include <geos/geom/CoordinateArraySequence.h>
 #include <geos/geom/Envelope.h>
 #include <geos/io/WKBReader.h>
 #include <geos/io/WKBWriter.h>
@@ -25,6 +26,7 @@
 #include <geos/simplify/TopologyPreservingSimplifier.h>
 #include <geos/util/AssertionFailedException.h>
 #include <geos/util/UnsupportedOperationException.h>
+
 #include <cmath>
 
 #include <velox/type/StringView.h>
@@ -173,7 +175,12 @@ struct StContainsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Contains)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -193,7 +200,12 @@ struct StCrossesFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -213,7 +225,12 @@ struct StDisjointFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = true;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -233,7 +250,12 @@ struct StEqualsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Equals)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -253,7 +275,12 @@ struct StIntersectsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -273,7 +300,12 @@ struct StOverlapsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -293,7 +325,12 @@ struct StTouchesFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -313,7 +350,12 @@ struct StWithinFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
+    if (!geospatial::checkEnvelopePredicate(
+            rightGeometry, leftGeometry, geospatial::EnvelopeOp::Contains)) {
+      result = false;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -335,8 +377,12 @@ struct StDifferenceFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      result = leftGeometry;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -378,8 +424,18 @@ struct StIntersectionFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
+    auto leftType =
+        geospatial::GeometryDeserializer::deserializeType(leftGeometry);
+    auto rightType =
+        geospatial::GeometryDeserializer::deserializeType(rightGeometry);
+
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      geospatial::GeometrySerializer::serialize(
+          *geospatial::getGeometryFactory()->createPolygon(), result);
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -403,8 +459,23 @@ struct StSymDifferenceFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
+    // If envelopes are disjoint, return union of envelopes directly.
+    if (!geospatial::checkEnvelopePredicate(
+            leftGeometry, rightGeometry, geospatial::EnvelopeOp::Intersects)) {
+      // No intersection — symDifference is simply the union.
+      std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
+          geospatial::GeometryDeserializer::deserialize(leftGeometry);
+      std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
+          geospatial::GeometryDeserializer::deserialize(rightGeometry);
+
+      std::unique_ptr<geos::geom::Geometry> outputGeometry;
+      GEOS_TRY(outputGeometry = leftGeosGeometry->Union(&*rightGeosGeometry);
+               , "Failed to compute geometry union for disjoint symDifference");
+
+      geospatial::GeometrySerializer::serialize(*outputGeometry, result);
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -428,8 +499,30 @@ struct StUnionFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit if
-    // one/both are empty
+    auto leftEnvelope =
+        geospatial::GeometryDeserializer::deserializeEnvelope(leftGeometry);
+    auto rightEnvelope =
+        geospatial::GeometryDeserializer::deserializeEnvelope(rightGeometry);
+
+    // If both are empty, return empty polygon.
+    if (!leftEnvelope || leftEnvelope->isNull()) {
+      if (!rightEnvelope || rightEnvelope->isNull()) {
+        // Both are empty -> return empty polygon.
+        auto empty = geospatial::getGeometryFactory()->createPolygon();
+        geospatial::GeometrySerializer::serialize(*empty, result);
+        return Status::OK();
+      }
+      // Left is empty, return right.
+      result = rightGeometry;
+      return Status::OK();
+    }
+
+    if (!rightEnvelope || rightEnvelope->isNull()) {
+      // Right is empty, return left.
+      result = leftGeometry;
+      return Status::OK();
+    }
+
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =

--- a/velox/functions/prestosql/geospatial/GeometrySerde.cpp
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.cpp
@@ -53,6 +53,50 @@ std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::deserialize(
   }
 }
 
+const std::unique_ptr<geos::geom::Envelope>
+GeometryDeserializer::deserializeEnvelope(const StringView& geometry) {
+  velox::common::InputByteStream inputStream(geometry.data());
+  auto geometryType = static_cast<GeometrySerializationType>(
+      inputStream.read<GeometrySerializationType>());
+
+  switch (geometryType) {
+    case GeometrySerializationType::POINT:
+      return std::make_unique<geos::geom::Envelope>(
+          *readPoint(inputStream)->getEnvelopeInternal());
+    case GeometrySerializationType::MULTI_POINT:
+    case GeometrySerializationType::LINE_STRING:
+    case GeometrySerializationType::MULTI_LINE_STRING:
+    case GeometrySerializationType::POLYGON:
+    case GeometrySerializationType::MULTI_POLYGON:
+      skipEsriType(inputStream);
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::ENVELOPE:
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::GEOMETRY_COLLECTION:
+      return std::make_unique<geos::geom::Envelope>(
+          *readGeometryCollection(inputStream, geometry.size())
+               ->getEnvelopeInternal());
+    default:
+      VELOX_FAIL(
+          "Unrecognized geometry type: {}", static_cast<uint8_t>(geometryType));
+  }
+}
+
+std::unique_ptr<geos::geom::Envelope> GeometryDeserializer::deserializeEnvelope(
+    velox::common::InputByteStream& input) {
+  auto xMin = input.read<double>();
+  auto yMin = input.read<double>();
+  auto xMax = input.read<double>();
+  auto yMax = input.read<double>();
+
+  if (isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMax) ||
+      isEsriNaN(yMax)) {
+    return std::make_unique<geos::geom::Envelope>();
+  }
+
+  return std::make_unique<geos::geom::Envelope>(xMin, xMax, yMin, yMax);
+}
+
 geos::geom::Coordinate GeometryDeserializer::readCoordinate(
     velox::common::InputByteStream& input) {
   auto x = input.read<double>();
@@ -250,14 +294,6 @@ GeometryDeserializer::readGeometryCollection(
 
   return std::unique_ptr<geos::geom::GeometryCollection>(
       getGeometryFactory()->createGeometryCollection(rawGeometries));
-}
-
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry) {
-  std::unique_ptr<geos::geom::Geometry> geosGeometry =
-      geospatial::GeometryDeserializer::deserialize(geometry);
-  return std::make_unique<geos::geom::Envelope>(
-      *geosGeometry->getEnvelopeInternal());
 }
 
 } // namespace facebook::velox::functions::geospatial

--- a/velox/functions/prestosql/geospatial/GeometrySerde.cpp
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.cpp
@@ -82,6 +82,12 @@ GeometryDeserializer::deserializeEnvelope(const StringView& geometry) {
   }
 }
 
+const GeometrySerializationType GeometryDeserializer::deserializeType(
+    const StringView& geometry) {
+  return static_cast<GeometrySerializationType>(
+      static_cast<uint8_t>(geometry.data()[0]));
+}
+
 std::unique_ptr<geos::geom::Envelope> GeometryDeserializer::deserializeEnvelope(
     velox::common::InputByteStream& input) {
   auto xMin = input.read<double>();

--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -311,6 +311,9 @@ class GeometryDeserializer {
     return deserialize(inputStream, geometryString.size());
   }
 
+  static const std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      const StringView& geometry);
+
  private:
   static std::unique_ptr<geos::geom::Geometry> deserialize(
       velox::common::InputByteStream& stream,
@@ -327,6 +330,9 @@ class GeometryDeserializer {
   static void skipEnvelope(velox::common::InputByteStream& input) {
     input.read<double>(4); // Envelopes are 4 doubles (minX, minY, maxX, maxY)
   }
+
+  static std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      velox::common::InputByteStream& input);
 
   static geos::geom::Coordinate readCoordinate(
       velox::common::InputByteStream& input);
@@ -356,9 +362,5 @@ class GeometryDeserializer {
       velox::common::InputByteStream& input,
       size_t size);
 };
-
-/// Deserialize Velox's internal format to a geometry and get the Envelope.
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry);
 
 } // namespace facebook::velox::functions::geospatial

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -24,6 +24,7 @@
 #include <optional>
 
 #include "velox/common/base/Status.h"
+#include "velox/type/StringView.h"
 
 namespace facebook::velox::functions::geospatial {
 
@@ -57,6 +58,17 @@ namespace facebook::velox::functions::geospatial {
   }
 
 geos::geom::GeometryFactory* getGeometryFactory();
+
+enum class EnvelopeOp {
+  Contains,
+  Equals,
+  Intersects,
+};
+
+bool checkEnvelopePredicate(
+    const StringView& leftGeometry,
+    const StringView& rightGeometry,
+    EnvelopeOp op);
 
 FOLLY_ALWAYS_INLINE const
     std::unordered_map<geos::geom::GeometryTypeId, std::string>&


### PR DESCRIPTION
This PR introduces envelope-based short-circuit optimizations to various geometry functions.

By checking the envelopes of input geometries before performing full deserialization and expensive GEOS operations, the functions can now avoid unnecessary computation when the result is trivially determined by the envelopes alone.

**Note:** This PR depends on #13771 and can be landed after it is merged.