### PR TITLE
misc: Pass query context to WarmStorage reads

### DIFF
--- a/velox/common/caching/tests/CachedFactoryTest.cpp
+++ b/velox/common/caching/tests/CachedFactoryTest.cpp
@@ -31,7 +31,8 @@ struct DoublerGenerator {
   std::unique_ptr<int> operator()(
       const int& value,
       const void* /*properties*/ = nullptr,
-      void* /*statistics*/ = nullptr) {
+      void* /*statistics*/ = nullptr,
+      const void* /*context*/ = nullptr) {
     ++generated;
     return std::make_unique<int>(value * 2);
   }
@@ -42,7 +43,8 @@ struct IdentityGenerator {
   std::unique_ptr<int> operator()(
       const int& value,
       const void* /*properties*/ = nullptr,
-      void* /*statistics*/ = nullptr) {
+      void* /*statistics*/ = nullptr,
+      const void* /*context*/ = nullptr) {
     return std::make_unique<int>(value);
   }
 };
@@ -116,7 +118,8 @@ struct DoublerWithExceptionsGenerator {
   std::unique_ptr<int> operator()(
       const int& value,
       const void* /*properties*/ = nullptr,
-      void* /*statistics*/ = nullptr) {
+      void* /*statistics*/ = nullptr,
+      const void* /*context*/ = nullptr) {
     if (value == 3) {
       VELOX_FAIL("3 is bad");
     }

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -84,6 +84,9 @@ struct FileOptions {
   /// A hint to the file system for which region size of the file should be
   /// read. Specifically, the read length.
   std::optional<int64_t> readRangeHint{std::nullopt};
+
+  /// Used to pass user context and settings into a backend filesystem.
+  const config::ConfigBase* sessionProperties{nullptr};
 };
 
 /// Defines directory options

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -42,7 +42,8 @@ std::string groupName(const std::string& filename) {
 std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
     const std::string& filename,
     const FileProperties* properties,
-    filesystems::File::IoStats* stats) {
+    filesystems::File::IoStats* stats,
+    const config::ConfigBase* sessionProperties) {
   // We have seen cases where drivers are stuck when creating file handles.
   // Adding a trace here to spot this more easily in future.
   process::TraceContext trace("FileHandleGenerator::operator()");
@@ -53,6 +54,7 @@ std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
     fileHandle = std::make_unique<FileHandle>();
     filesystems::FileOptions options;
     options.stats = stats;
+    options.sessionProperties = sessionProperties;
     if (properties) {
       options.fileSize = properties->fileSize;
       options.readRangeHint = properties->readRangeHint;

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -70,7 +70,8 @@ class FileHandleGenerator {
   std::unique_ptr<FileHandle> operator()(
       const std::string& filename,
       const FileProperties* properties,
-      filesystems::File::IoStats* stats);
+      filesystems::File::IoStats* stats,
+      const config::ConfigBase* sessionProperties);
 
  private:
   const std::shared_ptr<const config::ConfigBase> properties_;
@@ -82,6 +83,7 @@ using FileHandleFactory = CachedFactory<
     FileHandleGenerator,
     FileProperties,
     filesystems::File::IoStats,
+    config::ConfigBase,
     FileHandleSizer>;
 
 using FileHandleCachedPtr = CachedPtr<std::string, FileHandle>;

--- a/velox/connectors/hive/FileProperties.h
+++ b/velox/connectors/hive/FileProperties.h
@@ -25,15 +25,20 @@
 
 #pragma once
 
-#include <cstdint>
+#include <memory>
+#include <optional>
 
 namespace facebook::velox {
+namespace config {
+class ConfigBase;
+}
 
 struct FileProperties {
   std::optional<int64_t> fileSize;
   std::optional<int64_t> modificationTime;
   std::optional<int64_t> readRangeHint{std::nullopt};
   std::shared_ptr<std::string> extraFileInfo{nullptr};
+  const config::ConfigBase* sessionProperties{nullptr};
 };
 
 } // namespace facebook::velox

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -294,7 +294,8 @@ void SplitReader::createReader() {
     fileHandleCachePtr = fileHandleFactory_->generate(
         hiveSplit_->filePath,
         hiveSplit_->properties.has_value() ? &*hiveSplit_->properties : nullptr,
-        fsStats_ ? fsStats_.get() : nullptr);
+        fsStats_ ? fsStats_.get() : nullptr,
+        connectorQueryCtx_->sessionProperties());
     VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
   } catch (const VeloxRuntimeError& e) {
     if (e.errorCode() == error_code::kFileNotFound &&

--- a/velox/dwio/common/Throttler.cpp
+++ b/velox/dwio/common/Throttler.cpp
@@ -271,7 +271,8 @@ std::unique_ptr<Throttler::ThrottleSignal>
 Throttler::ThrottleSignalGenerator::operator()(
     const std::string& /*unused*/,
     const void* /*unused*/,
-    void* /*unused*/) {
+    void* /*unused*/,
+    const void* /*unused*/) {
   return std::unique_ptr<ThrottleSignal>(new ThrottleSignal{1});
 }
 

--- a/velox/dwio/common/Throttler.h
+++ b/velox/dwio/common/Throttler.h
@@ -176,7 +176,8 @@ class Throttler {
     std::unique_ptr<ThrottleSignal> operator()(
         const std::string& /*unused*/,
         const void* /*unused*/,
-        void* /*unused*/);
+        void* /*unused*/,
+        const void* /*unused*/);
   };
 
   using CachedThrottleSignalPtr = CachedPtr<std::string, ThrottleSignal>;

--- a/velox/experimental/wave/common/KernelCache.cpp
+++ b/velox/experimental/wave/common/KernelCache.cpp
@@ -94,8 +94,11 @@ class AsyncCompiledKernel : public CompiledKernel {
 
 class KernelGenerator {
  public:
-  std::unique_ptr<ModulePtr>
-  operator()(const std::string, const KernelGenFunc* gen, void* /*unused*/) {
+  std::unique_ptr<ModulePtr> operator()(
+      const std::string,
+      const KernelGenFunc* gen,
+      void* /*unused*/,
+      const void* /*unused*/) {
     using ModulePromise = folly::Promise<ModulePtr>;
     struct PromiseHolder {
       ModulePromise promise;


### PR DESCRIPTION
Summary:
In Java we pass a context with extra "dw.*" fields about presto query to warmstorage. Basically it's just a `map<string, string>`. We need something similar in Prestissimo to improve debugging and monitoring.
https://fburl.com/scuba/warm_storage_file_service_activity/n84zevam
___
This is just a refactoring, I'm passing session properties through the connector stack for reads. The plan is to pass DW specific properties inside.

The most questionable part is probably changes in `CachedFactory.h`.
Currently `CachedFactory::generate` has 3 template params,
- `Key`, used as string for the path to file in FileHandleGenerator
- `Properties`, used for FileProperties struct. Looks like a const file properties according to this [comment](https://github.com/facebookincubator/velox/blob/main/velox/connectors/hive/HiveConnectorSplit.h?fbclid=IwY2xjawLASuFleHRuA2FlbQIxMQBicmlkETFlR2JVSktON2Y5eFRJT2lqAR4M46I6rtXwOiI0V8DukkBF_jXUaktPB_4qwzckyvYZweWaV3BVlcHWwj9fVA_aem_aVoQh-IF6xUzfJbZK-PPdQ#L67-L69).
- `Statistics`, used for statistics

I needed to pass SessionProperties there, so I added separate parameter `Context` to that class, but LMK if it can be done better.
___
WarmStorage writes and spills are not covered in this diff, those changes will be published in the next diffs.

Differential Revision: D76921538


