### PR TITLE
fix: Unloaded lazy vector in duplicate field project

### DIFF
--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -168,7 +168,8 @@ folly::Range<vector_size_t*> initializeRowNumberMapping(
 /// Projects children of 'src' row vector according to 'projections'. Optionally
 /// takes a 'mapping' and 'size' that represent the indices and size,
 /// respectively, of a dictionary wrapping that should be applied to the
-/// projections. The output param 'projectedChildren' will contain all the final
+/// projections. Dictionary wrapping of the same child vector is cached for
+/// reuse. The output param 'projectedChildren' will contain all the final
 /// projections at the expected channel index. Indices not specified in
 /// 'projections' will be left untouched in 'projectedChildren'.
 void projectChildren(

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -137,3 +137,12 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_vector_test_lib
   Folly::follybenchmark)
+
+add_executable(velox_exec_bm_duplicate_project DuplicateProjectBenchmark.cpp)
+
+target_link_libraries(
+  velox_exec_bm_duplicate_project
+  velox_exec_test_lib
+  velox_hive_connector
+  velox_vector_fuzzer
+  Folly::follybenchmark)

--- a/velox/exec/benchmarks/DuplicateProjectBenchmark.cpp
+++ b/velox/exec/benchmarks/DuplicateProjectBenchmark.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+static constexpr int32_t kNumVectors = 50;
+static constexpr int32_t kRowsPerVector = 10'000;
+
+class DuplicateProjectBenchmark : public HiveConnectorTestBase {
+ public:
+  explicit DuplicateProjectBenchmark() {
+    HiveConnectorTestBase::SetUp();
+
+    inputType_ = ROW({
+        {"a", INTEGER()},
+        {"b", INTEGER()},
+        {"c", VARCHAR()},
+        {"d", VARCHAR()},
+    });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0.2;
+    VectorFuzzer fuzzer(opts, pool_.get(), FLAGS_fuzzer_seed);
+    std::vector<RowVectorPtr> inputVectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      std::vector<VectorPtr> children;
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+      children.emplace_back(fuzzer.fuzzFlat(VARCHAR()));
+      children.emplace_back(fuzzer.fuzzFlat(VARCHAR()));
+
+      inputVectors.emplace_back(makeRowVector(inputType_->names(), children));
+    }
+
+    sourceFilePath_ = TempFilePath::create();
+    writeToFile(sourceFilePath_->getPath(), inputVectors);
+  }
+
+  ~DuplicateProjectBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  void run(const std::string& filter, const std::vector<std::string>& project) {
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .filter(filter)
+                    .project(project)
+                    .planNode();
+    auto result = exec::test::AssertQueryBuilder(plan)
+                      .split(makeHiveConnectorSplit(sourceFilePath_->getPath()))
+                      .copyResults(pool_.get());
+    auto numResultRows = result->size();
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  void addBenchmarks() {
+    folly::addBenchmark(
+        __FILE__, "filter_integer_duplicate_project_integer", [this]() {
+          run("a > 99999", {"b", "b"});
+          return 1;
+        });
+    folly::addBenchmark(
+        __FILE__, "filter_string_duplicate_project_string", [this]() {
+          run("length(c) > 10", {"d", "d"});
+          return 1;
+        });
+    folly::addBenchmark(__FILE__, "duplicate_project_integer", [this]() {
+      run("true", {"b", "b"});
+      return 1;
+    });
+    folly::addBenchmark(__FILE__, "duplicate_project_string", [this]() {
+      run("true", {"d", "d"});
+      return 1;
+    });
+    folly::addBenchmark(
+        __FILE__, "filter_integers_duplicate_project_integers", [this]() {
+          run("a > 9999 and b < 10000", {"a", "a", "b", "b"});
+          return 1;
+        });
+    folly::addBenchmark(
+        __FILE__, "filter_strings_duplicate_project_strings", [this]() {
+          run("length(c) > 10 and length(d) < 20", {"c", "c", "d", "d"});
+          return 1;
+        });
+  }
+
+ private:
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> sourceFilePath_;
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize(
+      facebook::velox::memory::MemoryManager::Options{});
+  memory::SharedArbitrator::registerFactory();
+  functions::prestosql::registerAllScalarFunctions();
+
+  DuplicateProjectBenchmark bm;
+  bm.addBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
The following error was noticed when running a query as below, where the filter 
expressions were for one field and duplicate projects were for another field.

> SELECT id, id FROM tmp WHERE name = 'John'

The lazy vector is not preloaded because it’s only referenced in identity 
projections, not in expressions, and the `fillOutput` calls `wrapInDictionary` 
multiple times on the same lazy vector. The lazy vector is still unloaded at 
the time, and thus, the dictionary vector wraps the same underlying lazy vector 
multiple times while unloaded.

This PR fixes this issue by caching the already wrapped children to avoid 
wrapping the same child multiple times.

```
E20250626 11:53:16.482720 23136090 Exceptions.h:66] Line: /Users/velox/./velox/vector/DictionaryVector-inl.h:38, Function:setInternalState, Expression: dictionaryValues_->markAsContainingLazyAndWrapped() An unloaded lazy vector cannot be wrapped by two different top level vectors., Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: An unloaded lazy vector cannot be wrapped by two different top level vectors.
Retriable: False
Expression: dictionaryValues_->markAsContainingLazyAndWrapped()
Context: Operator: FilterProject[2] 1
Function: setInternalState
File: /Users/velox/./velox/vector/DictionaryVector-inl.h
Line: 38
Stack trace:
```

Benchmark results:

Before fix:

```
duplicate_project_integer                                   7.88ms    126.97
duplicate_project_string                                   57.75ms     17.32
filter_integers_duplicate_project_integers                 10.19ms     98.15
filter_strings_duplicate_project_strings                   47.57ms     21.02
```

After fix:

```
duplicate_project_integer                                   7.68ms    130.17
duplicate_project_string                                   55.27ms     18.09
filter_integers_duplicate_project_integers                 11.24ms     89.00
filter_strings_duplicate_project_strings                   47.55ms     21.03
```
