### PR TITLE
fix(typeparser): Handle presence of special characters in quoted string names

### DIFF
--- a/velox/type/parser/TypeParser.ll
+++ b/velox/type/parser/TypeParser.ll
@@ -34,7 +34,7 @@ Y   [Y|y]
 Z   [Z|z]
 
 WORD              ([[:alpha:][:alnum:]_]*)
-QUOTED_ID         (['"'][[:alnum:][:space:]_]*['"'])
+QUOTED_ID         (['"']([^"\n]|"")*['"'])
 NUMBER            ([[:digit:]]+)
 VARIABLE          (VARCHAR|VARBINARY)
 

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -297,6 +297,11 @@ TEST_F(TypeParserTest, typesWithSpaces) {
           {"timestamp with time zone", "double"},
           {TIMESTAMP_WITH_TIME_ZONE(), DOUBLE()}));
 
+  // quoted filed name with special characters & spaces
+  ASSERT_EQ(
+      *parseType("row(\"Nested Some more weirdtt +- \\:\\: charact\" varchar)"),
+      *ROW({"Nested Some more weirdtt +- \\:\\: charact"}, {VARCHAR()}));
+
   // quoted field name with invalid type with spaces.
   VELOX_ASSERT_UNSUPPORTED_THROW(
       parseType(


### PR DESCRIPTION
### Summary:
Fixes an issue in the type parser where special characters in quoted string names were not handled correctly.
### Details:
- Modified FLEX lexer rules to accommodate special characters within quoted strings.
### Testing:
- Added test cases for strings with special characters.
- Verified that all existing and new tests pass.
### Impact:
- No impact on other functionalities.