### PR TITLE
feat(abfs): Add DynamicSasTokenClientProvider to support dynamic SAS token renewal

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
@@ -54,6 +54,11 @@ static constexpr const char* kAzureOAuthAuthType = "OAuth";
 
 static constexpr const char* kAzureSASAuthType = "SAS";
 
+// For performance, re - use SAS tokens until the expiry is within this number
+// of seconds.
+static constexpr const char* kAzureSasTokenRenewPeriod =
+    "fs.azure.sas.token.renew.period.for.streams";
+
 // Helper class to parse and extract information from a given ABFS path.
 class AbfsPath {
  public:

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProvider.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProvider.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "velox/common/config/Config.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AbfsPath.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AzureBlobClient.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AzureDataLakeFileClient.h"
 

--- a/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
@@ -26,6 +26,7 @@ if(VELOX_ENABLE_ABFS)
       AbfsWriteFile.cpp
       AzureClientProviderFactories.cpp
       AzureClientProviderImpl.cpp
+      DynamicSasTokenClientProvider.cpp
   )
 
   velox_link_libraries(

--- a/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h"
+
+#include <azure/core/datetime.hpp>
+
+namespace facebook::velox::filesystems {
+
+namespace {
+
+constexpr int64_t kDefaultSasTokenRenewPeriod = 120; // in seconds
+
+Azure::DateTime getExpiry(const std::string& token) {
+  if (token.empty()) {
+    return Azure::DateTime::clock::time_point::min();
+  }
+
+  const std::string signedExpiry = "se=";
+  const int32_t signedExpiryLen = 3;
+
+  auto start = token.find(signedExpiry);
+  if (start == std::string::npos) {
+    return Azure::DateTime::clock::time_point::min();
+  }
+  start += signedExpiryLen;
+
+  auto end = token.find("&", start);
+  std::string seValue = (end == std::string::npos)
+      ? token.substr(start)
+      : token.substr(start, end - start);
+
+  seValue = Azure::Core::Url::Decode(seValue);
+  auto seDate =
+      Azure::DateTime::Parse(seValue, Azure::DateTime::DateFormat::Rfc3339);
+
+  const std::string signedKeyExpiry = "ske=";
+  const int32_t signedKeyExpiryLen = 4;
+
+  start = token.find(signedKeyExpiry);
+  if (start == std::string::npos) {
+    return seDate;
+  }
+  start += signedKeyExpiryLen;
+
+  end = token.find("&", start);
+  std::string skeValue = (end == std::string::npos)
+      ? token.substr(start)
+      : token.substr(start, end - start);
+
+  skeValue = Azure::Core::Url::Decode(skeValue);
+  auto skeDate =
+      Azure::DateTime::Parse(skeValue, Azure::DateTime::DateFormat::Rfc3339);
+
+  return std::min(skeDate, seDate);
+}
+
+bool isNearExpiry(Azure::DateTime expiration, int64_t minExpirationInSeconds) {
+  if (expiration == Azure::DateTime::clock::time_point::min()) {
+    return true;
+  }
+  auto remaining = std::chrono::duration_cast<std::chrono::seconds>(
+                       expiration - Azure::DateTime::clock::now())
+                       .count();
+  return remaining <= minExpirationInSeconds;
+}
+
+class DynamicSasTokenDataLakeFileClient final : public AzureDataLakeFileClient {
+ public:
+  DynamicSasTokenDataLakeFileClient(
+      const std::shared_ptr<AbfsPath>& abfsPath,
+      const std::shared_ptr<SasTokenProvider>& sasKeyGenerator,
+      int64_t sasTokenRenewPeriod)
+      : abfsPath_(abfsPath),
+        sasKeyGenerator_(sasKeyGenerator),
+        sasTokenRenewPeriod_(sasTokenRenewPeriod) {}
+
+  void create() override {
+    getWriteClient()->Create();
+  }
+
+  Azure::Storage::Files::DataLake::Models::PathProperties getProperties()
+      override {
+    return getReadClient()->GetProperties().Value;
+  }
+
+  void append(const uint8_t* buffer, size_t size, uint64_t offset) override {
+    auto bodyStream = Azure::Core::IO::MemoryBodyStream(buffer, size);
+    getWriteClient()->Append(bodyStream, offset);
+  }
+
+  void flush(uint64_t position) override {
+    getWriteClient()->Flush(position);
+  }
+
+  void close() override {}
+
+  std::string getUrl() override {
+    return getWriteClient()->GetUrl();
+  }
+
+ private:
+  std::shared_ptr<AbfsPath> abfsPath_;
+  std::shared_ptr<SasTokenProvider> sasKeyGenerator_;
+  int64_t sasTokenRenewPeriod_;
+
+  std::unique_ptr<DataLakeFileClient> writeClient_{nullptr};
+  Azure::DateTime writeSasExpiration_{
+      Azure::DateTime::clock::time_point::min()};
+
+  std::unique_ptr<DataLakeFileClient> readClient_{nullptr};
+  Azure::DateTime readSasExpiration_{Azure::DateTime::clock::time_point::min()};
+
+  DataLakeFileClient* getWriteClient() {
+    if (writeClient_ == nullptr ||
+        isNearExpiry(writeSasExpiration_, sasTokenRenewPeriod_)) {
+      const auto sas = sasKeyGenerator_->getSasToken(
+          abfsPath_->fileSystem(), abfsPath_->filePath(), kAbfsWriteOperation);
+      writeSasExpiration_ = getExpiry(sas);
+      writeClient_ = std::make_unique<DataLakeFileClient>(
+          fmt::format("{}?{}", abfsPath_->getUrl(false), sas));
+    }
+    return writeClient_.get();
+  }
+
+  DataLakeFileClient* getReadClient() {
+    if (readClient_ == nullptr ||
+        isNearExpiry(readSasExpiration_, sasTokenRenewPeriod_)) {
+      const auto sas = sasKeyGenerator_->getSasToken(
+          abfsPath_->fileSystem(), abfsPath_->filePath(), kAbfsReadOperation);
+      readSasExpiration_ = getExpiry(sas);
+      readClient_ = std::make_unique<DataLakeFileClient>(
+          fmt::format("{}?{}", abfsPath_->getUrl(false), sas));
+    }
+    return readClient_.get();
+  }
+};
+
+class DynamicSasTokenBlobClient : public AzureBlobClient {
+ public:
+  DynamicSasTokenBlobClient(
+      const std::shared_ptr<AbfsPath>& abfsPath,
+      const std::shared_ptr<SasTokenProvider>& sasTokenProvider,
+      int64_t sasTokenRenewPeriod)
+      : abfsPath_(abfsPath),
+        sasTokenProvider_(sasTokenProvider),
+        sasTokenRenewPeriod_(sasTokenRenewPeriod) {}
+
+  Azure::Response<Azure::Storage::Blobs::Models::BlobProperties> getProperties()
+      override {
+    return getBlobClient()->GetProperties();
+  }
+
+  Azure::Response<Azure::Storage::Blobs::Models::DownloadBlobResult> download(
+      const Azure::Storage::Blobs::DownloadBlobOptions& options) override {
+    return getBlobClient()->Download(options);
+  }
+
+  std::string getUrl() override {
+    return getBlobClient()->GetUrl();
+  }
+
+ private:
+  std::shared_ptr<AbfsPath> abfsPath_;
+  std::shared_ptr<SasTokenProvider> sasTokenProvider_;
+  int64_t sasTokenRenewPeriod_;
+
+  std::unique_ptr<Azure::Storage::Blobs::BlobClient> blobClient_{nullptr};
+  Azure::DateTime sasExpiration_{Azure::DateTime::clock::time_point::min()};
+
+  BlobClient* getBlobClient() {
+    if (blobClient_ == nullptr ||
+        isNearExpiry(sasExpiration_, sasTokenRenewPeriod_)) {
+      const auto sas = sasTokenProvider_->getSasToken(
+          abfsPath_->fileSystem(), abfsPath_->filePath(), kAbfsReadOperation);
+      sasExpiration_ = getExpiry(sas);
+      blobClient_ = std::make_unique<Azure::Storage::Blobs::BlobClient>(
+          fmt::format("{}?{}", abfsPath_->getUrl(true), sas));
+    }
+    return blobClient_.get();
+  }
+};
+
+} // namespace
+
+DynamicSasTokenClientProvider::DynamicSasTokenClientProvider(
+    const std::shared_ptr<SasTokenProvider>& sasTokenProvider)
+    : AzureClientProvider(), sasTokenProvider_(sasTokenProvider) {}
+
+void DynamicSasTokenClientProvider::init(const config::ConfigBase& config) {
+  sasTokenRenewPeriod_ = config.get<int64_t>(
+      kAzureSasTokenRenewPeriod, kDefaultSasTokenRenewPeriod);
+}
+
+std::unique_ptr<AzureBlobClient>
+DynamicSasTokenClientProvider::getReadFileClient(
+    const std::shared_ptr<AbfsPath>& abfsPath,
+    const config::ConfigBase& config) {
+  init(config);
+  return std::make_unique<DynamicSasTokenBlobClient>(
+      abfsPath, sasTokenProvider_, sasTokenRenewPeriod_);
+}
+
+std::unique_ptr<AzureDataLakeFileClient>
+DynamicSasTokenClientProvider::getWriteFileClient(
+    const std::shared_ptr<AbfsPath>& abfsPath,
+    const config::ConfigBase& config) {
+  init(config);
+  return std::make_unique<DynamicSasTokenDataLakeFileClient>(
+      abfsPath, sasTokenProvider_, sasTokenRenewPeriod_);
+}
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h
+++ b/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/storage_adapters/abfs/AzureBlobClient.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AzureClientProvider.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AzureDataLakeFileClient.h"
+
+namespace facebook::velox::filesystems {
+
+/// SAS permissions reference:
+/// https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#permissions-for-a-directory-container-or-blob
+///
+/// ReadClient uses "read" permission for Download and GetProperties.
+/// WriteClient uses "read" permission for GetProperties, and "write" permission
+/// for other operations.
+static const std::string kAbfsReadOperation{"read"};
+static const std::string kAbfsWriteOperation{"write"};
+
+/// Interface for providing SAS tokens for ABFS file system operations.
+/// Adapted from the Hadoop Azure implementation:
+/// org.apache.hadoop.fs.azurebfs.extensions.SASTokenProvider
+class SasTokenProvider {
+ public:
+  virtual ~SasTokenProvider() = default;
+
+  virtual std::string getSasToken(
+      const std::string& fileSystem,
+      const std::string& path,
+      const std::string& operation) = 0;
+};
+
+/// Client provider that dynamically refreshes SAS tokens based on the
+/// expiration time of the token. A SasTokenProvider for retrieving SAS tokens
+/// must be provided to this class. Example for generating the SAS token can be
+/// found in:
+/// https://github.com/Azure/azure-sdk-for-cpp/blob/3d917e7c178f0a49b189395a907180084857cc70/sdk/storage/azure-storage-blobs/samples/blob_sas.cpp
+class DynamicSasTokenClientProvider : public AzureClientProvider {
+ public:
+  explicit DynamicSasTokenClientProvider(
+      const std::shared_ptr<SasTokenProvider>& sasTokenProvider);
+
+  std::unique_ptr<AzureBlobClient> getReadFileClient(
+      const std::shared_ptr<AbfsPath>& abfsPath,
+      const config::ConfigBase& config) override;
+
+  std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
+      const std::shared_ptr<AbfsPath>& abfsPath,
+      const config::ConfigBase& config) override;
+
+ private:
+  void init(const config::ConfigBase& config);
+
+  std::shared_ptr<SasTokenProvider> sasTokenProvider_;
+  int64_t sasTokenRenewPeriod_;
+};
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   AbfsUtilTest.cpp
   AzureClientProvidersTest.cpp
   AzureClientProviderFactoriesTest.cpp
+  DynamicSasTokenClientProviderTest.cpp
   AzuriteServer.cpp
   MockDataLakeFileClient.cpp
 )

--- a/velox/connectors/hive/storage_adapters/abfs/tests/DynamicSasTokenClientProviderTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/DynamicSasTokenClientProviderTest.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h"
+#include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
+
+#include "gtest/gtest.h"
+
+#include <azure/storage/blobs/blob_sas_builder.hpp>
+#include <chrono>
+#include <cstdint>
+
+using namespace facebook::velox::filesystems;
+using namespace facebook::velox;
+
+namespace {
+
+class MyDynamicAbfsSasTokenProvider : public SasTokenProvider {
+ public:
+  MyDynamicAbfsSasTokenProvider(int64_t expiration)
+      : expirationSeconds_(expiration) {}
+
+  std::string getSasToken(
+      const std::string& fileSystem,
+      const std::string& path,
+      const std::string& operation) override {
+    const auto lastSlash = path.find_last_of("/");
+    const auto containerName = path.substr(0, lastSlash);
+    const auto blobName = path.substr(lastSlash + 1);
+
+    Azure::Storage::Sas::BlobSasBuilder sasBuilder;
+    sasBuilder.ExpiresOn = Azure::DateTime::clock::now() +
+        std::chrono::seconds(expirationSeconds_);
+    sasBuilder.BlobContainerName = containerName;
+    sasBuilder.BlobName = blobName;
+    sasBuilder.Resource = Azure::Storage::Sas::BlobSasResource::Blob;
+    sasBuilder.SetPermissions(
+        Azure::Storage::Sas::BlobSasPermissions::Read &
+        Azure::Storage::Sas::BlobSasPermissions::Write);
+
+    std::string sasToken =
+        sasBuilder.GenerateSasToken(Azure::Storage::StorageSharedKeyCredential(
+            "test",
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="));
+
+    // Remove the leading '?' from the SAS token.
+    if (sasToken[0] == '?') {
+      sasToken = sasToken.substr(1);
+    }
+
+    return sasToken;
+  }
+
+ private:
+  int64_t expirationSeconds_;
+};
+
+} // namespace
+
+TEST(DynamicSasTokenClientProviderTest, dynamicSasToken) {
+  {
+    const std::string account = "account1";
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.account1.dfs.core.windows.net", "SAS"},
+         {"fs.azure.sas.token.renew.period.for.streams", "1"}},
+        false);
+    registerAzureClientProviderFactory(account, [](const std::string&) {
+      auto sasTokenProvider =
+          std::make_shared<MyDynamicAbfsSasTokenProvider>(3);
+      return std::make_unique<DynamicSasTokenClientProvider>(sasTokenProvider);
+    });
+
+    auto abfsPath = std::make_shared<AbfsPath>(
+        fmt::format("abfs://abc@{}.dfs.core.windows.net/file", account));
+    auto readClient =
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config);
+    auto writeClient =
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config);
+
+    auto readUrl = readClient->getUrl();
+    auto writeUrl = writeClient->getUrl();
+
+    // Let the current time pass 3 seconds to ensure the SAS token is expired.
+    std::this_thread::sleep_for(std::chrono::seconds(3)); // NOLINT
+
+    auto newReadUrl = readClient->getUrl();
+    ASSERT_NE(readUrl, newReadUrl);
+    // The SAS token should be reused.
+    ASSERT_EQ(newReadUrl, readClient->getUrl());
+
+    auto newWriteUrl = writeClient->getUrl();
+    ASSERT_NE(writeUrl, newWriteUrl);
+    // The SAS token should be reused.
+    ASSERT_EQ(newWriteUrl, writeClient->getUrl());
+  }
+
+  {
+    // SAS token expired by setting the renewal period to 120 seconds.
+    const std::string account = "account2";
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.account2.dfs.core.windows.net", "SAS"},
+         {"fs.azure.sas.token.renew.period.for.streams", "120"}},
+        false);
+    registerAzureClientProviderFactory(account, [](const std::string&) {
+      auto sasTokenProvider =
+          std::make_shared<MyDynamicAbfsSasTokenProvider>(60);
+      return std::make_unique<DynamicSasTokenClientProvider>(sasTokenProvider);
+    });
+
+    auto abfsPath = std::make_shared<AbfsPath>(
+        fmt::format("abfs://abc@{}.dfs.core.windows.net/file", account));
+    auto readClient =
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config);
+    auto writeClient =
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config);
+
+    auto readUrl = readClient->getUrl();
+    auto writeUrl = writeClient->getUrl();
+
+    // Let the current time pass 3 seconds to ensure the timestamp in the SAS
+    // token is updated.
+    std::this_thread::sleep_for(std::chrono::seconds(3)); // NOLINT
+
+    // Sas token should be renewed because the time left is less than the
+    // renewal period.
+    ASSERT_NE(readUrl, readClient->getUrl());
+    ASSERT_NE(writeUrl, writeClient->getUrl());
+  }
+}

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -970,6 +970,12 @@ These semantics are similar to the `Apache Hadoop-Aws module <https://hadoop.apa
      - Specifies the OAuth 2.0 token endpoint URL for the Azure AD application.
        This endpoint is used to acquire access tokens for authenticating with Azure storage.
        The URL follows the format: `https://login.microsoftonline.com/<tenant-id>/oauth2/token`.
+   * - fs.azure.sas.token.renew.period.for.streams
+     - string
+     - 120
+     - Specifies the period in seconds to re-use SAS tokens until the expiry is within this number of seconds.
+       This configuration is used together with `registerSasTokenProvider` for dynamic SAS token renewal.
+       When a SAS token is close to expiry, it will be renewed by getting a new token from the provider.
 
 Presto-specific Configuration
 -----------------------------


### PR DESCRIPTION
In the Java implementation, user can implement and configure the 
`SasTokenProvider` for SAS token generation with interface 
https://github.com/apache/hadoop/blob/trunk/hadoop-tools/hadoop-azure/src/main/java/org/apache/hadoop/fs/azurebfs/extensions/SASTokenProvider.java. 
Once the generated token has expired or is near expiry, it will be 
renewed by acquiring a new token from the provider. 

Currently in Velox, the SAS token is configured as a fixed token, 
and expiration is not considered. This patch adds 
`DynamicSasTokenClientProvider` to handle the SAS token renewal 
logic by updating the reader/writer client with a renewed SAS and 
adds `AbfsSasTokenProvider` interface to provide the SAS token. 
User can choose to register the `DynamicSasTokenClientProvider` 
with a custom `AbfsSasTokenProvider` implementation for 
accounts that requires dynamic SAS token renewal.

relies on https://github.com/facebookincubator/velox/pull/14281