### PR TITLE
fix(gcs): Optional config hive.gcs.endpoint is accessed when not set

### DIFF
--- a/velox/connectors/hive/storage_adapters/gcs/GcsUtil.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsUtil.h
@@ -30,6 +30,8 @@ namespace facebook::velox {
 // upload this buffer with zero copies if possible.
 auto constexpr kUploadBufferSize = 256 * 1024;
 
+constexpr const char* kGcsDefaultCacheKeyPrefix = "gcs-default-key";
+
 namespace {
 constexpr const char* kSep{"/"};
 constexpr std::string_view kGcsScheme{"gs://"};

--- a/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
@@ -16,6 +16,7 @@
 
 #ifdef VELOX_ENABLE_GCS
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h" // @manual
 #include "velox/connectors/hive/storage_adapters/gcs/GcsUtil.h" // @manual
 #include "velox/dwio/common/FileSink.h"
@@ -46,7 +47,9 @@ gcsFileSystemGenerator() {
         setBucketAndKeyFromGcsPath(file, bucket, object);
         auto cacheKey = fmt::format(
             "{}-{}",
-            properties->get<std::string>("hive.gcs.endpoint").value(),
+            properties->get<std::string>(
+                connector::hive::HiveConfig::kGcsEndpoint,
+                kGcsDefaultCacheKeyPrefix),
             bucket);
 
         // Check if an instance exists with a read lock (shared).

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
@@ -22,6 +22,7 @@
 #include "gtest/gtest.h"
 
 #include "velox/common/config/Config.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GcsUtil.h"
 #include "velox/exec/tests/utils/PortUtil.h"
 
@@ -92,7 +93,7 @@ class GcsEmulator : public testing::Environment {
       const std::unordered_map<std::string, std::string> configOverride = {})
       const {
     std::unordered_map<std::string, std::string> config(
-        {{"hive.gcs.endpoint", endpoint_}});
+        {{connector::hive::HiveConfig::kGcsEndpoint, endpoint_}});
 
     // Update the default config map with the supplied configOverride map
     for (const auto& [configName, configValue] : configOverride) {


### PR DESCRIPTION
When gcs config properties `hive.gcs.endpoint` is not present, query or insert from gcs leads to following error.

prestodb.exceptions.PrestoQueryError: PrestoQueryError(type=INTERNAL_ERROR, name=GENERIC_INTERNAL_ERROR, message=" Operator::addInput failed for [operator: TableWrite, plan node ID: 5]: Empty Optional cannot be unwrapped", query_id=20250714_062014_00309_swbg9)


