### PR TITLE
fix: Fmt V11 build errors

### DIFF
--- a/velox/common/memory/ArbitrationOperation.h
+++ b/velox/common/memory/ArbitrationOperation.h
@@ -154,7 +154,7 @@ struct fmt::formatter<facebook::velox::memory::ArbitrationOperation::State>
     : formatter<std::string> {
   auto format(
       facebook::velox::memory::ArbitrationOperation::State state,
-      format_context& ctx) {
+      format_context& ctx) const {
     return formatter<std::string>::format(
         facebook::velox::memory::ArbitrationOperation::stateName(state), ctx);
   }


### PR DESCRIPTION
Similar to #10904, fix build error if install fmt via brew:
```In file included from /opt/homebrew/include/fmt/format.h:41:
/opt/homebrew/include/fmt/base.h:2275:20: error: 'this' argument to member function 'format' has type 'const fmt::formatter<facebook::velox::memory::ArbitrationOperation::State>', but function is not marked const
 2275 |     ctx.advance_to(cf.format(*static_cast<qualified_type*>(arg), ctx));```