### PR TITLE
fix: Handling of empty nulls buffer in MapVector's Update API

### DIFF
--- a/velox/common/testutil/OptionalEmpty.h
+++ b/velox/common/testutil/OptionalEmpty.h
@@ -30,4 +30,13 @@ struct OptionalEmptyT {
 
 inline constexpr OptionalEmptyT optionalEmpty;
 
+struct EmptyT {
+  template <typename T>
+  operator std::vector<T>() const {
+    return {};
+  }
+};
+
+inline constexpr EmptyT Empty;
+
 } // namespace facebook::velox::common::testutil

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1660,12 +1660,17 @@ MapVectorPtr MapVector::updateImpl(
     }
     if (newNulls.get() == nulls().get()) {
       newNulls = allocateNulls(size(), pool());
-      bits::andBits(
-          newNulls->asMutable<uint64_t>(),
-          rawNulls(),
-          other.nulls(),
-          0,
-          size());
+      if (!rawNulls()) {
+        bits::copyBits(
+            other.nulls(), 0, newNulls->asMutable<uint64_t>(), 0, size());
+      } else {
+        bits::andBits(
+            newNulls->asMutable<uint64_t>(),
+            rawNulls(),
+            other.nulls(),
+            0,
+            size());
+      }
     } else {
       bits::andBits(newNulls->asMutable<uint64_t>(), other.nulls(), 0, size());
     }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3731,20 +3731,45 @@ TEST_F(VectorTest, getLargeStringBuffer) {
 }
 
 TEST_F(VectorTest, mapUpdate) {
-  auto base = makeNullableMapVector<int64_t, int64_t>({
+  auto verifyUpdate =
+      [](MapVectorPtr& base, MapVectorPtr& update, MapVectorPtr& expected) {
+        auto actual = base->update({update});
+        ASSERT_EQ(actual->size(), expected->size());
+        for (int i = 0; i < actual->size(); ++i) {
+          ASSERT_TRUE(actual->equalValueAt(expected.get(), i, i));
+        }
+      };
+
+  auto baseNoNulls = makeMapVector<int64_t, int64_t>({
+      {{{1, 1}, {2, 1}}},
+      common::testutil::Empty,
+      {{{3, 1}}},
+      {{{4, 1}}},
+      {{{4, 1}}},
+  });
+  auto updateNoNulls = makeMapVector<int64_t, int64_t>({
+      {{{2, 2}, {3, 2}}},
+      {{{4, 2}}},
+      common::testutil::Empty,
+      {{{5, 2}}},
+      {{{4, 1}}},
+  });
+  auto baseWithNulls = makeNullableMapVector<int64_t, int64_t>({
       {{{1, 1}, {2, 1}}},
       common::testutil::optionalEmpty,
       {{{3, 1}}},
       std::nullopt,
       {{{4, 1}}},
   });
-  auto update = makeNullableMapVector<int64_t, int64_t>({
+  auto updateWithNulls = makeNullableMapVector<int64_t, int64_t>({
       {{{2, 2}, {3, 2}}},
       {{{4, 2}}},
       common::testutil::optionalEmpty,
       {{{5, 2}}},
       std::nullopt,
   });
+
+  // Case 1: Both base and update have nulls
   auto expected = makeNullableMapVector<int64_t, int64_t>({
       {{{2, 2}, {3, 2}, {1, 1}}},
       {{{4, 2}}},
@@ -3752,11 +3777,35 @@ TEST_F(VectorTest, mapUpdate) {
       std::nullopt,
       std::nullopt,
   });
-  auto actual = base->update({update});
-  ASSERT_EQ(actual->size(), expected->size());
-  for (int i = 0; i < actual->size(); ++i) {
-    ASSERT_TRUE(actual->equalValueAt(expected.get(), i, i));
-  }
+  verifyUpdate(baseWithNulls, updateWithNulls, expected);
+
+  // Case 2: Only base has nulls
+  expected = makeNullableMapVector<int64_t, int64_t>({
+      {{{2, 2}, {3, 2}, {1, 1}}},
+      {{{4, 2}}},
+      {{{3, 1}}},
+      std::nullopt,
+      {{{4, 1}}},
+  });
+  verifyUpdate(baseWithNulls, updateNoNulls, expected);
+  // Case 3: Only update has nulls
+  expected = makeNullableMapVector<int64_t, int64_t>({
+      {{{2, 2}, {3, 2}, {1, 1}}},
+      {{{4, 2}}},
+      {{{3, 1}}},
+      {{{4, 1}, {5, 2}}},
+      std::nullopt,
+  });
+  verifyUpdate(baseNoNulls, updateWithNulls, expected);
+  // Case 4: Both base and update do not have nulls
+  expected = makeNullableMapVector<int64_t, int64_t>({
+      {{{2, 2}, {3, 2}, {1, 1}}},
+      {{{4, 2}}},
+      {{{3, 1}}},
+      {{{4, 1}, {5, 2}}},
+      {{{4, 1}}},
+  });
+  verifyUpdate(baseNoNulls, updateNoNulls, expected);
 }
 
 TEST_F(VectorTest, mapUpdateRowKeyType) {


### PR DESCRIPTION
Summary:
This fixes a bug in MapVector's Update API which does not handle the case
where the calling vector itself does not have a nulls buffer. This results in a
Segfault when it tries to access the nulls buffer.

Differential Revision: D77628699


