### PR TITLE
refactor: Consolidate resolve-aggregate-function APIs

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -244,32 +244,6 @@ std::vector<CompanionSignatureEntry> getCompanionSignaturesWithSuffix(
   return entries;
 }
 
-// Selects the signature by name and argument types. Returns the resolved result
-// type for the type signature retrieved by the callback. Throws a user
-// exception if the corresponding signature isn't found.
-TypePtr resolveResultType(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes,
-    const std::function<const TypeSignature&(
-        const AggregateFunctionSignature&)>& getResultType) {
-  auto signatures = exec::getAggregateFunctionSignatures(name);
-  if (!signatures.has_value()) {
-    VELOX_USER_FAIL("Aggregate function not registered: {}", name);
-  }
-  for (auto& signature : signatures.value()) {
-    SignatureBinder binder(*signature, argTypes);
-    if (binder.tryBind()) {
-      return binder.tryResolveType(getResultType(*signature));
-    }
-  }
-
-  std::stringstream error;
-  error << "Aggregate function signature is not supported: "
-        << toString(name, argTypes)
-        << ". Supported signatures: " << toString(signatures.value()) << ".";
-  VELOX_USER_FAIL(error.str());
-}
-
 } // namespace
 
 std::optional<CompanionFunctionSignatureMap> getCompanionFunctionSignatures(
@@ -345,40 +319,6 @@ std::unique_ptr<Aggregate> Aggregate::create(
   }
 
   VELOX_USER_FAIL("Aggregate function not registered: {}", name);
-}
-
-// static
-TypePtr Aggregate::intermediateType(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes) {
-  auto type = resolveResultType(
-      name,
-      argTypes,
-      [](const AggregateFunctionSignature& signature) -> const TypeSignature& {
-        return signature.intermediateType();
-      });
-  VELOX_USER_CHECK(
-      type,
-      "Cannot resolve intermediate type for aggregate function {}",
-      toString(name, argTypes));
-  return type;
-}
-
-// static
-TypePtr Aggregate::finalType(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes) {
-  auto type = resolveResultType(
-      name,
-      argTypes,
-      [](const AggregateFunctionSignature& signature) -> const TypeSignature& {
-        return signature.returnType();
-      });
-  VELOX_USER_CHECK(
-      type,
-      "Cannot resolve final type for aggregate function {}",
-      toString(name, argTypes));
-  return type;
 }
 
 void Aggregate::setLambdaExpressions(

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -341,18 +341,6 @@ class Aggregate {
       const TypePtr& resultType,
       const core::QueryConfig& config);
 
-  // Returns the intermediate type for 'name' with signature
-  // 'argTypes'. Throws if cannot resolve.
-  static TypePtr intermediateType(
-      const std::string& name,
-      const std::vector<TypePtr>& argTypes);
-
-  // Returns the final type for 'name' with signature
-  // 'argTypes'. Throws if cannot resolve.
-  static TypePtr finalType(
-      const std::string& name,
-      const std::vector<TypePtr>& argTypes);
-
  protected:
   virtual void setAllocatorInternal(HashStringAllocator* allocator);
 

--- a/velox/exec/AggregateFunctionRegistry.h
+++ b/velox/exec/AggregateFunctionRegistry.h
@@ -23,10 +23,12 @@
 namespace facebook::velox::exec {
 
 /// Given a name of aggregate function and argument types, returns a pair of the
-/// return type and intermediate type if the function exists. Returns a pair of
-/// nullptr otherwise.
+/// return type and intermediate type if the function exists. Throws if function
+/// doesn't exist or doesn't support specified argument types.
+///
+/// @return a pair of {finalType, intermediateType}
 std::pair<TypePtr, TypePtr> resolveAggregateFunction(
-    const std::string& functionName,
+    const std::string& name,
     const std::vector<TypePtr>& argTypes);
 
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateInfo.cpp
+++ b/velox/exec/AggregateInfo.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/AggregateInfo.h"
 #include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/exec/Operator.h"
 #include "velox/expression/Expr.h"
 
@@ -82,8 +83,9 @@ std::vector<AggregateInfo> toAggregateInfo(
     }
 
     info.distinct = aggregate.distinct;
-    info.intermediateType = Aggregate::intermediateType(
-        aggregate.call->name(), aggregate.rawInputTypes);
+    info.intermediateType = resolveAggregateFunction(
+                                aggregate.call->name(), aggregate.rawInputTypes)
+                                .second;
 
     // Setup aggregation mask: convert the Variable Reference name to the
     // channel (projection) index, if there is a mask.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/verax/pull/70

exec::resolveAggregateFunction API duplicates a pair of exec::Aggregate::{intermediateType, finalType) APIs.

Remove exec::Aggregate::xxxType APIs and update the callers to use exec::resolveAggregateFunction.

Differential Revision: D78893595


