### PR TITLE
fix: Fix the server crash caused by remote exchange error

### DIFF
--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -16,6 +16,10 @@
 #include "velox/exec/ExchangeQueue.h"
 #include <algorithm>
 
+#include "velox/common/testutil/TestValue.h"
+
+using facebook::velox::common::testutil::TestValue;
+
 namespace facebook::velox::exec {
 
 SerializedPage::SerializedPage(
@@ -136,6 +140,8 @@ std::vector<std::unique_ptr<SerializedPage>> ExchangeQueue::dequeueLocked(
     ContinueFuture* future,
     ContinuePromise* stalePromise) {
   VELOX_CHECK_NOT_NULL(future);
+  TestValue::adjust(
+      "facebook::velox::exec::ExchangeQueue::dequeueLocked", this);
   if (!error_.empty()) {
     *atEnd = true;
     VELOX_FAIL(error_);

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -91,6 +91,10 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 
   maybeStartNextMergeSourceGroup();
 
+  if (sourceMerger_ != nullptr) {
+    sourceMerger_->isBlocked(sourceBlockingFutures_);
+  }
+
   if (sourceBlockingFutures_.empty()) {
     return BlockingReason::kNotBlocked;
   }
@@ -176,12 +180,6 @@ void Merge::setupSpillMerger() {
 }
 
 void Merge::maybeStartNextMergeSourceGroup() {
-  SCOPE_EXIT {
-    if (sourceMerger_ != nullptr) {
-      sourceMerger_->isBlocked(sourceBlockingFutures_);
-    }
-  };
-
   if (sourceMerger_ != nullptr || numStartedSources_ >= sources_.size()) {
     return;
   }


### PR DESCRIPTION
Summary: The remote exchange might run into error so merge operator check if a remote merge source is blocked or not, it might trigger merge source to fetch data from the exchange client which in turn try to dequeue from the exchange source. The dequeue operation might throw if there is already an error. The recent merge spill support moves the merge source is blocked check inside SCOPE_EXIT which converts an throw to a server crash as we can't throw inside a dtor. This changes move the merge source is blocked check out of SCOPE_EXIT and add a unit test to reproduce and verify

Differential Revision: D77423282


