### PR TITLE
fix: Add atPhysicalEOF_ in TextReader

### DIFF
--- a/velox/dwio/text/reader/TextReader.h
+++ b/velox/dwio/text/reader/TextReader.h
@@ -207,6 +207,7 @@ class TextRowReader : public RowReader {
   bool atEOL_;
   bool atEOF_;
   bool atSOL_;
+  bool atPhysicalEOF_;
   uint8_t depth_;
   std::string unreadData_;
   int unreadIdx_;


### PR DESCRIPTION
Currently, the EOF flag is set to true in two cases.
1. when the end of the file is reached.
2. when the limit in the RowReaderOptions is reached.

These two scenarios result it different behaviors in the `next` function. In case 1, the number of rows read is returned, while in case 2, it returns rows read + 1 because the next row has been scanned.

Now we determine the case 1 by comparing `pos_` with `getLength()`. However, for compressed input streams, the exact length is not known until the entire stream is read. Therefore, it might be more reasonable to determine it by the return value of the `Next` function of the input stream.
