### PR TITLE
refactor: getCastOperator to accept TypePtr

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -930,7 +930,7 @@ CastOperatorPtr CastExpr::getCastOperator(const TypePtr& type) {
     return it->second;
   }
 
-  auto castOperator = getCustomTypeCastOperator(key);
+  auto castOperator = getCustomTypeCastOperator(type);
   if (castOperator == nullptr) {
     return nullptr;
   }

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -61,7 +61,8 @@ class TypeFactory : public CustomTypeFactory {
     return type_;
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2874,7 +2874,8 @@ class BigintTypeWithCustomComparisonTypeFactory : public CustomTypeFactory {
   }
 
   // Type casting from and to TimestampWithTimezone is not supported yet.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return BigintTypeWithCustomComparisonCastOperator::get();
   }
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -61,7 +61,8 @@ class FancyIntTypeFactory : public CustomTypeFactory {
     return FancyIntType::get();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     VELOX_UNSUPPORTED();
   }
 
@@ -152,7 +153,8 @@ class AlwaysFailingTypeFactory : public CustomTypeFactory {
     VELOX_UNSUPPORTED();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     VELOX_UNSUPPORTED();
   }
 

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -126,7 +126,8 @@ class BingTileTypeFactory : public CustomTypeFactory {
     return BINGTILE();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return BingTileCastOperator::get();
   }
 

--- a/velox/functions/prestosql/types/GeometryRegistration.cpp
+++ b/velox/functions/prestosql/types/GeometryRegistration.cpp
@@ -29,7 +29,8 @@ class GeometryTypeFactory : public CustomTypeFactory {
     return GEOMETRY();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/HyperLogLogRegistration.cpp
@@ -30,7 +30,8 @@ class HyperLogLogTypeFactory : public CustomTypeFactory {
   }
 
   // HyperLogLog should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -265,7 +265,8 @@ class IPAddressTypeFactory : public CustomTypeFactory {
     return IPADDRESS();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return std::make_shared<IPAddressCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -190,7 +190,8 @@ class IPPrefixTypeFactory : public CustomTypeFactory {
     return IPPrefixType::get();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return std::make_shared<IPPrefixCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/JsonRegistration.cpp
+++ b/velox/functions/prestosql/types/JsonRegistration.cpp
@@ -32,7 +32,8 @@ class JsonTypeFactory : public CustomTypeFactory {
     return JSON();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return std::make_shared<JsonCastOperator>();
   }
 

--- a/velox/functions/prestosql/types/QDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/QDigestRegistration.cpp
@@ -29,7 +29,8 @@ class QDigestTypeFactory : public CustomTypeFactory {
   }
 
   // QDigest should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/SfmSketchRegistration.cpp
+++ b/velox/functions/prestosql/types/SfmSketchRegistration.cpp
@@ -30,7 +30,8 @@ class SfmSketchTypeFactory : public CustomTypeFactory {
 
   // SfmSketch supports casting and should be treated as Varbinary during type
   // casting.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/TDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/TDigestRegistration.cpp
@@ -30,7 +30,8 @@ class TDigestTypeFactory : public CustomTypeFactory {
   }
 
   // TDigest should be treated as Varbinary during type castings.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return nullptr;
   }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -283,7 +283,8 @@ class TimestampWithTimeZoneTypeFactory : public CustomTypeFactory {
   }
 
   // Type casting from and to TimestampWithTimezone is not supported yet.
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return TimestampWithTimeZoneCastOperator::get();
   }
 

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -189,7 +189,8 @@ class UuidTypeFactory : public CustomTypeFactory {
     return UUID();
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(
+      const TypePtr& /*type*/) const override {
     return std::make_shared<UuidCastOperator>();
   }
 

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -97,7 +97,8 @@ class OpaqueCustomTypeRegister {
       return singletonTypePtr();
     }
 
-    exec::CastOperatorPtr getCastOperator() const override {
+    exec::CastOperatorPtr getCastOperator(
+        const TypePtr& /*type*/) const override {
       VELOX_UNSUPPORTED();
     }
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1033,10 +1033,11 @@ TypePtr getCustomType(
   return nullptr;
 }
 
-exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name) {
-  auto factory = getTypeFactory(name);
+exec::CastOperatorPtr getCustomTypeCastOperator(const TypePtr& type) {
+  auto key = type->name();
+  auto factory = getTypeFactory(key);
   if (factory) {
-    return factory->getCastOperator();
+    return factory->getCastOperator(type);
   }
 
   return nullptr;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2068,7 +2068,11 @@ class CustomTypeFactory {
   /// should be treated as its underlying native type during type castings,
   /// return a nullptr. If a custom type does not support castings, throw an
   /// exception.
-  virtual exec::CastOperatorPtr getCastOperator() const = 0;
+  /// The TypePtr input parameter is used when the cast operation depends on the
+  /// Type and its properties. For example, when casting to an enum type, the
+  /// CastOperator needs to check if the input value exists in the enum type's
+  /// value map.
+  virtual exec::CastOperatorPtr getCastOperator(const TypePtr& type) const = 0;
 
   virtual AbstractInputGeneratorPtr getInputGenerator(
       const InputGeneratorConfig& config) const = 0;
@@ -2167,7 +2171,11 @@ bool unregisterCustomType(const std::string& name);
 /// Returns the custom cast operator for the custom type with the specified
 /// name. Returns nullptr if a type with the specified name does not exist or
 /// does not have a dedicated custom cast operator.
-exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name);
+/// The TypePtr input parameter is used when the cast operation depends on the
+/// Type and its properties. For example, when casting to an enum type, the
+/// CastOperator needs to check if the input value exists in the enum type's
+/// value map.
+exec::CastOperatorPtr getCustomTypeCastOperator(const TypePtr& type);
 
 /// Returns the input generator for the custom type with the specified name.
 AbstractInputGeneratorPtr getCustomTypeInputGenerator(

--- a/velox/type/parser/tests/TypeParserTest.cpp
+++ b/velox/type/parser/tests/TypeParserTest.cpp
@@ -51,7 +51,8 @@ class TypeFactory : public CustomTypeFactory {
     return type_;
   }
 
-  exec::CastOperatorPtr getCastOperator() const override {
+  exec::CastOperatorPtr getCastOperator(const TypePtr& /*type*/
+  ) const override {
     return nullptr;
   }
 


### PR DESCRIPTION
Summary: For a new custom type (BigintEnumType which will be in a following PR), the cast operator requires the Type and its parameters to be able to fail on certain cases of cast. Refactoring getCastOperator and getCustomTypeCastOperator to accept this parameter as input.

Differential Revision: D78694010
