### PR TITLE
fix(build): Replace shellcheck pre-commit with python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,8 +91,8 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
     hooks:
       - id: shellcheck
         args: [-x, --severity=warning]

--- a/scripts/setup-manylinux.sh
+++ b/scripts/setup-manylinux.sh
@@ -30,7 +30,7 @@ set -efx -o pipefail
 # Some of the packages must be build with the same compiler flags
 # so that some low level types are the same size. Also, disable warnings.
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-source $SCRIPT_DIR/setup-common.sh
+source "$SCRIPT_DIR"/setup-common.sh
 CXXFLAGS=$(get_cxx_flags) # Used by boost.
 export CXXFLAGS
 export CFLAGS=${CXXFLAGS//"-std=c++17"/} # Used by LZO.
@@ -80,7 +80,7 @@ function install_conda {
 function install_gflags {
   # Remove an older version if present.
   dnf remove -y gflags
-  wget_and_untar https://github.com/gflags/gflags/archive/${GFLAGS_VERSION}.tar.gz gflags
+  wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
   cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON -DLIB_SUFFIX=64
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -30,7 +30,7 @@
 # Minimal setup for Ubuntu 22.04.
 set -eufx -o pipefail
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
-source $SCRIPT_DIR/setup-common.sh
+source "$SCRIPT_DIR"/setup-common.sh
 
 SUDO="${SUDO:-"sudo --preserve-env"}"
 USE_CLANG="${USE_CLANG:-false}"


### PR DESCRIPTION
Previously, the shellcheck used docker based check that doesn’t work in all environments. Switch to a python based version instead.