### PR TITLE
build(docker): Bump Presto Java version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
             tags: ghcr.io/facebookincubator/velox-dev:adapters
           - name: Presto Java
             file: scripts/docker/prestojava-container.dockerfile
-            args: PRESTO_VERSION=0.290
+            args: PRESTO_VERSION=0.293
             tags: ghcr.io/facebookincubator/velox-dev:presto-java
           - name: Spark server
             file: scripts/docker/spark-container.dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,7 @@ services:
     image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
-        - PRESTO_VERSION=0.290
+        - PRESTO_VERSION=0.293
       context: .
       dockerfile: scripts/docker/prestojava-container.dockerfile
     environment:

--- a/scripts/docker/prestojava-container.dockerfile
+++ b/scripts/docker/prestojava-container.dockerfile
@@ -15,7 +15,7 @@
 #
 FROM ghcr.io/facebookincubator/velox-dev:centos9
 
-ARG PRESTO_VERSION=0.290
+ARG PRESTO_VERSION=0.293
 
 COPY scripts /velox/scripts/
 RUN wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz


### PR DESCRIPTION
Summary: We have updated some function behavior in Presto java. To make the fuzzer pass, we need to bump up the presto version in the docker file.

Differential Revision: D78711698


