### PR TITLE
feat: Implement expand_envelope

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -166,6 +166,19 @@ Spatial Operations
     Returns the bounding rectangular polygon of a ``geometry``. Empty input will
     result in empty output.
 
+.. function:: ST_ExteriorRing(geometry: Geometry) -> output: Geometry
+
+    Returns a LineString representing the exterior ring of the input polygon.
+    Empty or null inputs result in null output. Non-polygon types will return
+    an error.
+
+.. function:: expand_envelope(geometry: Geometry, distance: double) -> output: Geometry
+
+    Returns the bounding rectangular polygon of a geometry, expanded by a distance.
+    Empty geometries will return an empty polygon. Negative or NaN distances will
+    return an error. Positive infinity distances may lead to undefined results.
+
+
 Accessors
 ---------
 .. function:: ST_IsValid(geometry: Geometry) -> valid: bool

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -244,6 +244,7 @@ std::unordered_set<std::string> skipFunctions = {
     "line_locate_point",
     "line_interpolate_point",
     "flatten_geometry_collections",
+    "expand_envelope",
 };
 
 std::unordered_set<std::string> skipFunctionsSOT = {

--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -86,6 +86,42 @@ class GeometrySerializer {
     writeGeometry(geometry, writer);
   }
 
+  template <typename StringWriter>
+  static void serializeEnvelope(
+      double xMin,
+      double yMin,
+      double xMax,
+      double yMax,
+      StringWriter& stringWriter) {
+    VarbinaryWriter writer(stringWriter);
+    writer.write(static_cast<uint8_t>(GeometrySerializationType::ENVELOPE));
+    writer.write(xMin);
+    writer.write(yMin);
+    writer.write(xMax);
+    writer.write(yMax);
+  }
+
+  template <typename StringWriter>
+  static void serializeEnvelope(
+      geos::geom::Envelope& envelope,
+      StringWriter& stringWriter) {
+    if (FOLLY_UNLIKELY(envelope.isNull())) {
+      serializeEnvelope(
+          std::numeric_limits<double>::quiet_NaN(),
+          std::numeric_limits<double>::quiet_NaN(),
+          std::numeric_limits<double>::quiet_NaN(),
+          std::numeric_limits<double>::quiet_NaN(),
+          stringWriter);
+    } else {
+      serializeEnvelope(
+          envelope.getMinX(),
+          envelope.getMinY(),
+          envelope.getMaxX(),
+          envelope.getMaxY(),
+          stringWriter);
+    }
+  }
+
  private:
   template <typename T>
   static void writeGeometry(
@@ -123,7 +159,6 @@ class GeometrySerializer {
     }
   }
 
- private:
   template <typename T>
   static void writeEnvelope(
       const geos::geom::Geometry& geometry,

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -71,6 +71,8 @@ void registerOverlayOperations(const std::string& prefix) {
       {{prefix + "ST_Union"}});
   registerFunction<StEnvelopeAsPtsFunction, Array<Geometry>, Geometry>(
       {{prefix + "ST_EnvelopeAsPts"}});
+  registerFunction<ExpandEnvelopeFunction, Geometry, Geometry, double>(
+      {{prefix + "expand_envelope"}});
 }
 
 void registerAccessors(const std::string& prefix) {


### PR DESCRIPTION
Summary:
This diff adds `expand_envelope` UDF to velox, and adds `GeometrySerializer::serializeEnvelope` utility to efficiently write envelopes. These are coupled because `testExpandEnvelope` functions as a test for `serializeEnvelope`

This also moves `ST_ExteriorRing` documentation to the correct section and makes some improvements.

Reviewed By: jagill

Differential Revision: D78792373
