### PR TITLE
Fix unused-local-typedef issue in velox/exec/VectorHasher.cpp +1

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -82,7 +82,6 @@ void VectorHasher::hashValues(
     const SelectivityVector& rows,
     bool mix,
     uint64_t* result) {
-  using T = typename TypeTraits<Kind>::NativeType;
   if (decoded_.isConstantMapping()) {
     auto hash = decoded_.isNullAt(rows.begin())
         ? kNullHash


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-local-typedef` which we are enabling to remove unused code. This has the side-effect of making it easier to do refactors should as removing unnecessary includes.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D77272313


