### PR TITLE
fix(build): Comparison of double to max int64

### DIFF
--- a/velox/functions/prestosql/aggregates/sfm/SfmSketch.cpp
+++ b/velox/functions/prestosql/aggregates/sfm/SfmSketch.cpp
@@ -219,8 +219,7 @@ int64_t SfmSketch::cardinality() const {
     return 0;
   }
 
-  VELOX_CHECK_LE(
-      guess, static_cast<double>(std::numeric_limits<int64_t>::max()));
+  VELOX_CHECK_LE(guess, std::numeric_limits<double>::max());
   // Clamp negative values to 0 before rounding to avoid undefined behavior
   // when casting negative values to unsigned types.
   double clampedGuess = std::max(0.0, guess);


### PR DESCRIPTION
A double type value is compared to numeric_limits<int64_t> when it should be compared to numeric_limits<double>. Not using the correct max value leads to Clang build error
error: implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
[-Werror,-Wimplicit-const-int-float-conversion]

Also another Clang fix is here: https://github.com/facebookincubator/velox/pull/13818
However, this affects the PrestoC++ build CI because it builds with Clang.