### PR TITLE
feat(wave): Support Nimble trivial decoding in Wave

### DIFF
--- a/velox/experimental/wave/dwio/ColumnReader.h
+++ b/velox/experimental/wave/dwio/ColumnReader.h
@@ -42,7 +42,11 @@ class ColumnReader {
             fileType_,
             scanSpec,
             operand ? operand->id : kNoOperand)),
-        scanSpec_(&scanSpec) {}
+        scanSpec_(&scanSpec) {
+    if (operand) {
+      operand->notNull = !formatData_->hasNulls();
+    }
+  }
 
   virtual ~ColumnReader() = default;
 

--- a/velox/experimental/wave/dwio/FormatData.cpp
+++ b/velox/experimental/wave/dwio/FormatData.cpp
@@ -58,8 +58,7 @@ void SplitStaging::copyColumns(
     char* destination,
     bool release) {
   for (auto i = begin; i < end; ++i) {
-    memcpy(destination, staging_[i].hostData, staging_[i].size);
-    destination += staging_[i].size;
+    memcpy(destination + offsets_[i], staging_[i].hostData, staging_[i].size);
   }
   if (release) {
     sem_.release();

--- a/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
+++ b/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
@@ -108,7 +108,8 @@ class NimbleEncoding {
       SplitStaging& staging,
       BufferId bufferId,
       const NimbleEncoding& rootEncoding,
-      int32_t blockIdx) = 0;
+      int32_t blockIdx,
+      int32_t resultOffset) = 0;
 
   void* deviceEncodedDataPtr() const {
     return deviceEncodedData_;
@@ -121,8 +122,11 @@ class NimbleEncoding {
  protected:
   facebook::velox::TypePtr nimbleDataTypeToVeloxType(
       facebook::wave::nimble::DataType nimbleDataType) const;
-  std::unique_ptr<GpuDecode>
-  makeStepCommon(ColumnOp& op, ReadStream& stream, int32_t blockIdx);
+  std::unique_ptr<GpuDecode> makeStepCommon(
+      ColumnOp& op,
+      ReadStream& stream,
+      int32_t blockIdx,
+      int32_t resultOffset);
   void getDeviceEncodingInput(
       SplitStaging& staging,
       BufferId bufferId,
@@ -156,7 +160,8 @@ class NimbleDictionaryEncoding : public NimbleEncoding {
       SplitStaging& staging,
       BufferId bufferId,
       const NimbleEncoding& rootEncoding,
-      int32_t blockIdx) override;
+      int32_t blockIdx,
+      int32_t resultOffset) override;
 };
 
 // Trivial encoding subclass
@@ -171,7 +176,8 @@ class NimbleTrivialEncoding : public NimbleEncoding {
       SplitStaging& staging,
       BufferId bufferId,
       const NimbleEncoding& rootEncoding,
-      int32_t blockIdx) override;
+      int32_t blockIdx,
+      int32_t resultOffset) override;
 };
 
 // RLE encoding subclass
@@ -187,7 +193,8 @@ class NimbleRLEEncoding : public NimbleEncoding {
       SplitStaging& staging,
       BufferId bufferId,
       const NimbleEncoding& rootEncoding,
-      int32_t blockIdx) override;
+      int32_t blockIdx,
+      int32_t resultOffset) override;
 };
 
 // Nullable encoding subclass
@@ -203,7 +210,8 @@ class NimbleNullableEncoding : public NimbleEncoding {
       SplitStaging& staging,
       BufferId bufferId,
       const NimbleEncoding& rootEncoding,
-      int32_t blockIdx) override;
+      int32_t blockIdx,
+      int32_t resultOffset) override;
 };
 
 class NimbleChunk {

--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -981,6 +981,7 @@ int32_t WaveStream::getOutput(
     auto id = operands[i];
     auto exe = operandExecutable(id);
     VELOX_CHECK_NOT_NULL(exe);
+    exe->stream->wait();
     auto ordinal = exe->outputOperands.ordinal(id);
     auto waveVectorPtr = &exe->output[ordinal];
     if (!waveVectorPtr->get()) {


### PR DESCRIPTION
Summary:
This diff implements the trivial decoding of Nimble file format in Velox Wave. Specifically,

1. Support multiple chunks and multiple streams.
2. Fix an issue in `splitStaging`, which sets incorrect destination pointers when calling `memcpy`.
3. Fix potential lack of synchronization before transferring results back to the CPU.

Not supported yet:

1. Decompression in the trivial encoding.

Differential Revision: D78248219


