### PR TITLE
fix: Avoid passing `std::vector<bool, Alloc>::reference` to fmt

### DIFF
--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -741,7 +741,7 @@ bool QuantileDigest<T, Allocator>::validateDigest() const {
       root_,
       [&free, &visited](int32_t node) {
         VELOX_CHECK_EQ(free.count(node), 0);
-        VELOX_CHECK_EQ(visited[node], false);
+        VELOX_CHECK_EQ(bool(visited[node]), false);
         visited[node] = true;
 
         return true;


### PR DESCRIPTION
Summary:
The expression `visited[node]` is of `std::vector<bool, Alloc>::reference` type, and some versions of `fmt` library doesn't handle it well under libc++ (P1850535374), especially when custom allocator is present. Since we are just comparing equality (no need for mutation) here, casting it to bool is the most straightforward fix.

Since `std::vector<bool>::const_reference` is just `bool`, I suspected that using `vector::at() const` will suffice here. However, that's not the case since the vector itself is non-const, causing overload resolution to choose the best overload, which is the non-const one, returning the `reference`, and the conversion becomes unavoidable again.

Differential Revision: D77275081


