### PR TITLE
feat(type): Add BigintEnum type in Velox

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -176,6 +176,7 @@ IPPREFIX                  ROW(HUGEINT,TINYINT)
 GEOMETRY                  VARBINARY
 TDIGEST                   VARBINARY
 QDIGEST                   VARBINARY
+BIGINT_ENUM               BIGINT
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
@@ -222,6 +223,14 @@ data for a given input set, and can be queried to retrieve approximate quantile 
 distribution. They may be merged without losing precision, and for storage and retrieval they may
 be cast to/from VARBINARY. The parameter type (BIGINT, REAL, or DOUBLE) represents
 the set of numbers that may be ingested by the quantile digest.
+
+BIGINT_ENUM([TypeParameters]) type represents an enumerated value where the physical type is BIGINT.
+It takes a vector of TypeParameters as input. This vector should have 2 stringLiteral TypeParameter elements:
+a name and a mapping. The name is the name of the enum type. The mapping is a json string a mapping of
+string keys to BIGINT values
+Casting is permitted between the same enum types or between an enum type and integer types.
+Casting between different enum types is not permitted.
+Comparison operations are only allowed between values of the same enum type.
 
 Spark Types
 ~~~~~~~~~~~~

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -930,7 +930,8 @@ CastOperatorPtr CastExpr::getCastOperator(const TypePtr& type) {
     return it->second;
   }
 
-  auto castOperator = getCustomTypeCastOperator(key);
+  auto typeParameters = type->parameters();
+  auto castOperator = getCustomTypeCastOperator(key, typeParameters);
   if (castOperator == nullptr) {
     return nullptr;
   }

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -261,6 +261,8 @@ bool SignatureBinderBase::tryBind(
           return false;
         }
         break;
+      case TypeParameterKind::kStringLiteral:
+        break;
       case TypeParameterKind::kType:
         if (!checkNamedRowField(params[i], actualType, i)) {
           return false;

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -61,7 +61,9 @@ class TypeFactories : public CustomTypeFactories {
     return type_;
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return nullptr;
   }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2874,7 +2874,8 @@ class BigintTypeWithCustomComparisonTypeFactories : public CustomTypeFactories {
   }
 
   // Type casting from and to TimestampWithTimezone is not supported yet.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
     return BigintTypeWithCustomComparisonCastOperator::get();
   }
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -60,7 +60,8 @@ class FancyIntTypeFactories : public CustomTypeFactories {
     return FancyIntType::get();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
     VELOX_UNSUPPORTED();
   }
 
@@ -151,7 +152,8 @@ class AlwaysFailingTypeFactories : public CustomTypeFactories {
     VELOX_UNSUPPORTED();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
     VELOX_UNSUPPORTED();
   }
 
@@ -233,7 +235,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "BINGTILE",
           "TDIGEST",
           "QDIGEST",
-          "GEOMETRY"}),
+          "GEOMETRY",
+          "BIGINT_ENUM"}),
       names);
 
   ASSERT_TRUE(registerCustomType(
@@ -252,7 +255,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
           "FANCY_INT",
           "TDIGEST",
           "QDIGEST",
-          "GEOMETRY"}),
+          "GEOMETRY",
+          "BIGINT_ENUM"}),
       names);
 
   ASSERT_TRUE(unregisterCustomType("fancy_int"));
@@ -284,6 +288,12 @@ TEST_F(CustomTypeTest, nullConstant) {
         checkNullConstant(
             type, fmt::format("QDIGEST({})", parameter->toString()));
       }
+    } else if (name == "BIGINT_ENUM") {
+      auto enumName = "test.enum.mood";
+      auto enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+      auto typeParameters = {TypeParameter(enumName), TypeParameter(enumMap)};
+      auto type = getCustomType(name, typeParameters);
+      checkNullConstant(type, type->toString());
     } else {
       auto type = getCustomType(name, {});
       checkNullConstant(type, type->toString());

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
@@ -59,7 +60,11 @@ std::string typeName(const TypePtr& type) {
       if (isBingTileType(type)) {
         return "bingtile";
       }
+      if (isBigintEnumType(type)) {
+        return (dynamic_pointer_cast<const BigintEnumType>(type))->enumName();
+      }
       return "bigint";
+
     case TypeKind::HUGEINT: {
       if (isUuidType(type)) {
         return "uuid";

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include "velox/functions/prestosql/IPAddressFunctions.h"
 #include "velox/functions/prestosql/UuidFunctions.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
 
 namespace facebook::velox::functions {
 
@@ -126,6 +127,7 @@ void registerBitwiseFunctions(const std::string& prefix) {
 }
 
 void registerAllScalarFunctions(const std::string& prefix) {
+  registerBigintEnumType();
   registerArithmeticFunctions(prefix);
   registerCheckedArithmeticFunctions(prefix);
   registerComparisonFunctions(prefix);

--- a/velox/functions/prestosql/tests/BigintEnumCastTest.cpp
+++ b/velox/functions/prestosql/tests/BigintEnumCastTest.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+
+class BigintEnumCastTest : public functions::test::CastBaseTest {
+ protected:
+  BigintEnumCastTest() {
+    registerBigintEnumType();
+  }
+};
+
+TEST_F(BigintEnumCastTest, ToBigintEnum) {
+  auto enumName = "test.enum.mood";
+  auto enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+  auto typeParameters = {TypeParameter(enumName), TypeParameter(enumMap)};
+
+  // Cast base type to enum type
+  testCast<int64_t, int64_t>(
+      BIGINT(),
+      BIGINT_ENUM(typeParameters),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast TINYINT to enum type
+  testCast<int8_t, int64_t>(
+      TINYINT(),
+      BIGINT_ENUM(typeParameters),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast SMALLINT to enum type
+  testCast<int16_t, int64_t>(
+      SMALLINT(),
+      BIGINT_ENUM(typeParameters),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast INTEGER to enum type
+  testCast<int32_t, int64_t>(
+      INTEGER(),
+      BIGINT_ENUM(typeParameters),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast enum type to same enum type
+  testCast<int64_t, int64_t>(
+      BIGINT_ENUM(typeParameters),
+      BIGINT_ENUM(typeParameters),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast base type to enum type where the value does not exist in the enum
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BIGINT(),
+          BIGINT_ENUM(typeParameters),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, BIGINT())})),
+      "No value '1' in test.enum.mood");
+
+  // Cast enum type to different enum type
+  auto enumName2 = "someEnumType";
+  auto enumMap2 = "\"CURIOUSs\": -2, \"HAPPY\": 3";
+  auto typeParameters2 = {TypeParameter(enumName2), TypeParameter(enumMap2)};
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BIGINT_ENUM(typeParameters),
+          BIGINT_ENUM(typeParameters2),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, BIGINT_ENUM(typeParameters))})),
+      "Cannot cast test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 0}) to someEnumType:BigintEnum(someEnumType{\"CURIOUSs\": -2, \"HAPPY\": 3}).");
+
+  // Cast enum type to different enum type with same name
+  auto typeParameters3 = {TypeParameter(enumName), TypeParameter(enumMap2)};
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BIGINT_ENUM(typeParameters),
+          BIGINT_ENUM(typeParameters3),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, BIGINT_ENUM(typeParameters))})),
+      "Cannot cast test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 0}) to test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 3})");
+
+  // Cast varchar type to enum type
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          VARCHAR(),
+          BIGINT_ENUM(typeParameters),
+          makeRowVector({makeNullableFlatVector<StringView>(
+              {"a"_sv, "b"_sv, std::nullopt})})),
+      "Cannot cast VARCHAR to test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 0}).");
+}
+
+TEST_F(BigintEnumCastTest, FromBigintEnum) {
+  auto enumName = "test.enum.mood";
+  auto enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+  auto typeParameters = {TypeParameter(enumName), TypeParameter(enumMap)};
+  // Cast enum type to base type
+  testCast<int64_t, int64_t>(
+      BIGINT_ENUM(typeParameters),
+      BIGINT(),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast enum type to TINYINT
+  testCast<int64_t, int8_t>(
+      BIGINT_ENUM(typeParameters),
+      TINYINT(),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast enum type to SMALLINT
+  testCast<int64_t, int8_t>(
+      BIGINT_ENUM(typeParameters),
+      TINYINT(),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast enum type to INTEGER
+  testCast<int64_t, int8_t>(
+      BIGINT_ENUM(typeParameters),
+      TINYINT(),
+      {0, -2, std::nullopt},
+      {0, -2, std::nullopt});
+
+  // Cast enum type to varchar type
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BIGINT_ENUM(typeParameters),
+          VARCHAR(),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, BIGINT())})),
+      "Cannot cast test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 0}) to VARCHAR.");
+}

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
@@ -68,6 +69,16 @@ TEST_F(TypeOfTest, basic) {
   EXPECT_EQ("qdigest(bigint)", typeOf(QDIGEST(BIGINT())));
   EXPECT_EQ("qdigest(real)", typeOf(QDIGEST(REAL())));
   EXPECT_EQ("qdigest(double)", typeOf(QDIGEST(DOUBLE())));
+
+  std::string enumName = "test.enum.mood";
+  std::string enumName2 = "someEnumType";
+  std::string enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+  const std::vector<TypeParameter>& typeParameters = {
+      TypeParameter(enumName), TypeParameter(enumMap)};
+  const std::vector<TypeParameter>& typeParameters2 = {
+      TypeParameter(enumName2), TypeParameter(enumMap)};
+  EXPECT_EQ("test.enum.mood", typeOf(BIGINT_ENUM(typeParameters)));
+  EXPECT_EQ("someEnumType", typeOf(BIGINT_ENUM(typeParameters2)));
 
   EXPECT_EQ("unknown", typeOf(UNKNOWN()));
 

--- a/velox/functions/prestosql/types/BigintEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+namespace facebook::velox {
+namespace {
+class BigintEnumCastOperator : public exec::CastOperator {
+ public:
+  explicit BigintEnumCastOperator(
+      std::shared_ptr<const BigintEnumType> bigintEnum)
+      : bigintEnum_(bigintEnum) {}
+
+  bool isSupportedFromType(const TypePtr& other) const override {
+    return isCompatibleWith(other);
+  }
+
+  bool isSupportedToType(const TypePtr& other) const override {
+    return isCompatibleWith(other);
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    switch (input.typeKind()) {
+      case TypeKind::TINYINT:
+        castFromType<int8_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::SMALLINT:
+        castFromType<int16_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::INTEGER:
+        castFromType<int32_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::BIGINT:
+        castFromType<int64_t>(input, context, rows, resultType, result);
+        break;
+      default:
+        VELOX_UNREACHABLE("Unsupported type: {}", input.type()->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    switch (resultType->kind()) {
+      case TypeKind::TINYINT:
+        castToType<int8_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::SMALLINT:
+        castToType<int16_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::INTEGER:
+        castToType<int32_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::BIGINT:
+        castToType<int64_t>(input, context, rows, resultType, result);
+        break;
+      default:
+        VELOX_UNREACHABLE("Unsupported type: {}", input.type()->toString());
+    }
+  }
+
+ private:
+  // Cast is supported for all integer types.
+  // Casting to and from a different BigintEnumType is not supported
+  bool isCompatibleWith(const TypePtr& other) const {
+    return BIGINT()->equivalent(*other) || TINYINT()->equivalent(*other) ||
+        SMALLINT()->equivalent(*other) || INTEGER()->equivalent(*other) ||
+        bigintEnum_->equivalent(*other);
+  }
+
+  template <typename T>
+  void castToType(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<T>>();
+    const auto* enumInts = input.as<SimpleVector<int64_t>>();
+    flatResult->clearNulls(rows);
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      int64_t value = enumInts->valueAt(row);
+      if (value < std::numeric_limits<T>::min() ||
+          value > std::numeric_limits<T>::max()) {
+        context.setStatus(
+            row,
+            Status::UserError(
+                "Value '{}' out of range for {}",
+                value,
+                resultType->toString()));
+        return;
+      }
+      flatResult->set(row, static_cast<T>(value));
+    });
+  }
+
+  template <typename T>
+  void castFromType(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<int64_t>>();
+    const auto* intVector = input.as<SimpleVector<T>>();
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const int64_t intToCast = intVector->valueAt(row);
+      if (!bigintEnum_->containsValue(intToCast)) {
+        context.setStatus(
+            row,
+            Status::UserError(
+                "No value '{}' in {}", intToCast, bigintEnum_->enumName()));
+        return;
+      }
+      flatResult->set(row, intToCast);
+    });
+  }
+
+  const std::shared_ptr<const BigintEnumType> bigintEnum_;
+};
+
+class BigintEnumTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK_EQ(parameters.size(), 2);
+    return BIGINT_ENUM(parameters);
+  }
+
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK_EQ(parameters.size(), 2);
+
+    auto bigintEnum = BIGINT_ENUM(parameters);
+    return std::make_shared<BigintEnumCastOperator>(bigintEnum);
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+} // namespace
+
+void registerBigintEnumType() {
+  registerCustomType(
+      "BIGINT_ENUM", std::make_unique<const BigintEnumTypeFactories>());
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumRegistration.h
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+void registerBigintEnumType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumType.cpp
+++ b/velox/functions/prestosql/types/BigintEnumType.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <mutex>
+
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+namespace facebook::velox {
+const std::shared_ptr<const BigintEnumType>& BigintEnumType::get(
+    const std::vector<TypeParameter>& typeParameters) {
+  VELOX_CHECK_EQ(typeParameters.size(), 2);
+  VELOX_CHECK(typeParameters[0].stringLiteral.has_value());
+  VELOX_CHECK(typeParameters[1].stringLiteral.has_value());
+
+  auto name = typeParameters[0].stringLiteral.value();
+  auto mapString = typeParameters[1].stringLiteral.value();
+  auto mapKey = name + mapString;
+
+  const int maxCacheSize = 1000;
+  static folly::
+      EvictingCacheMap<std::string, std::shared_ptr<const BigintEnumType>>
+          typeCache(maxCacheSize);
+  static std::mutex cacheMutex;
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    if (typeCache.exists(mapKey)) {
+      return typeCache.get(mapKey);
+    }
+  }
+  static std::shared_ptr<const BigintEnumType> bigintInstance;
+  bigintInstance =
+      std::shared_ptr<const BigintEnumType>(new BigintEnumType(typeParameters));
+  {
+    std::lock_guard<std::mutex> lock(cacheMutex);
+    typeCache.insert(mapKey, bigintInstance);
+  }
+  return bigintInstance;
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumType.h
+++ b/velox/functions/prestosql/types/BigintEnumType.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/EvictingCacheMap.h>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class BigintEnumType : public BigintType {
+ public:
+  static const std::shared_ptr<const BigintEnumType>& get(
+      const std::vector<TypeParameter>& typeParameters);
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "BIGINT_ENUM";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    return parameters_;
+  }
+
+  std::string toString() const override {
+    return fmt::format(
+        "{}:BigintEnum({}{{{}}})",
+        parameters_[0].stringLiteral.value(),
+        parameters_[0].stringLiteral.value(),
+        parameters_[1].stringLiteral.value());
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "Type";
+    obj["type"] = name();
+    std::vector<std::string> stringParams;
+    stringParams.reserve(parameters_.size());
+    for (auto& param : parameters_) {
+      stringParams.push_back(param.stringLiteral.value());
+    }
+    obj["stringParams"] = velox::ISerializable::serialize(stringParams);
+
+    return obj;
+  }
+
+  bool containsValue(const int64_t& value) const {
+    return std::any_of(
+        valuesObj_.items().begin(),
+        valuesObj_.items().end(),
+        [value](const auto& pair) { return pair.second == value; });
+  }
+
+  const std::string& enumName() const {
+    return parameters_[0].stringLiteral.value();
+  }
+
+ private:
+  BigintEnumType(const std::vector<TypeParameter>& typeParameters)
+      : parameters_{typeParameters} {
+    VELOX_CHECK_EQ(typeParameters.size(), 2);
+    VELOX_CHECK(typeParameters[0].stringLiteral.has_value());
+    VELOX_CHECK(typeParameters[1].stringLiteral.has_value());
+    try {
+      valuesObj_ =
+          folly::parseJson("{" + typeParameters[1].stringLiteral.value() + "}");
+    } catch (const std::runtime_error& e) {
+      VELOX_FAIL(
+          "Failed to parse enum values {}, {}",
+          typeParameters[1].stringLiteral.value(),
+          e.what());
+    }
+  }
+
+  const std::vector<TypeParameter> parameters_;
+  folly::dynamic valuesObj_;
+};
+
+inline std::shared_ptr<const BigintEnumType> BIGINT_ENUM(
+    const std::vector<TypeParameter>& typeParameters) {
+  return BigintEnumType::get(typeParameters);
+}
+
+FOLLY_ALWAYS_INLINE bool isBigintEnumType(const TypePtr& type) {
+  if (type->parameters().size() != 2) {
+    return false;
+  }
+  return BigintEnumType::get(type->parameters()) == type;
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -126,7 +126,9 @@ class BingTileTypeFactories : public CustomTypeFactories {
     return BINGTILE();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return BingTileCastOperator::get();
   }
 

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -13,6 +13,8 @@
 # limitations under the License.
 velox_add_library(
   velox_presto_types
+  BigintEnumRegistration.cpp
+  BigintEnumType.cpp
   BingTileRegistration.cpp
   BingTileType.cpp
   GeometryRegistration.cpp

--- a/velox/functions/prestosql/types/GeometryRegistration.cpp
+++ b/velox/functions/prestosql/types/GeometryRegistration.cpp
@@ -29,7 +29,9 @@ class GeometryTypeFactories : public CustomTypeFactories {
     return GEOMETRY();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
@@ -30,7 +30,9 @@ class HyperLogLogTypeFactories : public CustomTypeFactories {
   }
 
   // HyperLogLog should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -265,7 +265,9 @@ class IPAddressTypeFactories : public CustomTypeFactories {
     return IPADDRESS();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return std::make_shared<IPAddressCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -190,7 +190,9 @@ class IPPrefixTypeFactories : public CustomTypeFactories {
     return IPPrefixType::get();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return std::make_shared<IPPrefixCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/JsonRegistration.cpp
+++ b/velox/functions/prestosql/types/JsonRegistration.cpp
@@ -32,7 +32,9 @@ class JsonTypeFactories : public CustomTypeFactories {
     return JSON();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return std::make_shared<JsonCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/QDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/QDigestRegistration.cpp
@@ -29,7 +29,8 @@ class QDigestTypeFactories : public CustomTypeFactories {
   }
 
   // QDigest should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& /*parameters*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/SfmSketchRegistration.cpp
+++ b/velox/functions/prestosql/types/SfmSketchRegistration.cpp
@@ -30,7 +30,9 @@ class SfmSketchTypeFactories : public CustomTypeFactories {
 
   // SfmSketch supports casting and should be treated as Varbinary during type
   // casting.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/TDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/TDigestRegistration.cpp
@@ -30,7 +30,8 @@ class TDigestTypeFactories : public CustomTypeFactories {
   }
 
   // TDigest should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& /*parameters*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -283,7 +283,9 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
   }
 
   // Type casting from and to TimestampWithTimezone is not supported yet.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return TimestampWithTimeZoneCastOperator::get();
   }
 

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -189,7 +189,9 @@ class UuidTypeFactories : public CustomTypeFactories {
     return UUID();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK(parameters.empty());
     return std::make_shared<UuidCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox::test {
+
+class BigintEnumTypeTest : public testing::Test, public TypeTestBase {
+ protected:
+  BigintEnumTypeTest() {
+    registerBigintEnumType();
+  }
+};
+
+TEST_F(BigintEnumTypeTest, basic) {
+  std::string enumName = "test.enum.mood";
+  std::string enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+  std::string enumName2 = "someEnumType";
+  std::string enumMap2 = "\"CURIOUSs\": -2, \"HAPPY\": 3";
+  const std::vector<TypeParameter>& typeParameters = {
+      TypeParameter(enumName), TypeParameter(enumMap)};
+  const std::vector<TypeParameter>& typeParameters2 = {
+      TypeParameter(enumName2), TypeParameter(enumMap)};
+  ASSERT_STREQ(BIGINT_ENUM(typeParameters)->name(), "BIGINT_ENUM");
+  ASSERT_STREQ(BIGINT_ENUM(typeParameters)->kindName(), "BIGINT");
+  ASSERT_EQ(BIGINT_ENUM(typeParameters)->enumName(), "test.enum.mood");
+  ASSERT_EQ(BIGINT_ENUM(typeParameters)->parameters().size(), 2);
+  ASSERT_EQ(
+      BIGINT_ENUM(typeParameters)->toString(),
+      "test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUSs\": -2, \"HAPPY\": 0})");
+
+  ASSERT_TRUE(hasType("BIGINT_ENUM"));
+  ASSERT_EQ(
+      getType("BIGINT_ENUM", {TypeParameter(enumName), TypeParameter(enumMap)}),
+      BIGINT_ENUM(typeParameters));
+}
+
+TEST_F(BigintEnumTypeTest, serde) {
+  std::string enumName = "test.enum.mood";
+  std::string enumMap = "\"CURIOUSs\": -2, \"HAPPY\": 0";
+  const std::vector<TypeParameter>& typeParameters = {
+      TypeParameter(enumName), TypeParameter(enumMap)};
+  testTypeSerde(BIGINT_ENUM(typeParameters));
+}
+
+TEST_F(BigintEnumTypeTest, parse) {
+  // Missing quotations around key
+  std::string enumName = "test.enum.mood";
+  std::string invalidJsonMap = "CURIOUS: -2, HAPPY: 0";
+  const std::vector<TypeParameter>& typeParameters = {
+      TypeParameter(enumName), TypeParameter(invalidJsonMap)};
+  VELOX_ASSERT_THROW(
+      BIGINT_ENUM(typeParameters),
+      "Failed to parse enum values CURIOUS: -2, HAPPY: 0, json parse error on line 0 near `CURIOUS: -2, HAP': expected json value");
+
+  // Missing value
+  std::string invalidJsonMap2 = "\"CURIOUSs\": -2, \"HAPPY\"";
+  const std::vector<TypeParameter>& typeParameters2 = {
+      TypeParameter(enumName), TypeParameter(invalidJsonMap2)};
+  VELOX_ASSERT_THROW(
+      BIGINT_ENUM(typeParameters2),
+      "Failed to parse enum values \"CURIOUSs\": -2, \"HAPPY\", json parse error on line 0 near `}': expected ':'");
+
+  // Trailing comma
+  std::string invalidJsonMap3 = "\"CURIOUSs\": -2, \"HAPPY\": 0,";
+  const std::vector<TypeParameter>& typeParameters3 = {
+      TypeParameter(enumName), TypeParameter(invalidJsonMap3)};
+  VELOX_ASSERT_THROW(
+      BIGINT_ENUM(typeParameters3),
+      "Failed to parse enum values \"CURIOUSs\": -2, \"HAPPY\": 0,, json parse error on line 0 near `}': expected json value");
+}
+
+} // namespace facebook::velox::test

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -97,7 +97,9 @@ class OpaqueCustomTypeRegister {
       return singletonTypePtr();
     }
 
-    exec::CastOperatorPtr getCastOperator() const override {
+    exec::CastOperatorPtr getCastOperator(
+        const std::vector<TypeParameter>& parameters) const override {
+      VELOX_CHECK(parameters.empty());
       VELOX_UNSUPPORTED();
     }
 

--- a/velox/type/parser/ParserUtil.cpp
+++ b/velox/type/parser/ParserUtil.cpp
@@ -65,4 +65,18 @@ std::pair<std::string, std::shared_ptr<const Type>> inferTypeWithSpaces(
       fieldName, typeFromString(allWords.substr(fieldName.size() + 1)));
 }
 
+TypePtr getEnumType(
+    std::string enumType,
+    const std::string& name,
+    const std::string& map) {
+  std::vector<TypeParameter> params;
+  params.emplace_back(TypeParameter(name));
+  params.emplace_back(TypeParameter(map));
+  if (enumType == "BigintEnum") {
+    enumType = "BIGINT_ENUM";
+  }
+  auto type = getType(enumType, params);
+
+  return type;
+}
 } // namespace facebook::velox

--- a/velox/type/parser/ParserUtil.h
+++ b/velox/type/parser/ParserUtil.h
@@ -31,6 +31,11 @@ TypePtr customTypeWithChildren(
     const std::string& name,
     const std::vector<TypePtr>& children);
 
+TypePtr getEnumType(
+    std::string name,
+    const std::string& children,
+    const std::string& children2);
+
 /// Convert words with spaces to a Velox type.
 /// First check if all the words are a Velox type.
 /// Then check if the first word is a field name and the remaining words are a

--- a/velox/type/parser/TypeParser.ll
+++ b/velox/type/parser/TypeParser.ll
@@ -1,13 +1,14 @@
 %{
 #include <vector>
 #include <memory>
+#include <map>
 
 #include "velox/type/parser/TypeParser.yy.h"  // @manual
 #include "velox/type/parser/Scanner.h"
 #define YY_DECL int facebook::velox::type::Scanner::lex(facebook::velox::type::Parser::semantic_type *yylval)
 %}
 
-%option c++ noyywrap noyylineno nodefault caseless
+%option c++ noyywrap noyylineno nodefault caseless ecs
 
 A   [A|a]
 B   [B|b]
@@ -36,13 +37,19 @@ Z   [Z|z]
 WORD              ([[:alpha:][:alnum:]_]*)
 QUOTED_ID         (['"']([^"\n]|"")*['"'])
 NUMBER            ([[:digit:]]+)
+SIGNED_INT        (-?[[:digit:]]+)
 VARIABLE          (VARCHAR|VARBINARY)
+WORD_WITH_PERIODS ([[:alpha:]_][[:alnum:]_]*)(\.([[:alpha:]_][[:alnum:]_]*))*
 
 %%
 
 "("                return Parser::token::LPAREN;
 ")"                return Parser::token::RPAREN;
+"{"                return Parser::token::LBRACE;
+"}"                return Parser::token::RBRACE;
 ","                return Parser::token::COMMA;
+"."                return Parser::token::PERIOD;
+":"                return Parser::token::COLON;
 (ARRAY)            return Parser::token::ARRAY;
 (MAP)              return Parser::token::MAP;
 (FUNCTION)         return Parser::token::FUNCTION;
@@ -50,7 +57,9 @@ VARIABLE          (VARCHAR|VARBINARY)
 (ROW)              return Parser::token::ROW;
 {VARIABLE}         yylval->build<std::string>(YYText()); return Parser::token::VARIABLE;
 {NUMBER}           yylval->build<long long>(folly::to<int>(YYText())); return Parser::token::NUMBER;
+{SIGNED_INT}       yylval->build<long long>(folly::to<int>(YYText())); return Parser::token::SIGNED_INT;
 {WORD}             yylval->build<std::string>(YYText()); return Parser::token::WORD;
+{WORD_WITH_PERIODS}             yylval->build<std::string>(YYText()); return Parser::token::WORD_WITH_PERIODS;
 {QUOTED_ID}        yylval->build<std::string>(YYText()); return Parser::token::QUOTED_ID;
 <<EOF>>            return Parser::token::YYEOF;
 .               /* no action on unmatched input */

--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -33,13 +33,13 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION DECIMAL
-%token <std::string> WORD VARIABLE QUOTED_ID
-%token <long long>   NUMBER
+%token               LPAREN RPAREN COMMA PERIOD COLON  ARRAY MAP ROW FUNCTION DECIMAL LBRACE RBRACE NUMBER
+%token <std::string> WORD VARIABLE QUOTED_ID WORD_WITH_PERIODS
+%token <long long>   NUMBER SIGNED_INT
 %token YYEOF         0
 
 %nterm <std::shared_ptr<const Type>> type type_single_word
-%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children
+%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children enum_type
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
 %nterm <std::pair<std::string, std::shared_ptr<const Type>>> named_type
@@ -47,6 +47,8 @@
 %nterm <std::string> field_name
 
 %start type_spec
+
+%type <std::string> enum_name enum_kind enum_map_entry enum_map_entries
 
 %%
 
@@ -69,6 +71,7 @@ special_type : array_type     { $$ = $1; }
              | variable_type  { $$ = $1; }
              | decimal_type   { $$ = $1; }
              | custom_type_with_children { $$ = $1; }
+             | enum_type { $$ = $1; }
 
 /*
  * Types with spaces have at least two words. They are joined in an
@@ -148,6 +151,36 @@ named_type : type_single_word        { $$ = std::make_pair("", $1); }
            | type_with_spaces        { $$ = inferTypeWithSpaces($1, false); }
            | QUOTED_ID type          { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
            ;
+
+/*
+ * Enum types have a format of:
+ * "test.enum.mood:BigintEnum(test.enum.mood{"CURIOUS":2, "HAPPY":0})"
+ * where "test.enum.mood" is the enum name, "BigintEnum" is the enum kind,
+ * and "CURIOUS":2, "HAPPY":0 are the enum values.
+ * These values are passed as parameters to BIGINT_ENUM type.
+ */
+enum_map_entries : enum_map_entry { $$ = $1; }
+            | enum_map_entries COMMA enum_map_entry { $$ = $1 + ", " + $3; }
+            ;
+
+enum_map_entry : QUOTED_ID COLON SIGNED_INT {  $$ = $1 + ": " + std::to_string($3); }
+               | QUOTED_ID COLON NUMBER     {  $$ = $1 + ": " + std::to_string($3); }
+               ;
+
+enum_kind : WORD { if ($1 != "BigintEnum" && $1 != "VarcharEnum" )
+                    {
+                        std::string msg = "Invalid type " + $1 + ", expected BigintEnum or VarcharEnum";
+                        error(msg.c_str());
+                    }
+                $$ = $1; }
+                ;
+
+enum_name : WORD_WITH_PERIODS { $$ = $1; }
+          | WORD { $$ = $1; }
+
+enum_type : enum_name COLON enum_kind LPAREN enum_name LBRACE enum_map_entries RBRACE RPAREN
+          { $$ = getEnumType($3, $1, $7); }
+
 
 %%
 


### PR DESCRIPTION
Summary:
Adding BigintEnum type as a parametric type in Velox. This type will get registered once with name "BigintEnum", but the BIGINT_ENUM type takes in a std::vector<TypeParameters> which contain the enum name and values name both as string literals. This way, each different enum type can be instantiated separate from the other enums with a different name and map. The values map is parsed in the constructor of BigintEnumType and stored as a folly::dynamic.

Instances are stored in a static folly EvictingCacheMap with a set max size. (Not sure what a good max size number would be)

Enum Cast Operator requires the enum map to check if a given value exists in the values map. So, getCastOperator was also updated to be able to take parameters.

New parsing rules were added to the flex/bison TypeParser to be able to recognize a string in the format of "enum_name:BigintEnum(enum_name{valuesmap})", which matches the way the type is serialized from the Java coordinator.

Remaining TODOs are:
1. SignatureBinder - not sure if kStringLiteral, which was added as a new TypeParameterKind, needs to be resolved here.
2. Add e2e tests.

3. (probably in a separate diff) change all TypeFactories -> TypeFactory

Differential Revision: D78373157
