### PR TITLE
feat(cudf): Support set pool resource percent

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -182,8 +182,9 @@ bool CompileState::compile() {
     auto id = oper->operatorId();
     if (previousOperatorIsNotGpu and acceptsGpuInput(oper)) {
       auto planNode = getPlanNode(oper->planNodeId());
-      replaceOp.push_back(std::make_unique<CudfFromVelox>(
-          id, planNode->outputType(), ctx, planNode->id() + "-from-velox"));
+      replaceOp.push_back(
+          std::make_unique<CudfFromVelox>(
+              id, planNode->outputType(), ctx, planNode->id() + "-from-velox"));
       replaceOp.back()->initialize();
     }
 
@@ -239,8 +240,9 @@ bool CompileState::compile() {
       // If filter only, filter node only exists.
       // If project only, or filter and project, project node only exists.
       VELOX_CHECK(projectPlanNode != nullptr or filterPlanNode != nullptr);
-      replaceOp.push_back(std::make_unique<CudfFilterProject>(
-          id, ctx, info, idProjections, filterPlanNode, projectPlanNode));
+      replaceOp.push_back(
+          std::make_unique<CudfFilterProject>(
+              id, ctx, info, idProjections, filterPlanNode, projectPlanNode));
       replaceOp.back()->initialize();
     } else if (auto limitOp = dynamic_cast<exec::Limit*>(oper)) {
       auto planNode = std::dynamic_pointer_cast<const core::LimitNode>(
@@ -261,8 +263,9 @@ bool CompileState::compile() {
     if (producesGpuOutput(oper) and
         (nextOperatorIsNotGpu or isLastOperatorOfTask)) {
       auto planNode = getPlanNode(oper->planNodeId());
-      replaceOp.push_back(std::make_unique<CudfToVelox>(
-          id, planNode->outputType(), ctx, planNode->id() + "-to-velox"));
+      replaceOp.push_back(
+          std::make_unique<CudfToVelox>(
+              id, planNode->outputType(), ctx, planNode->id() + "-to-velox"));
       replaceOp.back()->initialize();
     }
 
@@ -318,7 +321,7 @@ void registerCudf(const CudfOptions& options) {
   cudaFree(nullptr); // Initialize CUDA context at startup
 
   const std::string mrMode = options.cudfMemoryResource;
-  auto mr = cudf_velox::createMemoryResource(mrMode);
+  auto mr = cudf_velox::createMemoryResource(mrMode, options.memoryPercent);
   cudf::set_current_device_resource(mr.get());
 
   exec::Operator::registerOperator(

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -65,12 +65,16 @@ class CudfOptions {
   const bool cudfEnabled;
   const std::string cudfMemoryResource;
   const bool cudfTableScan;
+  // The initial percent of GPU memory to allocate for memory resource for one
+  // thread.
+  int memoryPercent;
 
  private:
   CudfOptions()
       : cudfEnabled(FLAGS_velox_cudf_enabled),
         cudfMemoryResource(FLAGS_velox_cudf_memory_resource),
         cudfTableScan(FLAGS_velox_cudf_table_scan),
+        memoryPercent(50),
         prefix_("") {}
   CudfOptions(const CudfOptions&) = delete;
   CudfOptions& operator=(const CudfOptions&) = delete;

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -43,44 +43,46 @@ namespace {
   return std::make_shared<rmm::mr::cuda_memory_resource>();
 }
 
-[[nodiscard]] auto makePoolMr() {
+[[nodiscard]] auto makePoolMr(int percent) {
   return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
       makeCudaMr(), rmm::percent_of_free_device_memory(50));
 }
 
-[[nodiscard]] auto makeAsyncMr() {
-  return std::make_shared<rmm::mr::cuda_async_memory_resource>();
+[[nodiscard]] auto makeAsyncMr(int percent) {
+  return std::make_shared<rmm::mr::cuda_async_memory_resource>(
+      rmm::percent_of_free_device_memory(percent));
 }
 
 [[nodiscard]] auto makeManagedMr() {
   return std::make_shared<rmm::mr::managed_memory_resource>();
 }
 
-[[nodiscard]] auto makeArenaMr() {
+[[nodiscard]] auto makeArenaMr(int percent) {
   return rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(
-      makeCudaMr());
+      makeCudaMr(), rmm::percent_of_free_device_memory(percent));
 }
 
-[[nodiscard]] auto makeManagedPoolMr() {
+[[nodiscard]] auto makeManagedPoolMr(int percent) {
   return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      makeManagedMr(), rmm::percent_of_free_device_memory(50));
+      makeManagedMr(), rmm::percent_of_free_device_memory(percent));
 }
 } // namespace
 
 std::shared_ptr<rmm::mr::device_memory_resource> createMemoryResource(
-    std::string_view mode) {
+    std::string_view mode,
+    int percent) {
   if (mode == "cuda")
     return makeCudaMr();
   if (mode == "pool")
-    return makePoolMr();
+    return makePoolMr(percent);
   if (mode == "async")
-    return makeAsyncMr();
+    return makeAsyncMr(percent);
   if (mode == "arena")
-    return makeArenaMr();
+    return makeArenaMr(percent);
   if (mode == "managed")
     return makeManagedMr();
   if (mode == "managed_pool")
-    return makeManagedPoolMr();
+    return makeManagedPoolMr(percent);
   VELOX_FAIL(
       "Unknown memory resource mode: " + std::string(mode) +
       "\nExpecting: cuda, pool, async, arena, managed, or managed_pool");

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -32,7 +32,7 @@ namespace facebook::velox::cudf_velox {
  * @brief Creates a memory resource based on the given mode.
  */
 [[nodiscard]] std::shared_ptr<rmm::mr::device_memory_resource>
-createMemoryResource(std::string_view mode);
+createMemoryResource(std::string_view mode, int percent);
 
 /**
  * @brief Returns the global CUDA stream pool used by cudf.


### PR DESCRIPTION
The memory resource pool initial size is default to half of the available memory on the current device for one thread. Make it configurable would help control the number of task. If too much concurrent tasks access the memory, may cause OOM.