### PR TITLE
feat: Extend unnest to support left join semantics by producing output for input row which has empty/null unnest value

### DIFF
--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -867,7 +867,7 @@ TEST_F(PlanNodeBuilderTest, UnnestNode) {
     EXPECT_EQ(node->id(), id);
     EXPECT_EQ(node->replicateVariables(), replicateVariables);
     EXPECT_EQ(node->unnestVariables(), unnestVariables);
-    EXPECT_TRUE(node->withOrdinality());
+    EXPECT_TRUE(node->hasOrdinality());
     EXPECT_EQ(node->sources()[0], source);
 
     for (int i = 0; i < node->outputType()->size(); ++i) {

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -652,8 +652,12 @@ The unnest operation expands arrays and maps into separate columns. Arrays are
 expanded into a single column, and maps are expanded into two columns
 (key, value). Can be used to expand multiple columns. In this case produces as
 many rows as the highest cardinality array or map (the other columns are padded
-with nulls). Optionally can produce an ordinality column that specifies the row
-number starting with 1.
+with nulls). Optionally, it can include an ordinality column to indicate the row
+number starting from 1, and an emptyUnnestValue column to indicate whether an
+output row has empty unnest value or not. If the ordinality column is specified
+along with the emptyUnnestValue column, the ordinality for the output row with
+empty unnest values is set to zero. If the emptyUnnestValue column is not specified,
+output rows with empty unnest values are not produced.
 
 .. list-table::
    :widths: 10 30
@@ -670,6 +674,8 @@ number starting with 1.
      - Names to use for expanded columns. One name per array column. Two names per map column.
    * - ordinalityName
      - Optional name for the ordinality column.
+   * - emptyUnnestValueName
+     - Optional name for the emptyUnnestValue column.
 
 .. _TableWriteNode:
 

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -429,6 +429,7 @@ core::PlanNodePtr getTraceNode(
         unnestNode->unnestVariables(),
         unnestNode->unnestNames(),
         unnestNode->ordinalityName(),
+        unnestNode->emptyUnnestValueName(),
         std::make_shared<DummySourceNode>(
             unnestNode->sources().front()->outputType()));
   }

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -538,6 +538,12 @@ TEST_F(PlanNodeSerdeTest, unnest) {
   plan =
       PlanBuilder().values({data}).unnest({"c0"}, {"c1"}, "ordinal").planNode();
   testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data})
+             .unnest({"c0"}, {"c1"}, "ordinal", "emptyUnnestValue")
+             .planNode();
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, values) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1926,7 +1926,8 @@ PlanBuilder& PlanBuilder::indexLookupJoin(
 PlanBuilder& PlanBuilder::unnest(
     const std::vector<std::string>& replicateColumns,
     const std::vector<std::string>& unnestColumns,
-    const std::optional<std::string>& ordinalColumn) {
+    const std::optional<std::string>& ordinalColumn,
+    const std::optional<std::string>& emptyUnnestValueName) {
   VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
       replicateFields;
@@ -1962,6 +1963,7 @@ PlanBuilder& PlanBuilder::unnest(
       unnestFields,
       unnestNames,
       ordinalColumn,
+      emptyUnnestValueName,
       planNode_);
   VELOX_CHECK(planNode_->supportsBarrier());
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1228,10 +1228,16 @@ class PlanBuilder {
   /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
   /// This column contains the index of the element of the unnested array or
   /// map. If not specified, the output will not contain this column.
+  /// @param emptyUnnestValueName An optional name for the
+  /// 'emptyUnnestValue' column to produce. This column contains a boolean
+  /// indicating if the output row has empty unnest value or not. If not
+  /// specified, the output will not contain this column and the unnest operator
+  /// also skips producing output rows with empty unnest value.
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,
-      const std::optional<std::string>& ordinalColumn = std::nullopt);
+      const std::optional<std::string>& ordinalColumn = std::nullopt,
+      const std::optional<std::string>& emptyUnnestValueName = std::nullopt);
 
   /// Add a WindowNode to compute one or more windowFunctions.
   /// @param windowFunctions A list of one or more window function SQL like

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -141,7 +141,8 @@ PlanNodePtr toVeloxPlan(
                 sources[0]->outputType()->childAt(0),
                 sources[0]->outputType()->asRow().nameOf(0))},
         std::vector<std::string>{"a"},
-        std::nullopt, // ordinalityName
+        /*ordinalityName=*/std::nullopt,
+        /*emptyUnnestValueName=*/std::nullopt,
         std::move(sources[0]));
   }
 

--- a/velox/tool/trace/UnnestReplayer.cpp
+++ b/velox/tool/trace/UnnestReplayer.cpp
@@ -36,6 +36,7 @@ core::PlanNodePtr UnnestReplayer::createPlanNode(
       unnestNode->unnestVariables(),
       unnestNode->unnestNames(),
       unnestNode->ordinalityName(),
+      unnestNode->emptyUnnestValueName(),
       source);
 }
 } // namespace facebook::velox::tool::trace


### PR DESCRIPTION
Summary: Add option in Unnest plan node to support yield one output row for the input row with all empty or null unnest values. If configured, the output has one additional column to indicate if the output row has empty unnest value or not. If it is empty, then the corresponding unnest columns are all set to null for that row. This is to extend to support left join semantics for unnest operation which only supports inner join semantics. The left join semantics is required for Meta internal AI index join use case.

Differential Revision: D78238081


