### PR TITLE
feat: Fix the full outer join result mismatch issue

### DIFF
--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -282,6 +282,7 @@ int32_t MergeJoin::compare(
 bool MergeJoin::findEndOfMatch(
     const RowVectorPtr& input,
     const std::vector<column_index_t>& keys,
+    uint64_t inputBatchId,
     Match& match) {
   if (match.complete) {
     return true;
@@ -299,6 +300,7 @@ bool MergeJoin::findEndOfMatch(
 
   if (endRow == numInputRows) {
     match.inputs.push_back(input);
+    match.inputBatchIds.push_back(inputBatchId);
     match.endRowIndex = endRow;
     return false;
   }
@@ -306,6 +308,7 @@ bool MergeJoin::findEndOfMatch(
   if (endRow > 0) {
     // Match ends here, no need to pre-load lazies.
     match.inputs.push_back(input);
+    match.inputBatchIds.push_back(inputBatchId);
     match.endRowIndex = endRow;
   }
   match.complete = true;
@@ -346,7 +349,7 @@ bool MergeJoin::tryAddOutputRowForLeftJoin() {
   rawLeftOutputIndices_[outputSize_] = leftRowIndex_++;
   if (rawRightRowIds_ != nullptr) {
     rawRightRowIds_[outputSize_] = 0;
-    rawRightRowIsCandidate_[outputSize_] = 0;
+    rawIsProvisionalRightRow_[outputSize_] = 0;
   }
 
   for (const auto& projection : rightProjections_) {
@@ -376,7 +379,7 @@ bool MergeJoin::tryAddOutputRowForRightJoin() {
 
   if (rawRightRowIds_ != nullptr) {
     rawRightRowIds_[outputSize_] = 0;
-    rawRightRowIsCandidate_[outputSize_] = 0;
+    rawIsProvisionalRightRow_[outputSize_] = 0;
   }
 
   if (!isRightFlattened_) {
@@ -417,7 +420,20 @@ void MergeJoin::flattenRightProjections() {
     newFlat->copy(currentVector.get(), 0, 0, outputSize_);
     children[projection.outputChannel] = std::move(newFlat);
   }
+
+  if (filterInput_ != nullptr) {
+    for (const auto& [filterChannel, outputChannel] :
+         filterInputToOutputChannel_) {
+      filterInput_->childAt(filterChannel) = children[outputChannel];
+    }
+  }
   isRightFlattened_ = true;
+}
+
+uint64_t MergeJoin::rightRowId(
+    uint64_t rightBatchId,
+    vector_size_t rightRowIndex) const {
+  return (rightBatchId << 32) | static_cast<uint32_t>(rightRowIndex);
 }
 
 bool MergeJoin::tryAddOutputRow(
@@ -425,16 +441,14 @@ bool MergeJoin::tryAddOutputRow(
     vector_size_t leftRow,
     const RowVectorPtr& rightBatch,
     vector_size_t rightRow,
-    size_t rightBatchIndex) {
+    uint64_t rightBatchId) {
   if (outputSize_ == outputBatchSize_) {
     return false;
   }
 
   if (rawRightRowIds_ != nullptr) {
-    rawRightRowIds_[outputSize_] =
-        (static_cast<uint64_t>(rightBatchIndex) << 32) |
-        static_cast<uint32_t>(rightRow);
-    rawRightRowIsCandidate_[outputSize_] = 0;
+    rawRightRowIds_[outputSize_] = rightRowId(rightBatchId, rightRow);
+    rawIsProvisionalRightRow_[outputSize_] = 0;
   }
 
   // All left side projections share the same dictionary indices (leftIndices_).
@@ -570,14 +584,14 @@ bool MergeJoin::prepareOutput(
   if (isFullJoin(joinType_) && filter_) {
     rightRowIds_ = AlignedBuffer::allocate<uint64_t>(outputBatchSize_, pool());
     rawRightRowIds_ = rightRowIds_->asMutable<uint64_t>();
-    rightRowIsCandidate_ =
-        AlignedBuffer::allocate<uint64_t>(outputBatchSize_, pool());
-    rawRightRowIsCandidate_ = rightRowIsCandidate_->asMutable<uint64_t>();
+    isProvisionalRightRow_ =
+        AlignedBuffer::allocate<uint8_t>(outputBatchSize_, pool());
+    rawIsProvisionalRightRow_ = isProvisionalRightRow_->asMutable<uint8_t>();
   } else {
     rightRowIds_.reset();
     rawRightRowIds_ = nullptr;
-    rightRowIsCandidate_.reset();
-    rawRightRowIsCandidate_ = nullptr;
+    isProvisionalRightRow_.reset();
+    rawIsProvisionalRightRow_ = nullptr;
   }
 
   if (filterInput_ != nullptr) {
@@ -638,11 +652,12 @@ bool MergeJoin::addToOutput() {
 template <bool IsLeftJoin>
 bool MergeJoin::addToOutputImpl() {
   if constexpr (IsLeftJoin) {
-    if (isFullJoin(joinType_) && filter_ && rightCandidateCursor_.has_value()) {
-      if (appendRightCandidates()) {
+    if (isFullJoin(joinType_) && filter_ &&
+        provisionalRightOutputCursor_.has_value()) {
+      if (appendProvisionalRightRows()) {
         return true;
       }
-      passedRightRows_.clear();
+      matchedRightRowIds_.clear();
       leftMatch_.reset();
       rightMatch_.reset();
       return outputSize_ == outputBatchSize_;
@@ -723,6 +738,7 @@ bool MergeJoin::addToOutputImpl() {
         }
 
         if (IsLeftJoin) {
+          VELOX_CHECK_LT(innerBatchIndex, innerMatch->inputBatchIds.size());
           for (auto innerRow = innerStartRow; innerRow < innerEndRow;
                ++innerRow) {
             if (!tryAddOutputRow(
@@ -730,7 +746,7 @@ bool MergeJoin::addToOutputImpl() {
                     outerRow,
                     rightBatch,
                     innerRow,
-                    innerBatchIndex)) {
+                    innerMatch->inputBatchIds[innerBatchIndex])) {
               outerMatch->setCursor(outerBatchIndex, outerRow);
               innerMatch->setCursor(innerBatchIndex, innerRow);
               return true;
@@ -740,7 +756,11 @@ bool MergeJoin::addToOutputImpl() {
           for (auto innerRow = innerStartRow; innerRow < innerEndRow;
                ++innerRow) {
             if (!tryAddOutputRow(
-                    leftBatch, innerRow, rightBatch, outerRow, 0)) {
+                    leftBatch,
+                    innerRow,
+                    rightBatch,
+                    outerRow,
+                    0 /* rightBatchId */)) {
               outerMatch->setCursor(outerBatchIndex, outerRow);
               innerMatch->setCursor(innerBatchIndex, innerRow);
               return true;
@@ -753,10 +773,10 @@ bool MergeJoin::addToOutputImpl() {
 
   if constexpr (IsLeftJoin) {
     if (isFullJoin(joinType_) && filter_) {
-      if (appendRightCandidates()) {
+      if (appendProvisionalRightRows()) {
         return true;
       }
-      passedRightRows_.clear();
+      matchedRightRowIds_.clear();
     }
   }
 
@@ -765,7 +785,39 @@ bool MergeJoin::addToOutputImpl() {
   return outputSize_ == outputBatchSize_;
 }
 
-bool MergeJoin::appendRightCandidates() {
+void MergeJoin::appendProvisionalRightRow(
+    const RowVectorPtr& rightBatch,
+    vector_size_t rightRowIndex,
+    uint64_t rightRowId) {
+  if (!isRightFlattened_) {
+    rawRightOutputIndices_[outputSize_] = rightRowIndex;
+  } else {
+    copyRow(rightBatch, rightRowIndex, output_, outputSize_, rightProjections_);
+  }
+
+  rawLeftOutputIndices_[outputSize_] = 0;
+  for (const auto& projection : leftProjections_) {
+    auto& target = output_->childAt(projection.outputChannel);
+    addNull(
+        target,
+        outputSize_,
+        leftOutputIndices_,
+        outputBatchSize_,
+        currentLeft_);
+  }
+
+  if (joinTracker_) {
+    joinTracker_->addMiss(outputSize_);
+  }
+
+  VELOX_CHECK_NOT_NULL(rawRightRowIds_);
+  rawRightRowIds_[outputSize_] = rightRowId;
+  rawIsProvisionalRightRow_[outputSize_] = 1;
+
+  ++outputSize_;
+}
+
+bool MergeJoin::appendProvisionalRightRows() {
   VELOX_CHECK(isFullJoin(joinType_));
   VELOX_CHECK_NOT_NULL(filter_);
   VELOX_CHECK(rightMatch_);
@@ -773,12 +825,13 @@ bool MergeJoin::appendRightCandidates() {
 
   const size_t numRightBatches = rightMatch_->inputs.size();
   VELOX_CHECK_GT(numRightBatches, 0);
+  VELOX_CHECK_EQ(numRightBatches, rightMatch_->inputBatchIds.size());
 
-  size_t rightBatchIndex = rightCandidateCursor_.has_value()
-      ? rightCandidateCursor_->rightBatchIndex
+  size_t rightBatchIndex = provisionalRightOutputCursor_.has_value()
+      ? provisionalRightOutputCursor_->rightBatchIndex
       : 0;
-  vector_size_t rightRowIndex = rightCandidateCursor_.has_value()
-      ? rightCandidateCursor_->rightRowIndex
+  vector_size_t rightRowIndex = provisionalRightOutputCursor_.has_value()
+      ? provisionalRightOutputCursor_->rightRowIndex
       : rightMatch_->startRowIndex;
 
   for (; rightBatchIndex < numRightBatches; ++rightBatchIndex) {
@@ -791,56 +844,32 @@ bool MergeJoin::appendRightCandidates() {
 
     for (auto row = std::max(batchStartRow, rightRowIndex); row < batchEndRow;
          ++row) {
-      const uint64_t rightRowId =
-          (static_cast<uint64_t>(rightBatchIndex) << 32) |
-          static_cast<uint32_t>(row);
-      if (!passedRightRows_.empty() && passedRightRows_.contains(rightRowId)) {
+      const uint64_t rightRowIdValue =
+          rightRowId(rightMatch_->inputBatchIds[rightBatchIndex], row);
+      if (!matchedRightRowIds_.empty() &&
+          matchedRightRowIds_.contains(rightRowIdValue)) {
         continue;
       }
 
       if (prepareOutput(currentLeft_, rightBatch)) {
         output_->resize(outputSize_);
-        rightCandidateCursor_ = RightCandidateCursor{rightBatchIndex, row};
+        provisionalRightOutputCursor_ =
+            ProvisionalRightOutputCursor{rightBatchIndex, row};
         return true;
       }
 
       if (outputSize_ == outputBatchSize_) {
-        rightCandidateCursor_ = RightCandidateCursor{rightBatchIndex, row};
+        provisionalRightOutputCursor_ =
+            ProvisionalRightOutputCursor{rightBatchIndex, row};
         return true;
       }
-
-      if (!isRightFlattened_) {
-        rawRightOutputIndices_[outputSize_] = row;
-      } else {
-        copyRow(rightBatch, row, output_, outputSize_, rightProjections_);
-      }
-
-      rawLeftOutputIndices_[outputSize_] = 0;
-      for (const auto& projection : leftProjections_) {
-        auto& target = output_->childAt(projection.outputChannel);
-        addNull(
-            target,
-            outputSize_,
-            leftOutputIndices_,
-            outputBatchSize_,
-            currentLeft_);
-      }
-
-      if (joinTracker_) {
-        joinTracker_->addMiss(outputSize_);
-      }
-
-      VELOX_CHECK_NOT_NULL(rawRightRowIds_);
-      rawRightRowIds_[outputSize_] = rightRowId;
-      rawRightRowIsCandidate_[outputSize_] = 1;
-
-      ++outputSize_;
+      appendProvisionalRightRow(rightBatch, row, rightRowIdValue);
     }
 
     rightRowIndex = 0;
   }
 
-  rightCandidateCursor_.reset();
+  provisionalRightOutputCursor_.reset();
   return false;
 }
 
@@ -1000,6 +1029,7 @@ bool MergeJoin::getNextFromRightSide() {
     }
 
     if (rightInput_) {
+      currentRightInputBatchId_ = nextRightInputBatchId_++;
       if (isFullJoin(joinType_) || isRightJoin(joinType_)) {
         rightRowIndex_ = 0;
       } else {
@@ -1153,6 +1183,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
       }
       leftMatch_ = Match{
           {input_},
+          {0},
           leftRowIndex_,
           leftEndRow,
           leftEndRow < input_->size(),
@@ -1166,14 +1197,15 @@ RowVectorPtr MergeJoin::doGetOutput() {
 
       rightMatch_ = Match{
           {rightInput_},
+          {currentRightInputBatchId_},
           rightRowIndex_,
           rightEndRow,
           rightEndRow < rightInput_->size(),
           std::nullopt};
 
       if (isFullJoin(joinType_) && filter_) {
-        passedRightRows_.clear();
-        rightCandidateCursor_.reset();
+        matchedRightRowIds_.clear();
+        provisionalRightOutputCursor_.reset();
       }
 
       // Track matched rows for this key match.
@@ -1375,7 +1407,11 @@ bool MergeJoin::advanceMatchImpl() {
 
   if (input) {
     // Look for continuation of a match.
-    if (!findEndOfMatch(input, keyChannels, match.value())) {
+    if (!findEndOfMatch(
+            input,
+            keyChannels,
+            IsLeft ? 0 : currentRightInputBatchId_,
+            match.value())) {
       VELOX_CHECK(!match->complete);
       // Continue looking for the end of the match.
       if constexpr (IsLeft) {
@@ -1436,6 +1472,7 @@ void MergeJoin::clearLeftInput() {
 
 void MergeJoin::clearRightInput() {
   rightInput_ = nullptr;
+  currentRightInputBatchId_ = 0;
 }
 
 void MergeJoin::updateOutputBatchSize(const RowVectorPtr& output) {
@@ -1478,10 +1515,11 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
     if (!filterRows.hasSelections()) {
       if (isFullJoin(joinType_) && filter_ &&
-          rawRightRowIsCandidate_ != nullptr && !passedRightRows_.empty()) {
+          rawIsProvisionalRightRow_ != nullptr &&
+          !matchedRightRowIds_.empty()) {
         for (auto i = 0; i < numRows; ++i) {
-          if (rawRightRowIsCandidate_[i] == 1 &&
-              passedRightRows_.contains(rawRightRowIds_[i])) {
+          if (rawIsProvisionalRightRow_[i] == 1 &&
+              matchedRightRowIds_.contains(rawRightRowIds_[i])) {
             continue;
           }
           rawIndices[numPassed++] = i;
@@ -1501,7 +1539,7 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
     if (isFullJoin(joinType_) && filter_) {
       VELOX_CHECK_NOT_NULL(rawRightRowIds_);
-      VELOX_CHECK_NOT_NULL(rawRightRowIsCandidate_);
+      VELOX_CHECK_NOT_NULL(rawIsProvisionalRightRow_);
     }
 
     evaluateFilter(filterRows);
@@ -1542,15 +1580,15 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
             decodedFilterResult_.valueAt<bool>(i);
 
         if (passed && isFullJoin(joinType_) && filter_) {
-          passedRightRows_.insert(rawRightRowIds_[i]);
+          matchedRightRowIds_.insert(rawRightRowIds_[i]);
         }
 
         joinTracker_->processFilterResult(i, passed, onMiss, onMatch);
       } else {
         if (isFullJoin(joinType_) && filter_ &&
-            rawRightRowIsCandidate_ != nullptr &&
-            rawRightRowIsCandidate_[i] == 1) {
-          if (passedRightRows_.contains(rawRightRowIds_[i])) {
+            rawIsProvisionalRightRow_ != nullptr &&
+            rawIsProvisionalRightRow_[i] == 1) {
+          if (matchedRightRowIds_.contains(rawRightRowIds_[i])) {
             continue;
           }
         }
@@ -1663,10 +1701,11 @@ void MergeJoin::finishDrain() {
   rightHasDrained_ = false;
   clearLeftInput();
   clearRightInput();
+  nextRightInputBatchId_ = 1;
   leftMatch_.reset();
   rightMatch_.reset();
-  rightCandidateCursor_.reset();
-  passedRightRows_.clear();
+  provisionalRightOutputCursor_.reset();
+  matchedRightRowIds_.clear();
   if (joinTracker_.has_value()) {
     joinTracker_->reset();
   }

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/MergeJoin.h"
+
+#include <folly/container/F14Set.h>
+#include <algorithm>
+
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
@@ -340,6 +344,10 @@ bool MergeJoin::tryAddOutputRowForLeftJoin() {
   }
 
   rawLeftOutputIndices_[outputSize_] = leftRowIndex_++;
+  if (rawRightRowIds_ != nullptr) {
+    rawRightRowIds_[outputSize_] = 0;
+    rawRightRowIsCandidate_[outputSize_] = 0;
+  }
 
   for (const auto& projection : rightProjections_) {
     auto& target = output_->childAt(projection.outputChannel);
@@ -364,6 +372,11 @@ bool MergeJoin::tryAddOutputRowForRightJoin() {
   VELOX_CHECK(isRightJoin(joinType_) || isFullJoin(joinType_));
   if (outputSize_ == outputBatchSize_) {
     return false;
+  }
+
+  if (rawRightRowIds_ != nullptr) {
+    rawRightRowIds_[outputSize_] = 0;
+    rawRightRowIsCandidate_[outputSize_] = 0;
   }
 
   if (!isRightFlattened_) {
@@ -411,9 +424,17 @@ bool MergeJoin::tryAddOutputRow(
     const RowVectorPtr& leftBatch,
     vector_size_t leftRow,
     const RowVectorPtr& rightBatch,
-    vector_size_t rightRow) {
+    vector_size_t rightRow,
+    size_t rightBatchIndex) {
   if (outputSize_ == outputBatchSize_) {
     return false;
+  }
+
+  if (rawRightRowIds_ != nullptr) {
+    rawRightRowIds_[outputSize_] =
+        (static_cast<uint64_t>(rightBatchIndex) << 32) |
+        static_cast<uint32_t>(rightRow);
+    rawRightRowIsCandidate_[outputSize_] = 0;
   }
 
   // All left side projections share the same dictionary indices (leftIndices_).
@@ -546,6 +567,19 @@ bool MergeJoin::prepareOutput(
       std::move(localColumns));
   outputSize_ = 0;
 
+  if (isFullJoin(joinType_) && filter_) {
+    rightRowIds_ = AlignedBuffer::allocate<uint64_t>(outputBatchSize_, pool());
+    rawRightRowIds_ = rightRowIds_->asMutable<uint64_t>();
+    rightRowIsCandidate_ =
+        AlignedBuffer::allocate<uint64_t>(outputBatchSize_, pool());
+    rawRightRowIsCandidate_ = rightRowIsCandidate_->asMutable<uint64_t>();
+  } else {
+    rightRowIds_.reset();
+    rawRightRowIds_ = nullptr;
+    rightRowIsCandidate_.reset();
+    rawRightRowIsCandidate_ = nullptr;
+  }
+
   if (filterInput_ != nullptr) {
     for (auto i = 0; i < filterInputType_->size(); ++i) {
       auto& child = filterInput_->childAt(i);
@@ -603,6 +637,18 @@ bool MergeJoin::addToOutput() {
 
 template <bool IsLeftJoin>
 bool MergeJoin::addToOutputImpl() {
+  if constexpr (IsLeftJoin) {
+    if (isFullJoin(joinType_) && filter_ && rightCandidateCursor_.has_value()) {
+      if (appendRightCandidates()) {
+        return true;
+      }
+      passedRightRows_.clear();
+      leftMatch_.reset();
+      rightMatch_.reset();
+      return outputSize_ == outputBatchSize_;
+    }
+  }
+
   // For left join: outerMatch=left, innerMatch=right
   // For right join: outerMatch=right, innerMatch=left
   auto& outerMatch = IsLeftJoin ? leftMatch_ : rightMatch_;
@@ -679,7 +725,12 @@ bool MergeJoin::addToOutputImpl() {
         if (IsLeftJoin) {
           for (auto innerRow = innerStartRow; innerRow < innerEndRow;
                ++innerRow) {
-            if (!tryAddOutputRow(leftBatch, outerRow, rightBatch, innerRow)) {
+            if (!tryAddOutputRow(
+                    leftBatch,
+                    outerRow,
+                    rightBatch,
+                    innerRow,
+                    innerBatchIndex)) {
               outerMatch->setCursor(outerBatchIndex, outerRow);
               innerMatch->setCursor(innerBatchIndex, innerRow);
               return true;
@@ -688,7 +739,8 @@ bool MergeJoin::addToOutputImpl() {
         } else {
           for (auto innerRow = innerStartRow; innerRow < innerEndRow;
                ++innerRow) {
-            if (!tryAddOutputRow(leftBatch, innerRow, rightBatch, outerRow)) {
+            if (!tryAddOutputRow(
+                    leftBatch, innerRow, rightBatch, outerRow, 0)) {
               outerMatch->setCursor(outerBatchIndex, outerRow);
               innerMatch->setCursor(innerBatchIndex, innerRow);
               return true;
@@ -699,9 +751,97 @@ bool MergeJoin::addToOutputImpl() {
     }
   }
 
+  if constexpr (IsLeftJoin) {
+    if (isFullJoin(joinType_) && filter_) {
+      if (appendRightCandidates()) {
+        return true;
+      }
+      passedRightRows_.clear();
+    }
+  }
+
   leftMatch_.reset();
   rightMatch_.reset();
   return outputSize_ == outputBatchSize_;
+}
+
+bool MergeJoin::appendRightCandidates() {
+  VELOX_CHECK(isFullJoin(joinType_));
+  VELOX_CHECK_NOT_NULL(filter_);
+  VELOX_CHECK(rightMatch_);
+  VELOX_CHECK_NOT_NULL(currentLeft_);
+
+  const size_t numRightBatches = rightMatch_->inputs.size();
+  VELOX_CHECK_GT(numRightBatches, 0);
+
+  size_t rightBatchIndex = rightCandidateCursor_.has_value()
+      ? rightCandidateCursor_->rightBatchIndex
+      : 0;
+  vector_size_t rightRowIndex = rightCandidateCursor_.has_value()
+      ? rightCandidateCursor_->rightRowIndex
+      : rightMatch_->startRowIndex;
+
+  for (; rightBatchIndex < numRightBatches; ++rightBatchIndex) {
+    const auto& rightBatch = rightMatch_->inputs[rightBatchIndex];
+    const auto batchStartRow =
+        (rightBatchIndex == 0) ? rightMatch_->startRowIndex : 0;
+    const auto batchEndRow = (rightBatchIndex == numRightBatches - 1)
+        ? rightMatch_->endRowIndex
+        : rightBatch->size();
+
+    for (auto row = std::max(batchStartRow, rightRowIndex); row < batchEndRow;
+         ++row) {
+      const uint64_t rightRowId =
+          (static_cast<uint64_t>(rightBatchIndex) << 32) |
+          static_cast<uint32_t>(row);
+      if (!passedRightRows_.empty() && passedRightRows_.contains(rightRowId)) {
+        continue;
+      }
+
+      if (prepareOutput(currentLeft_, rightBatch)) {
+        output_->resize(outputSize_);
+        rightCandidateCursor_ = RightCandidateCursor{rightBatchIndex, row};
+        return true;
+      }
+
+      if (outputSize_ == outputBatchSize_) {
+        rightCandidateCursor_ = RightCandidateCursor{rightBatchIndex, row};
+        return true;
+      }
+
+      if (!isRightFlattened_) {
+        rawRightOutputIndices_[outputSize_] = row;
+      } else {
+        copyRow(rightBatch, row, output_, outputSize_, rightProjections_);
+      }
+
+      rawLeftOutputIndices_[outputSize_] = 0;
+      for (const auto& projection : leftProjections_) {
+        auto& target = output_->childAt(projection.outputChannel);
+        addNull(
+            target,
+            outputSize_,
+            leftOutputIndices_,
+            outputBatchSize_,
+            currentLeft_);
+      }
+
+      if (joinTracker_) {
+        joinTracker_->addMiss(outputSize_);
+      }
+
+      VELOX_CHECK_NOT_NULL(rawRightRowIds_);
+      rawRightRowIds_[outputSize_] = rightRowId;
+      rawRightRowIsCandidate_[outputSize_] = 1;
+
+      ++outputSize_;
+    }
+
+    rightRowIndex = 0;
+  }
+
+  rightCandidateCursor_.reset();
+  return false;
 }
 
 bool MergeJoin::addToOutputForLeftJoin() {
@@ -763,8 +903,8 @@ RowVectorPtr MergeJoin::getOutput() {
   // Make sure to have is-blocked or needs-input as true if returning null
   // output. Otherwise, Driver assumes the operator is finished.
 
-  // Use Operator::noMoreInput() as a no-more-input-on-the-left indicator and a
-  // noMoreRightInput_ flag as no-more-input-on-the-right indicator.
+  // Use Operator::noMoreInput() as a no-more-input-on-the-left indicator and
+  // a noMoreRightInput_ flag as no-more-input-on-the-right indicator.
 
   // TODO Finish early if ran out of data on either side of the join.
   for (;;) {
@@ -1030,6 +1170,11 @@ RowVectorPtr MergeJoin::doGetOutput() {
           rightEndRow,
           rightEndRow < rightInput_->size(),
           std::nullopt};
+
+      if (isFullJoin(joinType_) && filter_) {
+        passedRightRows_.clear();
+        rightCandidateCursor_.reset();
+      }
 
       // Track matched rows for this key match.
       matchedLeftRows_ += leftEndRow - leftMatch_->startRowIndex;
@@ -1324,8 +1469,6 @@ void MergeJoin::updateOutputBatchSize(const RowVectorPtr& output) {
 RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
   const auto numRows = output->size();
 
-  RowVectorPtr fullOuterOutput = nullptr;
-
   BufferPtr indices = allocateIndices(numRows, pool());
   auto* rawIndices = indices->asMutable<vector_size_t>();
   vector_size_t numPassed = 0;
@@ -1334,8 +1477,31 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
     const auto& filterRows = joinTracker_->matchingRows(numRows);
 
     if (!filterRows.hasSelections()) {
-      // No matches in the output, no need to evaluate the filter.
+      if (isFullJoin(joinType_) && filter_ &&
+          rawRightRowIsCandidate_ != nullptr && !passedRightRows_.empty()) {
+        for (auto i = 0; i < numRows; ++i) {
+          if (rawRightRowIsCandidate_[i] == 1 &&
+              passedRightRows_.contains(rawRightRowIds_[i])) {
+            continue;
+          }
+          rawIndices[numPassed++] = i;
+        }
+
+        if (numPassed == 0) {
+          return nullptr;
+        }
+        if (numPassed == numRows) {
+          return output;
+        }
+        return wrap(numPassed, indices, output);
+      }
+
       return output;
+    }
+
+    if (isFullJoin(joinType_) && filter_) {
+      VELOX_CHECK_NOT_NULL(rawRightRowIds_);
+      VELOX_CHECK_NOT_NULL(rawRightRowIsCandidate_);
     }
 
     evaluateFilter(filterRows);
@@ -1348,61 +1514,7 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
       }
       rawIndices[numPassed++] = row;
 
-      if (isFullJoin(joinType_)) {
-        // For filtered rows, it is necessary to insert additional data
-        // to ensure the result set is complete. Specifically, we
-        // need to generate two records: one record containing the
-        // columns from the left table along with nulls for the
-        // right table, and another record containing the columns
-        // from the right table along with nulls for the left table.
-        // For instance, the current output is filtered based on the condition
-        // t > 1.
-
-        // 1, 1
-        // 2, 2
-        // 3, 3
-
-        // In this scenario, we need to additionally insert a record 1, 1.
-        // Subsequently, we will set the values of the columns on the left to
-        // null and the values of the columns on the right to null as well. By
-        // doing so, we will obtain the final result set.
-
-        // 1,   null
-        // null,  1
-        // 2, 2
-        // 3, 3
-        fullOuterOutput = BaseVector::create<RowVector>(
-            output->type(), output->size() + 1, pool());
-
-        for (auto i = 0; i < row + 1; ++i) {
-          for (auto j = 0; j < output->type()->size(); ++j) {
-            fullOuterOutput->childAt(j)->copy(
-                output->childAt(j).get(), i, i, 1);
-          }
-        }
-
-        for (auto j = 0; j < output->type()->size(); ++j) {
-          fullOuterOutput->childAt(j)->copy(
-              output->childAt(j).get(), row + 1, row, 1);
-        }
-
-        for (auto i = row + 1; i < output->size(); ++i) {
-          for (auto j = 0; j < output->type()->size(); ++j) {
-            fullOuterOutput->childAt(j)->copy(
-                output->childAt(j).get(), i + 1, i, 1);
-          }
-        }
-
-        for (auto& projection : leftProjections_) {
-          auto& target = fullOuterOutput->childAt(projection.outputChannel);
-          target->setNull(row, true);
-        }
-
-        for (auto& projection : rightProjections_) {
-          auto& target = fullOuterOutput->childAt(projection.outputChannel);
-          target->setNull(row + 1, true);
-        }
-      } else if (!isRightJoin(joinType_)) {
+      if (!isRightJoin(joinType_)) {
         for (auto& projection : rightProjections_) {
           auto& target = output->childAt(projection.outputChannel);
           target->setNull(row, true);
@@ -1429,10 +1541,20 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
         const bool passed = !decodedFilterResult_.isNullAt(i) &&
             decodedFilterResult_.valueAt<bool>(i);
 
+        if (passed && isFullJoin(joinType_) && filter_) {
+          passedRightRows_.insert(rawRightRowIds_[i]);
+        }
+
         joinTracker_->processFilterResult(i, passed, onMiss, onMatch);
       } else {
-        // This row doesn't have a match on the right side. Keep it
-        // unconditionally.
+        if (isFullJoin(joinType_) && filter_ &&
+            rawRightRowIsCandidate_ != nullptr &&
+            rawRightRowIsCandidate_[i] == 1) {
+          if (passedRightRows_.contains(rawRightRowIds_[i])) {
+            continue;
+          }
+        }
+
         rawIndices[numPassed++] = i;
       }
     }
@@ -1480,17 +1602,10 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
   if (numPassed == numRows) {
     // All rows passed.
-    if (fullOuterOutput) {
-      return fullOuterOutput;
-    }
     return output;
   }
 
   // Some, but not all rows passed.
-  if (fullOuterOutput) {
-    return wrap(numPassed, indices, fullOuterOutput);
-  }
-
   return wrap(numPassed, indices, output);
 }
 
@@ -1550,6 +1665,8 @@ void MergeJoin::finishDrain() {
   clearRightInput();
   leftMatch_.reset();
   rightMatch_.reset();
+  rightCandidateCursor_.reset();
+  passedRightRows_.clear();
   if (joinTracker_.has_value()) {
     joinTracker_->reset();
   }

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstdint>
 #include <string_view>
 
 #include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
 
 #include "velox/exec/MergeSource.h"
 #include "velox/exec/Operator.h"
@@ -260,7 +262,15 @@ class MergeJoin : public Operator {
       const RowVectorPtr& leftBatch,
       vector_size_t leftRow,
       const RowVectorPtr& rightBatch,
-      vector_size_t rightRow);
+      vector_size_t rightRow,
+      size_t rightBatchIndex);
+
+  struct RightCandidateCursor {
+    size_t rightBatchIndex{0};
+    vector_size_t rightRowIndex{0};
+  };
+
+  bool appendRightCandidates();
 
   // If the right side projected columns in the current output vector happen to
   // span more than one vector from the right side, they cannot be simply
@@ -562,6 +572,11 @@ class MergeJoin : public Operator {
   vector_size_t* rawLeftOutputIndices_;
   vector_size_t* rawRightOutputIndices_;
 
+  BufferPtr rightRowIds_;
+  uint64_t* rawRightRowIds_{nullptr};
+  BufferPtr rightRowIsCandidate_;
+  uint64_t* rawRightRowIsCandidate_{nullptr};
+
   // Stores the current left and right vectors being used by the output
   // dictionaries.
   RowVectorPtr currentLeft_;
@@ -644,6 +659,8 @@ class MergeJoin : public Operator {
 
   // A set of rows with matching keys on the right side.
   std::optional<Match> rightMatch_;
+  std::optional<RightCandidateCursor> rightCandidateCursor_;
+  folly::F14FastSet<uint64_t> passedRightRows_;
 
   RowVectorPtr output_;
 

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -176,6 +176,11 @@ class MergeJoin : public Operator {
     // One or more batches of inputs that contain rows with matching keys.
     std::vector<RowVectorPtr> inputs;
 
+    // Stable ids of the corresponding input batches. For right-side matches,
+    // these ids are used to construct globally unique right row ids across
+    // different key matches.
+    std::vector<uint64_t> inputBatchIds;
+
     // Row number in the first batch pointing to the first row with matching
     // keys.
     vector_size_t startRowIndex{0};
@@ -219,6 +224,7 @@ class MergeJoin : public Operator {
   bool findEndOfMatch(
       const RowVectorPtr& input,
       const std::vector<column_index_t>& keys,
+      uint64_t inputBatchId,
       Match& match);
 
   // Ensures `output_` is ready to receive records via `addOutput()` or
@@ -263,14 +269,45 @@ class MergeJoin : public Operator {
       vector_size_t leftRow,
       const RowVectorPtr& rightBatch,
       vector_size_t rightRow,
-      size_t rightBatchIndex);
+      uint64_t rightBatchId);
 
-  struct RightCandidateCursor {
+  // Encodes a stable identity for a physical right-side row using the
+  // right-side batch id and the row index within that batch. This id is used
+  // to recognize when a provisional right-only row corresponds to a right row
+  // that already has a passing match.
+  uint64_t rightRowId(uint64_t rightBatchId, vector_size_t rightRowIndex) const;
+
+  struct ProvisionalRightOutputCursor {
+    // Position to resume appending provisional right-only rows from when the
+    // previous output batch filled up before all right rows for the current
+    // match were processed.
     size_t rightBatchIndex{0};
     vector_size_t rightRowIndex{0};
   };
 
-  bool appendRightCandidates();
+  // Appends one provisional right-only row for full join + filter: copies the
+  // right-side values, fills the left-side projections with nulls, records the
+  // row as a miss in JoinTracker, and stores the encoded rightRowId so that
+  // applyFilter() can later decide whether to keep or drop this row.
+  void appendProvisionalRightRow(
+      const RowVectorPtr& rightBatch,
+      vector_size_t rightRowIndex,
+      uint64_t rightRowId);
+
+  // Full join + filter needs to produce unmatched rows from both sides. For
+  // the right side, a row is "unmatched" only if none of its left-side matches
+  // passed the filter.
+  //
+  // This method appends such right-side rows as provisional output rows: it
+  // writes the right projections, sets left projections to null, and marks the
+  // row via rawIsProvisionalRightRow_. Rows whose ids are present in
+  // matchedRightRowIds_ are skipped.
+  //
+  // Returns true if the current output vector needs to be returned first
+  // (e.g. output buffer switch or output batch full). In that case it records
+  // a restart position in provisionalRightOutputCursor_ and can be resumed on
+  // the next getOutput() call.
+  bool appendProvisionalRightRows();
 
   // If the right side projected columns in the current output vector happen to
   // span more than one vector from the right side, they cannot be simply
@@ -572,10 +609,15 @@ class MergeJoin : public Operator {
   vector_size_t* rawLeftOutputIndices_;
   vector_size_t* rawRightOutputIndices_;
 
+  // Per-output-row metadata used by full join + filter to decide whether a
+  // provisional right-only row should be kept or dropped after filter
+  // evaluation.
   BufferPtr rightRowIds_;
+  // Encoded stable identity of the corresponding right-side row.
   uint64_t* rawRightRowIds_{nullptr};
-  BufferPtr rightRowIsCandidate_;
-  uint64_t* rawRightRowIsCandidate_{nullptr};
+  BufferPtr isProvisionalRightRow_;
+  // 1 if the output row is a provisional right-only row, 0 otherwise.
+  uint8_t* rawIsProvisionalRightRow_{nullptr};
 
   // Stores the current left and right vectors being used by the output
   // dictionaries.
@@ -648,6 +690,11 @@ class MergeJoin : public Operator {
   // Latest batch of input from the right side.
   RowVectorPtr rightInput_;
 
+  // Stable id of the current physical right input batch. Incremented whenever
+  // a new right batch is pulled from the source.
+  uint64_t currentRightInputBatchId_{0};
+  uint64_t nextRightInputBatchId_{1};
+
   // Row number on the left side (input_) to process next.
   vector_size_t leftRowIndex_{0};
 
@@ -659,8 +706,14 @@ class MergeJoin : public Operator {
 
   // A set of rows with matching keys on the right side.
   std::optional<Match> rightMatch_;
-  std::optional<RightCandidateCursor> rightCandidateCursor_;
-  folly::F14FastSet<uint64_t> passedRightRows_;
+
+  // Resume position for emitting provisional right-only rows for the current
+  // rightMatch_ when the output batch fills up mid-way.
+  std::optional<ProvisionalRightOutputCursor> provisionalRightOutputCursor_;
+  // Set of encoded rightRowId values that have at least one passing match in
+  // the current equal-key window. Used to drop provisional right-only rows for
+  // right-side rows that are already matched after filter evaluation.
+  folly::F14FastSet<uint64_t> matchedRightRowIds_;
 
   RowVectorPtr output_;
 

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -63,7 +63,7 @@ DEFINE_bool(
 
 DEFINE_double(
     filter_ratio,
-    0,
+    0.5,
     "The chance of testing plans with filters enabled.");
 
 namespace facebook::velox::exec {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -2532,6 +2532,81 @@ TEST_F(MergeJoinTest, dynamicOutputBatchSizingDisabledByDefault) {
   EXPECT_LE(outputBatchSizes.back(), preferredRows);
 }
 
+TEST_F(MergeJoinTest, fullOuterJoinWithoutDuplicateMatch) {
+  auto left = makeRowVector(
+      {"a", "b"},
+      {
+          makeNullableFlatVector<int32_t>({1, 2, 3, 5, 6, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {2.0, 1.0, 3.0, 1.0, 6.0, std::nullopt}),
+      });
+
+  auto right = makeRowVector(
+      {"c", "d"},
+      {
+          makeNullableFlatVector<int32_t>({0, 2, 3, 4, 5, 7, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {0.0, 3.0, 2.0, 1.0, 3.0, 7.0, std::nullopt}),
+      });
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto rightPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"a"},
+              {"c"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "b < d",
+              {"a", "b", "c", "d"},
+              core::JoinType::kFull)
+          .planNode();
+  AssertQueryBuilder(rightPlan, duckDbQueryRunner_)
+      .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
+}
+
+TEST_F(MergeJoinTest, fullOuterJoinWithDuplicateMatch) {
+  auto left = makeRowVector(
+      {"a", "b"},
+      {
+          makeNullableFlatVector<int32_t>({1, 2, 2, 2, 3, 5, 6, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {2.0, 100.0, 1.0, 1.0, 3.0, 1.0, 6.0, std::nullopt}),
+      });
+
+  auto right = makeRowVector(
+      {"c", "d"},
+      {
+          makeNullableFlatVector<int32_t>(
+              {0, 2, 2, 2, 2, 3, 4, 5, 7, std::nullopt}),
+          makeNullableFlatVector<double>(
+              {0.0, 3.0, -1.0, -1.0, 3.0, 2.0, 1.0, 3.0, 7.0, std::nullopt}),
+      });
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto rightPlan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"a"},
+              {"c"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "b < d",
+              {"a", "b", "c", "d"},
+              core::JoinType::kFull)
+          .planNode();
+  AssertQueryBuilder(rightPlan, duckDbQueryRunner_)
+      .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
+}
+
 TEST_F(MergeJoinTest, flatMapVectorInnerJoin) {
   auto left = makeRowVector(
       {"t_c0", "t_c1"},

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -2607,6 +2607,50 @@ TEST_F(MergeJoinTest, fullOuterJoinWithDuplicateMatch) {
       .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
 }
 
+TEST_F(MergeJoinTest, fullOuterJoinRightRowIdCollisionAcrossBatches) {
+  auto left = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<int32_t>({5, 5}),
+      });
+
+  auto rightBatch1 = makeRowVector(
+      {"c", "d"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1}),
+          makeFlatVector<int32_t>({10, 10, 10, 10}),
+      });
+
+  auto rightBatch2 = makeRowVector(
+      {"c", "d"},
+      {
+          makeFlatVector<int32_t>({2, 2, 2, 2}),
+          makeFlatVector<int32_t>({0, 0, 0, 0}),
+      });
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {rightBatch1, rightBatch2});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values({left})
+                  .mergeJoin(
+                      {"a"},
+                      {"c"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values({rightBatch1, rightBatch2})
+                          .planNode(),
+                      "b < d",
+                      {"a", "b", "c", "d"},
+                      core::JoinType::kFull)
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "32")
+      .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
+}
+
 TEST_F(MergeJoinTest, flatMapVectorInnerJoin) {
   auto left = makeRowVector(
       {"t_c0", "t_c1"},


### PR DESCRIPTION
# Problem
Assume the left table has columns a and b:

| a | b   |
|--:|----:|
| 2 | 100 |
| 2 | 1   |
| 2 | 1   |

The right table has columns c and d:

| c | d  |
|--:|---:|
| 2 | 3  |
| 2 | -1 |
| 2 | -1 |
| 2 | 3  |

The two tables are joined using a full outer join on the condition a == c and b < d. During the doGetOutput phase, the result is matched using a left join, resulting in 3 * 4 = 12 records:

| No | a | b   | c | d  |
|---:|--:|----:|--:|---:|
| 0  | 2 | 100 | 2 | 3  |
| 1  | 2 | 100 | 2 | -1 |
| 2  | 2 | 100 | 2 | -1 |
| 3  | 2 | 100 | 2 | 3  |
| 4  | 2 | 1   | 2 | 3  |
| 5  | 2 | 1   | 2 | -1 |
| 6  | 2 | 1   | 2 | -1 |
| 7  | 2 | 1   | 2 | 3  |
| 8  | 2 | 1   | 2 | 3  |
| 9  | 2 | 1   | 2 | -1 |
| 10 | 2 | 1   | 2 | -1 |
| 11 | 2 | 1   | 2 | 3  |

Then, in the filter method, the records are filtered based on the condition a == c and b < d, resulting in the following:

| No | a | b   | c | d  | matched |
|---:|--:|----:|--:|---:|---------|
| 0  | 2 | 100 | 2 | 3  | FALSE   |
| 1  | 2 | 100 | 2 | -1 | FALSE   |
| 2  | 2 | 100 | 2 | -1 | FALSE   |
| 3  | 2 | 100 | 2 | 3  | FALSE   |
| 4  | 2 | 1   | 2 | 3  | TRUE    |
| 5  | 2 | 1   | 2 | -1 | FALSE   |
| 6  | 2 | 1   | 2 | -1 | FALSE   |
| 7  | 2 | 1   | 2 | 3  | TRUE    |
| 8  | 2 | 1   | 2 | 3  | TRUE    |
| 9  | 2 | 1   | 2 | -1 | FALSE   |
| 10 | 2 | 1   | 2 | -1 | FALSE   |
| 11 | 2 | 1   | 2 | 3  | TRUE    |


Finally, records from the left table that do not have a match are filled with nulls, resulting in the following final output:

| No | a | b   | c    | d    |
|---:|--:|----:|------|------|
| 0  | 2 | 100 | null | null |
| 1  | 2 | 1   | 2    | 3    |
| 2  | 2 | 1   | 2    | 3    |
| 3  | 2 | 1   | 2    | 3    |
| 4  | 2 | 1   | 2    | 3    |

The above result is incorrect because it is missing rows from the right table that do not have a match. Among the 12 rows above, rows 0, 4, and 8 correspond to the first record (2, 3) from the right table, rows 1, 5, and 9 correspond to the second record (2, -1) from the right table, rows 2, 6, and 10 correspond to the third record (2, -1) from the right table, and rows 3, 7, and 11 correspond to the fourth record (2, 3) from the right table. From the matching results above, rows 1, 5, and 9, as well as rows 2, 6, and 10, are all false, meaning that the third and fourth records from the right table do not have matching rows. Therefore, the final result is missing rows from the right table that do not have matches. The correct final result should be:

| No | a    | b    | c    | d    |
|---:|------|------|------|------|
| 0  | 2    | 100  | null | null |
| 1  | 2    | 1    | 2    | 3    |
| 2  | 2    | 1    | 2    | 3    |
| 3  | 2    | 1    | 2    | 3    |
| 4  | 2    | 1    | 2    | 3    |
| 5  | null | null | 2    | -1   |
| 6  | null | null | 2    | -1   |

# How to Fix

## Step 1: `doGetOutput` emits regular match rows (Cartesian product 3×4 = 12)

This corresponds to the 12-row table in the PR. At this point:

- `isProvisionalRightRow = 0` for all rows
- `rightRowId` identifies the physical right-side row that produced the output row
- after this change, `rightRowId` is treated as a stable right-row identity, not as a per-match local batch index

For this example there is only one physical right batch, so the 4 right rows map to:

- `(1, 0) -> 4294967296`
- `(1, 1) -> 4294967297`
- `(1, 2) -> 4294967298`
- `(1, 3) -> 4294967299`

| outRow | a | b   | c | d  | rightRowId |
|------:|--:|----:|--:|---:|-----------:|
| 0  | 2 | 100 | 2 | 3  | 4294967296 |
| 1  | 2 | 100 | 2 | -1 | 4294967297 |
| 2  | 2 | 100 | 2 | -1 | 4294967298 |
| 3  | 2 | 100 | 2 | 3  | 4294967299 |
| 4  | 2 | 1   | 2 | 3  | 4294967296 |
| 5  | 2 | 1   | 2 | -1 | 4294967297 |
| 6  | 2 | 1   | 2 | -1 | 4294967298 |
| 7  | 2 | 1   | 2 | 3  | 4294967299 |
| 8  | 2 | 1   | 2 | 3  | 4294967296 |
| 9  | 2 | 1   | 2 | -1 | 4294967297 |
| 10 | 2 | 1   | 2 | -1 | 4294967298 |
| 11 | 2 | 1   | 2 | 3  | 4294967299 |

## Step 2: `doGetOutput` appends provisional right-only rows (one per right row)

After all regular match rows are emitted for this equal-key window, we append one
provisional row for each right row:

- `(a, b)` are set to `NULL`
- `(c, d)` keep the right-side values
- `isProvisionalRightRow = 1`
- `rightRowId` is the same stable identity used by the regular match rows

| outRow | a    | b    | c | d   | rightRowId | isProvisionalRightRow |
|------:|------|------|--:|----:|-----------:|----------------------:|
| 12 | null | null | 2 | 3   | 4294967296 | 1 |
| 13 | null | null | 2 | -1  | 4294967297 | 1 |
| 14 | null | null | 2 | -1  | 4294967298 | 1 |
| 15 | null | null | 2 | 3   | 4294967299 | 1 |

At this point, `doGetOutput` has produced 16 rows total:

- 12 regular match rows
- 4 provisional right-only rows

## Step 3: `applyFilter` evaluates only regular match rows

Predicate:

```sql
a = c AND b < d
```

Within this equal-key window, `a = c` is already satisfied, so the effective check is
just `b < d`.

`applyFilter()` evaluates only the regular match rows. The provisional right-only rows
(12–15) are not included in `filterRows`, so they are not evaluated by the filter.

| outRow | a | b   | c | d   | rightRowId | isProvisionalRightRow | matched (`b < d`) |
|------:|--:|----:|--:|----:|-----------:|----------------------:|------------------:|
| 0  | 2 | 100 | 2 | 3   | 4294967296 | 0 | F |
| 1  | 2 | 100 | 2 | -1  | 4294967297 | 0 | F |
| 2  | 2 | 100 | 2 | -1  | 4294967298 | 0 | F |
| 3  | 2 | 100 | 2 | 3   | 4294967299 | 0 | F |
| 4  | 2 | 1   | 2 | 3   | 4294967296 | 0 | T |
| 5  | 2 | 1   | 2 | -1  | 4294967297 | 0 | F |
| 6  | 2 | 1   | 2 | -1  | 4294967298 | 0 | F |
| 7  | 2 | 1   | 2 | 3   | 4294967299 | 0 | T |
| 8  | 2 | 1   | 2 | 3   | 4294967296 | 0 | T |
| 9  | 2 | 1   | 2 | -1  | 4294967297 | 0 | F |
| 10 | 2 | 1   | 2 | -1  | 4294967298 | 0 | F |
| 11 | 2 | 1   | 2 | 3   | 4294967299 | 0 | T |

## Step 4: Build `matchedRightRowIds_`

We scan all regular match rows where the filter passed and collect their `rightRowId`.

- rows with `matched = true`: `4, 7, 8, 11`
- corresponding `rightRowId`: `4294967296, 4294967299, 4294967296, 4294967299`

So:

| setName | values |
|---------|--------|
| `matchedRightRowIds_` | `{ 4294967296, 4294967299 }` |

Interpretation:

| rightRowId | right row `(c, d)` | has any passing match? |
|-----------:|--------------------|-----------------------:|
| 4294967296 | `(2, 3)`  | Yes |
| 4294967297 | `(2, -1)` | No  |
| 4294967298 | `(2, -1)` | No  |
| 4294967299 | `(2, 3)`  | Yes |

This is the key idea of the fix:

- keep a stable identity for each physical right row
- record which right rows have at least one passing match
- later drop only provisional rows whose `rightRowId` is in `matchedRightRowIds_`

## Step 5: Left-side fill

If all regular match rows for one left row fail the filter, we keep one row and null
out the right-side columns.

Left row `(2, 100)` corresponds to outRows `0..3`, and all of them are `F`, so we keep:

| output row | a | b   | c    | d    |
|------------|--:|----:|------|------|
| left-fill  | 2 | 100 | null | null |

Left rows `(2, 1)` have passing matches, so we keep all passing rows `(2, 1, 2, 3)`.

If we only applied the left-side rule, the kept rows would be:

| No | a | b   | c    | d    |
|---:|--:|----:|------|------|
| 0 | 2 | 100 | null | null |
| 1 | 2 | 1   | 2    | 3    |
| 2 | 2 | 1   | 2    | 3    |
| 3 | 2 | 1   | 2    | 3    |
| 4 | 2 | 1   | 2    | 3    |

This is the incorrect 5-row result because it is still missing the right-side rows that
had no passing match.

## Step 6: Decide which provisional right-only rows should be kept

Rule for provisional rows:

- if `isProvisionalRightRow = 1` and `rightRowId ∈ matchedRightRowIds_` => drop
- otherwise => keep

Decision for outRows `12..15`:

| outRow | a    | b    | c | d   | rightRowId | isProvisionalRightRow | in `matchedRightRowIds_`? | keep? |
|------:|------|------|--:|----:|-----------:|----------------------:|--------------------------:|------:|
| 12 | null | null | 2 | 3   | 4294967296 | 1 | Yes | No  |
| 13 | null | null | 2 | -1  | 4294967297 | 1 | No  | Yes |
| 14 | null | null | 2 | -1  | 4294967298 | 1 | No  | Yes |
| 15 | null | null | 2 | 3   | 4294967299 | 1 | Yes | No  |

So we keep the provisional rows for `4294967297` and `4294967298`, i.e. the two
`(2, -1)` rows.

## Step 7: Final output (correct result)

Kept rows:

- left fill: `(2, 100, NULL, NULL)` × 1
- passing matches: `(2, 1, 2, 3)` × 4
- right fill: `(NULL, NULL, 2, -1)` × 2

One possible final ordering:

| No | a    | b    | c    | d    |
|---:|------|------|------|------|
| 0 | 2    | 100  | null | null |
| 1 | 2    | 1    | 2    | 3    |
| 2 | 2    | 1    | 2    | 3    |
| 3 | 2    | 1    | 2    | 3    |
| 4 | 2    | 1    | 2    | 3    |
| 5 | null | null | 2    | -1   |
| 6 | null | null | 2    | -1   |

## Additional note on the current fix

In addition to using a stable `rightRowId`, this change also updates the
`filterInput_` aliases when right projections are flattened. This ensures that
filter evaluation always reads the current right-side values even when output
crosses right-batch boundaries.