### PR TITLE
feat: Add hive config option to enable preserving flatmap encoding

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -238,4 +238,11 @@ std::string HiveConfig::hiveLocalFileFormat() const {
   return config_->get<std::string>(kLocalFileFormat, "");
 }
 
+bool HiveConfig::preserveFlatMapsInMemory(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kPreserveFlatMapsInMemorySession,
+      config_->get<bool>(kPreserveFlatMapsInMemory, false));
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -187,6 +187,13 @@ class HiveConfig {
   static constexpr const char* kLocalDataPath = "hive_local_data_path";
   static constexpr const char* kLocalFileFormat = "hive_local_file_format";
 
+  /// Whether to preserve flat maps in memory as FlatMapVectors instead of
+  /// converting them to MapVectors.
+  static constexpr const char* kPreserveFlatMapsInMemory =
+      "preserve-flat-maps-in-memory";
+  static constexpr const char* kPreserveFlatMapsInMemorySession =
+      "preserve_flat_maps_in_memory";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const config::ConfigBase* session) const;
 
@@ -266,6 +273,10 @@ class HiveConfig {
   /// Returns the name of the file format to use in interpreting the contents of
   /// hiveLocalDataPath().
   std::string hiveLocalFileFormat() const;
+
+  /// Whether to preserve flat maps in memory as FlatMapVectors instead of
+  /// converting them to MapVectors.
+  bool preserveFlatMapsInMemory(const config::ConfigBase* session) const;
 
   HiveConfig(std::shared_ptr<const config::ConfigBase> config) {
     VELOX_CHECK_NOT_NULL(

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -628,6 +628,8 @@ void configureRowReaderOptions(
   if (hiveConfig && sessionProperties) {
     rowReaderOptions.setTimestampPrecision(static_cast<TimestampPrecision>(
         hiveConfig->readTimestampUnit(sessionProperties)));
+    rowReaderOptions.setPreserveFlatMapsInMemory(
+        hiveConfig->preserveFlatMapsInMemory(sessionProperties));
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -53,6 +53,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_TRUE(hiveConfig.isPartitionPathAsLowerCase(emptySession.get()));
   ASSERT_TRUE(hiveConfig.allowNullPartitionKeys(emptySession.get()));
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
+  ASSERT_FALSE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -75,7 +76,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kSortWriterFinishTimeSliceLimitMs, "400"},
       {HiveConfig::kReadStatsBasedFilterReorderDisabled, "true"},
       {HiveConfig::kLoadQuantum, std::to_string(4 << 20)},
-      {HiveConfig::kMaxBucketCount, std::to_string(100'000)}};
+      {HiveConfig::kMaxBucketCount, std::to_string(100'000)},
+      {HiveConfig::kPreserveFlatMapsInMemory, "true"}};
   HiveConfig hiveConfig(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   auto emptySession = std::make_shared<config::ConfigBase>(
@@ -106,6 +108,7 @@ TEST(HiveConfigTest, overrideConfig) {
       hiveConfig.readStatsBasedFilterReorderDisabled(emptySession.get()));
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 4 << 20);
   ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
+  ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -123,7 +126,9 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kAllowNullPartitionKeysSession, "false"},
       {HiveConfig::kIgnoreMissingFilesSession, "true"},
       {HiveConfig::kReadStatsBasedFilterReorderDisabledSession, "true"},
-      {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)}};
+      {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)},
+      {HiveConfig::kPreserveFlatMapsInMemorySession, "true"},
+  };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
   ASSERT_EQ(
@@ -149,4 +154,5 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_TRUE(hiveConfig.ignoreMissingFiles(session.get()));
   ASSERT_TRUE(hiveConfig.readStatsBasedFilterReorderDisabled(session.get()));
   ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
+  ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(session.get()));
 }


### PR DESCRIPTION
Summary: The hive config option is wired into the row reader options for hive connector which gets used during file reading and writing.

Differential Revision: D79173949


