### PR TITLE
misc: Add a defensive check for nullptr from allocation

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -367,6 +367,7 @@ class AlignedBuffer : public Buffer {
     }
 
     void* memory = pool->allocate(preferredSize);
+    VELOX_CHECK_NOT_NULL(memory);
     auto* buffer = new (memory) ImplClass<T>(pool, preferredSize - kPaddedSize);
     // set size explicitly instead of setSize because `fillNewMemory` already
     // called the constructors


### PR DESCRIPTION
Summary:
Per suggestion from Yuhta, we can be more defensive in OOMing scenarios. Though typically we shouldn't see nullptr being returned by malloc or realloc. This might mean we have an edge case in error handling that needs follow-up.

We recently saw crashes in OOM scenarios such as T227957911.

Differential Revision: D77318087


