### PR TITLE
feat: Make global arbitration consider query priority

### DIFF
--- a/velox/common/memory/ArbitrationParticipant.cpp
+++ b/velox/common/memory/ArbitrationParticipant.cpp
@@ -31,7 +31,7 @@ using namespace facebook::velox::memory;
 
 std::string ArbitrationParticipant::Config::toString() const {
   return fmt::format(
-      "initCapacity {}, minCapacity {}, fastExponentialGrowthCapacityLimit {}, slowCapacityGrowRatio {}, minFreeCapacity {}, minFreeCapacityRatio {}, minReclaimBytes {}, minReclaimPct {}, abortCapacityLimit {}",
+      "initCapacity {}, minCapacity {}, fastExponentialGrowthCapacityLimit {}, slowCapacityGrowRatio {}, minFreeCapacity {}, minFreeCapacityRatio {}, minReclaimBytes {}, minReclaimPct {}",
       succinctBytes(initCapacity),
       succinctBytes(minCapacity),
       succinctBytes(fastExponentialGrowthCapacityLimit),
@@ -39,8 +39,7 @@ std::string ArbitrationParticipant::Config::toString() const {
       succinctBytes(minFreeCapacity),
       minFreeCapacityRatio,
       succinctBytes(minReclaimBytes),
-      minReclaimPct,
-      succinctBytes(abortCapacityLimit));
+      minReclaimPct);
 }
 
 ArbitrationParticipant::Config::Config(
@@ -51,8 +50,7 @@ ArbitrationParticipant::Config::Config(
     uint64_t _minFreeCapacity,
     double _minFreeCapacityRatio,
     uint64_t _minReclaimBytes,
-    double _minReclaimPct,
-    uint64_t _abortCapacityLimit)
+    double _minReclaimPct)
     : initCapacity(_initCapacity),
       minCapacity(_minCapacity),
       fastExponentialGrowthCapacityLimit(_fastExponentialGrowthCapacityLimit),
@@ -60,8 +58,7 @@ ArbitrationParticipant::Config::Config(
       minFreeCapacity(_minFreeCapacity),
       minFreeCapacityRatio(_minFreeCapacityRatio),
       minReclaimBytes(_minReclaimBytes),
-      minReclaimPct(_minReclaimPct),
-      abortCapacityLimit(_abortCapacityLimit) {
+      minReclaimPct(_minReclaimPct) {
   VELOX_CHECK_GE(slowCapacityGrowRatio, 0);
   VELOX_CHECK_EQ(
       fastExponentialGrowthCapacityLimit == 0,
@@ -82,10 +79,6 @@ ArbitrationParticipant::Config::Config(
       "adjustment.",
       minFreeCapacity,
       minFreeCapacityRatio);
-  VELOX_CHECK(
-      bits::isPowerOfTwo(abortCapacityLimit),
-      "abortCapacityLimit {} not a power of two",
-      abortCapacityLimit);
   VELOX_CHECK(
       0 <= minReclaimPct && minReclaimPct <= 1,
       "minReclaimPct {} must be in [0, 1]",

--- a/velox/common/memory/ArbitrationParticipant.h
+++ b/velox/common/memory/ArbitrationParticipant.h
@@ -119,17 +119,6 @@ class ArbitrationParticipant
     uint64_t minReclaimBytes;
     double minReclaimPct;
 
-    /// Specifies the starting memory capacity limit for global arbitration to
-    /// search for victim participant to reclaim used memory by abort. For
-    /// participants with capacity larger than the limit, the global arbitration
-    /// choose to abort the youngest participant which has the largest
-    /// participant id. This helps to let the old queries to run to completion.
-    /// The abort capacity limit is reduced by half if couldn't find a victim
-    /// participant until reaches to zero.
-    ///
-    /// NOTE: the limit must be zero or a power of 2.
-    uint64_t abortCapacityLimit;
-
     Config(
         uint64_t _initCapacity,
         uint64_t _minCapacity,
@@ -138,8 +127,7 @@ class ArbitrationParticipant
         uint64_t _minFreeCapacity,
         double _minFreeCapacityRatio,
         uint64_t _minReclaimBytes,
-        double _minReclaimPct,
-        uint64_t _abortCapacityLimit);
+        double _minReclaimPct);
 
     std::string toString() const;
   };

--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -103,7 +103,6 @@ constexpr double kMemoryPoolMinFreeCapacityRatio = 0.25;
 constexpr uint64_t kFastExponentialGrowthCapacityLimit = 256 * MB;
 constexpr uint64_t kMemoryPoolMinReclaimBytes = 0;
 constexpr double kMemoryPoolMinReclaimPct = 0;
-constexpr uint64_t kMemoryPoolAbortCapacityLimit = 0;
 constexpr double kSlowCapacityGrowRatio = 0.25;
 
 class MemoryReclaimer;
@@ -415,8 +414,7 @@ static ArbitrationParticipant::Config arbitrationConfig(
     uint64_t minFreeCapacity = kMemoryPoolMinFreeCapacity,
     double minFreeCapacityRatio = kMemoryPoolMinFreeCapacityRatio,
     uint64_t minReclaimBytes = kMemoryPoolMinReclaimBytes,
-    double minReclaimPct = kMemoryPoolMinReclaimPct,
-    uint64_t abortCapacityLimit = kMemoryPoolAbortCapacityLimit) {
+    double minReclaimPct = kMemoryPoolMinReclaimPct) {
   return ArbitrationParticipant::Config{
       0,
       minCapacity,
@@ -425,8 +423,7 @@ static ArbitrationParticipant::Config arbitrationConfig(
       minFreeCapacity,
       minFreeCapacityRatio,
       minReclaimBytes,
-      minReclaimPct,
-      abortCapacityLimit};
+      minReclaimPct};
 }
 
 TEST_F(ArbitrationParticipantTest, config) {
@@ -439,13 +436,12 @@ TEST_F(ArbitrationParticipantTest, config) {
     double minFreeCapacityRatio;
     uint64_t minReclaimBytes;
     double minReclaimPct;
-    uint64_t abortCapacityLimit;
     bool expectedError;
     std::string expectedToString;
 
     std::string debugString() const {
       return fmt::format(
-          "initCapacity {}, minCapacity {}, fastExponentialGrowthCapacityLimit {}, slowCapacityGrowRatio {}, minFreeCapacity {}, minFreeCapacityRatio {}, minReclaimBytes {}, minReclaimPct {}, abortCapacityLimit {}, expectedError {}, expectedToString: {}",
+          "initCapacity {}, minCapacity {}, fastExponentialGrowthCapacityLimit {}, slowCapacityGrowRatio {}, minFreeCapacity {}, minFreeCapacityRatio {}, minReclaimBytes {}, minReclaimPct {}, expectedError {}, expectedToString: {}",
           succinctBytes(initCapacity),
           succinctBytes(minCapacity),
           succinctBytes(fastExponentialGrowthCapacityLimit),
@@ -454,7 +450,6 @@ TEST_F(ArbitrationParticipantTest, config) {
           minFreeCapacityRatio,
           succinctBytes(minReclaimBytes),
           minReclaimPct,
-          succinctBytes(abortCapacityLimit),
           expectedError,
           expectedToString);
     }
@@ -467,9 +462,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        1,
        0.25,
-       2,
        false,
-       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.25, abortCapacityLimit 2B"},
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.25"},
       {0,
        1,
        0,
@@ -478,9 +472,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
+       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5"},
       {0,
        1,
        0,
@@ -489,9 +482,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
+       "initCapacity 0B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0, minReclaimBytes 1B, minReclaimPct 0.5"},
       {1,
        1,
        0,
@@ -500,9 +492,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5"},
       {1,
        0,
        1,
@@ -511,9 +502,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
+       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 0.1, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5"},
       {1,
        0,
        0,
@@ -522,9 +512,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        0,
        0.5,
-       1,
        false,
-       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 0B, minReclaimPct 0.5, abortCapacityLimit 1B"},
+       "initCapacity 1B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 0B, minReclaimPct 0.5"},
       {0,
        0,
        0,
@@ -533,9 +522,8 @@ TEST_F(ArbitrationParticipantTest, config) {
        0,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
+       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 0B, minFreeCapacityRatio 0, minReclaimBytes 1B, minReclaimPct 0.5"},
       {0,
        0,
        0,
@@ -544,12 +532,11 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        1,
        0.5,
-       0,
        false,
-       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5, abortCapacityLimit 0B"},
-      {0, 1, 0, 0.1, 1, 0.1, 1, 0.5, 2, true, ""},
-      {0, 1, 1, 0.1, 0, 0.1, 1, 0.5, 2, true, ""},
-      {0, 1, 1, 0.1, 1, 0, 1, 0.5, 2, true, ""},
+       "initCapacity 0B, minCapacity 0B, fastExponentialGrowthCapacityLimit 0B, slowCapacityGrowRatio 0, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 1B, minReclaimPct 0.5"},
+      {0, 1, 0, 0.1, 1, 0.1, 1, 0.5, true, ""},
+      {0, 1, 1, 0.1, 0, 0.1, 1, 0.5, true, ""},
+      {0, 1, 1, 0.1, 1, 0, 1, 0.5, true, ""},
       {1,
        1,
        1,
@@ -558,15 +545,12 @@ TEST_F(ArbitrationParticipantTest, config) {
        0.1,
        0,
        0.5,
-       0,
        false,
-       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 2, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 0B, minReclaimPct 0.5, abortCapacityLimit 0B"},
-      {0, 1, 1, -1, 1, 0.1, 1, 0.5, 0, true, ""},
-      {0, 1, 1, 0.1, 1, 2, 1, 0.5, 0, true, ""},
-      {0, 1, 1, 0.1, 1, -1, 1, 0.5, 0, true, ""},
-      {0, 0, 0, 0, 1, 0.1, 0, 0.5, 3, true, ""},
-      {0, 0, 0, 0, 1, 0.1, 1, 0.5, 3, true, ""},
-      {0, 0, 0, 0, 1, 0.1, 1, 1.5, 0, true, ""}};
+       "initCapacity 1B, minCapacity 1B, fastExponentialGrowthCapacityLimit 1B, slowCapacityGrowRatio 2, minFreeCapacity 1B, minFreeCapacityRatio 0.1, minReclaimBytes 0B, minReclaimPct 0.5"},
+      {0, 1, 1, -1, 1, 0.1, 1, 0.5, true, ""},
+      {0, 1, 1, 0.1, 1, 2, 1, 0.5, true, ""},
+      {0, 1, 1, 0.1, 1, -1, 1, 0.5, true, ""},
+      {0, 0, 0, 0, 1, 0.1, 1, 1.5, true, ""}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -580,8 +564,7 @@ TEST_F(ArbitrationParticipantTest, config) {
               testData.minFreeCapacity,
               testData.minFreeCapacityRatio,
               testData.minReclaimBytes,
-              testData.minReclaimPct,
-              testData.abortCapacityLimit),
+              testData.minReclaimPct),
           "");
       continue;
     }
@@ -593,8 +576,7 @@ TEST_F(ArbitrationParticipantTest, config) {
         testData.minFreeCapacity,
         testData.minFreeCapacityRatio,
         testData.minReclaimBytes,
-        testData.minReclaimPct,
-        testData.abortCapacityLimit);
+        testData.minReclaimPct);
     ASSERT_EQ(testData.initCapacity, config.initCapacity);
     ASSERT_EQ(testData.minCapacity, config.minCapacity);
     ASSERT_EQ(
@@ -605,7 +587,6 @@ TEST_F(ArbitrationParticipantTest, config) {
     ASSERT_EQ(testData.minFreeCapacityRatio, config.minFreeCapacityRatio);
     ASSERT_EQ(testData.minReclaimBytes, config.minReclaimBytes);
     ASSERT_EQ(testData.minReclaimPct, config.minReclaimPct);
-    ASSERT_EQ(testData.abortCapacityLimit, config.abortCapacityLimit);
     ASSERT_EQ(config.toString(), testData.expectedToString);
   }
 }
@@ -1964,8 +1945,7 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperationState) {
 #ifndef TSAN_BUILD
 TEST_F(ArbitrationParticipantTest, arbitrationOperationTimedLock) {
   auto participantPool = manager_->addRootPool("arbitrationOperationTimedLock");
-  auto config =
-      ArbitrationParticipant::Config(0, 1024, 0, 0, 0, 0, 128, 0, 512);
+  auto config = ArbitrationParticipant::Config(0, 1024, 0, 0, 0, 0, 128, 0);
   auto participant = ArbitrationParticipant::create(
       folly::Random::rand64(), participantPool, &config);
 

--- a/velox/common/memory/tests/SharedArbitratorTestUtil.h
+++ b/velox/common/memory/tests/SharedArbitratorTestUtil.h
@@ -109,43 +109,4 @@ class ArbitrationParticipantTestHelper {
   ArbitrationParticipant* const participant_;
 };
 
-struct ArbitrationTestStructs {
-  ArbitrationParticipant::Config config;
-  std::shared_ptr<ArbitrationParticipant> participant{nullptr};
-  std::shared_ptr<ArbitrationOperation> operation{nullptr};
-
-  static ArbitrationTestStructs createArbitrationTestStructs(
-      const std::shared_ptr<MemoryPool>& pool,
-      uint64_t initCapacity = 1024,
-      uint64_t minCapacity = 128,
-      uint64_t fastExponentialGrowthCapacityLimit = 0,
-      double slowCapacityGrowRatio = 0,
-      uint64_t minFreeCapacity = 0,
-      double minFreeCapacityRatio = 0,
-      uint64_t minReclaimBytes = 128,
-      double minReclaimPct = 0,
-      uint64_t abortCapacityLimit = 512,
-      uint64_t requestBytes = 128,
-      uint64_t maxArbitrationTimeNs = 1'000'000'000'000UL /* 1'000s */) {
-    ArbitrationTestStructs ret{
-        .config = ArbitrationParticipant::Config(
-            initCapacity,
-            minCapacity,
-            fastExponentialGrowthCapacityLimit,
-            slowCapacityGrowRatio,
-            minFreeCapacity,
-            minFreeCapacityRatio,
-            minReclaimBytes,
-            minReclaimPct,
-            abortCapacityLimit)};
-    ret.participant = ArbitrationParticipant::create(
-        folly::Random::rand64(), pool, &ret.config);
-    ret.operation = std::make_shared<ArbitrationOperation>(
-        ScopedArbitrationParticipant(ret.participant, pool),
-        requestBytes,
-        maxArbitrationTimeNs);
-    return ret;
-  }
-};
-
 } // namespace facebook::velox::memory::test


### PR DESCRIPTION
Summary: similarly as we consider query priority when pushback by abort, we should also consider priority when global arbitration.

Differential Revision: D76935498
