### PR TITLE
refactor: Reduce allocations

### DIFF
--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -352,7 +352,7 @@ void LocalPlanner::plan(
       planFragment.planNode,
       nullptr,
       nullptr,
-      detail::makeOperatorSupplier(consumerSupplier),
+      detail::makeOperatorSupplier(std::move(consumerSupplier)),
       driverFactories);
 
   (*driverFactories)[0]->outputDriver = true;
@@ -402,14 +402,14 @@ void LocalPlanner::determineGroupedExecutionPipelines(
       size_t numGroupedExecutionSources{0};
       for (const auto& sourceNode : localPartitionNode->sources()) {
         for (auto& anotherFactory : driverFactories) {
-          if (sourceNode == anotherFactory->planNodes.back() and
+          if (sourceNode == anotherFactory->planNodes.back() &&
               anotherFactory->groupedExecution) {
             ++numGroupedExecutionSources;
             break;
           }
         }
       }
-      if (numGroupedExecutionSources > 0 and
+      if (numGroupedExecutionSources > 0 &&
           numGroupedExecutionSources == localPartitionNode->sources().size()) {
         factory->groupedExecution = true;
       }

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -791,7 +791,7 @@ class HashJoinTestBase : public HiveConnectorTestBase {
   }
 
   // Make splits with each plan node having a number of source files.
-  SplitInput makeSpiltInput(
+  SplitInput makeSplitInput(
       const std::vector<core::PlanNodeId>& nodeIds,
       const std::vector<std::vector<std::shared_ptr<TempFilePath>>>& files) {
     VELOX_CHECK_EQ(nodeIds.size(), files.size());

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -209,23 +209,23 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
         infoColumns) {
   auto file =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
-  const int64_t fileSize = file->size();
+  const uint64_t fileSize = file->size();
   // Take the upper bound.
-  const int64_t splitSize = std::ceil((fileSize) / splitCount);
+  const uint64_t splitSize = std::ceil((fileSize) / splitCount);
   std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;
   // Add all the splits.
-  for (int i = 0; i < splitCount; i++) {
+  for (uint32_t i = 0; i < splitCount; i++) {
     auto splitBuilder = HiveConnectorSplitBuilder(filePath)
                             .fileFormat(format)
                             .start(i * splitSize)
                             .length(splitSize);
     if (infoColumns.has_value()) {
-      for (auto infoColumn : infoColumns.value()) {
+      for (const auto& infoColumn : infoColumns.value()) {
         splitBuilder.infoColumn(infoColumn.first, infoColumn.second);
       }
     }
     if (partitionKeys.has_value()) {
-      for (auto partitionKey : partitionKeys.value()) {
+      for (const auto& partitionKey : partitionKeys.value()) {
         splitBuilder.partitionKey(partitionKey.first, partitionKey.second);
       }
     }
@@ -265,7 +265,8 @@ std::vector<std::shared_ptr<connector::ConnectorSplit>>
 HiveConnectorTestBase::makeHiveConnectorSplits(
     const std::vector<std::shared_ptr<TempFilePath>>& filePaths) {
   std::vector<std::shared_ptr<connector::ConnectorSplit>> splits;
-  for (auto filePath : filePaths) {
+  splits.reserve(filePaths.size());
+  for (const auto& filePath : filePaths) {
     splits.push_back(makeHiveConnectorSplit(
         filePath->getPath(),
         filePath->fileSize(),

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -248,7 +248,7 @@ class HiveConnectorSplitBuilder
     : public connector::hive::HiveConnectorSplitBuilder {
  public:
   explicit HiveConnectorSplitBuilder(std::string filePath)
-      : connector::hive::HiveConnectorSplitBuilder(filePath) {
+      : connector::hive::HiveConnectorSplitBuilder(std::move(filePath)) {
     connectorId(kHiveConnectorId);
   }
 };

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -526,6 +526,7 @@ PlanBuilder& PlanBuilder::projectExpressions(
 PlanBuilder& PlanBuilder::project(const std::vector<std::string>& projections) {
   VELOX_CHECK_NOT_NULL(planNode_, "Project cannot be the source node");
   std::vector<std::shared_ptr<const core::IExpr>> expressions;
+  expressions.reserve(projections.size());
   for (auto i = 0; i < projections.size(); ++i) {
     expressions.push_back(parse::parseExpr(projections[i], options_));
   }

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -383,6 +383,7 @@ PlanNodePtr toVeloxPlan(
   auto columnBindings = logicalProjection.GetColumnBindings();
 
   std::vector<std::string> names;
+  names.reserve(projections.size());
   for (auto i = 0; i < projections.size(); ++i) {
     names.push_back(queryContext.nextColumnName("_p"));
   }
@@ -480,6 +481,7 @@ PlanNodePtr toVeloxPlan(
   }
 
   std::vector<std::string> names;
+  names.reserve(aggregates.size());
   for (auto i = 0; i < aggregates.size(); ++i) {
     names.push_back(queryContext.nextColumnName("_a"));
   }
@@ -503,7 +505,7 @@ PlanNodePtr toVeloxPlan(
   VeloxColumnProjections projections(queryContext);
   std::vector<FieldAccessTypedExprPtr> keys;
   std::vector<SortOrder> sortOrder;
-  auto source = sources[0];
+  const auto& source = sources[0];
   for (auto& order : logicalOrder.orders) {
     keys.push_back(
         projections.toFieldAccess(*order.expression, source->outputType()));


### PR DESCRIPTION
Summary:
Reduce unnecessary allocations (copies and vector reallocations), as well
as clean up integer types and a typo.

Differential Revision: D78687699


