### PR TITLE
misc: Add dummy memory reclaimer for sys root for the query ctx use case

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -389,8 +389,8 @@ class MemoryManager {
   std::string toString(bool detail = false) const;
 
   /// Returns the memory manger's internal default root memory pool for testing
-  /// purpose.
-  MemoryPool& testingDefaultRoot() const {
+  /// purpose and legacy use cases.
+  MemoryPool& deprecatedSysRootPool() const {
     return *sysRoot_;
   }
 
@@ -484,6 +484,9 @@ std::shared_ptr<MemoryPool> deprecatedAddDefaultLeafMemoryPool(
 /// TODO: deprecate this API after all the use cases are able to manage the
 /// lifecycle of the allocated memory pools properly.
 MemoryPool& deprecatedSharedLeafPool();
+
+/// Returns the sys root memory pool from the default memory manager.
+MemoryPool& deprecatedRootPool();
 
 /// Returns the system-wide memory pool for spilling memory usage.
 memory::MemoryPool* spillMemoryPool();

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -35,7 +35,7 @@ class BenchmarkHelper {
 
   std::vector<MemoryPool*> findLeaves() {
     std::vector<MemoryPool*> leaves;
-    findLeavesOf(manager_.testingDefaultRoot(), leaves);
+    findLeavesOf(manager_.deprecatedSysRootPool(), leaves);
     return leaves;
   }
 
@@ -158,7 +158,7 @@ void addNLeaves(MemoryPool& pool, size_t n) {
 BENCHMARK(FlatTree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  addNLeaves(manager.testingDefaultRoot(), 10 * 20);
+  addNLeaves(manager.deprecatedSysRootPool(), 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
   helper.runForEachPool([iters](MemoryPool& pool) {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -945,7 +945,7 @@ TEST_P(MemoryPoolTest, childUsageTest) {
 
 TEST_P(MemoryPoolTest, getPreferredSize) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.testingDefaultRoot());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
 
   // size < 8
   EXPECT_EQ(8, pool.preferredSize(1));
@@ -1047,7 +1047,7 @@ TEST_P(MemoryPoolTest, customizedGetPreferredSize) {
 
 TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.testingDefaultRoot());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
 
   EXPECT_EQ(1ULL << 32, pool.preferredSize((1ULL << 32) - 1));
   EXPECT_EQ(1ULL << 63, pool.preferredSize((1ULL << 62) - 1 + (1ULL << 62)));
@@ -1055,7 +1055,7 @@ TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
 
 TEST_P(MemoryPoolTest, allocatorOverflow) {
   MemoryManager& manager = *getMemoryManager();
-  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.testingDefaultRoot());
+  auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.deprecatedSysRootPool());
   StlAllocator<int64_t> alloc(pool);
   EXPECT_THROW(alloc.allocate(1ULL << 62), VeloxException);
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), VeloxException);

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   PlanFragmentTest.cpp
   PlanNodeTest.cpp
   QueryConfigTest.cpp
+  QueryCtxTest.cpp
   StringTest.cpp
   TypeAnalysisTest.cpp
   TypedExprSerdeTest.cpp)

--- a/velox/core/tests/QueryCtxTest.cpp
+++ b/velox/core/tests/QueryCtxTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/QueryCtx.h"
+
+namespace facebook::velox::core::test {
+
+class QueryCtxTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+};
+
+TEST_F(QueryCtxTest, withSysRootPool) {
+  auto queryCtx = QueryCtx::create(
+      nullptr,
+      QueryConfig{{}},
+      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      nullptr,
+      memory::deprecatedRootPool().shared_from_this());
+  auto* queryPool = queryCtx->pool();
+  ASSERT_EQ(&memory::deprecatedRootPool(), queryPool);
+  ASSERT_NE(queryPool->reclaimer(), nullptr);
+  try {
+    VELOX_FAIL("Trigger Error");
+  } catch (const velox::VeloxRuntimeError& e) {
+    VELOX_ASSERT_THROW(
+        queryPool->reclaimer()->abort(queryPool, std::current_exception()),
+        "SysMemoryReclaimer::abort is not supported");
+  }
+  ASSERT_EQ(queryPool->reclaimer()->priority(), 0);
+  memory::MemoryReclaimer::Stats stats;
+  ASSERT_EQ(queryPool->reclaimer()->reclaim(queryPool, 1'000, 1'000, stats), 0);
+  uint64_t reclaimableBytes{0};
+  ASSERT_FALSE(
+      queryPool->reclaimer()->reclaimableBytes(*queryPool, reclaimableBytes));
+}
+} // namespace facebook::velox::core::test

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -240,7 +240,7 @@ class MemoryArbitrationFuzzer {
           memory::kMaxMemory,
           memory::MemoryReclaimer::create())};
   std::shared_ptr<memory::MemoryPool> pool_{
-      memory::memoryManager()->testingDefaultRoot().addLeafChild(
+      memory::memoryManager()->deprecatedSysRootPool().addLeafChild(
           "memoryArbitrationFuzzerLeaf",
           true)};
   std::shared_ptr<memory::MemoryPool> writerPool_{rootPool_->addAggregateChild(


### PR DESCRIPTION
Summary: Meta internal use might need to create query ctx with default system root pool which doesn't expect memory arbitration. However the query ctx will set memory reclaimer for memory arbitration integration. This PR adds a dummy memory reclaimer for system root pool just in case if memory arbitration is unexpected triggered to catch.

Differential Revision: D77331518


