### PR TITLE
refactor: Make SplitsStore abstract to support split pulling execution

### DIFF
--- a/velox/common/future/VeloxPromise.h
+++ b/velox/common/future/VeloxPromise.h
@@ -42,7 +42,7 @@ class VeloxPromise : public folly::Promise<T> {
     }
   }
 
-  explicit VeloxPromise(VeloxPromise<T>&& other) noexcept
+  VeloxPromise(VeloxPromise<T>&& other) noexcept
       : folly::Promise<T>(std::move(other)),
         context_(std::move(other.context_)) {}
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -67,6 +67,7 @@ velox_add_library(
   OperatorTraceScan.cpp
   OperatorTraceWriter.cpp
   ParallelProject.cpp
+  TaskStructs.cpp
   TaskTraceReader.cpp
   TaskTraceWriter.cpp
   Trace.cpp

--- a/velox/exec/TaskStructs.cpp
+++ b/velox/exec/TaskStructs.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/TaskStructs.h"
+
+namespace facebook::velox::exec {
+
+void SplitsStore::addSplit(
+    Split split,
+    std::vector<ContinuePromise>& promises) {
+  VELOX_CHECK(!noMoreSplits_);
+  VELOX_CHECK(!(remoteSplit_ && split.isBarrier()));
+  splits_.push_back(std::move(split));
+  if (promises_.empty()) {
+    return;
+  }
+  promises.push_back(std::move(promises_.back()));
+  promises_.pop_back();
+}
+
+ContinueFuture SplitsStore::makeFuture() {
+  auto [promise, future] =
+      makeVeloxContinuePromiseContract("SplitsStore::makeFuture");
+  promises_.push_back(std::move(promise));
+  return std::move(future);
+}
+
+Split SplitsStore::getSplit(
+    int maxPreloadSplits,
+    const ConnectorSplitPreloadFunc& preload) {
+  int readySplitIndex = -1;
+  if (maxPreloadSplits > 0) {
+    for (int i = 0, end = std::min<size_t>(maxPreloadSplits, splits_.size());
+         i < end;
+         ++i) {
+      if (splits_[i].isBarrier()) {
+        VELOX_CHECK(!remoteSplit_);
+        continue;
+      }
+      auto& connectorSplit = splits_[i].connectorSplit;
+      if (!connectorSplit->dataSource) {
+        // Initializes split->dataSource.
+        preload(connectorSplit);
+        preloadingSplits_->insert(connectorSplit);
+      } else if (
+          readySplitIndex == -1 && connectorSplit->dataSource->hasValue()) {
+        readySplitIndex = i;
+        preloadingSplits_->erase(connectorSplit);
+      }
+    }
+  }
+  if (readySplitIndex == -1) {
+    readySplitIndex = 0;
+  }
+  VELOX_CHECK(!splits_.empty());
+  auto split = std::move(splits_[readySplitIndex]);
+  splits_.erase(splits_.begin() + readySplitIndex);
+  --taskStats_->numQueuedSplits;
+  ++taskStats_->numRunningSplits;
+  if (!remoteSplit_ && split.connectorSplit) {
+    --taskStats_->numQueuedTableScanSplits;
+    ++taskStats_->numRunningTableScanSplits;
+    taskStats_->queuedTableScanSplitWeights -=
+        split.connectorSplit->splitWeight;
+    taskStats_->runningTableScanSplitWeights +=
+        split.connectorSplit->splitWeight;
+  }
+  taskStats_->lastSplitStartTimeMs = getCurrentTimeMs();
+  if (taskStats_->firstSplitStartTimeMs == 0) {
+    taskStats_->firstSplitStartTimeMs = taskStats_->lastSplitStartTimeMs;
+  }
+  return split;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -498,9 +498,11 @@ TEST_F(LocalPartitionTest, indicesBufferCapacity) {
   params.maxDrivers = 2;
   auto cursor = TaskCursor::create(params);
   for (auto i = 0; i < filePaths.size(); ++i) {
-    auto id = scanNodeIds[i % 3];
+    auto& id = scanNodeIds[i % 3];
     cursor->task()->addSplit(
         id, Split(makeHiveConnectorSplit(filePaths[i]->getPath())));
+  }
+  for (auto& id : scanNodeIds) {
     cursor->task()->noMoreSplits(id);
   }
   int numRows = 0;

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -2487,8 +2487,8 @@ DEBUG_ONLY_TEST_P(MultiFragmentTest, mergeWithEarlyTermination) {
   mergeIsBlockedReady.store(true);
   mergeIsBlockedWait.notifyAll();
 
-  ASSERT_TRUE(waitForTaskCompletion(partialSortTask.get(), 1'000'000'000));
-  ASSERT_TRUE(waitForTaskAborted(finalSortTask.get(), 1'000'000'000));
+  ASSERT_TRUE(waitForTaskCompletion(partialSortTask.get(), 30'000'000));
+  ASSERT_TRUE(waitForTaskAborted(finalSortTask.get(), 30'000'000));
 }
 
 class DataFetcher {

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1419,7 +1419,7 @@ bool waitForTaskStateChange(
 void waitForAllTasksToBeDeleted(uint64_t maxWaitUs) {
   uint64_t waitUs = 0;
   while (Task::numRunningTasks() != 0) {
-    constexpr uint64_t kWaitInternalUs = 1'000;
+    constexpr uint64_t kWaitInternalUs = 50'000;
     std::this_thread::sleep_for(std::chrono::microseconds(kWaitInternalUs));
     waitUs += kWaitInternalUs;
     if (waitUs >= maxWaitUs) {


### PR DESCRIPTION
Summary:
To support split pulling execution model, we make split store abstract
and move some of the split handling logic from `Task` into `SplitsStore`.

This is a pure refactoring and should not cause any behavior change for the existing split push executions.

Differential Revision: D78711553


