### PR TITLE
fix: Remove std::move in return call

### DIFF
--- a/velox/functions/prestosql/BingTileFunctions.h
+++ b/velox/functions/prestosql/BingTileFunctions.h
@@ -56,7 +56,7 @@ struct BingTileFunction {
 
     auto zoomCheck = checkBingTileZoom(zoom);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
 
     uint64_t tile = BingTileType::bingTileCoordsToInt(
@@ -217,7 +217,7 @@ struct BingTileChildrenFunction {
     VELOX_DCHECK(BingTileType::isBingTileIntValid(tileInt));
     auto zoomCheck = checkBingTileZoom(childZoom);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto childrenRes =
         BingTileType::bingTileChildren(tileInt, childZoom, maxZoomShift);
@@ -255,7 +255,7 @@ struct BingTileAtFunction {
       const arg_type<int32_t>& zoomLevel) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto latitudeLongitudeToTileResult = BingTileType::latitudeLongitudeToTile(
         latitude, longitude, static_cast<uint8_t>(zoomLevel));
@@ -278,7 +278,7 @@ struct BingTilesAroundFunction {
       const arg_type<int32_t>& zoomLevel) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto bingTilesAroundResult = BingTileType::bingTilesAround(
         latitude, longitude, static_cast<uint8_t>(zoomLevel));
@@ -299,7 +299,7 @@ struct BingTilesAroundFunction {
       const arg_type<double>& radiusInKm) {
     auto zoomCheck = checkBingTileZoom(zoomLevel);
     if (FOLLY_UNLIKELY(!zoomCheck.ok())) {
-      return std::move(zoomCheck);
+      return zoomCheck;
     }
     auto bingTilesAroundResult = BingTileType::bingTilesAround(
         latitude, longitude, static_cast<uint8_t>(zoomLevel), radiusInKm);


### PR DESCRIPTION
fix: #14188 