### PR TITLE
misc: Add max_num_splits_listened_to query config

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -656,6 +656,12 @@ class QueryConfig {
   static constexpr const char* kQueryMemoryReclaimerPriority =
       "query_memory_reclaimer_priority";
 
+  /// The max number of input splits to listen to by SplitListener per table
+  /// scan node per worker. It's up to the SplitListener implementation to
+  /// respect this config.
+  static constexpr const char* kMaxNumSplitsListenedTo =
+      "max_num_splits_listened_to";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -1191,6 +1197,10 @@ class QueryConfig {
   int32_t queryMemoryReclaimerPriority() const {
     return get<int32_t>(
         kQueryMemoryReclaimerPriority, std::numeric_limits<int32_t>::max());
+  }
+
+  int32_t maxNumSplitsListenedTo() const {
+    return get<int32_t>(kMaxNumSplitsListenedTo, 0);
   }
 
   template <typename T>

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -33,6 +33,7 @@ TEST_F(QueryConfigTest, emptyConfig) {
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_FALSE(config.isLegacyCast());
+  EXPECT_EQ(config.maxNumSplitsListenedTo(), 0);
 }
 
 TEST_F(QueryConfigTest, setConfig) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -178,6 +178,11 @@ Generic Configuration
      - true
      - If this is true, then the unnest operator might split output for each input batch based on the
        output batch size control. Otherwise, it produces a single output for each input batch.
+   * - max_num_splits_listened_to
+     - integer
+     - 0
+     - Specifies The max number of input splits to listen to by SplitListener per table scan node per
+       worker. It's up to the SplitListener implementation to respect this config.
 
 .. _expression-evaluation-conf:
 


### PR DESCRIPTION
Summary: This diff adds a max_num_splits_listened_to query config to indicate the max number of splits to listen to by the SplitListener.

Differential Revision: D76469144
