### PR TITLE
feat(cudf): Special handling of VARCHAR literals in expression trees

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -16,6 +16,7 @@
 #include "velox/experimental/cudf/exec/ExpressionEvaluator.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
+#include "cudf/column/column_factories.hpp"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/type/Type.h"
@@ -278,6 +279,9 @@ struct AstContext {
   const std::vector<RowTypePtr> inputRowSchema;
   const std::vector<std::reference_wrapper<std::vector<PrecomputeInstruction>>>
       precomputeInstructions;
+  const std::shared_ptr<velox::exec::Expr>
+      rootExpr; // Track the root expression
+
   cudf::ast::expression const& pushExprToTree(
       const std::shared_ptr<velox::exec::Expr>& expr);
   cudf::ast::expression const& addPrecomputeInstruction(
@@ -296,7 +300,8 @@ cudf::ast::expression const& createAstTree(
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     const RowTypePtr& inputRowSchema,
     std::vector<PrecomputeInstruction>& precomputeInstructions) {
-  AstContext context{tree, scalars, {inputRowSchema}, {precomputeInstructions}};
+  AstContext context{
+      tree, scalars, {inputRowSchema}, {precomputeInstructions}, expr};
   return context.pushExprToTree(expr);
 }
 
@@ -312,7 +317,8 @@ cudf::ast::expression const& createAstTree(
       tree,
       scalars,
       {leftRowSchema, rightRowSchema},
-      {leftPrecomputeInstructions, rightPrecomputeInstructions}};
+      {leftPrecomputeInstructions, rightPrecomputeInstructions},
+      expr};
   return context.pushExprToTree(expr);
 }
 
@@ -379,7 +385,24 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     VELOX_CHECK_NOT_NULL(c, "literal expression should be ConstantExpr");
     auto value = c->value();
     VELOX_CHECK(value->isConstantEncoding());
-    // convert to cudf scalar
+
+    // Special case: VARCHAR literals cannot be handled by cudf::compute_column
+    // as the final output due to variable-width output limitation.
+    // However, if this is part of a larger expression tree (e.g., string
+    // comparison), then cudf can handle it fine since the final output won't be
+    // VARCHAR. We only need special handling when this literal will be the
+    // final output.
+    if (expr->type()->kind() == TypeKind::VARCHAR && expr == rootExpr) {
+      // convert to cudf scalar and store it
+      createLiteral(value, scalars);
+      // The scalar index is scalars.size() - 1 since we just added it
+      std::string fillExpr = "fill " + std::to_string(scalars.size() - 1);
+      // For literals, we use the first column just to get the size, but create
+      // a new column The new column will be appended after the original input
+      // columns
+      return addPrecomputeInstruction(inputRowSchema[0]->nameOf(0), fillExpr);
+    }
+
     return tree.push(createLiteral(value, scalars));
   } else if (binaryOps.find(name) != binaryOps.end()) {
     if (len > 2 and (name == "and" or name == "or")) {
@@ -590,6 +613,15 @@ void addPrecomputedColumns(
           *static_cast<cudf::string_scalar*>(scalars[scalarIndex].get()),
           cudf::string_scalar(
               "", true, stream, cudf::get_current_device_resource_ref()),
+          stream,
+          cudf::get_current_device_resource_ref());
+      input_table_columns.emplace_back(std::move(newColumn));
+    } else if (ins_name.rfind("fill", 0) == 0) {
+      auto scalarIndex =
+          std::stoi(ins_name.substr(5)); // "fill " is 5 characters
+      auto newColumn = cudf::make_column_from_scalar(
+          *static_cast<cudf::string_scalar*>(scalars[scalarIndex].get()),
+          input_table_columns[dependent_column_index]->size(),
           stream,
           cudf::get_current_device_resource_ref());
       input_table_columns.emplace_back(std::move(newColumn));

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -370,6 +370,41 @@ class CudfFilterProjectTest : public OperatorTestBase {
         "SELECT c0 IN (1, 2, 3) OR c1 IN (1.5, 2.5) OR c2 IN ('test1', 'test2') AS result FROM tmp");
   }
 
+  void testStringLiteralExpansion(const std::vector<RowVectorPtr>& input) {
+    // Test VARCHAR literal as standalone expression (needs special handling)
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .project({"'literal_value' AS result"})
+                    .planNode();
+
+    runTest(plan, "SELECT 'literal_value' AS result FROM tmp");
+  }
+
+  void testStringLiteralInComparison(const std::vector<RowVectorPtr>& input) {
+    // Test VARCHAR literal within comparison (should work normally)
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .project({"c2 = 'test_value' AS result"})
+                    .planNode();
+
+    runTest(plan, "SELECT c2 = 'test_value' AS result FROM tmp");
+  }
+
+  void testMixedLiteralProjection(const std::vector<RowVectorPtr>& input) {
+    // Test mixing standalone literals with expressions containing literals
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .project(
+                        {"'standalone_string' AS str_literal",
+                         "42 AS int_literal",
+                         "c2 = 'comparison_string' AS bool_result"})
+                    .planNode();
+
+    runTest(
+        plan,
+        "SELECT 'standalone_string' AS str_literal, 42 AS int_literal, c2 = 'comparison_string' AS bool_result FROM tmp");
+  }
+
   void runTest(core::PlanNodePtr planNode, const std::string& duckDbSql) {
     SCOPED_TRACE("run without spilling");
     assertQuery(planNode, duckDbSql);
@@ -773,5 +808,29 @@ TEST_F(CudfFilterProjectTest, filterWithEmptyResult) {
 
   // Run the test - should return empty result
   assertQuery(plan, "SELECT c0, c1, c2 FROM tmp WHERE c0 < 0 AND c0 > 1000");
+}
+
+TEST_F(CudfFilterProjectTest, stringLiteralExpansion) {
+  vector_size_t batchSize = 1000;
+  auto vectors = makeVectors(rowType_, 2, batchSize);
+  createDuckDbTable(vectors);
+
+  testStringLiteralExpansion(vectors);
+}
+
+TEST_F(CudfFilterProjectTest, stringLiteralInComparison) {
+  vector_size_t batchSize = 1000;
+  auto vectors = makeVectors(rowType_, 2, batchSize);
+  createDuckDbTable(vectors);
+
+  testStringLiteralInComparison(vectors);
+}
+
+TEST_F(CudfFilterProjectTest, mixedLiteralProjection) {
+  vector_size_t batchSize = 1000;
+  auto vectors = makeVectors(rowType_, 2, batchSize);
+  createDuckDbTable(vectors);
+
+  testMixedLiteralProjection(vectors);
 }
 } // namespace


### PR DESCRIPTION
For a special case where the expression is a single string literal, `cudf::compute_column` fails to create a column out of it because it cannot output variable width types. This PR adds special handling for this case and uses a cudf column factory to stand in.

This fix is required for TPCH query 21 to work in presto.