### PR TITLE
fix: TestIndexSource::initOutputProjections

### DIFF
--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -283,7 +283,7 @@ IndexLookupJoinTestBase::makeIndexScanNode(
     const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>
         indexTableHandle,
     const facebook::velox::RowTypePtr& outputType,
-    std::unordered_map<
+    const std::unordered_map<
         std::string,
         std::shared_ptr<facebook::velox::connector::ColumnHandle>>&
         assignments) {

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -125,7 +125,7 @@ class IndexLookupJoinTestBase
       const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>
           indexTableHandle,
       const facebook::velox::RowTypePtr& outputType,
-      std::unordered_map<
+      const std::unordered_map<
           std::string,
           std::shared_ptr<facebook::velox::connector::ColumnHandle>>&
           assignments);

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "velox/exec/HashTable.h"
-#include "velox/exec/OperatorUtils.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::exec::test {
@@ -38,6 +37,13 @@ struct TestIndexTable {
       : keyType(std::move(_keyType)),
         dataType(std::move(_dataType)),
         table(std::move(_table)) {}
+
+  // Create index table with the given key and value inputs.
+  static std::shared_ptr<TestIndexTable> create(
+      size_t numEqualJoinKeys,
+      const RowVectorPtr& keyData,
+      const RowVectorPtr& valueData,
+      velox::memory::MemoryPool& pool);
 };
 
 // The index table handle which provides the index table for index lookup.

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -66,19 +66,11 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
     velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
-    connector::registerConnectorFactory(
-        std::make_shared<TestIndexConnectorFactory>());
     auto connectorCpuExecutor =
         std::make_unique<folly::CPUThreadPoolExecutor>(128);
-    std::shared_ptr<connector::Connector> connector =
-        connector::getConnectorFactory(kTestIndexConnectorName)
-            ->newConnector(
-                kTestIndexConnectorName,
-                {},
-                nullptr,
-                connectorCpuExecutor.get());
-    connector::registerConnector(connector);
+    TestIndexConnectorFactory::registerConnector(connectorCpuExecutor.get());
     TestIndexTableHandle::registerSerDe();
+    TestIndexColumnHandle::registerSerDe();
   }
 
   void TearDown() override {
@@ -159,11 +151,10 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
 
   // Makes index table handle with the specified index table and async lookup
   // flag.
-  std::shared_ptr<TestIndexTableHandle> makeIndexTableHandle(
-      const std::shared_ptr<TestIndexTable>& indexTable,
-      bool asyncLookup) {
+  static std::shared_ptr<TestIndexTableHandle> makeIndexTableHandle(
+      const std::shared_ptr<TestIndexTable>& indexTable) {
     return std::make_shared<TestIndexTableHandle>(
-        kTestIndexConnectorName, indexTable, asyncLookup);
+        kTestIndexConnectorName, indexTable, /*asyncLookup*/ false);
   }
 
   struct PlanWithSplits {
@@ -256,18 +247,13 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
            makeFlatVector<StringView>({"x", "y", "z"})}));
 
   // Create a TestIndexTableHandle with the TestIndexTable
-  auto indexTableHandle = std::make_shared<TestIndexTableHandle>(
-      kTestIndexConnectorName, indexTable, /*asyncLookup=*/false);
+  auto indexTableHandle = makeIndexTableHandle(indexTable);
 
   // Create a table scan node with the TestIndexTableHandle
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       columnHandles;
   for (const auto& name : indexType_->names()) {
-    columnHandles[name] = std::make_shared<HiveColumnHandle>(
-        name,
-        HiveColumnHandle::ColumnType::kRegular,
-        indexType_->findChild(name),
-        indexType_->findChild(name));
+    columnHandles[name] = std::make_shared<TestIndexColumnHandle>(name);
   }
 
   auto indexScan = std::make_shared<core::TableScanNode>(


### PR DESCRIPTION
Summary:
TestIndexSource didn't support using column assignments in TableScan plan node to project columns under different names.

Also, introduce TestIndexConnectorFactory::registerConnector helper method to reduce boiler plate.

Differential Revision: D77173098


