### PR TITLE
fix: Fix BingTileFunctions build error on Ubuntu

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -171,6 +171,7 @@ jobs:
         if: ${{ github.event_name != 'schedule' && steps.get-sig.outputs.stash-hit != 'true' }}
         working-directory: velox_main
         run: |
+          make clean
           make python-build
 
       - name: Create Baseline Signatures

--- a/velox/functions/prestosql/BingTileFunctions.h
+++ b/velox/functions/prestosql/BingTileFunctions.h
@@ -56,7 +56,7 @@ struct BingTileFunction {
 
     auto zoomCheck = checkBingTileZoom(zoom);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
 
     uint64_t tile = BingTileType::bingTileCoordsToInt(
@@ -217,7 +217,7 @@ struct BingTileChildrenFunction {
     VELOX_DCHECK(BingTileType::isBingTileIntValid(tileInt));
     auto zoomCheck = checkBingTileZoom(childZoom);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto childrenRes =
         BingTileType::bingTileChildren(tileInt, childZoom, maxZoomShift);
@@ -255,7 +255,7 @@ struct BingTileAtFunction {
       const arg_type<int32_t>& zoomLevel) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto latitudeLongitudeToTileResult = BingTileType::latitudeLongitudeToTile(
         latitude, longitude, static_cast<uint8_t>(zoomLevel));
@@ -278,7 +278,7 @@ struct BingTilesAroundFunction {
       const arg_type<int32_t>& zoomLevel) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto bingTilesAroundResult = BingTileType::bingTilesAround(
         latitude, longitude, static_cast<uint8_t>(zoomLevel));
@@ -299,7 +299,7 @@ struct BingTilesAroundFunction {
       const arg_type<double>& radiusInKm) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto bingTilesAroundResult = BingTileType::bingTilesAround(
         latitude, longitude, static_cast<uint8_t>(zoomLevel), radiusInKm);


### PR DESCRIPTION
    The "return std::move(zoomCheck) caused build failure on Ubuntu with
    "error: moving a local object in a return statement prevents copy
    elision [-Werror=pessimizing-move] return std::move(zoomCheck);".
    This commit fixes it.