### PR TITLE
fix: Update orderable-ness for custom types

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -71,6 +71,7 @@ int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
+  facebook::velox::functions::prestosql::registerInternalFunctions();
 
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
@@ -211,6 +212,8 @@ int main(int argc, char** argv) {
       exprTransformers = {
           {"array_intersect", std::make_shared<SortArrayTransformer>()},
           {"array_except", std::make_shared<SortArrayTransformer>()},
+          {"array_duplicates", std::make_shared<SortArrayTransformer>()},
+          {"map_entries", std::make_shared<SortArrayTransformer>()},
           {"map_keys", std::make_shared<SortArrayTransformer>()},
           {"map_values", std::make_shared<SortArrayTransformer>()}};
 
@@ -386,6 +389,8 @@ int main(int argc, char** argv) {
         // Skipping until the new signature is merged and released in Presto:
         // https://github.com/prestodb/presto/pull/25521
         "xxhash64(varbinary,bigint) -> varbinary",
+        "$internal$canonicalize",
+        "$internal$contains",
     });
 
     referenceQueryRunner = std::make_shared<PrestoQueryRunner>(

--- a/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
+++ b/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
@@ -41,7 +41,9 @@ class SortArrayTransformer : public ExprTransformer {
           type, facebook::velox::variant::null(type->kind()));
     } else {
       return std::make_shared<facebook::velox::core::CallTypedExpr>(
-          type, std::vector<TypedExprPtr>{std::move(expr)}, "array_sort");
+          type,
+          std::vector<TypedExprPtr>{std::move(expr)},
+          "$internal$canonicalize");
     }
   }
 

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -75,15 +75,15 @@ class BingTileType : public BigintType {
     return name();
   }
 
-  bool isOrderable() const override {
-    return false;
-  }
-
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";
     obj["type"] = name();
     return obj;
+  }
+
+  bool isOrderable() const override {
+    return false;
   }
 
   static constexpr uint8_t kBingTileVersion = 0;

--- a/velox/functions/prestosql/types/GeometryType.h
+++ b/velox/functions/prestosql/types/GeometryType.h
@@ -51,6 +51,10 @@ class GeometryType : public VarbinaryType {
     obj["type"] = name();
     return obj;
   }
+
+  bool isOrderable() const override {
+    return false;
+  }
 };
 
 FOLLY_ALWAYS_INLINE bool isGeometryType(const TypePtr& type) {

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -50,6 +50,10 @@ class HyperLogLogType : public VarbinaryType {
     obj["type"] = name();
     return obj;
   }
+
+  bool isOrderable() const override {
+    return false;
+  }
 };
 
 inline bool isHyperLogLogType(const TypePtr& type) {

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -50,6 +50,10 @@ class JsonType : public VarcharType {
     obj["type"] = name();
     return obj;
   }
+
+  bool isOrderable() const override {
+    return false;
+  }
 };
 
 FOLLY_ALWAYS_INLINE bool isJsonType(const TypePtr& type) {

--- a/velox/functions/prestosql/types/QDigestType.h
+++ b/velox/functions/prestosql/types/QDigestType.h
@@ -73,6 +73,10 @@ class QDigestType : public VarbinaryType {
     return obj;
   }
 
+  bool isOrderable() const override {
+    return false;
+  }
+
  private:
   explicit QDigestType(const TypePtr& dataType)
       : parameters_({TypeParameter(dataType)}) {}

--- a/velox/functions/prestosql/types/TDigestType.h
+++ b/velox/functions/prestosql/types/TDigestType.h
@@ -61,6 +61,10 @@ class TDigestType : public VarbinaryType {
     return obj;
   }
 
+  bool isOrderable() const override {
+    return false;
+  }
+
  private:
   explicit TDigestType(const TypePtr& dataType)
       : parameters_({TypeParameter(dataType)}) {}

--- a/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BingTileTypeTest.cpp
@@ -34,6 +34,8 @@ TEST_F(BingTileTypeTest, basic) {
 
   ASSERT_TRUE(hasType("BINGTILE"));
   ASSERT_EQ(*getType("BINGTILE", {}), *BINGTILE());
+
+  ASSERT_FALSE(BINGTILE()->isOrderable());
 }
 
 TEST_F(BingTileTypeTest, serde) {

--- a/velox/functions/prestosql/types/tests/GeometryTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/GeometryTypeTest.cpp
@@ -35,6 +35,8 @@ TEST_F(GeometryTypeTest, basic) {
 
   ASSERT_TRUE(hasType("GEOMETRY"));
   ASSERT_EQ(*getType("GEOMETRY", {}), *GEOMETRY());
+
+  ASSERT_FALSE(GEOMETRY()->isOrderable());
 }
 
 TEST_F(GeometryTypeTest, serde) {

--- a/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
@@ -34,6 +34,8 @@ TEST_F(HyperLogLogTypeTest, basic) {
 
   ASSERT_TRUE(hasType("HYPERLOGLOG"));
   ASSERT_EQ(*getType("HYPERLOGLOG", {}), *HYPERLOGLOG());
+
+  ASSERT_FALSE(HYPERLOGLOG()->isOrderable());
 }
 
 TEST_F(HyperLogLogTypeTest, serde) {

--- a/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
@@ -34,6 +34,8 @@ TEST_F(JsonTypeTest, basic) {
 
   ASSERT_TRUE(hasType("JSON"));
   ASSERT_EQ(*getType("JSON", {}), *JSON());
+
+  ASSERT_FALSE(JSON()->isOrderable());
 }
 
 TEST_F(JsonTypeTest, serde) {

--- a/velox/functions/prestosql/types/tests/QDigestTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/QDigestTypeTest.cpp
@@ -39,6 +39,8 @@ TEST_F(QDigestTypeTest, basic) {
 
     ASSERT_TRUE(hasType("QDIGEST"));
     ASSERT_EQ(*getType("QDIGEST", {TypeParameter(parameterType)}), *type);
+
+    ASSERT_FALSE(type->isOrderable());
   };
   testType("QDIGEST(BIGINT)", BIGINT());
   testType("QDIGEST(REAL)", REAL());

--- a/velox/functions/prestosql/types/tests/TDigestTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TDigestTypeTest.cpp
@@ -36,6 +36,8 @@ TEST_F(TDigestTypeTest, basic) {
 
   ASSERT_TRUE(hasType("TDIGEST"));
   ASSERT_EQ(*getType("TDIGEST", {TypeParameter(DOUBLE())}), *TDIGEST(DOUBLE()));
+
+  ASSERT_FALSE(TDIGEST(DOUBLE())->isOrderable());
 }
 
 TEST_F(TDigestTypeTest, serde) {


### PR DESCRIPTION
Summary:
In Presto, custom types JSON, for example, are not orderable because of their AbstractType inheritance, which is defaulted as false. In Velox, since we inherit directly from scalar types, they are marked as orderable because they inherit a true isOrderable field, which allows them to be called by UDFs with orderable type signatures:

https://github.com/facebookincubator/velox/issues/13767

Let's update the orderable-ness of these types. These include: Bingtile, Geometry, Json, Q/TDigest and Hyperloglog. Additionally, in order to test these functions, the fuzzer has been updated to use the internal array sort for the expression transform in order to sort non-orderable types.

Differential Revision: D77615175


