### PR TITLE
feat: Add seeded xxhash64 Presto function

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -150,3 +150,7 @@ Binary Functions
 .. function:: xxhash64(binary) -> varbinary
 
     Computes the xxhash64 hash of ``binary``.
+
+.. function:: xxhash64(binary, bigint) -> varbinary
+
+    Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -44,15 +44,19 @@ struct CRC32Function {
 };
 
 /// xxhash64(varbinary) → varbinary
-/// Return an 8-byte binary to hash64 of input (varbinary such as string)
+/// Return an 8-byte binary to hash64 of input (varbinary such as string) with
+/// optional seed
 template <typename T>
 struct XxHash64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE
-  void call(out_type<Varbinary>& result, const arg_type<Varbinary>& input) {
-    // Seed is set to 0.
-    int64_t hash = folly::Endian::swap64(XXH64(input.data(), input.size(), 0));
+  void call(
+      out_type<Varbinary>& result,
+      const arg_type<Varbinary>& input,
+      const arg_type<int64_t>& seed = 0) {
+    int64_t hash =
+        folly::Endian::swap64(XXH64(input.data(), input.size(), seed));
     static constexpr auto kLen = sizeof(int64_t);
 
     // Resizing output and copy

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -24,6 +24,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<CRC32Function, int64_t, Varbinary>({prefix + "crc32"});
   registerFunction<XxHash64Function, Varbinary, Varbinary>(
       {prefix + "xxhash64"});
+  registerFunction<XxHash64Function, Varbinary, Varbinary, int64_t>(
+      {prefix + "xxhash64"});
   registerFunction<Md5Function, Varbinary, Varbinary>({prefix + "md5"});
   registerFunction<Murmur3X64_128Function, Varbinary, Varbinary>(
       {prefix + "murmur3_x64_128"});

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -315,6 +315,20 @@ TEST_F(BinaryFunctionsTest, xxhash64) {
       hexToDec("D73C92CF24E6EC82"), xxhash64("more_than_12_characters_string"));
 }
 
+TEST_F(BinaryFunctionsTest, xxhash64WithSeed) {
+  const auto xxhash64WithSeed = [&](std::optional<std::string> value,
+                                    std::optional<int64_t> seed) {
+    return evaluateOnce<std::string>(
+        "xxhash64(c0, c1)", {VARBINARY(), BIGINT()}, value, seed);
+  };
+
+  EXPECT_EQ(hexToDec("F9D96E0E1165E892"), xxhash64WithSeed("hashme", 0));
+  EXPECT_NE(hexToDec("F9D96EAE1165E892"), xxhash64WithSeed("hashme", 0));
+  EXPECT_NE(hexToDec("F9D96E0E1165E892"), xxhash64WithSeed("hashme", 1));
+  EXPECT_EQ(hexToDec("26C7827D889F6DA3"), xxhash64WithSeed("hello", 0));
+  EXPECT_NE(hexToDec("26C7827D889F6DA3"), xxhash64WithSeed("hello", 1224));
+}
+
 TEST_F(BinaryFunctionsTest, toHex) {
   const auto toHex = [&](std::optional<std::string> value) {
     return evaluateOnce<std::string>("to_hex(cast(c0 as varbinary))", value);


### PR DESCRIPTION
Summary: This change introduces a new override of the xxhash64 function that accepts a seed argument. The seeded version of xxhash64 allows hashing of binary input with a specified seed value. This functionality is useful for scenarios requiring consistent and uniform sharding or partitioning based on a seeded hash.

Differential Revision: D78699434


