### PR TITLE
feat: Add a option to include only plan node headers in plan summary

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2997,9 +2997,9 @@ void PlanNode::toSummaryString(
 
   stream << indentation << "-- " << name() << "[" << id()
          << "]: " << summarizeOutputType(outputType(), options) << std::endl;
-
-  addSummaryDetails(indentation + "      ", options, stream);
-
+  if (!options.nodeHeaderOnly) {
+    addSummaryDetails(indentation + "      ", options, stream);
+  }
   for (auto& source : sources()) {
     source->toSummaryString(options, stream, indentationSize + 2);
   }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -143,6 +143,11 @@ struct PlanSummaryOptions {
   /// summary.
   size_t maxLength = 50;
 
+  /// To provide a simplified, skeleton view of the query plan by removing
+  /// additional details from node summaries. If true, the output contains just
+  /// one line per plan node.
+  bool nodeHeaderOnly = false;
+
   /// Options that apply specifically to AGGREGATION nodes.
   struct AggregateOptions {
     /// For a given AGGREGATION node, maximum number of aggregate expressions

--- a/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
@@ -96,6 +96,14 @@ TEST_F(PlanNodeToSummaryStringTest, basic) {
           .maxOutputFields = 3,
           .maxChildTypes = 2,
       }));
+
+  ASSERT_EQ(
+      "-- Project[2]: 7 fields: p0 BIGINT, p1 BIGINT, p2 BIGINT, p3 BIGINT, p4 BIGINT, ...\n"
+      "  -- Filter[1]: 3 fields: a INTEGER, b ARRAY, c MAP\n"
+      "    -- TableScan[0]: 3 fields: a INTEGER, b ARRAY, c MAP\n",
+      plan->toSummaryString({
+          .nodeHeaderOnly = true,
+      }));
 }
 
 TEST_F(PlanNodeToSummaryStringTest, expressions) {
@@ -148,6 +156,13 @@ TEST_F(PlanNodeToSummaryStringTest, expressions) {
       "        table: hive_table\n",
       plan->toSummaryString(
           {.project = {.maxProjections = 3, .maxDereferences = 2}}));
+
+  ASSERT_EQ(
+      "-- Project[1]: 7 fields: a INTEGER, p1 ARRAY, c MAP, p3 BIGINT, y BIGINT, ...\n"
+      "  -- TableScan[0]: 4 fields: a INTEGER, b ARRAY, c MAP, d ROW(3)\n",
+      plan->toSummaryString({
+          .nodeHeaderOnly = true,
+      }));
 }
 
 TEST_F(PlanNodeToSummaryStringTest, aggregation) {
@@ -189,6 +204,14 @@ TEST_F(PlanNodeToSummaryStringTest, aggregation) {
       "  -- TableScan[0]: 3 fields: a INTEGER, b INTEGER, c INTEGER\n"
       "        table: hive_table\n",
       plan->toSummaryString({.aggregate = {.maxAggregations = 3}}));
+
+  ASSERT_EQ(
+      "-- Aggregation[1]: 6 fields: a INTEGER, a0 BIGINT, a1 DOUBLE, a2 BIGINT, a3"
+      " INTEGER, ...\n"
+      "  -- TableScan[0]: 3 fields: a INTEGER, b INTEGER, c INTEGER\n",
+      plan->toSummaryString({
+          .nodeHeaderOnly = true,
+      }));
 }
 
 } // namespace


### PR DESCRIPTION
**Summary:**

- Further helps decrease the summary of a very large query plan.

noHeaderOnly=false

```
-- Project[proj-0]: 11 fields: num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), nro_id_list_features ROW(29), ...
      expressions: call: 44, field: 96
      functions: array_cast_to_float: 43, row_constructor: 1
      projections: 1 out of 11
         raw_label_presences: row_constructor(array_cast_to_float(ROW["raw_label...
      dereferences: 0 out of 11
  -- Project[proj-1]: 11 fields: num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), nro_id_list_features ROW(29), ...
        expressions: call: 1, field: 11
        functions: cast: 1
        projections: 1 out of 11
           raw_label_presences: cast(ROW["model_label_presences"])
        dereferences: 0 out of 11
    -- Project[proj-2]: 11 fields: model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), ...
          expressions: call: 2, constant: 2, field: 11
          functions: cast: 1, padded_make_row_from_map_ROW_6: 1
          constants: ARRAY: 2
          projections: 1 out of 11
             raw_labels: cast(padded_make_row_from_map_ROW_6(ROW["model_flo...
          dereferences: 0 out of 11
      -- Project[proj-3]: 11 fields: model_float_labels MAP, model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ...
            expressions: call: 10, constant: 8, field: 26
            functions: cast: 1, coalesce: 8, row_constructor: 1
            constants: ARRAY: 8
            projections: 2 out of 11
               ro_embedding_features: row_constructor(coalesce(ROW["ro_embedding_feature...
               nro_embedding_features: cast(ROW["candidate_embedding_features"])
            dereferences: 0 out of 11
        -- Project[proj-4]: 11 fields: candidate_embedding_features ROW(2), model_float_labels MAP, model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), ...
              expressions: call: 4, constant: 1, field: 12
              functions: cast: 2, coalesce: 1, row_constructor: 1
              constants: ARRAY: 1
              projections: 2 out of 11
                 nro_id_score_list_features: row_constructor(coalesce(cast(ROW["candidate_id_sc...
                 ro_embedding_features: cast(ROW["user_embedding_features"])
              dereferences: 0 out of 11
          -- Project[proj-5]: 11 fields: user_embedding_features ROW(8), candidate_id_score_list_features ROW(1), candidate_embedding_features ROW(2), model_float_labels MAP, model_label_presences ROW(43), ...
                expressions: call: 2, field: 11
                functions: cast: 1, convert_format_ROW_0: 1
                projections: 1 out of 11
                   ro_id_score_list_features: convert_format_ROW_0(cast(ROW["user_id_score_list_...
                dereferences: 0 out of 11
```

noHeaderOnly=true

```
-- Project[proj-0]: 11 fields: num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), nro_id_list_features ROW(29), ...
  -- Project[proj-1]: 11 fields: num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), nro_id_list_features ROW(29), ...
    -- Project[proj-2]: 11 fields: model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ro_id_list_features ROW(167), ...
      -- Project[proj-3]: 11 fields: model_float_labels MAP, model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), nro_float_features ROW(1925), ...
        -- Project[proj-4]: 11 fields: candidate_embedding_features ROW(2), model_float_labels MAP, model_label_presences ROW(43), num_candidates INTEGER, ro_float_features ROW(1450), ...
          -- Project[proj-5]: 11 fields: user_embedding_features ROW(8), candidate_id_score_list_features ROW(1), candidate_embedding_features ROW(2), model_float_labels MAP, model_label_presences ROW(43), ...
```

Differential Revision: D77551564


