### PR TITLE
misc: Update SplitListner creation API

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -656,6 +656,12 @@ class QueryConfig {
   static constexpr const char* kQueryMemoryReclaimerPriority =
       "query_memory_reclaimer_priority";
 
+  /// The max number of input splits to listen to by SplitListener per table
+  /// scan node per worker. It's up to the SplitListener implementation to
+  /// respect this config.
+  static constexpr const char* kMaxNumSplitsListenedTo =
+      "max_num_splits_listened_to";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -1191,6 +1197,10 @@ class QueryConfig {
   int32_t queryMemoryReclaimerPriority() const {
     return get<int32_t>(
         kQueryMemoryReclaimerPriority, std::numeric_limits<int32_t>::max());
+  }
+
+  int32_t maxNumSplitsListenedTo() const {
+    return get<int32_t>(kMaxNumSplitsListenedTo, 0);
   }
 
   template <typename T>

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -33,6 +33,7 @@ TEST_F(QueryConfigTest, emptyConfig) {
   const QueryConfig& config = queryCtx->queryConfig();
 
   ASSERT_FALSE(config.isLegacyCast());
+  EXPECT_EQ(config.maxNumSplitsListenedTo(), 0);
 }
 
 TEST_F(QueryConfigTest, setConfig) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -178,6 +178,11 @@ Generic Configuration
      - true
      - If this is true, then the unnest operator might split output for each input batch based on the
        output batch size control. Otherwise, it produces a single output for each input batch.
+   * - max_num_splits_listened_to
+     - integer
+     - 0
+     - Specifies The max number of input splits to listen to by SplitListener per table scan node per
+       worker. It's up to the SplitListener implementation to respect this config.
 
 .. _expression-evaluation-conf:
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -361,7 +361,10 @@ Task::Task(
 void Task::initSplitListeners() {
   splitListenerFactories().withRLock([&](const auto& factories) {
     for (const auto& factory : factories) {
-      splitListeners_.emplace_back(factory->create(taskId_, uuid_));
+      auto listener = factory->create(taskId_, uuid_, queryCtx_->queryConfig());
+      if (listener != nullptr) {
+        splitListeners_.emplace_back(std::move(listener));
+      }
     }
   });
 }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -1464,9 +1464,16 @@ class SplitListenerFactory {
  public:
   virtual ~SplitListenerFactory() = default;
 
+  /// Create and return an std::unique_ptr<SplitListener> to be used by a Task
+  /// of the given taskId, taskUuid and config. The Task constructor calls this
+  /// method and holds the SplitListener. The SplitListener is destroyed when
+  /// the Task is destructed. This method can return a nullptr, e.g., if taskId
+  /// doesn't satisfy certain criteria or if config.maxNumSplitsListenedTo() is
+  /// 0. In this situation, the Task doesn't hold this SplitListener.
   virtual std::unique_ptr<SplitListener> create(
-      const std::string& taskId_,
-      const std::string& taskUuid_) = 0;
+      const std::string& taskId,
+      const std::string& taskUuid,
+      const core::QueryConfig& config) = 0;
 };
 
 bool registerSplitListenerFactory(


### PR DESCRIPTION
Summary:
This diff makes two updates to the creation API of SplitListener:
1. Avoid adding to splitListeners_ if the SplitListenerFactory::create returns a nullptr.
2. Make SplitListenerFactory::create receive a QueryConfig argument.

Differential Revision: D76469143
