### PR TITLE
fix: Make BingTile type non-orderable

### DIFF
--- a/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BingTileFunctionsRegistration.cpp
@@ -27,7 +27,7 @@ namespace {
 
 void registerSimpleBingTileFunctions(const std::string& prefix) {
   // BingTile constructors
-  registerFunction<BingTileFunction, BingTile, int32_t, int32_t, int8_t>(
+  registerFunction<BingTileFunction, BingTile, int32_t, int32_t, int32_t>(
       {prefix + "bing_tile"});
   registerFunction<BingTileFunction, BingTile, Varchar>({prefix + "bing_tile"});
 
@@ -48,24 +48,27 @@ void registerSimpleBingTileFunctions(const std::string& prefix) {
       {prefix + "bing_tile_parent"});
   registerFunction<BingTileChildrenFunction, Array<BingTile>, BingTile>(
       {prefix + "bing_tile_children"});
-  registerFunction<BingTileChildrenFunction, Array<BingTile>, BingTile, int8_t>(
-      {prefix + "bing_tile_children"});
+  registerFunction<
+      BingTileChildrenFunction,
+      Array<BingTile>,
+      BingTile,
+      int32_t>({prefix + "bing_tile_children"});
   registerFunction<BingTileToQuadKeyFunction, Varchar, BingTile>(
       {prefix + "bing_tile_quadkey"});
-  registerFunction<BingTileAtFunction, BingTile, double, double, int8_t>(
+  registerFunction<BingTileAtFunction, BingTile, double, double, int32_t>(
       {prefix + "bing_tile_at"});
   registerFunction<
       BingTilesAroundFunction,
       Array<BingTile>,
       double,
       double,
-      int8_t>({prefix + "bing_tiles_around"});
+      int32_t>({prefix + "bing_tiles_around"});
   registerFunction<
       BingTilesAroundFunction,
       Array<BingTile>,
       double,
       double,
-      int8_t,
+      int32_t,
       double>({prefix + "bing_tiles_around"});
 }
 

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -670,3 +670,18 @@ TEST_F(BingTileFunctionsTest, bingTilesAroundWithRadius) {
       testBingTilesAroundWithRadiusFunc(-85, -180, 1, 1001, std::nullopt),
       "Radius in km must between 0 and 1000, got 1001");
 }
+
+TEST_F(BingTileFunctionsTest, bingTileOrdering) {
+  auto bingTileType = BINGTILE();
+  ASSERT_FALSE(bingTileType->isOrderable());
+  ASSERT_TRUE(bingTileType->isComparable());
+
+  // Test that ARRAY_SORT fails with BingTile arrays since they're not orderable
+  VELOX_ASSERT_THROW(
+      evaluateOnce<int64_t>(
+          "CAST(ARRAY_SORT(ARRAY[bing_tile(c0, c1, c2), bing_tile(c0, c1, c2)])[1] AS BIGINT)",
+          std::optional<int32_t>(1),
+          std::optional<int32_t>(1),
+          std::optional<int32_t>(5)),
+      "Scalar function signature is not supported: array_sort(ARRAY<BINGTILE>).");
+}

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -75,6 +75,10 @@ class BingTileType : public BigintType {
     return name();
   }
 
+  bool isOrderable() const override {
+    return false;
+  }
+
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";


### PR DESCRIPTION
Summary:
BingTile type is not orderable in presto, this diff ensures the same for velox BingTile type. The discrepancy caused some fuzzing errors (https://github.com/facebookincubator/velox/actions/runs/16262347645/job/45913071254?pr=14091)

We may want to add ordering for BingTile in the future, but for now we should aim to achieve the same behavior as presto.

Differential Revision: D78291421


