### PR TITLE
feat: Support comparing MapVectors and FlatMapVectors

### DIFF
--- a/velox/common/base/CompareFlags.h
+++ b/velox/common/base/CompareFlags.h
@@ -171,6 +171,13 @@ struct CompareFlags {
     }
   }
 
+  /// Returns a copy of the flags with the ascending flag flipped.
+  static CompareFlags reverseDirection(const CompareFlags& flags) {
+    CompareFlags result = flags;
+    result.ascending = !result.ascending;
+    return result;
+  }
+
   std::string toString() const {
     return fmt::format(
         "[NullFirst[{}] Ascending[{}] EqualsOnly[{}] NullHandleMode[{}]]",

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -369,6 +369,24 @@ class FlatMapVector : public BaseVector {
       const uint64_t* sourceInMaps,
       const folly::Range<const BaseVector::CopyRange*>& ranges);
 
+  /// Compares a map in this Vector with a map in a MapVector.
+  std::optional<int32_t> compareToMap(
+      const MapVector* other,
+      vector_size_t index,
+      // The other MapVector may have been encoded, pass the wrappedIndex from
+      // the other Vector here.
+      vector_size_t wrappedOtherIndex,
+      CompareFlags flags) const;
+
+  /// Compares a map in this Vector with a map in another FlatMapVector.
+  std::optional<int32_t> compareToFlatMap(
+      const FlatMapVector* other,
+      vector_size_t index,
+      // The other FlatMapVector may have been encoded, pass the wrappedIndex
+      // from the other Vector here.
+      vector_size_t wrappedOtherIndex,
+      CompareFlags flags) const;
+
   // Vector containing the distinct map keys.
   VectorPtr distinctKeys_;
 


### PR DESCRIPTION
Summary:
Given that MapVectors and FlatMapVectors have the same Type, we may find ourselves
needing to compare maps in Vectors of each encoding. E.g. this comes up frequently in
testing.

This diff adds support for this to FlatMapVector's compare function. For the sake of
consolidation MapVector simply flips the order and invokes FlatMapVector's compare 
function.

Differential Revision: D77563385


