### PR TITLE
test: Fix MockSharedArbitrationTest.freeUnusedCapacityWhenReclaimMemoryPool

### DIFF
--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -4211,7 +4211,7 @@ DEBUG_ONLY_TEST_F(
   folly::EventCount reclaimBlock;
   std::atomic_bool reclaimBlockFlag{true};
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::memory::SharedArbitrator::sortSpillCandidates",
+      "facebook::velox::memory::SharedArbitrator::sortAndGroupSpillCandidates",
       std::function<void(const MemoryPool*)>(([&](const MemoryPool* /*unsed*/) {
         reclaimWaitFlag = false;
         reclaimWait.notifyAll();


### PR DESCRIPTION
Summary:
AFAICT MockSharedArbitrationTest.freeUnusedCapacityWhenReclaimMemoryPool has been 
broken since it was introduced.

It looks like a simple typo in SCOPED_TESTVALUE_SET, there is no TestValue::adjust call 
associated with "facebook::velox::memory::SharedArbitrator::sortSpillCandidates".  I 
assume the author meant 
"facebook::velox::memory::SharedArbitrator::sortAndGroupSpillCandidates".

Differential Revision: D77897628


