### PR TITLE
Fix shadow variable warning in TableScanTest.cpp

### DIFF
--- a/velox/experimental/wave/exec/tests/TableScanTest.cpp
+++ b/velox/experimental/wave/exec/tests/TableScanTest.cpp
@@ -468,7 +468,7 @@ TEST_P(TableScanTest, scanDict) {
         makeNumbers(row->childAt(row->childrenSize() - 1), 1000000000, counter);
         for (auto i = 0; i < row->childrenSize() - 1; ++i) {
           auto child = row->childAt(i);
-          for (auto i = 0; i < card; ++i) {
+          for (auto idx = 0; idx < card; ++idx) {
           }
           for (auto j = card; j < child->size(); ++j) {
             child->copy(child.get(), j, (j * 121) % card, 1);


### PR DESCRIPTION
Summary:
## Instructions about RACER Diffs:
**This feature is still in BETA and we are continuously improving it. Your constructive feedback would help improving RACER and highly appreciated.** 

This diff was pre-created by Racer AI agent for your convenience on top of T229258004. How-to-code instruction is provided by oncall [Sky Jazayeri](https://www.internalfb.com/profile/view/1047504621). For questions or suggestions please post in [RACER Autonomous Codebase Management](https://fb.workplace.com/groups/742040101615185) group.



This diff fixes a 'Shadow Variable Warning' issue identified by Quality Insight from [Monetization codehub](https://fburl.com/quality/wmkbc0si).

- If you are happy with the changes, commandeer it if minor edits are needed. (**we encourage commandeer to get the diff credit**)
- If you are not happy with the changes, please comment on the diff with clear actions and send it back to the author. Racer will pick it up and re-generate.
- If you really feel the Racer is not helping with this change (alas, some complex changes are hard for AI) feel free to abandon this diff.

## Summary:
This diff fixes a shadow variable warning in TableScanTest.cpp by renaming the inner loop variable from 'i' to 'idx' to avoid shadowing the outer loop variable with the same name. This change helps improve code clarity and prevents potential bugs that could arise from variable shadowing.
---
> Generated by [RACER](https://www.internalfb.com/wiki/RACER_(Risk-Aware_Code_Editing_and_Refactoring)/), powered by [Confucius](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Session](https://www.internalfb.com/confucius?session_id=94497639-5c54-11f0-8d18-bed4f0155e97&tab=Chat), [Trace](https://www.internalfb.com/confucius?session_id=94497639-5c54-11f0-8d18-bed4f0155e97&tab=Trace)

Reviewed By: xiaoxmeng

Differential Revision: D77974104


