### PR TITLE
fix: PlanBuilder::tableWriteMerge API

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1294,6 +1294,8 @@ class AggregationNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
+using AggregationNodePtr = std::shared_ptr<const AggregationNode>;
+
 inline std::ostream& operator<<(
     std::ostream& out,
     const AggregationNode::Step& step) {
@@ -1322,7 +1324,7 @@ class TableWriteNode : public PlanNode {
       const PlanNodeId& id,
       const RowTypePtr& columns,
       const std::vector<std::string>& columnNames,
-      std::shared_ptr<AggregationNode> aggregationNode,
+      AggregationNodePtr aggregationNode,
       std::shared_ptr<InsertTableHandle> insertTableHandle,
       bool hasPartitioningScheme,
       RowTypePtr outputType,
@@ -1379,7 +1381,7 @@ class TableWriteNode : public PlanNode {
       return *this;
     }
 
-    Builder& aggregationNode(std::shared_ptr<AggregationNode> aggregationNode) {
+    Builder& aggregationNode(AggregationNodePtr aggregationNode) {
       aggregationNode_ = std::move(aggregationNode);
       return *this;
     }
@@ -1449,7 +1451,7 @@ class TableWriteNode : public PlanNode {
     std::optional<PlanNodeId> id_;
     std::optional<RowTypePtr> columns_;
     std::optional<std::vector<std::string>> columnNames_;
-    std::optional<std::shared_ptr<AggregationNode>> aggregationNode_;
+    std::optional<AggregationNodePtr> aggregationNode_;
     std::optional<std::shared_ptr<InsertTableHandle>> insertTableHandle_;
     std::optional<bool> hasPartitioningScheme_;
     std::optional<RowTypePtr> outputType_;
@@ -1498,7 +1500,7 @@ class TableWriteNode : public PlanNode {
   }
 
   /// Optional aggregation node for column statistics collection
-  std::shared_ptr<AggregationNode> aggregationNode() const {
+  const AggregationNodePtr& aggregationNode() const {
     return aggregationNode_;
   }
 
@@ -1520,7 +1522,7 @@ class TableWriteNode : public PlanNode {
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr columns_;
   const std::vector<std::string> columnNames_;
-  const std::shared_ptr<AggregationNode> aggregationNode_;
+  const AggregationNodePtr aggregationNode_;
   const std::shared_ptr<InsertTableHandle> insertTableHandle_;
   const bool hasPartitioningScheme_;
   const RowTypePtr outputType_;
@@ -1535,7 +1537,7 @@ class TableWriteMergeNode : public PlanNode {
   TableWriteMergeNode(
       const PlanNodeId& id,
       RowTypePtr outputType,
-      std::shared_ptr<AggregationNode> aggregationNode,
+      AggregationNodePtr aggregationNode,
       PlanNodePtr source)
       : PlanNode(id),
         aggregationNode_(std::move(aggregationNode)),
@@ -1564,7 +1566,7 @@ class TableWriteMergeNode : public PlanNode {
       return *this;
     }
 
-    Builder& aggregationNode(std::shared_ptr<AggregationNode> aggregationNode) {
+    Builder& aggregationNode(AggregationNodePtr aggregationNode) {
       aggregationNode_ = std::move(aggregationNode);
       return *this;
     }
@@ -1594,12 +1596,12 @@ class TableWriteMergeNode : public PlanNode {
    private:
     std::optional<PlanNodeId> id_;
     std::optional<RowTypePtr> outputType_;
-    std::optional<std::shared_ptr<AggregationNode>> aggregationNode_;
+    std::optional<AggregationNodePtr> aggregationNode_;
     std::optional<PlanNodePtr> source_;
   };
 
   /// Optional aggregation node for column statistics collection
-  std::shared_ptr<AggregationNode> aggregationNode() const {
+  AggregationNodePtr aggregationNode() const {
     return aggregationNode_;
   }
 
@@ -1625,7 +1627,7 @@ class TableWriteMergeNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
-  const std::shared_ptr<AggregationNode> aggregationNode_;
+  const AggregationNodePtr aggregationNode_;
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
 };

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -473,7 +473,7 @@ const TypePtr& TableWriteTraits::contextColumnType() {
 }
 
 const RowTypePtr TableWriteTraits::outputType(
-    const std::shared_ptr<core::AggregationNode>& aggregationNode) {
+    const core::AggregationNodePtr& aggregationNode) {
   static const auto kOutputTypeWithoutStats =
       ROW({rowCountColumnName(), fragmentColumnName(), contextColumnName()},
           {rowCountColumnType(), fragmentColumnType(), contextColumnType()});

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -77,7 +77,7 @@ class TableWriteTraits {
   static constexpr std::string_view klastPageContextKey = "lastPage";
 
   static const RowTypePtr outputType(
-      const std::shared_ptr<core::AggregationNode>& aggregationNode = nullptr);
+      const core::AggregationNodePtr& aggregationNode = nullptr);
 
   /// Returns the parsed commit context from table writer 'output'.
   static folly::dynamic getTableCommitContext(const RowVectorPtr& output);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -637,7 +637,7 @@ PlanBuilder& PlanBuilder::tableWrite(
 }
 
 PlanBuilder& PlanBuilder::tableWriteMerge(
-    const std::shared_ptr<core::AggregationNode>& aggregationNode) {
+    const core::AggregationNodePtr& aggregationNode) {
   planNode_ = std::make_shared<core::TableWriteMergeNode>(
       nextPlanNodeId(),
       TableWriteTraits::outputType(aggregationNode),

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -736,7 +736,7 @@ class PlanBuilder {
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge(
-      const std::shared_ptr<core::AggregationNode>& aggregationNode = nullptr);
+      const core::AggregationNodePtr& aggregationNode = nullptr);
 
   /// Add an AggregationNode representing partial aggregation with the
   /// specified grouping keys, aggregates and optional masks.


### PR DESCRIPTION
Summary:
PlanBuilder::tableWriteMerge should take `std::shared_ptr<const AggregationNode>`, not `std::shared_ptr<AggregationNode>`. 

See https://github.com/facebookincubator/velox/pull/13758#discussion_r2161523058

Differential Revision: D77148564


