### PR TITLE
docs: Document T-Digest and Q-Digest Presto functions

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -174,6 +174,8 @@ UUID                      HUGEINT
 IPADDRESS                 HUGEINT
 IPPREFIX                  ROW(HUGEINT,TINYINT)
 GEOMETRY                  VARBINARY
+TDIGEST                   VARBINARY
+QDIGEST                   VARBINARY
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
@@ -208,6 +210,18 @@ As a result the IPPREFIX object stores *FFFF:FFFF::* and the length 32 for both 
 
    IPPREFIX 'FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF/32' -- IPPREFIX 'FFFF:FFFF:0000:0000:0000:0000:0000:0000/32'
    IPPREFIX 'FFFF:FFFF:4455:6677:8899:AABB:CCDD:EEFF/32' -- IPPREFIX 'FFFF:FFFF:0000:0000:0000:0000:0000:0000/32'
+
+TDIGEST(DOUBLE) is a data sketch for estimating rank-based metrics.
+T-digests may be merged without losing precision, and for storage and retrieval
+they may be cast to/from VARBINARY. The T-digest accepts a parameter of type
+DOUBLE which represents the set of numbers to be ingested by the T-digest.
+
+QDIGEST(BIGINT), QDIGEST(REAL), QDIGEST(DOUBLE) are data sketches for
+estimating rank-based metrics. A quantile digest captures the approximate distribution of
+data for a given input set, and can be queried to retrieve approximate quantile values from the
+distribution. They may be merged without losing precision, and for storage and retrieval they may
+be cast to/from VARBINARY. The parameter type (BIGINT, REAL, or DOUBLE) represents
+the set of numbers that may be ingested by the quantile digest.
 
 Spark Types
 ~~~~~~~~~~~~

--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -21,6 +21,10 @@ Presto Functions
     functions/presto/aggregate
     functions/presto/window
     functions/presto/hyperloglog
+    functions/presto/tdigest
+    functions/presto/qdigest
+    functions/presto/geospatial
+    functions/presto/ipaddress
     functions/presto/uuid
     functions/presto/misc
 

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -30,7 +30,7 @@ are supported if the conversion of their element types are supported. In additio
 supported conversions to/from JSON are listed in :doc:`json`.
 
 .. list-table::
-   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
+   :widths: 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
    :header-rows: 1
 
    * -
@@ -50,6 +50,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - decimal
      - ipaddress
      - ipprefix
+     - tdigest
+     - qdigest
    * - tinyint
      - Y
      - Y
@@ -65,6 +67,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
      -
      -
    * - smallint
@@ -84,6 +88,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      -
+     -
+     -
    * - integer
      - Y
      - Y
@@ -99,6 +105,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
      -
      -
    * - bigint
@@ -118,6 +126,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      -
+     -
+     -
    * - boolean
      - Y
      - Y
@@ -133,6 +143,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
      -
      -
    * - real
@@ -152,6 +164,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      -
+     -
+     -
    * - double
      - Y
      - Y
@@ -167,6 +181,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
      -
      -
    * - varchar
@@ -186,6 +202,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     -
+     -
    * - varbinary
      -
      -
@@ -202,7 +220,9 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
-     -
+     - Y
+     - Y
+     - Y
    * - timestamp
      -
      -
@@ -216,6 +236,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
+     -
+     -
      -
      -
      -
@@ -237,6 +259,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     -
+     -
    * - date
      -
      -
@@ -254,6 +278,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
+     -
+     -
    * - interval day to second
      -
      -
@@ -263,6 +289,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
      -
      -
      -
@@ -288,6 +316,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      -
+     -
+     -
    * - ipaddress
      -
      -
@@ -305,6 +335,8 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      - Y
+     -
+     -
    * - ipprefix
      -
      -
@@ -322,6 +354,47 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      - Y
      - Y
+     -
+     -
+   * - tdigest
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     - Y
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+   * - qdigest
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     - Y
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+
 Cast to Integral Types
 ----------------------
 
@@ -570,7 +643,7 @@ Invalid example
   SELECT cast(decimal '300.001' as tinyint); -- Out of range
 
 Cast to VARCHAR
---------------
+---------------
 
 Casting from scalar types to string is allowed.
 
@@ -776,6 +849,26 @@ IPV4 mapped IPV6:
 ::
 
   SELECT cast('::ffff:ffff:ffff' as ipaddress); -- 0x00000000000000000000ffffffffffff
+
+From TDIGEST(DOUBLE)
+^^^^^^^^^^^^^^^^^^^^
+
+Returns the T-digest as a varbinary string containing the serialized representation of the T-digest data structure.
+This allows T-digests to be stored and retrieved for later use.
+
+::
+
+  SELECT cast(tdigest_agg(cast(1.0 as double)) as varbinary); -- AQAAAAAAAADwPwAAAAAAAPA/AAAAAAAA8D8AAAAAAABZQAAAAAAAAPA/AQAAAAAAAAAAAPA/AAAAAAAA8D8=
+
+From QDIGEST(BIGINT), QDIGEST(REAL), QDIGEST(DOUBLE)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returns the quantile digest as a varbinary string containing the serialized representation of the quantile digest data structure.
+This allows quantile digests to be stored and retrieved for later use.
+
+::
+
+  SELECT cast(qdigest_agg(cast(1.0 as double)) as varbinary); -- AHsUrkfheoQ/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAPA/AAAAAAAA8D8BAAAAAAAAAAAAAPA/AAAAAAAA8L8=
 
 Cast to TIMESTAMP
 -----------------
@@ -1202,6 +1295,34 @@ Examples:
 
   SELECT cast(ipprefix '1.2.3.4/24' as ipaddress) -- ipaddress '1.2.3.0'
   SELECT cast(ipprefix '2001:db8::ff00:42:8329/64' as ipaddress) -- ipaddress '2001:db8::'
+
+Cast to TDIGEST(DOUBLE)
+-----------------------
+
+From VARBINARY
+^^^^^^^^^^^^^^
+
+Returns a T-digest reconstructed from the varbinary string containing the serialized representation.
+This allows previously stored T-digests to be restored for use.
+
+::
+
+  SELECT cast(stored_tdigest_binary as tdigest(double));
+
+Cast to QDIGEST(BIGINT), QDIGEST(REAL), QDIGEST(DOUBLE)
+-------------------------------------------------------
+
+From VARBINARY
+^^^^^^^^^^^^^^
+
+Returns a quantile digest reconstructed from the varbinary string containing the serialized representation.
+This allows previously stored quantile digests to be restored for use.
+
+::
+
+  SELECT cast(stored_qdigest_binary as qdigest(bigint));
+  SELECT cast(stored_qdigest_binary as qdigest(real));
+  SELECT cast(stored_qdigest_binary as qdigest(double));
 
 Cast to IPPREFIX
 ----------------

--- a/velox/docs/functions/presto/qdigest.rst
+++ b/velox/docs/functions/presto/qdigest.rst
@@ -1,0 +1,65 @@
+=========================
+Quantile Digest Functions
+=========================
+
+Quantile digest and `T-digest <https://doi.org/10.1016/j.simpa.2020.100049>`_ are two
+older algorithms for estimating rank-based metrics. While T-digest generally has `better
+performance <https://arxiv.org/abs/1902.04023>`_ and better accuracy at the tails,
+quantile digest supports more numeric types (``bigint``, ``double``, ``real``) and
+provides a maximum rank error guarantee, which ensures relative uniformity of precision
+along the quantiles. Quantile digests are also formally proven to support lossless merges,
+while T-digest is not (though it does empirically demonstrate lossless merges).
+
+Velox uses the modern KLL sketch algorithm for the ``approx_percentile`` function, which
+provides stronger accuracy guarantees than both quantile digest and T-digest.
+The quantile digest functions documented here exist primarily to support
+pre-existing workloads that have data stored using the `quantile
+digest <http://dx.doi.org/10.1145/347090.347195>`_ format for backward compatibility.
+
+Data Structures
+---------------
+
+A quantile digest is a data sketch which stores approximate percentile
+information. The Velox type for this data structure is called ``qdigest``,
+and it takes a parameter which must be one of ``bigint``, ``double`` or
+``real`` which represent the set of numbers that may be ingested by the
+``qdigest``. They may be merged without losing precision, and for storage
+and retrieval they may be cast to/from ``VARBINARY``.
+
+In the function signatures below, ``T`` represents the parameterized type of the qdigest,
+which can be ``bigint``, ``double``, or ``real``.
+
+Functions
+---------
+
+.. function:: merge(qdigest<T>) -> qdigest<T>
+
+    Merges all input ``qdigest``\ s into a single ``qdigest``.
+
+.. function:: qdigest_agg(x: T) -> qdigest<T>
+
+    Returns the ``qdigest`` which summarizes the approximate distribution of all input values of ``x``.
+
+.. function:: qdigest_agg(x: T, w: bigint) -> qdigest<T>
+   :noindex:
+
+    Returns the ``qdigest`` which summarizes the approximate distribution of all input values of ``x`` using
+    the per-item weight ``w``.
+
+.. function:: qdigest_agg(x: T, w: bigint, accuracy: double) -> qdigest<T>
+   :noindex:
+
+    Returns the ``qdigest`` which summarizes the approximate distribution of all input values of ``x`` using
+    the per-item weight ``w`` and maximum error of ``accuracy``. ``accuracy``
+    must be a value greater than zero and less than one, and it must be constant
+    for all input rows.
+
+.. function:: value_at_quantile(digest: qdigest<T>, quantile: double) -> T
+
+    Returns the approximate percentile values from the quantile digest ``digest`` given the ``quantile``.
+    The ``quantile`` must be between zero and one (inclusive).
+
+.. function:: values_at_quantiles(digest: qdigest<T>, quantiles: array<double>) -> array<T>
+
+    Returns the approximate percentile values as an array from the quantile digest ``digest`` at each of the specified quantiles given in the ``quantiles`` array.
+    All quantile values must be between zero and one (inclusive).

--- a/velox/docs/functions/presto/tdigest.rst
+++ b/velox/docs/functions/presto/tdigest.rst
@@ -1,0 +1,116 @@
+==================
+T-Digest Functions
+==================
+
+T-digest and `quantile digest <http://dx.doi.org/10.1145/347090.347195>`_ are two
+older algorithms for estimating rank-based metrics. T-digest generally has `better
+performance <https://arxiv.org/abs/1902.04023>`_ than quantile digest and better accuracy
+at the tails (often dramatically better), but may have worse accuracy at the median
+depending on the compression factor used. In comparison, quantile digest supports more
+numeric types and provides a maximum rank error guarantee, which ensures relative uniformity
+of precision along the quantiles. Quantile digests are also formally proven to support
+lossless merges, while T-digest is not (though it does empirically demonstrate lossless merges).
+
+T-digest was developed by Ted Dunning and is more restrictive in its type support,
+accepting only ``double`` type parameters. This contrasts with quantile digest, which
+supports a broader range of numeric types including ``bigint``, ``double``, and ``real``,
+making quantile digest more versatile for different data types.
+
+Velox uses the modern KLL sketch algorithm for the ``approx_percentile`` function, which
+provides stronger accuracy guarantees than both T-digest and quantile digest.
+The T-digest functions documented here exist primarily to support
+pre-existing workloads that have data stored using the `T-digest
+<https://doi.org/10.1016/j.simpa.2020.100049>`_ format for backward compatibility.
+
+Data Structures
+---------------
+
+A T-digest is a data sketch which stores approximate percentile information.
+The Velox type for this data structure is called ``tdigest``,
+and it accepts a parameter of type ``double`` which represents the set of
+numbers to be ingested by the ``tdigest``.
+
+T-digests may be merged without losing precision, and for storage and retrieval
+they may be cast to/from ``VARBINARY``.
+
+Functions
+---------
+
+.. function:: construct_tdigest(means: array<double>, counts: array<integer>, compression: double, min: double, max: double, sum: double, count: bigint) -> tdigest<double>
+
+    Constructs a T-digest from the given parameters:
+
+    * ``means`` - array of centroid means
+    * ``counts`` - array of centroid counts (weights)
+    * ``compression`` - compression factor
+    * ``min`` - minimum value
+    * ``max`` - maximum value
+    * ``sum`` - sum of all values
+    * ``count`` - total count of values
+
+.. function:: destructure_tdigest(digest: tdigest<double>) -> row(means array<double>, counts array<integer>, compression double, min double, max double, sum double, count bigint)
+
+    Destructures a T-digest into its component parts, returning a row containing:
+
+    * ``means`` - array of centroid means
+    * ``counts`` - array of centroid counts
+    * ``compression`` - compression factor
+    * ``min`` - minimum value
+    * ``max`` - maximum value
+    * ``sum`` - sum of all values
+    * ``count`` - total count of values
+
+.. function:: merge(tdigest<double>) -> tdigest<double>
+
+    Merges all input ``tdigest``\ s into a single ``tdigest``.
+
+.. function:: merge_tdigest(digests: array<tdigest<double>>) -> tdigest<double>
+
+    Merges an array of T-digests into a single T-digest.
+
+.. function:: quantile_at_value(digest: tdigest<double>, value: double) -> double
+
+    Returns the approximate quantile (percentile) of the given ``value`` based on the T-digest ``digest``.
+    The result will be between zero and one (inclusive).
+
+.. function:: quantiles_at_values(digest: tdigest<double>, values: array<double>) -> array<double>
+
+    Returns the approximate quantiles (percentiles) as an array for each of the given ``values`` based on the T-digest ``digest``.
+    All results will be between zero and one (inclusive).
+
+.. function:: scale_tdigest(digest: tdigest<double>, scale: double) -> tdigest<double>
+
+    Scales the T-digest ``digest`` by the given ``scale`` factor.
+    This multiplies all the centroid values in the T-digest by the scale factor.
+
+.. function:: tdigest_agg(x: double) -> tdigest<double>
+
+    Returns the ``tdigest`` which summarizes the approximate distribution of all input values of ``x``.
+    The default compression factor is ``100``.
+
+.. function:: tdigest_agg(x: double, w: double) -> tdigest<double>
+   :noindex:
+
+    Returns the ``tdigest`` which summarizes the approximate distribution of all input values of ``x`` using per-item weight ``w``.
+    The default compression factor is ``100``.
+
+.. function:: tdigest_agg(x: double, w: double, compression: double) -> tdigest<double>
+   :noindex:
+
+    Returns the ``tdigest`` which summarizes the approximate distribution of all input values of ``x`` using per-item weight ``w`` and the specified compression factor.
+    ``compression`` must be a positive constant for all input rows. The default is ``100``, maximum is ``1000``, and values lower than ``10`` are rounded to ``10``. Higher compression means more accuracy at the cost of more memory.
+
+.. function:: trimmed_mean(digest: tdigest<double>, low_quantile: double, high_quantile: double) -> double
+
+    Returns the mean of values between ``low_quantile`` and ``high_quantile`` (inclusive) from the T-digest ``digest``.
+    Both quantile values must be between zero and one (inclusive), and ``low_quantile`` must be less than or equal to ``high_quantile``.
+
+.. function:: value_at_quantile(digest: tdigest<double>, quantile: double) -> double
+
+    Returns the approximate percentile value from the T-digest ``digest`` at the given ``quantile``.
+    The ``quantile`` must be between zero and one (inclusive).
+
+.. function:: values_at_quantiles(digest: tdigest<double>, quantiles: array<double>) -> array<double>
+
+    Returns the approximate percentile values as an array from the T-digest ``digest`` at each of the specified quantiles given in the ``quantiles`` array.
+    All quantile values must be between zero and one (inclusive).


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/13963

Add documentation for TDigest and QDigest Functions in Velox similar to Presto
https://prestodb.io/docs/current/functions/tdigest.html
https://prestodb.io/docs/current/functions/qdigest.html

Note - For QDigest - scale_qdigest, quantile_at_value will be added when the functions are added.

Differential Revision: D77612795


