### PR TITLE
fix: Fix the next row offset set for rows with duplicate keys

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1799,7 +1799,7 @@ int32_t HashTable<ignoreNullKeys>::listJoinResults(
   uint64_t totalBytes{0};
   while (iter.lastRowIndex < iter.rows->size()) {
     if (!iter.nextHit) {
-      auto row = (*iter.rows)[iter.lastRowIndex];
+      const auto row = (*iter.rows)[iter.lastRowIndex];
       iter.nextHit = (*iter.hits)[row]; // NOLINT
       if (!iter.nextHit) {
         ++iter.lastRowIndex;

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -2574,6 +2574,56 @@ TEST_P(IndexLookupJoinTest, joinFuzzer) {
       GetParam().numPrefetches,
       "SELECT u.c0, u.c1, u.c2, u.c3, u.c4, u.c5, t.c0, t.c1, t.c2, t.c3, t.c4, t.c5 FROM t, u WHERE t.c0 = u.c0 AND array_contains(t.c4, u.c1) AND u.c2 BETWEEN t.c1 AND t.c2");
 }
+
+TEST_P(IndexLookupJoinTest, tableRowsWithDuplicateKeys) {
+  SequenceTableData tableData;
+  generateIndexTableData({10, 1, 1}, tableData, pool_);
+  for (int i = 0; i < keyType_->size(); ++i) {
+    tableData.keyData->childAt(i) = makeFlatVector<int64_t>(
+        tableData.keyData->childAt(i)->size(),
+        [](auto /*unused*/) { return 1; });
+    tableData.tableData->childAt(i) = makeFlatVector<int64_t>(
+        tableData.keyData->childAt(i)->size(),
+        [](auto /*unused*/) { return 1; });
+  }
+
+  auto probeVectors = generateProbeInput(
+      4, 32, 1, tableData, pool_, {"t0", "t1", "t2"}, false, {}, {}, 100);
+  std::vector<std::shared_ptr<TempFilePath>> probeFiles =
+      createProbeFiles(probeVectors);
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableData});
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3, tableData.keyData, tableData.valueData, *pool());
+  const auto indexTableHandle =
+      makeIndexTableHandle(indexTable, GetParam().asyncLookup);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto scanOutput = tableType_->names();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType(scanOutput),
+      makeIndexColumnHandles(scanOutput));
+
+  auto plan = makeLookupPlan(
+      planNodeIdGenerator,
+      indexScanNode,
+      {"t0", "t1", "t2"},
+      {"u0", "u1", "u2"},
+      {},
+      core::JoinType::kInner,
+      scanOutput);
+  runLookupQuery(
+      plan,
+      probeFiles,
+      GetParam().serialExecution,
+      GetParam().serialExecution,
+      32,
+      GetParam().numPrefetches,
+      "SELECT u.c0, u.c1, u.c2, u.c3, u.c4, u.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND u.c2 = t.c2");
+}
 } // namespace
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -85,9 +85,11 @@ std::shared_ptr<TestIndexTable> TestIndexTable::create(
     decodedVectors.emplace_back(*vector);
   }
 
+  const auto nextOffset = rowContainer->nextOffset();
+  VELOX_CHECK_GT(nextOffset, 0);
   for (auto row = 0; row < numRows; ++row) {
     auto* newRow = rowContainer->newRow();
-
+    *reinterpret_cast<char**>(newRow + nextOffset) = nullptr;
     for (auto col = 0; col < decodedVectors.size(); ++col) {
       rowContainer->store(decodedVectors[col], row, newRow, col);
     }


### PR DESCRIPTION
Summary: The current TestIndexTable doesn't initialize the next row offset which can cause crashes in case of rows with duplicate keys. This change fixes this with unit tests.

Differential Revision: D78032701


