### PR TITLE
feat: Unblock Tpch for native query execution

### DIFF
--- a/velox/connectors/tpch/CMakeLists.txt
+++ b/velox/connectors/tpch/CMakeLists.txt
@@ -15,6 +15,7 @@
 velox_add_library(velox_tpch_connector OBJECT TpchConnector.cpp)
 
 velox_link_libraries(velox_tpch_connector velox_connector velox_tpch_gen
+                     velox_core velox_exec velox_expression velox_vector
                      fmt::fmt)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/expression/Expr.h"
 #include "velox/tpch/gen/TpchGen.h"
 
 namespace facebook::velox::connector::tpch {
@@ -88,8 +90,9 @@ TpchDataSource::TpchDataSource(
     const RowTypePtr& outputType,
     const connector::ConnectorTableHandlePtr& tableHandle,
     const connector::ColumnHandleMap& columnHandles,
-    velox::memory::MemoryPool* pool)
-    : pool_(pool) {
+    ConnectorQueryCtx* connectorQueryCtx)
+    : connectorQueryCtx_(connectorQueryCtx),
+      pool_(connectorQueryCtx->memoryPool()) {
   auto tpchTableHandle =
       std::dynamic_pointer_cast<const TpchTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(
@@ -102,7 +105,6 @@ TpchDataSource::TpchDataSource(
   VELOX_CHECK_NOT_NULL(tpchTableSchema, "TpchSchema can't be null.");
 
   outputColumnMappings_.reserve(outputType->size());
-
   for (const auto& outputName : outputType->names()) {
     auto it = columnHandles.find(outputName);
     VELOX_CHECK(
@@ -128,6 +130,11 @@ TpchDataSource::TpchDataSource(
     outputColumnMappings_.emplace_back(*idx);
   }
   outputType_ = outputType;
+
+  if (tpchTableHandle->filterExpression()) {
+    filterExpression_ = connectorQueryCtx_->expressionEvaluator()->compile(
+        tpchTableHandle->filterExpression());
+  }
 }
 
 RowVectorPtr TpchDataSource::projectOutputColumns(RowVectorPtr inputVector) {
@@ -168,6 +175,55 @@ void TpchDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   splitEnd_ = splitOffset_ + partSize;
 }
 
+RowVectorPtr TpchDataSource::applyFilter(
+    RowVectorPtr& vector,
+    exec::ExprSet* filter) {
+  if (!filter) {
+    return projectOutputColumns(vector);
+  }
+
+  filterSelectivityVector_.resize(vector->size());
+  filterSelectivityVector_.setAll();
+  filterEvalCtx_.selectedIndices =
+      allocateIndices(vector->size(), vector->pool());
+
+  if (!filterMask_ || filterMask_->size() < vector->size()) {
+    filterMask_ = BaseVector::create(BOOLEAN(), vector->size(), pool_);
+  }
+  connectorQueryCtx_->expressionEvaluator()->evaluate(
+      filter, filterSelectivityVector_, *vector, filterMask_);
+
+  auto filterResults = filterMask_->as<SimpleVector<bool>>();
+  filterSelectivityVector_.applyToSelected([&](vector_size_t row) {
+    if (filterResults->isNullAt(row) || !filterResults->valueAt(row)) {
+      filterSelectivityVector_.setValid(row, false);
+    }
+  });
+  filterSelectivityVector_.updateBounds();
+
+  if (filterSelectivityVector_.isAllSelected()) {
+    return projectOutputColumns(vector);
+  }
+
+  auto* selected = filterEvalCtx_.getRawSelectedIndices(
+      filterSelectivityVector_.size(), pool_);
+  vector_size_t remaining = 0;
+  filterSelectivityVector_.applyToSelected(
+      [&selected, &remaining](int32_t row) { selected[remaining++] = row; });
+
+  std::vector<VectorPtr> children;
+  children.reserve(outputType_->size());
+  for (int i = 0; i < outputType_->size(); ++i) {
+    auto& child = vector->childAt(outputColumnMappings_[i]);
+    children.emplace_back(
+        exec::wrapChild(remaining, filterEvalCtx_.selectedIndices, child));
+  }
+
+  filterEvalCtx_.selectedIndices.reset();
+  return std::make_shared<RowVector>(
+      vector->pool(), outputType_, BufferPtr(), remaining, std::move(children));
+}
+
 std::optional<RowVectorPtr> TpchDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /*future*/) {
@@ -200,7 +256,8 @@ std::optional<RowVectorPtr> TpchDataSource::next(
   completedRows_ += outputVector->size();
   completedBytes_ += outputVector->retainedSize();
 
-  return projectOutputColumns(outputVector);
+  // Apply any filters pushed down into the DataSource
+  return applyFilter(outputVector, filterExpression_.get());
 }
 
 bool TpchDataSource::isLineItem() const {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -193,11 +193,14 @@ class PlanBuilder {
   /// @param columnNames The columns to be returned from that table.
   /// @param scaleFactor The TPC-H scale factor.
   /// @param connectorId The TPC-H connector id.
+  /// @param filter Optional SQL expression to filter the data at the connector
+  /// level.
   PlanBuilder& tpchTableScan(
       tpch::Table table,
       std::vector<std::string> columnNames,
       double scaleFactor = 1,
-      std::string_view connectorId = kTpchDefaultConnectorId);
+      std::string_view connectorId = kTpchDefaultConnectorId,
+      const std::string& filter = "");
 
   /// Helper class to build a custom TableScanNode.
   /// Uses a planBuilder instance to get the next plan id, memory pool, and


### PR DESCRIPTION
Summary:
as part of the Axiom project, we are adding an end-to-end query execution pipeline in C++. There are two changes which need to be made to make this possible with a Tpch backend:

1. need to be able to pushdown filters into the TPC-H data source
2. need the ability to distinguish between TPC-H tables of different scale factors using the public ConnectorTableHandle APIs

For (1), we can store the filters in an optional field inside the TableHandle and pass them down through the data source. Then, when reading from the data source, apply filters to the rows generated via the Tpch generator.

Rather than deal with the complexity of subfields, I am combining all filters in a `remainingFilter` expression and evaluating that directly. If a filter was not emplaced into the parent table handle, the data source path remains the sam

For (2), modifying the `name()` API to return a fully-qualified name inferred from the scale factor rather than just the name of the base table. Anything with a scale factor <1.0 is resolved to the `tiny` table

Differential Revision: D78605275


