### PR TITLE
feat: Implement Variant::toString for all types

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -252,12 +252,10 @@ std::string Variant::toString(const TypePtr& type) const {
     case TypeKind::FUNCTION:
     case TypeKind::UNKNOWN:
     case TypeKind::INVALID:
-      VELOX_NYI();
+      return toJson(type);
   }
 
-  VELOX_UNSUPPORTED(
-      "Given type {} is not supported in Variant::toString()",
-      mapTypeKindToName(kind_));
+  folly::assume_unreachable();
 }
 
 std::string Variant::toJson(const TypePtr& type) const {


### PR DESCRIPTION
Summary: Variant::toString() used to fail for complex types.

Differential Revision: D78441157


