### PR TITLE
feat(vector): EnsureWritable support for FlatMapVector

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -608,17 +608,22 @@ void BaseVector::ensureWritable(
     }
     return;
   }
+
   if (result->encoding() == VectorEncoding::Simple::LAZY) {
     result = BaseVector::loadedVectorShared(result);
   }
+
   const auto& resultType = result->type();
   const bool isUnknownType = resultType->containsUnknown();
+
+  // Check if ensure writable can work in place.
   if (result.use_count() == 1 && !isUnknownType) {
     switch (result->encoding()) {
       case VectorEncoding::Simple::FLAT:
       case VectorEncoding::Simple::ROW:
       case VectorEncoding::Simple::ARRAY:
       case VectorEncoding::Simple::MAP:
+      case VectorEncoding::Simple::FLAT_MAP:
       case VectorEncoding::Simple::FUNCTION: {
         result->ensureWritable(rows);
         return;
@@ -627,6 +632,8 @@ void BaseVector::ensureWritable(
         break; /** NOOP **/
     }
   }
+
+  // Otherwise, allocate a new vector and copy the remaining values over.
 
   // The copy-on-write size is the max of the writable row set and the
   // vector.
@@ -639,8 +646,10 @@ void BaseVector::ensureWritable(
     copy =
         BaseVector::create(isUnknownType ? type : resultType, targetSize, pool);
   }
+
   SelectivityVector copyRows(result->size());
   copyRows.deselect(rows);
+
   if (copyRows.hasSelections()) {
     copy->copy(result.get(), copyRows, nullptr);
   }

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -303,6 +303,12 @@ class FlatMapVector : public BaseVector {
       const BaseVector* source,
       const folly::Range<const CopyRange*>& ranges) override;
 
+  void ensureWritable(const SelectivityVector& rows) override;
+
+  bool isWritable() const override {
+    return true;
+  }
+
   /// Returns the hash of the value at the given index in this vector.
   uint64_t hashValueAt(vector_size_t index) const override;
 


### PR DESCRIPTION
Summary:
Adding proper support for ensureWritable for flat map vectors,
making them writable and copying on write buffers when appropriate.

Reviewed By: kevinwilfong

Differential Revision: D77979157
