### PR TITLE
fix: ConstantTypedExpr::equals null behavior

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -364,7 +364,7 @@ bool equalsImpl(
 
   if (otherNull || thisNull) {
     return BaseVector::compareNulls(thisNull, otherNull, kEqualValueAtFlags)
-        .value();
+               .value() == 0;
   }
 
   return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
@@ -383,11 +383,9 @@ bool ConstantTypedExpr::equals(const ITypedExpr& other) const {
   }
 
   if (this->hasValueVector() != casted->hasValueVector()) {
-    if (this->hasValueVector()) {
-      return equalsImpl(this->valueVector_, 0, casted->value_);
-    } else {
-      return equalsImpl(casted->valueVector_, 0, this->value_);
-    }
+    return this->hasValueVector()
+        ? equalsImpl(this->valueVector_, 0, casted->value_)
+        : equalsImpl(casted->valueVector_, 0, this->value_);
   }
 
   if (this->hasValueVector()) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2597,6 +2597,25 @@ TEST_P(ParameterizedExprTest, constantToString) {
   EXPECT_EQ("{1, 2, 3, 4, 5, ...4 more}:ARRAY<INTEGER>", exprs[3]->toString());
 }
 
+TEST_F(ExprTest, constantEqualsNullConsistency) {
+  // Constant expr created using variant
+  auto nullVariantToExpr =
+      std::make_shared<core::ConstantTypedExpr>(VARCHAR(), Variant{});
+  auto nonNullVariantToExpr =
+      std::make_shared<core::ConstantTypedExpr>(VARCHAR(), Variant{"test"});
+
+  // Constant expr created using vectors
+  auto nullBaseVectorToExpr = std::make_shared<core::ConstantTypedExpr>(
+      BaseVector::createNullConstant(VARCHAR(), 1, pool()));
+  auto nonNullBaseVectorToExpr = std::make_shared<core::ConstantTypedExpr>(
+      BaseVector::createConstant(VARCHAR(), Variant{"test"}, 1, pool()));
+
+  EXPECT_FALSE(nonNullVariantToExpr->equals(*nullBaseVectorToExpr));
+  EXPECT_FALSE(nullVariantToExpr->equals(*nonNullBaseVectorToExpr));
+  EXPECT_TRUE(nonNullVariantToExpr->equals(*nonNullBaseVectorToExpr));
+  EXPECT_TRUE(nullVariantToExpr->equals(*nullBaseVectorToExpr));
+}
+
 // Verify consistency of ConstantTypeExpr::toString/hash/equals APIs. The
 // outcome should not depend on whether expression was created using a Variant
 // of a Vector.


### PR DESCRIPTION
Summary:
Fixes ConstantTypedExpr::equals for constant expressions with null values. Currently, we simply return the value of BaseVector::compareNulls, which operators like a comparator (0 if same 1/-1 otherwise), which returns the opposite value we want (1 or true if same, 0 otherwise).

This will also solve the issues and reduce the flakiness we see in fuzzers because of this error: https://github.com/facebookincubator/velox/issues/14122

Differential Revision: D78771083


