### PR TITLE
fix: TableScanNode's ctor and Connector::createDataSource/Sink APIs

### DIFF
--- a/velox/benchmarks/QueryBenchmarkBase.cpp
+++ b/velox/benchmarks/QueryBenchmarkBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/benchmarks/QueryBenchmarkBase.h"
+#include "velox/connectors/hive/HiveConnector.h"
 
 DEFINE_string(data_format, "parquet", "Data format");
 

--- a/velox/connectors/fuzzer/FuzzerConnector.cpp
+++ b/velox/connectors/fuzzer/FuzzerConnector.cpp
@@ -20,12 +20,12 @@
 namespace facebook::velox::connector::fuzzer {
 
 FuzzerDataSource::FuzzerDataSource(
-    const std::shared_ptr<const RowType>& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+    const RowTypePtr& outputType,
+    const connector::ConnectorTableHandlePtr& tableHandle,
     velox::memory::MemoryPool* pool)
     : outputType_(outputType), pool_(pool) {
   auto fuzzerTableHandle =
-      std::dynamic_pointer_cast<FuzzerTableHandle>(tableHandle);
+      std::dynamic_pointer_cast<const FuzzerTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(
       fuzzerTableHandle,
       "TableHandle must be an instance of FuzzerTableHandle");

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -55,8 +55,8 @@ class FuzzerTableHandle : public ConnectorTableHandle {
 class FuzzerDataSource : public DataSource {
  public:
   FuzzerDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+      const RowTypePtr& outputType,
+      const connector::ConnectorTableHandlePtr& tableHandle,
       velox::memory::MemoryPool* pool);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
@@ -109,11 +109,9 @@ class FuzzerConnector final : public Connector {
       : Connector(id) {}
 
   std::unique_ptr<DataSource> createDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& /*columnHandles*/,
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const connector::ColumnHandleMap& /*columnHandles*/,
       ConnectorQueryCtx* connectorQueryCtx) override final {
     return std::make_unique<FuzzerDataSource>(
         outputType, tableHandle, connectorQueryCtx->memoryPool());
@@ -121,8 +119,7 @@ class FuzzerConnector final : public Connector {
 
   std::unique_ptr<DataSink> createDataSink(
       RowTypePtr /*inputType*/,
-      std::shared_ptr<
-          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorInsertTableHandlePtr /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI("FuzzerConnector does not support data sink.");

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,13 +16,10 @@
 
 #include "velox/connectors/hive/HiveConnector.h"
 
-#include "velox/common/base/Fs.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include "velox/expression/ExprToSubfieldFilter.h"
-#include "velox/expression/FieldReference.h"
 
 #include <boost/lexical_cast.hpp>
 #include <memory>
@@ -72,10 +69,8 @@ HiveConnector::HiveConnector(
 
 std::unique_ptr<DataSource> HiveConnector::createDataSource(
     const RowTypePtr& outputType,
-    const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+    const ConnectorTableHandlePtr& tableHandle,
+    const std::unordered_map<std::string, ColumnHandlePtr>& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
   return std::make_unique<HiveDataSource>(
       outputType,
@@ -89,11 +84,12 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
 
 std::unique_ptr<DataSink> HiveConnector::createDataSink(
     RowTypePtr inputType,
-    std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
+    ConnectorInsertTableHandlePtr connectorInsertTableHandle,
     ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy commitStrategy) {
-  auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
-      connectorInsertTableHandle);
+  auto hiveInsertHandle =
+      std::dynamic_pointer_cast<const HiveInsertTableHandle>(
+          connectorInsertTableHandle);
   VELOX_CHECK_NOT_NULL(
       hiveInsertHandle, "Hive connector expecting hive write handle!");
   return std::make_unique<HiveDataSink>(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -50,10 +50,8 @@ class HiveConnector : public Connector {
 
   std::unique_ptr<DataSource> createDataSource(
       const RowTypePtr& outputType,
-      const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+      const ConnectorTableHandlePtr& tableHandle,
+      const connector::ColumnHandleMap& columnHandles,
       ConnectorQueryCtx* connectorQueryCtx) override;
 
   bool supportsSplitPreload() override {
@@ -62,7 +60,7 @@ class HiveConnector : public Connector {
 
   std::unique_ptr<DataSink> createDataSink(
       RowTypePtr inputType,
-      std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
+      ConnectorInsertTableHandlePtr connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx,
       CommitStrategy commitStrategy) override;
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -242,8 +242,7 @@ inline uint8_t parseDelimiter(const std::string& delim) {
 
 inline bool isSynthesizedColumn(
     const std::string& name,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        infoColumns) {
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& infoColumns) {
   return infoColumns.count(name) != 0;
 }
 
@@ -263,7 +262,7 @@ const std::string& getColumnName(const common::Subfield& subfield) {
   return field->name();
 }
 
-void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type) {
+void checkColumnNameLowerCase(const TypePtr& type) {
   switch (type->kind()) {
     case TypeKind::ARRAY:
       checkColumnNameLowerCase(type->asArray().elementType());
@@ -289,8 +288,7 @@ void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type) {
 
 void checkColumnNameLowerCase(
     const common::SubfieldFilters& filters,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        infoColumns) {
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& infoColumns) {
   for (const auto& filterIt : filters) {
     const auto name = filterIt.first.toString();
     if (isSynthesizedColumn(name, infoColumns)) {
@@ -355,10 +353,8 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
         outputSubfields,
     const common::SubfieldFilters& filters,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeys,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        infoColumns,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& partitionKeys,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& infoColumns,
     const SpecialColumnNames& specialColumns,
     bool disableStatsBasedFilterReorder,
     memory::MemoryPool* pool) {
@@ -696,7 +692,7 @@ bool testFilters(
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKeys,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+    const std::unordered_map<std::string, HiveColumnHandlePtr>&
         partitionKeysHandle,
     bool asLocalTime) {
   const auto totalRows = reader->numberOfRows();

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -36,8 +36,9 @@ void checkColumnNameLowerCase(const std::shared_ptr<const Type>& type);
 
 void checkColumnNameLowerCase(
     const common::SubfieldFilters& filters,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        infoColumns);
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& infoColumns);
 
 void checkColumnNameLowerCase(const core::TypedExprPtr& typeExpr);
 
@@ -52,10 +53,12 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
         outputSubfields,
     const common::SubfieldFilters& filters,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeys,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        infoColumns,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& partitionKeys,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& infoColumns,
     const SpecialColumnNames& specialColumns,
     bool disableStatsBasedFilterReorder,
     memory::MemoryPool* pool);
@@ -91,8 +94,9 @@ bool testFilters(
     const std::string& filePath,
     const std::unordered_map<std::string, std::optional<std::string>>&
         partitionKey,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeysHandle,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& partitionKeysHandle,
     bool asLocalTime);
 
 std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -58,10 +58,8 @@ bool shouldEagerlyMaterialize(
 
 HiveDataSource::HiveDataSource(
     const RowTypePtr& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+    const connector::ConnectorTableHandlePtr& tableHandle,
+    const connector::ColumnHandleMap& columnHandles,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
@@ -75,7 +73,8 @@ HiveDataSource::HiveDataSource(
       expressionEvaluator_(connectorQueryCtx->expressionEvaluator()) {
   // Column handled keyed on the column alias, the name used in the query.
   for (const auto& [canonicalizedName, columnHandle] : columnHandles) {
-    auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(columnHandle);
+    auto handle =
+        std::dynamic_pointer_cast<const HiveColumnHandle>(columnHandle);
     VELOX_CHECK_NOT_NULL(
         handle,
         "ColumnHandle must be an instance of HiveColumnHandle for {}",
@@ -118,7 +117,8 @@ HiveDataSource::HiveDataSource(
     }
   }
 
-  hiveTableHandle_ = std::dynamic_pointer_cast<HiveTableHandle>(tableHandle);
+  hiveTableHandle_ =
+      std::dynamic_pointer_cast<const HiveTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(
       hiveTableHandle_, "TableHandle must be an instance of HiveTableHandle");
   if (hiveConfig_->isFileColumnNamesReadAsLowerCase(

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -36,10 +36,8 @@ class HiveDataSource : public DataSource {
  public:
   HiveDataSource(
       const RowTypePtr& outputType,
-      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+      const connector::ConnectorTableHandlePtr& tableHandle,
+      const connector::ColumnHandleMap& columnHandles,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
@@ -80,11 +78,10 @@ class HiveDataSource : public DataSource {
 
   using WaveDelegateHookFunction =
       std::function<std::shared_ptr<wave::WaveDataSource>(
-          const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+          const HiveTableHandlePtr& hiveTableHandle,
           const std::shared_ptr<common::ScanSpec>& scanSpec,
           const RowTypePtr& readerOutputType,
-          std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-              partitionKeys,
+          std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
           FileHandleFactory* fileHandleFactory,
           folly::Executor* executor,
           const ConnectorQueryCtx* connectorQueryCtx,
@@ -111,7 +108,7 @@ class HiveDataSource : public DataSource {
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<HiveConnectorSplit> split_;
-  std::shared_ptr<HiveTableHandle> hiveTableHandle_;
+  HiveTableHandlePtr hiveTableHandle_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
   VectorPtr output_;
   std::unique_ptr<SplitReader> splitReader_;
@@ -123,8 +120,7 @@ class HiveDataSource : public DataSource {
 
   // Column handles for the partition key columns keyed on partition key column
   // name.
-  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
-      partitionKeys_;
+  std::unordered_map<std::string, HiveColumnHandlePtr> partitionKeys_;
 
   std::shared_ptr<io::IoStatistics> ioStats_;
   std::shared_ptr<filesystems::File::IoStats> fsStats_;
@@ -156,8 +152,7 @@ class HiveDataSource : public DataSource {
   core::ExpressionEvaluator* const expressionEvaluator_;
 
   // Column handles for the Split info columns keyed on their column names.
-  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>
-      infoColumns_;
+  std::unordered_map<std::string, HiveColumnHandlePtr> infoColumns_;
   SpecialColumnNames specialColumns_{};
   std::vector<common::Subfield> remainingFilterSubfields_;
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -22,9 +22,7 @@
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/ReaderFactory.h"
-#include "velox/type/TimestampConversion.h"
 
 namespace facebook::velox::connector::hive {
 namespace {
@@ -77,9 +75,8 @@ VectorPtr newConstantFromString(
 
 std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
-    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-        partitionKeys,
+    const HiveTableHandlePtr& hiveTableHandle,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const RowTypePtr& readerOutputType,
@@ -121,9 +118,8 @@ std::unique_ptr<SplitReader> SplitReader::create(
 
 SplitReader::SplitReader(
     const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
-    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-        partitionKeys,
+    const HiveTableHandlePtr& hiveTableHandle,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const RowTypePtr& readerOutputType,

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -58,8 +58,9 @@ class SplitReader {
   static std::unique_ptr<SplitReader> create(
       const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-          partitionKeys,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<const HiveColumnHandle>>* partitionKeys,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
       const RowTypePtr& readerOutputType,
@@ -110,8 +111,9 @@ class SplitReader {
   SplitReader(
       const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-          partitionKeys,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<const HiveColumnHandle>>* partitionKeys,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
       const RowTypePtr& readerOutputType,
@@ -176,7 +178,7 @@ class SplitReader {
   const std::shared_ptr<const HiveTableHandle> hiveTableHandle_;
   const std::unordered_map<
       std::string,
-      std::shared_ptr<HiveColumnHandle>>* const partitionKeys_;
+      std::shared_ptr<const HiveColumnHandle>>* const partitionKeys_;
   const ConnectorQueryCtx* connectorQueryCtx_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;
 

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -132,6 +132,10 @@ class HiveColumnHandle : public ColumnHandle {
   const ColumnParseParameters columnParseParameters_;
 };
 
+using HiveColumnHandlePtr = std::shared_ptr<const HiveColumnHandle>;
+using HiveColumnHandleMap =
+    std::unordered_map<std::string, HiveColumnHandlePtr>;
+
 class HiveTableHandle : public ConnectorTableHandle {
  public:
   HiveTableHandle(
@@ -190,5 +194,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const RowTypePtr dataColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
 };
+
+using HiveTableHandlePtr = std::shared_ptr<const HiveTableHandle>;
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -26,9 +26,8 @@ namespace facebook::velox::connector::hive::iceberg {
 
 IcebergSplitReader::IcebergSplitReader(
     const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
-    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-    const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-        partitionKeys,
+    const HiveTableHandlePtr& hiveTableHandle,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const RowTypePtr& readerOutputType,

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -28,9 +28,8 @@ class IcebergSplitReader : public SplitReader {
  public:
   IcebergSplitReader(
       const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
-      const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
-      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-          partitionKeys,
+      const HiveTableHandlePtr& hiveTableHandle,
+      const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
       const RowTypePtr& readerOutputType,

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -721,8 +721,7 @@ TEST_F(HiveIcebergTest, testPartitionedRead) {
     splits.insert(splits.end(), icebergSplits.begin(), icebergSplits.end());
   }
 
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments.insert(
       {"c0",
        std::make_shared<HiveColumnHandle>(

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 
 #include "gtest/gtest.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/TableWriter.h"

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -16,9 +16,9 @@
 
 #include <gtest/gtest.h>
 #include "velox/connectors/Connector.h"
-#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/type/tests/SubfieldFiltersBuilder.h"
 
 namespace facebook::velox::connector::hive::test {
 namespace {

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -32,18 +32,15 @@ class TestConnector : public connector::Connector {
 
   std::unique_ptr<connector::DataSource> createDataSource(
       const RowTypePtr& /* outputType */,
-      const std::shared_ptr<ConnectorTableHandle>& /* tableHandle */,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& /* columnHandles */,
+      const ConnectorTableHandlePtr& /* tableHandle */,
+      const connector::ColumnHandleMap& /* columnHandles */,
       connector::ConnectorQueryCtx* connectorQueryCtx) override {
     VELOX_NYI();
   }
 
   std::unique_ptr<connector::DataSink> createDataSink(
       RowTypePtr /*inputType*/,
-      std::shared_ptr<
-          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorInsertTableHandlePtr /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI();

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -58,15 +58,13 @@ std::string TpchTableHandle::toString() const {
 }
 
 TpchDataSource::TpchDataSource(
-    const std::shared_ptr<const RowType>& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+    const RowTypePtr& outputType,
+    const connector::ConnectorTableHandlePtr& tableHandle,
+    const connector::ColumnHandleMap& columnHandles,
     velox::memory::MemoryPool* pool)
     : pool_(pool) {
   auto tpchTableHandle =
-      std::dynamic_pointer_cast<TpchTableHandle>(tableHandle);
+      std::dynamic_pointer_cast<const TpchTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(
       tpchTableHandle, "TableHandle must be an instance of TpchTableHandle");
   tpchTable_ = tpchTableHandle->getTable();
@@ -86,7 +84,7 @@ TpchDataSource::TpchDataSource(
         outputName,
         toTableName(tpchTable_));
 
-    auto handle = std::dynamic_pointer_cast<TpchColumnHandle>(it->second);
+    auto handle = std::dynamic_pointer_cast<const TpchColumnHandle>(it->second);
     VELOX_CHECK_NOT_NULL(
         handle,
         "ColumnHandle must be an instance of TpchColumnHandle "

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -71,11 +71,9 @@ class TpchTableHandle : public ConnectorTableHandle {
 class TpchDataSource : public DataSource {
  public:
   TpchDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+      const RowTypePtr& outputType,
+      const connector::ConnectorTableHandlePtr& tableHandle,
+      const connector::ColumnHandleMap& columnHandles,
       velox::memory::MemoryPool* pool);
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
@@ -138,11 +136,9 @@ class TpchConnector final : public Connector {
       : Connector(id) {}
 
   std::unique_ptr<DataSource> createDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const connector::ColumnHandleMap& columnHandles,
       ConnectorQueryCtx* connectorQueryCtx) override final {
     return std::make_unique<TpchDataSource>(
         outputType,
@@ -153,8 +149,7 @@ class TpchConnector final : public Connector {
 
   std::unique_ptr<DataSink> createDataSink(
       RowTypePtr /*inputType*/,
-      std::shared_ptr<
-          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorInsertTableHandlePtr /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI("TpchConnector does not support data sink.");

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -186,11 +186,9 @@ TEST_F(PlanNodeBuilderTest, TableScanNode) {
   const RowTypePtr outputType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});
   const auto tableHandle =
       std::make_shared<connector::ConnectorTableHandle>("connector_id");
-  const std::
-      unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          assignments{
-              {"c0", std::make_shared<connector::ColumnHandle>()},
-              {"c1", std::make_shared<connector::ColumnHandle>()}};
+  const connector::ColumnHandleMap assignments{
+      {"c0", std::make_shared<connector::ColumnHandle>()},
+      {"c1", std::make_shared<connector::ColumnHandle>()}};
 
   const auto verify = [&](const std::shared_ptr<const TableScanNode>& node) {
     EXPECT_EQ(node->id(), id);

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -46,8 +46,7 @@ TEST_F(PlanNodeTest, findFirstNode) {
   auto rowType = ROW({"name1"}, {BIGINT()});
 
   std::shared_ptr<connector::ConnectorTableHandle> tableHandle;
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
 
   std::shared_ptr<PlanNode> tableScan3 =
       std::make_shared<TableScanNode>("3", rowType, tableHandle, assignments);
@@ -174,20 +173,13 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
   const RowTypePtr outputType = ROW({"c0", "c1"}, {BIGINT(), BIGINT()});
   auto indexTableHandle = std::make_shared<TestIndexTableHandle>();
   const auto probeNode = std::make_shared<TableScanNode>(
-      "tableScan-probe",
-      probeType,
-      nullptr,
-      std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>{});
+      "tableScan-probe", probeType, nullptr, connector::ColumnHandleMap{});
   ASSERT_FALSE(isIndexLookupJoin(probeNode.get()));
   const auto buildNode = std::make_shared<TableScanNode>(
       "tableScan-build",
       buildType,
       indexTableHandle,
-      std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>{});
+      connector::ColumnHandleMap{});
   ASSERT_FALSE(isIndexLookupJoin(buildNode.get()));
   const std::vector<FieldAccessTypedExprPtr> leftKeys{
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -69,8 +69,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   void assertSelectWithAssignments(
       std::vector<std::string>&& outputColumnNames,
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>&
-          assignments,
+      const connector::ColumnHandleMap& assignments,
       const std::string& sql) {
     auto rowType = getRowType(std::move(outputColumnNames));
     auto plan = PlanBuilder()
@@ -84,9 +83,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
       const std::vector<std::string>& subfieldFilters,
       const std::string& remainingFilter,
       const std::string& sql,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {}) {
+      const connector::ColumnHandleMap& assignments = {}) {
     auto rowType = getRowType(std::move(outputColumnNames));
     parse::ParseOptions options;
     options.parseDecimalAsDouble = false;
@@ -730,8 +727,7 @@ TEST_F(ParquetTableScanTest, rowIndex) {
           }),
       std::nullopt,
       std::unordered_map<std::string, std::string>{{kPath, filePath}});
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["a"] = std::make_shared<connector::hive::HiveColumnHandle>(
       "a",
       connector::hive::HiveColumnHandle::ColumnType::kRegular,
@@ -828,16 +824,14 @@ TEST_F(ParquetTableScanTest, filterNullIcebergPartition) {
       {"c1 IS NOT NULL"},
       "",
       "SELECT c0, c1 FROM tmp WHERE c1 IS NOT NULL",
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>{
-          {"c0", c0}, {"c1", c1}});
+      connector::ColumnHandleMap{{"c0", c0}, {"c1", c1}});
 
   assertSelectWithFilter(
       {"c0", "c1"},
       {"c1 IS NULL"},
       "",
       "SELECT c0, c1 FROM tmp WHERE c1 IS NULL",
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>{
-          {"c0", c0}, {"c1", c1}});
+      connector::ColumnHandleMap{{"c0", c0}, {"c1", c1}});
 }
 
 TEST_F(ParquetTableScanTest, sessionTimezone) {

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -226,10 +226,9 @@ class IndexLookupJoin : public Operator {
   const size_t numKeys_;
   const RowTypePtr probeType_;
   const RowTypePtr lookupType_;
-  const std::shared_ptr<connector::ConnectorTableHandle> lookupTableHandle_;
+  const connector::ConnectorTableHandlePtr lookupTableHandle_;
   const std::vector<core::IndexLookupConditionPtr> lookupConditions_;
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      lookupColumnHandles_;
+  const connector::ColumnHandleMap lookupColumnHandles_;
   const std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   const std::shared_ptr<connector::Connector> connector_;
   const size_t maxNumInputBatches_;

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -17,8 +17,6 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Task.h"
-#include "velox/exec/TraceUtil.h"
-#include "velox/expression/Expr.h"
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -30,10 +28,8 @@ std::unique_ptr<connector::DataSource> createDataSource(
     folly::Synchronized<PushdownFilters>& pushdownFilters,
     connector::Connector& connector,
     const RowTypePtr& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+    const connector::ConnectorTableHandlePtr& tableHandle,
+    const connector::ColumnHandleMap& columnHandles,
     connector::ConnectorQueryCtx* connectorQueryCtx) {
   auto dataSource = connector.createDataSource(
       outputType, tableHandle, columnHandles, connectorQueryCtx);

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -99,10 +99,8 @@ class TableScan : public SourceOperator {
   // processing or not.
   void tryScaleUp();
 
-  const std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
-  const std::
-      unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          columnHandles_;
+  const connector::ConnectorTableHandlePtr tableHandle_;
+  const connector::ColumnHandleMap columnHandles_;
   DriverCtx* const driverCtx_;
   const int32_t maxSplitPreloadPerDriver_{0};
   const vector_size_t maxReadBatchSize_;

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/exec/TableWriter.h"
 
-#include "HashAggregation.h"
+#include "velox/exec/HashAggregation.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -24,7 +24,7 @@ namespace facebook::velox::exec {
 TableWriter::TableWriter(
     int32_t operatorId,
     DriverCtx* driverCtx,
-    const std::shared_ptr<const core::TableWriteNode>& tableWriteNode)
+    const core::TableWriteNodePtr& tableWriteNode)
     : Operator(
           driverCtx,
           tableWriteNode->outputType(),
@@ -68,7 +68,7 @@ TableWriter::TableWriter(
 }
 
 void TableWriter::setTypeMappings(
-    const std::shared_ptr<const core::TableWriteNode>& tableWriteNode) {
+    const core::TableWriteNodePtr& tableWriteNode) {
   auto outputNames = tableWriteNode->columnNames();
   auto outputTypes = tableWriteNode->columns()->children();
 

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include "OperatorUtils.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
@@ -102,7 +101,7 @@ class TableWriter : public Operator {
   TableWriter(
       int32_t operatorId,
       DriverCtx* driverCtx,
-      const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
+      const core::TableWriteNodePtr& tableWriteNode);
 
   BlockingReason isBlocked(ContinueFuture* future) override;
 
@@ -214,8 +213,7 @@ class TableWriter : public Operator {
 
   // Sets type mappings in `inputMapping_`, `mappedInputType_`, and
   // `mappedOutputType_`.
-  void setTypeMappings(
-      const std::shared_ptr<const core::TableWriteNode>& tableWriteNode);
+  void setTypeMappings(const core::TableWriteNodePtr& tableWriteNode);
 
   std::string createTableCommitContext(bool lastOutput);
 
@@ -223,8 +221,7 @@ class TableWriter : public Operator {
 
   const DriverCtx* const driverCtx_;
   memory::MemoryPool* const connectorPool_;
-  const std::shared_ptr<connector::ConnectorInsertTableHandle>
-      insertTableHandle_;
+  const connector::ConnectorInsertTableHandlePtr insertTableHandle_;
   const connector::CommitStrategy commitStrategy_;
   // Records the writer operator creation time in ns. This is used to record
   // the running wall time of a writer operator. This can helps to detect the

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -203,7 +203,7 @@ void PrestoQueryRunnerToSqlPlanNodeVisitor::visit(
       static_cast<PrestoSqlPlanNodeVisitorContext&>(ctx);
 
   auto insertTableHandle =
-      std::dynamic_pointer_cast<connector::hive::HiveInsertTableHandle>(
+      std::dynamic_pointer_cast<const connector::hive::HiveInsertTableHandle>(
           node.insertTableHandle()->connectorInsertTableHandle());
 
   // Returns a CTAS sql with specified table properties from TableWriteNode,

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -149,8 +149,7 @@ class WriterFuzzer {
       const std::shared_ptr<TempDirectoryPath>& outputDirectoryPath);
 
   // Generates table column handles based on table column properties
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-  getTableColumnHandles(
+  connector::ColumnHandleMap getTableColumnHandles(
       const std::vector<std::string>& names,
       const std::vector<TypePtr>& types,
       int32_t partitionOffset,
@@ -635,14 +634,12 @@ void WriterFuzzer::verifyWriter(
   LOG(INFO) << "Verified results against reference DB";
 }
 
-std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-WriterFuzzer::getTableColumnHandles(
+connector::ColumnHandleMap WriterFuzzer::getTableColumnHandles(
     const std::vector<std::string>& names,
     const std::vector<TypePtr>& types,
     const int32_t partitionOffset,
     const int32_t bucketCount) {
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      columnHandle;
+  connector::ColumnHandleMap columnHandle;
   for (int i = 0; i < names.size(); ++i) {
     HiveColumnHandle::ColumnType columnType;
     if (i < partitionOffset) {

--- a/velox/exec/tests/AssertQueryBuilderTest.cpp
+++ b/velox/exec/tests/AssertQueryBuilderTest.cpp
@@ -125,7 +125,7 @@ TEST_F(AssertQueryBuilderTest, hiveSplits) {
   }
 
   // Split with partition key.
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"ds", partitionKey("ds", VARCHAR())},
       {"c0", regularColumn("c0", BIGINT())}};
 

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -137,18 +137,17 @@ class TestConnector : public connector::Connector {
 
   std::unique_ptr<connector::DataSource> createDataSource(
       const RowTypePtr& /* outputType */,
-      const std::shared_ptr<ConnectorTableHandle>& /* tableHandle */,
+      const ConnectorTableHandlePtr& /* tableHandle */,
       const std::unordered_map<
           std::string,
-          std::shared_ptr<connector::ColumnHandle>>& /* columnHandles */,
+          connector::ColumnHandlePtr>& /* columnHandles */,
       connector::ConnectorQueryCtx* connectorQueryCtx) override {
     return std::make_unique<TestDataSource>(connectorQueryCtx->memoryPool());
   }
 
   std::unique_ptr<connector::DataSink> createDataSink(
       RowTypePtr /*inputType*/,
-      std::shared_ptr<
-          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorInsertTableHandlePtr /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -36,12 +36,12 @@
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox;
-using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::common::testutil;
 
 using facebook::velox::test::BatchMaker;
 
+namespace facebook::velox::exec {
 namespace {
 
 class HashJoinTest : public HashJoinTestBase {
@@ -3722,7 +3722,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     SCOPED_TRACE("Inner join column rename");
     auto scanOutputType = ROW({"a", "b"}, {INTEGER(), BIGINT()});
-    ColumnHandleMap assignments;
+    connector::ColumnHandleMap assignments;
     assignments["a"] = regularColumn("c0", INTEGER());
     assignments["b"] = regularColumn("c1", BIGINT());
 
@@ -4512,7 +4512,7 @@ TEST_F(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
   }
 
   auto outputType = ROW({"p0", "p1"}, {BIGINT(), BIGINT()});
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"p0", regularColumn("p0", BIGINT())},
       {"p1", partitionKey("p1", BIGINT())}};
   createDuckDbTable("p", probeVectors);
@@ -4906,7 +4906,7 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
                    .partitionKey("k", "0")
                    .build();
   auto outputType = ROW({"n1_0", "n1_1"}, {BIGINT(), BIGINT()});
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"n1_0", regularColumn("c0", BIGINT())},
       {"n1_1", partitionKey("k", BIGINT())}};
 
@@ -8151,4 +8151,6 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashTableCleanupAfterProbeFinish) {
       .run();
   ASSERT_TRUE(tableEmpty);
 }
+
 } // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -120,11 +120,9 @@ class IndexLookupJoinTest : public IndexLookupJoinTestBase,
         kTestIndexConnectorName, indexTable, asyncLookup);
   }
 
-  static std::
-      unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      makeIndexColumnHandles(const std::vector<std::string>& names) {
-    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-        handles;
+  static connector::ColumnHandleMap makeIndexColumnHandles(
+      const std::vector<std::string>& names) {
+    connector::ColumnHandleMap handles;
     for (const auto& name : names) {
       handles.emplace(name, std::make_shared<TestIndexColumnHandle>(name));
     }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -16,6 +16,7 @@
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/PartitionFunction.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
 

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/WindowFunction.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
 
-using namespace facebook;
-using namespace facebook::velox;
-using namespace facebook::velox::common::test;
-
 using facebook::velox::exec::test::PlanBuilder;
+
+namespace facebook::velox::exec {
+namespace {
 
 class PlanNodeToStringTest : public testing::Test,
                              public velox::test::VectorTestBase {
@@ -971,3 +971,6 @@ TEST_F(PlanNodeToStringTest, markDistinct) {
       "-- MarkDistinct[1][a, b] -> a:VARCHAR, b:BIGINT, c:BIGINT, marker:BOOLEAN\n",
       op->toString(true, false));
 }
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -25,7 +25,6 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/tests/CacheTestUtil.h"
-#include "velox/common/file/tests/FaultyFile.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
@@ -33,16 +32,13 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
-#include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
-#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TableScanTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -55,13 +51,13 @@ using namespace facebook::velox;
 using namespace facebook::velox::cache;
 using namespace facebook::velox::connector::hive;
 using namespace facebook::velox::core;
-using namespace facebook::velox::exec;
 using namespace facebook::velox::common::test;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::tests::utils;
 
 DECLARE_int32(cache_prefetch_min_pct);
 
+namespace facebook::velox::exec {
 namespace {
 void verifyCacheStats(
     const FileHandleCacheStats& cacheStats,
@@ -72,7 +68,6 @@ void verifyCacheStats(
   EXPECT_EQ(cacheStats.numHits, numHits);
   EXPECT_EQ(cacheStats.numLookups, numLookups);
 }
-} // namespace
 
 class TableScanTest : public TableScanTestBase {};
 
@@ -286,7 +281,7 @@ TEST_F(TableScanTest, partitionKeyAlias) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
 
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"a", regularColumn("c0", BIGINT())},
       {"ds_alias", partitionKey("ds", VARCHAR())}};
 
@@ -520,8 +515,7 @@ TEST_F(TableScanTest, subfieldPruningRowType) {
   writeToFile(filePath->getPath(), vectors);
   std::vector<common::Subfield> requiredSubfields;
   requiredSubfields.emplace_back("e.c");
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["e"] = std::make_shared<HiveColumnHandle>(
       "e",
       HiveColumnHandle::ColumnType::kRegular,
@@ -577,8 +571,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterSubfieldsMissing) {
   writeToFile(filePath->getPath(), vectors);
   std::vector<common::Subfield> requiredSubfields;
   requiredSubfields.emplace_back("e.c");
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["e"] = std::make_shared<HiveColumnHandle>(
       "e",
       HiveColumnHandle::ColumnType::kRegular,
@@ -633,8 +626,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterRootFieldMissing) {
   auto vectors = makeVectors(10, 1'000, rowType);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->getPath(), vectors);
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["d"] = std::make_shared<HiveColumnHandle>(
       "d", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
   auto op = PlanBuilder()
@@ -676,8 +668,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterStruct) {
     for (int filterColumn = kWholeColumn; filterColumn <= kSubfieldOnly;
          ++filterColumn) {
       SCOPED_TRACE(fmt::format("{} {}", outputColumn, filterColumn));
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          assignments;
+      connector::ColumnHandleMap assignments;
       assignments["d"] = std::make_shared<HiveColumnHandle>(
           "d", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
       if (outputColumn > kNoOutput) {
@@ -762,8 +753,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterMap) {
     for (int filterColumn = kWholeColumn; filterColumn <= kSubfieldOnly;
          ++filterColumn) {
       SCOPED_TRACE(fmt::format("{} {}", outputColumn, filterColumn));
-      std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          assignments;
+      connector::ColumnHandleMap assignments;
       assignments["a"] = std::make_shared<HiveColumnHandle>(
           "a", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
       if (outputColumn > kNoOutput) {
@@ -862,8 +852,7 @@ TEST_F(TableScanTest, subfieldPruningMapType) {
   requiredSubfields.emplace_back("c[0]");
   requiredSubfields.emplace_back("c[2]");
   requiredSubfields.emplace_back("c[4]");
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["c"] = std::make_shared<HiveColumnHandle>(
       "c",
       HiveColumnHandle::ColumnType::kRegular,
@@ -946,8 +935,7 @@ TEST_F(TableScanTest, subfieldPruningArrayType) {
   writeToFile(filePath->getPath(), vectors);
   std::vector<common::Subfield> requiredSubfields;
   requiredSubfields.emplace_back("c[3]");
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["c"] = std::make_shared<HiveColumnHandle>(
       "c",
       HiveColumnHandle::ColumnType::kRegular,
@@ -1109,7 +1097,7 @@ TEST_F(TableScanTest, missingColumns) {
   filters[common::Subfield("c1")] = lessThanOrEqualDouble(1050.0, true);
   auto tableHandle = std::make_shared<HiveTableHandle>(
       kHiveConnectorId, "tmp", true, std::move(filters), nullptr, dataColumns);
-  ColumnHandleMap assignments;
+  connector::ColumnHandleMap assignments;
   assignments["c0"] = regularColumn("c0", BIGINT());
   op = PlanBuilder(pool_.get())
            .startTableScan()
@@ -1882,7 +1870,7 @@ TEST_F(TableScanTest, partitionedTableDateKey) {
                      .partitionKey("pkey", partitionValue)
                      .build();
     auto outputType = ROW({"pkey", "c0", "c1"}, {DATE(), BIGINT(), DOUBLE()});
-    ColumnHandleMap assignments = {
+    connector::ColumnHandleMap assignments = {
         {"pkey", partitionKey("pkey", DATE())},
         {"c0", regularColumn("c0", BIGINT())},
         {"c1", regularColumn("c1", DOUBLE())}};
@@ -1922,7 +1910,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
                    .partitionKey("pkey", partitionValue)
                    .build();
 
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"pkey", partitionKey("pkey", TIMESTAMP())},
       {"c0", regularColumn("c0", BIGINT())},
       {"c1", regularColumn("c1", DOUBLE())}};
@@ -2250,7 +2238,8 @@ TEST_F(TableScanTest, statsBasedSkipping) {
   // c0 <= -1 -> whole file should be skipped based on stats
   auto subfieldFilters = singleSubfieldFilter("c0", lessThanOrEqual(-1));
 
-  ColumnHandleMap assignments = {{"c1", regularColumn("c1", INTEGER())}};
+  connector::ColumnHandleMap assignments = {
+      {"c1", regularColumn("c1", INTEGER())}};
 
   auto assertQuery = [&](const std::string& query) {
     auto tableHandle = makeTableHandle(
@@ -3513,7 +3502,8 @@ TEST_F(TableScanTest, remainingFilter) {
       "SELECT * FROM tmp WHERE c1 > c0 AND c0 >= 0");
 
   // Remaining filter uses columns that are not used otherwise.
-  ColumnHandleMap assignments = {{"c2", regularColumn("c2", DOUBLE())}};
+  connector::ColumnHandleMap assignments = {
+      {"c2", regularColumn("c2", DOUBLE())}};
 
   assertQuery(
       PlanBuilder(pool_.get())
@@ -4122,7 +4112,8 @@ TEST_F(TableScanTest, interleaveLazyEager) {
   auto eagerFile = TempFilePath::create();
   writeToFile(eagerFile->getPath(), rowsWithNulls);
 
-  ColumnHandleMap assignments = {{"c0", regularColumn("c0", column->type())}};
+  connector::ColumnHandleMap assignments = {
+      {"c0", regularColumn("c0", column->type())}};
   CursorParameters params;
   params.planNode = PlanBuilder()
                         .startTableScan()
@@ -4935,7 +4926,7 @@ TEST_F(TableScanTest, varbinaryPartitionKey) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
 
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"a", regularColumn("c0", BIGINT())},
       {"ds_alias", partitionKey("ds", VARBINARY())}};
 
@@ -4992,7 +4983,8 @@ TEST_F(TableScanTest, timestampPartitionKey) {
     return splits;
   };
 
-  ColumnHandleMap assignments = {{"t", partitionKey("t", TIMESTAMP())}};
+  connector::ColumnHandleMap assignments = {
+      {"t", partitionKey("t", TIMESTAMP())}};
   auto plan = PlanBuilder()
                   .startTableScan()
                   .outputType(ROW({"t"}, {TIMESTAMP()}))
@@ -5163,8 +5155,7 @@ TEST_F(TableScanTest, dynamicFilterWithRowIndexColumn) {
       {"row_index", "a"},
       {makeFlatVector<int64_t>(5, folly::identity),
        makeFlatVector<int64_t>(5, folly::identity)});
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["a"] = std::make_shared<connector::hive::HiveColumnHandle>(
       "a",
       connector::hive::HiveColumnHandle::ColumnType::kRegular,
@@ -5798,3 +5789,5 @@ TEST_F(TableScanTest, prevBatchEmptyAdaptivity) {
     EXPECT_GT(numBatchesReadWithoutAdaptivity, numBatchesRead);
   }
 }
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -18,10 +18,10 @@
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-#include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -15,23 +15,17 @@
  */
 #pragma once
 
-#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
-#include "velox/exec/Operator.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
-#include "velox/type/tests/SubfieldFiltersBuilder.h"
 
 namespace facebook::velox::exec::test {
 
 static const std::string kHiveConnectorId = "test-hive";
-
-using ColumnHandleMap =
-    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>;
 
 class HiveConnectorTestBase : public OperatorTestBase {
  public:
@@ -236,8 +230,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::string& name,
       const TypePtr& type);
 
-  static ColumnHandleMap allRegularColumns(const RowTypePtr& rowType) {
-    ColumnHandleMap assignments;
+  static connector::ColumnHandleMap allRegularColumns(
+      const RowTypePtr& rowType) {
+    connector::ColumnHandleMap assignments;
     assignments.reserve(rowType->size());
     for (uint32_t i = 0; i < rowType->size(); ++i) {
       const auto& name = rowType->nameOf(i);

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/tests/utils/IndexLookupJoinTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace fecebook::velox::exec::test {
@@ -319,13 +320,9 @@ facebook::velox::core::TableScanNodePtr
 IndexLookupJoinTestBase::makeIndexScanNode(
     const std::shared_ptr<facebook::velox::core::PlanNodeIdGenerator>&
         planNodeIdGenerator,
-    const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>
-        indexTableHandle,
+    const facebook::velox::connector::ConnectorTableHandlePtr& indexTableHandle,
     const facebook::velox::RowTypePtr& outputType,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<facebook::velox::connector::ColumnHandle>>&
-        assignments) {
+    const facebook::velox::connector::ColumnHandleMap& assignments) {
   auto planBuilder = facebook::velox::exec::test::PlanBuilder(
       planNodeIdGenerator, pool_.get());
   auto indexTableScan =

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -16,7 +16,6 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/core/PlanNode.h"
-#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 
@@ -124,13 +123,10 @@ class IndexLookupJoinTestBase
   facebook::velox::core::TableScanNodePtr makeIndexScanNode(
       const std::shared_ptr<facebook::velox::core::PlanNodeIdGenerator>&
           planNodeIdGenerator,
-      const std::shared_ptr<facebook::velox::connector::ConnectorTableHandle>
+      const facebook::velox::connector::ConnectorTableHandlePtr&
           indexTableHandle,
       const facebook::velox::RowTypePtr& outputType,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<facebook::velox::connector::ColumnHandle>>&
-          assignments);
+      const facebook::velox::connector::ColumnHandleMap& assignments);
 
   /// Generate sequence storage table which will be persisted by mock zippydb
   /// client for testing.

--- a/velox/exec/tests/utils/LocalRunnerTestBase.cpp
+++ b/velox/exec/tests/utils/LocalRunnerTestBase.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/tests/utils/LocalRunnerTestBase.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 
 namespace facebook::velox::exec::test {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -72,9 +72,7 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::vector<std::string>& subfieldFilters,
     const std::string& remainingFilter,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
+    const connector::ColumnHandleMap& assignments) {
   return TableScanBuilder(*this)
       .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
       .outputType(outputType)
@@ -92,9 +90,7 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::vector<std::string>& subfieldFilters,
     const std::string& remainingFilter,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
+    const connector::ColumnHandleMap& assignments) {
   return TableScanBuilder(*this)
       .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
       .tableName(tableName)
@@ -112,9 +108,7 @@ PlanBuilder& PlanBuilder::tableScanWithPushDown(
     const PushdownConfig& pushdownConfig,
     const std::string& remainingFilter,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& assignments) {
+    const connector::ColumnHandleMap& assignments) {
   return TableScanBuilder(*this)
       .filtersAsNode(filtersAsNode_ ? planNodeIdGenerator_ : nullptr)
       .outputType(outputType)
@@ -130,8 +124,7 @@ PlanBuilder& PlanBuilder::tpchTableScan(
     std::vector<std::string> columnNames,
     double scaleFactor,
     std::string_view connectorId) {
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignmentsMap;
+  connector::ColumnHandleMap assignmentsMap;
   std::vector<TypePtr> outputTypes;
 
   assignmentsMap.reserve(columnNames.size());

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -140,9 +140,7 @@ class PlanBuilder {
       const std::vector<std::string>& subfieldFilters = {},
       const std::string& remainingFilter = "",
       const RowTypePtr& dataColumns = nullptr,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+      const connector::ColumnHandleMap& assignments = {});
 
   /// Add a TableScanNode to scan a Hive table.
   ///
@@ -172,9 +170,7 @@ class PlanBuilder {
       const std::vector<std::string>& subfieldFilters = {},
       const std::string& remainingFilter = "",
       const RowTypePtr& dataColumns = nullptr,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+      const connector::ColumnHandleMap& assignments = {});
 
   /// Add a TableScanNode to scan a Hive table with direct SubfieldFilters.
   ///
@@ -189,9 +185,7 @@ class PlanBuilder {
       const PushdownConfig& pushdownConfig,
       const std::string& remainingFilter = "",
       const RowTypePtr& dataColumns = nullptr,
-      const std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::ColumnHandle>>& assignments = {});
+      const connector::ColumnHandleMap& assignments = {});
 
   /// Add a TableScanNode to scan a TPC-H table.
   ///
@@ -297,7 +291,7 @@ class PlanBuilder {
     /// @param tableHandle Optional tableHandle. Other builder arguments such as
     /// the `subfieldFilters` and `remainingFilter` will be ignored.
     TableScanBuilder& tableHandle(
-        std::shared_ptr<connector::ConnectorTableHandle> tableHandle) {
+        connector::ConnectorTableHandlePtr tableHandle) {
       tableHandle_ = std::move(tableHandle);
       return *this;
     }
@@ -306,10 +300,7 @@ class PlanBuilder {
     /// outputType names should match the keys in the 'assignments' map. The
     /// 'assignments' map may contain more columns than 'outputType' if some
     /// columns are only used by pushed-down filters.
-    TableScanBuilder& assignments(
-        std::unordered_map<
-            std::string,
-            std::shared_ptr<connector::ColumnHandle>> assignments) {
+    TableScanBuilder& assignments(connector::ColumnHandleMap assignments) {
       assignments_ = std::move(assignments);
       return *this;
     }
@@ -332,9 +323,8 @@ class PlanBuilder {
     core::ExprPtr remainingFilter_;
     RowTypePtr dataColumns_;
     std::unordered_map<std::string, std::string> columnAliases_;
-    std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
-    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-        assignments_;
+    connector::ConnectorTableHandlePtr tableHandle_;
+    connector::ColumnHandleMap assignments_;
 
     // produce filters as a FilterNode instead of pushdown.
     bool filtersAsNode_{false};

--- a/velox/exec/tests/utils/TableScanTestBase.cpp
+++ b/velox/exec/tests/utils/TableScanTestBase.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/exec/tests/utils/TableScanTestBase.h"
-
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -159,7 +158,7 @@ void TableScanTestBase::testPartitionedTableImpl(
                    .build();
   auto outputType =
       ROW({"pkey", "c0", "c1"}, {partitionType, BIGINT(), DOUBLE()});
-  ColumnHandleMap assignments = {
+  connector::ColumnHandleMap assignments = {
       {"pkey", partitionKey("pkey", partitionType)},
       {"c0", regularColumn("c0", BIGINT())},
       {"c1", regularColumn("c1", DOUBLE())}};

--- a/velox/exec/tests/utils/TableScanTestBase.h
+++ b/velox/exec/tests/utils/TableScanTestBase.h
@@ -20,6 +20,7 @@
 #include <folly/experimental/EventCount.h>
 #include <folly/synchronization/Baton.h>
 #include <folly/synchronization/Latch.h>
+#include "velox/connectors/hive/FileHandle.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/type/Type.h"

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -105,9 +105,7 @@ core::TypedExprPtr toJoinConditionExpr(
         joinConditions,
     const std::shared_ptr<TestIndexTable>& indexTable,
     const RowTypePtr& inputType,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles) {
+    const connector::ColumnHandleMap& columnHandles) {
   if (joinConditions.empty()) {
     return nullptr;
   }
@@ -175,10 +173,9 @@ TestIndexSource::TestIndexSource(
     const RowTypePtr& outputType,
     size_t numEqualJoinKeys,
     const core::TypedExprPtr& joinConditionExpr,
-    const std::shared_ptr<TestIndexTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<TestIndexColumnHandle>>& columnHandles,
+    const TestIndexTableHandlePtr& tableHandle,
+    const std::unordered_map<std::string, TestIndexColumnHandlePtr>&
+        columnHandles,
     connector::ConnectorQueryCtx* connectorQueryCtx,
     folly::Executor* executor)
     : tableHandle_(tableHandle),
@@ -266,9 +263,8 @@ void TestIndexSource::initConditionProjections() {
 }
 
 void TestIndexSource::initOutputProjections(
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<TestIndexColumnHandle>>& columnHandles) {
+    const std::unordered_map<std::string, TestIndexColumnHandlePtr>&
+        columnHandles) {
   VELOX_CHECK(lookupOutputProjections_.empty());
 
   lookupOutputProjections_.reserve(outputType_->size());
@@ -545,24 +541,21 @@ std::shared_ptr<connector::IndexSource> TestIndexConnector::createIndexSource(
     size_t numJoinKeys,
     const std::vector<core::IndexLookupConditionPtr>& joinConditions,
     const RowTypePtr& outputType,
-    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<
-        std::string,
-        std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+    const connector::ConnectorTableHandlePtr& tableHandle,
+    const connector::ColumnHandleMap& columnHandles,
     connector::ConnectorQueryCtx* connectorQueryCtx) {
   VELOX_CHECK_GE(inputType->size(), numJoinKeys + joinConditions.size());
   auto testIndexTableHandle =
-      std::dynamic_pointer_cast<TestIndexTableHandle>(tableHandle);
+      std::dynamic_pointer_cast<const TestIndexTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(testIndexTableHandle);
   const auto& indexTable = testIndexTableHandle->indexTable();
   auto joinConditionExpr =
       toJoinConditionExpr(joinConditions, indexTable, inputType, columnHandles);
 
-  std::unordered_map<std::string, std::shared_ptr<TestIndexColumnHandle>>
-      testColumnHandles;
+  std::unordered_map<std::string, TestIndexColumnHandlePtr> testColumnHandles;
   for (const auto& [name, handle] : columnHandles) {
     auto testColumnHandle =
-        std::dynamic_pointer_cast<TestIndexColumnHandle>(handle);
+        std::dynamic_pointer_cast<const TestIndexColumnHandle>(handle);
     VELOX_CHECK_NOT_NULL(testColumnHandle);
 
     testColumnHandles.emplace(name, testColumnHandle);

--- a/velox/experimental/cudf/connectors/parquet/ParquetConnector.cpp
+++ b/velox/experimental/cudf/connectors/parquet/ParquetConnector.cpp
@@ -32,10 +32,9 @@ ParquetConnector::ParquetConnector(
 }
 
 std::unique_ptr<DataSource> ParquetConnector::createDataSource(
-    const std::shared_ptr<const RowType>& outputType,
-    const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<std::string, std::shared_ptr<ColumnHandle>>&
-        columnHandles,
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
   return std::make_unique<ParquetDataSource>(
       outputType,
@@ -48,11 +47,11 @@ std::unique_ptr<DataSource> ParquetConnector::createDataSource(
 
 std::unique_ptr<DataSink> ParquetConnector::createDataSink(
     RowTypePtr inputType,
-    std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
+    ConnectorInsertTableHandlePtr connectorInsertTableHandle,
     ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy /*commitStrategy*/) {
   auto parquetInsertHandle =
-      std::dynamic_pointer_cast<ParquetInsertTableHandle>(
+      std::dynamic_pointer_cast<const ParquetInsertTableHandle>(
           connectorInsertTableHandle);
   VELOX_CHECK_NOT_NULL(
       parquetInsertHandle, "Parquet connector expecting parquet write handle!");

--- a/velox/experimental/cudf/connectors/parquet/ParquetConnector.h
+++ b/velox/experimental/cudf/connectors/parquet/ParquetConnector.h
@@ -40,10 +40,9 @@ class ParquetConnector final : public Connector {
       folly::Executor* executor);
 
   std::unique_ptr<DataSource> createDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<std::string, std::shared_ptr<ColumnHandle>>&
-          columnHandles,
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& columnHandles,
       ConnectorQueryCtx* connectorQueryCtx) override final;
 
   const std::shared_ptr<const ConfigBase>& connectorConfig() const override {
@@ -52,7 +51,7 @@ class ParquetConnector final : public Connector {
 
   std::unique_ptr<DataSink> createDataSink(
       RowTypePtr inputType,
-      std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
+      ConnectorInsertTableHandlePtr connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx,
       CommitStrategy commitStrategy) override final;
 

--- a/velox/experimental/cudf/connectors/parquet/ParquetDataSource.cpp
+++ b/velox/experimental/cudf/connectors/parquet/ParquetDataSource.cpp
@@ -41,10 +41,9 @@ namespace facebook::velox::cudf_velox::connector::parquet {
 using namespace facebook::velox::connector;
 
 ParquetDataSource::ParquetDataSource(
-    const std::shared_ptr<const RowType>& outputType,
-    const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-    const std::unordered_map<std::string, std::shared_ptr<ColumnHandle>>&
-        columnHandles,
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& columnHandles,
     folly::Executor* executor,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<ParquetConfig>& parquetConfig)
@@ -72,7 +71,8 @@ ParquetDataSource::ParquetDataSource(
   }
 
   // Dynamic cast tableHandle to ParquetTableHandle
-  tableHandle_ = std::dynamic_pointer_cast<ParquetTableHandle>(tableHandle);
+  tableHandle_ =
+      std::dynamic_pointer_cast<const ParquetTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(
       tableHandle_, "TableHandle must be an instance of ParquetTableHandle");
 

--- a/velox/experimental/cudf/connectors/parquet/ParquetDataSource.h
+++ b/velox/experimental/cudf/connectors/parquet/ParquetDataSource.h
@@ -38,10 +38,9 @@ using namespace facebook::velox::connector;
 class ParquetDataSource : public DataSource, public NvtxHelper {
  public:
   ParquetDataSource(
-      const std::shared_ptr<const RowType>& outputType,
-      const std::shared_ptr<ConnectorTableHandle>& tableHandle,
-      const std::unordered_map<std::string, std::shared_ptr<ColumnHandle>>&
-          columnHandles,
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& columnHandles,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<ParquetConfig>& ParquetConfig);
@@ -90,7 +89,7 @@ class ParquetDataSource : public DataSource, public NvtxHelper {
   RowVectorPtr emptyOutput_;
 
   std::shared_ptr<ParquetConnectorSplit> split_;
-  std::shared_ptr<ParquetTableHandle> tableHandle_;
+  std::shared_ptr<const ParquetTableHandle> tableHandle_;
 
   const std::shared_ptr<ParquetConfig> parquetConfig_;
 

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -100,10 +100,8 @@ class TableScan : public WaveSourceOperator {
   // Process-wide IO wait time.
   static std::atomic<uint64_t> ioWaitNanos_;
 
-  const std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
-  const std::
-      unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-          columnHandles_;
+  const connector::ConnectorTableHandlePtr tableHandle_;
+  const connector::ColumnHandleMap columnHandles_;
   exec::DriverCtx* const driverCtx_;
   memory::MemoryPool* const connectorPool_;
   ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -21,11 +21,10 @@ namespace facebook::velox::wave {
 using namespace connector::hive;
 
 WaveHiveDataSource::WaveHiveDataSource(
-    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const HiveTableHandlePtr& hiveTableHandle,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
     const RowTypePtr& readerOutputType,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-        partitionKeys,
+    std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* executor,
     const connector::ConnectorQueryCtx* connectorQueryCtx,
@@ -167,11 +166,10 @@ void WaveHiveDataSource::registerConnector() {
           ->newConnector("wavemock", config, nullptr);
   connector::registerConnector(hiveConnector);
   connector::hive::HiveDataSource::registerWaveDelegateHook(
-      [](const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      [](const HiveTableHandlePtr& hiveTableHandle,
          const std::shared_ptr<common::ScanSpec>& scanSpec,
          const RowTypePtr& readerOutputType,
-         std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>*
-             partitionKeys,
+         std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
          FileHandleFactory* fileHandleFactory,
          folly::Executor* executor,
          const connector::ConnectorQueryCtx* connectorQueryCtx,
@@ -183,7 +181,6 @@ void WaveHiveDataSource::registerConnector() {
             hiveTableHandle,
             scanSpec,
             readerOutputType,
-
             partitionKeys,
             fileHandleFactory,
             executor,

--- a/velox/experimental/wave/exec/WaveHiveDataSource.h
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.h
@@ -24,12 +24,11 @@ namespace facebook::velox::wave {
 class WaveHiveDataSource : public WaveDataSource {
  public:
   WaveHiveDataSource(
-      const std::shared_ptr<connector::hive::HiveTableHandle>& hiveTableHandle,
+      const connector::hive::HiveTableHandlePtr& hiveTableHandle,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
       const RowTypePtr& readerOutputType,
-      std::unordered_map<
-          std::string,
-          std::shared_ptr<connector::hive::HiveColumnHandle>>* partitionKeys,
+      std::unordered_map<std::string, connector::hive::HiveColumnHandlePtr>*
+          partitionKeys,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const connector::ConnectorQueryCtx* connectorQueryCtx,

--- a/velox/experimental/wave/exec/WaveSplitReader.h
+++ b/velox/experimental/wave/exec/WaveSplitReader.h
@@ -30,12 +30,11 @@ namespace facebook::velox::wave {
 
 /// Parameters for a Wave Hive SplitReaderFactory.
 struct SplitReaderParams {
-  std ::shared_ptr<connector::hive::HiveTableHandle> hiveTableHandle;
+  connector::hive::HiveTableHandlePtr hiveTableHandle;
   std::shared_ptr<common::ScanSpec> scanSpec;
   RowTypePtr readerOutputType;
-  std::unordered_map<
-      std::string,
-      std::shared_ptr<connector::hive::HiveColumnHandle>>* partitionKeys;
+  std::unordered_map<std::string, connector::hive::HiveColumnHandlePtr>*
+      partitionKeys;
   FileHandleFactory* fileHandleFactory;
   folly::Executor* executor;
   const connector::ConnectorQueryCtx* connectorQueryCtx;

--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -22,14 +22,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
 #include "velox/core/PlanNode.h"
-#include "velox/dwio/dwrf/RegisterDwrfReader.h"
-#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/TypeResolver.h"
 #include "velox/python/vector/PyVector.h"
 #include "velox/tpch/gen/TpchGen.h"
 
@@ -138,8 +131,7 @@ PyPlanBuilder& PyPlanBuilder::tableScan(
   // If there are subfields, create the appropriate structures and add to the
   // scan.
   if (!subfields.empty() || !rowIndexColumnName.empty()) {
-    std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-        assignments;
+    connector::ColumnHandleMap assignments;
 
     for (size_t i = 0; i < outputRowSchema->size(); ++i) {
       auto name = outputRowSchema->nameOf(i);

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -430,8 +430,7 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
   // Get assignments and out names.
   std::vector<std::string> outNames;
   outNames.reserve(colNameList.size());
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   for (int idx = 0; idx < colNameList.size(); idx++) {
     auto outName = substraitParser_->makeNodeName(planNodeId_, idx);
     assignments[outName] = std::make_shared<connector::hive::HiveColumnHandle>(

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -33,7 +33,7 @@ makeHiveInsertTableHandle(
     const core::TableWriteNode* node,
     std::string targetDir) {
   const auto tracedHandle =
-      std::dynamic_pointer_cast<connector::hive::HiveInsertTableHandle>(
+      std::dynamic_pointer_cast<const connector::hive::HiveInsertTableHandle>(
           node->insertTableHandle()->connectorInsertTableHandle());
   const auto inputColumns = tracedHandle->inputColumns();
   const auto compressionKind =

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -250,8 +250,7 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
   auto indexTableHandle = makeIndexTableHandle(indexTable);
 
   // Create a table scan node with the TestIndexTableHandle
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      columnHandles;
+  connector::ColumnHandleMap columnHandles;
   for (const auto& name : indexType_->names()) {
     columnHandles[name] = std::make_shared<TestIndexColumnHandle>(name);
   }

--- a/velox/tool/trace/tests/TableScanReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableScanReplayerTest.cpp
@@ -301,8 +301,7 @@ TEST_F(TableScanReplayerTest, subfieldPrunning) {
   writeToFile(filePath->getPath(), vectors);
   std::vector<common::Subfield> requiredSubfields;
   requiredSubfields.emplace_back("e.c");
-  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
-      assignments;
+  connector::ColumnHandleMap assignments;
   assignments["e"] = std::make_shared<HiveColumnHandle>(
       "e",
       HiveColumnHandle::ColumnType::kRegular,


### PR DESCRIPTION
Summary: TableScanNode, Connector::createDataSource, createIndexSource and createDataSink APIs used to take table and column handles as non-const forcing calling code to use std::const_pointer_cast, which is an anti-pattern.

Differential Revision: D77490731
