### PR TITLE
Fix shadow variable warning in CastExprTest.cpp

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1484,16 +1484,16 @@ TEST_F(CastExprTest, arrayCast) {
   {
     // Array with all inner elements null.
     auto sizeAtLocal = [](vector_size_t /* row */) { return 5; };
-    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
+    auto nullElementsArrayVector = vectorMaker_.arrayVector<int32_t>(
         kVectorSize, sizeAtLocal, nullptr, nullptr, nullEvery(1));
 
     SelectivityVector rows(5);
     rows.setValid(2, false);
-    arrayVector->setOffsetAndSize(2, 100, 5);
-    arrayVector->setOffsetAndSize(20, 10, 5);
+    nullElementsArrayVector->setOffsetAndSize(2, 100, 5);
+    nullElementsArrayVector->setOffsetAndSize(20, 10, 5);
     std::vector<VectorPtr> results(1);
 
-    auto rowVector = makeRowVector({arrayVector});
+    auto rowVector = makeRowVector({nullElementsArrayVector});
     auto castExpr =
         makeTypedExpr("cast (c0 as bigint[])", asRowType(rowVector->type()));
     exec::ExprSet exprSet({castExpr}, &execCtx_);


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
This diff fixes a 'Shadow Variable Warning' issue identified by Quality Insight from [Monetization codehub](https://fburl.com/quality/wmkbc0si):
 - Accept and ship the diff (racer does not do auto land)
 - [**Recommended**] Commandeer and land this diff.

If you are happy with the changes, please accept and ship, or commandeer it if minor edits are needed.
If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and regenerate.
If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.


This diff was pre-created by Racer AI agent for your convenience on top of T228612828. More details about the program see this [post](https://fb.workplace.com/groups/1177219810659335/permalink/1198503531864296/). For questions or suggestions please post in [RACER Feedback and Q&A](https://fb.workplace.com/groups/2477474979269093) group. 
## Summary:
Fixed shadow variable warning in CastExprTest.cpp by renaming the inner 'arrayVector' variable to 'nullElementsArrayVector' to avoid shadowing the outer variable with the same name. The new variable name is more descriptive as it represents an array vector with all null elements.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=a112e5f1-54e8-11f0-9457-c6613fa751c6&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=a112e5f1-54e8-11f0-9457-c6613fa751c6&tab=Trace)

Differential Revision: D77507473


