### PR TITLE
docs: Update Spark function documents

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -1,6 +1,6 @@
-=============================
+===============
 Array Functions
-=============================
+===============
 
 .. spark:function:: aggregate(array(E), start, merge, finish) -> array(E)
 

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -16,16 +16,6 @@ Binary Functions
     Computes the hash of one or more input values using specified seed. For
     multiple arguments, their types can be different.
 
-.. spark:function:: xxhash64(x, ...) -> bigint
-
-    Computes the xxhash64 of one or more input values using seed value of 42.
-    For multiple arguments, their types can be different.
-
-.. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
-
-    Computes the xxhash64 of one or more input values using specified seed. For
-    multiple arguments, their types can be different.
-
 .. spark:function:: md5(x) -> varbinary
 
     Computes the md5 of x.
@@ -50,3 +40,13 @@ Binary Functions
     have a value of 224, 256, 384, 512, or 0 (which is equivalent to 256). If asking
     for an unsupported bitLength, the return value is NULL.
     Note: x can only be varbinary type.
+
+.. spark:function:: xxhash64(x, ...) -> bigint
+
+    Computes the xxhash64 of one or more input values using seed value of 42.
+    For multiple arguments, their types can be different.
+
+.. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
+
+    Computes the xxhash64 of one or more input values using specified seed. For
+    multiple arguments, their types can be different.

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -1,6 +1,6 @@
-=====================================
+====================
 Comparison Functions
-=====================================
+====================
 
 .. spark:function:: between(x, min, max) -> boolean
 
@@ -86,33 +86,3 @@ Comparison Functions
 
     Returns true if x is not equal to y. Supports all scalar types. The types
     of x and y must be the same. Corresponds to Spark's operator ``!=``.
-
-.. spark:function:: decimal_lessthan(x, y) -> boolean
-
-    Returns true if x is less than y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``<``.
-
-.. spark:function:: decimal_lessthanorequal(x, y) -> boolean
-
-    Returns true if x is less than y or x is equal to y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``<=``.
-
-.. spark:function:: decimal_equalto(x, y) -> boolean
-
-    Returns true if x is equal to y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``==``.
-
-.. spark:function:: decimal_notequalto(x, y) -> boolean
-
-    Returns true if x is not equal to y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``!=``.
-
-.. spark:function:: decimal_greaterthan(x, y) -> boolean
-
-    Returns true if x is greater than y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``>``.
-
-.. spark:function:: decimal_greaterthanorequal(x, y) -> boolean
-
-    Returns true if x is greater than y or x is equal to y. Supports decimal types with different precisions and scales.
-    Corresponds to Spark's operator ``>=``.

--- a/velox/docs/functions/spark/coverage.rst
+++ b/velox/docs/functions/spark/coverage.rst
@@ -6,71 +6,192 @@
     table.coverage td:nth-child(6) {background-color: lightblue;}
     table.coverage td:nth-child(8) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(2) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(4) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(7) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(9) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(10) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(9) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(21) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(21) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(22) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(22) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(35) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(43) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(44) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(44) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(45) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(62) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(67) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(4) {background-color: #6BA81E;}
     </style>
 
@@ -81,73 +202,73 @@
     =========================================  =========================================  =========================================  =========================================  =========================================  ==  =========================================  ==  =========================================
     Scalar Functions                                                                                                                                                                                                           Aggregate Functions                            Window Functions
     =====================================================================================================================================================================================================================  ==  =========================================  ==  =========================================
-    :spark:func:`abs`                          count_if                                   inline                                     nvl                                        sqrt                                           any                                            cume_dist
-    :spark:func:`acos                          count_min_sketch                           inline_outer                               nvl2                                       stack                                          approx_count_distinct                          dense_rank
+    :spark:func:`abs`                          count_if                                   inline                                     nvl                                        :spark:func:`sqrt`                             any                                            cume_dist
+    :spark:func:`acos`                         count_min_sketch                           inline_outer                               nvl2                                       stack                                          approx_count_distinct                          :spark:func:`dense_rank`
     :spark:func:`acosh`                        covar_pop                                  input_file_block_length                    octet_length                               std                                            approx_percentile                              first_value
-    add_months                                 covar_samp                                 input_file_block_start                     or                                         stddev                                         array_agg                                      lag
-    :spark:func:`aggregate`                    crc32                                      input_file_name                            overlay                                    stddev_pop                                     avg                                            last_value
+    :spark:func:`add_months`                   covar_samp                                 input_file_block_start                     or                                         stddev                                         array_agg                                      lag
+    :spark:func:`aggregate`                    :spark:func:`crc32`                        input_file_name                            :spark:func:`overlay`                      stddev_pop                                     :spark:func:`avg`                              last_value
     and                                        cume_dist                                  :spark:func:`instr`                        parse_url                                  stddev_samp                                    bit_and                                        lead
-    any                                        current_catalog                            int                                        percent_rank                               str_to_map                                     bit_or                                         :spark:func:`nth_value`
-    approx_count_distinct                      current_database                           isnan                                      percentile                                 string                                         :spark:func:`bit_xor`                          ntile
+    any                                        current_catalog                            int                                        percent_rank                               :spark:func:`str_to_map`                       bit_or                                         :spark:func:`nth_value`
+    approx_count_distinct                      current_database                           :spark:func:`isnan`                        percentile                                 string                                         :spark:func:`bit_xor`                          :spark:func:`ntile`
     approx_percentile                          current_date                               :spark:func:`isnotnull`                    percentile_approx                          struct                                         bool_and                                       percent_rank
-    :spark:func:`array`                        current_timestamp                          :spark:func:`isnull`                       pi                                         substr                                         bool_or                                        rank
-    :spark:func:`array_contains`               current_timezone                           java_method                                :spark:func:`pmod`                         :spark:func:`substring`                        collect_list                                   row_number
-    array_distinct                             current_user                               json_array_length                          posexplode                                 substring_index                                collect_set
-    array_except                               date                                       json_object_keys                           posexplode_outer                           sum                                            corr
-    :spark:func:`array_intersect`              date_add                                   json_tuple                                 position                                   tan                                            count
-    array_join                                 date_format                                kurtosis                                   positive                                   tanh                                           count_if
-    array_max                                  date_from_unix_date                        lag                                        pow                                        timestamp                                      count_min_sketch
-    array_min                                  date_part                                  last                                       :spark:func:`power`                        timestamp_micros                               covar_pop
-    array_position                             date_sub                                   last_day                                   printf                                     timestamp_millis                               covar_samp
-    array_remove                               date_trunc                                 last_value                                 quarter                                    timestamp_seconds                              every
-    array_repeat                               datediff                                   lcase                                      radians                                    tinyint                                        :spark:func:`first`
-    :spark:func:`array_sort`                   day                                        lead                                       raise_error                                to_csv                                         first_value
-    array_union                                dayofmonth                                 :spark:func:`least`                        :spark:func:`rand`                         to_date                                        grouping
-    arrays_overlap                             dayofweek                                  :spark:func:`left`                         randn                                      to_json                                        grouping_id
-    arrays_zip                                 dayofyear                                  :spark:func:`length`                       random                                     to_timestamp                                   histogram_numeric
-    :spark:func:`ascii`                        decimal                                    levenshtein                                range                                      :spark:func:`to_unix_timestamp`                kurtosis
-    asin                                       decode                                     like                                       rank                                       to_utc_timestamp                               :spark:func:`last`
-    :spark:func:`asinh`                        degrees                                    ln                                         reflect                                    :spark:func:`transform`                        last_value
-    assert_true                                dense_rank                                 locate                                     regexp                                     transform_keys                                 max
-    atan                                       div                                        log                                        :spark:func:`regexp_extract`               transform_values                               max_by
-    atan2                                      double                                     log10                                      regexp_extract_all                         translate                                      mean
-    :spark:func:`atanh`                        e                                          :spark:func:`log1p`                        regexp_like                                :spark:func:`trim`                             min
-    avg                                        :spark:func:`element_at`                   log2                                       regexp_replace                             trunc                                          min_by
-    base64                                     elt                                        :spark:func:`lower`                        repeat                                     try_add                                        percentile
-    :spark:func:`between`                      encode                                     lpad                                       :spark:func:`replace`                      try_divide                                     percentile_approx
-    bigint                                     every                                      :spark:func:`ltrim`                        reverse                                    typeof                                         regr_avgx
-    :spark:func:`bin`                          exists                                     make_date                                  right                                      ucase                                          regr_avgy
-    binary                                     :spark:func:`exp`                          make_dt_interval                           rint                                       unbase64                                       regr_count
-    bit_and                                    explode                                    make_interval                              :spark:func:`rlike`                        unhex                                          regr_r2
-    bit_count                                  explode_outer                              make_timestamp                             :spark:func:`round`                        unix_date                                      skewness
-    bit_get                                    expm1                                      make_ym_interval                           row_number                                 unix_micros                                    some
-    bit_length                                 extract                                    :spark:func:`map`                          rpad                                       unix_millis                                    std
-    bit_or                                     factorial                                  map_concat                                 :spark:func:`rtrim`                        unix_seconds                                   stddev
-    bit_xor                                    :spark:func:`filter`                       map_entries                                schema_of_csv                              :spark:func:`unix_timestamp`                   stddev_pop
-    bool_and                                   find_in_set                                :spark:func:`map_filter`                   schema_of_json                             :spark:func:`upper`                            stddev_samp
-    bool_or                                    first                                      :spark:func:`map_from_arrays`              second                                     uuid                                           sum
+    :spark:func:`array`                        current_timestamp                          :spark:func:`isnull`                       pi                                         substr                                         bool_or                                        :spark:func:`rank`
+    :spark:func:`array_contains`               current_timezone                           java_method                                :spark:func:`pmod`                         :spark:func:`substring`                        :spark:func:`collect_list`                     :spark:func:`row_number`
+    :spark:func:`array_distinct`               current_user                               :spark:func:`json_array_length`            posexplode                                 :spark:func:`substring_index`                  :spark:func:`collect_set`
+    :spark:func:`array_except`                 date                                       :spark:func:`json_object_keys`             posexplode_outer                           sum                                            :spark:func:`corr`
+    :spark:func:`array_intersect`              :spark:func:`date_add`                     json_tuple                                 position                                   tan                                            count
+    :spark:func:`array_join`                   :spark:func:`date_format`                  kurtosis                                   positive                                   tanh                                           count_if
+    :spark:func:`array_max`                    :spark:func:`date_from_unix_date`          lag                                        pow                                        timestamp                                      count_min_sketch
+    :spark:func:`array_min`                    date_part                                  last                                       :spark:func:`power`                        :spark:func:`timestamp_micros`                 covar_pop
+    :spark:func:`array_position`               :spark:func:`date_sub`                     :spark:func:`last_day`                     printf                                     :spark:func:`timestamp_millis`                 :spark:func:`covar_samp`
+    :spark:func:`array_remove`                 :spark:func:`date_trunc`                   last_value                                 :spark:func:`quarter`                      timestamp_seconds                              every
+    :spark:func:`array_repeat`                 :spark:func:`datediff`                     lcase                                      radians                                    tinyint                                        :spark:func:`first`
+    :spark:func:`array_sort`                   :spark:func:`day`                          lead                                       :spark:func:`raise_error`                  to_csv                                         first_value
+    :spark:func:`array_union`                  :spark:func:`dayofmonth`                   :spark:func:`least`                        :spark:func:`rand`                         to_date                                        grouping
+    arrays_overlap                             :spark:func:`dayofweek`                    :spark:func:`left`                         randn                                      to_json                                        grouping_id
+    :spark:func:`arrays_zip`                   :spark:func:`dayofyear`                    :spark:func:`length`                       :spark:func:`random`                       to_timestamp                                   histogram_numeric
+    :spark:func:`ascii`                        decimal                                    :spark:func:`levenshtein`                  range                                      :spark:func:`to_unix_timestamp`                :spark:func:`kurtosis`
+    :spark:func:`asin`                         decode                                     :spark:func:`like`                         rank                                       :spark:func:`to_utc_timestamp`                 :spark:func:`last`
+    :spark:func:`asinh`                        :spark:func:`degrees`                      ln                                         reflect                                    :spark:func:`transform`                        last_value
+    assert_true                                dense_rank                                 :spark:func:`locate`                       regexp                                     transform_keys                                 :spark:func:`max`
+    :spark:func:`atan`                         div                                        :spark:func:`log`                          :spark:func:`regexp_extract`               transform_values                               :spark:func:`max_by`
+    :spark:func:`atan2`                        double                                     :spark:func:`log10`                        :spark:func:`regexp_extract_all`           :spark:func:`translate`                        mean
+    :spark:func:`atanh`                        e                                          :spark:func:`log1p`                        regexp_like                                :spark:func:`trim`                             :spark:func:`min`
+    avg                                        :spark:func:`element_at`                   :spark:func:`log2`                         :spark:func:`regexp_replace`               :spark:func:`trunc`                            :spark:func:`min_by`
+    base64                                     elt                                        :spark:func:`lower`                        :spark:func:`repeat`                       try_add                                        percentile
+    :spark:func:`between`                      encode                                     :spark:func:`lpad`                         :spark:func:`replace`                      try_divide                                     percentile_approx
+    bigint                                     every                                      :spark:func:`ltrim`                        :spark:func:`reverse`                      typeof                                         regr_avgx
+    :spark:func:`bin`                          :spark:func:`exists`                       :spark:func:`make_date`                    right                                      ucase                                          regr_avgy
+    binary                                     :spark:func:`exp`                          make_dt_interval                           :spark:func:`rint`                         :spark:func:`unbase64`                         regr_count
+    bit_and                                    explode                                    make_interval                              :spark:func:`rlike`                        :spark:func:`unhex`                            regr_r2
+    :spark:func:`bit_count`                    explode_outer                              :spark:func:`make_timestamp`               :spark:func:`round`                        :spark:func:`unix_date`                        :spark:func:`skewness`
+    :spark:func:`bit_get`                      :spark:func:`expm1`                        :spark:func:`make_ym_interval`             row_number                                 :spark:func:`unix_micros`                      some
+    :spark:func:`bit_length`                   extract                                    :spark:func:`map`                          :spark:func:`rpad`                         :spark:func:`unix_millis`                      std
+    bit_or                                     :spark:func:`factorial`                    :spark:func:`map_concat`                   :spark:func:`rtrim`                        :spark:func:`unix_seconds`                     :spark:func:`stddev`
+    bit_xor                                    :spark:func:`filter`                       :spark:func:`map_entries`                  schema_of_csv                              :spark:func:`unix_timestamp`                   stddev_pop
+    bool_and                                   :spark:func:`find_in_set`                  :spark:func:`map_filter`                   schema_of_json                             :spark:func:`upper`                            :spark:func:`stddev_samp`
+    bool_or                                    first                                      :spark:func:`map_from_arrays`              :spark:func:`second`                       :spark:func:`uuid`                             :spark:func:`sum`
     boolean                                    first_value                                map_from_entries                           sentences                                  var_pop                                        try_avg
-    bround                                     flatten                                    map_keys                                   sequence                                   var_samp                                       try_sum
-    btrim                                      float                                      map_values                                 session_window                             variance                                       var_pop
-    cardinality                                :spark:func:`floor`                        map_zip_with                               sha                                        version                                        var_samp
-    case                                       forall                                     max                                        :spark:func:`sha1`                         weekday                                        variance
+    bround                                     :spark:func:`flatten`                      :spark:func:`map_keys`                     sequence                                   var_samp                                       try_sum
+    btrim                                      float                                      :spark:func:`map_values`                   session_window                             variance                                       var_pop
+    cardinality                                :spark:func:`floor`                        :spark:func:`map_zip_with`                 sha                                        version                                        :spark:func:`var_samp`
+    case                                       :spark:func:`forall`                       max                                        :spark:func:`sha1`                         :spark:func:`weekday`                          :spark:func:`variance`
     cast                                       format_number                              max_by                                     :spark:func:`sha2`                         weekofyear
-    cbrt                                       format_string                              :spark:func:`md5`                          :spark:func:`shiftleft`                    when
-    :spark:func:`ceil`                         from_csv                                   mean                                       :spark:func:`shiftright`                   width_bucket
+    :spark:func:`cbrt`                         format_string                              :spark:func:`md5`                          :spark:func:`shiftleft`                    when
+    :spark:func:`ceil`                         from_csv                                   mean                                       :spark:func:`shiftright`                   :spark:func:`width_bucket`
     ceiling                                    from_json                                  min                                        shiftrightunsigned                         window
-    char                                       from_unixtime                              min_by                                     shuffle                                    xpath
-    char_length                                from_utc_timestamp                         minute                                     sign                                       xpath_boolean
+    char                                       :spark:func:`from_unixtime`                min_by                                     :spark:func:`shuffle`                      xpath
+    char_length                                :spark:func:`from_utc_timestamp`           :spark:func:`minute`                       :spark:func:`sign`                         xpath_boolean
     character_length                           :spark:func:`get_json_object`              mod                                        signum                                     xpath_double
-    :spark:func:`chr`                          getbit                                     monotonically_increasing_id                sin                                        xpath_float
-    coalesce                                   :spark:func:`greatest`                     month                                      :spark:func:`sinh`                         xpath_int
+    :spark:func:`chr`                          getbit                                     :spark:func:`monotonically_increasing_id`  sin                                        xpath_float
+    coalesce                                   :spark:func:`greatest`                     :spark:func:`month`                        :spark:func:`sinh`                         xpath_int
     collect_list                               grouping                                   months_between                             :spark:func:`size`                         xpath_long
     collect_set                                grouping_id                                named_struct                               skewness                                   xpath_number
-    :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      slice                                      xpath_short
-    concat_ws                                  hex                                        negative                                   smallint                                   xpath_string
-    conv                                       hour                                       next_day                                   some                                       :spark:func:`xxhash64`
+    :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      :spark:func:`slice`                        xpath_short
+    concat_ws                                  :spark:func:`hex`                          negative                                   smallint                                   xpath_string
+    :spark:func:`conv`                         :spark:func:`hour`                         :spark:func:`next_day`                     some                                       :spark:func:`xxhash64`
     corr                                       :spark:func:`hypot`                        :spark:func:`not`                          :spark:func:`sort_array`                   :spark:func:`year`
-    cos                                        if                                         now                                        soundex                                    zip_with
-    cosh                                       ifnull                                     nth_value                                  space
-    cot                                        :spark:func:`in`                           ntile                                      spark_partition_id
+    :spark:func:`cos`                          if                                         now                                        :spark:func:`soundex`                      :spark:func:`zip_with`
+    :spark:func:`cosh`                         ifnull                                     nth_value                                  space
+    :spark:func:`cot`                          :spark:func:`in`                           ntile                                      :spark:func:`spark_partition_id`
     count                                      initcap                                    nullif                                     :spark:func:`split`
     =========================================  =========================================  =========================================  =========================================  =========================================  ==  =========================================  ==  =========================================

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -1,6 +1,6 @@
-=====================================
+=======================
 Date and Time Functions
-=====================================
+=======================
 
 Convenience Extraction Functions
 --------------------------------
@@ -183,35 +183,6 @@ These functions support TIMESTAMP and DATE input types.
     ``day`` need to be from 1 to 31, and matches the number of days in each month.
     days of ``year-month-day - 1970-01-01`` need to be in the range of INTEGER type.
 
-.. spark:function:: make_ym_interval([years[, months]]) -> interval year to month
-
-    Make year-month interval from ``years`` and ``months`` fields.
-    Returns the actual year-month with month in the range of [0, 11].
-    Both ``years`` and ``months`` can be zero, positive or negative.
-    Throws an error when inputs lead to int overflow,
-    e.g., make_ym_interval(178956970, 8). ::
-
-        SELECT make_ym_interval(1, 2); -- 1-2
-        SELECT make_ym_interval(1, 0); -- 1-0
-        SELECT make_ym_interval(-1, 1); -- -0-11
-        SELECT make_ym_interval(1, 100); -- 9-4
-        SELECT make_ym_interval(1, 12); -- 2-0
-        SELECT make_ym_interval(1, -12); -- 0-0
-        SELECT make_ym_interval(2); -- 2-0
-        SELECT make_ym_interval(); -- 0-0
-
-.. spark:function:: minute(timestamp) -> integer
-
-    Returns the minutes of ``timestamp``.::
-
-        SELECT minute('2009-07-30 12:58:59'); -- 58
-
-.. spark:function:: quarter(date) -> integer
-
-    Returns the quarter of ``date``. The value ranges from ``1`` to ``4``. ::
-
-        SELECT quarter('2009-07-30'); -- 3
-
 .. spark:function:: make_timestamp(year, month, day, hour, minute, second[, timezone]) -> timestamp
 
     Create timestamp from ``year``, ``month``, ``day``, ``hour``, ``minute`` and ``second`` fields.
@@ -244,6 +215,29 @@ These functions support TIMESTAMP and DATE input types.
         SELECT make_timestamp(2014, 12, 28, 6, 30, 60.000001); -- NULL
         SELECT make_timestamp(2014, 13, 28, 6, 30, 45.887); -- NULL
 
+.. spark:function:: make_ym_interval([years[, months]]) -> interval year to month
+
+    Make year-month interval from ``years`` and ``months`` fields.
+    Returns the actual year-month with month in the range of [0, 11].
+    Both ``years`` and ``months`` can be zero, positive or negative.
+    Throws an error when inputs lead to int overflow,
+    e.g., make_ym_interval(178956970, 8). ::
+
+        SELECT make_ym_interval(1, 2); -- 1-2
+        SELECT make_ym_interval(1, 0); -- 1-0
+        SELECT make_ym_interval(-1, 1); -- -0-11
+        SELECT make_ym_interval(1, 100); -- 9-4
+        SELECT make_ym_interval(1, 12); -- 2-0
+        SELECT make_ym_interval(1, -12); -- 0-0
+        SELECT make_ym_interval(2); -- 2-0
+        SELECT make_ym_interval(); -- 0-0
+
+.. spark:function:: minute(timestamp) -> integer
+
+    Returns the minutes of ``timestamp``.::
+
+        SELECT minute('2009-07-30 12:58:59'); -- 58
+
 .. spark:function:: month(date) -> integer
 
     Returns the month of ``date``. ::
@@ -264,6 +258,12 @@ These functions support TIMESTAMP and DATE input types.
         SELECT next_day('2015-07-23', "Tue"); -- '2015-07-28'
         SELECT next_day('2015-07-23', "tu"); -- '2015-07-28'
         SELECT next_day('2015-07-23', "we"); -- '2015-07-29'
+
+.. spark:function:: quarter(date) -> integer
+
+    Returns the quarter of ``date``. The value ranges from ``1`` to ``4``. ::
+
+        SELECT quarter('2009-07-30'); -- 3
 
 .. spark:function:: second(timestamp) -> integer
 

--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -122,6 +122,36 @@ Decimal Functions
 
         SELECT ceil(cast(1.23 as DECIMAL(3, 2))); -- 2 // Output type: decimal(2,0)
 
+.. spark:function:: decimal_equalto(x, y) -> boolean
+
+    Returns true if x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``==``.
+
+.. spark:function:: decimal_greaterthan(x, y) -> boolean
+
+    Returns true if x is greater than y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``>``.
+
+.. spark:function:: decimal_greaterthanorequal(x, y) -> boolean
+
+    Returns true if x is greater than y or x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``>=``.
+
+.. spark:function:: decimal_lessthan(x, y) -> boolean
+
+    Returns true if x is less than y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``<``.
+
+.. spark:function:: decimal_lessthanorequal(x, y) -> boolean
+
+    Returns true if x is less than y or x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``<=``.
+
+.. spark:function:: decimal_notequalto(x, y) -> boolean
+
+    Returns true if x is not equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``!=``.
+
 .. spark:function:: floor(x: decimal(p, s)) -> r: decimal(pr, 0)
 
     Returns ``x`` rounded down to the type ``decimal(min(38, p - s + min(1, s)), 0)``.
@@ -149,12 +179,6 @@ Decimal Functions
 
 Decimal Special Forms
 ---------------------
-
-.. spark:function:: make_decimal(x[, nullOnOverflow]) -> decimal
-
-    Create ``decimal`` of requsted precision and scale from an unscaled bigint value ``x``.
-    By default, the value of ``nullOnOverflow`` is true, and null will be returned when ``x`` is too large for the result precision.
-    Otherwise, exception will be thrown when ``x`` overflows.
 
 .. spark:function:: decimal_round(decimal[, scale]) -> [decimal]
 
@@ -195,3 +219,9 @@ Decimal Special Forms
         SELECT round(cast (85.681 as DECIMAL(5, 3)), 1); -- decimal 85.7
         SELECT round(cast (85.681 as DECIMAL(5, 3)), 999); -- decimal 85.681
         SELECT round(cast (0.1234567890123456789 as DECIMAL(19, 19)), 14); -- decimal 0.12345678901235
+
+.. spark:function:: make_decimal(x[, nullOnOverflow]) -> decimal
+
+    Create ``decimal`` of requsted precision and scale from an unscaled bigint value ``x``.
+    By default, the value of ``nullOnOverflow`` is true, and null will be returned when ``x`` is too large for the result precision.
+    Otherwise, exception will be thrown when ``x`` overflows.

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -1,6 +1,6 @@
-===========================
+=============
 Map Functions
-===========================
+=============
 
 .. spark:function:: element_at(map(K,V), key) -> V
 
@@ -75,7 +75,7 @@ Map Functions
                             (k, v1, v2) -> k || CAST(v1/v2 AS VARCHAR));
 
 .. spark:function:: size(map(K,V), legacySizeOfNull) -> integer
-   :noindex:
+    :noindex:
 
     Returns the size of the input map. Returns null for null input if ``legacySizeOfNull``
     is set to false. Otherwise, returns -1 for null input. ::

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -1,6 +1,6 @@
-====================================
+======================
 Mathematical Functions
-====================================
+======================
 
 .. spark:function:: abs(x) -> [same as x]
 
@@ -61,6 +61,10 @@ Mathematical Functions
 .. spark:function:: bin(x) -> varchar
 
     Returns the string representation of the long value ``x`` represented in binary.
+
+.. spark:function:: cbrt(x) -> double
+
+    Returns the cube root of ``x``.
 
 .. spark:function:: ceil(x) -> [same as x]
 
@@ -202,10 +206,6 @@ Mathematical Functions
 .. spark:function:: sqrt(x) -> double
 
     Returns the square root of ``x``.
-
-.. spark:function:: cbrt(x) -> double
-
-    Returns the cube root of ``x``.
 
 .. spark:function:: multiply(x, y) -> [same as x]
 

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -1,6 +1,6 @@
-====================================
+=======================
 Miscellaneous Functions
-====================================
+=======================
 
 .. spark:function:: at_least_n_non_nulls(n, value1, value2, ..., valueN) -> bool
 

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -32,7 +32,7 @@ See https://github.com/google/re2/wiki/Syntax for more information.
     '%hello', '%__hello_', '%hello%', where 'hello', 'velox'
     contains only regular characters and '_' wildcards are evaluated without
     using regular expressions. Only those patterns that require the compilation of
-    regular expressions are counted towards the limit.
+    regular expressions are counted towards the limit. ::
 
         SELECT like('abc', '%b%'); -- true
         SELECT like('a_c', '%#_%', '#'); -- true
@@ -48,7 +48,7 @@ See https://github.com/google/re2/wiki/Syntax for more information.
         SELECT regexp_extract('1a 2b 14m', '\d+'); -- 1
 
 .. spark:function:: regexp_extract(string, pattern, group) -> varchar
-   :noindex:
+    :noindex:
 
     Finds the first occurrence of the regular expression ``pattern`` in
     ``string`` and returns the capturing group number ``group``.

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -1,6 +1,6 @@
-====================================
+================
 String Functions
-====================================
+================
 
 .. note::
 
@@ -184,7 +184,7 @@ String Functions
         SELECT ltrim('  data  '); -- "data  "
 
 .. spark:function:: ltrim(trimCharacters, string) -> varchar
-   :noindex:
+    :noindex:
 
     Removes specified leading characters from ``string``. The specified character
     is any character contained in ``trimCharacters``.
@@ -294,7 +294,7 @@ String Functions
         SELECT rtrim('  data  '); -- "  data"
 
 .. spark:function:: rtrim(trimCharacters, string) -> varchar
-   :noindex:
+    :noindex:
 
     Removes specified trailing characters from ``string``. The specified character
     is any character contained in ``trimCharacters``.
@@ -360,7 +360,7 @@ String Functions
     the meaning is to refer to the first character.Type of 'start' must be an INTEGER.
 
 .. spark:function:: substring(string, start, length) -> varchar
-   :noindex:
+    :noindex:
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
@@ -425,7 +425,7 @@ String Functions
         SELECT trim('  data  '); -- "data"
 
 .. spark:function:: trim(trimCharacters, string) -> varchar
-   :noindex:
+    :noindex:
 
     Removes specified leading and trailing characters from ``string``.
     The specified character is any character contained in ``trimCharacters``.

--- a/velox/docs/functions/spark/url.rst
+++ b/velox/docs/functions/spark/url.rst
@@ -48,6 +48,11 @@ digits after the percent character "%". All the url extract functions will retur
 Encoding Functions
 ------------------
 
+.. spark:function:: url_decode(value) -> varchar
+
+    Unescapes the URL encoded ``value``.
+    This function is the inverse of :spark:func:`url_encode`.
+
 .. spark:function:: url_encode(value) -> varchar
 
     Escapes ``value`` by encoding it so that it can be safely included in
@@ -59,8 +64,3 @@ Encoding Functions
     * All other characters are converted to UTF-8 and the bytes are encoded
       as the string ``%XX`` where ``XX`` is the uppercase hexadecimal
       value of the UTF-8 byte.
-
-.. spark:function:: url_decode(value) -> varchar
-
-    Unescapes the URL encoded ``value``.
-    This function is the inverse of :spark:func:`url_encode`.

--- a/velox/docs/functions/spark/window.rst
+++ b/velox/docs/functions/spark/window.rst
@@ -3,7 +3,7 @@ Window functions
 ================
 
 Spark window functions can be used to compute SQL window functions.
-More details about window functions can be found at :doc:`/develop/window`
+More details about window functions can be found at :doc:`/develop/window`.
 
 Value functions
 ---------------
@@ -18,14 +18,6 @@ in the window, null is returned. It is an error for the offset to be zero or neg
 Rank functions
 ---------------
 
-.. spark:function:: row_number() -> integer
-
-Returns a unique, sequential number to each row, starting with one, according to the ordering of rows within the window partition.
-
-.. spark:function:: rank() -> integer
-
-Returns the rank of a value in a group of values. The rank is one plus the number of rows preceding the row that are not peer with the row. Thus, the values in the ordering will produce gaps in the sequence. The ranking is performed for each window partition.
-
 .. spark:function:: dense_rank() -> integer
 
 Returns the rank of a value in a group of values. This is similar to rank(), except that tie values do not produce gaps in the sequence.
@@ -35,3 +27,11 @@ Returns the rank of a value in a group of values. This is similar to rank(), exc
 Divides the rows for each window partition into n buckets ranging from 1 to at most ``n``. Bucket values will differ by at most 1. If the number of rows in the partition does not divide evenly into the number of buckets, then the remainder values are distributed one per bucket, starting with the first bucket.
 
 For example, with 6 rows and 4 buckets, the bucket values would be as follows: ``1 1 2 2 3 4``
+
+.. spark:function:: rank() -> integer
+
+Returns the rank of a value in a group of values. The rank is one plus the number of rows preceding the row that are not peer with the row. Thus, the values in the ordering will produce gaps in the sequence. The ranking is performed for each window partition.
+
+.. spark:function:: row_number() -> integer
+
+Returns a unique, sequential number to each row, starting with one, according to the ordering of rows within the window partition.

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -61,35 +61,80 @@ for :doc:`all <functions/spark/coverage>` functions.
     :widths: auto
     :class: rows
 
-    ================================  ================================  ================================  ==  ================================  ==  ================================
-    Scalar Functions                                                                                          Aggregate Functions                   Window Functions
-    ====================================================================================================  ==  ================================  ==  ================================
-    :spark:func:`abs`                 :spark:func:`floor`               :spark:func:`power`                   :spark:func:`bit_xor`                 :spark:func:`nth_value`
-    :spark:func:`acos`                :spark:func:`get_json_object`     :spark:func:`rand`                    :spark:func:`first`
-    :spark:func:`acosh`               :spark:func:`greaterthan`         :spark:func:`regexp_extract`          :spark:func:`first_ignore_null`
-    :spark:func:`add`                 :spark:func:`greaterthanorequal`  :spark:func:`remainder`               :spark:func:`last`
-    :spark:func:`aggregate`           :spark:func:`greatest`            :spark:func:`replace`                 :spark:func:`last_ignore_null`
-    :spark:func:`array`               :spark:func:`hash`                :spark:func:`rlike`
-    :spark:func:`array_contains`      :spark:func:`hypot`               :spark:func:`round`
-    :spark:func:`array_intersect`     :spark:func:`in`                  :spark:func:`rtrim`
-    :spark:func:`array_sort`          :spark:func:`instr`               :spark:func:`sec`
-    :spark:func:`ascii`               :spark:func:`isnotnull`           :spark:func:`sha1`
-    :spark:func:`asinh`               :spark:func:`isnull`              :spark:func:`sha2`
-    :spark:func:`atanh`               :spark:func:`least`               :spark:func:`shiftleft`
-    :spark:func:`between`             :spark:func:`left`                :spark:func:`shiftright`
-    :spark:func:`bin`                 :spark:func:`length`              :spark:func:`sinh`
-    :spark:func:`bitwise_and`         :spark:func:`lessthan`            :spark:func:`size`
-    :spark:func:`bitwise_or`          :spark:func:`lessthanorequal`     :spark:func:`sort_array`
-    :spark:func:`ceil`                :spark:func:`log1p`               :spark:func:`split`
-    :spark:func:`chr`                 :spark:func:`lower`               :spark:func:`startswith`
-    :spark:func:`concat`              :spark:func:`ltrim`               :spark:func:`substring`
-    :spark:func:`contains`            :spark:func:`map`                 :spark:func:`subtract`
-    :spark:func:`csc`                 :spark:func:`map_filter`          :spark:func:`to_unix_timestamp`
-    :spark:func:`divide`              :spark:func:`map_from_arrays`     :spark:func:`transform`
-    :spark:func:`element_at`          :spark:func:`md5`                 :spark:func:`trim`
-    :spark:func:`endswith`            :spark:func:`might_contain`       :spark:func:`unaryminus`
-    :spark:func:`equalnullsafe`       :spark:func:`multiply`            :spark:func:`unix_timestamp`
-    :spark:func:`equalto`             :spark:func:`not`                 :spark:func:`upper`
-    :spark:func:`exp`                 :spark:func:`notequalto`          :spark:func:`xxhash64`
-    :spark:func:`filter`              :spark:func:`pmod`                :spark:func:`year`
-    ================================  ================================  ================================  ==  ================================  ==  ================================
+    ===========================================  ===========================================  ===========================================  ==  ===========================================  ==  ===========================================
+    Scalar Functions                                                                                                                           Aggregate Functions                              Window Functions
+    =====================================================================================================================================  ==  ===========================================  ==  ===========================================
+    :spark:func:`abs`                            :spark:func:`divide_deny_precision_loss`     :spark:func:`not`                                :spark:func:`avg`                                :spark:func:`dense_rank`
+    :spark:func:`acos`                           :spark:func:`doy`                            :spark:func:`overlay`                            :spark:func:`bit_xor`                            :spark:func:`nth_value`
+    :spark:func:`acosh`                          :spark:func:`element_at`                     :spark:func:`pmod`                               :spark:func:`bloom_filter_agg`                   :spark:func:`ntile`
+    :spark:func:`add`                            :spark:func:`empty2null`                     :spark:func:`power`                              :spark:func:`collect_list`                       :spark:func:`rank`
+    :spark:func:`add_deny_precision_loss`        :spark:func:`endswith`                       :spark:func:`quarter`                            :spark:func:`collect_set`                        :spark:func:`row_number`
+    :spark:func:`add_months`                     :spark:func:`equalnullsafe`                  :spark:func:`raise_error`                        :spark:func:`corr`
+    :spark:func:`aggregate`                      :spark:func:`equalto`                        :spark:func:`rand`                               :spark:func:`covar_samp`
+    :spark:func:`array`                          :spark:func:`exists`                         :spark:func:`random`                             :spark:func:`first`
+    :spark:func:`array_append`                   :spark:func:`exp`                            :spark:func:`regexp_extract`                     :spark:func:`first_ignore_null`
+    :spark:func:`array_compact`                  :spark:func:`expm1`                          :spark:func:`regexp_extract_all`                 :spark:func:`kurtosis`
+    :spark:func:`array_contains`                 :spark:func:`factorial`                      :spark:func:`regexp_replace`                     :spark:func:`last`
+    :spark:func:`array_distinct`                 :spark:func:`filter`                         :spark:func:`remainder`                          :spark:func:`last_ignore_null`
+    :spark:func:`array_except`                   :spark:func:`find_in_set`                    :spark:func:`repeat`                             :spark:func:`max`
+    :spark:func:`array_insert`                   :spark:func:`flatten`                        :spark:func:`replace`                            :spark:func:`max_by`
+    :spark:func:`array_intersect`                :spark:func:`floor`                          :spark:func:`reverse`                            :spark:func:`min`
+    :spark:func:`array_join`                     :spark:func:`forall`                         :spark:func:`rint`                               :spark:func:`min_by`
+    :spark:func:`array_max`                      :spark:func:`from_unixtime`                  :spark:func:`rlike`                              :spark:func:`mode`
+    :spark:func:`array_min`                      :spark:func:`from_utc_timestamp`             :spark:func:`round`                              :spark:func:`regr_replacement`
+    :spark:func:`array_position`                 :spark:func:`get`                            :spark:func:`rpad`                               :spark:func:`skewness`
+    :spark:func:`array_prepend`                  :spark:func:`get_json_object`                :spark:func:`rtrim`                              :spark:func:`stddev`
+    :spark:func:`array_remove`                   :spark:func:`get_timestamp`                  :spark:func:`sec`                                :spark:func:`stddev_samp`
+    :spark:func:`array_repeat`                   :spark:func:`greaterthan`                    :spark:func:`second`                             :spark:func:`sum`
+    :spark:func:`array_sort`                     :spark:func:`greaterthanorequal`             :spark:func:`sha1`                               :spark:func:`var_samp`
+    :spark:func:`array_union`                    :spark:func:`greatest`                       :spark:func:`sha2`                               :spark:func:`variance`
+    :spark:func:`arrays_zip`                     :spark:func:`hash`                           :spark:func:`shiftleft`
+    :spark:func:`ascii`                          :spark:func:`hash_with_seed`                 :spark:func:`shiftright`
+    :spark:func:`asin`                           :spark:func:`hex`                            :spark:func:`shuffle`
+    :spark:func:`asinh`                          :spark:func:`hour`                           :spark:func:`sign`
+    :spark:func:`atan`                           :spark:func:`hypot`                          :spark:func:`sinh`
+    :spark:func:`atan2`                          :spark:func:`in`                             :spark:func:`size`
+    :spark:func:`atanh`                          :spark:func:`instr`                          :spark:func:`slice`
+    :spark:func:`between`                        :spark:func:`isnan`                          :spark:func:`sort_array`
+    :spark:func:`bin`                            :spark:func:`isnotnull`                      :spark:func:`soundex`
+    :spark:func:`bit_count`                      :spark:func:`isnull`                         :spark:func:`spark_partition_id`
+    :spark:func:`bit_get`                        :spark:func:`json_array_length`              :spark:func:`split`
+    :spark:func:`bit_length`                     :spark:func:`json_object_keys`               :spark:func:`sqrt`
+    :spark:func:`bitwise_and`                    :spark:func:`last_day`                       :spark:func:`startswith`
+    :spark:func:`bitwise_not`                    :spark:func:`least`                          :spark:func:`str_to_map`
+    :spark:func:`bitwise_or`                     :spark:func:`left`                           :spark:func:`substring`
+    :spark:func:`bitwise_xor`                    :spark:func:`length`                         :spark:func:`substring_index`
+    :spark:func:`cbrt`                           :spark:func:`lessthan`                       :spark:func:`subtract`
+    :spark:func:`ceil`                           :spark:func:`lessthanorequal`                :spark:func:`subtract_deny_precision_loss`
+    :spark:func:`checked_add`                    :spark:func:`levenshtein`                    :spark:func:`timestamp_micros`
+    :spark:func:`checked_divide`                 :spark:func:`like`                           :spark:func:`timestamp_millis`
+    :spark:func:`checked_multiply`               :spark:func:`locate`                         :spark:func:`to_unix_timestamp`
+    :spark:func:`checked_subtract`               :spark:func:`log`                            :spark:func:`to_utc_timestamp`
+    :spark:func:`chr`                            :spark:func:`log10`                          :spark:func:`transform`
+    :spark:func:`concat`                         :spark:func:`log1p`                          :spark:func:`translate`
+    :spark:func:`contains`                       :spark:func:`log2`                           :spark:func:`trim`
+    :spark:func:`conv`                           :spark:func:`lower`                          :spark:func:`trunc`
+    :spark:func:`cos`                            :spark:func:`lpad`                           :spark:func:`unaryminus`
+    :spark:func:`cosh`                           :spark:func:`ltrim`                          :spark:func:`unbase64`
+    :spark:func:`cot`                            :spark:func:`luhn_check`                     :spark:func:`unhex`
+    :spark:func:`crc32`                          :spark:func:`make_date`                      :spark:func:`unix_date`
+    :spark:func:`csc`                            :spark:func:`make_timestamp`                 :spark:func:`unix_micros`
+    :spark:func:`date_add`                       :spark:func:`make_ym_interval`               :spark:func:`unix_millis`
+    :spark:func:`date_format`                    :spark:func:`map`                            :spark:func:`unix_seconds`
+    :spark:func:`date_from_unix_date`            :spark:func:`map_concat`                     :spark:func:`unix_timestamp`
+    :spark:func:`date_sub`                       :spark:func:`map_entries`                    :spark:func:`unscaled_value`
+    :spark:func:`date_trunc`                     :spark:func:`map_filter`                     :spark:func:`upper`
+    :spark:func:`datediff`                       :spark:func:`map_from_arrays`                :spark:func:`url_decode`
+    :spark:func:`day`                            :spark:func:`map_keys`                       :spark:func:`url_encode`
+    :spark:func:`dayofmonth`                     :spark:func:`map_values`                     :spark:func:`uuid`
+    :spark:func:`dayofweek`                      :spark:func:`map_zip_with`                   :spark:func:`varchar_type_write_side_check`
+    :spark:func:`dayofyear`                      :spark:func:`mask`                           :spark:func:`week_of_year`
+    :spark:func:`decimal_equalto`                :spark:func:`md5`                            :spark:func:`weekday`
+    :spark:func:`decimal_greaterthan`            :spark:func:`might_contain`                  :spark:func:`width_bucket`
+    :spark:func:`decimal_greaterthanorequal`     :spark:func:`minute`                         :spark:func:`xxhash64`
+    :spark:func:`decimal_lessthan`               :spark:func:`monotonically_increasing_id`    :spark:func:`xxhash64_with_seed`
+    :spark:func:`decimal_lessthanorequal`        :spark:func:`month`                          :spark:func:`year`
+    :spark:func:`decimal_notequalto`             :spark:func:`multiply`                       :spark:func:`year_of_week`
+    :spark:func:`degrees`                        :spark:func:`multiply_deny_precision_loss`   :spark:func:`zip_with`
+    :spark:func:`divide`                         :spark:func:`next_day`
+    ===========================================  ===========================================  ===========================================  ==  ===========================================  ==  ===========================================


### PR DESCRIPTION
Update the coverage map and function list for Spark functions. The new map and 
list are generated by running `velox_sparksql_coverage`. Fix document format 
issues.