### PR TITLE
feat: Add Spark char_type_write_side_check function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -25,6 +25,25 @@ String Functions
 
         SELECT bit_length('123'); -- 24
 
+.. spark:function:: char_type_write_side_check(string, limit) -> varchar
+
+    Ensures that input ``string`` fits within the specified length ``limit`` in characters by padding or trimming spaces as needed.
+    If the length of ``string`` is less than ``limit``, it is padded with trailing spaces (ASCII 32) to reach ``limit``.
+    If the length of ``string`` is greater than ``limit``, trailing spaces are trimmed to fit within ``limit``.
+    Throws exception when ``string`` still exceeds ``limit`` after trimming trailing spaces or when ``limit`` is not greater than 0.
+    Note: This function is not directly callable in Spark SQL, but internally used for length check when writing char type columns. ::
+
+        -- Function call examples (this function is not directly callable in Spark SQL).
+        char_type_write_side_check("abc", 3) -- "abc"
+        char_type_write_side_check("ab", 3) -- "ab "
+        char_type_write_side_check("a", 3) -- "a  "
+        char_type_write_side_check("abc  ", 3) -- "abc"
+        char_type_write_side_check("abcd", 3) -- VeloxUserError: "Exceeds allowed length limitation: '3'"
+        char_type_write_side_check("世界", 2) -- "世界"
+        char_type_write_side_check("世", 3) -- "世  "
+        char_type_write_side_check("世界人", 2) -- VeloxUserError: "Exceeds allowed length limitation: '2'"
+        char_type_write_side_check("abc", 0) -- VeloxUserError: "The length limit must be greater than 0."
+
 .. spark:function:: chr(n) -> varchar
 
     Returns the Unicode code point ``n`` as a single character string.
@@ -464,25 +483,6 @@ String Functions
     Returns string with all characters changed to uppercase. ::
 
         SELECT upper('SparkSql'); -- SPARKSQL
-
-.. spark:function:: char_type_write_side_check(string, limit) -> varchar
-
-    Ensures that input ``string`` fits within the specified length ``limit`` in characters by padding or trimming spaces as needed.
-    If the length of ``string`` is less than ``limit``, it is padded with trailing spaces (ASCII 32) to reach ``limit``.
-    If the length of ``string`` is greater than ``limit``, trailing spaces are trimmed to fit within ``limit``.
-    Throws exception when ``string`` still exceeds ``limit`` after trimming trailing spaces or when ``limit`` is not greater than 0.
-    Note: This function is not directly callable in Spark SQL, but internally used for length check when writing char type columns. ::
-
-        -- Function call examples (this function is not directly callable in Spark SQL).
-        char_type_write_side_check("abc", 3) -- "abc"
-        char_type_write_side_check("ab", 3) -- "ab "
-        char_type_write_side_check("a", 3) -- "a  "
-        char_type_write_side_check("abc  ", 3) -- "abc"
-        char_type_write_side_check("abcd", 3) -- VeloxUserError: "Exceeds allowed length limitation: '3'"
-        char_type_write_side_check("世界", 2) -- "世界"
-        char_type_write_side_check("世", 3) -- "世  "
-        char_type_write_side_check("世界人", 2) -- VeloxUserError: "Exceeds allowed length limitation: '2'"
-        char_type_write_side_check("abc", 0) -- VeloxUserError: "The length limit must be greater than 0."
 
 .. spark:function:: varchar_type_write_side_check(string, limit) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -465,6 +465,25 @@ String Functions
 
         SELECT upper('SparkSql'); -- SPARKSQL
 
+.. spark:function:: char_type_write_side_check(string, limit) -> varchar
+
+    Ensures that input ``string`` fits within the specified length ``limit`` in characters by padding or trimming spaces as needed.
+    If the length of ``string`` is less than ``limit``, it is padded with trailing spaces (ASCII 32) to reach ``limit``.
+    If the length of ``string`` is greater than ``limit``, trailing spaces are trimmed to fit within ``limit``.
+    Throws exception when ``string`` still exceeds ``limit`` after trimming trailing spaces or when ``limit`` is not greater than 0.
+    Note: This function is not directly callable in Spark SQL, but internally used for length check when writing char type columns. ::
+
+        -- Function call examples (this function is not directly callable in Spark SQL).
+        char_type_write_side_check("abc", 3) -- "abc"
+        char_type_write_side_check("ab", 3) -- "ab "
+        char_type_write_side_check("a", 3) -- "a  "
+        char_type_write_side_check("abc  ", 3) -- "abc"
+        char_type_write_side_check("abcd", 3) -- VeloxUserError: "Exceeds allowed length limitation: '3'"
+        char_type_write_side_check("世界", 2) -- "世界"
+        char_type_write_side_check("世", 3) -- "世  "
+        char_type_write_side_check("世界人", 2) -- VeloxUserError: "Exceeds allowed length limitation: '2'"
+        char_type_write_side_check("abc", 0) -- VeloxUserError: "The length limit must be greater than 0."
+
 .. spark:function:: varchar_type_write_side_check(string, limit) -> varchar
 
     Removes trailing space characters (ASCII 32) that exceed the length ``limit`` from the end of input ``string``. ``limit`` is the maximum length of characters that can be allowed.

--- a/velox/functions/sparksql/CharTypeWriteSideCheck.h
+++ b/velox/functions/sparksql/CharTypeWriteSideCheck.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/string/StringImpl.h"
+#include "velox/functions/sparksql/CharVarcharUtils.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// Ensures that `'abc'` fits within the specified length `n` in
+/// characters. If the length of `'abc'` is equal to `n`, it is returned as-is.
+/// If the length of `'abc'` is less than `n`, it is padded with trailing
+/// spaces(0x20) to the length of `n`. If the length of `'abc'` is greater
+/// than `n`, trailing spaces are trimmed to fit within `n`.
+/// Throws an exception if the trimmed string still exceeds `n` or if `n`
+/// is not a positive value.
+template <typename T>
+struct CharTypeWriteSideCheckFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    doCall<false>(result, input, limit);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    doCall<true>(result, input, limit);
+  }
+
+ private:
+  template <bool isAscii>
+  FOLLY_ALWAYS_INLINE void doCall(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t limit) {
+    VELOX_USER_CHECK_GT(limit, 0, "The length limit must be greater than 0.");
+
+    auto numCharacters = stringImpl::length<isAscii>(input);
+
+    if (numCharacters == limit) {
+      result.setNoCopy(input);
+      return;
+    } else if (numCharacters < limit) {
+      // rpad spaces(0x20) to limit.
+      stringImpl::pad<false /*lpad*/, isAscii>(result, input, limit, {" "});
+    } else {
+      trimTrailingSpaces(result, input, numCharacters, limit);
+    }
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql
+

--- a/velox/functions/sparksql/CharTypeWriteSideCheck.h
+++ b/velox/functions/sparksql/CharTypeWriteSideCheck.h
@@ -76,4 +76,3 @@ struct CharTypeWriteSideCheckFunction {
 };
 
 } // namespace facebook::velox::functions::sparksql
-

--- a/velox/functions/sparksql/CharTypeWriteSideCheck.h
+++ b/velox/functions/sparksql/CharTypeWriteSideCheck.h
@@ -15,21 +15,18 @@
  */
 #pragma once
 
-#include <string>
-
-#include "velox/functions/Macros.h"
 #include "velox/functions/lib/string/StringImpl.h"
 #include "velox/functions/sparksql/CharVarcharUtils.h"
 
 namespace facebook::velox::functions::sparksql {
 
-/// Ensures that `'abc'` fits within the specified length `n` in
-/// characters. If the length of `'abc'` is equal to `n`, it is returned as-is.
-/// If the length of `'abc'` is less than `n`, it is padded with trailing
-/// spaces(0x20) to the length of `n`. If the length of `'abc'` is greater
-/// than `n`, trailing spaces are trimmed to fit within `n`.
-/// Throws an exception if the trimmed string still exceeds `n` or if `n`
-/// is not a positive value.
+/// Ensures that an input string fits within the specified length `limit` in
+/// characters. If the length of the input string is equal to `limit`, it is
+/// returned as-is. If the length of the input string is less than `limit`, it
+/// is padded with trailing spaces(0x20) to the length of `limit`. If the
+/// length of the input string is greater than `limit`, trailing spaces are
+/// trimmed to fit within `limit`. Throws an exception if the trimmed string
+/// still exceeds `limit` or if `limit` is not a positive value.
 template <typename T>
 struct CharTypeWriteSideCheckFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
@@ -65,10 +62,9 @@ struct CharTypeWriteSideCheckFunction {
 
     if (numCharacters == limit) {
       result.setNoCopy(input);
-      return;
     } else if (numCharacters < limit) {
-      // rpad spaces(0x20) to limit.
-      stringImpl::pad<false /*lpad*/, isAscii>(result, input, limit, {" "});
+      // Rpad spaces(0x20) to limit.
+      stringImpl::pad</*lpad=*/false, isAscii>(result, input, limit, {" "});
     } else {
       trimTrailingSpaces(result, input, numCharacters, limit);
     }

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/prestosql/URLFunctions.h"
 #include "velox/functions/sparksql/Base64Function.h"
+#include "velox/functions/sparksql/CharTypeWriteSideCheck.h"
 #include "velox/functions/sparksql/ConcatWs.h"
 #include "velox/functions/sparksql/InitcapFunction.h"
 #include "velox/functions/sparksql/LuhnCheckFunction.h"
@@ -170,6 +171,12 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       Varchar,
       int32_t>({prefix + "varchar_type_write_side_check"});
+
+  registerFunction<
+      CharTypeWriteSideCheckFunction,
+      Varchar,
+      Varchar,
+      int32_t>({prefix + "char_type_write_side_check"});
 
   registerFunction<Base64Function, Varchar, Varbinary>({prefix + "base64"});
   registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -172,11 +172,8 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       int32_t>({prefix + "varchar_type_write_side_check"});
 
-  registerFunction<
-      CharTypeWriteSideCheckFunction,
-      Varchar,
-      Varchar,
-      int32_t>({prefix + "char_type_write_side_check"});
+  registerFunction<CharTypeWriteSideCheckFunction, Varchar, Varchar, int32_t>(
+      {prefix + "char_type_write_side_check"});
 
   registerFunction<Base64Function, Varchar, Varbinary>({prefix + "base64"});
   registerFunction<UnBase64Function, Varbinary, Varchar>({prefix + "unbase64"});

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
   BitwiseTest.cpp
+  CharTypeWriteSideCheckTest.cpp
   ComparisonsTest.cpp
   ConcatWsTest.cpp
   DateTimeFunctionsTest.cpp

--- a/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
+++ b/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
@@ -19,16 +19,17 @@
 namespace facebook::velox::functions::sparksql::test {
 namespace {
 
-class CharTypeWriteSideCheckTest : public SparkFunctionBaseTest {};
+class CharTypeWriteSideCheckTest : public SparkFunctionBaseTest {
+ protected:
+  auto charTypeWriteSideCheck(
+      const std::optional<std::string>& input,
+      const std::optional<int32_t>& limit) {
+    return evaluateOnce<std::string>(
+        "char_type_write_side_check(c0, c1)", input, limit);
+  }
+};
 
 TEST_F(CharTypeWriteSideCheckTest, ascii) {
-  const auto charTypeWriteSideCheck =
-      [&](const std::optional<std::string>& input,
-          const std::optional<int32_t>& limit) {
-        return evaluateOnce<std::string>(
-            "char_type_write_side_check(c0, c1)", input, limit);
-      };
-
   // Case 1: String length equals limit (return as-is).
   EXPECT_EQ(charTypeWriteSideCheck("abc", 3), "abc");
 
@@ -46,13 +47,6 @@ TEST_F(CharTypeWriteSideCheckTest, ascii) {
 }
 
 TEST_F(CharTypeWriteSideCheckTest, unicode) {
-  const auto charTypeWriteSideCheck =
-      [&](const std::optional<std::string>& input,
-          const std::optional<int32_t>& limit) {
-        return evaluateOnce<std::string>(
-            "char_type_write_side_check(c0, c1)", input, limit);
-      };
-
   // Case 1: String length equals limit (return as-is).
   EXPECT_EQ(charTypeWriteSideCheck("世界", 2), "世界");
   EXPECT_EQ(charTypeWriteSideCheck("a世", 2), "a世");
@@ -74,13 +68,6 @@ TEST_F(CharTypeWriteSideCheckTest, unicode) {
 }
 
 TEST_F(CharTypeWriteSideCheckTest, error) {
-  const auto charTypeWriteSideCheck =
-      [&](const std::optional<std::string>& input,
-          const std::optional<int32_t>& limit) {
-        return evaluateOnce<std::string>(
-            "char_type_write_side_check(c0, c1)", input, limit);
-      };
-
   // Error cases - string length > limit even after trimming trailing spaces.
   VELOX_ASSERT_USER_THROW(
       charTypeWriteSideCheck("abcd", 3),
@@ -97,9 +84,6 @@ TEST_F(CharTypeWriteSideCheckTest, error) {
   VELOX_ASSERT_USER_THROW(
       charTypeWriteSideCheck("Γειάσου", 4),
       "Exceeds allowed length limitation: 4");
-
-  // Null input cases.
-  EXPECT_EQ(charTypeWriteSideCheck(std::nullopt, 5), std::nullopt);
 
   // Edge cases - length limit must be positive.
   VELOX_ASSERT_USER_THROW(

--- a/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
+++ b/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
@@ -76,4 +76,3 @@ TEST_F(CharTypeWriteSideCheckTest, charTypeWriteSideCheck) {
 
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test
-

--- a/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
+++ b/velox/functions/sparksql/tests/CharTypeWriteSideCheckTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class CharTypeWriteSideCheckTest : public SparkFunctionBaseTest {};
+
+TEST_F(CharTypeWriteSideCheckTest, charTypeWriteSideCheck) {
+  const auto charTypeWriteSideCheck =
+      [&](const std::optional<std::string>& input,
+          const std::optional<int32_t>& limit) {
+        return evaluateOnce<std::string>(
+            "char_type_write_side_check(c0, c1)", input, limit);
+      };
+
+  // Case 1: String length equals limit (return as-is).
+  EXPECT_EQ(charTypeWriteSideCheck("abc", 3), "abc");
+  EXPECT_EQ(charTypeWriteSideCheck("世界", 2), "世界");
+  EXPECT_EQ(charTypeWriteSideCheck("a世", 2), "a世");
+
+  // Case 2: String length < limit (pad with spaces to reach limit).
+  EXPECT_EQ(charTypeWriteSideCheck("a", 3), "a  ");
+  EXPECT_EQ(charTypeWriteSideCheck("ab", 3), "ab ");
+  EXPECT_EQ(charTypeWriteSideCheck("", 3), "   ");
+  EXPECT_EQ(charTypeWriteSideCheck("世", 3), "世  ");
+  EXPECT_EQ(charTypeWriteSideCheck("世界", 3), "世界 ");
+
+  // Case 3: String length > limit (try trimming trailing spaces).
+  // Case 3a: Successful trimming (exactly fits after trimming).
+  EXPECT_EQ(charTypeWriteSideCheck("abc  ", 3), "abc");
+  EXPECT_EQ(charTypeWriteSideCheck("世界   ", 2), "世界");
+  EXPECT_EQ(charTypeWriteSideCheck("a世  ", 2), "a世");
+
+  // Case 3b: Successful trimming but contain spare spaces to fit the limit.
+  EXPECT_EQ(charTypeWriteSideCheck("a   ", 2), "a ");
+  EXPECT_EQ(charTypeWriteSideCheck("世   ", 2), "世 ");
+
+  // Error cases - string length > limit even after trimming trailing spaces.
+  VELOX_ASSERT_USER_THROW(
+      charTypeWriteSideCheck("abcd", 3),
+      "Exceeds allowed length limitation: 3");
+  VELOX_ASSERT_USER_THROW(
+      charTypeWriteSideCheck("世界人", 2),
+      "Exceeds allowed length limitation: 2");
+  VELOX_ASSERT_USER_THROW(
+      charTypeWriteSideCheck("a世界b", 3),
+      "Exceeds allowed length limitation: 3");
+
+  // Null input cases.
+  EXPECT_EQ(charTypeWriteSideCheck(std::nullopt, 5), std::nullopt);
+
+  // Edge cases - length limit must be positive.
+  VELOX_ASSERT_USER_THROW(
+      charTypeWriteSideCheck("a", 0),
+      "The length limit must be greater than 0.");
+  VELOX_ASSERT_USER_THROW(
+      charTypeWriteSideCheck("abc", -1),
+      "The length limit must be greater than 0.");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test
+


### PR DESCRIPTION
This PR adds the `char_type_write_side_check` function. This function ensures 
input strings fit within a specified length limit by padding shorter strings 
with trailing spaces to reach the limit or trimming trailing spaces from longer 
strings. It throws exceptions if the string still exceeds the limit after 
trimming or if the specified limit is not greater than 0.

Examples:

```
char_type_write_side_check("abc", 3) -- "abc"
char_type_write_side_check("ab", 3) -- "ab "
char_type_write_side_check("abc  ", 3) -- "abc"
char_type_write_side_check("abcd", 3) -- VeloxUserError: "Exceeds allowed length limitation: '3'"
char_type_write_side_check("abc", 0) -- VeloxUserError: "The length limit must be greater than 0."
```

Note: This PR is a 2/3 of the splitted work of PR https://github.com/facebookincubator/velox/pull/12773, as outlined in PR https://github.com/facebookincubator/velox/issues/12772.

