### PR TITLE
misc: Enable decimal expression fuzzer test in workflow

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -414,6 +414,7 @@ jobs:
                 --seed ${random_seed} \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
                 --lazy_vector_generation_ratio 0.2 \
                 --common_dictionary_wraps_generation_ratio=0.3 \
                 --velox_fuzzer_enable_column_reuse \
@@ -542,6 +543,7 @@ jobs:
                 --duration_sec 3600 \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
                 --velox_fuzzer_enable_column_reuse \
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
@@ -633,6 +635,7 @@ jobs:
           ./spark_expression_fuzzer_test \
                 --seed ${random_seed} \
                 --duration_sec $DURATION \
+                --velox_fuzzer_enable_decimal_type \
                 --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/spark_bias_fuzzer_repro/logs \
@@ -678,6 +681,7 @@ jobs:
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
                 --enable_dereference \
+                --velox_fuzzer_enable_decimal_type \
                 --duration_sec $DURATION \
                 --minloglevel=0 \
                 --stderrthreshold=2 \
@@ -1155,6 +1159,7 @@ jobs:
                 --duration_sec $DURATION \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
                 --velox_fuzzer_enable_column_reuse \
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -163,6 +163,12 @@ bool SignatureBinderBase::checkOrSetIntegerParameter(
     return false;
   }
 
+  const auto& constraint = variables().at(parameterName).constraint();
+  if (isPositiveInteger(constraint) && atoi(constraint.c_str()) != value) {
+    // Return false if the actual value does not match the constraint.
+    return false;
+  }
+
   if (integerVariablesBindings_.count(parameterName)) {
     // Return false if the parameter is found with a different value.
     if (integerVariablesBindings_[parameterName] != value) {

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -49,7 +49,7 @@ class SignatureBinderBase {
     return signature_.variables();
   }
 
-  /// The funcion signature we are trying to bind.
+  /// The function signature we are trying to bind.
   const exec::FunctionSignature& signature_;
 
   /// Record concrete types that are bound to type variables.

--- a/velox/expression/tests/ReverseSignatureBinderTest.cpp
+++ b/velox/expression/tests/ReverseSignatureBinderTest.cpp
@@ -109,5 +109,18 @@ TEST_F(ReverseSignatureBinderTest, unsupported) {
   testBindingFailure(signature, DECIMAL(13, 6));
 }
 
+TEST_F(ReverseSignatureBinderTest, integerConstraint) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .integerVariable("r_precision", "38")
+                       .integerVariable("r_scale", "0")
+                       .returnType("decimal(r_precision, r_scale)")
+                       .argumentType("varchar")
+                       .build();
+
+  // The precision and scale are fixed to the constraints.
+  testBindingSuccess(signature, DECIMAL(38, 0), {});
+  testBindingFailure(signature, DECIMAL(13, 6));
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -281,6 +281,19 @@ TEST(SignatureBinderTest, decimals) {
       assertCannotResolve(signature, {DECIMAL(11, 8), DECIMAL(18, 4)});
     }
   }
+
+  // The precision and scale are fixed to the constraints.
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .integerVariable("a_precision", "38")
+                         .integerVariable("a_scale", "0")
+                         .returnType("varchar")
+                         .argumentType("decimal(a_precision, a_scale)")
+                         .build();
+
+    testSignatureBinder(signature, {DECIMAL(38, 0)}, VARCHAR());
+    assertCannotResolve(signature, {DECIMAL(18, 6)});
+  }
 }
 
 TEST(SignatureBinderTest, computation) {

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(
   MapZipWithTest.cpp
   MultimapFromEntriesTest.cpp
   NotTest.cpp
+  ParsePrestoDataSizeTest.cpp
   ProbabilityTest.cpp
   RandTest.cpp
   ReduceTest.cpp


### PR DESCRIPTION
The decimal expression fuzzer test had been enabled in the experiment workflow, 
which was removed with https://github.com/facebookincubator/velox/commit/331b82de2b423af464ced0422df61d7009d6cce8. This PR enables it in the scheduled workflow.

Fixes the fuzzer failure issue for Presto `parse_presto_data_size` function. 
When `parse_presto_data_size` is nested inside another function `A`,the return 
type of `parse_presto_data_size` is decided when fuzzing argument types for `A`,
which is random and causes a mismatch with the expected DECIMAL(38, 0).
This PR fixes this issue by respecting integer constraints in the
`checkOrSetIntegerParameter` so as to skip the test for this function.

Includes ParsePrestoDataSizeTest.cpp in the CMakeLists.

Fixes https://github.com/facebookincubator/velox/issues/13144.