### PR TITLE
fix: Test Nested Rows

### DIFF
--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -912,6 +912,13 @@ TextRowReader::getDouble(TextRowReader& th, bool& isNull, DelimType& delim) {
   return v;
 }
 
+/// TODO: Reconsider error handling strategy for malformed data
+/// Currently, all read functions convert invalid/malformed data to NULL values.
+/// This approach may produce incorrect query results, particularly for
+/// aggregate operations where a high volume of NULLs can significantly skew
+/// calculations (e.g., COUNT, AVG, SUM). Consider alternative strategies such
+/// as throwing exceptions, logging warnings, or providing configurable error
+/// handling modes.
 void TextRowReader::readElement(
     const std::shared_ptr<const Type>& t,
     const std::shared_ptr<const Type>& reqT,

--- a/velox/dwio/text/tests/reader/examples/nested_row
+++ b/velox/dwio/text/tests/reader/examples/nested_row
@@ -1,0 +1,5 @@
+hello&42,true,3.14159#2.71828&false
+world&100,false,2.71828#1.41421#0.0&true
+test&-5,true,1.41421#-123.456&false
+sample&0,false,0.0#999.999&true
+data&999,true,-123.456#42.0#3.14159&false


### PR DESCRIPTION
Summary: Add unit tests for nested rows. Inner ROW are just like Hive STRUCTS. Unlike the outermost layer's ROW, inner rows will only have a single row to be read/written.

Differential Revision: D77963708


