### PR TITLE
Add TpchConnectorMetadata class

### DIFF
--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -132,8 +132,7 @@ class TpchConnector final : public Connector {
   TpchConnector(
       const std::string& id,
       std::shared_ptr<const config::ConfigBase> config,
-      folly::Executor* /*executor*/)
-      : Connector(id) {}
+      folly::Executor* /*executor*/);
 
   std::unique_ptr<DataSource> createDataSource(
       const RowTypePtr& outputType,
@@ -154,6 +153,14 @@ class TpchConnector final : public Connector {
       CommitStrategy /*commitStrategy*/) override final {
     VELOX_NYI("TpchConnector does not support data sink.");
   }
+
+  ConnectorMetadata* metadata() const override {
+    VELOX_CHECK_NOT_NULL(metadata_);
+    return metadata_.get();
+  }
+
+ private:
+  std::shared_ptr<ConnectorMetadata> metadata_;
 };
 
 class TpchConnectorFactory : public ConnectorFactory {
@@ -173,5 +180,16 @@ class TpchConnectorFactory : public ConnectorFactory {
     return std::make_shared<TpchConnector>(id, config, ioExecutor);
   }
 };
+
+class TpchConnectorMetadataFactory {
+ public:
+  virtual std::shared_ptr<ConnectorMetadata> create(
+      TpchConnector* connector) = 0;
+
+  virtual ~TpchConnectorMetadataFactory() = default;
+};
+
+bool registerTpchConnectorMetadataFactory(
+    std::unique_ptr<TpchConnectorMetadataFactory>);
 
 } // namespace facebook::velox::connector::tpch


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/verax/pull/32

This diff implements an initial version of TpchConnectorMetadata class and relvant tpch classes that are required to run tpchMetadata correctly. The implementation follows the existing implementation of HiveConnectorMetadata-related classes. The upper layer classes can fetch table and layout information from metadata of TpchConnector.

Reviewed By: kewang1024

Differential Revision: D77706613


