### PR TITLE
fix: Fix crash from hash aggregation row container cleanup due to abort

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -49,6 +49,9 @@ class TypedDistinctAggregations : public DistinctAggregations {
         },
         [this](folly::Range<char**> groups) {
           for (auto* group : groups) {
+            if (!isInitialized(group)) {
+              continue;
+            }
             auto* accumulator =
                 reinterpret_cast<AccumulatorType*>(group + offset_);
             accumulator->free(*allocator_);

--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -101,6 +101,10 @@ class DistinctAggregations {
       char** groups,
       folly::Range<const vector_size_t*> indices) = 0;
 
+  bool isInitialized(char* group) const {
+    return group[initializedByte_] & initializedMask_;
+  }
+
   HashStringAllocator* allocator_;
   int32_t offset_;
   int32_t nullByte_;


### PR DESCRIPTION
Summary: Aggregates could be uninitialized when destroying, causing process to crash. Avoid destroying uninitialized aggregates.

Differential Revision: D77632466


