### PR TITLE
fix: Handle integer overflow in abs Presto function

### DIFF
--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -218,8 +218,14 @@ struct FloorFunction {
 template <typename TExec>
 struct AbsFunction {
   template <typename T>
-  FOLLY_ALWAYS_INLINE void call(T& result, const T& a) {
-    result = abs(a);
+  FOLLY_ALWAYS_INLINE Status call(T& result, const T& a) {
+    if constexpr (std::is_integral_v<T>) {
+      if (a == std::numeric_limits<T>::min()) {
+        return Status::UserError("Out of range integer input to abs: {}.", a);
+      }
+    }
+    result = std::abs(a);
+    return Status::OK();
   }
 };
 

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -156,12 +156,6 @@ T negate(const T& arg) {
 }
 
 template <typename T>
-T abs(const T& arg) {
-  T results = std::abs(arg);
-  return results;
-}
-
-template <typename T>
 T floor(const T& arg) {
   T results = std::floor(arg);
   return results;

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -181,6 +181,11 @@ class ArithmeticTest : public functions::test::FunctionBaseTest {
     assertExpression("c0 * c1", op1, doubleOp, expected);
     assertExpression("c1 * c0", op1, doubleOp, expected);
   }
+
+  template <typename T>
+  std::optional<T> evaluateAbs(const T& input) {
+    return evaluateOnce<T>("abs(c0)", std::make_optional<T>(input));
+  }
 };
 
 TEST_F(ArithmeticTest, plus) {
@@ -1040,6 +1045,36 @@ TEST_F(ArithmeticTest, wilsonIntervalUpper) {
   VELOX_ASSERT_THROW(
       wilsonIntervalUpper(1, 3, -kInf), "z-score must not be negative");
   EXPECT_DOUBLE_EQ(wilsonIntervalUpper(1, 3, kInf).value(), 1.0);
+}
+
+TEST_F(ArithmeticTest, abs) {
+  ASSERT_EQ(
+      evaluateAbs(std::numeric_limits<int8_t>::min() + 1),
+      std::numeric_limits<int8_t>::max());
+  VELOX_ASSERT_THROW(
+      evaluateAbs(std::numeric_limits<int8_t>::min()),
+      "Out of range integer input to abs: -128.");
+
+  ASSERT_EQ(
+      evaluateAbs(std::numeric_limits<int16_t>::min() + 1),
+      std::numeric_limits<int16_t>::max());
+  VELOX_ASSERT_THROW(
+      evaluateAbs(std::numeric_limits<int16_t>::min()),
+      "Out of range integer input to abs: -32768.");
+
+  ASSERT_EQ(
+      evaluateAbs(std::numeric_limits<int32_t>::min() + 1),
+      std::numeric_limits<int32_t>::max());
+  VELOX_ASSERT_THROW(
+      evaluateAbs(std::numeric_limits<int32_t>::min()),
+      "Out of range integer input to abs: -2147483648.");
+
+  ASSERT_EQ(
+      evaluateAbs(std::numeric_limits<int64_t>::min() + 1),
+      std::numeric_limits<int64_t>::max());
+  VELOX_ASSERT_THROW(
+      evaluateAbs(std::numeric_limits<int64_t>::min()),
+      "Out of range integer input to abs: -9223372036854775808.");
 }
 
 } // namespace


### PR DESCRIPTION
Fixes `abs` Presto function implementation to throw in case of Integer overflow.
Presto fixes this with a similar [check](https://github.com/prestodb/presto/blob/821731906c7801a860397757e84cf0e16871659e/presto-main-base/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java#L128) for Integer minimum bounds. 