### PR TITLE
fix: FlatVector Ctor take ownership of Type shared_ptr

### DIFF
--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -54,7 +54,7 @@ class FlatVector final : public SimpleVector<T> {
 
   FlatVector(
       velox::memory::MemoryPool* pool,
-      const TypePtr& type,
+      TypePtr type,
       BufferPtr nulls,
       size_t length,
       BufferPtr values,


### PR DESCRIPTION
Summary:
FlatVector accepts a const & TypePtr. During our testing, the type_ set in recoding (runs asynchronously) went out of scope at access time.

Refer: P1843308469

Differential Revision: D76825242
