### PR TITLE
refactor: Reduce unneeded copies

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1265,14 +1265,14 @@ AbstractJoinNode::AbstractJoinNode(
       rightKeys_.size(),
       "JoinNode requires same number of join keys on left and right sides");
   auto leftType = sources_[0]->outputType();
-  for (auto key : leftKeys_) {
+  for (const auto& key : leftKeys_) {
     VELOX_CHECK(
         leftType->containsChild(key->name()),
         "Left side join key not found in left side output: {}",
         key->name());
   }
   auto rightType = sources_[1]->outputType();
-  for (auto key : rightKeys_) {
+  for (const auto& key : rightKeys_) {
     VELOX_CHECK(
         rightType->containsChild(key->name()),
         "Right side join key not found in right side output: {}",

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -162,7 +162,7 @@ struct PlanSummaryOptions {
 
 class PlanNode : public ISerializable {
  public:
-  explicit PlanNode(const PlanNodeId& id) : id_{id} {}
+  explicit PlanNode(PlanNodeId id) : id_{std::move(id)} {}
 
   virtual ~PlanNode() {}
 
@@ -822,6 +822,7 @@ class AbstractProjectNode : public PlanNode {
       const std::vector<std::string>& names,
       const std::vector<TypedExprPtr>& projections) {
     std::vector<TypePtr> types;
+    types.reserve(projections.size());
     for (auto& projection : projections) {
       types.push_back(projection->type());
     }


### PR DESCRIPTION
Summary:
Lint identified several places where we are implicitly copying variables.
Replace these patterns with ones that don't copy.

Also reserve a vector to reduce unnecessary allocations.

Differential Revision: D78016694


