### PR TITLE
feat: Add null key support for index join

### DIFF
--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -793,8 +793,7 @@ TEST_P(StreamingAggregationTest, closeUninitialized) {
 }
 
 TEST_P(StreamingAggregationTest, sortedAggregations) {
-  auto size = 1024;
-
+  const auto size = 512;
   std::vector<VectorPtr> keys = {
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
       makeFlatVector<int32_t>(size, [size](auto row) { return (size + row); }),
@@ -804,7 +803,7 @@ TEST_P(StreamingAggregationTest, sortedAggregations) {
           78, [size](auto row) { return (3 * size + row); }),
   };
 
-  testSortedAggregation(keys, 1024);
+  testSortedAggregation(keys, 512);
   testSortedAggregation(keys, 32);
 }
 

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -50,6 +50,7 @@ class IndexLookupJoinTestBase
   /// @param tableData: contains the sequence table data including key vectors
   /// and min/max key values.
   /// @param probeJoinKeys: the prefix key colums used for equality joins.
+  /// @param hasNullKeys: whether the probe input has null keys.
   /// @param inColumns: the ordered list of in conditions.
   /// @param betweenColumns: the ordered list of between conditions.
   /// @param equalMatchPct: percentage of rows in the probe input that matches
@@ -65,7 +66,8 @@ class IndexLookupJoinTestBase
       SequenceTableData& tableData,
       std::shared_ptr<facebook::velox::memory::MemoryPool>& pool,
       const std::vector<std::string>& probeJoinKeys,
-      const std::vector<std::string> inColumns = {},
+      bool hasNullKeys = false,
+      const std::vector<std::string>& inColumns = {},
       const std::vector<std::pair<std::string, std::string>>& betweenColumns =
           {},
       std::optional<int> equalMatchPct = std::nullopt,

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -427,7 +427,7 @@ class OptionalAccessor {
  private:
   const VectorReader<T>* reader_;
   // Index of element within the reader.
-  int64_t index_;
+  const int64_t index_;
 
   template <bool nullable, typename V>
   friend class ArrayView;


### PR DESCRIPTION
Summary:
Add null key support for index join. If a probe input has any null in the columns used for index join, the index join operator will skip the join and return the null result.
Also fix an invalid check in partition serde which expects the child vector has the same length as the parent row vector which is not always the case for velox vector. We shall only require the child vector is no less than parent vector size

Differential Revision: D77202778


