### PR TITLE
fix: Spark covar_samp aggregate function result

### DIFF
--- a/velox/functions/sparksql/aggregates/CovarianceAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CovarianceAggregate.cpp
@@ -40,6 +40,9 @@ struct CovarSampResultAccessor {
           "NaN is returned only when m2 is 0 and nullOnDivideByZero is false.");
       return std::numeric_limits<double>::quiet_NaN();
     }
+    if (FOLLY_UNLIKELY(std::isinf(accumulator.c2()))) {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
     return accumulator.c2() / (accumulator.count() - 1);
   }
 };

--- a/velox/functions/sparksql/aggregates/tests/CovarianceAggregatesTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CovarianceAggregatesTest.cpp
@@ -154,6 +154,15 @@ TEST_F(CovarianceAggregatesTest, covarSamp) {
   expected = makeRowVector({makeFlatVector<double>(
       std::vector<double>{std::numeric_limits<double>::quiet_NaN()})});
   testCovarianceAggResult(agg, input, expected, true);
+
+  // Output NaN when c2 is ±inf.
+  input = makeRowVector(
+      {makeFlatVector<double>({22, std::numeric_limits<double>::infinity()}),
+       makeFlatVector<double>({0.688, 0.225})});
+  expected = makeRowVector({makeFlatVector<double>(
+      std::vector<double>{std::numeric_limits<double>::quiet_NaN()})});
+  testCovarianceAggResult(agg, input, expected);
+  testCovarianceAggResult(agg, input, expected, true);
 }
 
 } // namespace

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -81,9 +81,7 @@ int main(int argc, char** argv) {
       "first_ignore_null",
       "last_ignore_null",
       "regr_replacement",
-      // TODO: Fix the incorrect result.
-      "corr",
-      "covar_samp"};
+      "corr"};
 
   using facebook::velox::exec::test::TransformResultVerifier;
 


### PR DESCRIPTION
Fixes the below result issue discovered by fuzzer test. When c2 is Inf,
covar_samp function used to return Inf, but Spark expects NaN.


```
1 extra rows, 1 missing rows
1 of extra rows:
	null | null | "-Infinity"

1 of missing rows:
	null | null | "NaN"

SELECT g0, g1, covar_samp(c0, c1) as a0 FROM (SELECT c0 as c0, c1 as c1, g0 as g0, g1 as g1 FROM (t_0)) GROUP BY g0, g1

```