### PR TITLE
fix(TextReader): Resize rowVecPtr when EOF is true

### DIFF
--- a/velox/dwio/text/reader/TextReaderImpl.cpp
+++ b/velox/dwio/text/reader/TextReaderImpl.cpp
@@ -164,6 +164,7 @@ uint64_t TextRowReaderImpl::next(
     rowsRead++;
     if (pos_ >= getLength()) {
       atEOF_ = true;
+      rowVecPtr->resize(rowsRead);
     }
 
     // handle empty file


### PR DESCRIPTION
The size of rowVectorPtr is initialized with the `rows` argument and should be resized to the actual value when an EOF is reached.