### PR TITLE
misc: Avoid the data copy in streaming aggregation to split at input source boundary

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -623,13 +623,6 @@ class QueryConfig {
   static constexpr const char* kStreamingAggregationMinOutputBatchRows =
       "streaming_aggregation_min_output_batch_rows";
 
-  /// If true, the streaming aggregation accumulates at least two input batches
-  /// and produce all the groups created from the previous input batch except
-  /// the last group.
-  static constexpr const char*
-      kStreamingAggregationTrySplitOutputAtInputBoundary =
-          "streaming_aggregation_try_split_output_at_input_boundary";
-
   /// TODO: Remove after dependencies are cleaned up.
   static constexpr const char* kStreamingAggregationEagerFlush =
       "streaming_aggregation_eager_flush";
@@ -1170,10 +1163,6 @@ class QueryConfig {
 
   int32_t streamingAggregationMinOutputBatchRows() const {
     return get<int32_t>(kStreamingAggregationMinOutputBatchRows, 0);
-  }
-
-  bool streamingAggregationTrySplitOutputAtInputBoundary() const {
-    return get<bool>(kStreamingAggregationTrySplitOutputAtInputBoundary, false);
   }
 
   bool isFieldNamesInJsonCastEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -450,12 +450,6 @@ Aggregation
      - In streaming aggregation, wait until we have enough number of output rows
        to produce a batch of size specified by this. If set to 0, then
        Operator::outputBatchRows will be used as the min output batch rows.
-   * - streaming_aggregation_try_split_output_at_input_boundary
-     - bool
-     - false
-     - If true, the streaming aggregation accumulates at least two batch inputs and
-       produce all the groups created from the previous input batch except the last
-       group.
 
 Table Scan
 ------------

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -41,19 +41,14 @@ class StreamingAggregationTest : public HiveConnectorTestBase,
 
   AssertQueryBuilder& config(
       AssertQueryBuilder builder,
-      uint32_t outputBatchSize,
-      bool splitOutput = false) {
+      uint32_t outputBatchSize) {
     return builder
         .config(
             core::QueryConfig::kPreferredOutputBatchRows,
             std::to_string(outputBatchSize))
         .config(
             core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
-            std::to_string(flushRows()))
-        .config(
-            core::QueryConfig::
-                kStreamingAggregationTrySplitOutputAtInputBoundary,
-            splitOutput ? "true" : "false");
+            std::to_string(flushRows()));
   }
 
   void testAggregation(
@@ -915,9 +910,9 @@ TEST_P(StreamingAggregationTest, clusteredInputWithOutputSplit) {
            {18},
            {19}}),
   });
-  for (auto splitOutput : {false, true}) {
-    SCOPED_TRACE(fmt::format("splitOutput={}", splitOutput));
-    config(AssertQueryBuilder(planWithOverlap), 1024, splitOutput)
+  for (auto batchSize : {1, 3, 20}) {
+    SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
+    config(AssertQueryBuilder(planWithOverlap), batchSize)
         .assertResults(expectedWithOverlap);
   }
 
@@ -956,9 +951,9 @@ TEST_P(StreamingAggregationTest, clusteredInputWithOutputSplit) {
             {17},
             {18},
             {19}})});
-  for (auto splitOutput : {false, true}) {
-    SCOPED_TRACE(fmt::format("splitOutput={}", splitOutput));
-    config(AssertQueryBuilder(planWithoutOverlap), 1024, splitOutput)
+  for (auto batchSize : {1, 3, 20}) {
+    SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
+    config(AssertQueryBuilder(planWithoutOverlap), batchSize)
         .assertResults(expectedWithoutOverlap);
   }
 
@@ -996,9 +991,9 @@ TEST_P(StreamingAggregationTest, clusteredInputWithOutputSplit) {
             {17},
             {18},
             {19}})});
-  for (auto splitOutput : {false, true}) {
-    SCOPED_TRACE(fmt::format("splitOutput={}", splitOutput));
-    config(AssertQueryBuilder(mixedPlan), 1024, splitOutput)
+  for (auto batchSize : {1, 3, 20}) {
+    SCOPED_TRACE(fmt::format("batchSize={}", batchSize));
+    config(AssertQueryBuilder(mixedPlan), batchSize)
         .assertResults(expectedMixedResult);
   }
 }


### PR DESCRIPTION
Summary:
For streaming aggregation, we try to split output at the input boundary if possible. For the last group which has mixed input across different batches, we output them separately. This can furthur reduce the cpu and memory usage in more general use cases.

This diff also deprecate the config added for a specialized optimization use case with prio known streaming input data distribution

Differential Revision: D77032615


