### PR TITLE
fix: Cast to JSON has wrong output size estimation for some invalid Unicode input

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -316,6 +316,14 @@ TEST_F(JsonCastTest, fromVarchar) {
         VARCHAR(), {StringView(utf8String)}, {StringView(expected)});
   }
 
+  {
+    SCOPED_TRACE("Invalid unicode size estimation");
+    testCastToJson<StringView>(
+        VARCHAR(),
+        {"\xf0\x88\xba\xaa\xdb\x9a\x4a\x71\x08\xae\x85\xd2\x6b\x26\x72\x2a"_sv},
+        {R"("\uFFFD\uFFFD\uFFFD\uFFFDۚJq\b\uFFFD\uFFFD\uFFFDk&r*")"_sv});
+  }
+
   testCastToJson<StringView>(
       VARCHAR(),
       {""_sv, std::nullopt, "\xc0"_sv},


### PR DESCRIPTION
Summary: When the input string is not valid Unicode, the size estimation skips all 4 bytes but we should only skip 1 byte and re-parse the input from second byte.  The actual conversion is done correctly, but the size estimation is wrong due to this mismatch.  This is causing out of boundary write and crashes.

Differential Revision: D78028993


