### PR TITLE
fix: Expose functions for lambda signatures

### DIFF
--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -463,11 +463,10 @@ const exec::FunctionSignature* FOLLY_NULLABLE findLambdaSignature(
 
   return matchingSignature;
 }
+} // namespace
 
-// Assumes no overlap in function names between scalar and aggregate functions,
-// i.e. 'foo' is either a scalar or aggregate function.
-const exec::FunctionSignature* FOLLY_NULLABLE
-findLambdaSignature(const std::shared_ptr<const CallExpr>& callExpr) {
+const exec::FunctionSignature* findLambdaSignature(
+    const std::shared_ptr<const CallExpr>& callExpr) {
   // Look for a scalar lambda function.
   auto scalarSignatures = getFunctionSignatures(callExpr->name());
   if (!scalarSignatures.empty()) {
@@ -482,8 +481,6 @@ findLambdaSignature(const std::shared_ptr<const CallExpr>& callExpr) {
 
   return nullptr;
 }
-
-} // namespace
 
 // static
 TypedExprPtr Expressions::tryResolveCallWithLambdas(

--- a/velox/parse/TypeResolver.h
+++ b/velox/parse/TypeResolver.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/ITypedExpr.h"
+#include "velox/expression/SignatureBinder.h"
 #include "velox/parse/Expressions.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
@@ -95,5 +96,13 @@ class Expressions {
   static TypeResolverHook resolverHook_;
   static FieldAccessHook fieldAccessHook_;
 };
+
+/// Returns a signature for 'call' if a signature involving lambda arguments is
+/// found, nullptr otherwise.
+/// Assumes no overlap in function names between scalar and aggregate
+// functions,
+/// i.e. 'foo' is either a scalar or aggregate function.
+const exec::FunctionSignature* findLambdaSignature(
+    const std::shared_ptr<const CallExpr>& callExpr);
 
 } // namespace facebook::velox::core


### PR DESCRIPTION
logical_plan::PlanBuilder needs access to lambda signature information. Expose existing function instead of copying the code.