### PR TITLE
feat: Implement ST_StartPoint, ST_EndPoint

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -260,6 +260,18 @@ Accessors
     Returns the maximum ``y`` coordinate of the geometries bounding box.
     Returns ``null`` if the geometry is empty.
 
+.. function:: ST_StartPoint(geometry: Geometry) -> point: Geometry
+
+    Returns the first point of a LineString geometry as a Point.
+    This is a shortcut for ``ST_PointN(geometry, 1)``. Empty
+    input will return ``null``.
+
+.. function:: ST_EndPoint(geometry: Geometry) -> point: Geometry
+
+    Returns the last point of a LineString geometry as a Point.
+    This is a shortcut for ``ST_PointN(geometry, ST_NumPoints(geometry))``.
+    Empty input will return ``null``.
+
 .. function:: simplify_geometry(geometry: Geometry, tolerance: double) -> output: Geometry
 
     Returns a "simplified" version of the input geometry using the

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -174,6 +174,8 @@ int main(int argc, char** argv) {
       "st_y",
       "st_isvalid",
       "st_issimple",
+      "st_startpoint",
+      "st_endpoint",
       "geometry_invalid_reason",
       "simplify_geometry",
       "st_xmax",

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -926,4 +926,64 @@ struct StPointNFunction {
   }
 };
 
+template <typename T>
+struct StStartPointFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& geometry) {
+    std::unique_ptr<geos::geom::Geometry> geosGeometry =
+        geospatial::GeometryDeserializer::deserialize(geometry);
+
+    auto validate = geospatial::validateType(
+        *geosGeometry,
+        {geos::geom::GeometryTypeId::GEOS_LINESTRING},
+        "ST_StartPoint");
+
+    if (!validate.ok()) {
+      VELOX_USER_FAIL(validate.message());
+    }
+    if (geosGeometry->isEmpty()) {
+      return false;
+    }
+    geos::geom::LineString* lineString =
+        static_cast<geos::geom::LineString*>(geosGeometry.get());
+    geospatial::GeometrySerializer::serialize(
+        *(lineString->getStartPoint()), result);
+
+    return true;
+  }
+};
+
+template <typename T>
+struct StEndPointFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Geometry>& result,
+      const arg_type<Geometry>& geometry) {
+    std::unique_ptr<geos::geom::Geometry> geosGeometry =
+        geospatial::GeometryDeserializer::deserialize(geometry);
+
+    auto validate = geospatial::validateType(
+        *geosGeometry,
+        {geos::geom::GeometryTypeId::GEOS_LINESTRING},
+        "ST_EndPoint");
+
+    if (!validate.ok()) {
+      VELOX_USER_FAIL(validate.message());
+    }
+    if (geosGeometry->isEmpty()) {
+      return false;
+    }
+    geos::geom::LineString* lineString =
+        static_cast<geos::geom::LineString*>(geosGeometry.get());
+    geospatial::GeometrySerializer::serialize(
+        *lineString->getEndPoint(), result);
+
+    return true;
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -105,6 +105,10 @@ void registerAccessors(const std::string& prefix) {
       {{prefix + "ST_Length"}});
   registerFunction<StPointNFunction, Geometry, Geometry, int32_t>(
       {{prefix + "ST_PointN"}});
+  registerFunction<StStartPointFunction, Geometry, Geometry>(
+      {{prefix + "ST_StartPoint"}});
+  registerFunction<StEndPointFunction, Geometry, Geometry>(
+      {{prefix + "ST_EndPoint"}});
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -1776,3 +1776,53 @@ TEST_F(GeometryFunctionsTest, testStPointN) {
       testStPointNFunc("POINT (1 2)", -1, std::nullopt),
       "ST_PointN only applies to LineString. Input type is: Point");
 }
+
+TEST_F(GeometryFunctionsTest, testStStartPoint) {
+  const auto testStStartPointFunc =
+      [&](const std::optional<std::string>& wkt,
+          const std::optional<std::string>& expected) {
+        std::optional<std::string> result = evaluateOnce<std::string>(
+            "ST_AsText(ST_StartPoint(ST_GeometryFromText(c0)))", wkt);
+
+        if (expected.has_value()) {
+          ASSERT_TRUE(result.has_value());
+          ASSERT_EQ(result.value(), expected.value());
+        } else {
+          ASSERT_FALSE(result.has_value());
+        }
+      };
+
+  testStStartPointFunc("LINESTRING (8 4, 4 8, 5 6)", "POINT (8 4)");
+  testStStartPointFunc("LINESTRING (8 2, 4 12, 0 0)", "POINT (8 2)");
+  testStStartPointFunc("LINESTRING (0 0, 4 12, 2 2)", "POINT (0 0)");
+  testStStartPointFunc("LINESTRING EMPTY", std::nullopt);
+
+  VELOX_ASSERT_USER_THROW(
+      testStStartPointFunc("POINT (1 2)", std::nullopt),
+      "ST_StartPoint only applies to LineString. Input type is: Point");
+}
+
+TEST_F(GeometryFunctionsTest, testStEndPoint) {
+  const auto testStEndPointFunc =
+      [&](const std::optional<std::string>& wkt,
+          const std::optional<std::string>& expected) {
+        std::optional<std::string> result = evaluateOnce<std::string>(
+            "ST_AsText(ST_EndPoint(ST_GeometryFromText(c0)))", wkt);
+
+        if (expected.has_value()) {
+          ASSERT_TRUE(result.has_value());
+          ASSERT_EQ(result.value(), expected.value());
+        } else {
+          ASSERT_FALSE(result.has_value());
+        }
+      };
+
+  testStEndPointFunc("LINESTRING (8 4, 4 8, 5 6)", "POINT (5 6)");
+  testStEndPointFunc("LINESTRING (8 2, 4 12, 0 0)", "POINT (0 0)");
+  testStEndPointFunc("LINESTRING (0 0, 4 12, 2 2)", "POINT (2 2)");
+  testStEndPointFunc("LINESTRING EMPTY", std::nullopt);
+
+  VELOX_ASSERT_USER_THROW(
+      testStEndPointFunc("POINT (1 2)", std::nullopt),
+      "ST_EndPoint only applies to LineString. Input type is: Point");
+}


### PR DESCRIPTION
Summary:
Adds 2 UDFs.

ST_StartPoint:
```
Returns the first point of a LineString geometry as a Point. This is a shortcut for ST_PointN(geometry, 1).
```

ST_EndPoint:
```
Returns the last point of a LineString geometry as a Point. This is a shortcut for ST_PointN(geometry, ST_NumPoints(geometry)).
```

Differential Revision: D77607205


