### PR TITLE
Fix unreachable-break issue in velox/dwio/dwrf/writer/StatisticsBuilder.cpp +9

### DIFF
--- a/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
@@ -206,7 +206,6 @@ void StatisticsBuilder::createTree(
     }
     default:
       DWIO_RAISE("Not supported type: ", kind);
-      break;
   }
   return;
 };

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -156,22 +156,16 @@ common::CompressionKind thriftCodecToCompressionKind(
   switch (codec) {
     case thrift::CompressionCodec::UNCOMPRESSED:
       return common::CompressionKind::CompressionKind_NONE;
-      break;
     case thrift::CompressionCodec::SNAPPY:
       return common::CompressionKind::CompressionKind_SNAPPY;
-      break;
     case thrift::CompressionCodec::GZIP:
       return common::CompressionKind::CompressionKind_GZIP;
-      break;
     case thrift::CompressionCodec::LZO:
       return common::CompressionKind::CompressionKind_LZO;
-      break;
     case thrift::CompressionCodec::LZ4:
       return common::CompressionKind::CompressionKind_LZ4;
-      break;
     case thrift::CompressionCodec::ZSTD:
       return common::CompressionKind::CompressionKind_ZSTD;
-      break;
     case thrift::CompressionCodec::LZ4_RAW:
       return common::CompressionKind::CompressionKind_LZ4;
     default:

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -728,7 +728,6 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           auto stream = merge->next();
           if (!stream) {
             FAIL() << "Stream ends after " << i << " entries";
-            break;
           }
           ASSERT_TRUE(rowVector_->equalValueAt(
               &stream->current(), indices[i], stream->currentIndex()));

--- a/velox/exec/tests/TreeOfLosersTest.cpp
+++ b/velox/exec/tests/TreeOfLosersTest.cpp
@@ -69,7 +69,6 @@ TEST_F(TreeOfLosersTest, nextWithEquals) {
     auto result = merge.nextWithEquals();
     if (result.first == nullptr) {
       FAIL() << "Merge ends too soon";
-      break;
     }
     auto number = result.first->current()->value();
     EXPECT_EQ(allNumbers[i], number);
@@ -95,7 +94,6 @@ TEST_F(TreeOfLosersTest, singleWithEquals) {
     auto result = merge.nextWithEquals();
     if (result.first == nullptr) {
       FAIL() << "Merge ends too soon";
-      break;
     }
     auto number = result.first->current()->value();
     EXPECT_EQ(allNumbers[i], number);

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -1145,16 +1145,12 @@ VectorPtr deserialize(
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
       return deserializeStrings(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ARRAY:
       return deserializeArrays(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::MAP:
       return deserializeMaps(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ROW:
       return deserializeRows(type, data, nulls, offsets, pool);
-      break;
     default:
       VELOX_UNREACHABLE("{}", type->toString());
   }

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -1023,16 +1023,12 @@ VectorPtr deserialize(
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
       return deserializeStrings(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ARRAY:
       return deserializeArrays(type, data, nulls, pool);
-      break;
     case TypeKind::MAP:
       return deserializeMaps(type, data, nulls, pool);
-      break;
     case TypeKind::ROW:
       return deserializeRows(type, data, nulls, offsets, pool);
-      break;
     default:
       VELOX_UNREACHABLE("{}", type->toString());
   }

--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -34,7 +34,6 @@ std::vector<exec::Split> listAllSplits(std::shared_ptr<SplitSource> source) {
     for (auto& split : splits) {
       if (split.split == nullptr) {
         return result;
-        break;
       }
       result.push_back(exec::Split(std::move(split.split)));
     }


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

Such statements once existed to prevent accidental fallthroughs in switch statements. However, this is no longer necessary in C++17 because `[[fallthrough]]` is used to indicate intentional fallthroughs and we raise compilation errors for fallthroughs that are not annotated with `[[fallthrough]]` using `-Wimplicit-fallthrough`.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D78276034


