### PR TITLE
fix: Avoid deadlock when drop child fails

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -384,7 +384,7 @@ void MemoryPool::dropChild(const MemoryPool* child) {
       1,
       "Child memory pool {} doesn't exist in {}",
       child->name(),
-      toString());
+      name());
 }
 
 bool MemoryPool::aborted() const {


### PR DESCRIPTION
Summary:
If we drop an non-exist child pool, the check failure triggers toString() call to log the parent child stats which grabs the mutex lock again, which leads to the deadlock.
We shall also investigate why there is a non-exist child pool to drop in the user case.

Differential Revision: D78815627


