### PR TITLE
fix: Access null value in makeInFilter

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -1344,6 +1344,32 @@ TEST_F(ParquetTableScanTest, shortAndLongDecimalReadWithLargerPrecision) {
   assertEqualVectors(expectedDecimalVectors->childAt(1), rows->childAt(1));
 }
 
+TEST_F(ParquetTableScanTest, inFilter) {
+  auto vectors = {makeRowVector(
+      {"name"},
+      {
+          makeNullableFlatVector<std::string>(
+              {"mary", "martin", "lucy", "alex", std::nullopt, "mary", "dan"}),
+      })};
+  auto filePath = TempFilePath::create();
+  WriterOptions options;
+  writeToParquetFile(filePath->getPath(), vectors, options);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder(pool_.get())
+                  .tableScan(
+                      ROW({"name"}, {VARCHAR()}),
+                      {},
+                      "name in ('alex', 'leo', 'mary', null, 'victor')")
+                  .planNode();
+  auto split = makeSplit(filePath->getPath());
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .split(split)
+      .assertResults(
+          "SELECT name FROM tmp where name in ('alex', 'leo', 'mary', null, 'victor')");
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   folly::Init init{&argc, &argv, false};

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -106,8 +106,16 @@ std::vector<int64_t>
 toInt64List(const VectorPtr& vector, vector_size_t start, vector_size_t size) {
   auto ints = vector->as<SimpleVector<T>>();
   std::vector<int64_t> values;
-  for (auto i = 0; i < size; i++) {
-    values.push_back(ints->valueAt(start + i));
+  if (!ints->mayHaveNulls()) {
+    for (auto i = 0; i < size; i++) {
+      values.push_back(ints->valueAt(start + i));
+    }
+  } else {
+    for (auto i = 0; i < size; i++) {
+      if (!ints->isNullAt(start + i)) {
+        values.push_back(ints->valueAt(start + i));
+      }
+    }
   }
   return values;
 }
@@ -400,9 +408,18 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
     case TypeKind::VARCHAR: {
       auto stringElements = elements->as<SimpleVector<StringView>>();
       std::vector<std::string> values;
-      for (auto i = 0; i < size; i++) {
-        values.push_back(stringElements->valueAt(offset + i).str());
+      if (!stringElements->mayHaveNulls()) {
+        for (auto i = 0; i < size; i++) {
+          values.push_back(stringElements->valueAt(offset + i).str());
+        }
+      } else {
+        for (auto i = 0; i < size; i++) {
+          if (!stringElements->isNullAt(offset + i)) {
+            values.push_back(stringElements->valueAt(offset + i).str());
+          }
+        }
       }
+
       if (negated) {
         return notIn(values);
       }


### PR DESCRIPTION
If the value at idx is null, the access to the underlying bit is undefined 
behavior, and can lead to a crash, invalid memory access, or other 
unpredictable behavior. This PR fixes the access to null value in the
`makeInFilter` by first checking if it is null.