### PR TITLE
refactor: Modernize code in velox/parse

### DIFF
--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -15,12 +15,10 @@
  */
 #pragma once
 
-#include <memory>
 #include <string>
-#include <vector>
+#include "velox/parse/IExpr.h"
 
 namespace facebook::velox::core {
-class IExpr;
 class SortOrder;
 } // namespace facebook::velox::core
 
@@ -44,20 +42,19 @@ struct ParseOptions {
 // are lower-cased, what prevents you to use functions and column names
 // containing upper case letters (e.g: "concatRow" will be parsed as
 // "concatrow").
-std::shared_ptr<const core::IExpr> parseExpr(
+core::ExprPtr parseExpr(
     const std::string& exprString,
     const ParseOptions& options);
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& exprString,
     const ParseOptions& options);
 
 struct AggregateExpr {
-  std::shared_ptr<const core::IExpr> expr;
-  std::vector<std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder>>
-      orderBy;
+  core::ExprPtr expr;
+  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
   bool distinct{false};
-  std::shared_ptr<const core::IExpr> maskExpr{nullptr};
+  core::ExprPtr maskExpr{nullptr};
 };
 
 /// Parses aggregate function call expression with optional ORDER by clause.
@@ -72,7 +69,7 @@ AggregateExpr parseAggregateExpr(
 // Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
 // converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC
 // NULLS LAST as the default sort order.
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& exprString);
 
 // Parses a WINDOW function SQL string using DuckDB's internal postgresql-based
@@ -93,19 +90,18 @@ enum class BoundType {
 struct IExprWindowFrame {
   WindowType type;
   BoundType startType;
-  std::shared_ptr<const core::IExpr> startValue;
+  core::ExprPtr startValue;
   BoundType endType;
-  std::shared_ptr<const core::IExpr> endValue;
+  core::ExprPtr endValue;
 };
 
 struct IExprWindowFunction {
-  std::shared_ptr<const core::IExpr> functionCall;
+  core::ExprPtr functionCall;
   IExprWindowFrame frame;
   bool ignoreNulls;
 
-  std::vector<std::shared_ptr<const core::IExpr>> partitionBy;
-  std::vector<std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder>>
-      orderBy;
+  std::vector<core::ExprPtr> partitionBy;
+  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
 };
 
 IExprWindowFunction parseWindowExpr(

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -645,8 +645,8 @@ TEST(DuckParserTest, windowWithIntegerConstant) {
       std::dynamic_pointer_cast<const core::CallExpr>(windowExpr.functionCall);
   ASSERT_TRUE(func != nullptr)
       << windowExpr.functionCall->toString() << " is not a call expr";
-  EXPECT_EQ(func->getInputs().size(), 2);
-  auto param = func->getInputs()[1];
+  EXPECT_EQ(func->inputs().size(), 2);
+  auto param = func->inputs()[1];
   auto constant = std::dynamic_pointer_cast<const core::ConstantExpr>(param);
   ASSERT_TRUE(constant != nullptr) << param->toString() << " is not a constant";
   EXPECT_EQ(*constant->type(), *INTEGER());

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -473,7 +473,7 @@ PlanBuilder& PlanBuilder::projectExpressions(
     } else if (
         auto fieldExpr =
             dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
-      projectNames.push_back(fieldExpr->getFieldName());
+      projectNames.push_back(fieldExpr->name());
     } else {
       projectNames.push_back(fmt::format("p{}", i));
     }
@@ -495,7 +495,7 @@ PlanBuilder& PlanBuilder::projectExpressions(
     expressions.push_back(projections[i]);
     if (auto fieldExpr =
             dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
-      projectNames.push_back(fieldExpr->getFieldName());
+      projectNames.push_back(fieldExpr->name());
     } else {
       projectNames.push_back(fmt::format("p{}", i));
     }
@@ -735,7 +735,7 @@ class AggregateTypeResolver {
       const std::vector<core::TypedExprPtr>& inputs,
       const std::shared_ptr<const core::CallExpr>& expr,
       bool nullOnFailure) const {
-    auto functionName = expr->getFunctionName();
+    auto functionName = expr->name();
 
     // Use raw input types (if available) to resolve intermediate and final
     // result types.
@@ -1066,7 +1066,7 @@ PlanBuilder& PlanBuilder::groupId(
         fieldAccessExpr,
         "Grouping key {} is not valid projection",
         groupingKey);
-    std::string inputField = fieldAccessExpr->getFieldName();
+    std::string inputField = fieldAccessExpr->name();
     std::string outputField = untypedExpr->alias().has_value()
         ?
         // This is a projection with a column alias with the format
@@ -1074,7 +1074,7 @@ PlanBuilder& PlanBuilder::groupId(
         untypedExpr->alias().value()
         :
         // This is a projection without a column alias.
-        fieldAccessExpr->getFieldName();
+        fieldAccessExpr->name();
 
     core::GroupIdNode::GroupingKeyInfo keyInfos;
     keyInfos.output = outputField;
@@ -1138,7 +1138,7 @@ PlanBuilder& PlanBuilder::expand(
           auto fieldExpr = dynamic_cast<const core::FieldAccessExpr*>(
               untypedExpression.get());
           VELOX_CHECK_NOT_NULL(fieldExpr);
-          aliases.push_back(fieldExpr->getFieldName());
+          aliases.push_back(fieldExpr->name());
         }
         projectExpr.push_back(typedExpression);
       } else {
@@ -2039,7 +2039,7 @@ class WindowTypeResolver {
       types.push_back(input->type());
     }
 
-    auto functionName = expr->getFunctionName();
+    const auto& functionName = expr->name();
 
     return resolveWindowType(functionName, types, nullOnFailure);
   }

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -18,9 +18,7 @@
 
 namespace facebook::velox::parse {
 
-std::shared_ptr<const core::IExpr> parseExpr(
-    const std::string& expr,
-    const ParseOptions& options) {
+core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
@@ -28,7 +26,7 @@ std::shared_ptr<const core::IExpr> parseExpr(
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& expr,
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
@@ -39,7 +37,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
       expr, duckConversionOptions);
 }
 
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& expr) {
   return facebook::velox::duckdb::parseOrderByExpr(expr);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -15,9 +15,7 @@
  */
 #pragma once
 
-#include <set>
 #include "velox/core/PlanNode.h"
-#include "velox/core/QueryCtx.h"
 #include "velox/parse/IExpr.h"
 
 namespace facebook::velox::parse {
@@ -34,14 +32,12 @@ struct ParseOptions {
   std::string functionPrefix;
 };
 
-std::shared_ptr<const core::IExpr> parseExpr(
-    const std::string& expr,
-    const ParseOptions& options);
+core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options);
 
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& expr);
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& expr,
     const ParseOptions& options);
 

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -17,7 +17,6 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
-#include "velox/expression/SignatureBinder.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/parse/Expressions.h"
 #include "velox/type/Type.h"
@@ -62,13 +61,12 @@ TypePtr resolveType(
     inputTypes.emplace_back(input->type());
   }
 
-  if (auto resolvedType = exec::resolveTypeForSpecialForm(
-          expr->getFunctionName(), inputTypes)) {
+  if (auto resolvedType =
+          exec::resolveTypeForSpecialForm(expr->name(), inputTypes)) {
     return resolvedType;
   }
 
-  return resolveScalarFunctionType(
-      expr->getFunctionName(), inputTypes, nullOnFailure);
+  return resolveScalarFunctionType(expr->name(), inputTypes, nullOnFailure);
 }
 
 } // namespace

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/parse/QueryPlanner.h"
-#include "velox/common/base/tests/GTestUtils.h"
+#include <gtest/gtest.h>
 
 namespace facebook::velox::core::test {
 

--- a/velox/python/legacy/pyvelox.cpp
+++ b/velox/python/legacy/pyvelox.cpp
@@ -257,7 +257,7 @@ static void addExpressionBindings(
           "getInputs",
           [](IExprWrapper& e) {
             const std::vector<std::shared_ptr<const core::IExpr>>& inputs =
-                e.expr->getInputs();
+                e.expr->inputs();
             std::vector<IExprWrapper> wrapped_inputs;
             wrapped_inputs.resize(inputs.size());
             for (const std::shared_ptr<const core::IExpr>& input : inputs) {


### PR DESCRIPTION
Summary:
- replace std::shared_ptr<IExpr> with ExprPtr
- move 'inputs' from derives classes to the base IExpr class
- rename getters to match coding style (getInputs -> inputs)
- cleanup includes

Differential Revision: D77863302


