### PR TITLE
feat: Track the memory allocation in velox parquet writer

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -807,7 +807,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
   writer->close();
 };
 
-DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteWithArrowMemoryPool) {
+TEST_F(ParquetWriterTest, parquetWriteWithArrowMemoryPool) {
   const auto data = makeRowVector({makeFlatVector<Timestamp>(
       10'000, [](auto row) { return Timestamp(row, row); })});
   parquet::WriterOptions writerOptions;

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -83,6 +83,67 @@ class ParquetWriterTest : public ParquetTestBase {
   inline static const std::string kHiveConnectorId = "test-hive";
 };
 
+class ArrowMemoryPool final : public ::arrow::MemoryPool {
+ public:
+  explicit ArrowMemoryPool() : allocated_(0) {}
+
+  ~ArrowMemoryPool() = default;
+
+  ::arrow::Status Allocate(int64_t size, int64_t alignment, uint8_t** out)
+      override {
+    *out = reinterpret_cast<uint8_t*>(malloc(size));
+    common::testutil::TestValue::adjust("ArrowMemoryPool::Allocate", *out);
+    if (!*out) {
+      return ::arrow::Status::OutOfMemory("Failed to allocate memory");
+    }
+    allocated_ += size;
+    return ::arrow::Status::OK();
+  }
+
+  ::arrow::Status Reallocate(
+      int64_t oldSize,
+      int64_t newSize,
+      int64_t alignment,
+      uint8_t** ptr) override {
+    uint8_t* newBuffer = reinterpret_cast<uint8_t*>(realloc(*ptr, newSize));
+    if (!newBuffer) {
+      return ::arrow::Status::OutOfMemory("Failed to reallocate memory");
+    }
+    *ptr = newBuffer;
+    allocated_ = allocated_ - oldSize + newSize;
+    return ::arrow::Status::OK();
+  }
+
+  void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
+    free(buffer);
+    allocated_ -= size;
+  }
+
+  int64_t bytes_allocated() const override {
+    return allocated_;
+    ;
+  }
+
+  int64_t max_memory() const override {
+    VELOX_UNSUPPORTED("ArrowMemoryPool#max_memory() unsupported");
+  }
+
+  int64_t total_bytes_allocated() const override {
+    VELOX_UNSUPPORTED("ArrowMemoryPool#total_bytes_allocated() unsupported");
+  }
+
+  int64_t num_allocations() const override {
+    VELOX_UNSUPPORTED("ArrowMemoryPool#num_allocations() unsupported");
+  }
+
+  std::string backend_name() const override {
+    return "arrow memory pool";
+  }
+
+ private:
+  int64_t allocated_;
+};
+
 std::vector<CompressionKind> params = {
     CompressionKind::CompressionKind_NONE,
     CompressionKind::CompressionKind_SNAPPY,
@@ -720,7 +781,7 @@ DEBUG_ONLY_TEST_F(ParquetWriterTest, unitFromWriterOptions) {
   writer->close();
 };
 
-TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
+DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
   SCOPED_TESTVALUE_SET(
       "facebook::velox::parquet::Writer::write",
       std::function<void(const ::arrow::Schema*)>(
@@ -737,6 +798,28 @@ TEST_F(ParquetWriterTest, parquetWriteTimestampTimeZoneWithDefault) {
   parquet::WriterOptions writerOptions;
   writerOptions.memoryPool = leafPool_.get();
   writerOptions.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+
+  // Create an in-memory writer.
+  auto sink = std::make_unique<MemorySink>(
+      200 * 1024 * 1024,
+      dwio::common::FileSink::Options{.pool = leafPool_.get()});
+  auto writer = std::make_unique<parquet::Writer>(
+      std::move(sink), writerOptions, rootPool_, ROW({"c0"}, {TIMESTAMP()}));
+  writer->write(data);
+  writer->close();
+};
+
+DEBUG_ONLY_TEST_F(ParquetWriterTest, parquetWriteWithArrowMemoryPool) {
+  SCOPED_TESTVALUE_SET(
+      "ArrowMemoryPool::Allocate",
+      std::function<void(const uint8_t*)>(
+          [&](const uint8_t* buffer) { ASSERT_TRUE(buffer != nullptr); }));
+
+  const auto data = makeRowVector({makeFlatVector<Timestamp>(
+      10'000, [](auto row) { return Timestamp(row, row); })});
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = leafPool_.get();
+  writerOptions.arrowMemoryPool = std::make_shared<ArrowMemoryPool>();
 
   // Create an in-memory writer.
   auto sink = std::make_unique<MemorySink>(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -350,6 +350,7 @@ Writer::Writer(
       getArrowParquetWriterOptions(options, flushPolicy_);
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = options.writeInt96AsTimestamp;
+  arrowMemoryPool_ = options.arrowMemoryPool;
 }
 
 Writer::Writer(
@@ -376,7 +377,7 @@ void Writer::flush() {
           arrowContext_->writer,
           FileWriter::Open(
               *arrowContext_->schema.get(),
-              ::arrow::default_memory_pool(),
+              arrowMemoryPool_.get(),
               stream_,
               arrowContext_->properties,
               arrowProperties));

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "arrow/memory_pool.h"
 #include "velox/common/compression/Compression.h"
 #include "velox/common/config/Config.h"
 #include "velox/dwio/common/DataBuffer.h"
@@ -113,6 +114,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 
+  std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
+
   // Parsing session and hive configs.
 
   // This isn't a typo; session and hive connector config names are different
@@ -204,6 +207,7 @@ class Writer : public dwio::common::Writer {
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> generalPool_;
+  std::shared_ptr<arrow::MemoryPool> arrowMemoryPool_;
 
   // Temporary Arrow stream for capturing the output.
   std::shared_ptr<ArrowDataBufferSink> stream_;


### PR DESCRIPTION
Currently, the Velox Parquet writer utilizes the arrow::default memory pool for memory allocation. This approach does not integrate with the VeloxMemoryManager, resulting in memory usage that is not tracked by Spark. Consequently, this can lead to issues such as killed by yarn in the Gluten project due to untracked memory consumption. Issue is recorded [here](https://github.com/apache/incubator-gluten/issues/9737).

To address this, we have developed a new ArrowMemoryPool within Gluten that allocates memory using Spark's memory allocator. This ensures that the memory usage is properly tracked by Spark.

Therefore, it is necessary to pass the newly created ArrowMemoryPool from Gluten into the Velox Parquet writer to enable proper memory tracking.