### PR TITLE
refactor: Decouple SQL parsing from type resolution

### DIFF
--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -15,12 +15,10 @@
  */
 #pragma once
 
-#include <memory>
 #include <string>
-#include <vector>
+#include "velox/parse/IExpr.h"
 
 namespace facebook::velox::core {
-class IExpr;
 class SortOrder;
 } // namespace facebook::velox::core
 
@@ -44,20 +42,19 @@ struct ParseOptions {
 // are lower-cased, what prevents you to use functions and column names
 // containing upper case letters (e.g: "concatRow" will be parsed as
 // "concatrow").
-std::shared_ptr<const core::IExpr> parseExpr(
+core::ExprPtr parseExpr(
     const std::string& exprString,
     const ParseOptions& options);
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& exprString,
     const ParseOptions& options);
 
 struct AggregateExpr {
-  std::shared_ptr<const core::IExpr> expr;
-  std::vector<std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder>>
-      orderBy;
+  core::ExprPtr expr;
+  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
   bool distinct{false};
-  std::shared_ptr<const core::IExpr> maskExpr{nullptr};
+  core::ExprPtr maskExpr{nullptr};
 };
 
 /// Parses aggregate function call expression with optional ORDER by clause.
@@ -72,7 +69,7 @@ AggregateExpr parseAggregateExpr(
 // Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
 // converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC
 // NULLS LAST as the default sort order.
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& exprString);
 
 // Parses a WINDOW function SQL string using DuckDB's internal postgresql-based
@@ -93,19 +90,18 @@ enum class BoundType {
 struct IExprWindowFrame {
   WindowType type;
   BoundType startType;
-  std::shared_ptr<const core::IExpr> startValue;
+  core::ExprPtr startValue;
   BoundType endType;
-  std::shared_ptr<const core::IExpr> endValue;
+  core::ExprPtr endValue;
 };
 
 struct IExprWindowFunction {
-  std::shared_ptr<const core::IExpr> functionCall;
+  core::ExprPtr functionCall;
   IExprWindowFrame frame;
   bool ignoreNulls;
 
-  std::vector<std::shared_ptr<const core::IExpr>> partitionBy;
-  std::vector<std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder>>
-      orderBy;
+  std::vector<core::ExprPtr> partitionBy;
+  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
 };
 
 IExprWindowFunction parseWindowExpr(

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -18,11 +18,16 @@
 #include <string>
 #include "velox/parse/IExpr.h"
 
-namespace facebook::velox::core {
-class SortOrder;
-} // namespace facebook::velox::core
-
 namespace facebook::velox::duckdb {
+
+struct OrderByClause {
+  core::ExprPtr expr;
+  bool ascending;
+  bool nullsFirst;
+
+  std::string toString() const;
+};
+
 /// Hold parsing options.
 struct ParseOptions {
   // Retain legacy behavior by default.
@@ -52,7 +57,7 @@ std::vector<core::ExprPtr> parseMultipleExpressions(
 
 struct AggregateExpr {
   core::ExprPtr expr;
-  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
+  std::vector<OrderByClause> orderBy;
   bool distinct{false};
   core::ExprPtr maskExpr{nullptr};
 };
@@ -66,11 +71,9 @@ AggregateExpr parseAggregateExpr(
     const std::string& exprString,
     const ParseOptions& options);
 
-// Parses an ORDER BY clause using DuckDB's internal postgresql-based parser,
-// converting it to a pair of an IExpr tree and a core::SortOrder. Uses ASC
-// NULLS LAST as the default sort order.
-std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
-    const std::string& exprString);
+// Parses an ORDER BY clause using DuckDB's internal postgresql-based parser.
+// Uses ASC NULLS LAST as the default sort order.
+OrderByClause parseOrderByExpr(const std::string& exprString);
 
 // Parses a WINDOW function SQL string using DuckDB's internal postgresql-based
 // parser. Window Functions are executed by Velox Window PlanNodes and not the
@@ -101,7 +104,7 @@ struct IExprWindowFunction {
   bool ignoreNulls;
 
   std::vector<core::ExprPtr> partitionBy;
-  std::vector<std::pair<core::ExprPtr, core::SortOrder>> orderBy;
+  std::vector<OrderByClause> orderBy;
 };
 
 IExprWindowFunction parseWindowExpr(

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -101,10 +101,7 @@ TEST(DuckParserTest, functions) {
 }
 
 namespace {
-std::string toString(
-    const std::vector<
-        std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder>>&
-        orderBy) {
+std::string toString(const std::vector<OrderByClause>& orderBy) {
   std::stringstream out;
   if (!orderBy.empty()) {
     out << "ORDER BY ";
@@ -112,8 +109,7 @@ std::string toString(
       if (i > 0) {
         out << ", ";
       }
-      out << orderBy[i].first->toString() << " "
-          << orderBy[i].second.toString();
+      out << orderBy[i].toString();
     }
   }
 
@@ -509,9 +505,7 @@ TEST(DuckParserTest, count) {
 
 TEST(DuckParserTest, orderBy) {
   auto parse = [](const auto& expr) {
-    auto orderBy = parseOrderByExpr(expr);
-    return fmt::format(
-        "{} {}", orderBy.first->toString(), orderBy.second.toString());
+    return parseOrderByExpr(expr).toString();
   };
 
   EXPECT_EQ("\"c1\" ASC NULLS LAST", parse("c1"));

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -645,8 +645,8 @@ TEST(DuckParserTest, windowWithIntegerConstant) {
       std::dynamic_pointer_cast<const core::CallExpr>(windowExpr.functionCall);
   ASSERT_TRUE(func != nullptr)
       << windowExpr.functionCall->toString() << " is not a call expr";
-  EXPECT_EQ(func->getInputs().size(), 2);
-  auto param = func->getInputs()[1];
+  EXPECT_EQ(func->inputs().size(), 2);
+  auto param = func->inputs()[1];
   auto constant = std::dynamic_pointer_cast<const core::ConstantExpr>(param);
   ASSERT_TRUE(constant != nullptr) << param->toString() << " is not a constant";
   EXPECT_EQ(*constant->type(), *INTEGER());

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -26,6 +26,7 @@
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::exec::test {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -473,7 +473,7 @@ PlanBuilder& PlanBuilder::projectExpressions(
     } else if (
         auto fieldExpr =
             dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
-      projectNames.push_back(fieldExpr->getFieldName());
+      projectNames.push_back(fieldExpr->name());
     } else {
       projectNames.push_back(fmt::format("p{}", i));
     }
@@ -495,7 +495,7 @@ PlanBuilder& PlanBuilder::projectExpressions(
     expressions.push_back(projections[i]);
     if (auto fieldExpr =
             dynamic_cast<const core::FieldAccessExpr*>(projections[i].get())) {
-      projectNames.push_back(fieldExpr->getFieldName());
+      projectNames.push_back(fieldExpr->name());
     } else {
       projectNames.push_back(fmt::format("p{}", i));
     }
@@ -735,7 +735,7 @@ class AggregateTypeResolver {
       const std::vector<core::TypedExprPtr>& inputs,
       const std::shared_ptr<const core::CallExpr>& expr,
       bool nullOnFailure) const {
-    auto functionName = expr->getFunctionName();
+    auto functionName = expr->name();
 
     // Use raw input types (if available) to resolve intermediate and final
     // result types.
@@ -1066,7 +1066,7 @@ PlanBuilder& PlanBuilder::groupId(
         fieldAccessExpr,
         "Grouping key {} is not valid projection",
         groupingKey);
-    std::string inputField = fieldAccessExpr->getFieldName();
+    std::string inputField = fieldAccessExpr->name();
     std::string outputField = untypedExpr->alias().has_value()
         ?
         // This is a projection with a column alias with the format
@@ -1074,7 +1074,7 @@ PlanBuilder& PlanBuilder::groupId(
         untypedExpr->alias().value()
         :
         // This is a projection without a column alias.
-        fieldAccessExpr->getFieldName();
+        fieldAccessExpr->name();
 
     core::GroupIdNode::GroupingKeyInfo keyInfos;
     keyInfos.output = outputField;
@@ -1138,7 +1138,7 @@ PlanBuilder& PlanBuilder::expand(
           auto fieldExpr = dynamic_cast<const core::FieldAccessExpr*>(
               untypedExpression.get());
           VELOX_CHECK_NOT_NULL(fieldExpr);
-          aliases.push_back(fieldExpr->getFieldName());
+          aliases.push_back(fieldExpr->name());
         }
         projectExpr.push_back(typedExpression);
       } else {
@@ -2039,7 +2039,7 @@ class WindowTypeResolver {
       types.push_back(input->type());
     }
 
-    auto functionName = expr->getFunctionName();
+    const auto& functionName = expr->name();
 
     return resolveWindowType(functionName, types, nullOnFailure);
   }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -20,7 +20,6 @@
 #include <velox/core/ITypedExpr.h>
 #include <velox/core/PlanFragment.h>
 #include <velox/core/PlanNode.h>
-#include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/IExpr.h"

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -22,6 +22,7 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/expression/Expr.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/vector/VectorSaver.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -20,7 +20,6 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/duckdb/conversion/DuckParser.h"
-#include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -65,10 +64,8 @@ WindowTestBase::QueryInfo WindowTestBase::buildStreamingWindowQuery(
   }
 
   // Extract the order by keys.
-  const auto& orderBy = windowExpr.orderBy;
-  for (auto i = 0; i < orderBy.size(); ++i) {
-    orderByClauses.push_back(
-        orderBy[i].first->toString() + " " + orderBy[i].second.toString());
+  for (const auto& clause : windowExpr.orderBy) {
+    orderByClauses.push_back(clause.toString());
   }
 
   // Sort the input data before streaming window.

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -19,8 +19,8 @@
 #include <utility>
 
 #include "velox/expression/Expr.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 #include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -12,12 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 velox_add_library(velox_parse_expression Expressions.cpp)
-velox_link_libraries(
-  velox_parse_expression
-  velox_type
-  velox_parse_utils
-  velox_expression
-  velox_exec)
+velox_link_libraries(velox_parse_expression velox_type velox_parse_utils
+                     velox_expression)
 
 velox_add_library(velox_parse_parser ExpressionsParser.cpp QueryPlanner.cpp)
 velox_link_libraries(velox_parse_parser velox_parse_expression velox_type
@@ -27,6 +23,7 @@ velox_add_library(velox_parse_utils TypeResolver.cpp)
 velox_link_libraries(
   velox_parse_utils
   velox_buffer
+  velox_exec
   velox_type
   velox_vector
   velox_function_registry)

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -14,440 +14,54 @@
  * limitations under the License.
  */
 #include "velox/parse/Expressions.h"
-#include "velox/common/base/Exceptions.h"
-#include "velox/core/Expressions.h"
-#include "velox/exec/Aggregate.h"
-#include "velox/expression/SignatureBinder.h"
-#include "velox/functions/FunctionRegistry.h"
-#include "velox/type/Type.h"
-#include "velox/vector/ConstantVector.h"
-#include "velox/vector/VariantToVector.h"
 
 namespace facebook::velox::core {
 
-// static
-Expressions::TypeResolverHook Expressions::resolverHook_;
-// static
-Expressions::FieldAccessHook Expressions::fieldAccessHook_;
-
 namespace {
 
-// Determine output type based on input types.
-TypePtr resolveTypeImpl(
-    const std::vector<TypedExprPtr>& inputs,
-    const std::shared_ptr<const CallExpr>& expr,
-    bool nullOnFailure) {
-  VELOX_CHECK_NOT_NULL(Expressions::getResolverHook());
-  return Expressions::getResolverHook()(inputs, expr, nullOnFailure);
-}
-
-CastTypedExprPtr makeTypedCast(const TypePtr& type, const TypedExprPtr& input) {
-  return std::make_shared<CastTypedExpr>(type, input, false);
-}
-
-std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
-  std::vector<TypePtr> targetTypes;
-  switch (type->kind()) {
-    // We decide not to implicitly upcast booleans because it maybe funky.
-    case TypeKind::BOOLEAN:
-      break;
-    case TypeKind::TINYINT:
-      targetTypes.emplace_back(SMALLINT());
-      [[fallthrough]];
-    case TypeKind::SMALLINT:
-      targetTypes.emplace_back(INTEGER());
-      targetTypes.emplace_back(REAL());
-      [[fallthrough]];
-    case TypeKind::INTEGER:
-      targetTypes.emplace_back(BIGINT());
-      targetTypes.emplace_back(DOUBLE());
-      [[fallthrough]];
-    case TypeKind::BIGINT:
-      break;
-    case TypeKind::REAL:
-      targetTypes.emplace_back(DOUBLE());
-      [[fallthrough]];
-    case TypeKind::DOUBLE:
-      break;
-    case TypeKind::ARRAY: {
-      auto childTargetTypes = implicitCastTargets(type->childAt(0));
-      for (const auto& childTarget : childTargetTypes) {
-        targetTypes.emplace_back(ARRAY(childTarget));
-      }
-      break;
-    }
-    default: // make compilers happy
-      break;
-  }
-  return targetTypes;
-}
-
-// All acceptable implicit casts on this expression.
-// TODO: If we get this to be recursive somehow, we can save on cast function
-// signatures that need to be compiled and registered.
-std::vector<TypedExprPtr> genImplicitCasts(const TypedExprPtr& typedExpr) {
-  auto targetTypes = implicitCastTargets(typedExpr->type());
-
-  std::vector<TypedExprPtr> implicitCasts;
-  implicitCasts.reserve(targetTypes.size());
-  for (const auto& targetType : targetTypes) {
-    implicitCasts.emplace_back(makeTypedCast(targetType, typedExpr));
-  }
-  return implicitCasts;
-}
-
-// TODO: Arguably all of this could be done with just Types.
-TypedExprPtr adjustLastNArguments(
-    std::vector<TypedExprPtr> inputs,
-    const std::shared_ptr<const CallExpr>& expr,
-    size_t n) {
-  auto type = resolveTypeImpl(inputs, expr, true /*nullOnFailure*/);
-  if (type != nullptr) {
-    return std::make_shared<CallTypedExpr>(
-        type, inputs, std::string{expr->name()});
-  }
-
-  if (n == 0) {
-    return nullptr;
-  }
-
-  size_t firstOfLastN = inputs.size() - n;
-  // use it
-  std::vector<TypedExprPtr> viableExprs{inputs[firstOfLastN]};
-  // or lose it
-  auto&& implicitCasts = genImplicitCasts(inputs[firstOfLastN]);
-  std::move(
-      implicitCasts.begin(),
-      implicitCasts.end(),
-      std::back_inserter(viableExprs));
-
-  for (auto& viableExpr : viableExprs) {
-    inputs[firstOfLastN] = viableExpr;
-    auto adjustedExpr = adjustLastNArguments(inputs, expr, n - 1);
-    if (adjustedExpr != nullptr) {
-      return adjustedExpr;
-    }
-  }
-
-  return nullptr;
-}
-
-TypedExprPtr createWithImplicitCast(
-    const std::shared_ptr<const CallExpr>& expr,
-    const std::vector<TypedExprPtr>& inputs) {
-  auto adjusted = adjustLastNArguments(inputs, expr, inputs.size());
-  if (adjusted) {
-    return adjusted;
-  }
-  auto type = resolveTypeImpl(inputs, expr, /*isTryCast=*/false);
-  return std::make_shared<CallTypedExpr>(type, inputs, expr->name());
-}
-
-bool isLambdaArgument(const exec::TypeSignature& typeSignature) {
-  return typeSignature.baseName() == "function";
-}
-
-bool isLambdaArgument(const exec::TypeSignature& typeSignature, int numInputs) {
-  return isLambdaArgument(typeSignature) &&
-      (typeSignature.parameters().size() == numInputs + 1);
-}
-
-bool hasLambdaArgument(const exec::FunctionSignature& signature) {
-  for (const auto& type : signature.argumentTypes()) {
-    if (isLambdaArgument(type)) {
-      return true;
-    }
-  }
-
-  return false;
+std::string escapeName(const std::string& name) {
+  return folly::cEscape<std::string>(name);
 }
 } // namespace
 
-// static
-TypedExprPtr Expressions::inferTypes(
-    const std::shared_ptr<const IExpr>& expr,
-    const TypePtr& inputRow,
-    memory::MemoryPool* pool,
-    const VectorPtr& complexConstants) {
-  return inferTypes(expr, inputRow, {}, pool, complexConstants);
+std::string FieldAccessExpr::toString() const {
+  if (isRootColumn()) {
+    return appendAliasIfExists(fmt::format("\"{}\"", escapeName(name_)));
+  }
+
+  return appendAliasIfExists(
+      fmt::format("dot({},\"{}\")", input()->toString(), escapeName(name_)));
 }
 
-// static
-TypedExprPtr Expressions::inferTypes(
-    const std::shared_ptr<const IExpr>& expr,
-    const TypePtr& inputRow,
-    const std::vector<TypePtr>& lambdaInputTypes,
-    memory::MemoryPool* pool,
-    const VectorPtr& complexConstants) {
-  VELOX_CHECK_NOT_NULL(expr);
-
-  if (auto lambdaExpr = std::dynamic_pointer_cast<const LambdaExpr>(expr)) {
-    return resolveLambdaExpr(
-        lambdaExpr, inputRow, lambdaInputTypes, pool, complexConstants);
-  }
-
-  if (auto call = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    if (!expr->inputs().empty()) {
-      if (auto returnType = tryResolveCallWithLambdas(
-              call, inputRow, pool, complexConstants)) {
-        return returnType;
-      }
+std::string CallExpr::toString() const {
+  std::string buf{name_ + "("};
+  bool first = true;
+  for (auto& f : inputs()) {
+    if (!first) {
+      buf += ",";
     }
+    buf += f->toString();
+    first = false;
   }
-
-  // try rebuilding complex constant type from vector
-  if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    if (fun->name() == "__complex_constant") {
-      VELOX_CHECK_NOT_NULL(
-          complexConstants,
-          "Expression contains __complex_constant function call, but complexConstants is missing");
-
-      auto ccInputRow = complexConstants->as<RowVector>();
-      VELOX_CHECK_NOT_NULL(
-          ccInputRow,
-          "Expected RowVector for complexConstants: {}",
-          complexConstants->toString());
-      auto name =
-          std::dynamic_pointer_cast<const FieldAccessExpr>(fun->inputAt(0))
-              ->name();
-      auto rowType = asRowType(ccInputRow->type());
-      return std::make_shared<ConstantTypedExpr>(
-          ccInputRow->childAt(rowType->getChildIdx(name)));
-    }
-  }
-
-  std::vector<TypedExprPtr> children;
-  for (auto& child : expr->inputs()) {
-    children.push_back(
-        inferTypes(child, inputRow, lambdaInputTypes, pool, complexConstants));
-  }
-
-  if (auto fae = std::dynamic_pointer_cast<const FieldAccessExpr>(expr)) {
-    if (fieldAccessHook_) {
-      if (auto result = fieldAccessHook_(fae, children)) {
-        return result;
-      }
-    }
-    VELOX_CHECK(!fae->name().empty(), "Anonymous columns are not supported");
-    VELOX_CHECK_EQ(
-        children.size(), 1, "Unexpected number of children in FieldAccessExpr");
-    auto input = children.at(0)->type();
-    auto& row = input->asRow();
-    auto childIndex = row.getChildIdx(fae->name());
-    if (fae->isRootColumn()) {
-      return std::make_shared<FieldAccessTypedExpr>(
-          input->childAt(childIndex), children.at(0), std::string{fae->name()});
-    } else {
-      return std::make_shared<DereferenceTypedExpr>(
-          input->childAt(childIndex), children.at(0), childIndex);
-    }
-  }
-
-  if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
-    return createWithImplicitCast(fun, children);
-  }
-
-  if (auto input = std::dynamic_pointer_cast<const InputExpr>(expr)) {
-    return std::make_shared<InputTypedExpr>(inputRow);
-  }
-
-  if (auto constant = std::dynamic_pointer_cast<const ConstantExpr>(expr)) {
-    if (constant->type()->kind() == TypeKind::ARRAY) {
-      // Transform variant vector into an ArrayVector, then wrap it into a
-      // ConstantVector<ComplexType>.
-      VELOX_CHECK_NOT_NULL(
-          pool, "parsing array literals requires a memory pool");
-      VectorPtr constantVector;
-      if (constant->value().isNull()) {
-        constantVector =
-            BaseVector::createNullConstant(constant->type(), 1, pool);
-      } else {
-        constantVector =
-            variantToVector(constant->type(), constant->value(), pool);
-      }
-      return std::make_shared<ConstantTypedExpr>(constantVector);
-    }
-    return std::make_shared<ConstantTypedExpr>(
-        constant->type(), constant->value());
-  }
-
-  if (auto cast = std::dynamic_pointer_cast<const CastExpr>(expr)) {
-    return std::make_shared<CastTypedExpr>(
-        cast->type(), std::move(children), cast->isTryCast());
-  }
-
-  if (auto alreadyTyped = std::dynamic_pointer_cast<const ITypedExpr>(expr)) {
-    return alreadyTyped;
-  }
-
-  VELOX_FAIL("Unknown expression type: {}", expr->toString());
+  buf += ")";
+  return appendAliasIfExists(buf);
 }
 
-// static
-TypedExprPtr Expressions::resolveLambdaExpr(
-    const std::shared_ptr<const LambdaExpr>& lambdaExpr,
-    const TypePtr& inputRow,
-    const std::vector<TypePtr>& lambdaInputTypes,
-    memory::MemoryPool* pool,
-    const VectorPtr& complexConstants) {
-  auto names = lambdaExpr->arguments();
-  auto body = lambdaExpr->body();
-
-  VELOX_CHECK_LE(names.size(), lambdaInputTypes.size());
-  std::vector<TypePtr> types;
-  types.reserve(names.size());
-  for (auto i = 0; i < names.size(); ++i) {
-    types.push_back(lambdaInputTypes[i]);
-  }
-
-  auto signature =
-      ROW(std::vector<std::string>(names), std::vector<TypePtr>(types));
-
-  auto& inputRowType = inputRow->asRow();
-  for (auto i = 0; i < inputRowType.size(); ++i) {
-    if (!signature->containsChild(inputRowType.names()[i])) {
-      names.push_back(inputRowType.names()[i]);
-      types.push_back(inputRowType.childAt(i));
-    }
-  }
-
-  auto lambdaRow = ROW(std::move(names), std::move(types));
-
-  return std::make_shared<LambdaTypedExpr>(
-      signature, inferTypes(body, lambdaRow, pool, complexConstants));
+std::string CastExpr::toString() const {
+  return appendAliasIfExists(
+      "cast(" + input()->toString() + ", " + type_->toString() + ")");
 }
 
-namespace {
-bool isLambdaSignature(
-    const exec::FunctionSignature* signature,
-    const std::shared_ptr<const CallExpr>& callExpr) {
-  if (!hasLambdaArgument(*signature)) {
-    return false;
+std::string LambdaExpr::toString() const {
+  std::ostringstream out;
+
+  if (arguments_.size() > 1) {
+    out << "(" << folly::join(", ", arguments_) << ")";
+  } else {
+    out << arguments_[0];
   }
-
-  const auto numArguments = callExpr->inputs().size();
-
-  if (numArguments != signature->argumentTypes().size()) {
-    return false;
-  }
-
-  bool match = true;
-  for (auto i = 0; i < numArguments; ++i) {
-    if (auto lambda =
-            dynamic_cast<const LambdaExpr*>(callExpr->inputAt(i).get())) {
-      const auto numLambdaInputs = lambda->arguments().size();
-      const auto& argumentType = signature->argumentTypes()[i];
-      if (!isLambdaArgument(argumentType, numLambdaInputs)) {
-        match = false;
-        break;
-      }
-    }
-  }
-
-  return match;
-}
-
-const exec::FunctionSignature* findLambdaSignature(
-    const std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
-        signatures,
-    const std::shared_ptr<const CallExpr>& callExpr) {
-  const exec::FunctionSignature* matchingSignature = nullptr;
-  for (const auto& signature : signatures) {
-    if (isLambdaSignature(signature.get(), callExpr)) {
-      VELOX_CHECK_NULL(
-          matchingSignature,
-          "Cannot resolve ambiguous lambda function signatures for {}.",
-          callExpr->name());
-      matchingSignature = signature.get();
-    }
-  }
-
-  return matchingSignature;
-}
-
-const exec::FunctionSignature* findLambdaSignature(
-    const std::vector<const exec::FunctionSignature*>& signatures,
-    const std::shared_ptr<const CallExpr>& callExpr) {
-  const exec::FunctionSignature* matchingSignature = nullptr;
-  for (const auto& signature : signatures) {
-    if (isLambdaSignature(signature, callExpr)) {
-      VELOX_CHECK_NULL(
-          matchingSignature,
-          "Cannot resolve ambiguous lambda function signatures for {}.",
-          callExpr->name());
-      matchingSignature = signature;
-    }
-  }
-
-  return matchingSignature;
-}
-
-// Assumes no overlap in function names between scalar and aggregate functions,
-// i.e. 'foo' is either a scalar or aggregate function.
-const exec::FunctionSignature* findLambdaSignature(
-    const std::shared_ptr<const CallExpr>& callExpr) {
-  // Look for a scalar lambda function.
-  auto scalarSignatures = getFunctionSignatures(callExpr->name());
-  if (!scalarSignatures.empty()) {
-    return findLambdaSignature(scalarSignatures, callExpr);
-  }
-
-  // Look for an aggregate lambda function.
-  if (auto signatures =
-          exec::getAggregateFunctionSignatures(callExpr->name())) {
-    return findLambdaSignature(signatures.value(), callExpr);
-  }
-
-  return nullptr;
-}
-
-} // namespace
-
-// static
-TypedExprPtr Expressions::tryResolveCallWithLambdas(
-    const std::shared_ptr<const CallExpr>& callExpr,
-    const TypePtr& inputRow,
-    memory::MemoryPool* pool,
-    const VectorPtr& complexConstants) {
-  auto signature = findLambdaSignature(callExpr);
-
-  if (signature == nullptr) {
-    return nullptr;
-  }
-
-  // Resolve non-lambda arguments first.
-  auto numArgs = callExpr->inputs().size();
-  std::vector<TypedExprPtr> children(numArgs);
-  std::vector<TypePtr> childTypes(numArgs);
-  for (auto i = 0; i < numArgs; ++i) {
-    if (!isLambdaArgument(signature->argumentTypes()[i])) {
-      children[i] =
-          inferTypes(callExpr->inputAt(i), inputRow, pool, complexConstants);
-      childTypes[i] = children[i]->type();
-    }
-  }
-
-  // Resolve lambda arguments.
-  exec::SignatureBinder binder(*signature, childTypes);
-  binder.tryBind();
-  for (auto i = 0; i < numArgs; ++i) {
-    auto argSignature = signature->argumentTypes()[i];
-    if (isLambdaArgument(argSignature)) {
-      std::vector<TypePtr> lambdaTypes;
-      for (auto j = 0; j < argSignature.parameters().size() - 1; ++j) {
-        auto type = binder.tryResolveType(argSignature.parameters()[j]);
-        if (type == nullptr) {
-          return nullptr;
-        }
-        lambdaTypes.push_back(type);
-      }
-
-      children[i] = inferTypes(
-          callExpr->inputAt(i), inputRow, lambdaTypes, pool, complexConstants);
-    }
-  }
-
-  return createWithImplicitCast(callExpr, children);
+  out << " -> " << body_->toString();
+  return out.str();
 }
 
 } // namespace facebook::velox::core

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -16,74 +16,10 @@
 #pragma once
 
 #include "velox/common/base/Exceptions.h"
-#include "velox/core/ITypedExpr.h"
 #include "velox/parse/IExpr.h"
 #include "velox/type/Variant.h"
-#include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::core {
-
-class CallExpr;
-class LambdaExpr;
-class FieldAccessExpr;
-
-class Expressions {
- public:
-  using TypeResolverHook = std::function<TypePtr(
-      const std::vector<TypedExprPtr>& inputs,
-      const std::shared_ptr<const CallExpr>& expr,
-      bool nullOnFailure)>;
-
-  using FieldAccessHook = std::function<TypedExprPtr(
-      std::shared_ptr<const FieldAccessExpr> fae,
-      std::vector<TypedExprPtr>& children)>;
-
-  static TypedExprPtr inferTypes(
-      const ExprPtr& expr,
-      const TypePtr& input,
-      memory::MemoryPool* pool,
-      const VectorPtr& complexConstants = nullptr);
-
-  static void setTypeResolverHook(TypeResolverHook hook) {
-    resolverHook_ = std::move(hook);
-  }
-
-  static TypeResolverHook getResolverHook() {
-    return resolverHook_;
-  }
-
-  static void setFieldAccessHook(FieldAccessHook hook) {
-    fieldAccessHook_ = std::move(hook);
-  }
-
-  static FieldAccessHook getFieldAccessHook() {
-    return fieldAccessHook_;
-  }
-
-  static TypedExprPtr inferTypes(
-      const ExprPtr& expr,
-      const TypePtr& input,
-      const std::vector<TypePtr>& lambdaInputTypes,
-      memory::MemoryPool* pool,
-      const VectorPtr& complexConstants = nullptr);
-
- private:
-  static TypedExprPtr resolveLambdaExpr(
-      const std::shared_ptr<const LambdaExpr>& lambdaExpr,
-      const TypePtr& inputRow,
-      const std::vector<TypePtr>& lambdaInputTypes,
-      memory::MemoryPool* pool,
-      const VectorPtr& complexConstants = nullptr);
-
-  static TypedExprPtr tryResolveCallWithLambdas(
-      const std::shared_ptr<const CallExpr>& expr,
-      const TypePtr& input,
-      memory::MemoryPool* pool,
-      const VectorPtr& complexConstants = nullptr);
-
-  static TypeResolverHook resolverHook_;
-  static FieldAccessHook fieldAccessHook_;
-};
 
 class InputExpr : public IExpr {
  public:
@@ -115,27 +51,11 @@ class FieldAccessExpr : public IExpr {
     return dynamic_cast<const InputExpr*>(input().get()) != nullptr;
   }
 
-  std::string toString() const override {
-    return appendAliasIfExists(
-        isRootColumn() ? toStringForRootColumn() : toStringForMemberAccess());
-  }
+  std::string toString() const override;
 
   VELOX_DEFINE_CLASS_NAME(FieldAccessExpr)
 
  private:
-  std::string toStringForRootColumn() const {
-    return "\"" + getEscapedName() + "\"";
-  }
-
-  std::string toStringForMemberAccess() const {
-    return "dot(" + inputs_.front()->toString() + ",\"" + getEscapedName() +
-        "\")";
-  }
-
-  std::string getEscapedName() const {
-    return folly::cEscape<std::string>(name_);
-  }
-
   const std::string name_;
 };
 
@@ -153,19 +73,7 @@ class CallExpr : public IExpr {
     return name_;
   }
 
-  std::string toString() const override {
-    std::string buf{name_ + "("};
-    bool first = true;
-    for (auto& f : inputs()) {
-      if (!first) {
-        buf += ",";
-      }
-      buf += f->toString();
-      first = false;
-    }
-    buf += ")";
-    return appendAliasIfExists(buf);
-  }
+  std::string toString() const override;
 
   VELOX_DEFINE_CLASS_NAME(CallExpr)
 
@@ -209,10 +117,7 @@ class CastExpr : public IExpr, public std::enable_shared_from_this<CastExpr> {
       std::optional<std::string> alias)
       : IExpr{{expr}, std::move(alias)}, type_(type), isTryCast_(isTryCast) {}
 
-  std::string toString() const override {
-    return appendAliasIfExists(
-        "cast(" + input()->toString() + ", " + type_->toString() + ")");
-  }
+  std::string toString() const override;
 
   const TypePtr& type() const {
     return type_;
@@ -249,17 +154,7 @@ class LambdaExpr : public IExpr,
     return body_;
   }
 
-  std::string toString() const override {
-    std::ostringstream out;
-
-    if (arguments_.size() > 1) {
-      out << "(" << folly::join(", ", arguments_) << ")";
-    } else {
-      out << arguments_[0];
-    }
-    out << " -> " << body_->toString();
-    return out.str();
-  }
+  std::string toString() const override;
 
  private:
   const std::vector<std::string> arguments_;

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -37,9 +37,13 @@ std::vector<core::ExprPtr> parseMultipleExpressions(
       expr, duckConversionOptions);
 }
 
-std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
-    const std::string& expr) {
-  return facebook::velox::duckdb::parseOrderByExpr(expr);
+OrderByClause parseOrderByExpr(const std::string& expr) {
+  auto orderBy = facebook::velox::duckdb::parseOrderByExpr(expr);
+
+  return {
+      .expr = std::move(orderBy.expr),
+      .ascending = orderBy.ascending,
+      .nullsFirst = orderBy.nullsFirst};
 }
 
 } // namespace facebook::velox::parse

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -18,9 +18,7 @@
 
 namespace facebook::velox::parse {
 
-std::shared_ptr<const core::IExpr> parseExpr(
-    const std::string& expr,
-    const ParseOptions& options) {
+core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
@@ -28,7 +26,7 @@ std::shared_ptr<const core::IExpr> parseExpr(
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& expr,
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
@@ -39,7 +37,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
       expr, duckConversionOptions);
 }
 
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& expr) {
   return facebook::velox::duckdb::parseOrderByExpr(expr);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -15,9 +15,7 @@
  */
 #pragma once
 
-#include <set>
 #include "velox/core/PlanNode.h"
-#include "velox/core/QueryCtx.h"
 #include "velox/parse/IExpr.h"
 
 namespace facebook::velox::parse {
@@ -34,14 +32,12 @@ struct ParseOptions {
   std::string functionPrefix;
 };
 
-std::shared_ptr<const core::IExpr> parseExpr(
-    const std::string& expr,
-    const ParseOptions& options);
+core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options);
 
-std::pair<std::shared_ptr<const core::IExpr>, core::SortOrder> parseOrderByExpr(
+std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
     const std::string& expr);
 
-std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
+std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& expr,
     const ParseOptions& options);
 

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include "velox/core/PlanNode.h"
 #include "velox/parse/IExpr.h"
 
 namespace facebook::velox::parse {
@@ -34,8 +33,13 @@ struct ParseOptions {
 
 core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options);
 
-std::pair<core::ExprPtr, core::SortOrder> parseOrderByExpr(
-    const std::string& expr);
+struct OrderByClause {
+  core::ExprPtr expr;
+  bool ascending;
+  bool nullsFirst;
+};
+
+OrderByClause parseOrderByExpr(const std::string& expr);
 
 std::vector<core::ExprPtr> parseMultipleExpressions(
     const std::string& expr,

--- a/velox/parse/PlanNodeIdGenerator.h
+++ b/velox/parse/PlanNodeIdGenerator.h
@@ -15,7 +15,8 @@
  */
 #pragma once
 
-#include "velox/core/PlanNode.h"
+#include <fmt/format.h>
+#include <string>
 
 namespace facebook::velox::core {
 
@@ -25,7 +26,7 @@ class PlanNodeIdGenerator {
  public:
   explicit PlanNodeIdGenerator(int startId = 0) : nextId_{startId} {}
 
-  PlanNodeId next() {
+  std::string next() {
     return fmt::format("{}", nextId_++);
   }
 

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -17,7 +17,6 @@
 #include "velox/parse/TypeResolver.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
-#include "velox/expression/SignatureBinder.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/parse/Expressions.h"
 #include "velox/type/Type.h"
@@ -62,13 +61,12 @@ TypePtr resolveType(
     inputTypes.emplace_back(input->type());
   }
 
-  if (auto resolvedType = exec::resolveTypeForSpecialForm(
-          expr->getFunctionName(), inputTypes)) {
+  if (auto resolvedType =
+          exec::resolveTypeForSpecialForm(expr->name(), inputTypes)) {
     return resolvedType;
   }
 
-  return resolveScalarFunctionType(
-      expr->getFunctionName(), inputTypes, nullOnFailure);
+  return resolveScalarFunctionType(expr->name(), inputTypes, nullOnFailure);
 }
 
 } // namespace

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -16,10 +16,13 @@
 
 #include "velox/parse/TypeResolver.h"
 #include "velox/core/ITypedExpr.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/SignatureBinder.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/parse/Expressions.h"
 #include "velox/type/Type.h"
+#include "velox/vector/VariantToVector.h"
 
 namespace facebook::velox::parse {
 namespace {
@@ -100,4 +103,433 @@ TypePtr resolveScalarFunctionType(
         toString(functionSignatures));
   }
 }
+
 } // namespace facebook::velox::parse
+
+namespace facebook::velox::core {
+
+// static
+Expressions::TypeResolverHook Expressions::resolverHook_;
+// static
+Expressions::FieldAccessHook Expressions::fieldAccessHook_;
+
+namespace {
+
+// Determine output type based on input types.
+TypePtr resolveTypeImpl(
+    const std::vector<TypedExprPtr>& inputs,
+    const std::shared_ptr<const CallExpr>& expr,
+    bool nullOnFailure) {
+  VELOX_CHECK_NOT_NULL(Expressions::getResolverHook());
+  return Expressions::getResolverHook()(inputs, expr, nullOnFailure);
+}
+
+CastTypedExprPtr makeTypedCast(const TypePtr& type, const TypedExprPtr& input) {
+  return std::make_shared<CastTypedExpr>(type, input, false);
+}
+
+std::vector<TypePtr> implicitCastTargets(const TypePtr& type) {
+  std::vector<TypePtr> targetTypes;
+  switch (type->kind()) {
+    // We decide not to implicitly upcast booleans because it maybe funky.
+    case TypeKind::BOOLEAN:
+      break;
+    case TypeKind::TINYINT:
+      targetTypes.emplace_back(SMALLINT());
+      [[fallthrough]];
+    case TypeKind::SMALLINT:
+      targetTypes.emplace_back(INTEGER());
+      targetTypes.emplace_back(REAL());
+      [[fallthrough]];
+    case TypeKind::INTEGER:
+      targetTypes.emplace_back(BIGINT());
+      targetTypes.emplace_back(DOUBLE());
+      [[fallthrough]];
+    case TypeKind::BIGINT:
+      break;
+    case TypeKind::REAL:
+      targetTypes.emplace_back(DOUBLE());
+      [[fallthrough]];
+    case TypeKind::DOUBLE:
+      break;
+    case TypeKind::ARRAY: {
+      auto childTargetTypes = implicitCastTargets(type->childAt(0));
+      for (const auto& childTarget : childTargetTypes) {
+        targetTypes.emplace_back(ARRAY(childTarget));
+      }
+      break;
+    }
+    default: // make compilers happy
+      break;
+  }
+  return targetTypes;
+}
+
+// All acceptable implicit casts on this expression.
+// TODO: If we get this to be recursive somehow, we can save on cast function
+// signatures that need to be compiled and registered.
+std::vector<TypedExprPtr> genImplicitCasts(const TypedExprPtr& typedExpr) {
+  auto targetTypes = implicitCastTargets(typedExpr->type());
+
+  std::vector<TypedExprPtr> implicitCasts;
+  implicitCasts.reserve(targetTypes.size());
+  for (const auto& targetType : targetTypes) {
+    implicitCasts.emplace_back(makeTypedCast(targetType, typedExpr));
+  }
+  return implicitCasts;
+}
+
+// TODO: Arguably all of this could be done with just Types.
+TypedExprPtr adjustLastNArguments(
+    std::vector<TypedExprPtr> inputs,
+    const std::shared_ptr<const CallExpr>& expr,
+    size_t n) {
+  auto type = resolveTypeImpl(inputs, expr, true /*nullOnFailure*/);
+  if (type != nullptr) {
+    return std::make_shared<CallTypedExpr>(
+        type, inputs, std::string{expr->name()});
+  }
+
+  if (n == 0) {
+    return nullptr;
+  }
+
+  size_t firstOfLastN = inputs.size() - n;
+  // use it
+  std::vector<TypedExprPtr> viableExprs{inputs[firstOfLastN]};
+  // or lose it
+  auto&& implicitCasts = genImplicitCasts(inputs[firstOfLastN]);
+  std::move(
+      implicitCasts.begin(),
+      implicitCasts.end(),
+      std::back_inserter(viableExprs));
+
+  for (auto& viableExpr : viableExprs) {
+    inputs[firstOfLastN] = viableExpr;
+    auto adjustedExpr = adjustLastNArguments(inputs, expr, n - 1);
+    if (adjustedExpr != nullptr) {
+      return adjustedExpr;
+    }
+  }
+
+  return nullptr;
+}
+
+TypedExprPtr createWithImplicitCast(
+    const std::shared_ptr<const CallExpr>& expr,
+    const std::vector<TypedExprPtr>& inputs) {
+  if (auto adjusted = adjustLastNArguments(inputs, expr, inputs.size())) {
+    return adjusted;
+  }
+  auto type = resolveTypeImpl(inputs, expr, /*nullOnFailure=*/false);
+  return std::make_shared<CallTypedExpr>(type, inputs, expr->name());
+}
+
+bool isLambdaArgument(const exec::TypeSignature& typeSignature) {
+  return typeSignature.baseName() == "function";
+}
+
+bool isLambdaArgument(const exec::TypeSignature& typeSignature, int numInputs) {
+  return isLambdaArgument(typeSignature) &&
+      (typeSignature.parameters().size() == numInputs + 1);
+}
+
+bool hasLambdaArgument(const exec::FunctionSignature& signature) {
+  for (const auto& type : signature.argumentTypes()) {
+    if (isLambdaArgument(type)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace
+
+// static
+TypedExprPtr Expressions::inferTypes(
+    const std::shared_ptr<const IExpr>& expr,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
+  return inferTypes(expr, inputRow, {}, pool, complexConstants);
+}
+
+// static
+TypedExprPtr Expressions::inferTypes(
+    const std::shared_ptr<const IExpr>& expr,
+    const TypePtr& inputRow,
+    const std::vector<TypePtr>& lambdaInputTypes,
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
+  VELOX_CHECK_NOT_NULL(expr);
+
+  if (auto lambdaExpr = std::dynamic_pointer_cast<const LambdaExpr>(expr)) {
+    return resolveLambdaExpr(
+        lambdaExpr, inputRow, lambdaInputTypes, pool, complexConstants);
+  }
+
+  if (auto call = std::dynamic_pointer_cast<const CallExpr>(expr)) {
+    if (!expr->inputs().empty()) {
+      if (auto returnType = tryResolveCallWithLambdas(
+              call, inputRow, pool, complexConstants)) {
+        return returnType;
+      }
+    }
+  }
+
+  // try rebuilding complex constant type from vector
+  if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
+    if (fun->name() == "__complex_constant") {
+      VELOX_CHECK_NOT_NULL(
+          complexConstants,
+          "Expression contains __complex_constant function call, but complexConstants is missing");
+
+      auto ccInputRow = complexConstants->as<RowVector>();
+      VELOX_CHECK_NOT_NULL(
+          ccInputRow,
+          "Expected RowVector for complexConstants: {}",
+          complexConstants->toString());
+      auto name =
+          std::dynamic_pointer_cast<const FieldAccessExpr>(fun->inputAt(0))
+              ->name();
+      auto rowType = asRowType(ccInputRow->type());
+      return std::make_shared<ConstantTypedExpr>(
+          ccInputRow->childAt(rowType->getChildIdx(name)));
+    }
+  }
+
+  std::vector<TypedExprPtr> children;
+  for (auto& child : expr->inputs()) {
+    children.push_back(
+        inferTypes(child, inputRow, lambdaInputTypes, pool, complexConstants));
+  }
+
+  if (auto fae = std::dynamic_pointer_cast<const FieldAccessExpr>(expr)) {
+    if (fieldAccessHook_) {
+      if (auto result = fieldAccessHook_(fae, children)) {
+        return result;
+      }
+    }
+    VELOX_CHECK(!fae->name().empty(), "Anonymous columns are not supported");
+    VELOX_CHECK_EQ(
+        children.size(), 1, "Unexpected number of children in FieldAccessExpr");
+    auto input = children.at(0)->type();
+    auto& row = input->asRow();
+    auto childIndex = row.getChildIdx(fae->name());
+    if (fae->isRootColumn()) {
+      return std::make_shared<FieldAccessTypedExpr>(
+          input->childAt(childIndex), children.at(0), std::string{fae->name()});
+    } else {
+      return std::make_shared<DereferenceTypedExpr>(
+          input->childAt(childIndex), children.at(0), childIndex);
+    }
+  }
+
+  if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
+    return createWithImplicitCast(fun, children);
+  }
+
+  if (auto input = std::dynamic_pointer_cast<const InputExpr>(expr)) {
+    return std::make_shared<InputTypedExpr>(inputRow);
+  }
+
+  if (auto constant = std::dynamic_pointer_cast<const ConstantExpr>(expr)) {
+    if (constant->type()->kind() == TypeKind::ARRAY) {
+      // Transform variant vector into an ArrayVector, then wrap it into a
+      // ConstantVector<ComplexType>.
+      VELOX_CHECK_NOT_NULL(
+          pool, "parsing array literals requires a memory pool");
+      VectorPtr constantVector;
+      if (constant->value().isNull()) {
+        constantVector =
+            BaseVector::createNullConstant(constant->type(), 1, pool);
+      } else {
+        constantVector =
+            variantToVector(constant->type(), constant->value(), pool);
+      }
+      return std::make_shared<ConstantTypedExpr>(constantVector);
+    }
+    return std::make_shared<ConstantTypedExpr>(
+        constant->type(), constant->value());
+  }
+
+  if (auto cast = std::dynamic_pointer_cast<const CastExpr>(expr)) {
+    return std::make_shared<CastTypedExpr>(
+        cast->type(), std::move(children), cast->isTryCast());
+  }
+
+  if (auto alreadyTyped = std::dynamic_pointer_cast<const ITypedExpr>(expr)) {
+    return alreadyTyped;
+  }
+
+  VELOX_FAIL("Unknown expression type: {}", expr->toString());
+}
+
+// static
+TypedExprPtr Expressions::resolveLambdaExpr(
+    const std::shared_ptr<const LambdaExpr>& lambdaExpr,
+    const TypePtr& inputRow,
+    const std::vector<TypePtr>& lambdaInputTypes,
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
+  auto names = lambdaExpr->arguments();
+  auto body = lambdaExpr->body();
+
+  VELOX_CHECK_LE(names.size(), lambdaInputTypes.size());
+  std::vector<TypePtr> types;
+  types.reserve(names.size());
+  for (auto i = 0; i < names.size(); ++i) {
+    types.push_back(lambdaInputTypes[i]);
+  }
+
+  auto signature =
+      ROW(std::vector<std::string>(names), std::vector<TypePtr>(types));
+
+  auto& inputRowType = inputRow->asRow();
+  for (auto i = 0; i < inputRowType.size(); ++i) {
+    if (!signature->containsChild(inputRowType.names()[i])) {
+      names.push_back(inputRowType.names()[i]);
+      types.push_back(inputRowType.childAt(i));
+    }
+  }
+
+  auto lambdaRow = ROW(std::move(names), std::move(types));
+
+  return std::make_shared<LambdaTypedExpr>(
+      signature, inferTypes(body, lambdaRow, pool, complexConstants));
+}
+
+namespace {
+bool isLambdaSignature(
+    const exec::FunctionSignature* signature,
+    const std::shared_ptr<const CallExpr>& callExpr) {
+  if (!hasLambdaArgument(*signature)) {
+    return false;
+  }
+
+  const auto numArguments = callExpr->inputs().size();
+
+  if (numArguments != signature->argumentTypes().size()) {
+    return false;
+  }
+
+  bool match = true;
+  for (auto i = 0; i < numArguments; ++i) {
+    if (auto lambda =
+            dynamic_cast<const LambdaExpr*>(callExpr->inputAt(i).get())) {
+      const auto numLambdaInputs = lambda->arguments().size();
+      const auto& argumentType = signature->argumentTypes()[i];
+      if (!isLambdaArgument(argumentType, numLambdaInputs)) {
+        match = false;
+        break;
+      }
+    }
+  }
+
+  return match;
+}
+
+const exec::FunctionSignature* FOLLY_NULLABLE findLambdaSignature(
+    const std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
+        signatures,
+    const std::shared_ptr<const CallExpr>& callExpr) {
+  const exec::FunctionSignature* matchingSignature = nullptr;
+  for (const auto& signature : signatures) {
+    if (isLambdaSignature(signature.get(), callExpr)) {
+      VELOX_CHECK_NULL(
+          matchingSignature,
+          "Cannot resolve ambiguous lambda function signatures for {}.",
+          callExpr->name());
+      matchingSignature = signature.get();
+    }
+  }
+
+  return matchingSignature;
+}
+
+const exec::FunctionSignature* FOLLY_NULLABLE findLambdaSignature(
+    const std::vector<const exec::FunctionSignature*>& signatures,
+    const std::shared_ptr<const CallExpr>& callExpr) {
+  const exec::FunctionSignature* matchingSignature = nullptr;
+  for (const auto& signature : signatures) {
+    if (isLambdaSignature(signature, callExpr)) {
+      VELOX_CHECK_NULL(
+          matchingSignature,
+          "Cannot resolve ambiguous lambda function signatures for {}.",
+          callExpr->name());
+      matchingSignature = signature;
+    }
+  }
+
+  return matchingSignature;
+}
+
+// Assumes no overlap in function names between scalar and aggregate functions,
+// i.e. 'foo' is either a scalar or aggregate function.
+const exec::FunctionSignature* FOLLY_NULLABLE
+findLambdaSignature(const std::shared_ptr<const CallExpr>& callExpr) {
+  // Look for a scalar lambda function.
+  auto scalarSignatures = getFunctionSignatures(callExpr->name());
+  if (!scalarSignatures.empty()) {
+    return findLambdaSignature(scalarSignatures, callExpr);
+  }
+
+  // Look for an aggregate lambda function.
+  if (auto signatures =
+          exec::getAggregateFunctionSignatures(callExpr->name())) {
+    return findLambdaSignature(signatures.value(), callExpr);
+  }
+
+  return nullptr;
+}
+
+} // namespace
+
+// static
+TypedExprPtr Expressions::tryResolveCallWithLambdas(
+    const std::shared_ptr<const CallExpr>& callExpr,
+    const TypePtr& inputRow,
+    memory::MemoryPool* pool,
+    const VectorPtr& complexConstants) {
+  auto signature = findLambdaSignature(callExpr);
+
+  if (signature == nullptr) {
+    return nullptr;
+  }
+
+  // Resolve non-lambda arguments first.
+  auto numArgs = callExpr->inputs().size();
+  std::vector<TypedExprPtr> children(numArgs);
+  std::vector<TypePtr> childTypes(numArgs);
+  for (auto i = 0; i < numArgs; ++i) {
+    if (!isLambdaArgument(signature->argumentTypes()[i])) {
+      children[i] =
+          inferTypes(callExpr->inputAt(i), inputRow, pool, complexConstants);
+      childTypes[i] = children[i]->type();
+    }
+  }
+
+  // Resolve lambda arguments.
+  exec::SignatureBinder binder(*signature, childTypes);
+  binder.tryBind();
+  for (auto i = 0; i < numArgs; ++i) {
+    auto argSignature = signature->argumentTypes()[i];
+    if (isLambdaArgument(argSignature)) {
+      std::vector<TypePtr> lambdaTypes;
+      for (auto j = 0; j < argSignature.parameters().size() - 1; ++j) {
+        auto type = binder.tryResolveType(argSignature.parameters()[j]);
+        if (type == nullptr) {
+          return nullptr;
+        }
+        lambdaTypes.push_back(type);
+      }
+
+      children[i] = inferTypes(
+          callExpr->inputAt(i), inputRow, lambdaTypes, pool, complexConstants);
+    }
+  }
+
+  return createWithImplicitCast(callExpr, children);
+}
+
+} // namespace facebook::velox::core

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/parse/QueryPlanner.h"
-#include "velox/common/base/tests/GTestUtils.h"
+#include <gtest/gtest.h>
 
 namespace facebook::velox::core::test {
 

--- a/velox/python/legacy/pyvelox.cpp
+++ b/velox/python/legacy/pyvelox.cpp
@@ -257,7 +257,7 @@ static void addExpressionBindings(
           "getInputs",
           [](IExprWrapper& e) {
             const std::vector<std::shared_ptr<const core::IExpr>>& inputs =
-                e.expr->getInputs();
+                e.expr->inputs();
             std::vector<IExprWrapper> wrapped_inputs;
             wrapped_inputs.resize(inputs.size());
             for (const std::shared_ptr<const core::IExpr>& input : inputs) {


### PR DESCRIPTION
Summary: SQL is parsed into IExpr (defined in velox/parse), then IExpr is type resolved into ITypedExpr (defined in velox/core).

Differential Revision: D77864254


