### PR TITLE
fix: Fix parsing EXTRA_CMAKE_FLAGS in CI

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -203,7 +203,7 @@ jobs:
 
       - name: Build
         env:
-          EXTRA_CMAKE_FLAGS: >
+          EXTRA_CMAKE_FLAGS: |
             -DVELOX_ENABLE_ARROW=ON \
             -DVELOX_MONO_LIBRARY=ON \
             -DVELOX_BUILD_PYTHON_PACKAGE=ON \


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/13991

Parsing the EXTRA_CMAKE_FLAGS on the same line would cause the second and following variables be lost. This PR fixes it by keeping the newlines.

Before this change:
```
2025-07-02T08:37:26.9521595Z cmake  -B \
2025-07-02T08:37:26.9521807Z 	"_build/debug" \
2025-07-02T08:37:26.9522471Z 	-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DVELOX_BUILD_MINIMAL="OFF" -DVELOX_BUILD_TESTING="ON" -DCMAKE_BUILD_TYPE=Debug \
2025-07-02T08:37:26.9523315Z 	-GNinja -DMAX_LINK_JOBS=4 -DMAX_HIGH_MEM_JOBS=8 -DVELOX_FORCE_COLORED_OUTPUT=ON \
2025-07-02T08:37:26.9524177Z 	-DVELOX_ENABLE_ARROW=ON \ -DVELOX_ENABLE_GEO=ON \ -DVELOX_MONO_LIBRARY=ON \ -DVELOX_BUILD_PYTHON_PACKAGE=ON \ -DVELOX_PYTHON_LEGACY_ONLY=ON \ 
2025-07-02T08:37:27.0111776Z CMake Warning:
2025-07-02T08:37:27.0112088Z   Ignoring extra path from command line:
2025-07-02T08:37:27.0112337Z 
2025-07-02T08:37:27.0112425Z    " "

```
After this change:

```
2025-07-02T14:00:23.7871492Z cmake  -B \
2025-07-02T14:00:23.7871676Z 	"_build/debug" \
2025-07-02T14:00:23.7872220Z 	-DTREAT_WARNINGS_AS_ERRORS=1 -DENABLE_ALL_WARNINGS=1 -DVELOX_BUILD_MINIMAL="OFF" -DVELOX_BUILD_TESTING="ON" -DCMAKE_BUILD_TYPE=Debug \
2025-07-02T14:00:23.7872968Z 	-GNinja -DMAX_LINK_JOBS=4 -DMAX_HIGH_MEM_JOBS=8 -DVELOX_FORCE_COLORED_OUTPUT=ON \
2025-07-02T14:00:23.7873397Z 	-DVELOX_ENABLE_ARROW=ON \
2025-07-02T14:00:23.7873619Z -DVELOX_ENABLE_GEO=OFF \
2025-07-02T14:00:23.7873841Z -DVELOX_MONO_LIBRARY=ON \
2025-07-02T14:00:23.7874069Z -DVELOX_BUILD_PYTHON_PACKAGE=ON \
2025-07-02T14:00:23.7874326Z -DVELOX_PYTHON_LEGACY_ONLY=ON \
```