### PR TITLE
Allow transferring a vector to a given memory pool

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -240,6 +240,12 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Frees an allocated buffer.
   virtual void free(void* p, int64_t size) = 0;
 
+  /// Transfer the ownership of memory at 'buffer' for 'size' bytes to the
+  /// memory pool 'dest'. Returns true if the transfer succeeds.
+  virtual bool transferTo(MemoryPool* dest, void* buffer, int64_t size) {
+    return false;
+  }
+
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
   /// <= the size of the largest size class. The new memory is returned in 'out'
@@ -603,6 +609,8 @@ class MemoryPoolImpl : public MemoryPool {
   void* reallocate(void* p, int64_t size, int64_t newSize) override;
 
   void free(void* p, int64_t size) override;
+
+  bool transferTo(MemoryPool* dest, void* buffer, int64_t size) override;
 
   void allocateNonContiguous(
       MachinePageCount numPages,

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -740,6 +740,18 @@ void BaseVector::copy(
   copyRanges(source, ranges);
 }
 
+void BaseVector::transferOrCopyTo(velox::memory::MemoryPool* pool) {
+  if (pool == pool_) {
+    return;
+  }
+
+  if (nulls_ && !nulls_->transferTo(pool)) {
+    nulls_ = AlignedBuffer::copy<bool>(pool, nulls_);
+    rawNulls_ = nulls_->as<uint64_t>();
+  }
+  pool_ = pool;
+}
+
 namespace {
 
 template <TypeKind kind>

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -547,6 +547,8 @@ class BaseVector {
   virtual VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const = 0;
 
+  virtual void transferOrCopyTo(velox::memory::MemoryPool* pool);
+
   /// Construct a zero-copy slice of the vector with the indicated offset and
   /// length.
   virtual VectorPtr slice(vector_size_t offset, vector_size_t length) const = 0;

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -181,6 +181,10 @@ class BiasVector : public SimpleVector<T> {
         BaseVector::storageByteCount_);
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    VELOX_UNSUPPORTED("transferTo not defined for BiasVector");
+  }
+
  private:
   template <typename U>
   inline xsimd::batch<T> loadSIMDInternal(size_t byteOffset) const {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -396,6 +396,18 @@ class ConstantVector final : public SimpleVector<T> {
         BaseVector::storageByteCount_);
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    BaseVector::transferOrCopyTo(pool);
+    if (valueVector_) {
+      valueVector_->transferOrCopyTo(pool);
+    }
+    if (stringBuffer_) {
+      if (!stringBuffer_->transferTo(pool)) {
+        stringBuffer_ = AlignedBuffer::copy<char>(pool, stringBuffer_);
+      }
+    }
+  }
+
  protected:
   std::string toSummaryString() const override {
     std::stringstream out;

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -250,6 +250,15 @@ class DictionaryVector : public SimpleVector<T> {
         BaseVector::storageByteCount_);
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    BaseVector::transferOrCopyTo(pool);
+    dictionaryValues_->transferOrCopyTo(pool);
+    if (!indices_->transferTo(pool)) {
+      indices_ = AlignedBuffer::copy<vector_size_t>(pool, indices_);
+      rawIndices_ = indices_->as<vector_size_t>();
+    }
+  }
+
  private:
   // return the dictionary index for the specified vector index.
   inline vector_size_t getDictionaryIndex(vector_size_t idx) const {

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -202,6 +202,10 @@ class FunctionVector : public BaseVector {
         "testingCopyPreserveEncodings not defined for FunctionVector");
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    VELOX_UNSUPPORTED("transferTo not defined for FunctionVector");
+  }
+
  private:
   std::vector<std::shared_ptr<Callable>> functions_;
   std::vector<SelectivityVector> rowSets_;

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -370,6 +370,13 @@ class LazyVector : public BaseVector {
     return loadedVector()->testingCopyPreserveEncodings(pool);
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    BaseVector::transferOrCopyTo(pool);
+    if (vector_) {
+      vector_->transferOrCopyTo(pool);
+    }
+  }
+
  private:
   static void ensureLoadedRowsImpl(
       const VectorPtr& vector,

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -210,6 +210,10 @@ class SequenceVector : public SimpleVector<T> {
         BaseVector::storageByteCount_);
   }
 
+  void transferOrCopyTo(velox::memory::MemoryPool* pool) override {
+    VELOX_UNSUPPORTED("transferTo not defined for SequenceVector");
+  }
+
  private:
   // Prepares for use after construction.
   void setInternalState();


### PR DESCRIPTION
Summary:
This diff adds an API `BaseVector::transferOrCopyTo(MemoryPool* pool)` to allow
transferring the ownership of a vector to a target memory pool. If a buffer in this
vector cannot be transferred (e.g., BufferView), it is copied to the target pool. After
the call, the vector is entirely owned by the new pool such that the original pool can
be destructed even if this vector is not released yet. (Note that this API transfers a
buffer to the target pool even if it's multiply referenced.)

Differential Revision: D75116719
