### PR TITLE
fix(build): Remove quotes for extra arrow options

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -196,7 +196,7 @@ function install_arrow {
     -DCMAKE_BUILD_TYPE=Release \
     -DARROW_BUILD_STATIC=ON \
     -DBOOST_ROOT="$INSTALL_PREFIX" \
-    "$EXTRA_ARROW_OPTIONS"
+    $EXTRA_ARROW_OPTIONS
 }
 
 function install_thrift {


### PR DESCRIPTION
Passing a value to the function results in
' <options> ' to be added which is ignored by CMake as a single value. Instead the content of EXTRA_ARROW_OPTIONS should simply be listed and not quoted.