### PR TITLE
fix(build): Fix build error with VELOX_ENABLE_AGGREGATES=OFF

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -51,6 +51,7 @@ velox_link_libraries(
   Folly::folly)
 
 add_subdirectory(aggregates)
+add_subdirectory(sfm)
 add_subdirectory(string)
 add_subdirectory(window)
 if(${VELOX_BUILD_TESTING})

--- a/velox/functions/lib/sfm/CMakeLists.txt
+++ b/velox/functions/lib/sfm/CMakeLists.txt
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_functions_prestosql_aggregates_sfm_test SfmSketchTest.cpp)
+velox_add_library(velox_functions_sfm SfmSketch.cpp SfmSketchAccumulator.cpp)
 
-add_test(velox_functions_prestosql_aggregates_sfm_test
-         velox_functions_prestosql_aggregates_sfm_test)
+velox_link_libraries(velox_functions_sfm velox_common_base velox_memory
+                     Folly::folly)
 
-target_link_libraries(
-  velox_functions_prestosql_aggregates_sfm_test
-  velox_functions_prestosql_aggregates_sfm
-  velox_memory
-  GTest::gtest
-  GTest::gtest_main)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/functions/lib/sfm/RandomizationStrategy.h
+++ b/velox/functions/lib/sfm/RandomizationStrategy.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
 /// Interface for randomization strategy. We will implement different
 /// randomization strategies in merging, enable-privacy and testing.
@@ -27,4 +27,4 @@ class RandomizationStrategy {
   virtual ~RandomizationStrategy() = default;
 };
 
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/SecureRandomizationStrategy.h
+++ b/velox/functions/lib/sfm/SecureRandomizationStrategy.h
@@ -16,28 +16,19 @@
 
 #pragma once
 
-#include <optional>
-#include <random>
-#include "velox/functions/prestosql/aggregates/sfm/RandomizationStrategy.h"
+#include <folly/Random.h>
+#include "velox/functions/lib/sfm/RandomizationStrategy.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
-/// A pseudorandomness strategy used to merge SfmSketches.
-class MersenneTwisterRandomizationStrategy : public RandomizationStrategy {
+/// A secure randomization strategy used to enable differential privacy for
+/// SfmSketch.
+class SecureRandomizationStrategy : public RandomizationStrategy {
  public:
-  explicit MersenneTwisterRandomizationStrategy(
-      std::optional<int32_t> seed = {}) {
-    if (seed.has_value()) {
-      rng_.seed(seed.value());
-    }
-  }
-
   bool nextBoolean(double probability) override {
-    std::uniform_real_distribution<double> dist(0.0, 1.0);
-    return dist(rng_) < probability;
+    // folly random generate random number in [0, 1)
+    return folly::Random::secureRandDouble01() < probability;
   }
-
- private:
-  std::mt19937_64 rng_;
 };
-} // namespace facebook::velox::functions::aggregate
+
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/SfmSketch.cpp
+++ b/velox/functions/lib/sfm/SfmSketch.cpp
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include <cmath>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/IOUtils.h"
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h"
-#include "velox/functions/prestosql/aggregates/sfm/SecureRandomizationStrategy.h"
+#include "velox/functions/lib/sfm/MersenneTwisterRandomizationStrategy.h"
+#include "velox/functions/lib/sfm/SecureRandomizationStrategy.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
 namespace {
 void validateNumIndexBits(int32_t numIndexBits) {
@@ -359,4 +359,4 @@ void SfmSketch::setBitTrue(int32_t bucketIndex, int32_t zeros) {
   bits::setBit(bits_.data(), bitPosition, true);
 }
 
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/SfmSketch.h
+++ b/velox/functions/lib/sfm/SfmSketch.h
@@ -22,9 +22,9 @@
 #include <folly/Range.h>
 #include <cstdint>
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/functions/prestosql/aggregates/sfm/MersenneTwisterRandomizationStrategy.h"
+#include "velox/functions/lib/sfm/MersenneTwisterRandomizationStrategy.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
 /// SFM sketch is used for estimating distinct count, very similar to
 /// HyperLogLog. This sketch is introduced in the paper Sketch-Flip-Merge:
@@ -233,4 +233,4 @@ class SfmSketch {
   // merging private sketches.
   std::optional<MersenneTwisterRandomizationStrategy> randomizationStrategy_;
 };
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/SfmSketchAccumulator.cpp
+++ b/velox/functions/lib/sfm/SfmSketchAccumulator.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h"
+#include "velox/functions/lib/sfm/SfmSketchAccumulator.h"
 #include "velox/common/base/IOUtils.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 SfmSketchAccumulator::SfmSketchAccumulator(HashStringAllocator* allocator)
     : sketch_(allocator) {}
 
@@ -103,4 +103,4 @@ int64_t SfmSketchAccumulator::cardinality() {
   }
   return sketch_.cardinality();
 }
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/SfmSketchAccumulator.h
+++ b/velox/functions/lib/sfm/SfmSketchAccumulator.h
@@ -17,9 +17,9 @@
 #pragma once
 
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
 class SfmSketchAccumulator {
   static constexpr int32_t kDefaultBuckets = 4096;
@@ -95,4 +95,4 @@ class SfmSketchAccumulator {
   SfmSketch sketch_;
 };
 
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/lib/sfm/tests/CMakeLists.txt
+++ b/velox/functions/lib/sfm/tests/CMakeLists.txt
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_functions_prestosql_aggregates_sfm SfmSketch.cpp
-                  SfmSketchAccumulator.cpp)
+add_executable(velox_functions_sfm_test SfmSketchTest.cpp)
 
-velox_link_libraries(velox_functions_prestosql_aggregates_sfm velox_common_base
-                     velox_memory Folly::folly)
+add_test(velox_functions_sfm_test velox_functions_sfm_test)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+target_link_libraries(
+  velox_functions_sfm_test
+  velox_functions_sfm
+  velox_memory
+  GTest::gtest
+  GTest::gtest_main)

--- a/velox/functions/lib/sfm/tests/SfmSketchTest.cpp
+++ b/velox/functions/lib/sfm/tests/SfmSketchTest.cpp
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/common/memory/Memory.h"
 
-namespace facebook::velox::functions::aggregate {
+namespace facebook::velox::functions::sfm {
 
 class SfmSketchTest : public ::testing::Test {
  public:
@@ -319,4 +319,4 @@ TEST_F(SfmSketchTest, javaSerializationCompatibility) {
   // Test that the deserialized sketch is the same as the original.
   ASSERT_EQ(sketch.cardinality(), 927499);
 }
-} // namespace facebook::velox::functions::aggregate
+} // namespace facebook::velox::functions::sfm

--- a/velox/functions/prestosql/SfmSketchFunctions.cpp
+++ b/velox/functions/prestosql/SfmSketchFunctions.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/functions/prestosql/SfmSketchFunctions.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 
 namespace facebook::velox::functions {
 
@@ -24,7 +24,7 @@ std::string createEmptySfmSketch(
     double epsilon,
     std::optional<int64_t> buckets,
     std::optional<int64_t> precison) {
-  using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+  using SfmSketch = facebook::velox::functions::sfm::SfmSketch;
 
   constexpr int64_t kDefaultBuckets = 4096;
   constexpr int64_t kDefaultPrecision = 24;

--- a/velox/functions/prestosql/SfmSketchFunctions.h
+++ b/velox/functions/prestosql/SfmSketchFunctions.h
@@ -18,7 +18,7 @@
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/Macros.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 
 namespace facebook::velox::functions {
@@ -45,7 +45,7 @@ struct SfmSketchCardinality {
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<SfmSketch>& input) {
-    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+    using SfmSketch = facebook::velox::functions::sfm::SfmSketch;
     result = SfmSketch::deserialize(
                  reinterpret_cast<const char*>(input.data()), allocator_.get())
                  .cardinality();
@@ -123,7 +123,7 @@ struct mergeSfmSketchArray {
       return false;
     }
 
-    using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+    using SfmSketch = facebook::velox::functions::sfm::SfmSketch;
 
     // Collect all non-null sketches.
     std::vector<const char*> validSketches;

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -69,10 +69,8 @@ velox_link_libraries(
   velox_functions_lib
   velox_functions_util
   velox_presto_types
-  velox_functions_prestosql_aggregates_sfm
+  velox_functions_sfm
   Folly::folly)
-
-add_subdirectory(sfm)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/aggregates/SfmSketchAggregate.h
+++ b/velox/functions/prestosql/aggregates/SfmSketchAggregate.h
@@ -16,8 +16,8 @@
 #pragma once
 
 #include "velox/exec/Aggregate.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketchAccumulator.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketchAccumulator.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -30,9 +30,9 @@ class SfmSketchAggregate : public exec::Aggregate {
   // SfmSketchAccumulator as the accumulator type.
   using Accumulator = typename std::conditional<
       sketchAsInput,
-      facebook::velox::functions::aggregate::SfmSketch,
-      facebook::velox::functions::aggregate::SfmSketchAccumulator>::type;
-  using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+      facebook::velox::functions::sfm::SfmSketch,
+      facebook::velox::functions::sfm::SfmSketchAccumulator>::type;
+  using SfmSketch = facebook::velox::functions::sfm::SfmSketch;
 
  public:
   explicit SfmSketchAggregate(TypePtr resultType)

--- a/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
@@ -19,7 +19,7 @@
 #include "velox/functions/lib/QuantileDigest.h"
 #include "velox/functions/lib/TDigest.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchRegistration.h"
@@ -31,7 +31,7 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;
 using namespace facebook::velox::functions::qdigest;
-using SfmSketchIn = facebook::velox::functions::aggregate::SfmSketch;
+using SfmSketchIn = facebook::velox::functions::sfm::SfmSketch;
 
 namespace facebook::velox::aggregate::test {
 namespace {
@@ -341,7 +341,7 @@ TEST_F(MergeAggregateTest, mergeQDigestOneNullMatchJava) {
 
 TEST_F(MergeAggregateTest, mergeSfmSketch) {
   registerSfmSketchType();
-  using SfmSketch = functions::aggregate::SfmSketch;
+  using SfmSketch = functions::sfm::SfmSketch;
   HashStringAllocator allocator_{pool_.get()};
 
   // non-private sketch1: values [1, 2, 3]

--- a/velox/functions/prestosql/aggregates/tests/NoisyApproxSfmAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NoisyApproxSfmAggregationTest.cpp
@@ -16,12 +16,12 @@
 
 #include <gtest/gtest.h>
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::aggregate::test {
 
-using SfmSketch = functions::aggregate::SfmSketch;
+using SfmSketch = functions::sfm::SfmSketch;
 using namespace facebook::velox::exec::test;
 
 class NoisyApproxSfmAggregationTest

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -63,7 +63,7 @@ velox_link_libraries(
   velox_functions_prestosql
   velox_functions_prestosql_impl
   velox_is_null_functions
-  velox_functions_prestosql_aggregates_sfm
+  velox_functions_sfm
   simdjson::simdjson)
 
 if(NOT VELOX_MONO_LIBRARY)

--- a/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/SfmSketchFunctionsTest.cpp
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 
 namespace facebook::velox::functions::test {
-using SfmSketch = facebook::velox::functions::aggregate::SfmSketch;
+using SfmSketch = facebook::velox::functions::sfm::SfmSketch;
 
 class SfmSketchFunctionsTest : public functions::test::FunctionBaseTest {
  protected:

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -21,7 +21,7 @@ velox_link_libraries(
   velox_common_fuzzer_util
   velox_presto_types
   velox_type_tz
-  velox_functions_prestosql_aggregates_sfm)
+  velox_functions_sfm)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/types/fuzzer_utils/SfmSketchInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/SfmSketchInputGenerator.h
@@ -17,14 +17,14 @@
 #pragma once
 
 #include "velox/common/fuzzer/Utils.h"
-#include "velox/functions/prestosql/aggregates/sfm/SfmSketch.h"
+#include "velox/functions/lib/sfm/SfmSketch.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
 
 namespace facebook::velox::fuzzer {
 
 using facebook::velox::UnknownValue;
-using facebook::velox::functions::aggregate::SfmSketch;
+using facebook::velox::functions::sfm::SfmSketch;
 
 class SfmSketchInputGenerator : public AbstractInputGenerator {
  public:


### PR DESCRIPTION
Fixes #14244.

#14152 introduced sfmSketch functions and used them unconditionally.

But we have `VELOX_ENABLE_AGGREGATES` CMake option that can disable aggregate functions including sfmSketch functions.

If we build Velox with `-DVELOX_BUILD_MINIMAL_WITH_DWIO=ON` (that implies `-DVELOX_ENABLE_AGGREGATES=OFF` and `-DVELOX_BUILD_TESTING=OFF`) like Nimble does, Velox build is failed because it refers `velox_functions_prestosql_aggregates_sfm` that isn't built with `-DVELOX_ENABLE_AGGREGATES=OFF`.

This PR moves `velox/functions/prestosql/aggregates/sfm/` (`velox_functions_prestosql_aggregates_sfm`) to `velox/functions/lib/sfm/` (`velox_functions_sfm`) and `velox_functions_sfm` is built with `-DVELOX_ENABLE_AGGREGATES=OFF`.

Note that `-DVELOX_ENABLE_AGGREGATES=OFF` and `-DVELOX_BUILD_TESTING=ON` combination still causes a build error. Because our tests always refer `velox_aggregates`.