### PR TITLE
fix: Do not crash when reading struct child larger than number of top level row

### DIFF
--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -61,7 +61,7 @@ VectorPtr RowReader::projectColumns(
       childType = inputRowType.childAt(childIdx);
       child = inputRow->childAt(childIdx);
       if (child) {
-        childSpec->applyFilter(*child, passed.data());
+        childSpec->applyFilter(*child, inputRow->size(), passed.data());
       }
     }
     if (!childSpec->projectOut()) {

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -355,10 +355,17 @@ class ScanSpec {
     }
   }
 
-  /// Apply filter to the input `vector' and set the passed bits in `result'.
+  /// Apply filter to the first `size' rows of input `vector' and set the passed
+  /// bits in `result'.  `size' is usually the size of top most RowVector, since
+  /// the child could be larger in some suboptimal/corrupted cases and we do not
+  /// want to crash the process for it.
+  ///
   /// This method is used by non-selective reader and delta update, so it
   /// ignores the filterDisabled_ state.
-  void applyFilter(const BaseVector& vector, uint64_t* result) const;
+  void applyFilter(
+      const BaseVector& vector,
+      vector_size_t size,
+      uint64_t* result) const;
 
   bool isFlatMapAsStruct() const {
     return isFlatMapAsStruct_;

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(
   ReadFileInputStreamTests.cpp
   ReaderTest.cpp
   RetryTests.cpp
+  ScanSpecTest.cpp
   TestBufferedInput.cpp
   ThrottlerTest.cpp
   TypeTests.cpp

--- a/velox/dwio/common/tests/ScanSpecTest.cpp
+++ b/velox/dwio/common/tests/ScanSpecTest.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::common {
+namespace {
+
+class ScanSpecTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+};
+
+TEST_F(ScanSpecTest, applyFilter) {
+  auto rowVector = makeRowVector({
+      makeFlatVector<int64_t>(64, folly::identity),
+      makeFlatVector<int64_t>(128, folly::identity),
+  });
+  ASSERT_EQ(rowVector->size(), 64);
+  ScanSpec scanSpec("<root>");
+  scanSpec.addAllChildFields(*rowVector->type());
+  scanSpec.childByName("c1")->setFilter(createBigintValues({63, 64}, false));
+  uint64_t result = -1ll;
+  scanSpec.applyFilter(*rowVector, rowVector->size(), &result);
+  ASSERT_EQ(result, 1ull << 63);
+  result = -1ll;
+  scanSpec.childByName("c1")->applyFilter(
+      *rowVector->childAt("c1"), rowVector->size(), &result);
+  ASSERT_EQ(result, 1ull << 63);
+  rowVector = makeRowVector({
+      makeFlatVector<int64_t>(128, folly::identity),
+      makeFlatVector<int64_t>(64, folly::identity),
+  });
+  ASSERT_THROW(
+      scanSpec.applyFilter(*rowVector, rowVector->size(), &result),
+      VeloxRuntimeError);
+}
+
+} // namespace
+} // namespace facebook::velox::common


### PR DESCRIPTION
Summary:
When we read file that has child vector larger than struct parent
vector (unlike in-memory case, this is suboptimal in file because the extra rows
in child would never be used), and when we apply filter on it in fallback mode
(e.g. delta update), we use the size of child vector instead of parent and
result in out of boundary access (because the result bitmask is created using top level row count).

Differential Revision: D77337719


