### PR TITLE
feat: Add sfmSketch scalar functions

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -833,7 +833,33 @@ Counts, Sums, and Averages
 
     .. note::
 
-        Unlike :func:`approx_distinct`, this function returns NULL when col is empty.
+        Unlike :func:`approx_distinct`, this function returns ``NULL`` when ``col`` is empty.
+
+.. function:: noisy_empty_approx_set_sfm(epsilon[, buckets[, precision]]) -> SfmSketch
+
+    Returns an SFM sketch with no items in it. This is analogous to the ``empty_approx_set()`` function,
+    which returns an empty (deterministic) ``HyperLogLog`` sketch.
+    * ``epsilon`` (double) is a positive number that controls the level of noise in the sketch, as described in [Hehir2023]_.
+      Smaller values of epsilon correspond to noisier sketches.
+    * ``buckets`` (int) defaults to 4096.
+    * ``precision`` (int) defaults to 24.
+
+.. function:: cardinality(SfmSketch) -> bigint
+
+    Returns the estimated cardinality (distinct count) of an ``SfmSketch`` object.
+
+.. function:: merge_sfm(ARRAY[SfmSketch, ...]) -> SfmSketch
+
+    A scalar function that returns a merged ``SfmSketch`` of the set union of an array of ``SfmSketch`` objects, similar to ``merge_hll()``.
+
+    ::
+
+        SELECT cardinality(merge_sfm(ARRAY[
+            noisy_approx_set_sfm(col_1, 5.0),
+            noisy_approx_set_sfm(col_2, 5.0),
+            noisy_approx_set_sfm(col_3, 5.0)
+        ])) AS distinct_count_over_3_cols
+        FROM my_table
 
 Limitations
 ~~~~~~~~~~~

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -809,6 +809,32 @@ Counts, Sums, and Averages
     If provided, random_seed is used to seed the random number generator.
     Otherwise, noise is drawn from a secure random.
 
+.. function:: noisy_approx_set_sfm(col, epsilon[, buckets[, precision]]) -> SfmSketch
+
+    Returns an SFM sketch of the input values in ``col``. This is analogous to the ``approx_set()`` function,
+    which returns a (deterministic) HyperLogLog sketch.
+
+    * ``col`` currently supports types: "integer", "double", "string", "varbinary".
+    * ``epsilon`` (double) is a positive number that controls the level of noise in the sketch, as described in [Hehir2023]_.
+      Smaller values of epsilon correspond to noisier sketches.
+    * ``buckets`` (int) defaults to 4096.
+    * ``precision`` (int) defaults to 24.
+
+    .. note::
+
+        Unlike ``approx_set()``, this function returns ``NULL`` when ``col`` is empty.
+        If this behavior is undesirable, use ``coalesce()`` with :func:`noisy_empty_approx_set_sfm`.
+
+.. function:: noisy_approx_distinct_sfm(col, epsilon[, buckets[, precision]]) -> bigint
+
+    Equivalent to ``cardinality(noisy_approx_set_sfm(col, epsilon, buckets, precision))``,
+    this returns the approximate cardinality (distinct count) of the column col.
+    This is analogous to the (deterministic) :func:`approx_distinct` function.
+
+    .. note::
+
+        Unlike :func:`approx_distinct`, this function returns NULL when col is empty.
+
 Limitations
 ~~~~~~~~~~~
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -233,7 +233,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "BINGTILE",
           "TDIGEST",
           "QDIGEST",
-          "GEOMETRY"}),
+          "GEOMETRY",
+          "SFMSKETCH"}),
       names);
 
   ASSERT_TRUE(registerCustomType(
@@ -252,7 +253,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "FANCY_INT",
           "TDIGEST",
           "QDIGEST",
-          "GEOMETRY"}),
+          "GEOMETRY",
+          "SFMSKETCH"}),
       names);
 
   ASSERT_TRUE(unregisterCustomType("fancy_int"));

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   Reverse.cpp
   RowFunction.cpp
   Sequence.cpp
+  SfmSketchFunctions.cpp
   SimpleComparisonMatcher.cpp
   Split.cpp
   SplitToMap.cpp

--- a/velox/functions/prestosql/SfmSketchFunctions.cpp
+++ b/velox/functions/prestosql/SfmSketchFunctions.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/SfmSketchFunctions.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+
+namespace facebook::velox::functions {
+
+std::string createEmptySfmSketch(
+    double epsilon,
+    std::optional<int64_t> buckets,
+    std::optional<int64_t> precison) {
+  using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+
+  constexpr int32_t kDefaultBuckets = 4096;
+  constexpr int32_t kDefaultPrecision = 24;
+
+  int32_t initBuckets = buckets.has_value() ? buckets.value() : kDefaultBuckets;
+  int32_t initPrecision =
+      precison.has_value() ? precison.value() : kDefaultPrecision;
+  SfmSketch sketch(&allocator);
+  sketch.initialize(initBuckets, initPrecision);
+  sketch.enablePrivacy(epsilon);
+
+  // Serialize the sketch.
+  auto serializedSize = sketch.serializedSize();
+  std::string result(serializedSize, '\0');
+  sketch.serialize(result.data());
+
+  return result;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/SfmSketchFunctions.h
+++ b/velox/functions/prestosql/SfmSketchFunctions.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
+
+namespace facebook::velox::functions {
+
+// Helper function to create empty SfmSketch.
+std::string createEmptySfmSketch(
+    double epsilon,
+    std::optional<int64_t> buckets = std::nullopt,
+    std::optional<int64_t> precison = std::nullopt);
+
+template <typename T>
+struct SfmSketchCardinality {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<SfmSketch>& input) {
+    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+    result = SfmSketch::deserialize(
+                 reinterpret_cast<const char*>(input.data()), &allocator)
+                 .cardinality();
+  }
+};
+
+template <typename T>
+struct NoisyEmptyApproxSetSfm {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon) {
+    auto serialized = createEmptySfmSketch(epsilon);
+    result.resize(serialized.size());
+    // SfmSketch is a binary type, so we can just copy the serialized data.
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon,
+      const int64_t& buckets) {
+    auto serialized = createEmptySfmSketch(epsilon, buckets);
+    result.resize(serialized.size());
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon,
+      const int64_t& buckets,
+      const int64_t& precision) {
+    auto serialized = createEmptySfmSketch(epsilon, buckets, precision);
+    result.resize(serialized.size());
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+};
+
+template <typename T>
+struct mergeSfmSketchArray {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<SfmSketch>& result,
+      const arg_type<Array<SfmSketch>>& input) {
+    if (input.size() == 0) {
+      return false;
+    }
+
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+
+    // Find the first non-null sketch to start with.
+    int firstValidIndex = -1;
+    for (auto i = 0; i < input.size(); ++i) {
+      if (input[i].has_value()) {
+        firstValidIndex = i;
+        break;
+      }
+    }
+
+    if (firstValidIndex == -1) {
+      return false;
+    }
+
+    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+    // Deserialize the first valid sketch.
+    const auto& firstValidData = input[firstValidIndex].value();
+    auto mergedSketch = SfmSketch::deserialize(
+        reinterpret_cast<const char*>(firstValidData.data()), &allocator);
+
+    // Merge all remaining valid sketches.
+    for (auto i = firstValidIndex + 1; i < input.size(); ++i) {
+      if (!input[i].has_value()) {
+        continue;
+      }
+      const auto& currentSketchData = input[i].value();
+      auto currentSketch = SfmSketch::deserialize(
+          reinterpret_cast<const char*>(currentSketchData.data()), &allocator);
+      mergedSketch.mergeWith(currentSketch);
+    }
+
+    // Serialize the merged sketch back to result.
+    auto serializedSize = mergedSketch.serializedSize();
+    result.resize(serializedSize);
+    mergedSketch.serialize(result.data());
+
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -84,4 +84,6 @@ const char* const kVarPop = "var_pop";
 const char* const kVarSamp = "var_samp";
 const char* const kMaxSizeForStats = "max_data_size_for_stats";
 const char* const kSumDataSizeForStats = "sum_data_size_for_stats";
+const char* const kNoisyApproxSetSfm = "noisy_approx_set_sfm";
+const char* const kNoisyApproxDistinctSfm = "noisy_approx_distinct_sfm";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -50,6 +50,7 @@ velox_add_library(
   NoisyCountGaussianAggregate.cpp
   NoisyHelperFunctionFactory.cpp
   NoisySumGaussianAggregate.cpp
+  NoisyApproxSfmAggregate.cpp
   SetAggregates.cpp
   SumAggregate.cpp
   SumDataSizeForStatsAggregate.cpp
@@ -66,7 +67,10 @@ velox_link_libraries(
   velox_functions_lib
   velox_functions_util
   velox_presto_types
+  velox_functions_prestosql_aggregates_sfm
   Folly::folly)
+
+add_subdirectory(sfm)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/SfmSketchAggregate.h"
+#include "velox/functions/prestosql/types/SfmSketchRegistration.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisyApproxSfmAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  // Register the SfmSketch type.
+  registerSfmSketchType();
+
+  std::vector<std::string> supportedInputTypes = {
+      "bigint", "double", "varchar", "varbinary"};
+
+  auto setBuilder = []() {
+    return exec::AggregateFunctionSignatureBuilder()
+        .returnType("sfmsketch")
+        .intermediateType("varbinary");
+  };
+  auto countBuilder = []() {
+    return exec::AggregateFunctionSignatureBuilder()
+        .returnType("bigint")
+        .intermediateType("varbinary");
+  };
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> setSignatures;
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>
+      countSignatures;
+  for (const auto& inputType : supportedInputTypes) {
+    setSignatures.push_back(setBuilder()
+                                .argumentType(inputType)
+                                .constantArgumentType("double")
+                                .build());
+    setSignatures.push_back(setBuilder()
+                                .argumentType(inputType)
+                                .constantArgumentType("double")
+                                .constantArgumentType("bigint")
+                                .build());
+    setSignatures.push_back(setBuilder()
+                                .argumentType(inputType)
+                                .constantArgumentType("double")
+                                .constantArgumentType("bigint")
+                                .constantArgumentType("bigint")
+                                .build());
+    countSignatures.push_back(countBuilder()
+                                  .argumentType(inputType)
+                                  .constantArgumentType("double")
+                                  .build());
+    countSignatures.push_back(countBuilder()
+                                  .argumentType(inputType)
+                                  .constantArgumentType("double")
+                                  .constantArgumentType("bigint")
+                                  .build());
+    countSignatures.push_back(countBuilder()
+                                  .argumentType(inputType)
+                                  .constantArgumentType("double")
+                                  .constantArgumentType("bigint")
+                                  .constantArgumentType("bigint")
+                                  .build());
+  }
+
+  exec::registerAggregateFunction(
+      prefix + kNoisyApproxSetSfm,
+      setSignatures,
+      [prefix](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& /*argTypes*/,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<SfmSketchAggregate<true>>(VARBINARY());
+        }
+        return std::make_unique<SfmSketchAggregate<true>>(resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+
+  exec::registerAggregateFunction(
+      prefix + kNoisyApproxDistinctSfm,
+      countSignatures,
+      [prefix](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& /*argTypes*/,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        if (exec::isPartialOutput(step)) {
+          return std::make_unique<SfmSketchAggregate<false>>(VARBINARY());
+        }
+        return std::make_unique<SfmSketchAggregate<false>>(resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerNoisyApproxSfmAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -41,6 +41,7 @@
 #include "velox/functions/prestosql/aggregates/MinByAggregate.h"
 #include "velox/functions/prestosql/aggregates/MinMaxAggregates.h"
 #include "velox/functions/prestosql/aggregates/MultiMapAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h"
 #include "velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h"
@@ -245,6 +246,7 @@ void registerAllAggregateFunctions(
   registerSumAggregate(prefix, withCompanionFunctions, overwrite);
   registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
   registerTDigestAggregate(prefix, withCompanionFunctions, overwrite);
+  registerNoisyApproxSfmAggregate(prefix, withCompanionFunctions, overwrite);
 }
 
 void registerInternalAggregateFunctions(const std::string& prefix) {

--- a/velox/functions/prestosql/aggregates/SfmSketchAggregate.h
+++ b/velox/functions/prestosql/aggregates/SfmSketchAggregate.h
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+template <bool sketchAsFinalResult>
+class SfmSketchAggregate : public exec::Aggregate {
+  using SfmSketchAccumulator =
+      facebook::velox::functions::aggregate::SfmSketchAccumulator;
+
+ public:
+  explicit SfmSketchAggregate(TypePtr resultType)
+      : exec::Aggregate(std::move(resultType)) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return static_cast<int32_t>(sizeof(SfmSketchAccumulator));
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(SfmSketchAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInput(rows, args);
+    rows.applyToSelected([&](vector_size_t i) {
+      auto group = groups[i];
+      updateFromInput(group, i);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    decodeInput(rows, args);
+    rows.applyToSelected([&](vector_size_t i) { updateFromInput(group, i); });
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    serializeToStringVector(
+        groups,
+        numGroups,
+        result,
+        [](const SfmSketchAccumulator& accumulator) -> size_t {
+          return accumulator.serializedSize();
+        },
+        [](const SfmSketchAccumulator& accumulator, char* buffer) -> void {
+          accumulator.serialize(buffer);
+        });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    if constexpr (sketchAsFinalResult) {
+      // For final sketch result, serialize only the SfmSketch, not the
+      // SfmSketchAccumulator.
+      serializeToStringVector(
+          groups,
+          numGroups,
+          result,
+          [](SfmSketchAccumulator& accumulator) -> size_t {
+            return accumulator.sketch().serializedSize();
+          },
+          [](SfmSketchAccumulator& accumulator, char* buffer) -> void {
+            accumulator.sketch().serialize(buffer);
+          });
+      return;
+    }
+
+    auto flatResult = (*result)->asFlatVector<int64_t>();
+    flatResult->resize(numGroups);
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto accumulator = value<SfmSketchAccumulator>(group);
+        if (!accumulator->isInitialized()) {
+          flatResult->setNull(i, true);
+          continue;
+        }
+        flatResult->set(i, accumulator->cardinality());
+      }
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      auto group = groups[i];
+      updateFromIntermediate(decodedVector, group, i);
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      [[maybe_unused]] bool mayPushdown) override {
+    DecodedVector decodedVector(*args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      updateFromIntermediate(decodedVector, group, i);
+    });
+  }
+
+ protected:
+  DecodedVector decodedValue_;
+  DecodedVector decodedEpsilon_;
+  DecodedVector decodedBuckets_;
+  DecodedVector decodedPrecision_;
+  size_t numArgs_ = 0;
+
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto* group = groups[i];
+      new (value<SfmSketchAccumulator>(group)) SfmSketchAccumulator(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<SfmSketchAccumulator>(groups);
+  }
+
+ private:
+  // Helper function to serialize data to StringView result.
+  template <typename SizeFunc, typename SerializeFunc>
+  void serializeToStringVector(
+      char** groups,
+      int32_t numGroups,
+      VectorPtr* result,
+      SizeFunc sizeFunc,
+      SerializeFunc serializeFunc) {
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+
+    // Calculate total size needed for all valid groups.
+    size_t totalSize = 0;
+    std::vector<size_t> groupSizes(numGroups, 0);
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (!isNull(group)) {
+        auto* accumulator = value<SfmSketchAccumulator>(group);
+        if (accumulator->isInitialized()) {
+          groupSizes[i] = sizeFunc(*accumulator);
+          totalSize += groupSizes[i];
+        }
+      }
+    }
+
+    // Allocate buffer for all serializations.
+    auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+    size_t offset = 0;
+
+    for (auto i = 0; i < numGroups; i++) {
+      auto group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        auto* accumulator = value<SfmSketchAccumulator>(group);
+        if (!accumulator->isInitialized()) {
+          flatResult->setNull(i, true);
+        } else {
+          // Serialize the data.
+          serializeFunc(*accumulator, rawBuffer + offset);
+          flatResult->setNoCopy(
+              i, StringView(rawBuffer + offset, groupSizes[i]));
+          offset += groupSizes[i];
+        }
+      }
+    }
+  }
+
+  void decodeInput(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    VELOX_CHECK(args.size() >= 2);
+    numArgs_ = args.size();
+    decodedValue_.decode(*args[0], rows);
+    decodedEpsilon_.decode(*args[1], rows);
+    if (args.size() > 2) {
+      decodedBuckets_.decode(*args[2], rows);
+    }
+    if (args.size() > 3) {
+      decodedPrecision_.decode(*args[3], rows);
+    }
+  }
+
+  void updateFromInput(char* group, vector_size_t i) {
+    if (!decodedValue_.isNullAt(i)) {
+      auto tracker = trackRowSize(group);
+      auto* accumulator = value<SfmSketchAccumulator>(group);
+      clearNull(group);
+      std::optional<int32_t> buckets =
+          (numArgs_ > 2 && !decodedBuckets_.isNullAt(i))
+          ? std::optional<int32_t>(decodedBuckets_.valueAt<int64_t>(i))
+          : std::nullopt;
+      std::optional<int32_t> precision =
+          (numArgs_ > 3 && !decodedPrecision_.isNullAt(i))
+          ? std::optional<int32_t>(decodedPrecision_.valueAt<int64_t>(i))
+          : std::nullopt;
+
+      if (!accumulator->isInitialized()) {
+        accumulator->initialize(buckets, precision);
+      }
+
+      accumulator->setEpsilon(decodedEpsilon_.valueAt<double>(i));
+
+      // Handle different input types.
+      auto inputType = decodedValue_.base()->type();
+      switch (inputType->kind()) {
+        case TypeKind::BIGINT:
+          accumulator->add(decodedValue_.valueAt<int64_t>(i));
+          break;
+        case TypeKind::DOUBLE:
+          accumulator->add(decodedValue_.valueAt<double>(i));
+          break;
+        case TypeKind::VARCHAR:
+        case TypeKind::VARBINARY: {
+          auto stringValue = decodedValue_.valueAt<StringView>(i);
+          accumulator->add(stringValue);
+          break;
+        }
+        default:
+          VELOX_UNSUPPORTED(
+              "Unsupported input type for SfmSketch: {}",
+              inputType->toString());
+      }
+    }
+  }
+
+  void updateFromIntermediate(
+      DecodedVector& decodedVector,
+      char* group,
+      vector_size_t i) {
+    if (decodedVector.isNullAt(i)) {
+      return;
+    }
+    auto tracker = trackRowSize(group);
+    auto* accumulator = value<SfmSketchAccumulator>(group);
+    clearNull(group);
+    auto serialized = decodedVector.valueAt<StringView>(i);
+    auto otherAccumulator =
+        SfmSketchAccumulator::deserialize(serialized.data(), allocator_);
+    accumulator->mergeWith(otherAccumulator);
+  }
+};
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/sfm/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/sfm/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_functions_prestosql_aggregates_sfm SfmSketch.cpp)
+velox_add_library(velox_functions_prestosql_aggregates_sfm SfmSketch.cpp
+                  SfmSketchAccumulator.cpp)
 
 velox_link_libraries(velox_functions_prestosql_aggregates_sfm velox_common_base
                      velox_memory Folly::folly)

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketch.h
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketch.h
@@ -16,8 +16,10 @@
 
 #pragma once
 
+#define XXH_INLINE_ALL
+#include <xxhash.h> // @manual=third-party//xxHash:xxhash
+
 #include <folly/Range.h>
-#include <xxhash.h>
 #include <cstdint>
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h"
@@ -148,6 +150,11 @@ class SfmSketch {
     return randomizedResponseProbability_ > 0;
   }
 
+  // Check if the sketch is initialized.
+  bool isInitialized() const {
+    return numIndexBits_ > 0;
+  }
+
  private:
   // Epsilon for non-private sketch.
   static constexpr double kNonPrivateEpsilon =
@@ -159,11 +166,6 @@ class SfmSketch {
   // Java implementation use a format_tag to identify the sketch.
   // We need this tag to be able to deserialize the sketch from Java.
   static constexpr int8_t kFormatTag = 7;
-
-  // Check if the sketch is initialized.
-  bool isInitialized() const {
-    return numIndexBits_ > 0;
-  }
 
   // Calculate the RandomizedResponseProbabilities for merged sketches.
   // For math details, see Theorem 4.8,

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h"
+#include "velox/common/base/IOUtils.h"
+
+namespace facebook::velox::functions::aggregate {
+SfmSketchAccumulator::SfmSketchAccumulator(HashStringAllocator* allocator)
+    : sketch_(allocator) {}
+
+SfmSketchAccumulator::SfmSketchAccumulator(
+    double epsilon,
+    int32_t buckets,
+    int32_t precision,
+    SfmSketch&& sketch)
+    : epsilon_{epsilon},
+      buckets_{buckets},
+      precision_{precision},
+      sketch_{std::move(sketch)} {}
+
+void SfmSketchAccumulator::initialize(
+    std::optional<int32_t> buckets,
+    std::optional<int32_t> precision) {
+  const auto initBuckets = buckets.value_or(kDefaultBuckets);
+  const auto initPrecision = precision.value_or(kDefaultPrecision);
+  sketch_.initialize(initBuckets, initPrecision);
+  buckets_ = initBuckets;
+  precision_ = initPrecision;
+}
+
+const SfmSketch& SfmSketchAccumulator::sketch() {
+  VELOX_CHECK(isInitialized(), "Sketch is not set");
+  if (!sketch_.privacyEnabled() && epsilon_ > 0) {
+    sketch_.enablePrivacy(epsilon_);
+  }
+  return sketch_;
+}
+
+size_t SfmSketchAccumulator::serializedSize() const {
+  return sizeof(epsilon_) + sizeof(buckets_) + sizeof(precision_) +
+      sketch_.serializedSize();
+}
+
+void SfmSketchAccumulator::serialize(char* outputBuffer) const {
+  common::OutputByteStream stream(outputBuffer);
+  stream.appendOne(epsilon_);
+  stream.appendOne(buckets_);
+  stream.appendOne(precision_);
+  sketch_.serialize(outputBuffer + stream.offset());
+}
+
+SfmSketchAccumulator SfmSketchAccumulator::deserialize(
+    const char* inputBuffer,
+    HashStringAllocator* allocator) {
+  common::InputByteStream stream(inputBuffer);
+  const auto epsilon = stream.read<double>();
+  const auto buckets = stream.read<int32_t>();
+  const auto precision = stream.read<int32_t>();
+  return SfmSketchAccumulator{
+      epsilon,
+      buckets,
+      precision,
+      SfmSketch::deserialize(inputBuffer + stream.offset(), allocator)};
+}
+
+void SfmSketchAccumulator::mergeWith(SfmSketchAccumulator& other) {
+  if (!other.isInitialized()) {
+    return;
+  }
+  if (!isInitialized()) {
+    epsilon_ = other.epsilon_;
+    this->initialize(other.buckets_, other.precision_);
+  }
+  sketch_.mergeWith(other.sketch_);
+}
+
+int64_t SfmSketchAccumulator::cardinality() {
+  VELOX_CHECK(
+      isInitialized(), "Cardinality is not available for empty sketch.");
+  // Add noise to the sketch before computing cardinality.
+  if (!sketch_.privacyEnabled() && epsilon_ > 0) {
+    sketch_.enablePrivacy(epsilon_);
+  }
+  return sketch_.cardinality();
+}
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+
+namespace facebook::velox::functions::aggregate {
+
+class SfmSketchAccumulator {
+  static constexpr int32_t kDefaultBuckets = 4096;
+  static constexpr int32_t kDefaultPrecision = 24;
+
+ public:
+  explicit SfmSketchAccumulator(HashStringAllocator* allocator);
+
+  // Constructor with all member variables, used for deserialization.
+  explicit SfmSketchAccumulator(
+      double epsilon,
+      int32_t buckets,
+      int32_t precision,
+      SfmSketch&& sketch);
+
+  // Initialize the sketch with the given parameters.
+  void initialize(
+      std::optional<int32_t> buckets = std::nullopt,
+      std::optional<int32_t> precision = std::nullopt);
+
+  // Apply privacy and return the sketch.
+  const SfmSketch& sketch();
+
+  double epsilon() const {
+    return epsilon_;
+  }
+
+  void setEpsilon(double epsilon) {
+    epsilon_ = epsilon;
+  }
+
+  // Check if the sketch is initialized. If not, the group is null or input is
+  // empty.
+  bool isInitialized() const {
+    return sketch_.isInitialized();
+  }
+
+  size_t serializedSize() const;
+
+  void serialize(char* outputBuffer) const;
+
+  static SfmSketchAccumulator deserialize(
+      const char* inputBuffer,
+      HashStringAllocator* allocator);
+
+  // Add a value to the sketch.
+  template <typename T>
+  void add(T value) {
+    VELOX_CHECK(isInitialized(), "Sketch is not set");
+    sketch_.add(value);
+  }
+
+  // Merge with another accumulator.
+  void mergeWith(SfmSketchAccumulator& other);
+
+  // Apply privacy with epsilon and return the estimated cardinality.
+  int64_t cardinality();
+
+ private:
+  // Epsilon to make the sketch private.
+  double epsilon_{-1.0};
+
+  // Buckets of the sketch.
+  int32_t buckets_{kDefaultBuckets};
+
+  // Precision of the sketch.
+  int32_t precision_{kDefaultPrecision};
+
+  // The sketch to aggregate cardinality.
+  SfmSketch sketch_;
+};
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/sfm/tests/CMakeLists.txt
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_functions_prestosql_aggregates_sketch_test
-               SfmSketchTest.cpp)
+add_executable(velox_functions_prestosql_aggregates_sfm_test SfmSketchTest.cpp)
 
-add_test(velox_functions_prestosql_aggregates_sketch_test
-         velox_functions_prestosql_aggregates_sketch_test)
+add_test(velox_functions_prestosql_aggregates_sfm_test
+         velox_functions_prestosql_aggregates_sfm_test)
 
 target_link_libraries(
-  velox_functions_prestosql_aggregates_sketch_test
-  velox_functions_prestosql_aggregates_sketch
+  velox_functions_prestosql_aggregates_sfm_test
+  velox_functions_prestosql_aggregates_sfm
   velox_memory
   GTest::gtest
   GTest::gtest_main)

--- a/velox/functions/prestosql/aggregates/sfm/tests/SfmSketchTest.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/tests/SfmSketchTest.cpp
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define XXH_INLINE_ALL
+#include <xxhash.h> // @manual=third-party//xxHash:xxhash
 
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
-#include <xxhash.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
 
 namespace facebook::velox::functions::aggregate {
 

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(
   NoisyCountGaussianAggregationTest.cpp
   NoisyCountIfGaussianAggregationTest.cpp
   NoisySumGaussianAggregationTest.cpp
+  NoisyApproxSfmAggregationTest.cpp
   PrestoHasherTest.cpp
   QDigestAggTest.cpp
   ReduceAggTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/NoisyApproxSfmAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyApproxSfmAggregationTest.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::aggregate::test {
+
+using SfmSketch = functions::aggregate::SfmSketch;
+using namespace facebook::velox::exec::test;
+
+class NoisyApproxSfmAggregationTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+
+  // Template helper to count distinct values for a specific type.
+  template <typename T>
+  size_t countDistinctForType(const VectorPtr& vector) {
+    const auto size = vector->size();
+    const auto* nulls = vector->rawNulls();
+    std::unordered_set<T> uniqueValues;
+    auto* flatVector = vector->asFlatVector<T>();
+
+    for (vector_size_t i = 0; i < size; ++i) {
+      if (!nulls || !bits::isBitNull(nulls, i)) {
+        uniqueValues.insert(flatVector->valueAt(i));
+      }
+    }
+    return uniqueValues.size();
+  }
+
+  // Dispatch function to count distinct non-null values in a vector.
+  size_t countDistinct(const VectorPtr& vector) {
+    if (!vector) {
+      return 0;
+    }
+
+    switch (vector->typeKind()) {
+      case TypeKind::BIGINT:
+        return countDistinctForType<int64_t>(vector);
+
+      case TypeKind::DOUBLE:
+        return countDistinctForType<double>(vector);
+
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+        return countDistinctForType<StringView>(vector);
+
+      default:
+        VELOX_FAIL("Unsupported type.");
+    }
+  }
+
+  // Helper method to test noisy_approx_sfm with a specific type.
+  void testFuzzerWithType(const TypePtr& type) {
+    const uint32_t seed = 1234;
+    const vector_size_t numElements = 100'000;
+    const double epsilon = 8.0;
+
+    VectorFuzzer::Options options;
+    options.vectorSize = numElements;
+    options.nullRatio = 0.1;
+    options.stringVariableLength = true;
+    options.stringLength = 10;
+
+    VectorFuzzer fuzzer(options, pool_.get(), seed);
+
+    const auto inputVector = fuzzer.fuzzFlat(type);
+    const auto vectors = makeRowVector(
+        {inputVector, makeConstant<double>(epsilon, numElements)});
+
+    const size_t actualCardinality = countDistinct(inputVector);
+
+    const auto distinctResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values({vectors})
+                .singleAggregation(
+                    {}, {"noisy_approx_distinct_sfm(c0, c1)"}, {})
+                .planNode())
+            .copyResults(pool());
+
+    const auto calculatedCardinality =
+        distinctResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+
+    ASSERT_NEAR(
+        calculatedCardinality, actualCardinality, actualCardinality * 0.25);
+
+    const auto setResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values({vectors})
+                .singleAggregation({}, {"noisy_approx_set_sfm(c0, c1)"}, {})
+                .planNode())
+            .copyResults(pool());
+
+    const auto serializedView =
+        setResult->childAt(0)->asFlatVector<StringView>()->valueAt(0);
+    const auto deserialized =
+        SfmSketch::deserialize(serializedView.data(), &allocator_);
+
+    ASSERT_NEAR(
+        deserialized.cardinality(),
+        actualCardinality,
+        actualCardinality * 0.25);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+TEST_F(NoisyApproxSfmAggregationTest, distinctNonPrivacy) {
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeConstant(std::numeric_limits<double>::infinity(), 10)});
+
+  const auto expectedResult = makeRowVector({makeConstant<int64_t>(10, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_approx_distinct_sfm(c0, c1)"}, {expectedResult});
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, setNonPrivacy) {
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+       makeConstant(std::numeric_limits<double>::infinity(), 10)});
+
+  const auto returnedSketch =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation({}, {"noisy_approx_set_sfm(c0, c1)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  const auto serializedView =
+      returnedSketch->childAt(0)->asFlatVector<StringView>()->valueAt(0);
+  const auto deserialized =
+      SfmSketch::deserialize(serializedView.data(), &allocator_);
+  ASSERT_EQ(deserialized.cardinality(), 10);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, distinctPrivacy) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant(8.0, numElements)});
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation({}, {"noisy_approx_distinct_sfm(c0, c1)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  ASSERT_NEAR(
+      result->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+      numElements,
+      numElements * 0.25); // 25% tolerance for 100k elements, 8.0 epsilon.
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, setPrivacy) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant(8.0, numElements)});
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation({}, {"noisy_approx_set_sfm(c0, c1)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  const auto serializedView =
+      result->childAt(0)->asFlatVector<StringView>()->valueAt(0);
+  const auto deserialized =
+      SfmSketch::deserialize(serializedView.data(), &allocator_);
+  ASSERT_NEAR(deserialized.cardinality(), numElements, numElements * 0.25);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, setBuckets) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant<double>(8.0, numElements),
+       makeConstant<int64_t>(8192, numElements)}); // specify buckets.
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation({}, {"noisy_approx_set_sfm(c0, c1, c2)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  const auto serializedView =
+      result->childAt(0)->asFlatVector<StringView>()->valueAt(0);
+  const auto deserialized =
+      SfmSketch::deserialize(serializedView.data(), &allocator_);
+  ASSERT_NEAR(deserialized.cardinality(), numElements, numElements * 0.25);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, distinctBuckets) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant<double>(8.0, numElements),
+       makeConstant<int64_t>(8192, numElements)});
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation(
+                  {}, {"noisy_approx_distinct_sfm(c0, c1, c2)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  ASSERT_NEAR(
+      result->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+      numElements,
+      numElements * 0.25);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, setBucketsAndPrecison) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant<double>(8.0, numElements),
+       makeConstant<int64_t>(8192, numElements), // specify buckets.
+       makeConstant<int64_t>(30, numElements)}); // specify precision.
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation(
+                  {}, {"noisy_approx_set_sfm(c0, c1, c2, c3)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  const auto serializedView =
+      result->childAt(0)->asFlatVector<StringView>()->valueAt(0);
+  const auto deserialized =
+      SfmSketch::deserialize(serializedView.data(), &allocator_);
+  ASSERT_NEAR(deserialized.cardinality(), numElements, numElements * 0.25);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, distinctBucketsAndPrecison) {
+  const vector_size_t numElements = 100'000;
+  const auto vectors = makeRowVector(
+      {makeFlatVector<int64_t>(
+           numElements, [](vector_size_t row) { return row + 1; }),
+       makeConstant<double>(8.0, numElements),
+       makeConstant<int64_t>(8192, numElements),
+       makeConstant<int64_t>(30, numElements)});
+
+  const auto result =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({vectors})
+              .singleAggregation(
+                  {}, {"noisy_approx_distinct_sfm(c0, c1, c2, c3)"}, {})
+              .planNode())
+          .copyResults(pool());
+
+  ASSERT_NEAR(
+      result->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+      numElements,
+      numElements * 0.25);
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, emptyInput) {
+  const auto vectors =
+      makeRowVector({makeFlatVector<int64_t>({}), makeConstant(3.0, 0)});
+
+  const auto expectedResult =
+      makeRowVector({makeNullConstant(TypeKind::BIGINT, 1)});
+  testAggregations(
+      {vectors}, {}, {"noisy_approx_distinct_sfm(c0, c1)"}, {expectedResult});
+}
+
+TEST_F(NoisyApproxSfmAggregationTest, fuzzerInput) {
+  // Test with different data types.
+  testFuzzerWithType(VARCHAR());
+  testFuzzerWithType(DOUBLE());
+  testFuzzerWithType(BIGINT());
+  testFuzzerWithType(VARBINARY());
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -149,6 +149,8 @@ int main(int argc, char** argv) {
       "max_data_size_for_stats",
       "any_value",
       // Skip non-deterministic functions.
+      "noisy_approx_set_sfm",
+      "noisy_approx_distinct_sfm",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -128,6 +128,8 @@ int main(int argc, char** argv) {
       "noisy_count_if_gaussian",
       "noisy_count_gaussian",
       "noisy_sum_gaussian",
+      "noisy_approx_set_sfm",
+      "noisy_approx_distinct_sfm",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   MathematicalOperatorsRegistration.cpp
   ProbabilityTrigonometricFunctionsRegistration.cpp
   RegistrationFunctions.cpp
+  SfmSketchFunctionsRegistration.cpp
   StringFunctionsRegistration.cpp
   TDigestFunctionsRegistration.cpp
   QDigestFunctionsRegistration.cpp

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -31,6 +31,7 @@ extern void registerGeneralFunctions(const std::string& prefix);
 extern void registerHyperLogFunctions(const std::string& prefix);
 extern void registerTDigestFunctions(const std::string& prefix);
 extern void registerQDigestFunctions(const std::string& prefix);
+extern void registerSfmSketchFunctions(const std::string& prefix);
 extern void registerIntegerFunctions(const std::string& prefix);
 extern void registerFloatingPointFunctions(const std::string& prefix);
 extern void registerJsonFunctions(const std::string& prefix);
@@ -85,6 +86,10 @@ void registerQDigestFunctions(const std::string& prefix) {
   functions::registerQDigestFunctions(prefix);
 }
 
+void registerSfmSketchFunctions(const std::string& prefix) {
+  functions::registerSfmSketchFunctions(prefix);
+}
+
 void registerIntegerFunctions(const std::string& prefix) {
   functions::registerIntegerFunctions(prefix);
 }
@@ -135,6 +140,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerHyperLogFunctions(prefix);
   registerTDigestFunctions(prefix);
   registerQDigestFunctions(prefix);
+  registerSfmSketchFunctions(prefix);
   registerIntegerFunctions(prefix);
   registerFloatingPointFunctions(prefix);
   registerBingTileFunctions(prefix);

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -37,6 +37,8 @@ void registerTDigestFunctions(const std::string& prefix = "");
 
 void registerQDigestFunctions(const std::string& prefix = "");
 
+void registerSfmSketchFunctions(const std::string& prefix = "");
+
 void registerBingTileFunctions(const std::string& prefix = "");
 
 void registerGeneralFunctions(const std::string& prefix = "");

--- a/velox/functions/prestosql/registration/SfmSketchFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/SfmSketchFunctionsRegistration.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/SfmSketchFunctions.h"
+#include "velox/functions/prestosql/types/SfmSketchRegistration.h"
+
+namespace facebook::velox::functions {
+
+void registerSfmSketchFunctions(const std::string& prefix) {
+  registerSfmSketchType();
+
+  registerFunction<SfmSketchCardinality, int64_t, SfmSketch>(
+      {prefix + "cardinality"});
+
+  registerFunction<NoisyEmptyApproxSetSfm, SfmSketch, Constant<double>>(
+      {prefix + "noisy_empty_approx_set_sfm"});
+  registerFunction<
+      NoisyEmptyApproxSetSfm,
+      SfmSketch,
+      Constant<double>,
+      Constant<int64_t>>({prefix + "noisy_empty_approx_set_sfm"});
+  registerFunction<
+      NoisyEmptyApproxSetSfm,
+      SfmSketch,
+      Constant<double>,
+      Constant<int64_t>,
+      Constant<int64_t>>({prefix + "noisy_empty_approx_set_sfm"});
+
+  registerFunction<mergeSfmSketchArray, SfmSketch, Array<SfmSketch>>(
+      {prefix + "merge_sfm"});
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(
   RoundTest.cpp
   ScalarFunctionRegTest.cpp
   SequenceTest.cpp
+  SfmSketchFunctionsTest.cpp
   SimpleComparisonMatcherTest.cpp
   SliceTest.cpp
   SplitTest.cpp

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -55,7 +55,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {
   auto signatures = getSignatureStrings("cardinality");
-  ASSERT_EQ(3, signatures.size());
+  ASSERT_LE(3, signatures.size());
 
   ASSERT_EQ(1, signatures.count("(map(__user_T1,__user_T2)) -> bigint"));
   ASSERT_EQ(1, signatures.count("(array(__user_T1)) -> bigint"));

--- a/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
+
+namespace facebook::velox::functions::test {
+using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+
+class SfmSketchFunctionsTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+TEST_F(SfmSketchFunctionsTest, cardinalitySignatures) {
+  auto signatures = getSignatureStrings("cardinality");
+  ASSERT_GE(signatures.size(), 1);
+  ASSERT_EQ(1, signatures.count("(sfmsketch) -> bigint"));
+}
+
+TEST_F(SfmSketchFunctionsTest, noisyEmptyApproxSetSfmSignatures) {
+  auto signatures = getSignatureStrings("noisy_empty_approx_set_sfm");
+  ASSERT_EQ(3, signatures.size());
+  ASSERT_EQ(1, signatures.count("(constant double) -> sfmsketch"));
+  ASSERT_EQ(
+      1, signatures.count("(constant double,constant bigint) -> sfmsketch"));
+  ASSERT_EQ(
+      1,
+      signatures.count(
+          "(constant double,constant bigint,constant bigint) -> sfmsketch"));
+}
+
+TEST_F(SfmSketchFunctionsTest, mergeSfmSketchSignatures) {
+  auto signatures = getSignatureStrings("merge_sfm");
+  ASSERT_EQ(1, signatures.size());
+  ASSERT_EQ(1, signatures.count("(array(sfmsketch)) -> sfmsketch"));
+}
+
+TEST_F(SfmSketchFunctionsTest, cardinalityTest) {
+  const auto cardinality = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), input);
+  };
+
+  // Test empty sketch.
+  SfmSketch sketch{&allocator_};
+  sketch.initialize(4096, 24);
+
+  auto serializedSize = sketch.serializedSize();
+
+  std::vector<char> buffer(serializedSize);
+  sketch.serialize(buffer.data());
+  std::string serializedEmpty(buffer.begin(), buffer.end());
+  EXPECT_EQ(*cardinality(serializedEmpty), 0);
+
+  // Add distinct elements
+  int64_t numElements = 100000;
+  for (int64_t i = 0; i < numElements; i++) {
+    sketch.add(i);
+  }
+  // Add noise to the sketch.
+  sketch.enablePrivacy(8.0);
+
+  std::vector<char> buffer2(sketch.serializedSize());
+  sketch.serialize(buffer2.data());
+  std::string serialized2(buffer2.begin(), buffer2.end());
+  auto result = cardinality(serialized2);
+
+  // SfmSketch is an approximate algorithm, so we allow 25% error.
+  EXPECT_NEAR(*result, numElements, numElements * 0.25);
+}
+
+TEST_F(SfmSketchFunctionsTest, cardinalityWithDuplicates) {
+  const auto cardinality = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), input);
+  };
+
+  SfmSketch sketch{&allocator_};
+  sketch.initialize(4096, 24);
+
+  for (int i = 0; i < 100000; i++) {
+    sketch.add(i % 100);
+  }
+
+  std::string buffer(sketch.serializedSize(), '\0');
+  sketch.serialize(buffer.data());
+  auto result = cardinality(buffer);
+
+  // It turns out that XXH64 has a collision for numbers 0-99,
+  // The cardinality using XXH64 is 99, while murmurHash is 100.
+  EXPECT_EQ(*result, 99);
+}
+
+TEST_F(SfmSketchFunctionsTest, noisyEmptyApproxSetSfm) {
+  // Test with epsilon only.
+  auto a = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY()))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*a, 0);
+
+  // Test with epsilon and buckets.
+  auto b = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY(), 1024))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*b, 0);
+
+  // Test with epsilon, buckets, and precision.
+  auto c = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY(), 1024, 20))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*c, 0);
+}
+
+TEST_F(SfmSketchFunctionsTest, mergeSfmSketchArray) {
+  // Create two sketches with different elements.
+  SfmSketch a{&allocator_};
+  a.initialize(4096, 24);
+  for (int i = 0; i < 50; i++) {
+    a.add(i);
+  }
+
+  SfmSketch b{&allocator_};
+  b.initialize(4096, 24);
+  for (int i = 25; i < 75; i++) {
+    b.add(i);
+  }
+
+  std::string aString(a.serializedSize(), '\0');
+  a.serialize(aString.data());
+
+  std::string bString(b.serializedSize(), '\0');
+  b.serialize(bString.data());
+
+  // Test merging array of sketches.
+  auto mergedResult = evaluateOnce<std::string>(
+      "merge_sfm(c0)",
+      makeRowVector(
+          {makeArrayVector<std::string>({{aString, bString}}, SFMSKETCH())}));
+
+  auto mergedCardinality =
+      evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), mergedResult);
+
+  // There are 75 distinct elements in the sketch.
+  ASSERT_EQ(mergedCardinality, 75);
+}
+
+TEST_F(SfmSketchFunctionsTest, mergeSfmSketchEmpty) {
+  // Test merging empty array should return null.
+  auto result = evaluate(
+      "merge_sfm(c0)",
+      makeRowVector({makeArrayVector<std::string>({}, SFMSKETCH())}));
+
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(SfmSketchFunctionsTest, cardinalityNull) {
+  // Test cardinality with null input.
+  auto result = evaluate(
+      "cardinality(c0)",
+      makeRowVector(
+          {makeNullableFlatVector<std::string>({std::nullopt}, SFMSKETCH())}));
+
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -21,6 +21,7 @@ velox_add_library(
   IPPrefixRegistration.cpp
   JsonCastOperator.cpp
   JsonRegistration.cpp
+  SfmSketchRegistration.cpp
   TDigestRegistration.cpp
   QDigestRegistration.cpp
   TimestampWithTimeZoneRegistration.cpp

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 velox_add_library(
   velox_presto_types_fuzzer_utils TimestampWithTimeZoneInputGenerator.cpp
-  HyperLogLogInputGenerator.cpp)
+  HyperLogLogInputGenerator.cpp SfmSketchInputGenerator.cpp)
 
 velox_link_libraries(
   velox_presto_types_fuzzer_utils


### PR DESCRIPTION
Summary:
The SFM sketch based scalar functions include:

* `noisy_empty_approx_set_sfm(epsilon[, buckets[, precision]]) -> SfmSketch`
* `cardinality(SfmSketch) -> bigint`
* `merge_sfm(ARRAY[SfmSketch, ...]) -> SfmSketch`

Differential Revision: D77898126


