### PR TITLE
fix: Missing joinType for probe phase in wave

### DIFF
--- a/velox/experimental/wave/exec/WavePlan.cpp
+++ b/velox/experimental/wave/exec/WavePlan.cpp
@@ -436,6 +436,7 @@ bool CompileState::tryPlanOperator(
     step->state = state;
     step->id = atoi(node->id().c_str());
     segments_.back().steps.push_back(step);
+    step->joinType = node->joinType();
     auto expand = makeStep<JoinExpand>();
     step->expand = expand;
     expand->nthWrap = wrapId_++;


### PR DESCRIPTION
`joinType` was not set in the `HashProbe` case of `CompileState::tryPlanOperator` with a result it always defaults to `kInner` in `JoinProbe::generateMain`.
