### PR TITLE
fix: Check for null partitionFunctionSpec in PartitionedOutputNode constructor

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2590,6 +2590,10 @@ PartitionedOutputNode::PartitionedOutputNode(
     VELOX_USER_CHECK(
         keys_.empty(),
         "Non-empty partitioning keys require more than one partition");
+  } else {
+    VELOX_USER_CHECK_NOT_NULL(
+        partitionFunctionSpec_,
+        "Partition function spec must be specified when the number of destinations is more than 1.");
   }
   if (!isPartitioned()) {
     VELOX_USER_CHECK(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2668,6 +2668,7 @@ class PartitionedOutputNode : public PlanNode {
   }
 
   const PartitionFunctionSpec& partitionFunctionSpec() const {
+    VELOX_CHECK_NOT_NULL(partitionFunctionSpec_);
     return *partitionFunctionSpec_;
   }
 


### PR DESCRIPTION
Summary:
The PartitionedOutputNode allows the user to specify a null partitionFunctionSpec.  This leads to a crash in the constructor for PartitionedOutput which attempts to dereference the pointer when the number of destinations is more than 1.

This change addresses the crash by:
1) Adding a check in the PartitionedOutputNode that if the number of destinations is > 1, the partitionFunctionSpec is non-null.  This will fail early with an exception rather than a crash.
2) Adding a check where we dereference partitionFunctionSpec that it is non-null as an added layer of safety.

Differential Revision: D77670782


