### PR TITLE
feat(sketch): Implement SfmSketch data structure

### DIFF
--- a/velox/functions/prestosql/aggregates/sfm/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/sfm/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(velox_functions_prestosql_aggregates_sfm SfmSketch.cpp)
+
+velox_link_libraries(velox_functions_prestosql_aggregates_sfm velox_common_base
+                     velox_memory Folly::folly)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h
+++ b/velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <random>
+#include "velox/functions/prestosql/aggregates/sfm/RandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+
+/// A pseudorandomness strategy used to merge SfmSketches.
+class MersenneTwisterRandomizationStrategy : public RandomizationStrategy {
+ public:
+  explicit MersenneTwisterRandomizationStrategy(
+      std::optional<int32_t> seed = {}) {
+    if (seed.has_value()) {
+      rng_.seed(seed.value());
+    }
+  }
+
+  bool nextBoolean(double probability) override {
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+    return dist(rng_) < probability;
+  }
+
+ private:
+  std::mt19937_64 rng_;
+};
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/RandomizationStrategy.h
+++ b/velox/functions/prestosql/aggregates/sfm/RandomizationStrategy.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::functions::aggregate {
+
+/// Interface for randomization strategy. We will implement different
+/// randomization strategies in merging, enable-privacy and testing.
+class RandomizationStrategy {
+ public:
+  virtual bool nextBoolean(double probability) = 0;
+
+  virtual ~RandomizationStrategy() = default;
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/SecureRandomizationStrategy.h
+++ b/velox/functions/prestosql/aggregates/sfm/SecureRandomizationStrategy.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Random.h>
+#include "velox/functions/prestosql/aggregates/sfm/RandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+
+/// A secure randomization strategy used to enable differential privacy for
+/// SfmSketch.
+class SecureRandomizationStrategy : public RandomizationStrategy {
+ public:
+  bool nextBoolean(double probability) override {
+    // folly random generate random number in [0, 1)
+    return folly::Random::secureRandDouble01() < probability;
+  }
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketch.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketch.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include <cmath>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h"
+#include "velox/functions/prestosql/aggregates/sfm/SecureRandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+
+namespace {
+void validateNumIndexBits(int32_t numIndexBits) {
+  VELOX_CHECK_LE(numIndexBits, 16, "numIndexBits must be <= 16.");
+  VELOX_CHECK_GE(numIndexBits, 1, "numIndexBits must be >= 1.");
+}
+
+int32_t numberOfTrailingZeros(uint64_t hash, int32_t numIndexBits) {
+  // Set the lowest bit in the prefix to ensure value is non-zero.
+  constexpr int32_t kBitWidth = sizeof(uint64_t) * 8;
+  const uint64_t value = hash | (1ULL << (kBitWidth - numIndexBits));
+
+  // Safe to call because value is guaranteed non-zero.
+  return __builtin_ctzll(value);
+}
+} // namespace
+
+using Allocator = StlAllocator<int8_t>;
+
+SfmSketch::SfmSketch(
+    HashStringAllocator* allocator,
+    std::optional<int32_t> seed)
+    : bits_{Allocator(allocator)} {
+  if (seed.has_value()) {
+    randomizationStrategy_ = MersenneTwisterRandomizationStrategy(*seed);
+  }
+}
+
+void SfmSketch::initialize(int32_t buckets, int32_t precision) {
+  const auto numIndexBits = SfmSketch::numIndexBits(buckets);
+  validateNumIndexBits(numIndexBits);
+
+  VELOX_CHECK_LE(
+      precision + numIndexBits,
+      64,
+      "Precision + numIndexBits cannot exceed 64");
+  numBuckets_ = buckets;
+  numIndexBits_ = numIndexBits;
+  precision_ = precision;
+
+  bits_.resize(bits::nbytes(buckets * precision));
+  rawBits_ = reinterpret_cast<uint64_t*>(bits_.data());
+}
+
+void SfmSketch::addHash(uint64_t hash) {
+  const auto bucketIndex = computeIndex(hash, numIndexBits_);
+  // Cap the number of trailing zeros to precision - 1, to avoid out of
+  // bounds.
+  const auto zeros =
+      std::min(precision_ - 1, numberOfTrailingZeros(hash, numIndexBits_));
+  setBitTrue(bucketIndex, zeros);
+}
+
+void SfmSketch::addIndexAndZeros(int32_t bucketIndex, int32_t zeros) {
+  VELOX_CHECK_GE(bucketIndex, 0, "Bucket index out of range.");
+  VELOX_CHECK_LT(bucketIndex, numBuckets_, "Bucket index out of range.");
+  VELOX_CHECK_GE(zeros, 0, "Zeros must be greater than or equal to 0.");
+  VELOX_CHECK_LE(zeros, 64, "Zeros must be less than or equal to 64.");
+  VELOX_CHECK(isInitialized(), "Sketch is not initialized.");
+
+  // Count of zeros in range [0, precision - 1].
+  zeros = std::min(precision_ - 1, zeros);
+  setBitTrue(bucketIndex, zeros);
+}
+
+// static
+int32_t SfmSketch::computeIndex(uint64_t hash, int32_t numIndexBits) {
+  validateNumIndexBits(numIndexBits);
+  constexpr int32_t kBitWidth = 64; // The hash is 64 bits.
+  return static_cast<int32_t>(hash >> (kBitWidth - numIndexBits));
+}
+
+// static
+int32_t SfmSketch::numBuckets(int32_t numIndexBits) {
+  validateNumIndexBits(numIndexBits);
+  return 1 << numIndexBits;
+}
+
+// static
+int32_t SfmSketch::numIndexBits(int32_t buckets) {
+  VELOX_CHECK_GT(buckets, 0, "Number of buckets must be greater than 0.");
+  VELOX_CHECK_EQ(
+      buckets & (buckets - 1), 0, "Number of buckets must be power of 2.");
+  return static_cast<int32_t>(std::log2(buckets));
+}
+
+// static
+double SfmSketch::calculateRandomizedResponseProbability(double epsilon) {
+  if (epsilon == kNonPrivateEpsilon) {
+    return 0.0;
+  }
+  return 1.0 / (1.0 + exp(epsilon));
+}
+
+void SfmSketch::mergeWith(const SfmSketch& other) {
+  VELOX_CHECK_EQ(
+      precision_,
+      other.precision_,
+      "Cannot merge two SFM sketches with different precision");
+  VELOX_CHECK_EQ(
+      numIndexBits_,
+      other.numIndexBits_,
+      "Cannot merge two SFM sketches with different numIndexBits");
+  VELOX_CHECK(isInitialized(), "Sketch is not initialized.");
+  const auto numBits = precision_ * numBuckets_;
+
+  // If neither sketch is private, we just take the OR of the sketches.
+  if (!privacyEnabled() && !other.privacyEnabled()) {
+    bits::orBits(rawBits_, other.rawBits_, 0, numBits);
+  } else {
+    // If either sketch is private, we combine using a randomized merge.
+    const double p1 = randomizedResponseProbability_;
+    const double p2 = other.randomizedResponseProbability_;
+    const double p = mergeRandomizedResponseProbabilities(p1, p2);
+    const double normalizer = (1 - 2 * p) / ((1 - 2 * p1) * (1 - 2 * p2));
+
+    if (!randomizationStrategy_.has_value()) {
+      randomizationStrategy_ = MersenneTwisterRandomizationStrategy();
+    }
+
+    for (int32_t i = 0; i < numBits; i++) {
+      const double bit1 = bits::isBitSet(rawBits_, i) ? 1.0 : 0.0;
+      const double bit2 = bits::isBitSet(other.rawBits_, i) ? 1.0 : 0.0;
+      const double x =
+          1 - 2 * p - normalizer * (1 - p1 - bit1) * (1 - p2 - bit2);
+      double probability = p + normalizer * x;
+      probability = std::min(1.0, std::max(0.0, probability));
+
+      bits::setBit(
+          rawBits_, i, randomizationStrategy_->nextBoolean(probability));
+    }
+  }
+
+  randomizedResponseProbability_ = mergeRandomizedResponseProbabilities(
+      randomizedResponseProbability_, other.randomizedResponseProbability_);
+}
+
+void SfmSketch::enablePrivacy(double epsilon) {
+  VELOX_CHECK(isInitialized(), "Sketch is not initialized.");
+  VELOX_CHECK(!privacyEnabled(), "Privacy is already enabled.");
+  VELOX_CHECK_GT(
+      epsilon, 0, "Epsilon must be greater than zero or equal to infinity");
+  randomizedResponseProbability_ =
+      calculateRandomizedResponseProbability(epsilon);
+
+  auto applyRandomization = [this](auto& randomizationStrategy) {
+    // Toggle each bit with a randomly generated probability.
+    // If seed is provided, use it to generate a deterministic randomization.
+    // Otherwise, use a secure randomization strategy.
+    const auto numBits = precision_ * numBuckets_;
+    for (int32_t i = 0; i < numBits; ++i) {
+      if (randomizationStrategy.nextBoolean(randomizedResponseProbability_)) {
+        bits::negateBit(bits_.data(), i);
+      }
+    }
+  };
+
+  // If randomizationStrategy_ is now set, it's guaranteed to be a deterministic
+  // randomization strategy set in constructor, otherwise it would have
+  // been set in private sketch merge which only happens after enablePrivacy().
+  if (randomizationStrategy_.has_value()) {
+    applyRandomization(*randomizationStrategy_);
+  } else {
+    SecureRandomizationStrategy randomizationStrategy;
+    applyRandomization(randomizationStrategy);
+  }
+}
+
+int32_t SfmSketch::countBits() const {
+  return bits::countBits(rawBits_, 0, precision_ * numBuckets_);
+}
+
+int64_t SfmSketch::cardinality() const {
+  VELOX_CHECK(isInitialized(), "Sketch is not initialized.");
+  // Handle empty sketch case.
+  if (countBits() == 0) {
+    return 0;
+  }
+
+  double guess = 1.0;
+  double changeInGuess = std::numeric_limits<double>::infinity();
+  int32_t iterations = 0;
+
+  while (std::abs(changeInGuess) > 0.1 && iterations < kMaxIteration) {
+    changeInGuess = -logLikelihoodFirstDerivative(guess) /
+        logLikelihoodSecondDerivative(guess);
+    guess += changeInGuess;
+    iterations++;
+  }
+
+  // Handle NaN values, which is unlikely from any real sketch but can happen.
+  // We add the check here to avoid undefined behavior.
+  if (std::isnan(guess)) {
+    return 0;
+  }
+
+  VELOX_CHECK_LE(guess, std::numeric_limits<int64_t>::max());
+  // Clamp negative values to 0 before rounding to avoid undefined behavior
+  // when casting negative values to unsigned types.
+  double clampedGuess = std::max(0.0, guess);
+  return static_cast<int64_t>(std::round(clampedGuess));
+}
+
+// Java-compatible format: FORMAT_TAG + numIndexBits + precision +
+// randomizedResponseProbability + compactBitSize + bitsData.
+int32_t SfmSketch::serializedSize() const {
+  return static_cast<int32_t>(
+      sizeof(int8_t) + sizeof(int32_t) + sizeof(int32_t) + sizeof(double) +
+      sizeof(int32_t) + compactBitSize());
+}
+
+void SfmSketch::serialize(char* out) const {
+  common::OutputByteStream stream(out);
+  stream.appendOne(kFormatTag);
+  stream.appendOne(numIndexBits_);
+  stream.appendOne(precision_);
+  stream.appendOne(randomizedResponseProbability_);
+  const auto compactBitSize = this->compactBitSize();
+  stream.appendOne(compactBitSize);
+
+  // Only append data if the vector is not empty to avoid null pointer issues.
+  if (compactBitSize > 0) {
+    stream.append(reinterpret_cast<const char*>(bits_.data()), compactBitSize);
+  }
+}
+
+SfmSketch SfmSketch::deserialize(
+    const char* in,
+    HashStringAllocator* allocator) {
+  common::InputByteStream stream(in);
+  const auto formatTag = stream.read<int8_t>();
+  const auto numIndexBits = stream.read<int32_t>();
+  const auto precision = stream.read<int32_t>();
+  const auto randomizedResponseProbability = stream.read<double>();
+  const auto compactBitSize = stream.read<int32_t>();
+
+  // Validate format tag.
+  VELOX_CHECK_EQ(formatTag, kFormatTag, "Invalid format tag");
+
+  // Validate numIndexBits before calling numBuckets.
+  validateNumIndexBits(numIndexBits);
+
+  // Create the sketch.
+  SfmSketch sketch(allocator);
+  const auto buckets = numBuckets(numIndexBits);
+  sketch.initialize(buckets, precision);
+
+  // Set the randomized response probability.
+  sketch.randomizedResponseProbability_ = randomizedResponseProbability;
+
+  // Read the serialized bitmap data directly into the sketch's bitset.
+  // The sketch's bitset is already the correct size and zero-initialized.
+  // We just need to copy the serialized data (which may be truncated).
+  stream.copyTo(sketch.bits_.data(), compactBitSize);
+
+  return sketch;
+}
+
+double SfmSketch::observationProbability(int32_t level) const {
+  return std::pow(2.0, -(level + 1.0)) / numBuckets_;
+}
+
+int32_t SfmSketch::compactBitSize() const {
+  // Find the last non-zero byte.
+  const int32_t lastSetBit =
+      bits::findLastBit(rawBits_, 0, precision_ * numBuckets_);
+
+  if (lastSetBit < 0) {
+    // No bits are set.
+    return 0;
+  }
+  return bits::nbytes(lastSetBit + 1);
+}
+
+double SfmSketch::logLikelihoodFirstDerivative(double n) const {
+  double result = 0.0;
+  for (int32_t level = 0; level < precision_; level++) {
+    const double termOn = logLikelihoodTermFirstDerivative(level, true, n);
+    const double termOff = logLikelihoodTermFirstDerivative(level, false, n);
+    for (int32_t bucket = 0; bucket < numBuckets_; bucket++) {
+      int32_t bitPosition = level * numBuckets_ + bucket;
+      result += bits::isBitSet(bits_.data(), bitPosition) ? termOn : termOff;
+    }
+  }
+  return result;
+}
+
+double SfmSketch::logLikelihoodTermFirstDerivative(
+    int32_t level,
+    bool on,
+    double n) const {
+  const double p = observationProbability(level);
+  const int32_t sign = on ? -1 : 1;
+  const double c1 = on ? onProbability() : 1 - onProbability();
+  const double c2 = onProbability() - randomizedResponseProbability_;
+  return std::log1p(-p) * (1 - c1 / (c1 + sign * c2 * std::pow(1 - p, n)));
+}
+
+double SfmSketch::logLikelihoodSecondDerivative(double n) const {
+  double result = 0.0;
+  for (int32_t level = 0; level < precision_; level++) {
+    const double termOn = logLikelihoodTermSecondDerivative(level, true, n);
+    const double termOff = logLikelihoodTermSecondDerivative(level, false, n);
+    for (int32_t bucket = 0; bucket < numBuckets_; bucket++) {
+      const int32_t bitPosition = level * numBuckets_ + bucket;
+      result += bits::isBitSet(bits_.data(), bitPosition) ? termOn : termOff;
+    }
+  }
+  return result;
+}
+
+double SfmSketch::logLikelihoodTermSecondDerivative(
+    int32_t level,
+    bool on,
+    double n) const {
+  const double p = observationProbability(level);
+  const int32_t sign = on ? -1 : 1;
+  const double c1 = on ? onProbability() : 1 - onProbability();
+  const double c2 = onProbability() - randomizedResponseProbability_;
+  return sign * c1 * c2 * std::pow(std::log1p(-p), 2) * std::pow(1 - p, n) *
+      std::pow(c1 + sign * c2 * std::pow(1 - p, n), -2);
+}
+
+void SfmSketch::setBitTrue(int32_t bucketIndex, int32_t zeros) {
+  VELOX_CHECK(!privacyEnabled(), "Private sketch is immutable.");
+  // It's more likely to have a hash with less zeros than more zeros.
+  // We keep the bitmap in the form of a bit matrix, where each row is a zero
+  // level instead of a bucket.
+  // In this way, we can save space by dropping the trailing zeros in
+  // serialization.
+  const auto bitPosition = zeros * numBuckets_ + bucketIndex;
+  bits::setBit(bits_.data(), bitPosition, true);
+}
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketch.h
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketch.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Range.h>
+#include <xxhash.h>
+#include <cstdint>
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h"
+
+namespace facebook::velox::functions::aggregate {
+
+/// SFM sketch is used for estimating distinct count, very similar to
+/// HyperLogLog. This sketch is introduced in the paper Sketch-Flip-Merge:
+/// Mergeable Sketches for Private Distinct Counting
+/// <https://arxiv.org/pdf/2302.02056.pdf>.
+
+/// The primary differences between SFM sketch and HyperLogLog are that
+///  (a) SFM sketch supports noise addition.
+///  (b) SFM sketch tracks a larger number of hash statistics (and is therefore
+///  larger).
+
+/// The SFM sketch data structure is initially created without noise.
+/// Noise is added by randomizing the bits of the sketch via the
+/// enablePrivacy() function. Once noise has been added, further items
+/// cannot be added to the sketch. However, two or more noisy sketches may be
+/// merged together. A typical work flow is: initialize -> add -> merge/
+/// enablePrivacy -> cardinality.
+
+/// The noise level is quantified by the parameter 'epsilon', a positive real
+/// number. A smaller value of 'epsilon' corresponds to a more noisy sketch.
+/// An 'epsilon' of 0 would yield a summary that is entirely noise, while an
+/// 'epsilon' that is infinite yields no noise. The estimated cardinality
+/// becomes less accurate with the addition of more noise (i.e., smaller
+/// 'epsilon' yield less accurate results. bits of the sketch are randomized
+/// with probability 1 / (1 + exp(epsilon)), an epsilon of 1 will flip about
+/// 1 / (1 + exp(1)) = 27% of the bits of the sketch).
+class SfmSketch {
+ public:
+  /// Creates an uninitialized instance. The caller must call initialize()
+  /// before using this instance. If seed is provided, the instance will
+  /// initialize a deterministic randomization strategy, which is useful for
+  /// testing. The deterministic randomization strategy is not retained in the
+  /// serialized sketch.
+  SfmSketch(HashStringAllocator* allocator, std::optional<int32_t> seed = {});
+
+  /// Specify the sketch size. The size is determined by the number of buckets
+  /// and precision. The sketch uses buckets * precision bits or (buckets *
+  /// precision) / 8 bytes.
+
+  /// When adding items to the sketch, we compute a 64-bit hash of the item,
+  /// then use first n bits as a bucket index and last precision bits to count
+  /// zeros. n = log2(buckets) so that buckets = 2^n. Hence, buckets must be a
+  /// power of two and n + precision must be <= 64.
+
+  /// This function should be called before any other functions.
+
+  /// @param buckets The number of buckets, should be a power of 2:
+  /// buckets = 2 ^ n. Later, n is referred to as numIndexBits.
+  /// @param precision The number of bits to count trailing zeros in a hash.
+  /// precision + n must be <= 64.
+  void initialize(int32_t buckets, int32_t precision);
+
+  /// @tparam T StringView, bigint, or double.
+  template <typename T>
+  void add(T value) {
+    VELOX_CHECK(isInitialized(), "Sketch is not initialized.");
+    addHash(XXH64(
+        reinterpret_cast<const void*>(&value),
+        sizeof(value),
+        /*seed*/ 0));
+  }
+
+  /// Another way to add an element to the sketch. Explicitly toggle the bit at
+  /// 'bucketIndex' and 'zeros' position.
+  void addIndexAndZeros(int32_t bucketIndex, int32_t zeros);
+
+  /// Compute the bit index with the given hash and numIndexBits.
+  static int32_t computeIndex(uint64_t hash, int32_t numIndexBits);
+
+  /// Compute the number of buckets given the numIndexBits.
+  /// @return 2 ^ numIndexBits.
+  static int32_t numBuckets(int32_t numIndexBits);
+
+  /// Compute the number of bits needed to represent the index of a bucket.
+  /// Range of numIndexBits is [1, 16].
+  /// @return log2(buckets).
+  static int32_t numIndexBits(int32_t buckets);
+
+  /// Merge another sketch into the current sketch. Items can be added to the
+  /// sketch after merging as long as the sketch is not private.
+  void mergeWith(const SfmSketch& other);
+
+  /// Make a non-private sketch private. This function is called
+  /// after adding all the items to the sketch to add noise to the sketch and
+  /// before calling cardinality().
+  /// @param epsilon The privacy parameter, the larger the epsilon, the less
+  /// noise will be added. The range of epsilon is (0, inf].
+  void enablePrivacy(double epsilon);
+
+  /// Estimate the number of distinct items added to the sketch via maximum
+  /// pseudolikelihood (Newton's method).
+  int64_t cardinality() const;
+
+  /// Return the size of the serialized sketch in bytes.
+  int32_t serializedSize() const;
+
+  /// Serialize the sketch into pre-allocated buffer of at least
+  /// 'serializedSize()' bytes. The Java serialization format is used in
+  /// production, so we need to ensure that the C++ implementation can read and
+  /// write the same format.
+  /// The Java serialization format is as follows:
+  /// 1. 1 byte for the FORMAT_TAG = 7, constant.
+  /// 2. 4 bytes for the numIndexBits.
+  /// 3. 4 bytes for the precision.
+  /// 4. 8 bytes for the randomized response probability.
+  /// 5. 4 bytes for the actual number of bytes in the serialized bits.
+  /// 6. The bits data.
+  void serialize(char* out) const;
+
+  /// Deserialize the sketch from a pre-allocated buffer of at least
+  /// 'serializedSize()' bytes.
+  static SfmSketch deserialize(const char* in, HashStringAllocator* allocator);
+
+  int32_t numIndexBits() const {
+    return numIndexBits_;
+  }
+
+  int32_t precision() const {
+    return precision_;
+  }
+
+  bool privacyEnabled() const {
+    return randomizedResponseProbability_ > 0;
+  }
+
+ private:
+  // Epsilon for non-private sketch.
+  static constexpr double kNonPrivateEpsilon =
+      std::numeric_limits<double>::infinity();
+
+  // Maximum number of iterations for Newton's method.
+  static constexpr int32_t kMaxIteration = 1000;
+
+  // Java implementation use a format_tag to identify the sketch.
+  // We need this tag to be able to deserialize the sketch from Java.
+  static constexpr int8_t kFormatTag = 7;
+
+  // Check if the sketch is initialized.
+  bool isInitialized() const {
+    return numIndexBits_ > 0;
+  }
+
+  // Calculate the RandomizedResponseProbabilities for merged sketches.
+  // For math details, see Theorem 4.8,
+  // <a href="https://arxiv.org/pdf/2302.02056.pdf">arXiv:2302.02056</a>.
+  static double mergeRandomizedResponseProbabilities(double p1, double p2) {
+    return (p1 + p2 - 3 * p1 * p2) / (1 - 2 * p1 * p2);
+  }
+
+  // Calculate the randomized response probability given epsilon.
+  static double calculateRandomizedResponseProbability(double epsilon);
+
+  // Add a hash to the sketch.
+  void addHash(uint64_t hash);
+
+  // Probability of a 1-bit remaining a 1-bit under randomized response.
+  double onProbability() const {
+    return 1 - randomizedResponseProbability_;
+  }
+
+  // Get the number of bits that are set to 1.
+  int32_t countBits() const;
+
+  // Return the size of the bits in bytes after dropping the trailing zeros.
+  int32_t compactBitSize() const;
+
+  // Probability of observing a run of zeros of length level in any single
+  // bucket.
+  double observationProbability(int32_t level) const;
+
+  // Set the bit at given bucketIndex and zeros position.
+  void setBitTrue(int32_t bucketIndex, int32_t zeros);
+
+  // Helper functions for cardinality estimation using Newton's method.
+  double logLikelihoodFirstDerivative(double n) const;
+  double logLikelihoodTermFirstDerivative(int32_t level, bool on, double n)
+      const;
+  double logLikelihoodSecondDerivative(double n) const;
+  double logLikelihoodTermSecondDerivative(int32_t level, bool on, double n)
+      const;
+
+  // Number of buckets in the sketch.
+  int32_t numBuckets_{0};
+
+  // Number of bits to represent the index of a bucket. We use first
+  // numIndexBits bits of a hash to represent the index of a bucket, meaning
+  // that total number of buckets is 2 ^ numIndexBits, and max index is
+  // 2 ^ numIndexBits - 1.
+  int32_t numIndexBits_{0};
+
+  // Number of bits to count trailing zeros in a hash value.
+  int32_t precision_{0};
+
+  // Probability of a bit being flipped.
+  double randomizedResponseProbability_{0.0};
+
+  // The underline bit representation of the sketch.
+  std::vector<int8_t, facebook::velox::StlAllocator<int8_t>> bits_;
+
+  // Pointer to the raw bits.
+  uint64_t* rawBits_{nullptr};
+
+  // Optional randomization strategy. If seed is provided at construction, the
+  // instance will initialize a deterministic randomization strategy.
+  // Otherwise the randomization strategy will be initialized unseeded when
+  // merging private sketches.
+  std::optional<MersenneTwisterRandomizationStrategy> randomizationStrategy_;
+};
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/sfm/tests/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_functions_prestosql_aggregates_sketch_test
+               SfmSketchTest.cpp)
+
+add_test(velox_functions_prestosql_aggregates_sketch_test
+         velox_functions_prestosql_aggregates_sketch_test)
+
+target_link_libraries(
+  velox_functions_prestosql_aggregates_sketch_test
+  velox_functions_prestosql_aggregates_sketch
+  velox_memory
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/prestosql/aggregates/sfm/tests/SfmSketchTest.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/tests/SfmSketchTest.cpp
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include <xxhash.h>
+#include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class SfmSketchTest : public ::testing::Test {
+ public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+ protected:
+  const int32_t numBuckets_ = 4096;
+  const int32_t precision_ = 24;
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+TEST_F(SfmSketchTest, add) {
+  SfmSketch a(&allocator_, 1);
+  VELOX_ASSERT_THROW(a.add(1), "Sketch is not initialized.");
+
+  a.initialize(numBuckets_, precision_);
+
+  for (int32_t i = 0; i < 1000; i++) {
+    a.add(i);
+  }
+  a.enablePrivacy(3.0);
+  const auto cardinality = a.cardinality();
+
+  // Add the same values through addIndexAndZeros, and check that the
+  // cardinality is the same.
+  auto computeIndexAndZeros = [&](int32_t value) {
+    const auto hash = XXH64(&value, sizeof(value), 0);
+    const int32_t kBitWidth = sizeof(uint64_t) * 8;
+    const auto numIndexBits = static_cast<int32_t>(std::log2(numBuckets_));
+    const uint64_t trailing = hash | (1ULL << (kBitWidth - numIndexBits));
+    const auto index = static_cast<int32_t>(hash >> (kBitWidth - numIndexBits));
+    const auto zeros = __builtin_ctzll(trailing);
+    return std::make_pair(index, zeros);
+  };
+
+  SfmSketch b(&allocator_, 1);
+  b.initialize(numBuckets_, precision_);
+
+  for (int32_t i = 0; i < 1000; i++) {
+    const auto [index, zeros] = computeIndexAndZeros(i);
+    b.addIndexAndZeros(index, zeros);
+  }
+
+  b.enablePrivacy(3.0);
+  ASSERT_EQ(b.cardinality(), cardinality);
+}
+
+TEST_F(SfmSketchTest, enablePrivacy) {
+  SfmSketch sketch(&allocator_);
+  VELOX_ASSERT_THROW(sketch.enablePrivacy(3.0), "Sketch is not initialized.");
+
+  sketch.initialize(numBuckets_, precision_);
+  ASSERT_FALSE(sketch.privacyEnabled());
+
+  sketch.enablePrivacy(std::numeric_limits<double>::infinity());
+  ASSERT_FALSE(sketch.privacyEnabled());
+
+  sketch.enablePrivacy(1.0);
+  ASSERT_TRUE(sketch.privacyEnabled());
+
+  VELOX_ASSERT_THROW(sketch.enablePrivacy(1.0), "Privacy is already enabled.");
+  VELOX_ASSERT_THROW(sketch.add(1), "Private sketch is immutable.");
+}
+
+TEST_F(SfmSketchTest, merge) {
+  SfmSketch a(&allocator_);
+  SfmSketch b(&allocator_);
+  VELOX_ASSERT_THROW(a.mergeWith(b), "Sketch is not initialized.");
+
+  a.initialize(numBuckets_, precision_);
+  b.initialize(numBuckets_, precision_);
+
+  a.add(1);
+  b.add(1);
+
+  a.mergeWith(b);
+
+  // Merging two non-private sketches results in a non-private sketch.
+  ASSERT_FALSE(a.privacyEnabled());
+
+  b.enablePrivacy(3.0);
+  a.mergeWith(b);
+
+  // Merging a private sketch with a non-private sketch results in a private
+  // sketch.
+  ASSERT_TRUE(a.privacyEnabled());
+}
+
+TEST_F(SfmSketchTest, cardinality) {
+  SfmSketch sketch(&allocator_, 3);
+  VELOX_ASSERT_THROW(sketch.cardinality(), "Sketch is not initialized.");
+  sketch.initialize(numBuckets_, precision_);
+
+  // Non-private sketch should have 0 cardinality.
+  ASSERT_EQ(sketch.cardinality(), 0);
+
+  // Private sketch should have approximately 0 cardinality, but not exactly 0.
+  sketch.enablePrivacy(3.0);
+  ASSERT_EQ(sketch.cardinality(), 4);
+
+  struct TestParams {
+    int32_t numDistinct;
+    double epsilon;
+    int32_t expectedCardinality;
+  };
+
+  std::vector<TestParams> testParams = {
+      {10000, 2.0, 9804},
+      {10000, 4.0, 9898},
+      {10000, std::numeric_limits<double>::infinity(), 9926},
+      {100000, 2.0, 101130},
+      {100000, 4.0, 100044},
+      {100000, std::numeric_limits<double>::infinity(), 100332},
+      {1000000, 2.0, 1017354},
+      {1000000, 4.0, 1003236},
+      {1000000, std::numeric_limits<double>::infinity(), 999603}};
+
+  for (const auto& params : testParams) {
+    SCOPED_TRACE(
+        "numDistinct = " + std::to_string(params.numDistinct) +
+        ", epsilon = " + std::to_string(params.epsilon));
+    SfmSketch sketch(&allocator_, 1);
+    sketch.initialize(numBuckets_, precision_);
+
+    for (auto i = 0; i < params.numDistinct; i++) {
+      sketch.add(i);
+    }
+    sketch.enablePrivacy(params.epsilon);
+
+    ASSERT_EQ(sketch.cardinality(), params.expectedCardinality);
+  }
+}
+
+TEST_F(SfmSketchTest, serializationRoundTrip) {
+  SfmSketch sketch(&allocator_);
+  sketch.initialize(numBuckets_, precision_);
+
+  for (int32_t i = 0; i < 10000; i++) {
+    sketch.add(i);
+  }
+
+  sketch.enablePrivacy(4.0);
+  const auto originalCardinality = sketch.cardinality();
+
+  // Allocate buffer for serialization.
+  const auto serializedSize = sketch.serializedSize();
+  std::vector<char> buffer(serializedSize);
+  char* out = buffer.data();
+
+  sketch.serialize(out);
+  auto deserialized = SfmSketch::deserialize(out, &allocator_);
+
+  // Test that the deserialized sketch is the same as the
+  // original.
+  ASSERT_EQ(deserialized.cardinality(), originalCardinality);
+  ASSERT_TRUE(deserialized.privacyEnabled());
+  ASSERT_EQ(sketch.numIndexBits(), deserialized.numIndexBits());
+  ASSERT_EQ(sketch.precision(), deserialized.precision());
+}
+
+TEST_F(SfmSketchTest, cardinalityConsistency) {
+  // This test validates the cardinality estimation functionality of SfmSketch
+  // across multiple scenarios and data sizes:
+  // 1. Duplicate handling
+  // 2. Order independence
+  // 3. Merge consistency
+  // 4. Serialization integrity
+  // 5. Privacy noise behavior
+
+  std::vector<int32_t> dataSizes = {1000, 10000, 100000};
+
+  auto testCardinalityConsistency = [&](int32_t dataSize) {
+    SCOPED_TRACE("dataSize = " + std::to_string(dataSize));
+
+    SfmSketch base(&allocator_, 1);
+    base.initialize(numBuckets_, precision_);
+    for (int32_t i = 0; i < dataSize; i++) {
+      base.add(i);
+    }
+    base.enablePrivacy(8.0);
+
+    // This is the baseCardinality other scenarios will be compared against.
+    // baseCardinality should be approximately dataSize, with a relative error
+    // tolerance.
+    const auto baseCardinality = base.cardinality();
+    ASSERT_NEAR(baseCardinality, dataSize, dataSize * 0.05);
+
+    // Test duplicate handling.
+    SfmSketch a(&allocator_, 1);
+    a.initialize(numBuckets_, precision_);
+    for (int j = 0; j < 10; j++) {
+      for (int32_t i = 0; i < dataSize; i++) {
+        a.add(i);
+      }
+    }
+    a.enablePrivacy(8.0);
+    ASSERT_EQ(baseCardinality, a.cardinality());
+
+    // Test order independence.
+    SfmSketch b(&allocator_, 1);
+    b.initialize(numBuckets_, precision_);
+    // We make sure that 0 - (dataSize-1) are all present in the sketch, but in
+    // random order.
+    std::vector<int32_t> values;
+    values.reserve(dataSize);
+    for (int32_t i = 0; i < dataSize; i++) {
+      values.emplace_back(i);
+    }
+    std::shuffle(values.begin(), values.end(), folly::ThreadLocalPRNG());
+    for (int32_t i = 0; i < dataSize; i++) {
+      b.add(values[i]);
+    }
+
+    // Then we add random duplicate values to the sketch.
+    int32_t duplicateCount = std::max(1, dataSize / 10);
+    for (int32_t i = 0; i < duplicateCount; i++) {
+      b.add(folly::Random::rand32(dataSize));
+    }
+
+    b.enablePrivacy(8.0);
+    ASSERT_EQ(baseCardinality, b.cardinality());
+
+    // Test merge consistency.
+    SfmSketch c(&allocator_, 1);
+    c.initialize(numBuckets_, precision_);
+    SfmSketch d(&allocator_, 1);
+    d.initialize(numBuckets_, precision_);
+    SfmSketch e(&allocator_, 1);
+    e.initialize(numBuckets_, precision_);
+    for (int32_t i = 0; i < dataSize; i++) {
+      if (i % 3 == 0) {
+        c.add(i);
+      } else if (i % 3 == 1) {
+        d.add(i);
+      } else {
+        e.add(i);
+      }
+    }
+    // Merge before enabling privacy.
+    c.mergeWith(d);
+    c.mergeWith(e);
+    c.enablePrivacy(8.0);
+    ASSERT_EQ(baseCardinality, c.cardinality());
+
+    // Test serialization integrity.
+    const auto serializedSize = c.serializedSize();
+    std::vector<char> buffer(serializedSize);
+    char* out = buffer.data();
+    c.serialize(out);
+    auto deserialized = SfmSketch::deserialize(out, &allocator_);
+    ASSERT_EQ(baseCardinality, deserialized.cardinality());
+
+    // Test privacy noise behavior.
+    // Now enable privacy for d and e and merge them into c.
+    // There should be noise added to the merged sketch.
+    d.enablePrivacy(8.0);
+    e.enablePrivacy(8.0);
+    c.mergeWith(d);
+    c.mergeWith(e);
+    ASSERT_NE(baseCardinality, c.cardinality());
+    ASSERT_NEAR(baseCardinality, c.cardinality(), baseCardinality * 0.05);
+  };
+
+  for (const auto dataSize : dataSizes) {
+    testCardinalityConsistency(dataSize);
+  }
+}
+
+TEST_F(SfmSketchTest, javaSerializationCompatibility) {
+  // This test is to ensure that the C++ serialization format is compatible
+  // with the Java serialization format.
+
+  // The string is from a Java sketch serialized with the Java SfmSketch.
+  std::string javaSketchBase64 =
+      "BwgAAAAQAAAAw8JDHvpqkj//AQAA77//////////////v///////////3////7//"
+      "////////////3/////////////////////////////////v//+/+ff/////////"
+      "f///v//+//////////////////////7//////3////v//////3////v/f//////"
+      "///3////v///////v/f///////////////////////////////f///////v/////"
+      "////f///////7////+////9///////////////v//////////////////////////"
+      "////////////f////////////3//////////////7////+////////////////////"
+      "3///////////////////////9///33///v///3////f//f//9//+//////r/3///"
+      "///9//Dfz/e/++vvfV3W//qtq33z//a7///+/m3/fz7/1///1v5hmo/ayTcv3l3Vv"
+      "XmnMr+t/B72YloTNgmBy7+IKv+mIBmaBwSO4GwxBMCwWChIoYSVFTAAIIhLylIEj"
+      "mJLamBAAooMYLQgikgBAUACEAQYJUAmxMGAhDAoBJGgRgAkBCCCAABAAkIIAAAAA"
+      "EQAYEECAQYACgAACEAAQEBAACCAgAAAAQgAAAAAKgAoERABAMAAQbABAAgADEAAQ"
+      "IABQ==";
+
+  // Decode base64 to binary data.
+  std::string decoded = encoding::Base64::decode(javaSketchBase64);
+
+  auto sketch = SfmSketch::deserialize(decoded.c_str(), &allocator_);
+  // Test that the deserialized sketch is the same as the original.
+  ASSERT_EQ(sketch.cardinality(), 927499);
+}
+} // namespace facebook::velox::functions::aggregate


### PR DESCRIPTION
This diff implements the SfmSketch data structure, which is a critical component in the noisy aggregation framework. The SfmSketch is designed to efficiently store and manipulate compact representations of large datasets, enabling relatively accurate distinct count estimating while keeping some noise.

To use the sketch, one need to follow these steps:

- create an instance
- call initialize
- add data
- addd noisy
- optionally merge in a few other sketches
- call cardinality()