### PR TITLE
fix: Respect Greek final sigma rule in Spark lower function

### DIFF
--- a/velox/functions/lib/UpperLower.h
+++ b/velox/functions/lib/UpperLower.h
@@ -24,9 +24,9 @@ namespace facebook::velox::functions {
 /// Function to convert string to upper or lower case. Ascii and unicode
 /// conversion are supported.
 /// @tparam isLower Instantiate for upper or lower.
-/// @tparam forSpark When true, Spark's specific behavior is considered, e.g.
-/// for 'İ' Spark's lower case is 'i̇' and Presto's is 'i'.
-template <bool isLower, bool forSpark>
+/// @tparam turkishCasing When true, Spark's specific behavior on Turkish casing
+/// is considered. For 'İ' Spark's lower case is 'i̇' and Presto's is 'i'.
+template <bool isLower, bool turkishCasing>
 class UpperLowerTemplateFunction : public exec::VectorFunction {
  private:
   // String encoding wrappable function.
@@ -39,10 +39,10 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
       rows.applyToSelected([&](auto row) {
         auto proxy = exec::StringWriter(results, row);
         if constexpr (isLower) {
-          stringImpl::lower<isAscii, forSpark>(
+          stringImpl::lower<isAscii, turkishCasing>(
               proxy, decodedInput->valueAt<StringView>(row));
         } else {
-          stringImpl::upper<isAscii, forSpark>(
+          stringImpl::upper<isAscii, turkishCasing>(
               proxy, decodedInput->valueAt<StringView>(row));
         }
         proxy.finalize();

--- a/velox/functions/lib/UpperLower.h
+++ b/velox/functions/lib/UpperLower.h
@@ -24,9 +24,12 @@ namespace facebook::velox::functions {
 /// Function to convert string to upper or lower case. Ascii and unicode
 /// conversion are supported.
 /// @tparam isLower Instantiate for upper or lower.
-/// @tparam turkishCasing When true, Spark's specific behavior on Turkish casing
+/// @tparam turkishCasing If true, Spark's specific behavior on Turkish casing
 /// is considered. For 'İ' Spark's lower case is 'i̇' and Presto's is 'i'.
-template <bool isLower, bool turkishCasing>
+/// @tparam greekFinalSigma If true, Greek final sigma rule is applied. For
+/// the uppercase letter Σ, if it appears at the end of a word, it becomes ς. In
+/// all other positions, it becomes σ. If false, it is always converted to σ.
+template <bool isLower, bool turkishCasing, bool greekFinalSigma>
 class UpperLowerTemplateFunction : public exec::VectorFunction {
  private:
   // String encoding wrappable function.
@@ -39,7 +42,7 @@ class UpperLowerTemplateFunction : public exec::VectorFunction {
       rows.applyToSelected([&](auto row) {
         auto proxy = exec::StringWriter(results, row);
         if constexpr (isLower) {
-          stringImpl::lower<isAscii, turkishCasing>(
+          stringImpl::lower<isAscii, turkishCasing, greekFinalSigma>(
               proxy, decodedInput->valueAt<StringView>(row));
         } else {
           stringImpl::upper<isAscii, turkishCasing>(

--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -43,6 +43,30 @@
 #endif
 
 namespace facebook::velox::functions {
+namespace detail {
+
+// Helper function to check if a character is cased. Compatible with the
+// 'isCased' implementation in 'ConditionalSpecialCasting.java' of JDK, which is
+// used by 'toLowerCase' function in Spark SQL.
+FOLLY_ALWAYS_INLINE bool isCased(utf8proc_int32_t ch) {
+  auto type = utf8proc_category(ch);
+  // Lowercase letter, uppercase letter or titlecase letter.
+  if (type == UTF8PROC_CATEGORY_LL || type == UTF8PROC_CATEGORY_LU ||
+      type == UTF8PROC_CATEGORY_LT) {
+    return true;
+  }
+  // Modifier letters and special cases.
+  if ((ch >= 0x02B0 && ch <= 0x02B8) || (ch >= 0x02C0 && ch <= 0x02C1) ||
+      (ch >= 0x02E0 && ch <= 0x02E4) || ch == 0x0345 || ch == 0x037A ||
+      (ch >= 0x1D2C && ch <= 0x1D61) || (ch >= 0x2160 && ch <= 0x217F) ||
+      (ch >= 0x24B6 && ch <= 0x24E9)) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace detail
+
 namespace stringCore {
 
 /// Check if a given string is ascii
@@ -172,8 +196,13 @@ FOLLY_ALWAYS_INLINE size_t upperUnicode(
 /// Perform lower for utf8 string input, output should be pre-allocated and
 /// large enough for the results outputLength refers to the number of bytes
 /// available in the output buffer, and inputLength is the number of bytes in
-/// the input string
-template <bool turkishCasing>
+/// the input string.
+/// @tparam turkishCasing If true, Spark's specific behavior on Turkish casing
+/// is considered. For 'İ' Spark's lower case is 'i̇' and Presto's is 'i'.
+/// @tparam greekFinalSigma If true, Greek final sigma rule is applied. For the
+/// uppercase letter Σ, if it appears at the end of a word, it becomes ς. In all
+/// other positions, it becomes σ. If false, it is always converted to σ.
+template <bool turkishCasing, bool greekFinalSigma>
 FOLLY_ALWAYS_INLINE size_t lowerUnicode(
     char* output,
     size_t outputLength,
@@ -204,6 +233,29 @@ FOLLY_ALWAYS_INLINE size_t lowerUnicode(
         output[outputIdx++] = 0x69;
         output[outputIdx++] = 0xCC;
         output[outputIdx++] = 0x87;
+        continue;
+      }
+    }
+
+    if constexpr (greekFinalSigma) {
+      // Handle Greek final sigma for Σ (U+03A3).
+      if (nextCodePoint == 0x03A3) {
+        // Look ahead to see if this is the end of a word.
+        bool isFinal = true;
+        if (inputIdx < inputLength) {
+          int lookaheadSize;
+          utf8proc_int32_t lookaheadCodePoint = utf8proc_codepoint(
+              &input[inputIdx], input + inputLength, lookaheadSize);
+          if (lookaheadCodePoint != -1 && detail::isCased(lookaheadCodePoint)) {
+            // If the next code point is cased, not the final.
+            isFinal = false;
+          }
+        }
+        // Convert to ς or σ.
+        utf8proc_int32_t lowerSigma = isFinal ? 0x03C2 : 0x03C3;
+        auto newSize = utf8proc_encode_char(
+            lowerSigma, reinterpret_cast<unsigned char*>(&output[outputIdx]));
+        outputIdx += newSize;
         continue;
       }
     }

--- a/velox/functions/lib/string/StringCore.h
+++ b/velox/functions/lib/string/StringCore.h
@@ -173,7 +173,7 @@ FOLLY_ALWAYS_INLINE size_t upperUnicode(
 /// large enough for the results outputLength refers to the number of bytes
 /// available in the output buffer, and inputLength is the number of bytes in
 /// the input string
-template <bool forSpark>
+template <bool turkishCasing>
 FOLLY_ALWAYS_INLINE size_t lowerUnicode(
     char* output,
     size_t outputLength,
@@ -197,7 +197,7 @@ FOLLY_ALWAYS_INLINE size_t lowerUnicode(
 
     inputIdx += size;
 
-    if constexpr (forSpark) {
+    if constexpr (turkishCasing) {
       // Handle Turkish-specific case for İ (U+0130).
       if (UNLIKELY(nextCodePoint == 0x0130)) {
         // Map to i̇ (U+0069 U+0307).

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -58,6 +58,7 @@ FOLLY_ALWAYS_INLINE bool upper(TOutString& output, const TInString& input) {
 template <
     bool ascii,
     bool turkishCasing = false,
+    bool greekFinalSigma = false,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
@@ -66,7 +67,7 @@ FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
     lowerAscii(output.data(), input.data(), input.size());
   } else {
     output.resize(input.size() * 4);
-    auto size = lowerUnicode<turkishCasing>(
+    auto size = lowerUnicode<turkishCasing, greekFinalSigma>(
         output.data(), output.size(), input.data(), input.size());
     output.resize(size);
   }
@@ -736,6 +737,7 @@ FOLLY_ALWAYS_INLINE void initcapAsciiImpl(
 template <
     bool strictSpace,
     bool turkishCasing,
+    bool greekFinalSigma,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool initcapUtf8Impl(
@@ -774,7 +776,7 @@ FOLLY_ALWAYS_INLINE bool initcapUtf8Impl(
       outputBytes += upperSize;
       isStartOfWord = false;
     } else {
-      auto lowerSize = lowerUnicode<turkishCasing>(
+      auto lowerSize = lowerUnicode<turkishCasing, greekFinalSigma>(
           outputBytes,
           static_cast<size_t>(outputStart + output.size() - outputBytes),
           inputBytes,
@@ -801,6 +803,7 @@ template <
     bool strictSpace,
     bool isAscii,
     bool turkishCasing,
+    bool greekFinalSigma,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool initcap(TOutString& output, const TInString& input) {
@@ -808,7 +811,8 @@ FOLLY_ALWAYS_INLINE bool initcap(TOutString& output, const TInString& input) {
     detail::initcapAsciiImpl<strictSpace>(output, input);
     return true;
   } else {
-    return detail::initcapUtf8Impl<strictSpace, turkishCasing>(output, input);
+    return detail::initcapUtf8Impl<strictSpace, turkishCasing, greekFinalSigma>(
+        output, input);
   }
 }
 

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -38,7 +38,7 @@ using namespace stringCore;
 /// Perform upper for a UTF8 string
 template <
     bool ascii,
-    bool forSpark = false,
+    bool turkishCasing = false,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool upper(TOutString& output, const TInString& input) {
@@ -57,7 +57,7 @@ FOLLY_ALWAYS_INLINE bool upper(TOutString& output, const TInString& input) {
 /// Perform lower for a UTF8 string
 template <
     bool ascii,
-    bool forSpark = false,
+    bool turkishCasing = false,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
@@ -66,7 +66,7 @@ FOLLY_ALWAYS_INLINE bool lower(TOutString& output, const TInString& input) {
     lowerAscii(output.data(), input.data(), input.size());
   } else {
     output.resize(input.size() * 4);
-    auto size = lowerUnicode<forSpark>(
+    auto size = lowerUnicode<turkishCasing>(
         output.data(), output.size(), input.data(), input.size());
     output.resize(size);
   }
@@ -733,7 +733,11 @@ FOLLY_ALWAYS_INLINE void initcapAsciiImpl(
   }
 }
 
-template <bool strictSpace, typename TOutString, typename TInString>
+template <
+    bool strictSpace,
+    bool turkishCasing,
+    typename TOutString,
+    typename TInString>
 FOLLY_ALWAYS_INLINE bool initcapUtf8Impl(
     TOutString& output,
     const TInString& input) {
@@ -770,7 +774,7 @@ FOLLY_ALWAYS_INLINE bool initcapUtf8Impl(
       outputBytes += upperSize;
       isStartOfWord = false;
     } else {
-      auto lowerSize = lowerUnicode<strictSpace>(
+      auto lowerSize = lowerUnicode<turkishCasing>(
           outputBytes,
           static_cast<size_t>(outputStart + output.size() - outputBytes),
           inputBytes,
@@ -786,9 +790,17 @@ FOLLY_ALWAYS_INLINE bool initcapUtf8Impl(
 
 } // namespace detail
 
+/// Converts the first character of each word to uppercase and all other
+/// characters in the word to lowercase. Words are separated by whitespace.
+/// @tparam strictSpace If true, only ASCII space is considered as word
+/// separators. If false, other ASCII or Unicode whitespace characters are also
+/// considered as word separators.
+/// @tparam turkishCasing If true, handles special Turkish case during
+/// the unicode lower-casing.
 template <
     bool strictSpace,
     bool isAscii,
+    bool turkishCasing,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE bool initcap(TOutString& output, const TInString& input) {
@@ -796,7 +808,7 @@ FOLLY_ALWAYS_INLINE bool initcap(TOutString& output, const TInString& input) {
     detail::initcapAsciiImpl<strictSpace>(output, input);
     return true;
   } else {
-    return detail::initcapUtf8Impl<strictSpace>(output, input);
+    return detail::initcapUtf8Impl<strictSpace, turkishCasing>(output, input);
   }
 }
 

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -991,7 +991,8 @@ TEST_F(StringImplTest, isAscii) {
 TEST_F(StringImplTest, initcapUnicodePresto) {
   for (const auto& [input, expected] : getInitcapUnicodePrestoTestData()) {
     std::string output;
-    initcap<false, false>(output, input);
+    initcap</*strictSpace=*/false, /*isAscii=*/false, /*turkishCasing=*/false>(
+        output, input);
     ASSERT_EQ(output, expected);
   }
 }
@@ -999,14 +1000,16 @@ TEST_F(StringImplTest, initcapUnicodePresto) {
 TEST_F(StringImplTest, initcapAsciiPresto) {
   for (const auto& [input, expected] : getInitcapAsciiPrestoTestData()) {
     std::string output;
-    initcap<false, true>(output, input);
+    initcap</*strictSpace=*/false, /*isAscii=*/true, /*turkishCasing=*/false>(
+        output, input);
     ASSERT_EQ(output, expected);
   }
 }
 TEST_F(StringImplTest, initcapUnicodeSpark) {
   for (const auto& [input, expected] : getInitcapUnicodeSparkTestData()) {
     std::string output;
-    initcap<true, false>(output, input);
+    initcap</*strictSpace=*/true, /*isAscii=*/false, /*turkishCasing=*/true>(
+        output, input);
     ASSERT_EQ(output, expected);
   }
 }
@@ -1014,7 +1017,8 @@ TEST_F(StringImplTest, initcapUnicodeSpark) {
 TEST_F(StringImplTest, initcapAsciiSpark) {
   for (const auto& [input, expected] : getInitcapAsciiSparkTestData()) {
     std::string output;
-    initcap<true, true>(output, input);
+    initcap</*strictSpace=*/true, /*isAscii=*/true, /*turkishCasing=*/true>(
+        output, input);
     ASSERT_EQ(output, expected);
   }
 }

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -68,6 +68,8 @@ class StringImplTest : public testing::Test {
         {"\u1E87", "\u1E86"},
         {"\u1E8B", "\u1E8A"},
         {"\u1E8F", "\u1E8E"},
+        {"πας", "ΠΑΣ"},
+        {"παςa", "ΠΑΣA"},
     };
   }
 
@@ -109,7 +111,10 @@ class StringImplTest : public testing::Test {
         {"\u1E6A", "\u1E6B"},
         {"\u1E86", "\u1E87"},
         {"\u1E8A", "\u1E8B"},
-        {"\u1E8E", "\u1E8F"}};
+        {"\u1E8E", "\u1E8F"},
+        {"ΠΑΣ", "πασ"},
+        {"ΠΑΣA", "πασa"},
+    };
   }
 
   static std::vector<std::pair<std::string, std::string>>
@@ -991,8 +996,11 @@ TEST_F(StringImplTest, isAscii) {
 TEST_F(StringImplTest, initcapUnicodePresto) {
   for (const auto& [input, expected] : getInitcapUnicodePrestoTestData()) {
     std::string output;
-    initcap</*strictSpace=*/false, /*isAscii=*/false, /*turkishCasing=*/false>(
-        output, input);
+    initcap<
+        /*strictSpace=*/false,
+        /*isAscii=*/false,
+        /*turkishCasing=*/false,
+        /*greekFinalSigma=*/false>(output, input);
     ASSERT_EQ(output, expected);
   }
 }
@@ -1000,16 +1008,22 @@ TEST_F(StringImplTest, initcapUnicodePresto) {
 TEST_F(StringImplTest, initcapAsciiPresto) {
   for (const auto& [input, expected] : getInitcapAsciiPrestoTestData()) {
     std::string output;
-    initcap</*strictSpace=*/false, /*isAscii=*/true, /*turkishCasing=*/false>(
-        output, input);
+    initcap<
+        /*strictSpace=*/false,
+        /*isAscii=*/true,
+        /*turkishCasing=*/false,
+        /*greekFinalSigma=*/false>(output, input);
     ASSERT_EQ(output, expected);
   }
 }
 TEST_F(StringImplTest, initcapUnicodeSpark) {
   for (const auto& [input, expected] : getInitcapUnicodeSparkTestData()) {
     std::string output;
-    initcap</*strictSpace=*/true, /*isAscii=*/false, /*turkishCasing=*/true>(
-        output, input);
+    initcap<
+        /*strictSpace=*/true,
+        /*isAscii=*/false,
+        /*turkishCasing=*/true,
+        /*greekFinalSigma=*/true>(output, input);
     ASSERT_EQ(output, expected);
   }
 }
@@ -1017,8 +1031,11 @@ TEST_F(StringImplTest, initcapUnicodeSpark) {
 TEST_F(StringImplTest, initcapAsciiSpark) {
   for (const auto& [input, expected] : getInitcapAsciiSparkTestData()) {
     std::string output;
-    initcap</*strictSpace=*/true, /*isAscii=*/true, /*turkishCasing=*/true>(
-        output, input);
+    initcap<
+        /*strictSpace=*/true,
+        /*isAscii=*/true,
+        /*turkishCasing=*/true,
+        /*greekFinalSigma=*/true>(output, input);
     ASSERT_EQ(output, expected);
   }
 }

--- a/velox/functions/prestosql/UpperLower.cpp
+++ b/velox/functions/prestosql/UpperLower.cpp
@@ -19,9 +19,9 @@
 namespace facebook::velox::functions {
 
 using PrestoUpperFunction =
-    UpperLowerTemplateFunction</*isLower=*/false, /*forSpark=*/false>;
+    UpperLowerTemplateFunction</*isLower=*/false, /*turkishCasing=*/false>;
 using PrestoLowerFunction =
-    UpperLowerTemplateFunction</*isLower=*/true, /*forSpark=*/false>;
+    UpperLowerTemplateFunction</*isLower=*/true, /*turkishCasing=*/false>;
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_upper,

--- a/velox/functions/prestosql/UpperLower.cpp
+++ b/velox/functions/prestosql/UpperLower.cpp
@@ -18,10 +18,14 @@
 
 namespace facebook::velox::functions {
 
-using PrestoUpperFunction =
-    UpperLowerTemplateFunction</*isLower=*/false, /*turkishCasing=*/false>;
-using PrestoLowerFunction =
-    UpperLowerTemplateFunction</*isLower=*/true, /*turkishCasing=*/false>;
+using PrestoUpperFunction = UpperLowerTemplateFunction<
+    /*isLower=*/false,
+    /*turkishCasing=*/false,
+    /*greekFinalSigma=*/false>;
+using PrestoLowerFunction = UpperLowerTemplateFunction<
+    /*isLower=*/true,
+    /*turkishCasing=*/false,
+    /*greekFinalSigma=*/false>;
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_upper,

--- a/velox/functions/sparksql/InitcapFunction.h
+++ b/velox/functions/sparksql/InitcapFunction.h
@@ -33,13 +33,19 @@ struct InitCapFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input) {
-    stringImpl::initcap<true, false>(result, input);
+    stringImpl::initcap<
+        /*strictSpace=*/true,
+        /*isAscii=*/false,
+        /*turkishCasing=*/true>(result, input);
   }
 
   FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input) {
-    stringImpl::initcap<true, true>(result, input);
+    stringImpl::initcap<
+        /*strictSpace=*/true,
+        /*isAscii=*/true,
+        /*turkishCasing=*/true>(result, input);
   }
 };
 

--- a/velox/functions/sparksql/InitcapFunction.h
+++ b/velox/functions/sparksql/InitcapFunction.h
@@ -36,7 +36,8 @@ struct InitCapFunction {
     stringImpl::initcap<
         /*strictSpace=*/true,
         /*isAscii=*/false,
-        /*turkishCasing=*/true>(result, input);
+        /*turkishCasing=*/true,
+        /*greekFinalSigma=*/true>(result, input);
   }
 
   FOLLY_ALWAYS_INLINE void callAscii(
@@ -45,7 +46,8 @@ struct InitCapFunction {
     stringImpl::initcap<
         /*strictSpace=*/true,
         /*isAscii=*/true,
-        /*turkishCasing=*/true>(result, input);
+        /*turkishCasing=*/true,
+        /*greekFinalSigma=*/true>(result, input);
   }
 };
 

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -153,10 +153,14 @@ void registerStringFunctions(const std::string& prefix) {
       std::make_unique<ConcatWsCallToSpecialForm>());
   registerFunction<LuhnCheckFunction, bool, Varchar>({prefix + "luhn_check"});
 
-  using SparkUpperFunction =
-      UpperLowerTemplateFunction</*isLower=*/false, /*turkishCasing=*/true>;
-  using SparkLowerFunction =
-      UpperLowerTemplateFunction</*isLower=*/true, /*turkishCasing=*/true>;
+  using SparkUpperFunction = UpperLowerTemplateFunction<
+      /*isLower=*/false,
+      /*turkishCasing=*/true,
+      /*greekFinalSigma=*/true>;
+  using SparkLowerFunction = UpperLowerTemplateFunction<
+      /*isLower=*/true,
+      /*turkishCasing=*/true,
+      /*greekFinalSigma=*/true>;
   exec::registerVectorFunction(
       prefix + "upper",
       SparkUpperFunction::signatures(),

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -154,9 +154,9 @@ void registerStringFunctions(const std::string& prefix) {
   registerFunction<LuhnCheckFunction, bool, Varchar>({prefix + "luhn_check"});
 
   using SparkUpperFunction =
-      UpperLowerTemplateFunction</*isLower=*/false, /*forSpark=*/true>;
+      UpperLowerTemplateFunction</*isLower=*/false, /*turkishCasing=*/true>;
   using SparkLowerFunction =
-      UpperLowerTemplateFunction</*isLower=*/true, /*forSpark=*/true>;
+      UpperLowerTemplateFunction</*isLower=*/true, /*turkishCasing=*/true>;
   exec::registerVectorFunction(
       prefix + "upper",
       SparkUpperFunction::signatures(),

--- a/velox/functions/sparksql/tests/UpperLowerTest.cpp
+++ b/velox/functions/sparksql/tests/UpperLowerTest.cpp
@@ -70,6 +70,21 @@ TEST_F(UpperLowerTest, lowerUnicode) {
   EXPECT_EQ("\u1E8F", lower("\u1E8E"));
 }
 
+TEST_F(UpperLowerTest, lowerGreek) {
+  EXPECT_EQ("πας", lower("ΠΑΣ"));
+  EXPECT_EQ("πας ", lower("ΠΑΣ "));
+  EXPECT_EQ("πασα", lower("ΠΑΣΑ"));
+  EXPECT_EQ("πας.", lower("ΠΑΣ."));
+  EXPECT_EQ("πας   a", lower("ΠΑΣ   A"));
+  EXPECT_EQ("πας`", lower("ΠΑΣ`"));
+  EXPECT_EQ("παςא", lower("ΠΑΣא"));
+  EXPECT_EQ("παςあ", lower("ΠΑΣあ"));
+  EXPECT_EQ("πασʰ", lower("ΠΑΣʰ"));
+  EXPECT_EQ("πασǆ", lower("ΠΑΣǅ"));
+  EXPECT_EQ("πασσ", lower("ΠΑΣσ"));
+  EXPECT_EQ("πασд", lower("ΠΑΣД"));
+}
+
 TEST_F(UpperLowerTest, upperAscii) {
   EXPECT_EQ("ABCDEFG", upper("abcdefg"));
   EXPECT_EQ("ABCDEFG", upper("ABCDEFG"));
@@ -108,6 +123,15 @@ TEST_F(UpperLowerTest, upperUnicode) {
   EXPECT_EQ("\u1E86", upper("\u1E87"));
   EXPECT_EQ("\u1E8A", upper("\u1E8B"));
   EXPECT_EQ("\u1E8E", upper("\u1E8F"));
+}
+
+TEST_F(UpperLowerTest, upperGreek) {
+  EXPECT_EQ("ΠΑΣ", upper("πασ"));
+  EXPECT_EQ("ΠΑΣ ", upper("πασ "));
+  EXPECT_EQ("ΠΑΣA", upper("πασa"));
+  EXPECT_EQ("ΠΑΣ", upper("πας"));
+  EXPECT_EQ("ΠΑΣ ", upper("πας "));
+  EXPECT_EQ("ΠΑΣA", upper("παςa"));
 }
 
 } // namespace


### PR DESCRIPTION
Respects the Greek final sigma rule in Spark lower function. For the uppercase 
letter Σ, if it appears at the end of a word, it becomes ς. In all other 
positions, it becomes σ. If false, it is always converted to σ.

Renames the template parameter of lowerUnicode as `turkishCasing` and adds it 
in the `initcap`.

Fixes https://github.com/facebookincubator/velox/issues/14155.