### PR TITLE
refactor: Rename CustomTypeFactories to CustomTypeFactory

### DIFF
--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -52,9 +52,9 @@ static const TypePtr& TIMESTAMP_WITH_TIME_ZONE() {
   return instance;
 }
 
-class TypeFactories : public CustomTypeFactories {
+class TypeFactory : public CustomTypeFactory {
  public:
-  TypeFactories(const TypePtr& type) : type_(type) {}
+  TypeFactory(const TypePtr& type) : type_(type) {}
 
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -78,10 +78,10 @@ class ParseTypeSignatureTest : public ::testing::Test {
  private:
   void SetUp() override {
     // Register custom types with and without spaces.
-    registerCustomType("json", std::make_unique<const TypeFactories>(JSON()));
+    registerCustomType("json", std::make_unique<const TypeFactory>(JSON()));
     registerCustomType(
         "timestamp with time zone",
-        std::make_unique<const TypeFactories>(TIMESTAMP_WITH_TIME_ZONE()));
+        std::make_unique<const TypeFactory>(TIMESTAMP_WITH_TIME_ZONE()));
   }
 };
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2866,7 +2866,7 @@ class BigintTypeWithCustomComparisonCastOperator : public exec::CastOperator {
   BigintTypeWithCustomComparisonCastOperator() = default;
 };
 
-class BigintTypeWithCustomComparisonTypeFactories : public CustomTypeFactories {
+class BigintTypeWithCustomComparisonTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -2898,8 +2898,7 @@ TEST_F(CastExprTest, skipUnnecessaryChildrenOfComplexTypes) {
   VELOX_CHECK(
       registerCustomType(
           BIGINT_TYPE_WITH_CUSTOM_COMPARISON()->name(),
-          std::make_unique<
-              const BigintTypeWithCustomComparisonTypeFactories>()),
+          std::make_unique<const BigintTypeWithCustomComparisonTypeFactory>()),
       "Failed to register custom type 'bigint type with custom comparison'");
 
   const auto valuesThatThrowOnCast = makeFlatVector<int64_t>(

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -54,7 +54,7 @@ class FancyIntType : public OpaqueType {
   }
 };
 
-class FancyIntTypeFactories : public CustomTypeFactories {
+class FancyIntTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -145,7 +145,7 @@ struct FancyPlusFunction {
   }
 };
 
-class AlwaysFailingTypeFactories : public CustomTypeFactories {
+class AlwaysFailingTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -168,11 +168,11 @@ class AlwaysFailingTypeFactories : public CustomTypeFactories {
 /// simple function that takes and returns this type. Verify function signatures
 /// and evaluate some expressions.
 TEST_F(CustomTypeTest, customType) {
-  ASSERT_TRUE(registerCustomType(
-      "fancy_int", std::make_unique<FancyIntTypeFactories>()));
+  ASSERT_TRUE(
+      registerCustomType("fancy_int", std::make_unique<FancyIntTypeFactory>()));
 
-  ASSERT_FALSE(registerCustomType(
-      "fancy_int", std::make_unique<AlwaysFailingTypeFactories>()));
+  ASSERT_FALSE(
+      registerCustomType("fancy_int", std::make_unique<FancyIntTypeFactory>()));
 
   registerFunction<FancyPlusFunction, TheFancyInt, TheFancyInt, TheFancyInt>(
       {"fancy_plus"});
@@ -244,8 +244,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
 #endif
   ASSERT_EQ(expectedTypes, getCustomTypeNames());
 
-  ASSERT_TRUE(registerCustomType(
-      "fancy_int", std::make_unique<FancyIntTypeFactories>()));
+  ASSERT_TRUE(
+      registerCustomType("fancy_int", std::make_unique<FancyIntTypeFactory>()));
   expectedTypes.insert("FANCY_INT");
 
   ASSERT_EQ(expectedTypes, getCustomTypeNames());
@@ -254,8 +254,8 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
 }
 
 TEST_F(CustomTypeTest, nullConstant) {
-  ASSERT_TRUE(registerCustomType(
-      "fancy_int", std::make_unique<FancyIntTypeFactories>()));
+  ASSERT_TRUE(
+      registerCustomType("fancy_int", std::make_unique<FancyIntTypeFactory>()));
   auto checkNullConstant = [&](const TypePtr& type,
                                const std::string& expectedTypeString) {
     auto null = BaseVector::createNullConstant(type, 10, pool());

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -118,7 +118,7 @@ class BingTileCastOperator : public exec::CastOperator {
   BingTileCastOperator() = default;
 };
 
-class BingTileTypeFactories : public CustomTypeFactories {
+class BingTileTypeFactory : public CustomTypeFactory {
  public:
   velox::TypePtr getType(
       const std::vector<velox::TypeParameter>& parameters) const override {
@@ -140,8 +140,7 @@ class BingTileTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerBingTileType() {
-  registerCustomType(
-      "bingtile", std::make_unique<const BingTileTypeFactories>());
+  registerCustomType("bingtile", std::make_unique<const BingTileTypeFactory>());
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/GeometryRegistration.cpp
+++ b/velox/functions/prestosql/types/GeometryRegistration.cpp
@@ -22,7 +22,7 @@
 namespace facebook::velox {
 
 namespace {
-class GeometryTypeFactories : public CustomTypeFactories {
+class GeometryTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -42,8 +42,7 @@ class GeometryTypeFactories : public CustomTypeFactories {
 
 void registerGeometryType() {
   // Register the geometry type with the type registry.
-  registerCustomType(
-      "geometry", std::make_unique<const GeometryTypeFactories>());
+  registerCustomType("geometry", std::make_unique<const GeometryTypeFactory>());
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
@@ -22,7 +22,7 @@
 
 namespace facebook::velox {
 namespace {
-class HyperLogLogTypeFactories : public CustomTypeFactories {
+class HyperLogLogTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -43,6 +43,6 @@ class HyperLogLogTypeFactories : public CustomTypeFactories {
 } // namespace
 void registerHyperLogLogType() {
   registerCustomType(
-      "hyperloglog", std::make_unique<const HyperLogLogTypeFactories>());
+      "hyperloglog", std::make_unique<const HyperLogLogTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -256,9 +256,9 @@ class IPAddressCastOperator : public exec::CastOperator {
   }
 };
 
-class IPAddressTypeFactories : public CustomTypeFactories {
+class IPAddressTypeFactory : public CustomTypeFactory {
  public:
-  IPAddressTypeFactories() = default;
+  IPAddressTypeFactory() = default;
 
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -283,6 +283,6 @@ class IPAddressTypeFactories : public CustomTypeFactories {
 
 void registerIPAddressType() {
   registerCustomType(
-      "ipaddress", std::make_unique<const IPAddressTypeFactories>());
+      "ipaddress", std::make_unique<const IPAddressTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -183,7 +183,7 @@ class IPPrefixCastOperator : public exec::CastOperator {
   }
 };
 
-class IPPrefixTypeFactories : public CustomTypeFactories {
+class IPPrefixTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -208,7 +208,6 @@ class IPPrefixTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerIPPrefixType() {
-  registerCustomType(
-      "ipprefix", std::make_unique<const IPPrefixTypeFactories>());
+  registerCustomType("ipprefix", std::make_unique<const IPPrefixTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/JsonRegistration.cpp
+++ b/velox/functions/prestosql/types/JsonRegistration.cpp
@@ -23,9 +23,9 @@
 
 namespace facebook::velox {
 namespace {
-class JsonTypeFactories : public CustomTypeFactories {
+class JsonTypeFactory : public CustomTypeFactory {
  public:
-  JsonTypeFactories() = default;
+  JsonTypeFactory() = default;
 
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -63,6 +63,6 @@ class JsonTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerJsonType() {
-  registerCustomType("json", std::make_unique<const JsonTypeFactories>());
+  registerCustomType("json", std::make_unique<const JsonTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/QDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/QDigestRegistration.cpp
@@ -21,7 +21,7 @@
 
 namespace facebook::velox {
 namespace {
-class QDigestTypeFactories : public CustomTypeFactories {
+class QDigestTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK_EQ(parameters.size(), 1);
@@ -60,6 +60,6 @@ class QDigestTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerQDigestType() {
-  registerCustomType("qdigest", std::make_unique<const QDigestTypeFactories>());
+  registerCustomType("qdigest", std::make_unique<const QDigestTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/SfmSketchRegistration.cpp
+++ b/velox/functions/prestosql/types/SfmSketchRegistration.cpp
@@ -21,7 +21,7 @@
 
 namespace facebook::velox {
 namespace {
-class SfmSketchTypeFactories : public CustomTypeFactories {
+class SfmSketchTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -43,6 +43,6 @@ class SfmSketchTypeFactories : public CustomTypeFactories {
 } // namespace
 void registerSfmSketchType() {
   registerCustomType(
-      "sfmsketch", std::make_unique<const SfmSketchTypeFactories>());
+      "sfmsketch", std::make_unique<const SfmSketchTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/TDigestRegistration.cpp
@@ -21,7 +21,7 @@
 
 namespace facebook::velox {
 namespace {
-class TDigestTypeFactories : public CustomTypeFactories {
+class TDigestTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK_EQ(parameters.size(), 1);
@@ -44,6 +44,6 @@ class TDigestTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerTDigestType() {
-  registerCustomType("tdigest", std::make_unique<const TDigestTypeFactories>());
+  registerCustomType("tdigest", std::make_unique<const TDigestTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -275,7 +275,7 @@ class TimestampWithTimeZoneCastOperator : public exec::CastOperator {
   TimestampWithTimeZoneCastOperator() = default;
 };
 
-class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
+class TimestampWithTimeZoneTypeFactory : public CustomTypeFactory {
  public:
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -298,6 +298,6 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
 void registerTimestampWithTimeZoneType() {
   registerCustomType(
       "timestamp with time zone",
-      std::make_unique<const TimestampWithTimeZoneTypeFactories>());
+      std::make_unique<const TimestampWithTimeZoneTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -180,9 +180,9 @@ class UuidCastOperator : public exec::CastOperator {
   }
 };
 
-class UuidTypeFactories : public CustomTypeFactories {
+class UuidTypeFactory : public CustomTypeFactory {
  public:
-  UuidTypeFactories() = default;
+  UuidTypeFactory() = default;
 
   TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
     VELOX_CHECK(parameters.empty());
@@ -201,6 +201,6 @@ class UuidTypeFactories : public CustomTypeFactories {
 } // namespace
 
 void registerUuidType() {
-  registerCustomType("uuid", std::make_unique<const UuidTypeFactories>());
+  registerCustomType("uuid", std::make_unique<const UuidTypeFactory>());
 }
 } // namespace facebook::velox

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -87,7 +87,7 @@ class OpaqueCustomTypeRegister {
   }
 
  private:
-  class TypeFactory : public CustomTypeFactories {
+  class TypeFactory : public CustomTypeFactory {
    public:
     TypeFactory() = default;
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -963,10 +963,10 @@ std::string Type::toSummaryString(TypeSummaryOptions options) const {
 
 namespace {
 
-std::unordered_map<std::string, std::unique_ptr<const CustomTypeFactories>>&
+std::unordered_map<std::string, std::unique_ptr<const CustomTypeFactory>>&
 typeFactories() {
   static std::
-      unordered_map<std::string, std::unique_ptr<const CustomTypeFactories>>
+      unordered_map<std::string, std::unique_ptr<const CustomTypeFactory>>
           factories;
   return factories;
 }
@@ -987,9 +987,9 @@ std::unordered_map<std::type_index, std::string>& getOpaqueAliasByTypeIndex() {
 
 bool registerCustomType(
     const std::string& name,
-    std::unique_ptr<const CustomTypeFactories> factories) {
+    std::unique_ptr<const CustomTypeFactory> factory) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
-  return typeFactories().emplace(uppercaseName, std::move(factories)).second;
+  return typeFactories().emplace(uppercaseName, std::move(factory)).second;
 }
 
 bool customTypeExists(const std::string& name) {
@@ -1010,8 +1010,8 @@ bool unregisterCustomType(const std::string& name) {
   return typeFactories().erase(uppercaseName) == 1;
 }
 
-const CustomTypeFactories* FOLLY_NULLABLE
-getTypeFactories(const std::string& name) {
+const CustomTypeFactory* FOLLY_NULLABLE
+getTypeFactory(const std::string& name) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
   auto it = typeFactories().find(uppercaseName);
 
@@ -1025,33 +1025,33 @@ getTypeFactories(const std::string& name) {
 TypePtr getCustomType(
     const std::string& name,
     const std::vector<TypeParameter>& parameters) {
-  auto factories = getTypeFactories(name);
-  if (factories) {
-    return factories->getType(parameters);
+  auto factory = getTypeFactory(name);
+  if (factory) {
+    return factory->getType(parameters);
   }
 
   return nullptr;
 }
 
 exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name) {
-  auto factories = getTypeFactories(name);
-  if (factories) {
-    return factories->getCastOperator();
+  auto factory = getTypeFactory(name);
+  if (factory) {
+    return factory->getCastOperator();
   }
 
   return nullptr;
 }
 
-CustomTypeFactories::~CustomTypeFactories() = default;
+CustomTypeFactory::~CustomTypeFactory() = default;
 
 AbstractInputGenerator::~AbstractInputGenerator() = default;
 
 AbstractInputGeneratorPtr getCustomTypeInputGenerator(
     const std::string& name,
     const InputGeneratorConfig& config) {
-  auto factories = getTypeFactories(name);
-  if (factories) {
-    return factories->getInputGenerator(config);
+  auto factory = getTypeFactory(name);
+  if (factory) {
+    return factory->getInputGenerator(config);
   }
 
   return nullptr;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2057,9 +2057,9 @@ struct InputGeneratorConfig {
 
 /// Associates custom types with their custom operators to be the payload in
 /// the custom type registry.
-class CustomTypeFactories {
+class CustomTypeFactory {
  public:
-  virtual ~CustomTypeFactories();
+  virtual ~CustomTypeFactory();
 
   /// Returns a shared pointer to the custom type.
   virtual TypePtr getType(
@@ -2109,7 +2109,7 @@ class AbstractInputGenerator {
 /// false if type with the specified name already exists.
 bool registerCustomType(
     const std::string& name,
-    std::unique_ptr<const CustomTypeFactories> factories);
+    std::unique_ptr<const CustomTypeFactory> factories);
 
 // See registerOpaqueType() for documentation on type index and opaque type
 // alias.

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -42,9 +42,9 @@ static const TypePtr& TIMESTAMP_WITH_TIME_ZONE() {
   return instance;
 }
 
-class TypeFactories : public CustomTypeFactories {
+class TypeFactory : public CustomTypeFactory {
  public:
-  TypeFactories(const TypePtr& type) : type_(type) {}
+  TypeFactory(const TypePtr& type) : type_(type) {}
 
   TypePtr getType(
       const std::vector<TypeParameter>& /*parameters*/) const override {
@@ -68,10 +68,10 @@ class TypeParserTest : public ::testing::Test {
  private:
   void SetUp() override {
     // Register custom types with and without spaces.
-    registerCustomType("json", std::make_unique<const TypeFactories>(JSON()));
+    registerCustomType("json", std::make_unique<const TypeFactory>(JSON()));
     registerCustomType(
         "timestamp with time zone",
-        std::make_unique<const TypeFactories>(TIMESTAMP_WITH_TIME_ZONE()));
+        std::make_unique<const TypeFactory>(TIMESTAMP_WITH_TIME_ZONE()));
   }
 };
 


### PR DESCRIPTION
Summary: CustomTypeFactories should be singular, as each custom type is associated with a single type factory

Differential Revision: D78680711


