### PR TITLE
fix: Add Spark abs function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -4,7 +4,9 @@ Mathematical Functions
 
 .. spark:function:: abs(x) -> [same as x]
 
-    Returns the absolute value of ``x``.
+    Returns the absolute value of ``x``. When ``x`` is negative minimum
+    value of integral type, returns the same value as ``x`` following
+    the behavior when Spark ANSI mode is disabled.
 
 .. spark:function:: acos(x) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -28,6 +28,24 @@
 
 namespace facebook::velox::functions::sparksql {
 
+// The abs implementation is used for primitive types except for decimal type.
+template <typename TExec>
+struct AbsFunction {
+  template <typename T>
+  FOLLY_ALWAYS_INLINE void call(T& result, const T& a) {
+    if constexpr (std::is_integral_v<T>) {
+      if (FOLLY_UNLIKELY(a == std::numeric_limits<T>::min())) {
+        // To be compatible with Spark's ANSI off mode, when the input is
+        // negative minimum value, returns the same value as input instead of
+        // throwing an error.
+        result = a;
+        return;
+      }
+    }
+    result = std::abs(a);
+  }
+};
+
 template <typename T>
 struct RemainderFunction {
   template <

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -25,7 +25,7 @@
 namespace facebook::velox::functions::sparksql {
 
 void registerMathFunctions(const std::string& prefix) {
-  registerUnaryNumeric<AbsFunction>({prefix + "abs"});
+  registerUnaryNumeric<sparksql::AbsFunction>({prefix + "abs"});
   registerFunction<
       DecimalAbsFunction,
       LongDecimal<P1, S1>,

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -218,6 +218,11 @@ class ArithmeticTest : public SparkFunctionBaseTest {
   }
 
   template <typename T>
+  std::optional<T> abs(const std::optional<T> input) {
+    return evaluateOnce<T>("abs(c0)", input);
+  }
+
+  template <typename T>
   void assertErrorForCheckedArithmetic(
       const std::string& func,
       const std::optional<T> a,
@@ -727,6 +732,33 @@ TEST_F(ArithmeticTest, checkedDivide) {
       INT64_MIN, -1, "Arithmetic overflow: -9223372036854775808 / -1");
   EXPECT_EQ(checkedDivide<float>(kInf, 1), kInf);
   EXPECT_EQ(checkedDivide<double>(kInfDouble, 1), kInfDouble);
+}
+
+TEST_F(ArithmeticTest, abs) {
+  EXPECT_EQ(abs<int8_t>(-127), 127);
+  EXPECT_EQ(
+      abs<int8_t>(std::numeric_limits<int8_t>::min()),
+      std::numeric_limits<int8_t>::min());
+  EXPECT_EQ(abs<int16_t>(-32767), 32767);
+  EXPECT_EQ(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()),
+      std::numeric_limits<int16_t>::min());
+  EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
+  EXPECT_EQ(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()),
+      std::numeric_limits<int32_t>::min());
+  EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
+  EXPECT_EQ(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()),
+      std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
+  EXPECT_EQ(
+      abs<float>(std::numeric_limits<float>::lowest()),
+      std::numeric_limits<float>::max());
+  EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
+  EXPECT_EQ(
+      abs<double>(std::numeric_limits<double>::lowest()),
+      std::numeric_limits<double>::max());
 }
 
 class LogNTest : public SparkFunctionBaseTest {


### PR DESCRIPTION
After 7316a8c, the overflow behavior of Presto abs function does not comply 
with Spark ANSI off mode. This PR fixes this by adding the Spark abs function.