### PR TITLE
fix: Fix Spark decimal multiply and divide functions

### DIFF
--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -427,7 +427,7 @@ struct DecimalMultiplyFunction {
       return in;
     }
 
-    int256_t divisor = velox::DecimalUtil::kPowersOfTen[reduceBy];
+    int256_t divisor = DecimalUtil::getPowersOfTen(reduceBy);
     auto result = in / divisor;
     auto remainder = in % divisor;
     // Round up.

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -411,6 +411,21 @@ TEST_F(DecimalArithmeticTest, multiply) {
            1,
            DECIMAL(38, 0)),
        makeConstant<int64_t>(100, 1, DECIMAL(2, 1))});
+
+  testArithmeticFunction(
+      "multiply",
+      makeConstant<int128_t>(
+          HugeInt::parse("9999542798541987451780195064133346831"),
+          1,
+          DECIMAL(38, 23)),
+      {makeConstant<int128_t>(
+           HugeInt::parse("99997713966580193276534859500386083931"),
+           1,
+           DECIMAL(38, 31)),
+       makeConstant<int128_t>(
+           HugeInt::parse("99997713966580193276534859500386083931"),
+           1,
+           DECIMAL(38, 31))});
 }
 
 TEST_F(DecimalArithmeticTest, divide) {
@@ -519,6 +534,17 @@ TEST_F(DecimalArithmeticTest, divide) {
       makeConstant<int128_t>(std::nullopt, 1, DECIMAL(38, 6)),
       {makeConstant<int128_t>(DecimalUtil::kLongDecimalMax, 1, DECIMAL(38, 0)),
        makeConstant<int64_t>(1, 1, DECIMAL(3, 2))});
+
+  testArithmeticFunction(
+      "divide",
+      makeConstant<int128_t>(
+          HugeInt::parse("106277793246728545582603"), 1, DECIMAL(38, 6)),
+      {makeConstant<int128_t>(
+           HugeInt::parse("104352831492914033"), 1, DECIMAL(19, 0)),
+       makeConstant<int128_t>(
+           HugeInt::parse("98188745084925098440983457564770612914"),
+           1,
+           DECIMAL(38, 38))});
 }
 
 TEST_F(DecimalArithmeticTest, denyPrecisionLoss) {


### PR DESCRIPTION
The `int256_t` type is needed when computing the intermediate result of large 
input values. To rescale down, the rescale factor can exceed the maximum value 
that `int128_t` can represent. The `DecimalUtil::kPowersOfTen` array is not 
large enough to hold these values, leading to unexpected result. This PR fixes 
this by adding `kLargeScalePowersOfTen`, which is sufficiently large for the 
decimal operation's rescale factor.

Reference: https://github.com/apache/arrow/blob/r-15.0.1/cpp/src/gandiva/decimal_xlarge.cc#L148-L164

