### PR TITLE
feat: Support to configure split index lookup output

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -607,6 +607,12 @@ class QueryConfig {
   static constexpr const char* kIndexLookupJoinMaxPrefetchBatches =
       "index_lookup_join_max_prefetch_batches";
 
+  /// If this is true, then the index join operator might split output for each
+  /// input batch based on the output batch size control. Otherwise, it tries to
+  /// produce a single output for each input batch.
+  static constexpr const char* kIndexLookupJoinSplitOutput =
+      "index_lookup_join_split_output";
+
   // Max wait time for exchange request in seconds.
   static constexpr const char* kRequestDataSizesMaxWaitSec =
       "request_data_sizes_max_wait_sec";
@@ -1132,6 +1138,10 @@ class QueryConfig {
 
   uint32_t indexLookupJoinMaxPrefetchBatches() const {
     return get<uint32_t>(kIndexLookupJoinMaxPrefetchBatches, 0);
+  }
+
+  bool indexLookupJoinSplitOutput() const {
+    return get<bool>(kIndexLookupJoinSplitOutput, true);
   }
 
   std::string shuffleCompressionKind() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -167,6 +167,12 @@ Generic Configuration
      - 0
      - Specifies the max number of input batches to prefetch to do index lookup ahead. If it is zero,
        then process one input batch at a time.
+   * - index_lookup_join_split_output
+     - bool
+     - true
+     - If this is true, then the index join operator might split output for each input batch based
+       on the output batch size control. Otherwise, it tries to produce a single output for each input
+       batch.
    * - unnest_split_output_batch
      - bool
      - true

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -154,6 +154,7 @@ class IndexLookupJoin : public Operator {
   // 'outputBatchSize'. This is only used by left join which needs to fill nulls
   // for output rows without lookup matches.
   void prepareOutputRowMappings(size_t outputBatchSize);
+
   // Prepare 'output_' for the next output batch with size of 'numOutputRows'.
   void prepareOutput(vector_size_t numOutputRows);
 

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -254,6 +254,7 @@ std::optional<std::unique_ptr<connector::IndexSource::LookupResult>>
 TestIndexSource::ResultIterator::next(
     vector_size_t size,
     ContinueFuture& future) {
+  const auto lookupSize = std::min(size, kMaxLookupSize);
   source_->checkNotFailed();
 
   if (hasPendingRequest_.exchange(true)) {
@@ -261,7 +262,7 @@ TestIndexSource::ResultIterator::next(
   }
 
   if (executor_ && !asyncResult_.has_value()) {
-    asyncLookup(size, future);
+    asyncLookup(lookupSize, future);
     return std::nullopt;
   }
 
@@ -274,7 +275,7 @@ TestIndexSource::ResultIterator::next(
     asyncResult_.reset();
     return result;
   }
-  return syncLookup(size);
+  return syncLookup(lookupSize);
 }
 
 void TestIndexSource::ResultIterator::extractLookupColumns(

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -158,6 +158,8 @@ class TestIndexSource : public connector::IndexSource,
         ContinueFuture& future) override;
 
    private:
+    static constexpr vector_size_t kMaxLookupSize = 8192;
+
     // Initializes the buffer used to store row pointers or indices for output
     // match result processing.
     template <typename T>


### PR DESCRIPTION
Summary: Add query config to avoid splitting index lookup output to optimize the followup operator processing like streaming aggregation which might be able to receive the entire lookup results for a given input or batch.

Differential Revision: D76243219
