### PR TITLE
fix: Constant input is not the right size in streaming aggregation

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -283,7 +283,8 @@ void StreamingAggregation::evaluateAggregates() {
     std::vector<VectorPtr> args;
     for (auto j = 0; j < inputs.size(); ++j) {
       if (inputs[j] == kConstantChannel) {
-        args.push_back(constantInputs[j]);
+        args.push_back(
+            BaseVector::wrapInConstant(input_->size(), 0, constantInputs[j]));
       } else {
         args.push_back(input_->childAt(inputs[j]));
       }


### PR DESCRIPTION
Summary:
This is failing some sanity check in `array_agg` currently.  The same
thing is handled correctly in `GroupingSet` used in hash aggregation.

Fix https://github.com/facebookincubator/velox/issues/13868

Differential Revision: D77547244


