### PR TITLE
build: test file compilation error

### DIFF
--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -422,7 +422,7 @@ TEST_F(FlatMapVectorTest, sortedKeyIndices) {
 
 TEST_F(FlatMapVectorTest, toString) {
   auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
-      {{}},
+      {std::vector<std::pair<int64_t, std::optional<int64_t>>>{}},
       {std::nullopt},
       {{{1, 0}}},
       {{{1, 1}, {2, std::nullopt}}},


### PR DESCRIPTION
Hi! I'm using gcc 13.3, on Ubuntu 24.04 kernel version 6.15.6 the source file `velox/vector/tests/FlatMapVectorTest.cpp` is failing to build for me when running `make release`.  The  error message is:
```
FlatMapVectorTest.cpp:424:63: error: converting to ‘std::optional<std::vector<std::pair<long int, std::optional<long int> > > >’ from initializer list would use explicit constructor ‘constexpr std::optional<_Tp>::optional(std::in_place_t, _Args&& ...) [with _Args = {}; typename std::enable_if<__and_v<std::is_constructible<_Tp, _Args ...> >, bool>::type <anonymous> = false; _Tp = std::vector<std::pair<long int, std::optional<long int> > >]’
  424 |   auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
  425 |       {{}},
      |       ~~~~~                                                    
  426 |       {std::nullopt},
      |       ~~~~~~~~~~~~~~~                                          
  427 |       {{{1, 0}}},
      |       ~~~~~~~~~~~                                              
  428 |       {{{1, 1}, {2, std::nullopt}}},
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                           
  429 |       {{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}},
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      
  430 |   });

```
This PR is fixing that build issue.

Thank you!
