### PR TITLE
build(CI): Increase timeout for velox_exec_test temporarily

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ add_test(
   COMMAND velox_exec_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-set_tests_properties(velox_exec_test PROPERTIES TIMEOUT 3000)
+set_tests_properties(velox_exec_test PROPERTIES TIMEOUT 6000)
 
 add_test(
   NAME velox_exec_infra_test


### PR DESCRIPTION
While the actual issue is being addressed in https://github.com/facebookincubator/velox/issues/13879 which ran into unexpected issues.