### PR TITLE
feat(wave): Create Nimble file format in Velox Wave

### DIFF
--- a/velox/experimental/wave/dwio/nimble/Encoding.h
+++ b/velox/experimental/wave/dwio/nimble/Encoding.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::wave::nimble {
+class Encoding {
+ public:
+  // The binary layout for each Encoding begins with the same prefix:
+  // 1 byte: EncodingType
+  // 1 byte: DataType
+  // 4 bytes: uint32_t num rows
+  static constexpr int kEncodingTypeOffset = 0;
+  static constexpr int kDataTypeOffset = 1;
+  static constexpr int kRowCountOffset = 2;
+  static constexpr int kPrefixSize = 6;
+};
+} // namespace facebook::wave::nimble

--- a/velox/experimental/wave/dwio/nimble/EncodingIdentifier.h
+++ b/velox/experimental/wave/dwio/nimble/EncodingIdentifier.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::wave::nimble {
+
+// When encoding contains nested encodings, each nested encoding has its
+// own identifier.
+using NestedEncodingIdentifier = uint8_t;
+
+struct EncodingIdentifiers {
+  struct Dictionary {
+    static constexpr NestedEncodingIdentifier Alphabet = 0;
+    static constexpr NestedEncodingIdentifier Indices = 1;
+  };
+
+  struct MainlyConstant {
+    static constexpr NestedEncodingIdentifier IsCommon = 0;
+    static constexpr NestedEncodingIdentifier OtherValues = 1;
+  };
+
+  struct Nullable {
+    static constexpr NestedEncodingIdentifier Data = 0;
+    static constexpr NestedEncodingIdentifier Nulls = 1;
+  };
+
+  struct RunLength {
+    static constexpr NestedEncodingIdentifier RunLengths = 0;
+    static constexpr NestedEncodingIdentifier RunValues = 1;
+  };
+
+  struct SparseBool {
+    static constexpr NestedEncodingIdentifier Indices = 0;
+  };
+
+  struct Trivial {
+    static constexpr NestedEncodingIdentifier Lengths = 0;
+  };
+};
+
+} // namespace facebook::wave::nimble

--- a/velox/experimental/wave/dwio/nimble/EncodingPrimitives.h
+++ b/velox/experimental/wave/dwio/nimble/EncodingPrimitives.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstring>
+#include <string_view>
+
+#include "folly/io/IOBuf.h"
+
+// Primitives for reading and writing to a stream of bytes.
+
+namespace facebook::wave::nimble::encoding {
+
+// The write functions serialize a datum into a buffer, advancing the
+// buffer pointer appropriately.
+
+// Write a type in native format for numeric types, via WriteString
+// for string types.
+template <typename T>
+inline void write(T value, char*& pos) {
+  *reinterpret_cast<T*>(pos) = value;
+  pos += sizeof(T);
+}
+
+inline void writeChar(char value, char*& pos) {
+  write<char>(value, pos);
+}
+
+inline void writeUint32(uint32_t value, char*& pos) {
+  write<uint32_t>(value, pos);
+}
+
+inline void writeUint64(uint64_t value, char*& pos) {
+  write<uint64_t>(value, pos);
+}
+
+// Just the chars, no leading length.
+inline void writeBytes(std::string_view value, char*& pos) {
+  std::copy(value.cbegin(), value.cend(), pos);
+  pos += value.size();
+}
+
+// Just the buffers, no leading length.
+inline void writeBuffers(const folly::IOBuf& buffers, char*& pos) {
+  for (const auto buffer : buffers) {
+    std::copy(buffer.cbegin(), buffer.cend(), pos);
+    pos += buffer.size();
+  }
+}
+
+// 4 byte length followed by chars.
+inline void writeString(std::string_view value, char*& pos) {
+  writeUint32(value.size(), pos);
+  writeBytes(value, pos);
+}
+
+template <>
+inline void write(std::string_view value, char*& pos) {
+  writeString(value, pos);
+}
+
+template <>
+inline void write(const std::string& value, char*& pos) {
+  writeString({value.data(), value.size()}, pos);
+}
+
+// The read functions extract a datum from the buffer (stored in the
+// format output by the Write functions), advancing the buffer
+// pointer appropriately.
+
+// Reads a type written via Write.
+template <typename T, typename TReturn = T>
+inline TReturn read(const char*& pos) {
+  const T value = *reinterpret_cast<const T*>(pos);
+  pos += sizeof(T);
+  return static_cast<TReturn>(value);
+}
+
+inline char readChar(const char*& pos) {
+  return read<char>(pos);
+}
+
+inline uint32_t readUint32(const char*& pos) {
+  return read<uint32_t>(pos);
+}
+
+inline uint64_t readUint64(const char*& pos) {
+  return read<uint64_t>(pos);
+}
+
+inline std::string_view readString(const char*& pos) {
+  const uint32_t size = readUint32(pos);
+  std::string_view result(pos, size);
+  pos += size;
+  return result;
+}
+
+inline std::string readOwnedString(const char*& pos) {
+  const uint32_t size = readUint32(pos);
+  std::string result(pos, size);
+  pos += size;
+  return result;
+}
+
+template <>
+inline std::string_view read<std::string_view, std::string_view>(
+    const char*& pos) {
+  return readString(pos);
+}
+
+template <>
+inline std::string read<std::string, std::string>(const char*& pos) {
+  return readOwnedString(pos);
+}
+
+template <typename T, typename TReturn = T>
+inline TReturn peek(const char* pos) {
+  return static_cast<TReturn>(*reinterpret_cast<const T*>(pos));
+}
+
+} // namespace facebook::wave::nimble::encoding

--- a/velox/experimental/wave/dwio/nimble/NimbleFileFormat.cpp
+++ b/velox/experimental/wave/dwio/nimble/NimbleFileFormat.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/dwio/nimble/NimbleFileFormat.h"
+#include "velox/experimental/wave/dwio/ColumnReader.h"
+#include "velox/experimental/wave/dwio/nimble/Encoding.h"
+#include "velox/experimental/wave/dwio/nimble/EncodingIdentifier.h"
+#include "velox/experimental/wave/dwio/nimble/EncodingPrimitives.h"
+#include "velox/experimental/wave/dwio/nimble/Types.h"
+
+using namespace facebook::wave::nimble;
+
+DECLARE_int32(wave_reader_rows_per_tb);
+
+namespace facebook::velox::wave {
+
+/// NimbleEncoding implementation
+NimbleEncoding::NimbleEncoding(std::string_view encodingData)
+    : encodingData_(encodingData) {
+  encodingType_ = encoding::peek<uint8_t, EncodingType>(encodingData_.data());
+  dataType_ = encoding::peek<uint8_t, DataType>(
+      encodingData_.data() + Encoding::kDataTypeOffset);
+  numValues_ = encoding::peek<uint32_t>(
+      encodingData_.data() + Encoding::kRowCountOffset);
+}
+
+uint8_t NimbleEncoding::childrenCount() const {
+  const auto encodingType = this->encodingType();
+  switch (encodingType) {
+    case EncodingType::Trivial: {
+      if (dataType() == DataType::String) {
+        VELOX_NYI("Unsupported encoding type");
+      }
+      return 0;
+    }
+    case EncodingType::Dictionary:
+    case EncodingType::Nullable: {
+      return 2;
+    }
+    case EncodingType::RLE: {
+      if (dataType() == DataType::Bool) {
+        VELOX_NYI("Unsupported encoding type");
+      }
+      return 2;
+    }
+    default:
+      VELOX_NYI(
+          "Unsupported encoding type: {}", static_cast<int>(encodingType));
+  }
+}
+
+facebook::velox::TypePtr NimbleEncoding::nimbleDataTypeToVeloxType(
+    DataType nimbleDataType) const {
+  switch (nimbleDataType) {
+    case DataType::Int8:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::TINYINT>::create();
+    case DataType::Uint8:
+      // Velox doesn't have unsigned types, map to signed equivalent
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::TINYINT>::create();
+    case DataType::Int16:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::SMALLINT>::create();
+    case DataType::Uint16:
+      // Velox doesn't have unsigned types, map to signed equivalent
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::SMALLINT>::create();
+    case DataType::Int32:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::INTEGER>::create();
+    case DataType::Uint32:
+      // Velox doesn't have unsigned types, map to signed equivalent
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::INTEGER>::create();
+    case DataType::Int64:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::BIGINT>::create();
+    case DataType::Uint64:
+      // Velox doesn't have unsigned types, map to signed equivalent
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::BIGINT>::create();
+    case DataType::Float:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::REAL>::create();
+    case DataType::Double:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::DOUBLE>::create();
+    case DataType::Bool:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::BOOLEAN>::create();
+    case DataType::String:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::VARCHAR>::create();
+    case DataType::Undefined:
+    default:
+      return facebook::velox::ScalarType<
+          facebook::velox::TypeKind::UNKNOWN>::create();
+  }
+}
+
+facebook::velox::TypePtr NimbleEncoding::veloxType() const {
+  return nimbleDataTypeToVeloxType(dataType());
+}
+
+facebook::velox::TypeKind NimbleEncoding::typeKind() const {
+  return veloxType()->kind();
+}
+
+NimbleEncoding* NimbleEncoding::childAt(uint8_t childIndex) {
+  VELOX_CHECK_LT(childIndex, childrenCount(), "Child index out of range");
+  return (childIndex >= children_.size())
+      ? createChildEncodingByIndex(childIndex)
+      : children_[childIndex].get();
+}
+
+NimbleEncoding* NimbleEncoding::createChildEncodingByIndex(uint8_t childIndex) {
+  VELOX_CHECK_LT(childIndex, childrenCount(), "Child index out of range");
+
+  const auto encodingType = this->encodingType();
+  const auto dataType = this->dataType();
+  const char* pos = encodedDataPtr();
+
+  std::string_view childEncodingData;
+
+  switch (encodingType) {
+    case EncodingType::Dictionary: {
+      if (childIndex == 0) {
+        const uint32_t alphabetBytes = encoding::readUint32(pos);
+        childEncodingData = std::string_view(pos, alphabetBytes);
+      } else if (childIndex == 1) {
+        const uint32_t alphabetBytes = encoding::readUint32(pos);
+        pos += alphabetBytes;
+        const size_t indicesBytes =
+            encodingData_.size() - (pos - encodingData_.data());
+        childEncodingData = std::string_view(pos, indicesBytes);
+      }
+      break;
+    }
+
+    case EncodingType::RLE: {
+      if (childIndex == 0) {
+        const uint32_t runLengthBytes = encoding::readUint32(pos);
+        childEncodingData = std::string_view(pos, runLengthBytes);
+      } else if (childIndex == 1 && dataType != DataType::Bool) {
+        const uint32_t runLengthBytes = encoding::readUint32(pos);
+        pos += runLengthBytes;
+        const size_t runValuesBytes =
+            encodingData_.size() - (pos - encodingData_.data());
+        childEncodingData = std::string_view(pos, runValuesBytes);
+      }
+      break;
+    }
+
+    case EncodingType::Nullable: {
+      if (childIndex == 0) {
+        const uint32_t dataBytes = encoding::readUint32(pos);
+        childEncodingData = std::string_view(pos, dataBytes);
+      } else if (childIndex == 1) {
+        const uint32_t dataBytes = encoding::readUint32(pos);
+        pos += dataBytes;
+        const size_t nullsBytes =
+            encodingData_.size() - (pos - encodingData_.data());
+        childEncodingData = std::string_view(pos, nullsBytes);
+      }
+      break;
+    }
+
+    default:
+      VELOX_NYI("Encoding type does not support child streams");
+  }
+
+  if (childEncodingData.empty()) {
+    VELOX_NYI("Invalid child index for this encoding type");
+  }
+
+  auto child = create(childEncodingData);
+  NimbleEncoding* childPtr = child.get();
+  children_.push_back(std::move(child));
+  return childPtr;
+}
+
+#define DEFINE_ENCODING_ACCESSOR(methodName)     \
+  NimbleEncoding* NimbleEncoding::methodName() { \
+    return nullptr;                              \
+  }
+
+DEFINE_ENCODING_ACCESSOR(alphabetEncoding)
+DEFINE_ENCODING_ACCESSOR(indicesEncoding)
+DEFINE_ENCODING_ACCESSOR(lengthsEncoding)
+DEFINE_ENCODING_ACCESSOR(runLengthsEncoding)
+DEFINE_ENCODING_ACCESSOR(runValuesEncoding)
+DEFINE_ENCODING_ACCESSOR(nullsEncoding)
+DEFINE_ENCODING_ACCESSOR(nonNullsEncoding)
+
+bool NimbleEncoding::isReadyToDecode() const {
+  for (auto& child : children_) {
+    if (!child->isDecoded()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+#define NIMBLE_ENCODING_FACTORY_CASE(type, className) \
+  case EncodingType::type:                            \
+    return std::make_unique<className>(encodingData);
+
+std::unique_ptr<NimbleEncoding> NimbleEncoding::create(
+    std::string_view encodingData) {
+  EncodingType encodingType =
+      encoding::peek<uint8_t, EncodingType>(encodingData.data());
+
+  switch (encodingType) {
+    NIMBLE_ENCODING_FACTORY_CASE(Trivial, NimbleTrivialEncoding)
+    NIMBLE_ENCODING_FACTORY_CASE(RLE, NimbleRLEEncoding)
+    NIMBLE_ENCODING_FACTORY_CASE(Dictionary, NimbleDictionaryEncoding)
+    NIMBLE_ENCODING_FACTORY_CASE(Nullable, NimbleNullableEncoding)
+    default:
+      VELOX_NYI("Unsupported encoding type");
+  }
+}
+
+#undef NIMBLE_ENCODING_FACTORY_CASE
+
+std::unique_ptr<GpuDecode> NimbleEncoding::makeStepCommon(
+    ColumnOp& op,
+    ReadStream& stream,
+    int32_t blockIdx) {
+  auto rowsPerBlock = FLAGS_wave_reader_rows_per_tb;
+  auto maxRowsPerThread = (rowsPerBlock / kBlockSize);
+  [[maybe_unused]] int32_t numBlocks =
+      bits::roundUp(numValues(), rowsPerBlock) / rowsPerBlock;
+  auto rowsInBlock =
+      std::min<int32_t>(rowsPerBlock, numValues() - (blockIdx * rowsPerBlock));
+
+  auto step = std::make_unique<GpuDecode>();
+  step->numRowsPerThread = bits::roundUp(rowsInBlock, kBlockSize) / kBlockSize;
+  step->gridNumRowsPerThread = maxRowsPerThread;
+  step->nthBlock = blockIdx;
+  step->maxRow = (blockIdx * rowsPerBlock) + rowsInBlock;
+  step->baseRow = rowsPerBlock * blockIdx;
+
+  step->nullMode = NullMode::kDenseNonNull; // TODO(bowenwu): support null
+
+  auto columnKind = static_cast<WaveTypeKind>(typeKind());
+  step->dataType = columnKind;
+  auto kindSize = waveTypeKindSize(columnKind);
+
+  step->result =
+      op.waveVector->values<char>() + kindSize * blockIdx * rowsPerBlock;
+  step->resultNulls = nullptr;
+
+  return step;
+}
+
+void NimbleEncoding::getDeviceEncodingInput(
+    SplitStaging& staging,
+    BufferId bufferId,
+    const NimbleEncoding& rootEncoding,
+    const void* hostPtr,
+    const void*& devicePtr) {
+  auto* hostBasePtr = rootEncoding.encodedDataPtr();
+  void* deviceBasePtr = rootEncoding.deviceEncodedDataPtr();
+  std::ptrdiff_t offset = static_cast<const char*>(hostPtr) - hostBasePtr;
+  if (deviceBasePtr != nullptr) {
+    devicePtr = static_cast<char*>(deviceBasePtr) + offset;
+  } else { // the root encoding is not transferred to the device yet
+    devicePtr = reinterpret_cast<void*>(offset);
+    staging.registerPointer(bufferId, &devicePtr, false);
+  }
+}
+
+// NimbleDictionaryEncoding implementation
+NimbleDictionaryEncoding::NimbleDictionaryEncoding(
+    std::string_view encodingData)
+    : NimbleEncoding(encodingData) {}
+
+NimbleEncoding* NimbleDictionaryEncoding::alphabetEncoding() {
+  return childAt(EncodingIdentifiers::Dictionary::Alphabet);
+}
+
+NimbleEncoding* NimbleDictionaryEncoding::indicesEncoding() {
+  return childAt(EncodingIdentifiers::Dictionary::Indices);
+}
+
+std::unique_ptr<GpuDecode> NimbleDictionaryEncoding::makeStep(
+    ColumnOp& op,
+    ReadStream& stream,
+    SplitStaging& staging,
+    BufferId bufferId,
+    const NimbleEncoding& rootEncoding,
+    int32_t blockIdx) {
+  // TODO(bowenwu): populate the the encoding specific data correctly
+  return makeStepCommon(op, stream, blockIdx);
+}
+
+// NimbleTrivialEncoding implementation
+NimbleTrivialEncoding::NimbleTrivialEncoding(std::string_view encodingData)
+    : NimbleEncoding(encodingData) {}
+
+NimbleEncoding* NimbleTrivialEncoding::lengthsEncoding() {
+  VELOX_NYI("Trivial encoding does not support strings yet");
+}
+
+std::unique_ptr<GpuDecode> NimbleTrivialEncoding::makeStep(
+    ColumnOp& op,
+    ReadStream& stream,
+    SplitStaging& staging,
+    BufferId bufferId,
+    const NimbleEncoding& rootEncoding,
+    int32_t blockIdx) {
+  auto step = makeStepCommon(op, stream, blockIdx);
+  step->step = DecodeStep::kTrivial;
+  step->data.trivial.dataType = step->dataType;
+  step->data.trivial.result = step->result;
+  step->data.trivial.begin = 0;
+  step->data.trivial.end = numValues();
+  step->data.trivial.scatter = nullptr;
+  auto hostPtr = encodedDataPtr();
+  encoding::readChar(hostPtr); // skip the lengths compression
+  getDeviceEncodingInput(
+      staging,
+      bufferId,
+      rootEncoding,
+      hostPtr + step->baseRow * waveTypeKindSize(step->dataType),
+      step->data.trivial.input);
+  return step;
+}
+
+// NimbleRLEEncoding implementation
+NimbleRLEEncoding::NimbleRLEEncoding(std::string_view encodingData)
+    : NimbleEncoding(encodingData) {}
+
+NimbleEncoding* NimbleRLEEncoding::runLengthsEncoding() {
+  return childAt(EncodingIdentifiers::RunLength::RunLengths);
+}
+
+NimbleEncoding* NimbleRLEEncoding::runValuesEncoding() {
+  if (dataType() != DataType::Bool) {
+    return childAt(EncodingIdentifiers::RunLength::RunValues);
+  }
+  VELOX_NYI("RLE encoding does not support bools yet");
+}
+
+std::unique_ptr<GpuDecode> NimbleRLEEncoding::makeStep(
+    ColumnOp& op,
+    ReadStream& stream,
+    SplitStaging& staging,
+    BufferId bufferId,
+    const NimbleEncoding& rootEncoding,
+    int32_t blockIdx) {
+  // TODO(bowenwu): populate the the encoding specific data correctly
+  return makeStepCommon(op, stream, blockIdx);
+}
+
+// NimbleNullableEncoding implementation
+NimbleNullableEncoding::NimbleNullableEncoding(std::string_view encodingData)
+    : NimbleEncoding(encodingData) {}
+
+NimbleEncoding* NimbleNullableEncoding::nullsEncoding() {
+  return childAt(EncodingIdentifiers::Nullable::Nulls);
+}
+
+NimbleEncoding* NimbleNullableEncoding::nonNullsEncoding() {
+  return childAt(EncodingIdentifiers::Nullable::Data);
+}
+
+std::unique_ptr<GpuDecode> NimbleNullableEncoding::makeStep(
+    ColumnOp& op,
+    ReadStream& stream,
+    SplitStaging& staging,
+    BufferId bufferId,
+    const NimbleEncoding& rootEncoding,
+    int32_t blockIdx) {
+  // TODO(bowenwu): populate the the encoding specific data correctly
+  return makeStepCommon(op, stream, blockIdx);
+}
+
+/// NimbleChunk implementation
+NimbleChunk::NimbleChunk(std::string_view chunkData) : chunkData_(chunkData) {}
+
+std::unique_ptr<NimbleEncoding> NimbleChunk::parseEncodingFromChunk(
+    std::string_view chunkData) {
+  VELOX_CHECK(
+      chunkData.size() >= sizeof(uint32_t) + sizeof(char),
+      "Chunk data too small to contain header");
+
+  const char* pos = chunkData.data();
+
+  auto encodingDataLength = encoding::readUint32(pos);
+
+  const size_t headerSize = sizeof(uint32_t) + sizeof(char);
+  VELOX_CHECK(
+      chunkData.size() >= headerSize + encodingDataLength,
+      "Chunk data size does not match header length");
+
+  std::string_view encodingData =
+      chunkData.substr(headerSize, encodingDataLength);
+
+  return NimbleEncoding::create(encodingData);
+}
+
+/// NimbleChunkedStream implementation
+NimbleChunkedStream::NimbleChunkedStream(
+    velox::memory::MemoryPool& memoryPool,
+    std::string_view streamData)
+    : streamData_(streamData), pos_(streamData.data()) {}
+
+bool NimbleChunkedStream::hasNext() {
+  return pos_ - streamData_.data() < streamData_.size();
+}
+
+NimbleChunk NimbleChunkedStream::nextChunk() {
+  VELOX_CHECK(
+      sizeof(uint32_t) + sizeof(char) <=
+          streamData_.size() - (pos_ - streamData_.data()),
+      "Read beyond end of stream");
+
+  // Read the chunk header to get length and compression type
+  const char* headerPos = pos_;
+  auto length = encoding::readUint32(pos_);
+  [[maybe_unused]] auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(pos_));
+
+  VELOX_CHECK(
+      length <= streamData_.size() - (pos_ - streamData_.data()),
+      "Read beyond end of stream");
+
+  const size_t headerSize = sizeof(uint32_t) + sizeof(char);
+  const size_t totalChunkSize = headerSize + length;
+
+  std::string_view chunkData;
+  chunkData = std::string_view(headerPos, totalChunkSize);
+
+  pos_ += length;
+
+  return NimbleChunk(chunkData);
+}
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
+++ b/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+#include <vector>
+#include "velox/experimental/wave/dwio/FormatData.h"
+#include "velox/experimental/wave/dwio/decode/DecodeStep.h"
+#include "velox/experimental/wave/dwio/nimble/Encoding.h"
+#include "velox/experimental/wave/dwio/nimble/Types.h"
+#include "velox/experimental/wave/vector/WaveVector.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::wave {
+
+// Base class for all Nimble encodings
+class NimbleEncoding {
+ public:
+  explicit NimbleEncoding(std::string_view encodingData);
+
+  virtual ~NimbleEncoding() = default;
+
+  std::string_view encodingData() const {
+    return encodingData_;
+  }
+
+  facebook::wave::nimble::EncodingType encodingType() const {
+    return encodingType_;
+  }
+
+  // Get a string_view of just the encoded data region (excluding prefix)
+  std::string_view encodedData() const {
+    return encodingData_.substr(facebook::wave::nimble::Encoding::kPrefixSize);
+  }
+
+  // Get pointer to the encoded data region (after the 6-byte prefix)
+  const char* encodedDataPtr() const {
+    return encodedData().data();
+  }
+
+  facebook::wave::nimble::DataType dataType() const {
+    return dataType_;
+  }
+
+  uint32_t numValues() const {
+    return numValues_;
+  }
+
+  facebook::velox::TypePtr veloxType() const;
+  facebook::velox::TypeKind typeKind() const;
+
+  uint8_t childrenCount() const;
+  NimbleEncoding* childAt(uint8_t childIndex);
+
+#define NIMBLE_ENCODING_TYPE_CHECK(name, type)                          \
+  bool is##name##Encoding() const {                                     \
+    return encodingType_ == facebook::wave::nimble::EncodingType::type; \
+  }
+
+  NIMBLE_ENCODING_TYPE_CHECK(Trivial, Trivial)
+  NIMBLE_ENCODING_TYPE_CHECK(RLE, RLE)
+  NIMBLE_ENCODING_TYPE_CHECK(Dictionary, Dictionary)
+  NIMBLE_ENCODING_TYPE_CHECK(Nullable, Nullable)
+
+#undef NIMBLE_ENCODING_TYPE_CHECK
+
+  // return nullptr if not applicable for this encoding type
+  // Dictionary
+  virtual NimbleEncoding* alphabetEncoding();
+  virtual NimbleEncoding* indicesEncoding();
+  // Trivial
+  virtual NimbleEncoding* lengthsEncoding();
+  // RLE
+  virtual NimbleEncoding* runLengthsEncoding();
+  virtual NimbleEncoding* runValuesEncoding();
+  // Nullable
+  virtual NimbleEncoding* nullsEncoding();
+  virtual NimbleEncoding* nonNullsEncoding();
+
+  static std::unique_ptr<NimbleEncoding> create(std::string_view encodingData);
+
+  // Check if the encoding is ready to be decoded
+  bool isDecoded() const {
+    return decoded_;
+  }
+  void setDecoded() {
+    decoded_ = true;
+  }
+  bool isReadyToDecode() const;
+
+  virtual std::unique_ptr<GpuDecode> makeStep(
+      ColumnOp& op,
+      ReadStream& stream,
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      int32_t blockIdx) = 0;
+
+  void* deviceEncodedDataPtr() const {
+    return deviceEncodedData_;
+  }
+
+  void** deviceEncodedDataPtrPtr() {
+    return &deviceEncodedData_;
+  }
+
+ protected:
+  facebook::velox::TypePtr nimbleDataTypeToVeloxType(
+      facebook::wave::nimble::DataType nimbleDataType) const;
+  std::unique_ptr<GpuDecode>
+  makeStepCommon(ColumnOp& op, ReadStream& stream, int32_t blockIdx);
+  void getDeviceEncodingInput(
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      const void* hostPtr,
+      const void*& devicePtr);
+
+ protected:
+  std::string_view encodingData_;
+  facebook::wave::nimble::EncodingType encodingType_;
+  facebook::wave::nimble::DataType dataType_;
+  uint32_t numValues_;
+  std::vector<std::unique_ptr<NimbleEncoding>> children_;
+  void* deviceEncodedData_{nullptr};
+  bool decoded_{false};
+
+ private:
+  NimbleEncoding* createChildEncodingByIndex(uint8_t childIndex);
+};
+
+// Dictionary encoding subclass
+class NimbleDictionaryEncoding : public NimbleEncoding {
+ public:
+  explicit NimbleDictionaryEncoding(std::string_view encodingData);
+
+  NimbleEncoding* alphabetEncoding() override;
+  NimbleEncoding* indicesEncoding() override;
+  std::unique_ptr<GpuDecode> makeStep(
+      ColumnOp& op,
+      ReadStream& stream,
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      int32_t blockIdx) override;
+};
+
+// Trivial encoding subclass
+class NimbleTrivialEncoding : public NimbleEncoding {
+ public:
+  explicit NimbleTrivialEncoding(std::string_view encodingData);
+
+  NimbleEncoding* lengthsEncoding() override;
+  std::unique_ptr<GpuDecode> makeStep(
+      ColumnOp& op,
+      ReadStream& stream,
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      int32_t blockIdx) override;
+};
+
+// RLE encoding subclass
+class NimbleRLEEncoding : public NimbleEncoding {
+ public:
+  explicit NimbleRLEEncoding(std::string_view encodingData);
+
+  NimbleEncoding* runLengthsEncoding() override;
+  NimbleEncoding* runValuesEncoding() override;
+  std::unique_ptr<GpuDecode> makeStep(
+      ColumnOp& op,
+      ReadStream& stream,
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      int32_t blockIdx) override;
+};
+
+// Nullable encoding subclass
+class NimbleNullableEncoding : public NimbleEncoding {
+ public:
+  explicit NimbleNullableEncoding(std::string_view encodingData);
+
+  NimbleEncoding* nullsEncoding() override;
+  NimbleEncoding* nonNullsEncoding() override;
+  std::unique_ptr<GpuDecode> makeStep(
+      ColumnOp& op,
+      ReadStream& stream,
+      SplitStaging& staging,
+      BufferId bufferId,
+      const NimbleEncoding& rootEncoding,
+      int32_t blockIdx) override;
+};
+
+class NimbleChunk {
+ public:
+  // Chunk layout: length + compression type + encoding data
+  explicit NimbleChunk(std::string_view chunkData);
+
+  // Get the raw chunk data including header
+  std::string_view chunkData() const {
+    return chunkData_;
+  }
+
+  static std::unique_ptr<NimbleEncoding> parseEncodingFromChunk(
+      std::string_view chunkData);
+
+ private:
+  std::string_view chunkData_;
+};
+
+class NimbleChunkedStream {
+ public:
+  NimbleChunkedStream(
+      velox::memory::MemoryPool& memoryPool,
+      std::string_view streamData);
+
+  bool hasNext();
+
+  NimbleChunk nextChunk();
+
+ private:
+  std::string_view streamData_;
+  const char* pos_;
+};
+
+class NimbleStripe {
+ public:
+  NimbleStripe(
+      std::vector<std::unique_ptr<NimbleChunkedStream>>&& in,
+      const std::shared_ptr<const dwio::common::TypeWithId>& type,
+      int32_t totalRows)
+      : typeWithId_(type), streams_(std::move(in)), totalRows_(totalRows) {}
+
+  NimbleChunkedStream* findStream(const dwio::common::TypeWithId& child) const {
+    for (auto i = 0; i < typeWithId_->size(); ++i) {
+      if (typeWithId_->childAt(i)->id() == child.id()) {
+        return streams_[i].get();
+      }
+    }
+    VELOX_FAIL("No such column {}", child.id());
+  }
+
+  int32_t numStreams() const {
+    return streams_.size();
+  }
+
+  int32_t totalRows() const {
+    return totalRows_;
+  }
+
+ private:
+  std::shared_ptr<const dwio::common::TypeWithId> typeWithId_;
+  std::vector<std::unique_ptr<NimbleChunkedStream>> streams_;
+  int32_t totalRows_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/dwio/nimble/Types.h
+++ b/velox/experimental/wave/dwio/nimble/Types.h
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+
+// Single file containing all the types and enums in nimble, as well as some
+// templates for mapping between those types and C++ types.
+//
+// A note on types: For all of our enum classes, we assume the number of
+// types will stay small, so that each one is representable by a single byte.
+// Don't violate this!
+
+namespace facebook::wave::nimble {
+
+using VariantType = std::variant<
+    int8_t,
+    uint8_t,
+    int16_t,
+    uint16_t,
+    int32_t,
+    uint32_t,
+    int64_t,
+    uint64_t,
+    float,
+    double,
+    bool,
+    std::string>;
+
+template <typename T>
+class Variant {
+ public:
+  static void set(VariantType& target, T source) {
+    target = source;
+  }
+
+  static T get(VariantType& source) {
+    return std::get<T>(source);
+  }
+};
+
+template <>
+void Variant<std::string_view>::set(
+    VariantType& target,
+    std::string_view source);
+
+template <>
+std::string_view Variant<std::string_view>::get(VariantType& source);
+
+enum class EncodingType {
+  // Native encoding for numerics, simple packed chars with offsets for strings,
+  // bitpacked for bools. All data types supported.
+  Trivial = 0,
+  // Run length encoded data. The runs lengths are bit packed, and the run
+  // values are encoded like the trivial encoding. All data types supported.
+  RLE = 1,
+  // Data with the uniques encoded in a dictionary and the indices into that
+  // dictionary. All data types except bools supported.
+  Dictionary = 2,
+  // Stores integer types packed into a fixed number of bits (namely, the
+  // smallest required to represent the largest element). Currently only
+  // works with non-negative values, we may add ZigZag encoding later.
+  FixedBitWidth = 3,
+  // Stores nullable data using a 'sentinel' value to represent nulls in a
+  // single non-nullable encoding.
+  Sentinel = 4,
+  // Stores nullable data by wrapping one subencoding representing the non-nulls
+  // with another subencoding marking which rows are null.
+  Nullable = 5,
+  // Stores indices to set (or unset) bits. Useful for storing sparse data, such
+  // as when only a few rows in a encoding are non-null.
+  SparseBool = 6,
+  // Stores integer types via varint encoding. Currently only
+  // works with non-negative values, we may add ZigZag encoding later.
+  Varint = 7,
+  // Stores integer types with a delta encoding. Currently only supports
+  // positive deltas.
+  Delta = 8,
+  // Stores constant (i.e. only 1 unique value) data.
+  Constant = 9,
+  // Stores 'mainly constant' data, i.e. treats one particular value as special,
+  // using a bool child vector to store whether each row is that special value,
+  // and stores the non-special values as a separate encoding.
+  MainlyConstant = 10,
+};
+std::string toString(EncodingType encodingType);
+std::ostream& operator<<(std::ostream& out, EncodingType encodingType);
+
+enum class DataType : uint8_t {
+  Undefined = 0,
+  Int8 = 1,
+  Uint8 = 2,
+  Int16 = 3,
+  Uint16 = 4,
+  Int32 = 5,
+  Uint32 = 6,
+  Int64 = 7,
+  Uint64 = 8,
+  Float = 9,
+  Double = 10,
+  Bool = 11,
+  String = 12,
+};
+
+std::string toString(DataType dataType);
+std::ostream& operator<<(std::ostream& out, DataType dataType);
+
+// General string compression. Make sure values here match those in the footer
+// specification
+enum class CompressionType : uint8_t {
+  Uncompressed = 0,
+  // Zstd doesn't require us to externally store level or any other info.
+  Zstd = 1,
+  MetaInternal = 2,
+};
+
+std::string toString(CompressionType compressionType);
+std::ostream& operator<<(std::ostream& out, CompressionType compressionType);
+
+enum class ChecksumType : uint8_t { XXH3_64 = 0 };
+
+std::string toString(ChecksumType type);
+
+// A CompresionType and any type-specific configuration params.
+struct CompressionParams {
+  CompressionType type;
+
+  // For zstd.
+  int zstdLevel = 1;
+};
+
+// Parameters controlling the search for the optimal encoding on a data set.
+struct OptimalSearchParams {
+  // Whether recursive structures are allowed. E.g. a encoding may use another
+  // encoding as a subencoding, and may use the encoding factory to find the
+  // best subencoding. We must terminate the recursion at some depth. With the
+  // default of 1 allowed recursion the top level encoding may use recursive
+  // encodings, but its subencodings may not.
+  int allowedRecursions = 1;
+
+  // Whether to log debug info during the search (such as estimated sizes of
+  // each encoding considered, etc.);
+  bool logSearch = false;
+
+  // Helps align log messages when log_search=true to help distinguish
+  // subencoding log messages from higher-level ones.
+  int logDepth = 0;
+
+  // Entropy encodings, such as HuffmanEncoding, can be much more compact than
+  // others, but are quite a bit slower. However, compared to applying a general
+  // string compression on top of another encoding they are relatively fast.
+  // In general the entropy encodings will also be smaller than GSC on top of
+  // a non-entropy encoding.
+  bool enableEntropyEncodings = true;
+
+  // For some dimension encodings that will frequently be grouped by, we may
+  // want to force dictionary enabled encodings so grouping by that can will be
+  // fast.
+  bool requireDictionaryEnabled = false;
+};
+
+template <typename T>
+struct TypeTraits {};
+
+template <>
+struct TypeTraits<int8_t> {
+  using physicalType = uint8_t;
+  using sumType = int64_t;
+  static constexpr DataType dataType = DataType::Int8;
+};
+
+template <>
+struct TypeTraits<uint8_t> {
+  using physicalType = uint8_t;
+  using sumType = uint64_t;
+  static constexpr DataType dataType = DataType::Uint8;
+};
+
+template <>
+struct TypeTraits<int16_t> {
+  using physicalType = uint16_t;
+  using sumType = int64_t;
+  static constexpr DataType dataType = DataType::Int16;
+};
+
+template <>
+struct TypeTraits<uint16_t> {
+  using physicalType = uint16_t;
+  using sumType = uint64_t;
+  static constexpr DataType dataType = DataType::Uint16;
+};
+
+template <>
+struct TypeTraits<int32_t> {
+  using physicalType = uint32_t;
+  using sumType = int64_t;
+  static constexpr DataType dataType = DataType::Int32;
+};
+
+template <>
+struct TypeTraits<uint32_t> {
+  using physicalType = uint32_t;
+  using sumType = uint64_t;
+  static constexpr DataType dataType = DataType::Uint32;
+};
+
+template <>
+struct TypeTraits<int64_t> {
+  using physicalType = uint64_t;
+  using sumType = int64_t;
+  static constexpr DataType dataType = DataType::Int64;
+};
+
+template <>
+struct TypeTraits<uint64_t> {
+  using physicalType = uint64_t;
+  using sumType = uint64_t;
+  static constexpr DataType dataType = DataType::Uint64;
+};
+
+template <>
+struct TypeTraits<float> {
+  using physicalType = uint32_t;
+  using sumType = double;
+  static constexpr DataType dataType = DataType::Float;
+};
+
+template <>
+struct TypeTraits<double> {
+  using physicalType = uint64_t;
+  using sumType = double;
+  static constexpr DataType dataType = DataType::Double;
+};
+
+template <>
+struct TypeTraits<bool> {
+  using physicalType = bool;
+  static constexpr DataType dataType = DataType::Bool;
+};
+
+template <>
+struct TypeTraits<std::string> {
+  using physicalType = std::string;
+  static constexpr DataType dataType = DataType::String;
+};
+
+template <>
+struct TypeTraits<std::string_view> {
+  using physicalType = std::string_view;
+  static constexpr DataType dataType = DataType::String;
+};
+
+template <typename T>
+constexpr bool isFourByteIntegralType() {
+  return std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>;
+}
+
+template <typename T>
+constexpr bool isSignedIntegralType() {
+  return std::is_same_v<T, int32_t> || std::is_same_v<T, int64_t> ||
+      std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>;
+}
+
+template <typename T>
+constexpr bool isUnsignedIntegralType() {
+  return std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t> ||
+      std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t>;
+}
+
+template <typename T>
+constexpr bool isIntegralType() {
+  return isSignedIntegralType<T>() || isUnsignedIntegralType<T>();
+}
+
+template <typename T>
+constexpr bool isFloatingPointType() {
+  return std::is_same_v<T, float> || std::is_same_v<T, double>;
+}
+
+template <typename T>
+constexpr bool isNumericType() {
+  return isIntegralType<T>() || isFloatingPointType<T>();
+}
+
+template <typename T>
+constexpr bool isStringType() {
+  return std::is_same_v<T, std::string_view> || std::is_same_v<T, std::string>;
+}
+
+template <typename T>
+constexpr bool isBoolType() {
+  return std::is_same_v<T, bool>;
+}
+
+} // namespace facebook::wave::nimble


### PR DESCRIPTION
Summary:
This diff adds the following features.

1. An in-memory representation of the Nimble encoding tree. The encoding in Nimble can be nested, therefore we need to use an encoding tree to track the dependencies. The `NimbleEncoding` class serves as a tree node and keeps track of the current encoding and its child encodings. Besides capturing the dependency, this class also keeps track if the encoding has been decoded (`decoded_`). 

2. Specialized Nimble encoding. For each available Nimble encoding, we create a specialized subclass inheriting the `NimbleEncoding`. Each subclass tailors the creation of `GpuDecode` step based its own encoding.

3. An in-memory representation of chunk (`NimbleChunk`) and stream (`NimbleChunkedStream`). As a stream in Nimble can contain multiple chunks, these two classes map to the chunk layout and stream layout, respectively. Each `NimbleChunk` is made up of a chunk header and the root-level `NimbleEncoding`.

4. An representation of the stripe (`NimbleStripe`). It is a collection of Nimble streams, which can be looked up with the `TypeWithId`. 

To do

1. The creation of some encodings are not fully supported yet.
2. Creating `GpuDecode` step (`makeStep`) is not yet fully implemented. (Maybe better in another diff).

Reviewed By: Yuhta

Differential Revision: D77079648


