### PR TITLE
fix: Fix build error caused by bad merge

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -822,8 +822,10 @@ struct StIsEmptyFunction {
 
   FOLLY_ALWAYS_INLINE Status
   call(out_type<bool>& result, const arg_type<Geometry>& geometry) {
-    GEOS_TRY(result = geospatial::getEnvelopeFromGeometry(geometry)->isNull();
-             , "Failed to get envelope from geometry");
+    GEOS_TRY(
+        result = geospatial::GeometryDeserializer::deserializeEnvelope(geometry)
+                     ->isNull();
+        , "Failed to get envelope from geometry");
     return Status::OK();
   }
 };


### PR DESCRIPTION
Summary:
In #13771 we merged a change to how we deserialize envelopes.
But between accepting and shipping another use of the old pattern was
committed.  This fixes that usage.

Differential Revision: D78488999


