### PR TITLE
Del redundant-static-def in velox/dwio/parquet/common/BloomFilter.cpp +1

### DIFF
--- a/velox/dwio/parquet/common/BloomFilter.cpp
+++ b/velox/dwio/parquet/common/BloomFilter.cpp
@@ -30,8 +30,6 @@
 
 namespace facebook::velox::parquet {
 
-constexpr uint32_t BlockSplitBloomFilter::SALT[kBitsSetPerBlock];
-
 BlockSplitBloomFilter::BlockSplitBloomFilter(memory::MemoryPool* pool)
     : pool_(pool),
       hashStrategy_(HashStrategy::XXHASH),


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wdeprecated-redundant-constexpr-static-def` which raises the warning:

> warning: out-of-line definition of constexpr static data member is redundant in C++17 and is deprecated

Since we are now on C++20, we can remove the out-of-line definition of constexpr static data members. This diff does so.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: meyering

Differential Revision: D78250583


