### PR TITLE
feat: Add output pool parameter in LocalRunner constructor

### DIFF
--- a/velox/runner/LocalRunner.cpp
+++ b/velox/runner/LocalRunner.cpp
@@ -93,11 +93,13 @@ std::vector<ExecutableFragment> topologicalSort(
 LocalRunner::LocalRunner(
     const MultiFragmentPlanPtr& plan,
     std::shared_ptr<core::QueryCtx> queryCtx,
-    std::shared_ptr<SplitSourceFactory> splitSourceFactory)
+    std::shared_ptr<SplitSourceFactory> splitSourceFactory,
+    std::shared_ptr<memory::MemoryPool> outputPool)
     : fragments_(topologicalSort(plan->fragments())),
       options_(plan->options()),
       splitSourceFactory_(std::move(splitSourceFactory)) {
   params_.queryCtx = std::move(queryCtx);
+  params_.outputPool = outputPool;
 }
 
 RowVectorPtr LocalRunner::next() {

--- a/velox/runner/LocalRunner.h
+++ b/velox/runner/LocalRunner.h
@@ -65,7 +65,8 @@ class LocalRunner : public Runner,
   LocalRunner(
       const MultiFragmentPlanPtr& plan,
       std::shared_ptr<core::QueryCtx> queryCtx,
-      std::shared_ptr<SplitSourceFactory> splitSourceFactory);
+      std::shared_ptr<SplitSourceFactory> splitSourceFactory,
+      std::shared_ptr<memory::MemoryPool> outputPool = nullptr);
 
   RowVectorPtr next() override;
 


### PR DESCRIPTION
Summary:
In LocalRunner, we lack the ability to pass in param_.outputpool. As a 
result, we create a new output pool for each LocalRunner, additionally,
the pool would be freed during LocalRunner desctruction.

However there are cases where we want to store the output vector
which means the output pool associated with the output vector need
to have longer lifespan than LocalRunner itself.

Add the ability to pass in output pool in LocalRunner constructor

Differential Revision: D78873789


