### PR TITLE
feat: Use shared_ptr for Operator::spillStats_

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -113,7 +113,7 @@ void HashAggregation::initialize() {
       spillConfig_.has_value() ? &spillConfig_.value() : nullptr,
       &nonReclaimableSection_,
       operatorCtx_.get(),
-      &spillStats_);
+      spillStats_.get());
 
   aggregationNode_.reset();
 }

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -116,7 +116,7 @@ void Merge::maybeSetupOutputSpiller() {
       HashBitRange{},
       sortingKeys_,
       &spillConfig_.value(),
-      &spillStats_);
+      spillStats_.get());
 }
 
 void Merge::spill() {
@@ -157,7 +157,7 @@ void Merge::setupSpillMerger() {
     spillReadFiles.reserve(spillFiles.size());
     for (const auto& spillFile : spillFiles) {
       spillReadFiles.emplace_back(SpillReadFile::create(
-          spillFile, spillConfig_->readBufferSize, pool(), &spillStats_));
+          spillFile, spillConfig_->readBufferSize, pool(), spillStats_.get()));
     }
     spillReadFilesGroups.push_back(std::move(spillReadFiles));
   }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -390,7 +390,7 @@ void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
 }
 
 void Operator::recordSpillStats() {
-  const auto lockedSpillStats = spillStats_.wlock();
+  const auto lockedSpillStats = spillStats_->wlock();
   auto lockedStats = stats_.wlock();
   lockedStats->spilledInputBytes += lockedSpillStats->spilledInputBytes;
   lockedStats->spilledBytes += lockedSpillStats->spilledBytes;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -643,7 +643,8 @@ class Operator : public BaseRuntimeStatWriter {
   bool initialized_{false};
 
   folly::Synchronized<OperatorStats> stats_;
-  folly::Synchronized<common::SpillStats> spillStats_;
+  std::shared_ptr<folly::Synchronized<common::SpillStats>> spillStats_ =
+      std::make_shared<folly::Synchronized<common::SpillStats>>();
 
   /// NOTE: only one of the two could be set for an operator for tracing .
   /// 'splitTracer_' is only set for table scan to record the processed split

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -67,7 +67,7 @@ OrderBy::OrderBy(
       &nonReclaimableSection_,
       driverCtx->prefixSortConfig(),
       spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
-      &spillStats_);
+      spillStats_.get());
 }
 
 void OrderBy::addInput(RowVectorPtr input) {

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -120,13 +120,13 @@ void RowNumber::restoreNextSpillPartition() {
   auto it = spillInputPartitionSet_.begin();
   restoringPartitionId_ = it->first;
   spillInputReader_ = it->second->createUnorderedReader(
-      spillConfig_->readBufferSize, pool(), &spillStats_);
+      spillConfig_->readBufferSize, pool(), spillStats_.get());
 
   // Find matching partition for the hash table.
   auto hashTableIt = spillHashTablePartitionSet_.find(it->first);
   if (hashTableIt != spillHashTablePartitionSet_.end()) {
     spillHashTableReader_ = hashTableIt->second->createUnorderedReader(
-        spillConfig_->readBufferSize, pool(), &spillStats_);
+        spillConfig_->readBufferSize, pool(), spillStats_.get());
 
     setSpillPartitionBits(&(it->first));
 
@@ -388,7 +388,7 @@ void RowNumber::reclaim(
                  << spillConfig_->maxSpillLevel
                  << ", and abandon spilling for memory pool: "
                  << pool()->name();
-    ++spillStats_.wlock()->spillMaxLevelExceededCount;
+    ++spillStats_->wlock()->spillMaxLevelExceededCount;
     return;
   }
 
@@ -408,7 +408,7 @@ SpillPartitionIdSet RowNumber::spillHashTable() {
       tableType,
       spillPartitionBits_,
       &spillConfig,
-      &spillStats_);
+      spillStats_.get());
 
   hashTableSpiller->spill();
   hashTableSpiller->finishSpill(spillHashTablePartitionSet_);
@@ -429,7 +429,7 @@ void RowNumber::setupInputSpiller(
       restoringPartitionId_,
       spillPartitionBits_,
       &spillConfig,
-      &spillStats_);
+      spillStats_.get());
 
   const auto& hashers = table_->hashers();
 

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -315,7 +315,7 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
             currentTimeNs - createTimeUs_, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
-    *spillStats_.wlock() += stats.spillStats;
+    *spillStats_->wlock() += stats.spillStats;
   }
 }
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -293,7 +293,7 @@ void TopNRowNumber::noMoreInput() {
     spiller_->finishSpill(spillPartitionSet);
     VELOX_CHECK_EQ(spillPartitionSet.size(), 1);
     merge_ = spillPartitionSet.begin()->second->createOrderedReader(
-        spillConfig_->readBufferSize, pool(), &spillStats_);
+        spillConfig_->readBufferSize, pool(), spillStats_.get());
   } else {
     outputRows_.resize(outputBatchSize_);
   }
@@ -750,6 +750,6 @@ void TopNRowNumber::setupSpiller() {
       inputType_,
       sortingKeys,
       &spillConfig_.value(),
-      &spillStats_);
+      spillStats_.get());
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -64,7 +64,7 @@ Window::Window(
             driverCtx->queryConfig().prefixSortMaxStringPrefixLength()},
         spillConfig,
         &nonReclaimableSection_,
-        &spillStats_);
+        spillStats_.get());
   }
 }
 


### PR DESCRIPTION
Use shared_ptr for Operator::spillStats_ so that its lifecycle
can be longer than the Operator itself.

Part of #13260 