### PR TITLE
fix: Compilation of SIMDJsonExtractor with 3.13.0 simdjson

### DIFF
--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -17,9 +17,6 @@
 #include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
 
 namespace facebook::velox::functions {
-namespace {
-using JsonVector = std::vector<simdjson::ondemand::value>;
-}
 
 /* static */ SIMDJsonExtractor& SIMDJsonExtractor::getInstance(
     folly::StringPiece path) {
@@ -104,7 +101,7 @@ simdjson::error_code extractArray(
     }
     auto val = jsonArray.at(i);
     if (!val.error()) {
-      ret.emplace(std::move(val));
+      ret.emplace(std::move(val.value()));
     }
   }
   return simdjson::SUCCESS;


### PR DESCRIPTION
Now it works for simdjson 3.13.0, error without patch was like this:

```
[3/7] Building CXX object ...on/SIMDJsonExtractor.cpp.o
FAILED: third_party/velox/velox/buffer/CMakeFiles/velox.dir/__/functions/prestosql/json/SIMDJsonExtractor.cpp.o 
/usr/bin/ccache /usr/local/bin/clang++ -DABSL_MAX_VLOG_VERBOSITY=-1 -DABSL_MIN_LOG_LEVEL=3 -DBOOST_ALL_NO_LIB=1 -DBOOST_ASIO_NO_DEPRECATED=1 -DBOOST_NO_CXX98_FUNCTION_BASE=1 -DBOOST_SYSTEM_STATIC_LINK=1 -DBOOST_THREAD_DONT_PROVIDE_INTERRUPTIONS=1 -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX=1 -DLIBCXX_BUILDING_LIBCXXABI -DNDEBUG -DSDB_DEV=1 -DSDB_FAULT_INJECTION=1 -DSDB_GTEST=1 -DSIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON -DVELOX_DISABLE_GOOGLETEST -DVELOX_ENABLE_INT64_BUILD_PARTITION_BOUND -D_LIBCPP_HAS_ALIGNED_ALLOC=1 -D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER -I/home/mironov/projects/serenedb/third_party/velox/. -I/home/mironov/projects/serenedb/third_party/velox/velox/external/xxhash -I/home/mironov/projects/serenedb/build/third_party/velox -I/home/mironov/projects/serenedb/third_party/llvm-project/libcxxabi/include -I/home/mironov/projects/serenedb/third_party/fake -I/home/mironov/projects/serenedb/third_party/double-conversion -I/home/mironov/projects/serenedb/third_party/xsimd/include -I/home/mironov/projects/serenedb/third_party/re2 -I/home/mironov/projects/serenedb/third_party/simdjson/include -I/home/mironov/projects/serenedb/third_party/snowball/include -isystem /home/mironov/projects/serenedb/third_party/velox/velox -isystem /home/mironov/projects/serenedb/third_party/velox/velox/external -isystem /home/mironov/projects/serenedb/build/third_party/llvm-project/runtimes/include/c++/v1 -isystem /home/mironov/projects/serenedb/third_party/folly -isystem /home/mironov/projects/serenedb/third_party/boost -isystem /home/mironov/projects/serenedb/third_party/abseil-cpp -isystem /home/mironov/projects/serenedb/third_party/icu/icu/icu4c/source/common -Wall -Wextra -Wthread-safety -Wdeprecated -Wno-unused-parameter -mfxsr -mmmx -msse -msse2 -mcx16 -msahf -mpopcnt -msse3 -msse4.1 -msse4.2 -mssse3 -mpclmul -mavx -mxsave -maes -mavx2 -mbmi -mbmi2 -mf16c -mfma -mlzcnt -mmovbe -Wsuggest-override -Wsuggest-destructor-override -Wno-missing-designated-field-initializers -Wno-deprecated-declarations -Wno-deprecated-copy-with-dtor -fsized-deallocation -fstrict-vtable-pointers -Wno-unused -Wno-sign-compare -Wno-deprecated -Wno-suggest-override -Wno-suggest-destructor-override -Wno-missing-field-initializers -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -DFOLLY_CFG_NO_COROUTINES -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-range-loop-analysis          -Wno-mismatched-tags          -Wno-nullability-completeness -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-limit-debug-info -g3 -fstandalone-debug -fdebug-macro -glldb -std=gnu++20 -fcolor-diagnostics -nostdinc++ -nostdlib++ -MD -MT third_party/velox/velox/buffer/CMakeFiles/velox.dir/__/functions/prestosql/json/SIMDJsonExtractor.cpp.o -MF third_party/velox/velox/buffer/CMakeFiles/velox.dir/__/functions/prestosql/json/SIMDJsonExtractor.cpp.o.d @third_party/velox/velox/buffer/CMakeFiles/velox.dir/__/functions/prestosql/json/SIMDJsonExtractor.cpp.o.modmap -o third_party/velox/velox/buffer/CMakeFiles/velox.dir/__/functions/prestosql/json/SIMDJsonExtractor.cpp.o -c /home/mironov/projects/serenedb/third_party/velox/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
In file included from /home/mironov/projects/serenedb/third_party/velox/velox/functions/prestosql/json/SIMDJsonExtractor.cpp:17:
In file included from /home/mironov/projects/serenedb/third_party/velox/./velox/functions/prestosql/json/SIMDJsonExtractor.h:25:
In file included from /home/mironov/projects/serenedb/third_party/velox/./velox/functions/prestosql/json/SIMDJsonUtil.h:18:
In file included from /home/mironov/projects/serenedb/third_party/velox/./velox/functions/prestosql/json/SIMDJsonWrapper.h:22:
In file included from /home/mironov/projects/serenedb/third_party/simdjson/include/simdjson.h:55:
In file included from /home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/ondemand.h:4:
In file included from /home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/builtin/ondemand.h:16:
In file included from /home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/haswell/ondemand.h:5:
In file included from /home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/generic/ondemand/amalgamated.h:9:
/home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/generic/ondemand/value.h:77:19: error: static assertion failed due to requirement '!sizeof(simdjson::haswell::ondemand::value)': The get<T> method with type T is not implemented by the simdjson library. And you do not seem to have added support for it. Indeed, we have that simdjson::custom_deserializable<T> is false and the type T is not a default type such as ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, int64_t, double, or bool.
   77 |     static_assert(!sizeof(T), "The get<T> method with type T is not implemented by the simdjson library. "
      |                   ^~~~~~~~~~
/home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/generic/ondemand/value.h:51:18: note: in instantiation of function template specialization 'simdjson::haswell::ondemand::value::get<simdjson::haswell::ondemand::value>' requested here
   51 |     SIMDJSON_TRY(get<T>(out));
      |                  ^
/home/mironov/projects/serenedb/third_party/simdjson/include/simdjson/generic/ondemand/value-inl.h:477:16: note: in instantiation of function template specialization 'simdjson::haswell::ondemand::value::get<simdjson::haswell::ondemand::value>' requested here
  477 |   return first.get<T>();
      |                ^
/home/mironov/projects/serenedb/build/third_party/llvm-project/runtimes/include/c++/v1/__memory/construct_at.h:40:53: note: in instantiation of function template specialization 'simdjson::simdjson_result<simdjson::haswell::ondemand::value>::operator value<simdjson::haswell::ondemand::value>' requested here
   40 |   return ::new (static_cast<void*>(__location)) _Tp(std::forward<_Args>(__args)...);
      |                                                     ^
1 error generated.
```