### PR TITLE
feat: Implement bing_tile_polygon

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -245,6 +245,7 @@ std::unordered_set<std::string> skipFunctions = {
     "line_interpolate_point",
     "flatten_geometry_collections",
     "expand_envelope",
+    "bing_tile_polygon",
 };
 
 std::unordered_set<std::string> skipFunctionsSOT = {

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -33,6 +33,7 @@
 #include "velox/functions/Macros.h"
 #include "velox/functions/prestosql/geospatial/GeometrySerde.h"
 #include "velox/functions/prestosql/geospatial/GeometryUtils.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/type/Variant.h"
 
@@ -1680,6 +1681,27 @@ struct ExpandEnvelopeFunction {
 
  private:
   geos::geom::GeometryFactory::Ptr factory_;
+};
+
+template <typename T>
+struct BingTilePolygonFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Geometry>& result,
+      const arg_type<BingTile>& tile) {
+    auto x = BingTileType::bingTileX(tile);
+    auto y = BingTileType::bingTileY(tile);
+    auto zoom = BingTileType::bingTileZoom(tile);
+
+    double minX = BingTileType::tileXToLongitude(x, zoom);
+    double maxX = BingTileType::tileXToLongitude(x + 1, zoom);
+    double minY = BingTileType::tileYToLatitude(y, zoom);
+    double maxY = BingTileType::tileYToLatitude(y + 1, zoom);
+
+    geospatial::GeometrySerializer::serializeEnvelope(
+        minX, minY, maxX, maxY, result);
+  }
 };
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/GeometryFunctions.h"
+#include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryRegistration.h"
 
 namespace facebook::velox::functions {
@@ -159,6 +160,11 @@ void registerAccessors(const std::string& prefix) {
       Geometry>({{prefix + "flatten_geometry_collections"}});
 }
 
+void registerBingTileGeometryFunctions(const std::string& prefix) {
+  registerFunction<BingTilePolygonFunction, Geometry, BingTile>(
+      {{prefix + "bing_tile_polygon"}});
+}
+
 } // namespace
 
 void registerGeometryFunctions(const std::string& prefix) {
@@ -167,6 +173,7 @@ void registerGeometryFunctions(const std::string& prefix) {
   registerRelationPredicates(prefix);
   registerOverlayOperations(prefix);
   registerAccessors(prefix);
+  registerBingTileGeometryFunctions(prefix);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -2916,3 +2916,68 @@ TEST_F(GeometryFunctionsTest, testExpandEnvelope) {
       wrappedEnvelopeResult.value(),
       "POLYGON ((-2 7, -2 13, 4 13, 4 7, -2 7))");
 }
+
+TEST_F(GeometryFunctionsTest, testBingTilePolygon) {
+  const auto testBingTilePolygonFunc =
+      [&](const std::optional<int32_t>& x,
+          const std::optional<int32_t>& y,
+          const std::optional<int8_t>& zoom,
+          const std::optional<std::string>& expected) {
+        std::optional<std::string> result = evaluateOnce<std::string>(
+            "ST_AsText(bing_tile_polygon(bing_tile(c0, c1, c2)))", x, y, zoom);
+
+        if (x.has_value() && y.has_value() && zoom.has_value()) {
+          ASSERT_TRUE(result.has_value());
+          ASSERT_EQ(result.value(), expected.value());
+        } else {
+          ASSERT_FALSE(result.has_value());
+        }
+      };
+
+  testBingTilePolygonFunc(
+      0,
+      0,
+      0,
+      "POLYGON ((-180 85.05112877980659, -180 -85.05112877980659, 180 -85.05112877980659, 180 85.05112877980659, -180 85.05112877980659))");
+  testBingTilePolygonFunc(
+      1,
+      1,
+      1,
+      "POLYGON ((0 0, 0 -85.05112877980659, 180 -85.05112877980659, 180 0, 0 0))");
+  testBingTilePolygonFunc(
+      3,
+      3,
+      2,
+      "POLYGON ((90 -66.51326044311185, 90 -85.05112877980659, 180 -85.05112877980659, 180 -66.51326044311185, 90 -66.51326044311185))");
+  testBingTilePolygonFunc(
+      7,
+      7,
+      3,
+      "POLYGON ((135 -79.17133464081945, 135 -85.05112877980659, 180 -85.05112877980659, 180 -79.17133464081945, 135 -79.17133464081945))");
+  testBingTilePolygonFunc(
+      15,
+      15,
+      4,
+      "POLYGON ((157.5 -82.67628497834906, 157.5 -85.05112877980659, 180 -85.05112877980659, 180 -82.67628497834906, 157.5 -82.67628497834906))");
+
+  testBingTilePolygonFunc(
+      31,
+      31,
+      5,
+      "POLYGON ((168.75 -83.97925949886206, 168.75 -85.05112877980659, 180 -85.05112877980659, 180 -83.97925949886206, 168.75 -83.97925949886206))");
+  testBingTilePolygonFunc(
+      0,
+      0,
+      1,
+      "POLYGON ((-180 85.05112877980659, -180 0, 0 0, 0 85.05112877980659, -180 85.05112877980659))");
+  testBingTilePolygonFunc(
+      1,
+      1,
+      2,
+      "POLYGON ((-90 66.51326044311186, -90 0, 0 0, 0 66.51326044311186, -90 66.51326044311186))");
+  testBingTilePolygonFunc(
+      1,
+      1,
+      23,
+      "POLYGON ((-179.99995708465576 85.05112507763845, -179.99995708465576 85.05112137546752, -179.99991416931152 85.05112137546752, -179.99991416931152 85.05112507763845, -179.99995708465576 85.05112507763845))");
+}

--- a/velox/functions/prestosql/types/BingTileType.cpp
+++ b/velox/functions/prestosql/types/BingTileType.cpp
@@ -161,24 +161,6 @@ addDistanceToLatitude(double latitude, double radiusInKm, double bearing) {
   return newLatitude;
 }
 
-/**
- * Return the longitude (in degrees) of the west edge of the tile.
- */
-double tileXToLongitude(uint32_t tileX, uint8_t zoomLevel) {
-  int32_t mapTileSize = 1 << zoomLevel;
-  double x = (std::clamp<double>(tileX, 0, mapTileSize) / mapTileSize) - 0.5;
-  return 360 * x;
-}
-
-/**
- * Return the latitude (in degrees) of the north edge of the tile.
- */
-double tileYToLatitude(uint32_t tileY, uint8_t zoomLevel) {
-  int32_t mapTileSize = 1 << zoomLevel;
-  double y = 0.5 - (std::clamp<double>(tileY, 0, mapTileSize) / mapTileSize);
-  return 90 - 360 * atan(exp(-y * 2 * M_PI)) / M_PI;
-}
-
 struct GreatCircleDistanceToPoint {
  public:
   GreatCircleDistanceToPoint(double latitude, double longitude) {
@@ -395,6 +377,18 @@ folly::Expected<uint64_t, std::string> BingTileType::latitudeLongitudeToTile(
   }
 
   return bingTileCoordsToInt(tileX.value(), tileY.value(), zoomLevel);
+}
+
+double BingTileType::tileXToLongitude(uint32_t tileX, uint8_t zoomLevel) {
+  int32_t mapTileSize = 1 << zoomLevel;
+  double x = (std::clamp<double>(tileX, 0, mapTileSize) / mapTileSize) - 0.5;
+  return 360 * x;
+}
+
+double BingTileType::tileYToLatitude(uint32_t tileY, uint8_t zoomLevel) {
+  int32_t mapTileSize = 1 << zoomLevel;
+  double y = 0.5 - (std::clamp<double>(tileY, 0, mapTileSize) / mapTileSize);
+  return 90 - 360 * atan(exp(-y * 2 * M_PI)) / M_PI;
 }
 
 // Given a (longitude, latitude) point, returns the surrounding Bing tiles at

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -157,6 +157,16 @@ class BingTileType : public BigintType {
   static folly::Expected<uint64_t, std::string>
   latitudeLongitudeToTile(double latitude, double longitude, uint8_t zoomLevel);
 
+  /**
+   * Return the longitude (in degrees) of the west edge of the tile.
+   */
+  static double tileXToLongitude(uint32_t tileX, uint8_t zoomLevel);
+
+  /**
+   * Return the latitude (in degrees) of the north edge of the tile.
+   */
+  static double tileYToLatitude(uint32_t tileY, uint8_t zoomLevel);
+
   static folly::Expected<std::vector<uint64_t>, std::string>
   bingTilesAround(double latitude, double longitude, uint8_t zoomLevel);
 


### PR DESCRIPTION
Summary:
This diffs adds `bing_tile_polygon`. This required:
-Adding Geometry dependencies to `BingTileFunctions.h` and `BingTileFunctionsRegistration.cpp`
-Making some helper functions from `BingTileType` public
-Registering Geometry type in `BingTileFunctionsRegistration`

Reviewed By: jagill

Differential Revision: D78794636
