### PR TITLE
fix(build): Remove cudf from clang build

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -63,8 +63,8 @@ jobs:
             mkdir /tmp/build
             cd /tmp/build
             source /opt/rh/gcc-toolset-12/enable
-            # install basic deps
-            bash /setup-centos9.sh
+            # Install basic deps with GCC. Some deps have problems (e.g. folly missing atomic lib).
+            USE_CLANG=false bash /setup-centos9.sh
 
             bash /setup-centos-adapters.sh
 
@@ -94,19 +94,25 @@ jobs:
             "-DVELOX_ENABLE_EXAMPLES=ON"
             "-DVELOX_ENABLE_ARROW=ON"
             "-DVELOX_ENABLE_GEO=ON"
-            "-DVELOX_ENABLE_FAISS=ON"
             "-DVELOX_ENABLE_PARQUET=ON"
             "-DVELOX_ENABLE_HDFS=ON"
             "-DVELOX_ENABLE_S3=ON"
             "-DVELOX_ENABLE_GCS=ON"
             "-DVELOX_ENABLE_ABFS=ON"
-            "-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
-            "-DVELOX_ENABLE_CUDF=ON"
             "-DVELOX_ENABLE_WAVE=ON"
             "-DVELOX_MONO_LIBRARY=ON"
             "-DVELOX_BUILD_SHARED=ON"
           )
-          if [[ "${USE_CLANG}" = "true" ]]; then scripts/setup-centos9.sh install_clang15; export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; CUDA_FLAGS="-ccbin /usr/lib64/llvm15/bin/clang++-15"; fi
+          if [[ "${USE_CLANG}" = "true" ]]; then
+             scripts/setup-centos9.sh install_clang15; export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; CUDA_FLAGS="-ccbin /usr/lib64/llvm15/bin/clang++-15";
+          else
+            # cuDF (unsupported for Clang) and Faiss (link issue when using Clang)
+            # are excluded for Clang compilation and need to be added back when using GCC.
+            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_CUDF=ON"
+            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_FAISS=ON"
+            # Investigate issues with remote function service: Issue #13897
+            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+          fi
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
 
       - name: Ccache after
@@ -174,9 +180,14 @@ jobs:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
           ICU_SOURCE: SYSTEM
           MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3
-          EXTRA_CMAKE_FLAGS: -DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_EXAMPLES=ON -DVELOX_ENABLE_FAISS=ON
+          EXTRA_CMAKE_FLAGS: -DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_EXAMPLES=ON
         run: |
-          if [[ "${USE_CLANG}" = "true" ]]; then export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15; fi
+          # Faiss (link issue when using Clang) is excluded for Clang compilation and needs to be added back when using GCC.
+          if [[ "${USE_CLANG}" = "true" ]]; then
+            export CC=/usr/bin/clang-15; export CXX=/usr/bin/clang++-15;
+          else
+            export EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS} -DVELOX_ENABLE_FAISS=ON"
+          fi
           make debug
 
       - name: CCache after

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1413,7 +1413,7 @@ jobs:
             /var/log
 
   linux-clang:
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
     name: Build with Clang
     uses: ./.github/workflows/linux-build-base.yml
     with:

--- a/velox/experimental/wave/exec/SimpleAggregate.cpp
+++ b/velox/experimental/wave/exec/SimpleAggregate.cpp
@@ -69,7 +69,7 @@ class SimpleAggregate : public AggregateGenerator {
   virtual void makeDeduppedUpdate(
       CompileState& state,
       const AggregateProbe& probe,
-      const AggregateUpdate& update) const {
+      const AggregateUpdate& update) const override {
     if (probe.keys.empty()) {
       VELOX_NYI();
     } else {

--- a/velox/experimental/wave/exec/ToWave.h
+++ b/velox/experimental/wave/exec/ToWave.h
@@ -279,7 +279,7 @@ struct Filter : public KernelStep {
     return true;
   }
 
-  int32_t sharedMemorySize() const {
+  int32_t sharedMemorySize() const override {
     return sizeof(WaveShared) + (kBlockSize / 32) * sizeof(int32_t);
   }
 
@@ -405,7 +405,7 @@ struct AggregateUpdate : public KernelStep {
     return StepKind::kAggregateUpdate;
   }
 
-  bool isSink() const {
+  bool isSink() const override {
     return true;
   }
 
@@ -456,7 +456,7 @@ struct AggregateProbe : public KernelStep {
     return !updates.empty() && allUpdatesInlined;
   }
 
-  int32_t sharedMemorySize() const {
+  int32_t sharedMemorySize() const override {
     // If no grouping, we have one word plus one byte of shared memory
     // per warp and a pad of 4 to align at 8. This is after the
     // regular WaveShared struct.
@@ -646,7 +646,7 @@ struct JoinExpand : public KernelStep {
     return true;
   }
 
-  int32_t sharedMemorySize() const {
+  int32_t sharedMemorySize() const override {
     return sizeof(WaveShared) + sizeof(JoinShared);
   }
 

--- a/velox/functions/lib/tests/QuantileDigestTest.cpp
+++ b/velox/functions/lib/tests/QuantileDigestTest.cpp
@@ -73,7 +73,7 @@ class QuantileDigestTest : public QuantileDigestTestBase {
   void testHugeWeight() {
     constexpr int N = 10;
     constexpr double kAccuracy = 0.99;
-    constexpr T kMaxValue = std::numeric_limits<T>::max();
+    constexpr double kMaxValue = std::numeric_limits<double>::max();
     QuantileDigest<T> digest{StlAllocator<T>(allocator()), kAccuracy};
     for (auto i = 0; i < N; ++i) {
       digest.add(T(i), kMaxValue);


### PR DESCRIPTION
cudf does not officially support building with the clang compiler.
Previously, this was fine but the current clang build fails and we need
to remove it.