### PR TITLE
feat: Introduce a pattern for handling mapping between enum values and names

### DIFF
--- a/velox/common/Enums.h
+++ b/velox/common/Enums.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "folly/container/F14Map.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+struct Enums {
+  /// Helper function to invert a mapping from enum type to name.
+  template <typename E>
+  static folly::F14FastMap<std::string, E> invertMap(
+      const folly::F14FastMap<E, std::string>& mapping) {
+    folly::F14FastMap<std::string, E> inverted;
+    for (const auto& [key, value] : mapping) {
+      bool ok = inverted.emplace(value, key).second;
+      VELOX_USER_CHECK(
+          ok, "Cannot invert a map with duplicate values: {}", value);
+    }
+    return inverted;
+  }
+};
+
+} // namespace facebook::velox
+
+/// Helper macros to implement bi-direction mappings between enum values and
+/// names.
+///
+/// Usage:
+///
+/// In the header file, define the enum:
+///
+/// #include "velox/common/Enums.h"
+///
+/// enum class Foo {...};
+///
+/// VELOX_DEFINE_ENUM_NAME(Foo);
+///
+/// In the cpp file, define the mapping:
+///
+/// namespace {
+/// folly::F14FastMap<Foo, std::string> fooNames() {
+///   return {
+///       {Foo::kFirst, "FIRST"},
+///       {Foo::kSecond, "SECOND"},
+///        ...
+///   };
+/// }
+/// } // namespace
+///
+/// VELOX_DECLARE_ENUM_NAME(Foo, fooNames);
+///
+/// In the client code, use FooName::toName(Foo::kFirst) to get the name of the
+/// enum and FooName::toFoo("FIRST") to get the enum value.
+///
+/// Use _EMBEDDED_ versions of the macros to define enums embedded in other
+/// classes.
+
+#define VELOX_DECLARE_ENUM_NAME(EnumType)                \
+  struct EnumType##Name {                                \
+    static std::string_view toName(EnumType value);      \
+    static EnumType to##EnumType(std::string_view name); \
+  };
+
+#define VELOX_DEFINE_ENUM_NAME(EnumType, Names)                             \
+  std::string_view EnumType##Name::toName(EnumType value) {                 \
+    static const auto kNames = Names();                                     \
+    auto it = kNames.find(value);                                           \
+    VELOX_CHECK(                                                            \
+        it != kNames.end(),                                                 \
+        "Invalid enum value: {}",                                           \
+        static_cast<int>(value));                                           \
+    return it->second.c_str();                                              \
+  }                                                                         \
+                                                                            \
+  EnumType EnumType##Name::to##EnumType(std::string_view name) {            \
+    static const auto kValues = facebook::velox::Enums::invertMap(Names()); \
+                                                                            \
+    auto it = kValues.find(name);                                           \
+    VELOX_CHECK(it != kValues.end(), "Invalid enum name: {}", name);        \
+    return it->second;                                                      \
+  }
+
+#define VELOX_DECLARE_EMBEDDED_ENUM_NAME(EnumType) \
+  static std::string_view toName(EnumType value);  \
+  static EnumType to##EnumType(std::string_view name);
+
+#define VELOX_DEFINE_EMBEDDED_ENUM_NAME(Class, EnumType, Names)             \
+  std::string_view Class::toName(Class::EnumType value) {                   \
+    static const auto kNames = Names();                                     \
+    auto it = kNames.find(value);                                           \
+    VELOX_CHECK(                                                            \
+        it != kNames.end(),                                                 \
+        "Invalid enum value: {}",                                           \
+        static_cast<int>(value));                                           \
+    return it->second.c_str();                                              \
+  }                                                                         \
+                                                                            \
+  Class::EnumType Class::to##EnumType(std::string_view name) {              \
+    static const auto kValues = facebook::velox::Enums::invertMap(Names()); \
+                                                                            \
+    auto it = kValues.find(name);                                           \
+    VELOX_CHECK(it != kValues.end(), "Invalid enum name: {}", name);        \
+    return it->second;                                                      \
+  }

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -149,8 +149,9 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
 
     std::string debugString() const {
       return fmt::format(
-          "aggregationStep:{} isSpillEnabled:{} isAggregationSpillEnabled:{} isDistinct:{} hasPreAggregation:{} expectedCanSpill:{}",
-          AggregationNode::stepName(aggregationStep),
+          "aggregationStep:{} isSpillEnabled:{} isAggregationSpillEnabled:{} "
+          "isDistinct:{} hasPreAggregation:{} expectedCanSpill:{}",
+          AggregationNode::toName(aggregationStep),
           isSpillEnabled,
           isAggregationSpillEnabled,
           isDistinct,

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -84,7 +84,7 @@ void HashAggregation::initialize() {
         "Unexpected result type for an aggregation: {}, expected {}, step {}",
         aggResultType->toString(),
         expectedType->toString(),
-        core::AggregationNode::stepName(aggregationNode_->step()));
+        core::AggregationNode::toName(aggregationNode_->step()));
   }
 
   for (auto i = 0; i < hashers.size(); ++i) {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -160,7 +160,7 @@ OperatorSupplier makeOperatorSupplier(
         VELOX_UNSUPPORTED(
             "Hash join currently does not support mixed grouped execution for join "
             "type {}",
-            core::joinTypeName(join->joinType()));
+            core::JoinTypeName::toName(join->joinType()));
       }
       return std::make_unique<HashBuild>(operatorId, ctx, join);
     };

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -55,9 +55,9 @@ MergeJoin::MergeJoin(
       rightNodeId_{joinNode->sources()[1]->id()},
       joinNode_(joinNode) {
   VELOX_USER_CHECK(
-      core::MergeJoinNode::isSupported(joinNode_->joinType()),
-      "The join type is not supported by merge join: ",
-      joinTypeName(joinNode_->joinType()));
+      core::MergeJoinNode::isSupported(joinType_),
+      "The join type is not supported by merge join: {}",
+      core::JoinTypeName::toName(joinType_));
 }
 
 void MergeJoin::initialize() {

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -471,8 +471,6 @@ bool OutputBuffer::enqueue(
         enqueuePartitionedOutputLocked(
             destination, std::move(data), dataAvailableCallbacks);
         break;
-      default:
-        VELOX_UNREACHABLE(PartitionedOutputNode::kindString(kind_));
     }
 
     if (bufferedBytes_ >= maxSize_ && future) {

--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -151,12 +151,12 @@ std::string WindowFuzzer::frameClauseString(
     const std::vector<std::string>& kRangeOffsetColumns) {
   auto frameType = [&](const core::WindowNode::BoundType boundType,
                        bool isStartBound) -> std::string {
-    const auto boundTypeString = core::WindowNode::boundTypeName(boundType);
+    const auto boundTypeString = core::WindowNode::toName(boundType);
     switch (boundType) {
       case core::WindowNode::BoundType::kUnboundedPreceding:
       case core::WindowNode::BoundType::kCurrentRow:
       case core::WindowNode::BoundType::kUnboundedFollowing:
-        return boundTypeString;
+        return std::string(boundTypeString);
       case core::WindowNode::BoundType::kPreceding:
       case core::WindowNode::BoundType::kFollowing: {
         std::string frameBound;
@@ -177,7 +177,7 @@ std::string WindowFuzzer::frameClauseString(
 
   return fmt::format(
       " {} BETWEEN {} AND {}",
-      core::WindowNode::windowTypeName(frameMetadata.windowType),
+      core::WindowNode::toName(frameMetadata.windowType),
       frameType(frameMetadata.startBoundType, true),
       frameType(frameMetadata.endBoundType, false));
 }
@@ -218,7 +218,7 @@ const T WindowFuzzer::genOffsetAtIdx(
       "Offset cannot be generated: orderBy key type: {}, sortOrder ascending {}, frameBoundType {}",
       CppToType<T>::name,
       sortOrder.toString(),
-      core::WindowNode::boundTypeName(frameBoundType));
+      core::WindowNode::toName(frameBoundType));
   return T{};
 }
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -341,7 +341,7 @@ TEST_F(GroupedExecutionTest, hashJoinWithMixedGroupedExecution) {
       return fmt::format(
           "mode {}, joinType {}, supported {}",
           modeToString(mode),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           supported);
     }
   };
@@ -449,7 +449,7 @@ TEST_F(GroupedExecutionTest, hashJoinWithMixedGroupedExecution) {
             task->start(3, 1),
             fmt::format(
                 "Hash join currently does not support mixed grouped execution for join type {}",
-                core::joinTypeName(testData.joinType)));
+                core::JoinTypeName::toName(testData.joinType)));
         continue;
       }
 

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -707,7 +707,7 @@ TEST(HashJoinBridgeTest, hashJoinTableSpillType) {
     std::string debugString() const {
       return fmt::format(
           "joinType: {}, expectedTableSpillType: {}",
-          joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           expectedTableSpillType->toString());
     }
   } testSettings[] = {

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -386,7 +386,7 @@ TEST_P(IndexLookupJoinTest, equalJoin) {
           matchPct,
           folly::join(",", scanOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {
@@ -790,7 +790,7 @@ TEST_P(IndexLookupJoinTest, betweenJoinCondition) {
           betweenMatchPct,
           folly::join(",", lookupOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {// Inner join.
@@ -1247,7 +1247,7 @@ TEST_P(IndexLookupJoinTest, inJoinCondition) {
           inMatchPct,
           folly::join(",", lookupOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {
@@ -1572,7 +1572,7 @@ TEST_P(IndexLookupJoinTest, prefixKeysEqualJoin) {
           numKeysToUse,
           folly::join(",", scanOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {
@@ -1710,7 +1710,7 @@ TEST_P(IndexLookupJoinTest, prefixKeysbetweenJoinCondition) {
           betweenMatchPct,
           folly::join(",", lookupOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {
@@ -1831,7 +1831,7 @@ TEST_P(IndexLookupJoinTest, prefixInJoinCondition) {
           inMatchPct,
           folly::join(",", lookupOutputColumns),
           folly::join(",", outputColumns),
-          core::joinTypeName(joinType),
+          core::JoinTypeName::toName(joinType),
           duckDbVerifySql);
     }
   } testSettings[] = {

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -873,7 +873,7 @@ TEST_F(MergeJoinTest, lazyVectors) {
         .assertResults(fmt::format(
             "SELECT c0, rc0, c1, rc1, c2, c3 FROM t {} JOIN u "
             "ON t.c0 = u.rc0 AND c1 + rc1 < 30",
-            joinTypeName(joinType)));
+            core::JoinTypeName::toName(joinType)));
   }
 }
 

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -102,7 +102,7 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
         SCOPED_TRACE(fmt::format(
             "maxDrivers:{} joinType:{} comparison:{}",
             std::to_string(numDrivers),
-            joinTypeName(joinType),
+            core::JoinTypeName::toName(joinType),
             comparison));
 
         params.planNode =
@@ -122,7 +122,9 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
         assertQuery(
             params,
             fmt::format(
-                fmt::runtime(queryStr_), joinTypeName(joinType), comparison));
+                fmt::runtime(queryStr_),
+                core::JoinTypeName::toName(joinType),
+                comparison));
       }
     }
   }
@@ -376,7 +378,7 @@ TEST_F(NestedLoopJoinTest, outerJoinWithoutCondition) {
         op,
         fmt::format(
             "SELECT count(*) FROM t {} join u on 1",
-            core::joinTypeName(joinType)));
+            core::JoinTypeName::toName(joinType)));
   };
   testOuterJoin(core::JoinType::kLeft);
   testOuterJoin(core::JoinType::kRight);

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -570,21 +570,18 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 
 TEST_F(OutputBufferManagerTest, outputType) {
   ASSERT_EQ(
-      PartitionedOutputNode::kindString(
-          PartitionedOutputNode::Kind::kPartitioned),
+      PartitionedOutputNode::toName(PartitionedOutputNode::Kind::kPartitioned),
       "PARTITIONED");
   ASSERT_EQ(
-      PartitionedOutputNode::kindString(
-          PartitionedOutputNode::Kind::kArbitrary),
+      PartitionedOutputNode::toName(PartitionedOutputNode::Kind::kArbitrary),
       "ARBITRARY");
   ASSERT_EQ(
-      PartitionedOutputNode::kindString(
-          PartitionedOutputNode::Kind::kBroadcast),
+      PartitionedOutputNode::toName(PartitionedOutputNode::Kind::kBroadcast),
       "BROADCAST");
   VELOX_ASSERT_THROW(
-      PartitionedOutputNode::kindString(
+      PartitionedOutputNode::toName(
           static_cast<PartitionedOutputNode::Kind>(100)),
-      "Invalid Output Kind 100");
+      "Invalid enum value: 100");
 }
 
 TEST_P(OutputBufferManagerWithDifferentSerdeKindsTest, destinationBuffer) {

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -115,7 +115,7 @@ struct TestParam {
         poolSize,
         compressionKindToString(compressionKind),
         std::to_string(enablePrefixSort),
-        joinTypeName(joinType));
+        core::JoinTypeName::toName(joinType));
   }
 };
 

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -945,7 +945,8 @@ class HashJoinTestBase : public HiveConnectorTestBase {
       case core::JoinType::kRightSemiProject:
         return core::JoinType::kLeftSemiProject;
       default:
-        VELOX_FAIL("Cannot flip join type: {}", core::joinTypeName(joinType));
+        VELOX_FAIL(
+            "Cannot flip join type: {}", core::JoinTypeName::toName(joinType));
     }
   }
 

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -952,7 +952,8 @@ class HashJoinTest : public HiveConnectorTestBase {
       case core::JoinType::kRightSemiProject:
         return core::JoinType::kLeftSemiProject;
       default:
-        VELOX_FAIL("Cannot flip join type: {}", core::joinTypeName(joinType));
+        VELOX_FAIL(
+            "Cannot flip join type: {}", core::JoinTypeName::toName(joinType));
     }
   }
 


### PR DESCRIPTION
Summary:
In the header file, declare the enum class and a XxxName struct:

```
enum class Foo {...};

struct FooName {
  static std::string_view toName(Foo foo);
  static Foo toFoo(std::string_view name);
};
```

In the .cpp file, implement XxxName's methods:

```
#include "velox/common/Enums.h"

namespace {
folly::F14FastMap<Foo, std::string> fooNames() {
  return {
      {Foo::kFirst, "FIRST"},
      {Foo::kSecond, "SECOND"},
       ...
  };
}
} // namespace

// static
std::string_view FooName::toName(Foo foo) {
  static const auto kNames = fooNames();
  auto it = kNames.find(foo);
  VELOX_CHECK(
      it != kNames.end(),
      "Invalid enum value: {}",
      static_cast<int>(foo));
  return it->second.c_str();
}

// static
Foo FooName::toFoo(std::string_view name) {
  static const auto kEnums = Enums::invertMap(fooNames());

  auto it = kEnums.find(name);
  VELOX_CHECK(it != kEnums.end(), "Invalid enum name: {}", name);
  return it->second;
}
```

To reduce boiler plate code required to implement this pattern, introduce helper macros.

.h

```
#include "velox/common/Enums.h"

enum class Foo {...};

VELOX_DEFINE_ENUM_NAME(Foo);
```

.cpp

```
namespace {
folly::F14FastMap<Foo, std::string> fooNames() {
  return {
      {Foo::kFirst, "FIRST"},
      {Foo::kSecond, "SECOND"},
       ...
  };
}
} // namespace

VELOX_DECLARE_ENUM_NAME(Foo, fooNames);
```

Migrate all enums in PlanNode.h to the new pattern.

Differential Revision: D77654609
