### PR TITLE
misc: Add ability to track stats on non-special form expressions

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -632,10 +632,11 @@ class QueryConfig {
   static constexpr const char* kFieldNamesInJsonCastEnabled =
       "field_names_in_json_cast_enabled";
 
-  /// If this is true, then operators that evaluate expressions will track their
-  /// stats and return them as part of their operator stats. Tracking these
-  /// stats can be expensive (especially if operator stats are retrieved
-  /// frequently) and this allows the user to explicitly enable it.
+  /// If this is true, then operators that evaluate expressions will track
+  /// stats for expressions that are not special forms and return them as
+  /// part of their operator stats. Tracking these stats can be expensive
+  /// (especially if operator stats are retrieved frequently) and this allows
+  /// the user to explicitly enable it.
   static constexpr const char* kOperatorTrackExpressionStats =
       "operator_track_expression_stats";
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -183,6 +183,13 @@ Generic Configuration
      - 0
      - Specifies The max number of input splits to listen to by SplitListener per table scan node per
        worker. It's up to the SplitListener implementation to respect this config.
+   * - operator_track_expression_stats
+     - bool
+     - false
+     - If this is true, then operators that evaluate expressions will track stats for expressions that
+       are not special forms and return them as part of their operator stats. Tracking these stats can
+       be expensive (especially if operator stats are retrieved frequently) and this allows the user to
+       explicitly enable it.
 
 .. _expression-evaluation-conf:
 

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -238,7 +238,7 @@ OperatorStats FilterProject::stats(bool clear) {
           ->queryConfig()
           .operatorTrackExpressionStats() &&
       exprs_ != nullptr) {
-    stats.expressionStats = exprs_->stats();
+    stats.expressionStats = exprs_->stats(true /*excludeSpecialForm*/);
   }
   return stats;
 }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1791,7 +1791,8 @@ namespace {
 void addStats(
     const exec::Expr& expr,
     std::unordered_map<std::string, exec::ExprStats>& stats,
-    std::unordered_set<const exec::Expr*>& uniqueExprs) {
+    std::unordered_set<const exec::Expr*>& uniqueExprs,
+    bool excludeSpecialForm) {
   auto it = uniqueExprs.find(&expr);
   if (it != uniqueExprs.end()) {
     // Common sub-expression. Skip to avoid double counting.
@@ -1800,13 +1801,16 @@ void addStats(
 
   uniqueExprs.insert(&expr);
 
+  bool excludeSplFormExpr = excludeSpecialForm && expr.isSpecialForm();
   // Do not aggregate empty stats.
-  if (expr.stats().numProcessedRows || expr.stats().defaultNullRowsSkipped) {
+  bool emptyStats =
+      !expr.stats().numProcessedRows && !expr.stats().defaultNullRowsSkipped;
+  if (!emptyStats && !excludeSplFormExpr) {
     stats[expr.name()].add(expr.stats());
   }
 
   for (const auto& input : expr.inputs()) {
-    addStats(*input, stats, uniqueExprs);
+    addStats(*input, stats, uniqueExprs, excludeSpecialForm);
   }
 }
 
@@ -1815,11 +1819,12 @@ std::string makeUuid() {
 }
 } // namespace
 
-std::unordered_map<std::string, exec::ExprStats> ExprSet::stats() const {
+std::unordered_map<std::string, exec::ExprStats> ExprSet::stats(
+    bool excludeSpecialForm) const {
   std::unordered_map<std::string, exec::ExprStats> stats;
   std::unordered_set<const exec::Expr*> uniqueExprs;
   for (const auto& expr : exprs()) {
-    addStats(*expr, stats, uniqueExprs);
+    addStats(*expr, stats, uniqueExprs, excludeSpecialForm);
   }
 
   return stats;

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -750,8 +750,9 @@ class ExprSet {
   /// name. If a function or a special form occurs in the expression
   /// multiple times, the statistics will be aggregated across all calls.
   /// Statistics will be missing for functions and special forms that didn't get
-  /// evaluated.
-  std::unordered_map<std::string, exec::ExprStats> stats() const;
+  /// evaluated. If 'excludeSpecialForm' is true, special forms are excluded.
+  std::unordered_map<std::string, exec::ExprStats> stats(
+      bool excludeSpecialForm = false) const;
 
  protected:
   void clearSharedSubexprs();


### PR DESCRIPTION
Summary:
Recently a query config `operator_track_expression_stats` was added to expose
expression stats via operator stats, however, the stats exposed turned out to
included every expression (constants and field references, etc) and became
unwieldy. For the use-case that motivated this change, we are only interested
in expressions that evaluate a UDF and therefore encompass all non-special
form expressions. We therefore update the query config to only track these
kind of expression. In the future, if we decide to expose more options, we can
enhance this config to support those.

Differential Revision: D77903975


