### PR TITLE
feat: Add enableEstimateFlatSize into QueryConfig to control the estimate stats collection

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -639,6 +639,13 @@ class QueryConfig {
   static constexpr const char* kOperatorTrackExpressionStats =
       "operator_track_expression_stats";
 
+  /// If this is true, enable the operator input/output batch size stats
+  /// collection in driver execution. This can be expensive for data types with
+  /// a large number of columns (e.g., ROW types) as it calls estimateFlatSize()
+  /// which recursively calculates sizes for all child vectors.
+  static constexpr const char* kEnableOperatorBatchSizeStats =
+      "enable_operator_batch_size_stats";
+
   /// If this is true, then the unnest operator might split output for each
   /// input batch based on the output batch size control. Otherwise, it produces
   /// a single output for each input batch.
@@ -1177,6 +1184,10 @@ class QueryConfig {
 
   bool operatorTrackExpressionStats() const {
     return get<bool>(kOperatorTrackExpressionStats, false);
+  }
+
+  bool enableOperatorBatchSizeStats() const {
+    return get<bool>(kEnableOperatorBatchSizeStats, true);
   }
 
   bool unnestSplitOutput() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -60,6 +60,11 @@ Generic Configuration
      - true
      - Whether to track CPU usage for stages of individual operators. Can be expensive when processing small batches,
        e.g. < 10K rows.
+   * - operator_batch_size_stats_enabled
+     - bool
+     - true
+     - If true, the driver will collect the operator's input/output batch size through vector flat size estimation, otherwise not.
+     - We might turn this off in use cases which have very wide column width and batch size estimation has non-trivial cpu cost.
    * - hash_adaptivity_enabled
      - bool
      - true

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -432,6 +432,11 @@ class Driver : public std::enable_shared_from_this<Driver> {
   /// time slice limit if set.
   bool shouldYield() const;
 
+  /// Inline function to check if operator batch size stats are enabled.
+  inline bool enableOperatorBatchSizeStats() const {
+    return enableOperatorBatchSizeStats_;
+  }
+
   /// Checks if the associated query is under memory arbitration or not. The
   /// function returns true if it is and set future which is fulfilled when the
   /// memory arbitration finishes.
@@ -671,6 +676,10 @@ class Driver : public std::enable_shared_from_this<Driver> {
       CancelGuard& guard);
 
   std::unique_ptr<DriverCtx> ctx_;
+
+  // If set, the operator output batch size stats will be collected during
+  // driver execution.
+  bool enableOperatorBatchSizeStats_{false};
 
   // If not zero, specifies the driver cpu time slice.
   size_t cpuSliceMs_{0};


### PR DESCRIPTION
Summary: Very large number of columns which increase the cost of estimate flat size calculation which took 6% of CPU, thus, add an option to open/close this function.

Differential Revision: D77554586


