### PR TITLE
fix: Add random ids to fuzzer PlanNode id to avoid fuzzing collisions

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -121,6 +121,7 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   // Creates an empty table with given data type and table name. The function
   // returns the root directory of table files.
   std::string createTable(const std::string& name, const TypePtr& type);
+  void cleanUp(const std::string& name);
 
   const std::string coordinatorUri_;
   const std::string user_;

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/expression/tests/ExpressionVerifier.h"
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include "velox/common/base/Fs.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
@@ -47,11 +50,20 @@ void logInputs(const std::vector<fuzzer::InputTestCase>& inputTestCases) {
   }
 }
 
+// Generate random id for plannode. Eventually used for fuzzer table
+// uniqueness in Presto SOT tests.
+std::string generateRandomId() {
+  auto id = boost::uuids::to_string(boost::uuids::random_generator()());
+  folly::MutableStringPiece msp(&id[0], id.size());
+  msp.replaceAll("-", "_");
+  return id;
+}
+
 core::PlanNodePtr makeSourcePlan(
     const RowVectorPtr& input,
     const std::vector<core::TypedExprPtr>& transformProjections) {
   core::PlanNodePtr source = std::make_shared<core::ValuesNode>(
-      "values", std::vector<RowVectorPtr>{input});
+      generateRandomId(), std::vector<RowVectorPtr>{input});
 
   std::vector<std::string> transformNames(transformProjections.size());
   // If we need to transform types into intermediate types, add an extra


### PR DESCRIPTION
Summary:
The id of the plan node is hard set to "value" which is directly used to generate tables names during SOT fuzzer executions.

Unfortunately, we see resource sharing during cogwheel tests, so often times, creates, deletes, drops across different tests affect the same tables, so we see flakiness.

This change adds randomness to these ids that are used for table names and should fix flakiness.

Differential Revision: D77262066


