### PR TITLE
Fix Variant::hash and BaseVector::hashValueAt for arrays and maps

### DIFF
--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -536,3 +536,14 @@ TEST(VariantTest, typeWithCustomComparison) {
   ASSERT_NE(zero.hash(), one.hash());
   ASSERT_NE(zero.hash(), null.hash());
 }
+
+TEST(VariantTest, hashMap) {
+  auto a = Variant::map({{1, 10}, {2, 20}});
+  auto b = Variant::map({{1, 20}, {2, 10}});
+  auto c = Variant::map({{2, 20}, {1, 10}});
+  auto d = Variant::map({{1, 10}, {2, 20}, {3, 30}});
+
+  ASSERT_NE(a.hash(), b.hash());
+  ASSERT_EQ(a.hash(), c.hash());
+  ASSERT_NE(a.hash(), d.hash());
+}

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -3648,6 +3648,44 @@ TEST_F(VectorTest, flatAllNulls) {
   }
 }
 
+TEST_F(VectorTest, hashValueAtArray) {
+  auto data = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+      "[2, 1, 3]",
+      "[3, 2, 1]",
+      "[1, 2, 3, 4]",
+      "[1, null, 3]",
+      "[1, 2, 3]",
+  });
+
+  std::unordered_set<uint64_t> hashes;
+  for (auto i = 0; i < 5; ++i) {
+    EXPECT_TRUE(hashes.insert(data->hashValueAt(i)).second);
+  }
+  EXPECT_EQ(5, hashes.size());
+
+  EXPECT_EQ(data->hashValueAt(0), data->hashValueAt(5));
+}
+
+TEST_F(VectorTest, hashValueAtMap) {
+  auto data = makeMapVectorFromJson<int32_t, int32_t>({
+      "{1: 10, 2: 20}",
+      "{1: 20, 2: 10}",
+      "{10: 1, 20: 2}",
+      "{1: 2, 3: 4}",
+      "{1: 2, 3: 4, 5: 6}",
+      "{2: 20, 1: 10}",
+  });
+
+  std::unordered_set<uint64_t> hashes;
+  for (auto i = 0; i < 5; ++i) {
+    EXPECT_TRUE(hashes.insert(data->hashValueAt(i)).second);
+  }
+  EXPECT_EQ(5, hashes.size());
+
+  EXPECT_EQ(data->hashValueAt(0), data->hashValueAt(5));
+}
+
 TEST_F(VectorTest, hashAll) {
   auto data = makeFlatVector<int32_t>({1, 2, 3});
   ASSERT_TRUE(data->getNullCount().has_value());


### PR DESCRIPTION
Summary:
Commutative hashes ignore the order in which values are added to the hash. 

When hashing arrays, one must not use commutative hash, but ArrayVector::hashValueAt used that. This caused unnecessary hash collisions as hashes of two arrays that contain same elements but in different order were always the same. hash([1, 2, 3]) was the same as hash([3, 2, 1]).

When hashing maps, we need to use non-commutative hash to combine hashes of each key and value in a pair, but then combine hashes of pairs using commutative hash. 

Variant::hash used commutative hash to combine hashes of all keys, commutative hash to combine hashes of all values and non-commutative hash to combine these the results. Thus, hash({1: 10, 2: 20}) was same as hash({2: 10, 1: 20}). MapVector::hashValueAt had even more severe problem as it used commutative hash to combine hashes of all keys and values together. Thus, hash({1: 10, 2: 20}) was the same as hash({10: 20, 2: 1}).

Fixes https://github.com/facebookincubator/velox/issues/14018

Fixes https://github.com/facebookincubator/velox/issues/14017

Differential Revision: D77823844


