### PR TITLE
feat: TDigest - Quantiles At Values

### DIFF
--- a/velox/expression/fuzzer/ArgValuesGenerators.cpp
+++ b/velox/expression/fuzzer/ArgValuesGenerators.cpp
@@ -379,6 +379,7 @@ std::vector<core::TypedExprPtr> TDigestArgValuesGenerator::generate(
       "values_at_quantiles",
       "scale_tdigest",
       "quantile_at_value",
+      "quantiles_at_values",
       "destructure_tdigest",
       "trimmed_mean"};
   if (std::find(functionNames.begin(), functionNames.end(), functionName_) !=

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -93,6 +93,7 @@ int main(int argc, char** argv) {
       // alias to VARBINARY).
       "merge_tdigest",
       "construct_tdigest",
+      "quantiles_at_values",
       // https://github.com/facebookincubator/velox/issues/13551
       "values_at_quantiles",
       // Fuzzer cannot generate valid 'comparator' lambda.

--- a/velox/functions/prestosql/TDigestFunctions.h
+++ b/velox/functions/prestosql/TDigestFunctions.h
@@ -47,7 +47,7 @@ struct ValuesAtQuantilesFunction {
     result.resize(quantiles.size());
     for (size_t i = 0; i < quantiles.size(); ++i) {
       VELOX_USER_CHECK(
-          quantiles[i].has_value(), "All values should be non-null.");
+          quantiles[i].has_value(), "All quantiles should be non-null.");
       double quantile = quantiles[i].value();
       VELOX_USER_CHECK(0 <= quantile && quantile <= 1);
       result[i] = digest.estimateQuantile(quantile);
@@ -115,7 +115,23 @@ struct QuantileAtValueFunction {
     return true;
   }
 };
+template <typename T>
+struct QuantilesAtValuesFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
 
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Array<double>>& result,
+      const arg_type<SimpleTDigest<double>>& input,
+      const arg_type<Array<double>>& values) {
+    auto digest = TDigest<>::fromSerialized(input.data());
+    result.resize(values.size());
+    for (size_t i = 0; i < values.size(); ++i) {
+      VELOX_USER_CHECK(values[i].has_value(), "All values should be non-null.");
+      double value = values[i].value();
+      result[i] = digest.getCdf(value);
+    }
+  }
+};
 template <typename T>
 struct ConstructTDigestFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
@@ -46,6 +46,11 @@ void registerTDigestFunctions(const std::string& prefix) {
       SimpleTDigest<double>,
       double>({prefix + "quantile_at_value"});
   registerFunction<
+      QuantilesAtValuesFunction,
+      Array<double>,
+      SimpleTDigest<double>,
+      Array<double>>({prefix + "quantiles_at_values"});
+  registerFunction<
       ConstructTDigestFunction,
       SimpleTDigest<double>,
       Array<double>,


### PR DESCRIPTION
Summary:
- Add TDigest Quantiles At Values, Java equivalent [here](https://www.internalfb.com/code/fbsource/[c9a529f3238d8f9f9a1dc47479a1caa65f8eb246]/fbcode/github/presto-trunk/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java?lines=87) 
- Minor change: Update error message for Values At Quantiles to follow Java [here](https://www.internalfb.com/code/fbsource/[c9a529f3238d8f9f9a1dc47479a1caa65f8eb246]/fbcode/github/presto-trunk/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java?lines=73)

Differential Revision: D77047702


