### PR TITLE
fix: Fix the result map size setting

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -333,7 +333,7 @@ VectorPtr extendSizeByWrappingInDictionary(
   VELOX_DCHECK(
       !vector->type()->isPrimitiveType(), "Only used for complex types.");
   BufferPtr indices = allocateIndices(targetSize, context.pool());
-  auto rawIndices = indices->asMutable<vector_size_t>();
+  auto* rawIndices = indices->asMutable<vector_size_t>();
   // Only fill in indices for existing rows in the vector.
   std::iota(rawIndices, rawIndices + currentSize, 0);
   // A nulls buffer is required otherwise wrapInDictionary() can return a

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -159,7 +159,7 @@ VectorPtr BaseVector::wrapInDictionary(
     shouldFlatten = !isLazyNotLoaded(*base) && (base->size() / 8) > size;
   }
 
-  auto kind = vector->typeKind();
+  const auto kind = vector->typeKind();
   auto result = VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
       addDictionary,
       kind,


### PR DESCRIPTION
Summary: The result map size is incorrectly set null bytes if the input has nulls. This is discovered by presto unit test which covers AIDN reconstruction udf

Differential Revision: D77424024


