### PR TITLE
feat: Support pushdown spec through ss table handle and the fallback eval processing

### DIFF
--- a/velox/core/ExpressionEvaluator.h
+++ b/velox/core/ExpressionEvaluator.h
@@ -41,6 +41,9 @@ class ExpressionEvaluator {
   virtual std::unique_ptr<exec::ExprSet> compile(
       const std::shared_ptr<const ITypedExpr>& expression) = 0;
 
+  virtual std::unique_ptr<exec::ExprSet> compile(
+      const std::vector<std::shared_ptr<const ITypedExpr>>& expressions) = 0;
+
   // Evaluates previously compiled expression on the specified rows.
   // Re-uses result vector if it is not null.
   virtual void evaluate(
@@ -48,6 +51,12 @@ class ExpressionEvaluator {
       const SelectivityVector& rows,
       const RowVector& input,
       VectorPtr& result) = 0;
+
+  virtual void evaluate(
+      exec::ExprSet* exprSet,
+      const SelectivityVector& rows,
+      const RowVector& input,
+      std::vector<VectorPtr>& results) = 0;
 
   // Memory pool used to construct input or output vectors.
   virtual memory::MemoryPool* pool() = 0;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2054,6 +2054,15 @@ void SimpleExpressionEvaluator::evaluate(
   result = results[0];
 }
 
+void SimpleExpressionEvaluator::evaluate(
+    exec::ExprSet* exprSet,
+    const SelectivityVector& rows,
+    const RowVector& input,
+    std::vector<VectorPtr>& results) {
+  EvalCtx context(ensureExecCtx(), exprSet, &input);
+  exprSet->eval(0, exprSet->size(), true, rows, context, results);
+}
+
 core::ExecCtx* SimpleExpressionEvaluator::ensureExecCtx() {
   if (!execCtx_) {
     execCtx_ = std::make_unique<core::ExecCtx>(pool_, queryCtx_);

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -938,11 +938,22 @@ class SimpleExpressionEvaluator : public core::ExpressionEvaluator {
         std::vector<core::TypedExprPtr>{expression}, ensureExecCtx());
   }
 
+  std::unique_ptr<ExprSet> compile(
+      const std::vector<core::TypedExprPtr>& expressions) override {
+    return std::make_unique<ExprSet>(expressions, ensureExecCtx());
+  }
+
   void evaluate(
       ExprSet* exprSet,
       const SelectivityVector& rows,
       const RowVector& input,
       VectorPtr& result) override;
+
+  void evaluate(
+      exec::ExprSet* exprSet,
+      const SelectivityVector& rows,
+      const RowVector& input,
+      std::vector<VectorPtr>& results) override;
 
   memory::MemoryPool* pool() override {
     return pool_;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -24,6 +24,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
@@ -5184,5 +5185,62 @@ TEST_F(ExprTest, lambdaConstantFolded) {
   exprSet.clear();
 }
 
+TEST_F(ExprTest, simpleExpressionEvaluator) {
+  exec::SimpleExpressionEvaluator evaluator{queryCtx_.get(), pool_.get()};
+  const auto rowType = ROW({"c0", "c1"}, {ARRAY(INTEGER()), INTEGER()});
+  const auto array = makeArrayVectorFromJson<int32_t>(
+      {"[1, 2, 3, 4]", "null", "[5, 6]", "[]", "[null]", "[7, 8, 9]"});
+  const auto data = makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6});
+  const auto input = makeRowVector({array, data});
+
+  const auto parseExpr = [&](const std::string& sql) {
+    return parseExpression(sql, rowType);
+  };
+  const auto arrayExpr = parseExpr("element_at(c0, 1)");
+  const auto expectedArrayExprResult = makeNullableFlatVector<int32_t>(
+      {1, std::nullopt, 5, std::nullopt, std::nullopt, 7});
+  const auto scalarExpr = parseExpr("cast(c1 + 1 as integer)");
+  const auto expectedScalarExprResult =
+      makeFlatVector<int32_t>({2, 3, 4, 5, 6, 7});
+
+  auto validateSingleExpr = [&](const core::TypedExprPtr typedExpr,
+                                const RowVectorPtr& input,
+                                const VectorPtr& expected) {
+    auto exprSet = evaluator.compile(typedExpr);
+    SelectivityVector rows;
+    rows.resize(input->size());
+    VectorPtr result;
+    evaluator.evaluate(exprSet.get(), rows, *input, result);
+    assertEqualVectors(expected, result);
+  };
+  validateSingleExpr(arrayExpr, input, expectedArrayExprResult);
+  validateSingleExpr(scalarExpr, input, expectedScalarExprResult);
+
+  auto validateMultiExprs =
+      [&](const std::vector<core::TypedExprPtr>& typedExprs,
+          const RowVectorPtr& input,
+          const std::vector<VectorPtr>& expectedResults) {
+        auto exprSet = evaluator.compile(typedExprs);
+        SelectivityVector rows;
+        rows.resize(input->size());
+        std::vector<VectorPtr> results;
+        evaluator.evaluate(exprSet.get(), rows, *input, results);
+        ASSERT_EQ(results.size(), expectedResults.size());
+        for (int i = 0; i < expectedResults.size(); ++i) {
+          assertEqualVectors(expectedResults[i], results[i]);
+        }
+      };
+  validateMultiExprs(
+      {arrayExpr, arrayExpr},
+      input,
+      {expectedArrayExprResult, expectedArrayExprResult});
+  validateMultiExprs({scalarExpr}, input, {expectedScalarExprResult});
+  validateMultiExprs(
+      {arrayExpr, scalarExpr, arrayExpr},
+      input,
+      {expectedArrayExprResult,
+       expectedScalarExprResult,
+       expectedArrayExprResult});
+}
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Extends SequenceStoragePushdownSpec to receive the expression pushdown from the query optimizer. Adds struct as map to handle the conversion from map to row.
Extends sequence storage connector to handle the feature projection fallback from the sequence storage client in case the latter does not use thrift map encoding.

The follow up is to use koski udf to handle map to row conversion, and then integrate into koski query optimizer.

Differential Revision: D78467818


