### PR TITLE
refactor: More efficient envelope deserialization

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -642,7 +642,7 @@ struct StXMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -657,7 +657,7 @@ struct StYMinFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -672,7 +672,7 @@ struct StXMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -687,7 +687,7 @@ struct StYMaxFunction {
 
   bool call(out_type<double>& result, const arg_type<Geometry>& geometry) {
     const std::unique_ptr<geos::geom::Envelope> env =
-        geospatial::getEnvelopeFromGeometry(geometry);
+        geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
     if (env->isNull()) {
       return false;
     }
@@ -822,8 +822,13 @@ struct StIsEmptyFunction {
 
   FOLLY_ALWAYS_INLINE Status
   call(out_type<bool>& result, const arg_type<Geometry>& geometry) {
-    GEOS_TRY(result = geospatial::getEnvelopeFromGeometry(geometry)->isNull();
-             , "Failed to get envelope from geometry");
+    GEOS_TRY(
+        {
+          const std::unique_ptr<geos::geom::Envelope> env =
+              geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
+          result = env->isNull();
+        },
+        "Failed to get envelope from geometry");
     return Status::OK();
   }
 };

--- a/velox/functions/prestosql/geospatial/GeometrySerde.cpp
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.cpp
@@ -53,6 +53,50 @@ std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::deserialize(
   }
 }
 
+const std::unique_ptr<geos::geom::Envelope>
+GeometryDeserializer::deserializeEnvelope(const StringView& geometry) {
+  velox::common::InputByteStream inputStream(geometry.data());
+  auto geometryType = inputStream.read<GeometrySerializationType>();
+
+  switch (geometryType) {
+    case GeometrySerializationType::POINT:
+      return std::make_unique<geos::geom::Envelope>(
+          *readPoint(inputStream)->getEnvelopeInternal());
+    case GeometrySerializationType::MULTI_POINT:
+    case GeometrySerializationType::LINE_STRING:
+    case GeometrySerializationType::MULTI_LINE_STRING:
+    case GeometrySerializationType::POLYGON:
+    case GeometrySerializationType::MULTI_POLYGON:
+      skipEsriType(inputStream);
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::ENVELOPE:
+      return deserializeEnvelope(inputStream);
+    case GeometrySerializationType::GEOMETRY_COLLECTION:
+      return std::make_unique<geos::geom::Envelope>(
+          *readGeometryCollection(inputStream, geometry.size())
+               ->getEnvelopeInternal());
+    default:
+      VELOX_FAIL(
+          "Unrecognized geometry type: {}", static_cast<uint8_t>(geometryType));
+  }
+}
+
+std::unique_ptr<geos::geom::Envelope> GeometryDeserializer::deserializeEnvelope(
+    velox::common::InputByteStream& input) {
+  auto xMin = input.read<double>();
+  auto yMin = input.read<double>();
+  auto xMax = input.read<double>();
+  auto yMax = input.read<double>();
+
+  if (FOLLY_UNLIKELY(
+          isEsriNaN(xMin) || isEsriNaN(yMin) || isEsriNaN(xMax) ||
+          isEsriNaN(yMax))) {
+    return std::make_unique<geos::geom::Envelope>();
+  }
+
+  return std::make_unique<geos::geom::Envelope>(xMin, xMax, yMin, yMax);
+}
+
 geos::geom::Coordinate GeometryDeserializer::readCoordinate(
     velox::common::InputByteStream& input) {
   auto x = input.read<double>();
@@ -250,14 +294,6 @@ GeometryDeserializer::readGeometryCollection(
 
   return std::unique_ptr<geos::geom::GeometryCollection>(
       getGeometryFactory()->createGeometryCollection(rawGeometries));
-}
-
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry) {
-  std::unique_ptr<geos::geom::Geometry> geosGeometry =
-      geospatial::GeometryDeserializer::deserialize(geometry);
-  return std::make_unique<geos::geom::Envelope>(
-      *geosGeometry->getEnvelopeInternal());
 }
 
 } // namespace facebook::velox::functions::geospatial

--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -311,6 +311,9 @@ class GeometryDeserializer {
     return deserialize(inputStream, geometryString.size());
   }
 
+  static const std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      const StringView& geometry);
+
  private:
   static std::unique_ptr<geos::geom::Geometry> deserialize(
       velox::common::InputByteStream& stream,
@@ -327,6 +330,9 @@ class GeometryDeserializer {
   static void skipEnvelope(velox::common::InputByteStream& input) {
     input.read<double>(4); // Envelopes are 4 doubles (minX, minY, maxX, maxY)
   }
+
+  static std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
+      velox::common::InputByteStream& input);
 
   static geos::geom::Coordinate readCoordinate(
       velox::common::InputByteStream& input);
@@ -356,9 +362,5 @@ class GeometryDeserializer {
       velox::common::InputByteStream& input,
       size_t size);
 };
-
-/// Deserialize Velox's internal format to a geometry and get the Envelope.
-const std::unique_ptr<geos::geom::Envelope> getEnvelopeFromGeometry(
-    const StringView& geometry);
 
 } // namespace facebook::velox::functions::geospatial


### PR DESCRIPTION
Summary:
Summary
In Presto's internal geometry representation, the envelope of a geometry is stored alongside most geometry types. As noted in https://github.com/facebookincubator/velox/issues/13674, it is unnecessary to fully deserialize a geometry to compute its envelope — the envelope can be read directly. This PR introduces a method in GeometryDeserializer that efficiently retrieves the envelope without requiring full deserialization.

This is a duplicate of https://github.com/facebookincubator/velox/pull/13771 rebased
and resubmitted due to internal build failures.

Differential Revision: D78513587

Pulled By: jagill
