### PR TITLE
feat: Add noisy_approx_set_sfm_from_index_and_zeros function

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -844,6 +844,30 @@ Counts, Sums, and Averages
     * ``buckets`` (int) defaults to 4096.
     * ``precision`` (int) defaults to 24.
 
+.. function:: noisy_approx_set_sfm_from_index_and_zeros(col_index, col_zeros, epsilon, buckets[, precision]) -> SfmSketch
+
+    Returns an SFM sketch of the input values in ``col_index`` and ``col_zeros``.
+
+    This is similar to :func:`noisy_approx_set_sfm` except that function calculates a ``xxhash64()`` of ``col``,
+    and calculates the SFM PCSA bucket index and number of trailing zeros as described in
+    [FlajoletMartin1985]_. In this function, the caller must explicitly calculate the hash bucket index
+    and zeros themselves and pass them as arguments ``col_index`` and ``col_zeros``.
+
+    - ``col_index`` (bigint) must be in the range ``0..buckets-1``.
+    - ``col_zeros`` (bigint) must be in the range ``0..64``. If it exceeds ``precision``, it
+      is cropped to ``precision-1``.
+    - ``epsilon`` (double) is a positive number that controls the level of noise in
+      the sketch, as described in [Hehir2023]_. Smaller values of epsilon correspond
+      to noisier sketches.
+    - ``buckets`` (int) is the number of buckets in the SFM PCSA sketch as described in [Hehir2023]_.
+    - ``precision`` (int) defaults to 24.
+
+    .. note::
+
+        Like  :func:`noisy_approx_set_sfm`, this function returns ``NULL`` when ``col_index``
+        or ``col_zeros`` is ``NULL``.
+        If this behavior is undesirable, use :func:`!coalesce` with :func:`noisy_empty_approx_set_sfm`.
+
 .. function:: cardinality(SfmSketch) -> bigint
 
     Returns the estimated cardinality (distinct count) of an ``SfmSketch`` object.

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -833,7 +833,33 @@ Counts, Sums, and Averages
 
     .. note::
 
-        Unlike :func:`approx_distinct`, this function returns NULL when col is empty.
+        Unlike :func:`approx_distinct`, this function returns ``NULL`` when ``col`` is empty.
+
+.. function:: noisy_empty_approx_set_sfm(epsilon[, buckets[, precision]]) -> SfmSketch
+
+    Returns an SFM sketch with no items in it. This is analogous to the ``empty_approx_set()`` function,
+    which returns an empty (deterministic) ``HyperLogLog`` sketch.
+    * ``epsilon`` (double) is a positive number that controls the level of noise in the sketch, as described in [Hehir2023]_.
+      Smaller values of epsilon correspond to noisier sketches.
+    * ``buckets`` (int) defaults to 4096.
+    * ``precision`` (int) defaults to 24.
+
+.. function:: cardinality(SfmSketch) -> bigint
+
+    Returns the estimated cardinality (distinct count) of an ``SfmSketch`` object.
+
+.. function:: merge_sfm(ARRAY[SfmSketch, ...]) -> SfmSketch
+
+    A scalar function that returns a merged ``SfmSketch`` of the set union of an array of ``SfmSketch`` objects, similar to ``merge_hll()``.
+
+    ::
+
+        SELECT cardinality(merge_sfm(ARRAY[
+            noisy_approx_set_sfm(col_1, 5.0),
+            noisy_approx_set_sfm(col_2, 5.0),
+            noisy_approx_set_sfm(col_3, 5.0)
+        ])) AS distinct_count_over_3_cols
+        FROM my_table
 
 Limitations
 ~~~~~~~~~~~

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -39,6 +39,7 @@
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
@@ -308,7 +309,8 @@ bool PrestoQueryRunner::isConstantExprSupported(
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
-        !isTDigestType(type) && !isQDigestType(type) && !isBingTileType(type);
+        !isTDigestType(type) && !isQDigestType(type) && !isBingTileType(type) &&
+        !isSfmSketchType(type);
     ;
   }
   return true;

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
@@ -61,6 +62,9 @@ intermediateTypeTransforms() {
           {QDIGEST(REAL()),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                QDIGEST(REAL()), VARBINARY())},
+          {SFMSKETCH(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               SFMSKETCH(), VARBINARY())},
           {JSON(), std::make_shared<JsonTransform>()},
           {BINGTILE(),
            std::make_shared<IntermediateTypeTransformUsingCast>(

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -85,6 +85,8 @@ int main(int argc, char** argv) {
   // Use function name to exclude all signatures of a given function from
   // testing. Use function signature to exclude only a specific signature.
   std::unordered_set<std::string> skipFunctions = {
+      "noisy_empty_approx_set_sfm", // Non-deterministic because of privacy.
+      "merge_sfm", // Fuzzer can generate sketches of different sizes.
       "element_at",
       "width_bucket",
       // Fuzzer and the underlying engine are confused about TDigest functions
@@ -240,6 +242,7 @@ int main(int argc, char** argv) {
     // Add additional functions to skip since we are now querying Presto
     // directly and are aware of certain failures.
     skipFunctions.insert({
+        "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
         // https://github.com/facebookincubator/velox/issues/11034
         "cast(real) -> varchar",
         "cast(row(real)) -> row(varchar)",

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   Reverse.cpp
   RowFunction.cpp
   Sequence.cpp
+  SfmSketchFunctions.cpp
   SimpleComparisonMatcher.cpp
   Split.cpp
   SplitToMap.cpp

--- a/velox/functions/prestosql/SfmSketchFunctions.cpp
+++ b/velox/functions/prestosql/SfmSketchFunctions.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/SfmSketchFunctions.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+
+namespace facebook::velox::functions {
+
+std::string createEmptySfmSketch(
+    HashStringAllocator* allocator,
+    double epsilon,
+    std::optional<int64_t> buckets,
+    std::optional<int64_t> precison) {
+  using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+
+  constexpr int64_t kDefaultBuckets = 4096;
+  constexpr int64_t kDefaultPrecision = 24;
+
+  int64_t initBuckets = buckets.has_value() ? buckets.value() : kDefaultBuckets;
+  int64_t initPrecision =
+      precison.has_value() ? precison.value() : kDefaultPrecision;
+  SfmSketch sketch(allocator);
+  sketch.initialize(
+      static_cast<int32_t>(initBuckets), static_cast<int32_t>(initPrecision));
+  sketch.enablePrivacy(epsilon);
+
+  // Serialize the sketch.
+  auto serializedSize = sketch.serializedSize();
+  std::string result(serializedSize, '\0');
+  sketch.serialize(result.data());
+
+  return result;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/SfmSketchFunctions.h
+++ b/velox/functions/prestosql/SfmSketchFunctions.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
+
+namespace facebook::velox::functions {
+
+// Helper function to create empty SfmSketch.
+std::string createEmptySfmSketch(
+    HashStringAllocator* allocator,
+    double epsilon,
+    std::optional<int64_t> buckets = std::nullopt,
+    std::optional<int64_t> precison = std::nullopt);
+
+template <typename T>
+struct SfmSketchCardinality {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<SfmSketch>* /*input*/) {
+    pool_ = memory::memoryManager()->addLeafPool();
+    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<SfmSketch>& input) {
+    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+    result = SfmSketch::deserialize(
+                 reinterpret_cast<const char*>(input.data()), allocator_.get())
+                 .cardinality();
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> allocator_;
+};
+
+template <typename T>
+struct NoisyEmptyApproxSetSfm {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const double* /*epsilon*/,
+      const int64_t* /*buckets*/ = nullptr,
+      const int64_t* /*precision*/ = nullptr) {
+    pool_ = memory::memoryManager()->addLeafPool();
+    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon) {
+    auto serialized = createEmptySfmSketch(allocator_.get(), epsilon);
+    result.resize(serialized.size());
+    // SfmSketch is a binary type, so we can just copy the serialized data.
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon,
+      const int64_t& buckets) {
+    auto serialized = createEmptySfmSketch(allocator_.get(), epsilon, buckets);
+    result.resize(serialized.size());
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<SfmSketch>& result,
+      const double& epsilon,
+      const int64_t& buckets,
+      const int64_t& precision) {
+    auto serialized =
+        createEmptySfmSketch(allocator_.get(), epsilon, buckets, precision);
+    result.resize(serialized.size());
+    memcpy(result.data(), serialized.data(), serialized.size());
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> allocator_;
+};
+
+template <typename T>
+struct mergeSfmSketchArray {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& config,
+      const arg_type<Array<SfmSketch>>* /*input*/) {
+    pool_ = memory::memoryManager()->addLeafPool();
+    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<SfmSketch>& result,
+      const arg_type<Array<SfmSketch>>& input) {
+    if (input.size() == 0) {
+      return false;
+    }
+
+    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+
+    // Collect all non-null sketches.
+    std::vector<const char*> validSketches;
+    for (auto i = 0; i < input.size(); ++i) {
+      if (input[i].has_value()) {
+        const auto& value = input[i].value();
+        validSketches.push_back(reinterpret_cast<const char*>(value.data()));
+      }
+    }
+
+    if (validSketches.empty()) {
+      return false;
+    }
+
+    auto mergedSketch =
+        SfmSketch::deserialize(validSketches[0], allocator_.get());
+
+    for (size_t i = 1; i < validSketches.size(); ++i) {
+      mergedSketch.mergeWith(
+          SfmSketch::deserialize(validSketches[i], allocator_.get()));
+    }
+
+    // Serialize the merged sketch back to result.
+    auto serializedSize = mergedSketch.serializedSize();
+    result.resize(serializedSize);
+    mergedSketch.serialize(result.data());
+
+    return true;
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> allocator_;
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -86,4 +86,6 @@ const char* const kMaxSizeForStats = "max_data_size_for_stats";
 const char* const kSumDataSizeForStats = "sum_data_size_for_stats";
 const char* const kNoisyApproxSetSfm = "noisy_approx_set_sfm";
 const char* const kNoisyApproxDistinctSfm = "noisy_approx_distinct_sfm";
+const char* const kNoisyApproxSetSfmFromIndexAndZeros =
+    "noisy_approx_set_sfm_from_index_and_zeros";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.cpp
@@ -87,6 +87,13 @@ void SfmSketchAccumulator::mergeWith(SfmSketchAccumulator& other) {
   sketch_.mergeWith(other.sketch_);
 }
 
+void SfmSketchAccumulator::addIndexAndZeros(
+    int32_t bucketIndex,
+    int32_t zeros) {
+  VELOX_CHECK(isInitialized(), "Sketch is not set");
+  sketch_.addIndexAndZeros(bucketIndex, zeros);
+}
+
 int64_t SfmSketchAccumulator::cardinality() {
   VELOX_CHECK(
       isInitialized(), "Cardinality is not available for empty sketch.");

--- a/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h
@@ -72,6 +72,9 @@ class SfmSketchAccumulator {
     sketch_.add(value);
   }
 
+  // Add a value to the sketch through index and zeros.
+  void addIndexAndZeros(int32_t bucketIndex, int32_t zeros);
+
   // Merge with another accumulator.
   void mergeWith(SfmSketchAccumulator& other);
 

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -151,6 +151,7 @@ int main(int argc, char** argv) {
       // Skip non-deterministic functions.
       "noisy_approx_set_sfm",
       "noisy_approx_distinct_sfm",
+      "noisy_approx_set_sfm_from_index_and_zeros",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -130,6 +130,7 @@ int main(int argc, char** argv) {
       "noisy_sum_gaussian",
       "noisy_approx_set_sfm",
       "noisy_approx_distinct_sfm",
+      "noisy_approx_set_sfm_from_index_and_zeros",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
   };

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   MathematicalOperatorsRegistration.cpp
   ProbabilityTrigonometricFunctionsRegistration.cpp
   RegistrationFunctions.cpp
+  SfmSketchFunctionsRegistration.cpp
   StringFunctionsRegistration.cpp
   TDigestFunctionsRegistration.cpp
   QDigestFunctionsRegistration.cpp
@@ -53,8 +54,12 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND NOT VELOX_MONO_LIBRARY)
                          PRIVATE -Wno-deprecated-declarations)
 endif()
 
-velox_link_libraries(velox_functions_prestosql velox_functions_prestosql_impl
-                     velox_is_null_functions simdjson::simdjson)
+velox_link_libraries(
+  velox_functions_prestosql
+  velox_functions_prestosql_impl
+  velox_is_null_functions
+  velox_functions_prestosql_aggregates_sfm
+  simdjson::simdjson)
 
 if(NOT VELOX_MONO_LIBRARY)
   set_property(TARGET velox_functions_prestosql PROPERTY JOB_POOL_COMPILE

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -31,6 +31,7 @@ extern void registerGeneralFunctions(const std::string& prefix);
 extern void registerHyperLogFunctions(const std::string& prefix);
 extern void registerTDigestFunctions(const std::string& prefix);
 extern void registerQDigestFunctions(const std::string& prefix);
+extern void registerSfmSketchFunctions(const std::string& prefix);
 extern void registerIntegerFunctions(const std::string& prefix);
 extern void registerFloatingPointFunctions(const std::string& prefix);
 extern void registerJsonFunctions(const std::string& prefix);
@@ -85,6 +86,10 @@ void registerQDigestFunctions(const std::string& prefix) {
   functions::registerQDigestFunctions(prefix);
 }
 
+void registerSfmSketchFunctions(const std::string& prefix) {
+  functions::registerSfmSketchFunctions(prefix);
+}
+
 void registerIntegerFunctions(const std::string& prefix) {
   functions::registerIntegerFunctions(prefix);
 }
@@ -135,6 +140,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerHyperLogFunctions(prefix);
   registerTDigestFunctions(prefix);
   registerQDigestFunctions(prefix);
+  registerSfmSketchFunctions(prefix);
   registerIntegerFunctions(prefix);
   registerFloatingPointFunctions(prefix);
   registerBingTileFunctions(prefix);

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -37,6 +37,8 @@ void registerTDigestFunctions(const std::string& prefix = "");
 
 void registerQDigestFunctions(const std::string& prefix = "");
 
+void registerSfmSketchFunctions(const std::string& prefix = "");
+
 void registerBingTileFunctions(const std::string& prefix = "");
 
 void registerGeneralFunctions(const std::string& prefix = "");

--- a/velox/functions/prestosql/registration/SfmSketchFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/SfmSketchFunctionsRegistration.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/SfmSketchFunctions.h"
+#include "velox/functions/prestosql/types/SfmSketchRegistration.h"
+
+namespace facebook::velox::functions {
+
+void registerSfmSketchFunctions(const std::string& prefix) {
+  registerSfmSketchType();
+
+  registerFunction<SfmSketchCardinality, int64_t, SfmSketch>(
+      {prefix + "cardinality"});
+
+  registerFunction<NoisyEmptyApproxSetSfm, SfmSketch, Constant<double>>(
+      {prefix + "noisy_empty_approx_set_sfm"});
+  registerFunction<
+      NoisyEmptyApproxSetSfm,
+      SfmSketch,
+      Constant<double>,
+      Constant<int64_t>>({prefix + "noisy_empty_approx_set_sfm"});
+  registerFunction<
+      NoisyEmptyApproxSetSfm,
+      SfmSketch,
+      Constant<double>,
+      Constant<int64_t>,
+      Constant<int64_t>>({prefix + "noisy_empty_approx_set_sfm"});
+
+  registerFunction<mergeSfmSketchArray, SfmSketch, Array<SfmSketch>>(
+      {prefix + "merge_sfm"});
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -98,6 +98,7 @@ add_executable(
   RoundTest.cpp
   ScalarFunctionRegTest.cpp
   SequenceTest.cpp
+  SfmSketchFunctionsTest.cpp
   SimpleComparisonMatcherTest.cpp
   SliceTest.cpp
   SplitTest.cpp

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -55,7 +55,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {
   auto signatures = getSignatureStrings("cardinality");
-  ASSERT_EQ(3, signatures.size());
+  ASSERT_LE(3, signatures.size());
 
   ASSERT_EQ(1, signatures.count("(map(__user_T1,__user_T2)) -> bigint"));
   ASSERT_EQ(1, signatures.count("(array(__user_T1)) -> bigint"));

--- a/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/SfmSketchType.h"
+
+namespace facebook::velox::functions::test {
+using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+
+class SfmSketchFunctionsTest : public functions::test::FunctionBaseTest {
+ protected:
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator allocator_{pool_.get()};
+};
+
+TEST_F(SfmSketchFunctionsTest, cardinalityTest) {
+  const auto cardinality = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), input);
+  };
+
+  // Test empty sketch.
+  SfmSketch sketch{&allocator_, /* seed */ 1};
+  sketch.initialize(4096, 24);
+
+  const auto serializedSize = sketch.serializedSize();
+
+  std::vector<char> buffer(serializedSize);
+  sketch.serialize(buffer.data());
+  std::string serializedEmpty(buffer.begin(), buffer.end());
+  EXPECT_EQ(*cardinality(serializedEmpty), 0);
+
+  // Add distinct elements
+  const int64_t numElements = 100'000;
+  for (auto i = 0; i < numElements; i++) {
+    sketch.add(i);
+  }
+  // Add noise to the sketch.
+  sketch.enablePrivacy(8.0);
+
+  std::vector<char> buffer2(sketch.serializedSize());
+  sketch.serialize(buffer2.data());
+  std::string serialized2(buffer2.begin(), buffer2.end());
+  const auto result = cardinality(serialized2);
+
+  // SfmSketch is an approximate algorithm, typically we allow 25% error.
+  // In the unit test, we are using deterministic seed.
+  EXPECT_EQ(*result, 100'305);
+}
+
+TEST_F(SfmSketchFunctionsTest, cardinalityWithDuplicates) {
+  const auto cardinality = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), input);
+  };
+
+  SfmSketch sketch{&allocator_, 1};
+  sketch.initialize(4096, 24);
+
+  for (int i = 0; i < 100000; i++) {
+    sketch.add(i % 100);
+  }
+
+  std::string buffer(sketch.serializedSize(), '\0');
+  sketch.serialize(buffer.data());
+  const auto result = cardinality(buffer);
+
+  EXPECT_EQ(*result, 99);
+}
+
+TEST_F(SfmSketchFunctionsTest, noisyEmptyApproxSetSfm) {
+  // Test with epsilon only.
+  auto a = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY()))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*a, 0);
+
+  // Test with epsilon and buckets.
+  auto b = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY(), 1024))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*b, 0);
+
+  // Test with epsilon, buckets, and precision.
+  auto c = evaluateOnce<int64_t>(
+      "cardinality(noisy_empty_approx_set_sfm(INFINITY(), 1024, 20))",
+      makeRowVector(ROW({}), 1));
+  ASSERT_EQ(*c, 0);
+}
+
+TEST_F(SfmSketchFunctionsTest, mergeSfmSketchArray) {
+  // Create two sketches with overlapping elements.
+  SfmSketch a{&allocator_};
+  a.initialize(4096, 24);
+  for (int i = 0; i < 50; i++) {
+    a.add(i);
+  }
+
+  SfmSketch b{&allocator_};
+  b.initialize(4096, 24);
+  for (int i = 25; i < 75; i++) {
+    b.add(i);
+  }
+
+  std::string aString(a.serializedSize(), '\0');
+  a.serialize(aString.data());
+
+  std::string bString(b.serializedSize(), '\0');
+  b.serialize(bString.data());
+
+  // Test merging array of sketches.
+  const auto mergedResult = evaluateOnce<std::string>(
+      "merge_sfm(c0)",
+      makeRowVector(
+          {makeArrayVector<std::string>({{aString, bString}}, SFMSKETCH())}));
+
+  const auto mergedCardinality =
+      evaluateOnce<int64_t>("cardinality(c0)", SFMSKETCH(), mergedResult);
+
+  // There are 75 distinct elements in the sketch.
+  ASSERT_EQ(mergedCardinality, 75);
+}
+
+TEST_F(SfmSketchFunctionsTest, mergeSfmSketchEmpty) {
+  // Test merging empty array should return null.
+  const auto result = evaluate(
+      "merge_sfm(c0)",
+      makeRowVector({makeArrayVector<std::string>({}, SFMSKETCH())}));
+
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(SfmSketchFunctionsTest, cardinalityNull) {
+  // Test cardinality with null input.
+  const auto result = evaluate(
+      "cardinality(c0)",
+      makeRowVector(
+          {makeNullableFlatVector<std::string>({std::nullopt}, SFMSKETCH())}));
+
+  EXPECT_TRUE(result->isNullAt(0));
+}
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -20,7 +20,8 @@ velox_link_libraries(
   velox_type
   velox_common_fuzzer_util
   velox_presto_types
-  velox_type_tz)
+  velox_type_tz
+  velox_functions_prestosql_aggregates_sfm)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_executable(
   velox_presto_types_fuzzer_utils_test
-  TimestampWithTimeZoneInputGeneratorTest.cpp HyperLogLogInputGeneratorTest.cpp)
+  TimestampWithTimeZoneInputGeneratorTest.cpp HyperLogLogInputGeneratorTest.cpp
+  SfmSketchInputGeneratorTest.cpp)
 
 add_test(velox_presto_types_fuzzer_utils_test
          velox_presto_types_fuzzer_utils_test)


### PR DESCRIPTION
Summary: Add a new function to Velox. The function is used to return a SfmSketch set by adding items from bucket_index and trailing zeros.

Differential Revision: D78391518
