### PR TITLE
feat(cudf): Support enable cudf in task level

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -306,6 +306,9 @@ struct CudfDriverAdapter {
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
+    if (!driver.driverCtx()->queryConfig().get<bool>(kCudfEnabled, true)) {
+      return false;
+    }
     auto state = CompileState(factory, driver);
     auto res = state.compile();
     return res;

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -30,6 +30,9 @@ namespace facebook::velox::cudf_velox {
 
 static const std::string kCudfAdapterName = "cuDF";
 
+// QueryConfig key. Enable or disable cudf in task level.
+static const std::string kCudfEnabled = "cudf.enabled";
+
 class CompileState {
  public:
   CompileState(const exec::DriverFactory& driverFactory, exec::Driver& driver)


### PR DESCRIPTION
Register cudf in executor, and may disable cudf in task plan level. For several plans, if the plan cannot fully be executed in GPU, we will not offload this stage to GPU to avoid format conversion cost, so we need this config to disable CUDF driver adapter.