### PR TITLE
misc: Remove cleanup from fuzzer runs to enable debugging

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -410,12 +410,7 @@ PrestoQueryRunner::executeAndReturnVector(const core::PlanNodePtr& plan) {
         writeToFile(filePath, input, writerPool.get());
       }
 
-      // Run the query. If successful, delete the table.
       auto result = execute(*sql);
-      for (const auto& [tableName, _] : inputMap) {
-        cleanUp(tableName);
-      }
-
       return std::make_pair(result, ReferenceQueryErrorCode::kSuccess);
     } catch (const VeloxRuntimeError& e) {
       // Throw if connection to Presto server is unsuccessful.


### PR DESCRIPTION
Summary: Remove table cleanup from fuzzer runs. Worst case scenario we store 3000 100 row tables, which may be a few MB of data. This will help with debugging.

Differential Revision: D77625048


