### PR TITLE
misc: Move arrow logging include to avoid potential macro errors

### DIFF
--- a/velox/dwio/parquet/writer/arrow/Encoding.cpp
+++ b/velox/dwio/parquet/writer/arrow/Encoding.cpp
@@ -40,6 +40,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/bitmap_writer.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_data_inline.h"
 

--- a/velox/dwio/parquet/writer/arrow/util/Hashing.h
+++ b/velox/dwio/parquet/writer/arrow/util/Hashing.h
@@ -41,7 +41,6 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_builders.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"
 


### PR DESCRIPTION
Arrow logging defines macro DCHECK which can be redefined and result in an error if VeloxExceptions is included after it.

This PR removes the logging.h from Hashing.h because it is not used there.
It adds it to Encoding.cpp due to use of some arrow macros. VeloxExceptions
is not used and doesn’t cause a problem there.