### PR TITLE
refactor: Rename variant class to match coding style

### DIFF
--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -25,7 +25,6 @@
 
 namespace facebook::velox {
 class BaseVector;
-class variant;
 using VectorPtr = std::shared_ptr<BaseVector>;
 } // namespace facebook::velox
 

--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -112,7 +112,7 @@ TypedExprPtr ConstantTypedExpr::create(
   auto type = core::deserializeType(obj, context);
 
   if (obj.count("value")) {
-    auto value = variant::create(obj["value"]);
+    auto value = Variant::create(obj["value"]);
     return std::make_shared<ConstantTypedExpr>(std::move(type), value);
   }
 

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -58,8 +58,8 @@ class InputTypedExpr : public ITypedExpr {
 class ConstantTypedExpr : public ITypedExpr {
  public:
   // Creates constant expression. For complex types, only
-  // variant::null() value is supported.
-  ConstantTypedExpr(TypePtr type, variant value)
+  // Variant::null() value is supported.
+  ConstantTypedExpr(TypePtr type, Variant value)
       : ITypedExpr{std::move(type)}, value_{std::move(value)} {}
 
   // Creates constant expression of scalar or complex type. The value comes from
@@ -91,8 +91,8 @@ class ConstantTypedExpr : public ITypedExpr {
     return valueVector_ != nullptr;
   }
 
-  /// Returns scalar value as variant if hasValueVector() is false.
-  const variant& value() const {
+  /// Returns scalar value as Variant if hasValueVector() is false.
+  const Variant& value() const {
     return value_;
   }
 
@@ -172,7 +172,7 @@ class ConstantTypedExpr : public ITypedExpr {
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
-  const variant value_;
+  const Variant value_;
   const VectorPtr valueVector_;
 };
 

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -32,21 +32,21 @@ using ::duckdb::dtime_t;
 using ::duckdb::string_t;
 using ::duckdb::timestamp_t;
 
-variant decimalVariant(const Value& val) {
+Variant decimalVariant(const Value& val) {
   VELOX_DCHECK(val.type().id() == LogicalTypeId::DECIMAL);
   switch (val.type().InternalType()) {
     case ::duckdb::PhysicalType::INT128: {
       auto unscaledValue = val.GetValueUnsafe<::duckdb::hugeint_t>();
-      return variant(HugeInt::build(unscaledValue.upper, unscaledValue.lower));
+      return Variant(HugeInt::build(unscaledValue.upper, unscaledValue.lower));
     }
     case ::duckdb::PhysicalType::INT16: {
-      return variant(static_cast<int64_t>(val.GetValueUnsafe<int16_t>()));
+      return Variant(static_cast<int64_t>(val.GetValueUnsafe<int16_t>()));
     }
     case ::duckdb::PhysicalType::INT32: {
-      return variant(static_cast<int64_t>(val.GetValueUnsafe<int32_t>()));
+      return Variant(static_cast<int64_t>(val.GetValueUnsafe<int32_t>()));
     }
     case ::duckdb::PhysicalType::INT64: {
-      return variant(val.GetValueUnsafe<int64_t>());
+      return Variant(val.GetValueUnsafe<int64_t>());
     }
     default:
       VELOX_UNSUPPORTED();
@@ -201,37 +201,37 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
   }
 }
 
-variant duckValueToVariant(const Value& val) {
+Variant duckValueToVariant(const Value& val) {
   switch (val.type().id()) {
     case LogicalTypeId::SQLNULL:
-      return variant(TypeKind::UNKNOWN);
+      return Variant(TypeKind::UNKNOWN);
     case LogicalTypeId::BOOLEAN:
-      return variant(val.GetValue<bool>());
+      return Variant(val.GetValue<bool>());
     case LogicalTypeId::TINYINT:
-      return variant(val.GetValue<int8_t>());
+      return Variant(val.GetValue<int8_t>());
     case LogicalTypeId::SMALLINT:
-      return variant(val.GetValue<int16_t>());
+      return Variant(val.GetValue<int16_t>());
     case LogicalTypeId::INTEGER:
-      return variant(val.GetValue<int32_t>());
+      return Variant(val.GetValue<int32_t>());
     case LogicalTypeId::BIGINT:
-      return variant(val.GetValue<int64_t>());
+      return Variant(val.GetValue<int64_t>());
     case LogicalTypeId::FLOAT:
-      return variant(val.GetValue<float>());
+      return Variant(val.GetValue<float>());
     case LogicalTypeId::DOUBLE:
-      return variant(val.GetValue<double>());
+      return Variant(val.GetValue<double>());
     case LogicalTypeId::TIMESTAMP:
-      return variant(duckdbTimestampToVelox(val.GetValue<timestamp_t>()));
+      return Variant(duckdbTimestampToVelox(val.GetValue<timestamp_t>()));
     case LogicalTypeId::DECIMAL:
       return decimalVariant(val);
     case LogicalTypeId::VARCHAR:
-      return variant(val.GetValue<std::string>());
+      return Variant(val.GetValue<std::string>());
     case LogicalTypeId::BLOB:
-      return variant::binary(val.GetValue<std::string>());
+      return Variant::binary(val.GetValue<std::string>());
     case LogicalTypeId::DATE:
-      return variant(val.GetValue<::duckdb::date_t>().days);
+      return Variant(val.GetValue<::duckdb::date_t>().days);
     default:
       throw std::runtime_error(
-          "unsupported type for duckdb value -> velox  variant conversion: " +
+          "unsupported type for duckdb value -> velox variant conversion: " +
           val.type().ToString());
   }
 }

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -20,7 +20,7 @@
 #include <duckdb.hpp> // @manual
 
 namespace facebook::velox {
-class variant;
+class Variant;
 }
 
 namespace facebook::velox::duckdb {
@@ -57,16 +57,16 @@ static Timestamp duckdbTimestampToVelox(
 }
 
 // Converts a duckDB Value (class that holds an arbitrary data type) into
-// Velox variant.
-variant duckValueToVariant(const ::duckdb::Value& val);
+// Velox Variant.
+Variant duckValueToVariant(const ::duckdb::Value& val);
 
-// Converts duckDB decimal Value into appropriate decimal variant.
+// Converts duckDB decimal Value into appropriate decimal Variant.
 // The duckdb::Value::GetValue() call for decimal type returns a double value.
 // To avoid this, this method uses the duckdb::Value::GetUnsafeValue<int>()
 // method.
 // @param val duckdb decimal value.
-// @return decimal variant.
-variant decimalVariant(const ::duckdb::Value& val);
+// @return decimal Variant.
+Variant decimalVariant(const ::duckdb::Value& val);
 
 // value conversion routines
 template <class T>

--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -256,11 +256,11 @@ std::shared_ptr<const core::ConstantExpr> tryParseInterval(
     }
     return std::make_shared<core::ConstantExpr>(
         INTERVAL_YEAR_MONTH(),
-        variant((int32_t)(value.value() * multiplier)),
+        Variant((int32_t)(value.value() * multiplier)),
         alias);
   }
   return std::make_shared<core::ConstantExpr>(
-      INTERVAL_DAY_TIME(), variant(value.value() * multiplier), alias);
+      INTERVAL_DAY_TIME(), Variant(value.value() * multiplier), alias);
 }
 
 // Parse a function call (avg(a), func(1, b), etc).
@@ -376,7 +376,7 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(
   // Code for array literal parsing (e.g. "ARRAY[1, 2, 3]")
   if (expr.GetExpressionType() == ExpressionType::ARRAY_CONSTRUCTOR) {
     if (areAllChildrenConstant(operExpr)) {
-      std::vector<variant> arrayElements;
+      std::vector<Variant> arrayElements;
       arrayElements.reserve(operExpr.children.size());
 
       TypePtr valueType = UNKNOWN();
@@ -397,7 +397,7 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(
         }
       }
       return std::make_shared<const core::ConstantExpr>(
-          ARRAY(valueType), variant::array(arrayElements), getAlias(expr));
+          ARRAY(valueType), Variant::array(arrayElements), getAlias(expr));
     } else {
       std::vector<std::shared_ptr<const core::IExpr>> params;
       params.reserve(operExpr.children.size());
@@ -415,7 +415,7 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(
       expr.GetExpressionType() == ExpressionType::COMPARE_NOT_IN) {
     auto numValues = operExpr.children.size() - 1;
 
-    std::vector<variant> values;
+    std::vector<Variant> values;
     values.reserve(numValues);
 
     TypePtr valueType = UNKNOWN();
@@ -453,7 +453,7 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(
     std::vector<std::shared_ptr<const core::IExpr>> params;
     params.emplace_back(parseExpr(*operExpr.children[0], options));
     params.emplace_back(std::make_shared<const core::ConstantExpr>(
-        ARRAY(valueType), variant::array(values), std::nullopt));
+        ARRAY(valueType), Variant::array(values), std::nullopt));
     auto inExpr = callExpr("in", std::move(params), getAlias(expr), options);
     // Translate COMPARE_NOT_IN into NOT(IN()).
     return (expr.GetExpressionType() == ExpressionType::COMPARE_IN)
@@ -561,7 +561,7 @@ std::shared_ptr<const core::IExpr> parseCastExpr(
           dynamic_cast<const core::ConstantExpr*>(params[0].get())) {
     if (constant->value().isNull()) {
       return std::make_shared<const core::ConstantExpr>(
-          targetType, variant::null(targetType->kind()), getAlias(expr));
+          targetType, Variant::null(targetType->kind()), getAlias(expr));
     }
 
     // DuckDB parses BOOLEAN literal as cast expression.  Try to restore it back
@@ -573,14 +573,14 @@ std::shared_ptr<const core::IExpr> parseCastExpr(
       if (s == "t") {
         return std::make_shared<const core::ConstantExpr>(
             BOOLEAN(),
-            variant::create<TypeKind::BOOLEAN>(true),
+            Variant::create<TypeKind::BOOLEAN>(true),
             getAlias(expr));
       }
 
       if (s == "f") {
         return std::make_shared<const core::ConstantExpr>(
             BOOLEAN(),
-            variant::create<TypeKind::BOOLEAN>(false),
+            Variant::create<TypeKind::BOOLEAN>(false),
             getAlias(expr));
       }
     }

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.cpp
@@ -60,8 +60,8 @@ std::vector<int16_t> excludeProblematicTimeZoneIds(
 } // namespace
 
 TimestampWithTimeZoneInputGenerator::TimestampWithTimeZoneInputGenerator(
-    const size_t seed,
-    const double nullRatio)
+    size_t seed,
+    double nullRatio)
     : AbstractInputGenerator(
           seed,
           TIMESTAMP_WITH_TIME_ZONE(),

--- a/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h
@@ -21,11 +21,9 @@
 namespace facebook::velox::fuzzer {
 class TimestampWithTimeZoneInputGenerator : public AbstractInputGenerator {
  public:
-  TimestampWithTimeZoneInputGenerator(
-      const size_t seed,
-      const double nullRatio);
+  TimestampWithTimeZoneInputGenerator(size_t seed, double nullRatio);
 
-  variant generate() override;
+  Variant generate() override;
 
  private:
   const std::vector<int16_t> timeZoneIds_;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2022,7 +2022,7 @@ using CastOperatorPtr = std::shared_ptr<const CastOperator>;
 } // namespace exec
 
 /// Forward declaration.
-class variant;
+class Variant;
 class AbstractInputGenerator;
 
 namespace memory {
@@ -2072,7 +2072,7 @@ class AbstractInputGenerator {
 
   virtual ~AbstractInputGenerator();
 
-  virtual variant generate() = 0;
+  virtual Variant generate() = 0;
 
   TypePtr type() const {
     return type_;

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -37,7 +37,7 @@ constexpr double kEpsilon{0.00001};
 //       it's probably worthwhile to make it not completely suck
 // todo(youknowjack): make this class not completely suck
 
-class variant;
+class Variant;
 
 template <TypeKind KIND>
 struct VariantEquality;
@@ -55,8 +55,8 @@ template <>
 struct VariantEquality<TypeKind::MAP>;
 
 bool dispatchDynamicVariantEquality(
-    const variant& a,
-    const variant& b,
+    const Variant& a,
+    const Variant& b,
     const bool& enableNullEqualsNull);
 
 namespace detail {
@@ -108,24 +108,24 @@ struct VariantTypeTraits<
 template <bool usesCustomComparison>
 struct VariantTypeTraits<TypeKind::ROW, usesCustomComparison> {
   using stored_type =
-      TypeStorage<std::vector<variant>, TypeKind::ROW, usesCustomComparison>;
-  using value_type = std::vector<variant>;
+      TypeStorage<std::vector<Variant>, TypeKind::ROW, usesCustomComparison>;
+  using value_type = std::vector<Variant>;
 };
 
 template <bool usesCustomComparison>
 struct VariantTypeTraits<TypeKind::MAP, usesCustomComparison> {
   using stored_type = TypeStorage<
-      std::map<variant, variant>,
+      std::map<Variant, Variant>,
       TypeKind::MAP,
       usesCustomComparison>;
-  using value_type = std::map<variant, variant>;
+  using value_type = std::map<Variant, Variant>;
 };
 
 template <bool usesCustomComparison>
 struct VariantTypeTraits<TypeKind::ARRAY, usesCustomComparison> {
   using stored_type =
-      TypeStorage<std::vector<variant>, TypeKind::ARRAY, usesCustomComparison>;
-  using value_type = std::vector<variant>;
+      TypeStorage<std::vector<Variant>, TypeKind::ARRAY, usesCustomComparison>;
+  using value_type = std::vector<Variant>;
 };
 
 struct OpaqueCapsule {
@@ -152,16 +152,16 @@ struct VariantTypeTraits<TypeKind::OPAQUE, usesCustomComparison> {
 };
 } // namespace detail
 
-class variant {
+class Variant {
  private:
-  variant(TypeKind kind, void* ptr, bool usesCustomComparison = false)
+  Variant(TypeKind kind, void* ptr, bool usesCustomComparison = false)
       : ptr_{ptr}, kind_{kind}, usesCustomComparison_(usesCustomComparison) {}
 
   template <TypeKind KIND>
-  bool lessThan(const variant& other) const;
+  bool lessThan(const Variant& other) const;
 
   template <TypeKind KIND>
-  bool equals(const variant& other) const;
+  bool equals(const Variant& other) const;
 
   template <TypeKind KIND>
   uint64_t hash() const;
@@ -203,19 +203,19 @@ class variant {
 
  public:
   struct Hasher {
-    size_t operator()(variant const& input) const noexcept {
+    size_t operator()(Variant const& input) const noexcept {
       return input.hash();
     }
   };
 
   struct NullEqualsNullsComparator {
-    bool operator()(const variant& a, const variant& b) const {
+    bool operator()(const Variant& a, const Variant& b) const {
       return a.equalsWithNullEqualsNull(b);
     }
   };
 
 #define VELOX_VARIANT_SCALAR_MEMBERS(KIND)                                \
-  /* implicit */ variant(                                                 \
+  /* implicit */ Variant(                                                 \
       typename detail::VariantTypeTraits<KIND, false>::native_type v)     \
       : ptr_{new detail::VariantTypeTraits<KIND, false>::stored_type{v}}, \
         kind_{KIND},                                                      \
@@ -235,7 +235,7 @@ class variant {
   VELOX_VARIANT_SCALAR_MEMBERS(TypeKind::UNKNOWN)
 #undef VELOX_VARIANT_SCALAR_MEMBERS
 
-  /* implicit */ variant(
+  /* implicit */ Variant(
       typename detail::VariantTypeTraits<TypeKind::VARCHAR, false>::native_type
           v)
       : ptr_{new detail::VariantTypeTraits<TypeKind::VARCHAR, false>::
@@ -252,9 +252,9 @@ class variant {
       std::enable_if_t<
           std::is_same_v<T, long long> && !std::is_same_v<long long, int64_t>,
           bool> = true>
-  /* implicit */ variant(const T& v) : variant(static_cast<int64_t>(v)) {}
+  /* implicit */ Variant(const T& v) : Variant(static_cast<int64_t>(v)) {}
 
-  static variant row(const std::vector<variant>& inputs) {
+  static Variant row(const std::vector<Variant>& inputs) {
     return {
         TypeKind::ROW,
         new
@@ -262,7 +262,7 @@ class variant {
             inputs}};
   }
 
-  static variant row(std::vector<variant>&& inputs) {
+  static Variant row(std::vector<Variant>&& inputs) {
     return {
         TypeKind::ROW,
         new
@@ -270,7 +270,7 @@ class variant {
             std::move(inputs)}};
   }
 
-  static variant map(const std::map<variant, variant>& inputs) {
+  static Variant map(const std::map<Variant, Variant>& inputs) {
     return {
         TypeKind::MAP,
         new
@@ -278,7 +278,7 @@ class variant {
             inputs}};
   }
 
-  static variant map(std::map<variant, variant>&& inputs) {
+  static Variant map(std::map<Variant, Variant>&& inputs) {
     return {
         TypeKind::MAP,
         new
@@ -286,7 +286,7 @@ class variant {
             std::move(inputs)}};
   }
 
-  static variant timestamp(const Timestamp& input) {
+  static Variant timestamp(const Timestamp& input) {
     return {
         TypeKind::TIMESTAMP,
         new typename detail::VariantTypeTraits<TypeKind::TIMESTAMP, false>::
@@ -294,7 +294,7 @@ class variant {
   }
 
   template <TypeKind KIND>
-  static variant typeWithCustomComparison(
+  static Variant typeWithCustomComparison(
       typename TypeTraits<KIND>::NativeType input,
       const TypePtr& type) {
     return {
@@ -307,23 +307,23 @@ class variant {
   }
 
   template <class T>
-  static variant opaque(const std::shared_ptr<T>& input) {
-    VELOX_CHECK(input.get(), "Can't create a variant of nullptr opaque type");
+  static Variant opaque(const std::shared_ptr<T>& input) {
+    VELOX_CHECK(input.get(), "Can't create a Variant of nullptr opaque type");
     return {
         TypeKind::OPAQUE,
         new detail::OpaqueCapsule{OpaqueType::create<T>(), input}};
   }
 
-  static variant opaque(
+  static Variant opaque(
       const std::shared_ptr<void>& input,
       const std::shared_ptr<const OpaqueType>& type) {
-    VELOX_CHECK(input.get(), "Can't create a variant of nullptr opaque type");
+    VELOX_CHECK(input.get(), "Can't create a Variant of nullptr opaque type");
     return {TypeKind::OPAQUE, new detail::OpaqueCapsule{type, input}};
   }
 
-  static void verifyArrayElements(const std::vector<variant>& inputs);
+  static void verifyArrayElements(const std::vector<Variant>& inputs);
 
-  static variant array(const std::vector<variant>& inputs) {
+  static Variant array(const std::vector<Variant>& inputs) {
     verifyArrayElements(inputs);
     return {
         TypeKind::ARRAY,
@@ -332,7 +332,7 @@ class variant {
             inputs}};
   }
 
-  static variant array(std::vector<variant>&& inputs) {
+  static Variant array(std::vector<Variant>&& inputs) {
     verifyArrayElements(inputs);
     return {
         TypeKind::ARRAY,
@@ -341,13 +341,13 @@ class variant {
             std::move(inputs)}};
   }
 
-  variant()
+  Variant()
       : ptr_{nullptr}, kind_{TypeKind::INVALID}, usesCustomComparison_(false) {}
 
-  /* implicit */ variant(TypeKind kind)
+  /* implicit */ Variant(TypeKind kind)
       : ptr_{nullptr}, kind_{kind}, usesCustomComparison_(false) {}
 
-  variant(const variant& other)
+  Variant(const Variant& other)
       : ptr_{nullptr},
         kind_{other.kind_},
         usesCustomComparison_(other.usesCustomComparison_) {
@@ -358,52 +358,52 @@ class variant {
   }
 
   // Support construction from StringView as well as StringPiece.
-  /* implicit */ variant(StringView view) : variant{folly::StringPiece{view}} {}
+  /* implicit */ Variant(StringView view) : Variant{folly::StringPiece{view}} {}
 
   // Break ties between implicit conversions to StringView/StringPiece.
-  /* implicit */ variant(std::string str)
+  /* implicit */ Variant(std::string str)
       : ptr_{new std::string{std::move(str)}},
         kind_{TypeKind::VARCHAR},
         usesCustomComparison_(false) {}
 
-  /* implicit */ variant(const char* str)
+  /* implicit */ Variant(const char* str)
       : ptr_{new std::string{str}},
         kind_{TypeKind::VARCHAR},
         usesCustomComparison_(false) {}
 
   template <TypeKind KIND>
-  static variant create(
+  static Variant create(
       typename detail::VariantTypeTraits<KIND, false>::value_type&& v) {
-    return variant{
+    return Variant{
         KIND,
         new typename detail::VariantTypeTraits<KIND, false>::stored_type{
             std::move(v)}};
   }
 
   template <TypeKind KIND>
-  static variant create(
+  static Variant create(
       const typename detail::VariantTypeTraits<KIND, false>::value_type& v) {
-    return variant{
+    return Variant{
         KIND,
         new typename detail::VariantTypeTraits<KIND, false>::stored_type{v}};
   }
 
   template <typename T>
-  static variant create(const typename detail::VariantTypeTraits<
+  static Variant create(const typename detail::VariantTypeTraits<
                         CppToType<T>::typeKind,
                         false>::value_type& v) {
     return create<CppToType<T>::typeKind>(v);
   }
 
-  static variant null(TypeKind kind) {
-    return variant{kind};
+  static Variant null(TypeKind kind) {
+    return Variant{kind};
   }
 
-  static variant binary(std::string val) {
-    return variant{TypeKind::VARBINARY, new std::string{std::move(val)}};
+  static Variant binary(std::string val) {
+    return Variant{TypeKind::VARBINARY, new std::string{std::move(val)}};
   }
 
-  variant& operator=(const variant& other) {
+  Variant& operator=(const Variant& other) {
     if (ptr_ != nullptr) {
       dynamicFree();
     }
@@ -415,7 +415,7 @@ class variant {
     return *this;
   }
 
-  variant& operator=(variant&& other) noexcept {
+  Variant& operator=(Variant&& other) noexcept {
     if (ptr_ != nullptr) {
       dynamicFree();
     }
@@ -428,25 +428,25 @@ class variant {
     return *this;
   }
 
-  bool operator<(const variant& other) const;
+  bool operator<(const Variant& other) const;
 
-  bool equals(const variant& other) const;
+  bool equals(const Variant& other) const;
 
-  bool equalsWithNullEqualsNull(const variant& other) const {
+  bool equalsWithNullEqualsNull(const Variant& other) const {
     if (other.kind_ != this->kind_) {
       return false;
     }
     return dispatchDynamicVariantEquality(*this, other, true);
   }
 
-  variant(variant&& other) noexcept
+  Variant(Variant&& other) noexcept
       : ptr_{other.ptr_},
         kind_{other.kind_},
         usesCustomComparison_(other.usesCustomComparison_) {
     other.ptr_ = nullptr;
   }
 
-  ~variant() {
+  ~Variant() {
     if (ptr_ != nullptr) {
       dynamicFree();
     }
@@ -460,13 +460,13 @@ class variant {
     return toJsonUnsafe();
   }
 
-  /// Returns a string of the variant value. Currently only supports scalar
+  /// Returns a string of the Variant value. Currently only supports scalar
   /// types.
   std::string toString(const TypePtr& type) const;
 
   folly::dynamic serialize() const;
 
-  static variant create(const folly::dynamic&);
+  static Variant create(const folly::dynamic&);
 
   bool hasValue() const {
     return !isNull();
@@ -542,15 +542,15 @@ class variant {
     return valuePointer<CppToType<T>::typeKind>();
   }
 
-  const std::vector<variant>& row() const {
+  const std::vector<Variant>& row() const {
     return value<TypeKind::ROW>();
   }
 
-  const std::map<variant, variant>& map() const {
+  const std::map<Variant, Variant>& map() const {
     return value<TypeKind::MAP>();
   }
 
-  const std::vector<variant>& array() const {
+  const std::vector<Variant>& array() const {
     return value<TypeKind::ARRAY>();
   }
 
@@ -566,7 +566,7 @@ class variant {
   }
 
   /// Try to cast to the target custom type
-  /// Throw if the variant is not an opaque type
+  /// Throw if the Variant is not an opaque type
   /// Return nullptr if it's opaque type but the underlying custom type doesn't
   /// match the target. Otherwise return the data in custom type.
   template <class T>
@@ -628,7 +628,7 @@ class variant {
     }
   }
 
-  friend std::ostream& operator<<(std::ostream& stream, const variant& k) {
+  friend std::ostream& operator<<(std::ostream& stream, const Variant& k) {
     const auto type = k.inferType();
     stream << k.toJson(type);
     return stream;
@@ -636,11 +636,11 @@ class variant {
 
   // Uses kEpsilon to compare floating point types (REAL and DOUBLE).
   // For testing purposes.
-  bool lessThanWithEpsilon(const variant& other) const;
+  bool lessThanWithEpsilon(const Variant& other) const;
 
   // Uses kEpsilon to compare floating point types (REAL and DOUBLE).
   // For testing purposes.
-  bool equalsWithEpsilon(const variant& other) const;
+  bool equalsWithEpsilon(const Variant& other) const;
 
  private:
   template <TypeKind KIND>
@@ -655,24 +655,24 @@ class variant {
   // problem
   const void* ptr_;
   TypeKind kind_;
-  // If the variant represents the value of a type that provides custom
+  // If the Variant represents the value of a type that provides custom
   // comparisons.
   bool usesCustomComparison_;
 };
 
-inline bool operator==(const variant& a, const variant& b) {
+inline bool operator==(const Variant& a, const Variant& b) {
   return a.equals(b);
 }
 
-inline bool operator!=(const variant& a, const variant& b) {
+inline bool operator!=(const Variant& a, const Variant& b) {
   return !(a == b);
 }
 
 struct VariantConverter {
   template <TypeKind FromKind, TypeKind ToKind>
-  static variant convert(const variant& value) {
+  static Variant convert(const Variant& value) {
     if (value.isNull()) {
-      return variant{value.kind()};
+      return Variant{value.kind()};
     }
 
     const auto converted =
@@ -684,7 +684,7 @@ struct VariantConverter {
   }
 
   template <TypeKind ToKind>
-  static variant convert(const variant& value) {
+  static Variant convert(const Variant& value) {
     switch (value.kind()) {
       case TypeKind::BOOLEAN:
         return convert<TypeKind::BOOLEAN, ToKind>(value);
@@ -717,9 +717,12 @@ struct VariantConverter {
     }
   }
 
-  static variant convert(const variant& value, TypeKind toKind) {
+  static Variant convert(const Variant& value, TypeKind toKind) {
     return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(convert, toKind, value);
   }
 };
+
+// For backward compatibility.
+using variant = Variant;
 
 } // namespace facebook::velox

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -649,7 +649,7 @@ void BaseVector::ensureWritable(
 template <TypeKind kind>
 VectorPtr newConstant(
     const TypePtr& type,
-    variant& value,
+    const Variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   using T = typename KindToFlatVector<kind>::WrapperType;
@@ -672,7 +672,7 @@ VectorPtr newConstant(
 template <>
 VectorPtr newConstant<TypeKind::OPAQUE>(
     const TypePtr& type,
-    variant& value,
+    const Variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   const auto& capsule = value.value<TypeKind::OPAQUE>();
@@ -684,7 +684,7 @@ VectorPtr newConstant<TypeKind::OPAQUE>(
 // static
 VectorPtr BaseVector::createConstant(
     const TypePtr& type,
-    variant value,
+    const Variant value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   VELOX_CHECK_EQ(type->kind(), value.kind());

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -598,7 +598,7 @@ class BaseVector {
 
   static VectorPtr createConstant(
       const TypePtr& type,
-      variant value,
+      Variant value,
       vector_size_t size,
       velox::memory::MemoryPool* pool);
 

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -23,7 +23,7 @@ namespace {
 template <TypeKind KIND>
 ArrayVectorPtr variantArrayToVectorImpl(
     const TypePtr& arrayType,
-    const std::vector<variant>& variantArray,
+    const std::vector<Variant>& variantArray,
     velox::memory::MemoryPool* pool) {
   using T = typename TypeTraits<KIND>::NativeType;
 
@@ -60,7 +60,7 @@ ArrayVectorPtr variantArrayToVectorImpl(
 
 ArrayVectorPtr variantArrayToVector(
     const TypePtr& arrayType,
-    const std::vector<variant>& variantArray,
+    const std::vector<Variant>& variantArray,
     velox::memory::MemoryPool* pool) {
   VELOX_CHECK_EQ(TypeKind::ARRAY, arrayType->kind());
 

--- a/velox/vector/VariantToVector.h
+++ b/velox/vector/VariantToVector.h
@@ -24,7 +24,7 @@ namespace facebook::velox::core {
 // extracted from the input variant vector.
 ArrayVectorPtr variantArrayToVector(
     const TypePtr& arrayType,
-    const std::vector<variant>& variantArray,
+    const std::vector<Variant>& variantArray,
     velox::memory::MemoryPool* pool);
 
 } // namespace facebook::velox::core

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -251,16 +251,16 @@ class VectorTestBase {
   // Create an ArrayVector<ROW> from nested std::vectors of variants.
   // Example:
   //   auto arrayVector = makeArrayOfRowVector({
-  //       {variant::row({1, "red"}), variant::row({1, "blue"})},
+  //       {Variant::row({1, "red"}), Variant::row({1, "blue"})},
   //       {},
-  //       {variant::row({3, "green"})},
+  //       {Variant::row({3, "green"})},
   //   });
   //   EXPECT_EQ(3, arrayVector->size());
   //
-  // Use variant(TypeKind::ROW) to specify a null array element.
+  // Use Variant(TypeKind::ROW) to specify a null array element.
   ArrayVectorPtr makeArrayOfRowVector(
       const RowTypePtr& rowType,
-      const std::vector<std::vector<variant>>& data) {
+      const std::vector<std::vector<Variant>>& data) {
     return vectorMaker_.arrayOfRowVector(rowType, data);
   }
 
@@ -662,7 +662,7 @@ class VectorTestBase {
     return vectorMaker_.allNullMapVector(size, keyType, valueType);
   }
 
-  VectorPtr makeConstant(const variant& value, vector_size_t size) {
+  VectorPtr makeConstant(const Variant& value, vector_size_t size) {
     return BaseVector::createConstant(value.inferType(), value, size, pool());
   }
 
@@ -693,7 +693,7 @@ class VectorTestBase {
   /// Create constant vector of type ROW from a Variant.
   VectorPtr makeConstantRow(
       const RowTypePtr& rowType,
-      variant value,
+      Variant value,
       vector_size_t size) {
     return vectorMaker_.constantRow(rowType, value, size);
   }


### PR DESCRIPTION
Summary: Class names should start with a capital letter.

Differential Revision: D77587739
