### PR TITLE
fix(vector): EnsureWritable should copy buffer views

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -686,6 +686,13 @@ class BufferView : public Buffer {
     return result;
   }
 
+  // Helper method to create a buffer view referencing another existing Buffer.
+  static BufferPtr
+  create(BufferPtr innerBuffer, Releaser releaser, bool podType = true) {
+    return create(
+        innerBuffer->as<uint8_t>(), innerBuffer->size(), releaser, podType);
+  }
+
   ~BufferView() override {
     releaser_.release();
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -662,7 +662,7 @@ class BaseVector {
   /// Returns true if the following conditions hold:
   ///  * The vector is singly referenced.
   ///  * The vector has a Flat-like encoding (Flat, Array, Map, Row).
-  ///  * Any child Buffers are mutable  and singly referenced.
+  ///  * Any child Buffers are mutable and singly referenced.
   ///  * All of these conditions hold for child Vectors recursively.
   /// This function is templated rather than taking a
   /// std::shared_ptr<BaseVector> because if we were to do that the compiler

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1165,7 +1165,7 @@ std::string ArrayVector::toString(vector_size_t index) const {
 
 void ArrayVector::ensureWritable(const SelectivityVector& rows) {
   auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
-  if (offsets_ && !offsets_->unique()) {
+  if (offsets_ && !offsets_->isMutable()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
     auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
@@ -1184,7 +1184,7 @@ void ArrayVector::ensureWritable(const SelectivityVector& rows) {
     rawOffsets_ = offsets_->as<vector_size_t>();
   }
 
-  if (sizes_ && !sizes_->unique()) {
+  if (sizes_ && !sizes_->isMutable()) {
     BufferPtr newSizes =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
     auto rawNewSizes = newSizes->asMutable<vector_size_t>();
@@ -1473,7 +1473,7 @@ std::string MapVector::toString(vector_size_t index) const {
 
 void MapVector::ensureWritable(const SelectivityVector& rows) {
   auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
-  if (offsets_ && !offsets_->unique()) {
+  if (offsets_ && !offsets_->isMutable()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
     auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
@@ -1492,7 +1492,7 @@ void MapVector::ensureWritable(const SelectivityVector& rows) {
     rawOffsets_ = offsets_->as<vector_size_t>();
   }
 
-  if (sizes_ && !sizes_->unique()) {
+  if (sizes_ && !sizes_->isMutable()) {
     BufferPtr newSizes =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
     auto rawNewSizes = newSizes->asMutable<vector_size_t>();

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -312,6 +312,7 @@ class RowVector : public BaseVector {
 /// 'sizes' data and provide manipulations on them.
 struct ArrayVectorBase : BaseVector {
   ArrayVectorBase(const ArrayVectorBase&) = delete;
+
   const BufferPtr& offsets() const {
     return offsets_;
   }


### PR DESCRIPTION
Summary:
Ensure that ensureWritable() copies buffer views in complex types used
for offsets and lengths. BaseVector already does the right thing for null
buffers, but complex types previouslyu only checked whether offsets and
lengths were unique, but not if they were not views (buffer->unique() vs.
buffer->isMutable()). Adding the fix plus unit tests.

Differential Revision: D77904499


