### PR TITLE
fix: Copy expired shared_ptr causing undefined behavior which causes memory leak

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -207,7 +207,9 @@ void plan(
     driverFactories->push_back(std::make_unique<DriverFactory>());
     currentPlanNodes = &driverFactories->back()->planNodes;
     driverFactories->back()->operatorSupplier = std::move(operatorSupplier);
-    driverFactories->back()->consumerNode = consumerNode;
+    if (consumerNode.use_count() > 0) {
+      driverFactories->back()->consumerNode = consumerNode;
+    }
   }
 
   const auto& sources = planNode->sources();


### PR DESCRIPTION
Summary: Using OOM injection found one of the iusse here ConsumerNode could be expired and copy it will cause undefined behavior which lead to memory leak at the end.

Differential Revision: D78065166


