### PR TITLE
fix: TableScan metrics collection type

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -231,10 +231,10 @@ RowVectorPtr TableScan::getOutput() {
                1.0 * data->size() / readBatchSize,
                1.0 / kMaxSelectiveBatchSizeMultiplier});
           if (ioTimeUs > 0) {
-            RECORD_HISTOGRAM_METRIC_VALUE(
+            RECORD_METRIC_VALUE(
                 velox::kMetricTableScanBatchProcessTimeMs, ioTimeUs / 1'000);
           }
-          RECORD_HISTOGRAM_METRIC_VALUE(
+          RECORD_METRIC_VALUE(
               velox::kMetricTableScanBatchBytes, data->estimateFlatSize());
           return data;
         } else {


### PR DESCRIPTION
PR #13773 changed the metric type for some table scan metrics from histogram to average type. However, the corresponding collection still called the histogram type collection for these metrics causing SEGVs when using Prometheus.

This PR changes the collection type to match the metric type.

We saw SEGV with some debug outputs when collecting the stats with Prometheus:

```
I20250723 19:41:33.072866    85 PrometheusStatsReporter.cpp:214] Collecting: velox.table_scan_batch_process_time_ms Value: 0
I20250723 19:41:33.072888    82 PrometheusStatsReporter.cpp:214] Collecting: velox.table_scan_batch_bytes Value: 0
E20250723 19:41:33.073149    85 Executor.cpp:31] ThreadPoolExecutor: func threw unhandled std::system_error: Invalid argument
*** Aborted at 1753299693 (Unix time, try 'date -d @1753299693') ***
*** Signal 11 (SIGSEGV) (0x3f92ad9b4670) received by PID 59 (pthread TID 0x7eecf17fa640) (linux TID 82) (code: address not mapped to object), stack trace: ***
```

Some more details:
```
#0  0x00007ff0a1843d10 in bool __gnu_cxx::__ops::_Iter_less_val::operator()<__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, double const>(__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, double const&) const () from /usr/lib64/prestissimo-libs/libprometheus-cpp-core.so.1.2
#2  0x00007ff0a184314f in __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > > std::lower_bound<__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, double>(__gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, __gnu_cxx::__normal_iterator<double*, std::vector<double, std::allocator<double> > >, double const&) ()
   from /usr/lib64/prestissimo-libs/libprometheus-cpp-core.so.1.2
#3  0x00007ff0a184290a in prometheus::Histogram::Observe(double) () from /usr/lib64/prestissimo-libs/libprometheus-cpp-core.so.1.2
#4  0x000000000d0bd46a in operator() (__closure=0x7fb82dff1e20) at /prestissimo/presto_cpp/main/runtime-metrics/PrometheusStatsReporter.cpp:222
#5  0x000000000d0bdbf1 in folly::detail::function::call_<facebook::presto::prometheus::PrometheusStatsReporter::addHistogramMetricValue(char const*, size_t) const::<lambda()>, true, false, void>(folly::detail::function::Data &) (p=...)
```