### PR TITLE
fix: HiveDataSink should materialize the input before any writes

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -474,6 +474,9 @@ bool HiveDataSink::canReclaim() const {
 void HiveDataSink::appendData(RowVectorPtr input) {
   checkRunning();
 
+  // Lazy load all the input columns.
+  input->loadedVector();
+
   // Write to unpartitioned (and unbucketed) table.
   if (!isPartitioned() && !isBucketed()) {
     const auto index = ensureWriter(HiveWriterId::unpartitionedId());
@@ -483,11 +486,6 @@ void HiveDataSink::appendData(RowVectorPtr input) {
 
   // Compute partition and bucket numbers.
   computePartitionAndBucketIds(input);
-
-  // Lazy load all the input columns.
-  for (column_index_t i = 0; i < input->childrenSize(); ++i) {
-    input->childAt(i)->loadedVector();
-  }
 
   // All inputs belong to a single non-bucketed partition. The partition id
   // must be zero.


### PR DESCRIPTION
`HiveDataSink` does not materialize input for unpartitioned and unbucked tables, when writing to parquet table, it would encounter this error:
```bash
function:asUnchecked, Expression: dynamic_cast<const T*>(this) != nullptr Wrong type cast expected N8facebook5velox9MapVectorE, but got N8facebook5velox10LazyVectorE, Source: RUNTIME, ErrorCode: INVALID_STATE
```

The root cause is that the input may be lazy vector, it should be loaded before writing to parquet.