### PR TITLE
Relax keyNodes check in SelceiveFlatMapColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -164,6 +164,12 @@ std::vector<KeyNode<T>> getKeyNodes(
       return x.sequence < y.sequence;
     });
   }
+
+  if (asStruct) {
+    VELOX_CHECK(
+        !keyNodes.empty() || streams == 0,
+        "For struct encoding, keys to project must be configured");
+  }
   return keyNodes;
 }
 
@@ -188,9 +194,6 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
             params,
             scanSpec,
             true)) {
-    VELOX_CHECK(
-        !keyNodes_.empty(),
-        "For struct encoding, keys to project must be configured");
     children_.resize(keyNodes_.size());
     for (auto& childSpec : scanSpec.children()) {
       childSpec->setSubscript(kConstantChildSpecSubscript);


### PR DESCRIPTION
Summary: It is possible that a stripe does not include any streams for a given node.  In this scenario, keyNodes would be empty, not because keys to project was misconfigured, but because there are no streams to visit for the current stripe.  In this case (when `streams == 0`), we should not fail the `VELOX_CHECK`.

Differential Revision: D77519471


