### PR TITLE
fix: AssignUniqueId::needsInput

### DIFF
--- a/velox/exec/AssignUniqueId.h
+++ b/velox/exec/AssignUniqueId.h
@@ -37,7 +37,7 @@ class AssignUniqueId : public Operator {
   }
 
   bool needsInput() const override {
-    return true;
+    return input_ == nullptr;
   }
 
   void addInput(RowVectorPtr input) override;


### PR DESCRIPTION
Summary: AssignUniqueId::needsInput() used to return 'true' unconditionally. This caused data to be dropped as addInput() would be called repeatedly without calling getOutput.

Reviewed By: wenqiwooo, xiaoxmeng

Differential Revision: D78461498


