### PR TITLE
fix(vector)!: Remove size parameter from FlatVector::mutableValues

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -722,7 +722,7 @@ cardinality function for maps:
 
       BaseVector::ensureWritable(rows, BIGINT(), context.pool(), result);
       BufferPtr resultValues =
-           result->as<FlatVector<int64_t>>()->mutableValues(rows.size());
+           result->as<FlatVector<int64_t>>()->mutableValues();
       auto rawResult = resultValues->asMutable<int64_t>();
 
       auto mapVector = args[0]->as<MapVector>();

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -302,7 +302,7 @@ void ByteRleColumnReader<FileType, RequestedType>::next(
 
   BufferPtr values;
   if (flatVector) {
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   if (flatVector) {
@@ -475,7 +475,7 @@ void DecimalColumnReader<DataT>::next(
   }
   BufferPtr values;
   if (flatVector) {
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -585,8 +585,8 @@ void IntegerDirectColumnReader<ReqT>::next(
   auto flatVector = resetIfWrongFlatVectorType<ReqT>(result);
   BufferPtr values;
   if (flatVector) {
-    values = flatVector->mutableValues(numValues);
     result->resize(numValues, false);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -743,7 +743,7 @@ void IntegerDictionaryColumnReader<ReqT>::next(
   BufferPtr values;
   if (result) {
     result->resize(numValues, false);
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -869,7 +869,7 @@ void TimestampColumnReader::next(
   BufferPtr values;
   if (flatVector) {
     result->resize(numValues, false);
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -1023,7 +1023,7 @@ void FloatingPointColumnReader<DataT, ReqT>::next(
   }
   BufferPtr values;
   if (flatVector) {
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -1544,7 +1544,7 @@ void StringDictionaryColumnReader::readFlatVector(
 
   BufferPtr data;
   if (flatVector) {
-    data = flatVector->mutableValues(numValues);
+    data = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);
@@ -1773,7 +1773,7 @@ void StringDirectColumnReader::next(
   BufferPtr values;
   if (flatVector) {
     flatVector->resize(numValues, false);
-    values = flatVector->mutableValues(numValues);
+    values = flatVector->mutableValues();
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1102,7 +1102,7 @@ class RowContainer {
 
     BufferPtr& nullBuffer = result->mutableNulls(maxRows, true);
     auto nulls = nullBuffer->asMutable<uint64_t>();
-    BufferPtr valuesBuffer = result->mutableValues(maxRows);
+    BufferPtr valuesBuffer = result->mutableValues();
     [[maybe_unused]] auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;
@@ -1134,9 +1134,9 @@ class RowContainer {
       int32_t offset,
       int32_t resultOffset,
       FlatVector<T>* result) {
-    auto maxRows = numRows + resultOffset;
+    [[maybe_unused]] auto maxRows = numRows + resultOffset;
     VELOX_DCHECK_LE(maxRows, result->size());
-    BufferPtr valuesBuffer = result->mutableValues(maxRows);
+    BufferPtr valuesBuffer = result->mutableValues();
     [[maybe_unused]] auto values = valuesBuffer->asMutableRange<T>();
     for (int32_t i = 0; i < numRows; ++i) {
       const char* row;

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -105,7 +105,7 @@ void ConjunctExpr::evalSpecialForm(
     rows.clearNulls(nulls);
   }
   // Initialize result to all true for AND and all false for OR.
-  auto values = flatResult->mutableValues(rows.end())->asMutable<uint64_t>();
+  auto values = flatResult->mutableValues()->asMutable<uint64_t>();
   if (isAnd_) {
     bits::orBits(values, rows.asRange().bits(), rows.begin(), rows.end());
   } else {

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -106,7 +106,7 @@ FlatVector<StringView>& ensureWritableStringView(
     VectorPtr& result) {
   context.ensureWritable(rows, VARCHAR(), result);
   auto* flat = result->as<FlatVector<StringView>>();
-  flat->mutableValues(rows.end());
+  flat->mutableValues();
   return *flat;
 }
 

--- a/velox/functions/prestosql/VectorArithmetic.cpp
+++ b/velox/functions/prestosql/VectorArithmetic.cpp
@@ -149,8 +149,7 @@ class VectorArithmetic : public VectorFunction {
       context.ensureWritable(rows, outputType, result);
     }
     // Here we provide a pointer to the raw flat results.
-    BufferPtr resultValues =
-        result->as<FlatVector<T>>()->mutableValues(rows.end());
+    BufferPtr resultValues = result->as<FlatVector<T>>()->mutableValues();
     T* __restrict rawResult = resultValues->asMutable<T>();
 
     // Step 2: handle input encodings and call the inner kernels

--- a/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
+++ b/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
@@ -47,7 +47,7 @@ class AtLeastNNonNullsExpr : public SpecialForm {
     LocalSelectivityVector activeRowsHolder(context, rows);
     auto activeRows = activeRowsHolder.get();
     VELOX_DCHECK_NOT_NULL(activeRows);
-    auto values = flatResult->mutableValues(rows.end())->asMutable<uint64_t>();
+    auto values = flatResult->mutableValues()->asMutable<uint64_t>();
     // If 'n_' <= 0, set result to all true.
     if (n_ <= 0) {
       bits::orBits(values, rows.asRange().bits(), rows.begin(), rows.end());

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -706,7 +706,7 @@ void read(
   auto nullCount = readNulls(
       source, size, resultOffset, incomingNulls, numIncomingNulls, *flatResult);
 
-  BufferPtr values = flatResult->mutableValues(resultOffset + numNewValues);
+  BufferPtr values = flatResult->mutableValues();
   if constexpr (std::is_same_v<T, Timestamp>) {
     if (opts.useLosslessTimestamp) {
       readLosslessTimestampValues(
@@ -780,7 +780,7 @@ void read<StringView>(
   result->resize(resultOffset + numNewValues);
 
   auto flatResult = result->as<FlatVector<StringView>>();
-  BufferPtr values = flatResult->mutableValues(resultOffset + size);
+  BufferPtr values = flatResult->mutableValues();
   auto rawValues = values->asMutable<StringView>();
   int32_t lastOffset = 0;
   for (int32_t i = 0; i < numNewValues; ++i) {
@@ -837,7 +837,7 @@ void read<OpaqueType>(
   auto deserialization = opaqueType->getDeserializeFunc();
 
   auto flatResult = result->as<FlatVector<std::shared_ptr<void>>>();
-  BufferPtr values = flatResult->mutableValues(resultOffset + size);
+  BufferPtr values = flatResult->mutableValues();
 
   auto rawValues = values->asMutable<std::shared_ptr<void>>();
   std::vector<int32_t> offsets;

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -141,23 +141,23 @@ class FlatVector final : public SimpleVector<T> {
     return values_;
   }
 
-  /// Ensures that 'values_' is singly-referenced and has space for 'size'
-  /// elements. Sets elements between the old and new sizes to T() if
-  /// the new size > old size.
+  /// Ensures that 'values_' is singly-referenced and has space for the current
+  /// size of the Vector. Sets any newly added elements to T() if the new size >
+  /// old size.
   ///
   /// If 'values_' is nullptr, read-only, not uniquely-referenced, or doesn't
   /// have capacity for 'size' elements allocates new buffer and copies data to
   /// it. Updates 'rawValues_' to point to element 0 of
   /// values_->as<T>().
-  BufferPtr mutableValues(vector_size_t size) {
-    const auto numNewBytes = BaseVector::byteSize<T>(size);
+  BufferPtr mutableValues(vector_size_t /*ignored*/ = 0) {
+    const auto numNewBytes = BaseVector::byteSize<T>(BaseVector::length_);
     if (values_ && !values_->isView() && values_->unique()) {
       if (values_->size() < numNewBytes) {
-        AlignedBuffer::reallocate<T>(&values_, size, T());
+        AlignedBuffer::reallocate<T>(&values_, BaseVector::length_, T());
       }
     } else {
-      BufferPtr newValues =
-          AlignedBuffer::allocate<T>(size, BaseVector::pool(), T());
+      BufferPtr newValues = AlignedBuffer::allocate<T>(
+          BaseVector::length_, BaseVector::pool(), T());
       if (values_) {
         const auto numCopyBytes =
             std::min<vector_size_t>(values_->size(), numNewBytes);

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3275,26 +3275,19 @@ TEST_F(VectorTest, mutableValues) {
   auto vector = makeFlatVector<int64_t>(1'000, [](auto row) { return row; });
 
   auto* rawValues = vector->rawValues();
-  vector->mutableValues(1'001);
+  vector->mutableValues();
   ASSERT_EQ(rawValues, vector->rawValues());
   for (auto i = 0; i < 1'000; ++i) {
     EXPECT_EQ(rawValues[i], i);
   }
 
-  vector->mutableValues(10'000);
-  ASSERT_NE(rawValues, vector->rawValues());
-  rawValues = vector->rawValues();
-  for (auto i = 0; i < 1'000; ++i) {
-    EXPECT_EQ(rawValues[i], i);
-  }
-
-  auto values = vector->mutableValues(2'000);
+  auto values = vector->mutableValues();
   ASSERT_EQ(rawValues, vector->rawValues());
   for (auto i = 0; i < 1'000; ++i) {
     EXPECT_EQ(rawValues[i], i);
   }
 
-  vector->mutableValues(500);
+  vector->mutableValues();
   ASSERT_NE(rawValues, vector->rawValues());
   rawValues = vector->rawValues();
   for (auto i = 0; i < 500; ++i) {


### PR DESCRIPTION
Summary:
Today FlatVector::mutableValues takes a size parameter and ensures the values Buffer in 
the FlatVector is sized to hold at least that many values.  If the Buffer is null, shared, or is a view, a new Buffer of that size is allocated.

This can result in the FlatVector ending up in an invalid state, if the size passed in is smaller
than the size of the Vector and a new Buffer is allocated.  In this case, if we call FlatVector::set, FlatVector::valueAt, or other functions that access the value at an index, this
can read or write off the end of the Buffer even for an index that seems valid based on the
size of the Vector.  All of our checks within FlatVector (or at least all that I saw in a cursory 
inspection) are based on the size of the Vector, not the size of the values Buffer.

This can be fixed by silently using the maximum of the size passed in or the size of the 
Vector. This is what BaseVector's mutableNulls does for example. I don't see any need for 
passing in a size greater than the size of the Vector, in particular I don't see any use cases 
for this in the existing calls to  mutableValues.

Therefore I've opted to simply remove the argument.

BREAKING CHANGE:
This change removes the size parameter from FlatVector::mutableValues.  Callers need to 
remove the argument from the function call and ensure they've sized the Vector 
appropriately before calling mutableValues.

Differential Revision: D77766602


