### PR TITLE
fix: Prevent readElement from throwing exception instead of returning when there is no data vector

### DIFF
--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -976,17 +976,18 @@ void TextRowReader::readElement(
 
     case TypeKind::VARBINARY: {
       const auto& strView = getStringView(*this, isNull, delim);
-      const auto& flatVector =
-          data ? data->asChecked<FlatVector<StringView>>() : nullptr;
+
+      // Early return if no data vector or at EOF
+      if ((atEOF_ && atSOL_) || (data == nullptr)) {
+        return;
+      }
+
+      const auto& flatVector = data->asChecked<FlatVector<StringView>>();
       if (!flatVector) {
         VELOX_FAIL(
             "Vector for column type does not match: expected FlatVector<StringView>, got {}",
             data ? data->type()->toString() : "null");
         return;
-      }
-
-      if ((atEOF_ && atSOL_) || (flatVector == nullptr)) {
-        break;
       }
 
       // Allocate a blob buffer
@@ -1032,17 +1033,18 @@ void TextRowReader::readElement(
     }
     case TypeKind::VARCHAR: {
       const auto& strView = getStringView(*this, isNull, delim);
-      const auto& flatVector =
-          data ? data->asChecked<FlatVector<StringView>>() : nullptr;
+
+      // Early return if no data vector or at EOF
+      if ((atEOF_ && atSOL_) || (data == nullptr)) {
+        return;
+      }
+
+      const auto& flatVector = data->asChecked<FlatVector<StringView>>();
       if (!flatVector) {
         VELOX_FAIL(
             "Vector for column type does not match: expected FlatVector<StringView>, got {}",
             data ? data->type()->toString() : "null");
         return;
-      }
-
-      if ((atEOF_ && atSOL_) || (flatVector == nullptr)) {
-        break;
       }
 
       flatVector->set(insertionRow, strView);
@@ -1314,13 +1316,13 @@ void TextRowReader::readElement(
 
     case TypeKind::TIMESTAMP: {
       const auto& s = getStringView(*this, isNull, delim);
+
       // Early return if no data vector or at EOF
       if ((atEOF_ && atSOL_) || (data == nullptr)) {
         return;
       }
 
-      auto flatVector =
-          data ? data->asChecked<FlatVector<Timestamp>>() : nullptr;
+      auto flatVector = data->asChecked<FlatVector<Timestamp>>();
       if (!flatVector) {
         VELOX_FAIL(
             "Vector for column type does not match: expected FlatVector<Timestamp>, got {}",

--- a/velox/dwio/text/tests/reader/TextReaderTest.cpp
+++ b/velox/dwio/text/tests/reader/TextReaderTest.cpp
@@ -775,7 +775,39 @@ TEST_F(TextReaderTest, filter) {
   }
 }
 
-TEST_F(TextReaderTest, DISABLED_shrinkBatch) {
+TEST_F(TextReaderTest, shrinkBatch) {
+  auto type = ROW(
+      {{"col_string", VARCHAR()},
+       {"col_int", INTEGER()},
+       {"col_float", DOUBLE()},
+       {"col_bool", BOOLEAN()}});
+  auto factory = dwio::common::getReaderFactory(dwio::common::FileFormat::TEXT);
+  auto path = velox::test::getDataFilePath(
+      "velox/dwio/text/tests/reader/", "examples/simple_types");
+  auto readFile = std::make_shared<LocalReadFile>(path);
+  auto readerOptions = dwio::common::ReaderOptions(pool());
+  readerOptions.setFileSchema(type);
+  auto input =
+      std::make_unique<dwio::common::BufferedInput>(readFile, poolRef());
+  auto reader = factory->createReader(std::move(input), readerOptions);
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(spec);
+  rowOptions.select(
+      std::make_shared<dwio::common::ColumnSelector>(ROW({}, {})));
+  auto rowReader = reader->createRowReader(rowOptions);
+  VectorPtr result;
+
+  ASSERT_EQ(rowReader->next(6, result), 6);
+  ASSERT_EQ(result->size(), 6);
+  ASSERT_EQ(rowReader->next(4, result), 4);
+  ASSERT_EQ(result->size(), 4);
+  ASSERT_EQ(rowReader->next(6, result), 6);
+  ASSERT_EQ(result->size(), 6);
+  ASSERT_EQ(rowReader->next(4, result), 0);
+}
+
+TEST_F(TextReaderTest, DISABLED_compressedShrinkBatch) {
   auto type = ROW(
       {{"col_string", VARCHAR()},
        {"col_int", INTEGER()},


### PR DESCRIPTION
Summary: Reordered early return when data vector is null

Differential Revision: D78105599


