### PR TITLE
fix slicing RowVector

### DIFF
--- a/velox/exec/Limit.cpp
+++ b/velox/exec/Limit.cpp
@@ -89,12 +89,8 @@ RowVectorPtr Limit::getOutput() {
     return output;
   }
 
-  auto output = std::make_shared<RowVector>(
-      input_->pool(),
-      input_->type(),
-      input_->nulls(),
-      remainingLimit_,
-      input_->children());
+  auto output =
+      std::dynamic_pointer_cast<RowVector>(input_->slice(0, remainingLimit_));
   input_.reset();
   remainingLimit_ = 0;
   return output;


### PR DESCRIPTION
Summary:
use slice method from RowVector instead of using constructor.
previous way doesn't correctly set size of child vectors and nulls buffer when remainingLimit_ is smaller than input size

Reviewed By: xiaoxmeng

Differential Revision: D77053238


