### PR TITLE
feat: Add initial support for coercions

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <boost/algorithm/string.hpp>
 #include <folly/Likely.h>
 #include <optional>
 
@@ -28,7 +27,6 @@
 #include "velox/expression/SignatureBinder.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
-#include "velox/type/Variant.h"
 
 namespace facebook::velox::core {
 
@@ -122,22 +120,24 @@ struct TypeAnalysisResults {
     size_t concreteCount = 0;
 
     // Set a priority based on the collected information. Lower priorities are
-    // picked first during function resolution. Each signature get a rank out
-    // of 4, those ranks form a Lattice ordering.
+    // picked first during function resolution. Each signature receives a rank
+    // from 1 to 4. Those ranks provice a lattice ordering.
+    //
     // rank 1: generic free and variadic free.
-    //    e.g: int, int, int -> int.
+    //          e.g: int, int, int -> int.
     // rank 2: has variadic but generic free.
-    //    e.g: Variadic<int> -> int.
+    //          e.g: Variadic<int> -> int.
     // rank 3: has generic but no variadic of generic.
-    //    e.g: Any, Any, -> int.
+    //          e.g: Any, Any, -> int.
     // rank 4: has variadic of generic.
-    //    e.g: Variadic<Any> -> int.
-
+    //          e.g: Variadic<Any> -> int.
+    //
     // If two functions have the same rank, then concreteCount is used to
     // to resolve the ordering.
-    // e.g: consider the two functions:
-    //    1. int, Any, Variadic<int> -> has rank 3. concreteCount =2
-    //    2. int, Any, Any     -> has rank 3. concreteCount =1
+    //
+    // E.g. consider the two functions:
+    //    1. int, Any, Variadic<int> -> rank 3; concreteCount 2
+    //    2. int, Any, Any           -> rank 3; concreteCount 1
     // in this case (1) is picked.
     // e.g: (Any, int) will be picked before (Any, Any)
     // e.g: Variadic<Array<Any>> is picked before Variadic<Any>.

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -76,7 +76,7 @@ class SimpleFunctionRegistry {
       bool overwrite) {
     const auto& metadata = singletonUdfMetadata<typename UDF::Metadata>(
         UDF::is_default_null_behavior, constraints);
-    const auto factory = []() { return CreateUdf<UDF>(); };
+    const auto factory = []() { return std::make_unique<UDF>(); };
 
     if (aliases.empty()) {
       return registerFunctionInternal(
@@ -152,13 +152,24 @@ class SimpleFunctionRegistry {
 
   std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
-      const std::vector<TypePtr>& argTypes) const;
+      const std::vector<TypePtr>& argTypes) const {
+    std::vector<TypePtr> coercions;
+    return resolveFunction(name, argTypes, false, coercions);
+  }
+
+  std::optional<ResolvedSimpleFunction> resolveFunctionWithCoercions(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      std::vector<TypePtr>& coercions) const {
+    return resolveFunction(name, argTypes, true, coercions);
+  }
 
  private:
-  template <typename T>
-  static std::unique_ptr<T> CreateUdf() {
-    return std::make_unique<T>();
-  }
+  std::optional<ResolvedSimpleFunction> resolveFunction(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      bool allowCoercion,
+      std::vector<TypePtr>& coercions) const;
 
   /// Registers a function with the given name and metadata. If an entry with
   /// the name already exists and 'overwrite' is true, the existing entry is

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -88,6 +88,58 @@ TypePtr resolveVectorFunction(
   return nullptr;
 }
 
+namespace {
+bool hasCoercion(const std::vector<Coercion>& coercions) {
+  for (const auto& coercion : coercions) {
+    if (coercion.type != nullptr) {
+      return true;
+    }
+  }
+
+  return false;
+}
+} // namespace
+
+TypePtr resolveVectorFunctionWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions) {
+  coercions.clear();
+
+  auto optionalType = applyToVectorFunctionEntry<TypePtr>(
+      functionName,
+      [&](const auto& /*name*/, const auto& entry) -> std::optional<TypePtr> {
+        std::vector<std::pair<std::vector<Coercion>, TypePtr>> candidates;
+        for (const auto& signature : entry.signatures) {
+          exec::SignatureBinder binder(*signature, argTypes);
+          std::vector<Coercion> requiredCoercions;
+          if (binder.tryBindWithCoercions(requiredCoercions)) {
+            auto type = binder.tryResolveReturnType();
+            if (!hasCoercion(requiredCoercions)) {
+              coercions.resize(argTypes.size(), nullptr);
+              return type;
+            }
+
+            candidates.emplace_back(requiredCoercions, type);
+          }
+        }
+
+        if (auto index = Coercion::pickLowestCost(candidates)) {
+          const auto& requiredCoercions = candidates[index.value()].first;
+          coercions.reserve(requiredCoercions.size());
+          for (const auto& coercion : requiredCoercions) {
+            coercions.push_back(coercion.type);
+          }
+
+          return candidates[index.value()].second;
+        }
+
+        return std::nullopt;
+      });
+
+  return optionalType.value_or(nullptr);
+}
+
 std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadata(
     const std::string& functionName,

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -187,6 +187,11 @@ TypePtr resolveVectorFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+TypePtr resolveVectorFunctionWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
 resolveVectorFunctionWithMetadata(
     const std::string& functionName,

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -32,6 +32,14 @@ void testSignatureBinder(
   exec::SignatureBinder binder(*signature, actualTypes);
   ASSERT_TRUE(binder.tryBind());
 
+  std::vector<Coercion> coercions;
+  ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+
+  ASSERT_EQ(coercions.size(), actualTypes.size());
+  for (const auto& coercion : coercions) {
+    ASSERT_TRUE(coercion.type == nullptr);
+  }
+
   auto returnType = binder.tryResolveReturnType();
   ASSERT_TRUE(returnType != nullptr);
   ASSERT_EQ(*expectedReturnType, *returnType);
@@ -39,9 +47,15 @@ void testSignatureBinder(
 
 void assertCannotResolve(
     const std::shared_ptr<exec::FunctionSignature>& signature,
-    const std::vector<TypePtr>& actualTypes) {
+    const std::vector<TypePtr>& actualTypes,
+    bool allowCoercion = false) {
   exec::SignatureBinder binder(*signature, actualTypes);
   ASSERT_FALSE(binder.tryBind());
+
+  if (allowCoercion) {
+    std::vector<Coercion> coercions;
+    ASSERT_FALSE(binder.tryBindWithCoercions(coercions));
+  }
 }
 
 TEST(SignatureBinderTest, decimals) {
@@ -981,6 +995,119 @@ TEST(SignatureBinderTest, namedRows) {
                          .build();
     testSignatureBinder(signature, {VARCHAR()}, ROW({{"foo", BIGINT()}}));
   }
+}
+
+std::string toString(const std::vector<TypePtr>& types) {
+  std::stringstream out;
+
+  for (auto i = 0; i < types.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << types.at(i)->toString();
+  }
+
+  return out.str();
+}
+
+void testCoercions(
+    const exec::FunctionSignaturePtr& signature,
+    const std::vector<TypePtr>& actualTypes,
+    const std::vector<TypePtr>& expectedCoercions,
+    const TypePtr& expectedReturnType) {
+  SCOPED_TRACE(fmt::format("Signature: {}", signature->toString()));
+  SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
+
+  exec::SignatureBinder binder(*signature, actualTypes);
+
+  ASSERT_FALSE(binder.tryBind());
+
+  std::vector<Coercion> coercions;
+  ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+
+  ASSERT_EQ(expectedCoercions.size(), coercions.size());
+  for (auto i = 0; i < expectedCoercions.size(); ++i) {
+    if (expectedCoercions[i] == nullptr) {
+      ASSERT_TRUE(coercions[i].type == nullptr);
+    } else {
+      ASSERT_EQ(*coercions[i].type, *expectedCoercions[i]);
+    }
+  }
+
+  auto returnType = binder.tryResolveReturnType();
+  ASSERT_TRUE(returnType != nullptr);
+  ASSERT_EQ(*expectedReturnType, *returnType);
+}
+
+void testNoCoercions(
+    const exec::FunctionSignaturePtr& signature,
+    const std::vector<TypePtr>& actualTypes,
+    const TypePtr& expectedReturnType) {
+  SCOPED_TRACE(fmt::format("Signature: {}", signature->toString()));
+  SCOPED_TRACE(fmt::format("Actual types: {}", toString(actualTypes)));
+
+  {
+    exec::SignatureBinder binder(*signature, actualTypes);
+    ASSERT_TRUE(binder.tryBind());
+
+    auto returnType = binder.tryResolveReturnType();
+    ASSERT_TRUE(returnType != nullptr);
+    ASSERT_EQ(*expectedReturnType, *returnType);
+  }
+
+  {
+    exec::SignatureBinder binder(*signature, actualTypes);
+
+    std::vector<Coercion> coercions;
+    ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+
+    auto returnType = binder.tryResolveReturnType();
+    ASSERT_TRUE(returnType != nullptr);
+    ASSERT_EQ(*expectedReturnType, *returnType);
+
+    ASSERT_EQ(actualTypes.size(), coercions.size());
+    for (auto i = 0; i < actualTypes.size(); ++i) {
+      ASSERT_TRUE(coercions[i].type == nullptr);
+    }
+  }
+}
+
+TEST(SignatureBinderTest, coercions) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("boolean")
+                       .argumentType("smallint")
+                       .argumentType("integer")
+                       .argumentType("bigint")
+                       .argumentType("real")
+                       .argumentType("double")
+                       .build();
+
+  testCoercions(
+      signature,
+      {TINYINT(), TINYINT(), TINYINT(), TINYINT(), TINYINT()},
+      {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
+      BOOLEAN());
+
+  testCoercions(
+      signature,
+      {SMALLINT(), SMALLINT(), SMALLINT(), REAL(), REAL()},
+      {nullptr, INTEGER(), BIGINT(), nullptr, DOUBLE()},
+      BOOLEAN());
+
+  testNoCoercions(
+      signature,
+      {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
+      BOOLEAN());
+
+  assertCannotResolve(
+      signature,
+      {INTEGER(), INTEGER(), INTEGER(), INTEGER(), INTEGER()},
+      /*allowCoercion*/ true);
+
+  assertCannotResolve(
+      signature,
+      {SMALLINT(), INTEGER(), VARCHAR(), INTEGER(), INTEGER()},
+      /*allowCoercion*/ true);
 }
 
 } // namespace

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -991,11 +991,11 @@ VectorPtr testVariadicArgReuse(
   // This is a bit of a round about way of creating the SimpleFunctionAdapter,
   // especially since it requires the caller to register the function as well,
   // but it should be easier to maintain.
-  auto function =
-      exec::simpleFunctions()
-          .resolveFunction(functionName, {})
-          ->createFunction()
-          ->createVectorFunction({}, {}, execCtx->queryCtx()->queryConfig());
+  auto resolved = exec::simpleFunctions().resolveFunction(functionName, {});
+  EXPECT_TRUE(resolved.has_value());
+
+  auto function = resolved->createFunction()->createVectorFunction(
+      {}, {}, execCtx->queryCtx()->queryConfig());
 
   // Create a dummy EvalCtx.
   SelectivityVector rows(inputs[0]->size());

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -128,6 +128,22 @@ TypePtr resolveFunction(
   return resolveVectorFunction(functionName, argTypes);
 }
 
+TypePtr resolveFunctionWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions) {
+  // Check if this is a simple function.
+  if (auto resolvedFunction =
+          exec::simpleFunctions().resolveFunctionWithCoercions(
+              functionName, argTypes, coercions)) {
+    return resolvedFunction->type();
+  }
+
+  // Check if VectorFunctions has this function name + signature.
+  return exec::resolveVectorFunctionWithCoercions(
+      functionName, argTypes, coercions);
+}
+
 std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
 resolveFunctionWithMetadata(
     const std::string& functionName,

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -52,6 +52,26 @@ TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Like 'resolveFunction', but with support for applying type conversions if no
+/// signature matches 'argTypes' exactly.
+///
+/// @param coercions A list of optional type coercions that were applied to
+/// resolve the function successfully. Contains one entry per argument. The
+/// entry is null if no coercion is required for that argument. The entry is not
+/// null if coercions is necessary.
+///
+/// Example, given functin plus(bigint, bigint) -> bigint and arguments
+/// (integer, bigint), returns bigint with coercions = {bigint, null}. The first
+/// argument needs to be coersed to bigint, while the second argument doesn't
+/// require coercion.
+///
+/// TODO: Add support for coercion for complex and user-defined types,
+/// signatures with generic types and variadic arguments.
+TypePtr resolveFunctionWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 /// Given a function name and argument types, returns a pair of return
 /// type and metadata if function exists. Otherwise, returns std::nullopt.
 std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>


### PR DESCRIPTION
Summary:
Coersion is an implicit type conversion that the query engine may apply to resolve a function call. Given a function that takes a bigint and a function call that passes an integer, the engine may apply an implicit cast from integer to bigint to compile that function call.

Given a function `foo: (bigint) -> bigint`, and an expression `foo(1::int)`, the query engine applies coersion to produce `foo(cast(1::int as bigint))`.

Velox doesn't support coersions because it expects the application to fully resolve types before calling Velox APIs. However, it is useful to provide coersion support as a building block for applications to use if they choose to.

This change introduces velox::resolveFunctionWithCoersions API to resolve functions with coersions.

```
/// Like 'resolveFunction', but with support for applying type conversions if no
/// signature matches 'argTypes' exactly.
///
/// param coersions A list of optional type coersions that were applied to
/// resolve the function successfully. Contains one entry per argument. The
/// entry is null if no coersion is required for that argument. The entry is not
/// null if coersions is necessary.
///
/// Example, given functin plus(bigint, bigint) -> bigint and arguments
/// (integer, bigint), returns bigint with coersions = {bigint, null}. The first
/// argument needs to be coersed to bigint, while the second argument doesn't
/// require coersion.
///
/// TODO: Add support for coersion for complex types, signatures with generic
/// types and variadic arguments.
TypePtr resolveFunctionWithCoersions(
    const std::string& functionName,
    const std::vector<TypePtr>& argTypes,
    std::vector<TypePtr>& coersions);
```

Supported coersions:

- TINYINT -> SMALLINT, INTEGER, BIGINT, REAL, DOUBLE
- SMALLINT -> INTEGER, BIGINT, REAL, DOUBLE
- INTEGER -> REAL, DOUBLE
- BIGINT -> DOUBLE
- REAL -> DOUBLE

If there is a signature that matches input types exactly, that signature is preferred.

If there are multiple signatures that match input types with coersions, the signature with the lowers "coersion cost" is preferred. 

Each coersion is assigned a cost: 
- TINYINT -> SMALLINT is 1
- TINYINT -> INTEGER is 2
- TINYINT -> BIGINT is 3
etc.

Overall cost for a list of coersions is computed as a sum of individual costs.

In case of a tie, when 2+ signatures have the same lowest cost, the call is considered ambiguous and type resolution fails.

Coersion rules are complex. We'll build them out incrementally adding functionality as the need arises. Check out C++ rules for coersions to get a feel for what they may look like: https://en.cppreference.com/w/cpp/language/implicit_conversion.html

Pre-existing wrinkle that affects functions present in both simple and vector registries and not being addressed here:
- Function signature selection is not consistent between simple and vector functions. Simple functions choose a signature with lowest priority, while vector functions pick first match.
- Type resolution looks at simple and vector function signatures separately. It picks simple signature with lowest priority among other simple signatures without considering priority of vector signature.

Differential Revision: D78251314


