### PR TITLE
misc: Optimize streaming agg performance

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -623,6 +623,13 @@ class QueryConfig {
   static constexpr const char* kStreamingAggregationMinOutputBatchRows =
       "streaming_aggregation_min_output_batch_rows";
 
+  /// If true, the streaming aggregation accumulates at least two input batches
+  /// and produce all the groups created from the previous input batch except
+  /// the last group.
+  static constexpr const char*
+      kStreamingAggregationTrySplitOutputAtInputBoundary =
+          "streaming_aggregation_try_split_output_at_input_boundary";
+
   /// TODO: Remove after dependencies are cleaned up.
   static constexpr const char* kStreamingAggregationEagerFlush =
       "streaming_aggregation_eager_flush";
@@ -1163,6 +1170,10 @@ class QueryConfig {
 
   int32_t streamingAggregationMinOutputBatchRows() const {
     return get<int32_t>(kStreamingAggregationMinOutputBatchRows, 0);
+  }
+
+  bool streamingAggregationTrySplitOutputAtInputBoundary() const {
+    return get<bool>(kStreamingAggregationTrySplitOutputAtInputBoundary, false);
   }
 
   bool isFieldNamesInJsonCastEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -450,6 +450,12 @@ Aggregation
      - In streaming aggregation, wait until we have enough number of output rows
        to produce a batch of size specified by this. If set to 0, then
        Operator::outputBatchRows will be used as the min output batch rows.
+   * - streaming_aggregation_try_split_output_at_input_boundary
+     - bool
+     - false
+     - If true, the streaming aggregation accumulates at least two batch inputs and
+       produce all the groups created from the previous input batch except the last
+       group.
 
 Table Scan
 ------------

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -87,11 +87,14 @@ class StreamingAggregation : public Operator {
   // Initialize the aggregations setting allocator and offsets.
   void initializeAggregates(uint32_t numKeys);
 
-  /// Maximum number of rows in the output batch.
+  // Maximum number of rows in the output batch.
   const vector_size_t maxOutputBatchSize_;
 
-  /// Maximum number of rows in the output batch.
+  // Maximum number of rows in the output batch.
   const vector_size_t minOutputBatchSize_;
+  // If true, we accumulate at least two batch inputs and produce all the groups
+  // created from the previous input batch except the last group.
+  const bool trySplitOutputAtInputBoundary_;
 
   // Used at initialize() and gets reset() afterward.
   std::shared_ptr<const core::AggregationNode> aggregationNode_;


### PR DESCRIPTION
Summary: Adds a config in streaming aggregation to try to split the group output at the input batch boundary if possible. With this config on, the streaming aggregation operator tries to produce the groups created from the previous input batch. This gives the array aggregation to avoid copy data when does array aggregation. The array aggregation avoids copy data if the array element comes from a single source input.

Differential Revision: D76790683
