### PR TITLE
refactor: Reduce usage of dynamic_cast in ExprCompiler

### DIFF
--- a/velox/benchmarks/basic/SimpleCastExpr.cpp
+++ b/velox/benchmarks/basic/SimpleCastExpr.cpp
@@ -19,6 +19,7 @@
 
 #include <gflags/gflags.h>
 
+#include "velox/core/Expressions.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 

--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 velox_add_library(
   velox_core
   Expressions.cpp
+  ITypedExpr.cpp
   FilterToExpression.cpp
   PlanFragment.cpp
   PlanNode.cpp

--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -640,7 +640,7 @@ TypePtr toRowType(
 ConcatTypedExpr::ConcatTypedExpr(
     const std::vector<std::string>& names,
     const std::vector<TypedExprPtr>& inputs)
-    : ITypedExpr{toRowType(names, inputs), inputs} {}
+    : ITypedExpr{ExprKind::kConcat, toRowType(names, inputs), inputs} {}
 
 std::string ConcatTypedExpr::toString() const {
   std::string str{};

--- a/velox/core/ITypedExpr.cpp
+++ b/velox/core/ITypedExpr.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/ITypedExpr.h"
+
+namespace facebook::velox::core {
+
+namespace {
+folly::F14FastMap<ExprKind, std::string> exprKindNames() {
+  static const folly::F14FastMap<ExprKind, std::string> kNames = {
+      {ExprKind::kInput, "INPUT"},
+      {ExprKind::kFieldAccess, "FIELD"},
+      {ExprKind::kDereference, "DEREFERENCE"},
+      {ExprKind::kCall, "CALL"},
+      {ExprKind::kCast, "CAST"},
+      {ExprKind::kConstant, "CONSTANT"},
+      {ExprKind::kConcat, "CONCAT"},
+      {ExprKind::kLambda, "LAMBDA"},
+  };
+
+  return kNames;
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(ExprKind, exprKindNames);
+} // namespace facebook::velox::core

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/memory/Memory.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/memory/Memory.h"
+#include "velox/core/Expressions.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/Type.h"

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -90,6 +90,7 @@ class CastExpr : public SpecialForm {
       bool isTryCast,
       std::shared_ptr<CastHooks> hooks)
       : SpecialForm(
+            SpecialFormKind::kCast,
             type,
             std::vector<ExprPtr>({expr}),
             isTryCast ? kTryCast.data() : kCast.data(),

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -22,6 +22,7 @@ CoalesceExpr::CoalesceExpr(
     std::vector<ExprPtr>&& inputs,
     bool inputsSupportFlatNoNullsFastPath)
     : SpecialForm(
+          SpecialFormKind::kCoalesce,
           std::move(type),
           std::move(inputs),
           kCoalesce,
@@ -39,7 +40,7 @@ CoalesceExpr::CoalesceExpr(
   auto expectedType = resolveType(inputTypes);
   VELOX_CHECK(
       *expectedType == *this->type(),
-      "Coalesce expression type different than its inputs. Expected {} but got Actual {}.",
+      "Coalesce expression type different than its inputs. Expected {}, but got {}.",
       expectedType->toString(),
       this->type()->toString());
 }

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -32,6 +32,7 @@ class ConjunctExpr : public SpecialForm {
       bool isAnd,
       bool inputsSupportFlatNoNullsFastPath)
       : SpecialForm(
+            isAnd ? SpecialFormKind::kAnd : SpecialFormKind::kOr,
             std::move(type),
             std::move(inputs),
             isAnd ? kAnd : kOr,
@@ -123,7 +124,7 @@ class ConjunctCallToSpecialForm : public FunctionCallToSpecialForm {
       const core::QueryConfig& config) override;
 
  private:
-  bool isAnd_;
+  const bool isAnd_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -22,6 +22,7 @@ class ConstantExpr : public SpecialForm {
  public:
   explicit ConstantExpr(VectorPtr value)
       : SpecialForm(
+            SpecialFormKind::kConstant,
             value->type(),
             std::vector<ExprPtr>(),
             "literal",

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -17,8 +17,6 @@
 #include "velox/expression/EvalCtx.h"
 #include <exception>
 #include "velox/common/testutil/TestValue.h"
-#include "velox/core/QueryConfig.h"
-#include "velox/expression/Expr.h"
 #include "velox/expression/PeeledEncoding.h"
 
 using facebook::velox::common::testutil::TestValue;

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -23,7 +23,6 @@
 #include "velox/common/base/Portability.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/vector/ComplexVector.h"
-#include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -22,8 +22,6 @@
 
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/ExpressionEvaluator.h"
-#include "velox/core/Expressions.h"
-#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/ExprStats.h"
 #include "velox/expression/VectorFunction.h"
@@ -106,6 +104,21 @@ class MutableRemainingRows {
   LocalSelectivityVector mutableRowsHolder_;
 };
 
+enum class SpecialFormKind : int32_t {
+  kFieldAccess = 0,
+  kConstant = 1,
+  kCast = 2,
+  kCoalesce = 3,
+  kSwitch = 4,
+  kLambda = 5,
+  kTry = 6,
+  kAnd = 7,
+  kOr = 8,
+  kCustom = 999,
+};
+
+VELOX_DECLARE_ENUM_NAME(SpecialFormKind);
+
 // An executable expression.
 class Expr {
  public:
@@ -113,14 +126,14 @@ class Expr {
       TypePtr type,
       std::vector<std::shared_ptr<Expr>>&& inputs,
       std::string name,
-      bool specialForm,
+      std::optional<SpecialFormKind> specialFormKind,
       bool supportsFlatNoNullsFastPath,
       bool trackCpuUsage)
       : type_(std::move(type)),
         inputs_(std::move(inputs)),
         name_(std::move(name)),
         vectorFunction_(nullptr),
-        specialForm_{specialForm},
+        specialFormKind_{specialFormKind},
         supportsFlatNoNullsFastPath_{supportsFlatNoNullsFastPath},
         trackCpuUsage_{trackCpuUsage} {}
 
@@ -248,7 +261,51 @@ class Expr {
   }
 
   bool isSpecialForm() const {
-    return specialForm_;
+    return specialFormKind_.has_value();
+  }
+
+  SpecialFormKind specialFormKind() const {
+    return specialFormKind_.value();
+  }
+
+  bool isFieldAccess() const {
+    return specialFormKind_ == SpecialFormKind::kFieldAccess;
+  }
+
+  bool isConstant() const {
+    return specialFormKind_ == SpecialFormKind::kConstant;
+  }
+
+  bool isCast() const {
+    return specialFormKind_ == SpecialFormKind::kCast;
+  }
+
+  bool isCoalesce() const {
+    return specialFormKind_ == SpecialFormKind::kCoalesce;
+  }
+
+  bool isSwitch() const {
+    return specialFormKind_ == SpecialFormKind::kSwitch;
+  }
+
+  bool isLambda() const {
+    return specialFormKind_ == SpecialFormKind::kLambda;
+  }
+
+  bool isTry() const {
+    return specialFormKind_ == SpecialFormKind::kTry;
+  }
+
+  bool isAnd() const {
+    return specialFormKind_ == SpecialFormKind::kAnd;
+  }
+
+  bool isOr() const {
+    return specialFormKind_ == SpecialFormKind::kOr;
+  }
+
+  bool isCustom() const {
+    return specialFormKind_ == SpecialFormKind::kCustom;
   }
 
   virtual bool isConditional() const {
@@ -263,7 +320,7 @@ class Expr {
     return deterministic_;
   }
 
-  virtual bool isConstant() const;
+  virtual bool isConstantExpr() const;
 
   bool supportsFlatNoNullsFastPath() const {
     return supportsFlatNoNullsFastPath_;
@@ -552,7 +609,7 @@ class Expr {
   const std::string name_;
   const std::shared_ptr<VectorFunction> vectorFunction_;
   const VectorFunctionMetadata vectorFunctionMetadata_;
-  const bool specialForm_;
+  const std::optional<SpecialFormKind> specialFormKind_;
   const bool supportsFlatNoNullsFastPath_;
   const bool trackCpuUsage_;
 

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -28,7 +28,7 @@ VectorPtr toConstant(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator) {
   auto exprSet = evaluator->compile(expr);
-  if (!exprSet->exprs()[0]->isConstant()) {
+  if (!exprSet->exprs()[0]->isConstantExpr()) {
     return nullptr;
   }
   RowVector input(

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -26,6 +26,7 @@ class FieldReference : public SpecialForm {
       const std::vector<ExprPtr>& inputs,
       const std::string& field)
       : SpecialForm(
+            SpecialFormKind::kFieldAccess,
             std::move(type),
             inputs,
             field,
@@ -38,6 +39,7 @@ class FieldReference : public SpecialForm {
       const std::vector<ExprPtr>& inputs,
       int32_t index)
       : SpecialForm(
+            SpecialFormKind::kFieldAccess,
             std::move(type),
             inputs,
             inputs.at(0)->type()->asRow().nameOf(index),
@@ -50,8 +52,8 @@ class FieldReference : public SpecialForm {
     return field_;
   }
 
-  bool isConstant() const override {
-    return SpecialForm::isConstant() && !inputs_.empty();
+  bool isConstantExpr() const override {
+    return Expr::isConstantExpr() && !inputs_.empty();
   }
 
   int32_t index(const EvalCtx& context) {

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -165,6 +165,7 @@ LambdaExpr::LambdaExpr(
     std::shared_ptr<Expr>&& body,
     bool trackCpuUsage)
     : SpecialForm(
+          SpecialFormKind::kLambda,
           std::move(type),
           std::vector<std::shared_ptr<Expr>>(),
           "lambda",
@@ -183,6 +184,7 @@ LambdaExpr::LambdaExpr(
 void LambdaExpr::computeDistinctFields() {
   SpecialForm::computeDistinctFields();
   std::vector<FieldReference*> capturedFields;
+  capturedFields.reserve(capture_.size());
   for (auto& field : capture_) {
     capturedFields.push_back(field.get());
   }

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -35,7 +35,7 @@ class LambdaExpr : public SpecialForm {
       std::shared_ptr<Expr>&& body,
       bool trackCpuUsage);
 
-  bool isConstant() const override {
+  bool isConstantExpr() const override {
     return false;
   }
 

--- a/velox/expression/SpecialForm.h
+++ b/velox/expression/SpecialForm.h
@@ -22,6 +22,7 @@ namespace facebook::velox::exec {
 class SpecialForm : public Expr {
  public:
   SpecialForm(
+      SpecialFormKind kind,
       TypePtr type,
       std::vector<ExprPtr> inputs,
       const std::string& name,
@@ -31,7 +32,7 @@ class SpecialForm : public Expr {
             std::move(type),
             std::move(inputs),
             name,
-            true /* specialForm */,
+            kind,
             supportsFlatNoNullsFastPath,
             trackCpuUsage) {}
 
@@ -39,6 +40,10 @@ class SpecialForm : public Expr {
   // expressions.
   virtual void computePropagatesNulls() {
     VELOX_NYI();
+  }
+
+  SpecialFormKind kind() const {
+    return specialFormKind();
   }
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -32,6 +32,7 @@ SwitchExpr::SwitchExpr(
     const std::vector<ExprPtr>& inputs,
     bool inputsSupportFlatNoNullsFastPath)
     : SpecialForm(
+          SpecialFormKind::kSwitch,
           std::move(type),
           inputs,
           "switch",
@@ -51,7 +52,7 @@ SwitchExpr::SwitchExpr(
   auto typeExpected = resolveType(inputTypes);
   VELOX_CHECK(
       *typeExpected == *this->type(),
-      "Switch expression type different than then clause. Expected {} but got Actual {}.",
+      "Switch expression type different than then clause. Expected {}, but got {}.",
       typeExpected->toString(),
       this->type()->toString());
 }

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -27,6 +27,7 @@ class TryExpr : public SpecialForm {
   /// Try expression adds nulls, hence, doesn't support flat-no-nulls fast path.
   TryExpr(TypePtr type, ExprPtr&& input)
       : SpecialForm(
+            SpecialFormKind::kTry,
             std::move(type),
             {std::move(input)},
             kTry,

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
-#include <unordered_map>
-#include "folly/Singleton.h"
 #include "folly/Synchronized.h"
 #include "velox/expression/SignatureBinder.h"
 

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -17,7 +17,7 @@
 #pragma once
 
 #include <vector>
-#include "velox/core/Expressions.h"
+#include "velox/core/ITypedExpr.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/FunctionMetadata.h"
 #include "velox/expression/FunctionSignature.h"

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -15,11 +15,11 @@
  */
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/types/JsonType.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -22,19 +22,17 @@
 #include "glog/logging.h"
 #include "gtest/gtest.h"
 
-#include "velox/expression/Expr.h"
-
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/Expr.h"
 #include "velox/expression/SwitchExpr.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/SelectivityVector.h"
@@ -4687,7 +4685,8 @@ TEST_P(ParameterizedExprTest, switchRowInputTypesAreTheSame) {
       EXPECT_TRUE(false) << "Expected an error";
     } catch (VeloxException& e) {
       EXPECT_EQ(
-          "Switch expression type different than then clause. Expected ROW<f1:BOOLEAN> but got Actual ROW<c0:BOOLEAN>.",
+          "Switch expression type different than then clause. "
+          "Expected ROW<f1:BOOLEAN>, but got ROW<c0:BOOLEAN>.",
           e.message());
     }
   }
@@ -4713,7 +4712,8 @@ TEST_P(ParameterizedExprTest, coalesceRowInputTypesAreTheSame) {
       EXPECT_TRUE(false) << "Expected an error";
     } catch (VeloxException& e) {
       EXPECT_EQ(
-          "Coalesce expression type different than its inputs. Expected ROW<f1:BOOLEAN> but got Actual ROW<c0:BOOLEAN>.",
+          "Coalesce expression type different than its inputs. "
+          "Expected ROW<f1:BOOLEAN>, but got ROW<c0:BOOLEAN>.",
           e.message());
     }
   }

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -17,7 +17,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include "velox/expression/Expr.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/type/Type.h"

--- a/velox/functions/lib/ArrayShuffle.cpp
+++ b/velox/functions/lib/ArrayShuffle.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include <random>
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
-#include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "MapConcat.h"
-#include "velox/expression/Expr.h"
+#include "velox/functions/lib/MapConcat.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/vector/TypeAliases.h"
 

--- a/velox/functions/lib/Slice.cpp
+++ b/velox/functions/lib/Slice.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/functions/lib/Slice.h"
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/ArrayPosition.cpp
+++ b/velox/functions/prestosql/ArrayPosition.cpp
@@ -15,7 +15,7 @@
  */
 #include <folly/CPortability.h>
 
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/vector/DecodedVector.h"

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/CheckDuplicateKeys.h"
 

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <optional>
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/base/RuntimeMetrics.h"
+#include "velox/core/Expressions.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 

--- a/velox/functions/prestosql/Split.cpp
+++ b/velox/functions/prestosql/Split.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
-#include "velox/expression/Expr.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/expression/VectorWriters.h"

--- a/velox/functions/prestosql/SplitToMap.cpp
+++ b/velox/functions/prestosql/SplitToMap.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/prestosql/SplitToMap.h"
+#include "velox/core/Expressions.h"
 
 namespace facebook::velox::functions {
 

--- a/velox/functions/prestosql/WidthBucketArray.cpp
+++ b/velox/functions/prestosql/WidthBucketArray.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/WidthBucketArray.h"
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/vector/DecodedVector.h"

--- a/velox/functions/prestosql/Zip.cpp
+++ b/velox/functions/prestosql/Zip.cpp
@@ -15,7 +15,7 @@
  */
 #include <boost/algorithm/string/join.hpp>
 #include <limits>
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/expression/Expr.h"
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/vector/DecodedVector.h"
 

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/OptionalEmpty.h"
-#include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
-#include "velox/type/tz/TimeZoneMap.h"
 
 using namespace facebook::velox::test;
 using namespace facebook::velox::functions::test;
@@ -30,7 +28,7 @@ class InPredicateTest : public FunctionBaseTest {
  protected:
   template <typename T>
   ArrayVectorPtr getInList(
-      std::vector<std::optional<T>> input,
+      const std::vector<std::optional<T>>& input,
       const TypePtr& type) {
     FlatVectorPtr<T> flatVec = makeNullableFlatVector<T>(input, type);
 

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -17,6 +17,7 @@
 #include "folly/Unicode.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/OptionalEmpty.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 

--- a/velox/functions/remote/server/RemoteFunctionService.cpp
+++ b/velox/functions/remote/server/RemoteFunctionService.cpp
@@ -15,10 +15,11 @@
  */
 
 #include "velox/functions/remote/server/RemoteFunctionService.h"
-#include "velox/common/base/Exceptions.h"
+#include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/remote/if/GetSerde.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/sparksql/Comparisons.cpp
+++ b/velox/functions/sparksql/Comparisons.cpp
@@ -15,8 +15,8 @@
  */
 #include "velox/functions/sparksql/LeastGreatest.h"
 
+#include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
-#include "velox/expression/Expr.h"
 #include "velox/functions/lib/SIMDComparisonUtil.h"
 #include "velox/functions/sparksql/Comparisons.h"
 #include "velox/type/Type.h"

--- a/velox/functions/sparksql/benchmarks/FromJsonBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FromJsonBenchmark.cpp
@@ -17,6 +17,7 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include "velox/core/Expressions.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/sparksql/registration/Register.h"
 

--- a/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
+++ b/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
@@ -30,6 +30,7 @@ class AtLeastNNonNullsExpr : public SpecialForm {
       std::vector<ExprPtr>&& inputs,
       int n)
       : SpecialForm(
+            SpecialFormKind::kCustom,
             std::move(type),
             std::move(inputs),
             AtLeastNNonNullsCallToSpecialForm::kAtLeastNNonNulls,

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/DecimalArithmetic.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 

--- a/velox/functions/sparksql/tests/DecimalRoundTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalRoundTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {

--- a/velox/functions/sparksql/tests/FromJsonTest.cpp
+++ b/velox/functions/sparksql/tests/FromJsonTest.cpp
@@ -15,6 +15,7 @@
  */
 #include <limits>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 using namespace facebook::velox::test;

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -17,6 +17,7 @@
 #include <optional>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/functions/sparksql/tests/MakeDecimalTest.cpp
+++ b/velox/functions/sparksql/tests/MakeDecimalTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {

--- a/velox/functions/sparksql/tests/MightContainTest.cpp
+++ b/velox/functions/sparksql/tests/MightContainTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/MightContain.h"
 #include "velox/common/base/BloomFilter.h"
+#include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {


### PR DESCRIPTION
Summary:
ExprCompiler uses dynamic_cast to switch on expr type. This is inefficient and shows up in the profile.

Introduce ExprKind enum and ITypedExpr::kind() getter to allow for more efficient switching.

Also, introduce SpecialFormKind enum.

Also, remove unnecessary includes.

Differential Revision: D78553108
