### PR TITLE
feat: Make AssignUniqueId operator support barriered execution.

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4262,6 +4262,10 @@ class AssignUniqueIdNode : public PlanNode {
       const int32_t taskUniqueId,
       PlanNodePtr source);
 
+  bool supportsBarrier() const override {
+    return true;
+  }
+
   class Builder {
    public:
     Builder() = default;

--- a/velox/exec/AssignUniqueId.h
+++ b/velox/exec/AssignUniqueId.h
@@ -48,6 +48,11 @@ class AssignUniqueId : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  bool startDrain() override {
+    // No need to drain for assignUniqueId operator.
+    return false;
+  }
+
   bool isFinished() override;
 
  private:

--- a/velox/exec/tests/AssignUniqueIdTest.cpp
+++ b/velox/exec/tests/AssignUniqueIdTest.cpp
@@ -16,31 +16,51 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 
-using namespace facebook::velox;
+namespace facebook::velox::exec {
+
 using namespace facebook::velox::test;
-using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
-class AssignUniqueIdTest : public OperatorTestBase {
+namespace {
+
+class AssignUniqueIdTest : public HiveConnectorTestBase {
  protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+  }
+
   void verifyUniqueId(
       const std::shared_ptr<const core::PlanNode>& plan,
       const std::vector<RowVectorPtr>& input) {
     CursorParameters params;
     params.planNode = plan;
-
     auto result = readCursor(params);
-    auto numColumns = result.second[0]->childrenSize();
+    ASSERT_EQ(result.second[0]->childrenSize(), input[0]->childrenSize() + 1);
+    verifyUniqueId(input, result.second);
+
+    auto task = result.first->task();
+    // Verify number of memory allocations. There should be exactly one
+    // allocation (per thread of execution) for the values buffer of the
+    // unique ID vector. Memory should be allocated when producing first
+    // batch of output and re-used for subsequent batches.
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(1, stats.at(uniqueNodeId_).numMemoryAllocations);
+  }
+
+  void verifyUniqueId(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<facebook::velox::RowVectorPtr>& vectors) {
+    auto numColumns = vectors[0]->childrenSize();
     ASSERT_EQ(numColumns, input[0]->childrenSize() + 1);
 
     std::set<int64_t> ids;
     for (int i = 0; i < numColumns; i++) {
-      for (auto batch = 0; batch < result.second.size(); ++batch) {
-        auto column = result.second[batch]->childAt(i);
+      for (auto batch = 0; batch < vectors.size(); ++batch) {
+        auto column = vectors[batch]->childAt(i);
         if (i < numColumns - 1) {
           assertEqualVectors(input[batch]->childAt(i), column);
         } else {
@@ -59,15 +79,6 @@ class AssignUniqueIdTest : public OperatorTestBase {
     }
 
     ASSERT_EQ(totalInputSize, ids.size());
-
-    auto task = result.first->task();
-
-    // Verify number of memory allocations. There should be exactly one
-    // allocation (per thread of execution) for the values buffer of the unique
-    // ID vector. Memory should be allocated when producing first batch of
-    // output and re-used for subsequent batches.
-    auto stats = toPlanStats(task->taskStats());
-    ASSERT_EQ(1, stats.at(uniqueNodeId_).numMemoryAllocations);
   }
 
   core::PlanNodeId uniqueNodeId_;
@@ -76,6 +87,7 @@ class AssignUniqueIdTest : public OperatorTestBase {
 TEST_F(AssignUniqueIdTest, multiBatch) {
   vector_size_t batchSize = 1000;
   std::vector<RowVectorPtr> input;
+  input.reserve(3);
   for (int i = 0; i < 3; ++i) {
     input.push_back(
         makeRowVector({makeFlatVector<int32_t>(batchSize, folly::identity)}));
@@ -133,9 +145,9 @@ TEST_F(AssignUniqueIdTest, multiThread) {
     ASSERT_EQ(batchSize * 8, ids.size());
 
     // Verify number of memory allocations. There should be exactly one
-    // allocation (per thread of execution) for the values buffer of the unique
-    // ID vector. Memory should be allocated when producing first batch of
-    // output and re-used for subsequent batches.
+    // allocation (per thread of execution) for the values buffer of the
+    // unique ID vector. Memory should be allocated when producing first batch
+    // of output and re-used for subsequent batches.
     auto stats = toPlanStats(task->taskStats());
     ASSERT_EQ(8, stats.at(uniqueNodeId_).numMemoryAllocations);
   }
@@ -166,3 +178,46 @@ TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {
       AssertQueryBuilder(plan).copyResults(pool()),
       "(16777216 vs. 16777216) Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
 }
+
+TEST_F(AssignUniqueIdTest, barrier) {
+  auto rowType{ROW({"c0", "c1"}, {BIGINT(), INTEGER()})};
+
+  const int numSplits{5};
+
+  std::vector<RowVectorPtr> vectors;
+  std::vector<std::shared_ptr<TempFilePath>> tempFiles;
+
+  const int numRowsPerSplit{100};
+  for (int32_t i = 0; i < numSplits; ++i) {
+    auto vector = makeRowVector(rowType, {.vectorSize = numRowsPerSplit});
+    vectors.push_back(vector);
+    tempFiles.push_back(TempFilePath::create());
+  }
+  writeToFiles(toFilePaths(tempFiles), vectors);
+
+  auto plan = PlanBuilder()
+                  .tableScan(rowType)
+                  .assignUniqueId("row_number")
+                  .project({"c0", "c1", "row_number"})
+                  .planNode();
+
+  for (const auto barrierExecution : {false, true}) {
+    SCOPED_TRACE(fmt::format("barrierExecution {}", barrierExecution));
+
+    std::shared_ptr<Task> task;
+    auto result = AssertQueryBuilder(plan)
+                      .splits(makeHiveConnectorSplits(tempFiles))
+                      .serialExecution(true)
+                      .barrierExecution(barrierExecution)
+                      .copyResults(pool(), task);
+    auto results = split(result, numSplits);
+
+    verifyUniqueId(vectors, results);
+
+    const auto taskStats = task->taskStats();
+    ASSERT_EQ(taskStats.numBarriers, barrierExecution ? numSplits : 0);
+    ASSERT_EQ(taskStats.numFinishedSplits, numSplits);
+  }
+}
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1294,7 +1294,7 @@ PlanBuilder& PlanBuilder::assignUniqueId(
     const int32_t taskUniqueId) {
   planNode_ = std::make_shared<core::AssignUniqueIdNode>(
       nextPlanNodeId(), idName, taskUniqueId, planNode_);
-  VELOX_CHECK(!planNode_->supportsBarrier());
+  VELOX_CHECK(planNode_->supportsBarrier());
   return *this;
 }
 

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1345,11 +1345,12 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
   // 'result' borrows memory from cursor so the life cycle must be shorter.
   std::vector<RowVectorPtr> result;
   auto* task = cursor->task().get();
-
   while (!cursor->noMoreSplits()) {
     addSplits(cursor.get());
     while (cursor->moveNext()) {
-      result.push_back(cursor->current());
+      auto vector = cursor->current();
+      vector->loadedVector();
+      result.push_back(std::move(vector));
       testingMaybeTriggerAbort(task);
     }
   }


### PR DESCRIPTION
Summary:
1. Make AssignUniqueId operator support barriered execution.
2. Add option to Cursor to optionally ensure loading vector. Currently query would fail execution via AssertQueryBuilder if only identify projection exists for multi split execution, since the vectors a lazy vectors and the access can be after file is closed. 

Differential Revision: D78876063


