### PR TITLE
fix: Filter signatures from only list if they are also part of skiplist

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -114,9 +114,11 @@ static void filterSignatures(
     facebook::velox::FunctionSignatureMap& input,
     const std::string& onlyFunctions,
     const std::unordered_set<std::string>& skipFunctions) {
-  if (!onlyFunctions.empty()) {
+  auto filteredFunctions = filterOnly(onlyFunctions, skipFunctions);
+
+  if (!filteredFunctions.empty()) {
     // Parse, lower case and trim it.
-    auto nameSet = exec::splitNames(onlyFunctions);
+    auto nameSet = exec::splitNames(filteredFunctions);
 
     // Use the generated set to filter the input signatures.
     for (auto it = input.begin(); it != input.end();) {

--- a/velox/expression/fuzzer/FuzzerToolkit.cpp
+++ b/velox/expression/fuzzer/FuzzerToolkit.cpp
@@ -235,4 +235,27 @@ core::TypedExprPtr ExprBank::getRandomExpression(
   return nullptr;
 }
 
+std::string filterOnly(
+    const std::string& onlyFunctions,
+    const std::unordered_set<std::string>& skipFunctions) {
+  if (onlyFunctions.empty() || skipFunctions.empty()) {
+    return onlyFunctions;
+  }
+
+  if (!onlyFunctions.empty()) {
+    std::vector<std::string> onlyFunctionsVec;
+    folly::split(',', onlyFunctions, onlyFunctionsVec);
+    std::vector<std::string> filteredFunctions;
+    for (const auto& func : onlyFunctionsVec) {
+      if (skipFunctions.find(func) == skipFunctions.end()) {
+        filteredFunctions.push_back(func);
+      }
+    }
+
+    return folly::join(",", filteredFunctions);
+  }
+
+  return onlyFunctions;
+}
+
 } // namespace facebook::velox::fuzzer


### PR DESCRIPTION
Summary:
Currently the bias aggregation fuzzers fail if the --only functions list has functions that are in the skip list. For e.g : https://github.com/facebookincubator/velox/actions/runs/16427655994/job/46426205042?pr=14117 . We fix the Aggregate fuzzer to filter signatures that are also part of the skip list. 
This change filters out signatures from only list if they are present in the skip list.

Differential Revision: D78793063


