### PR TITLE
fix(fuzzer): add noisy_count_if and noisy_count back to skipList

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -137,6 +137,9 @@ int main(int argc, char** argv) {
       "max_data_size_for_stats",
       "any_value",
       // Skip non-deterministic functions.
+      "noisy_count_gaussian",
+      // https://github.com/facebookincubator/velox/issues/13795
+      "noisy_count_if_gaussian",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };


### PR DESCRIPTION
Summary: Current verifier may fail edge cases, add noisy_count_if and noisy_count back to skipList.

Reviewed By: peterenescu

Differential Revision: D76843201
