### PR TITLE
feat: Add remainingFilter into PushConfig

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -664,7 +664,6 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeScanTask(
                         .tableScanWithPushDown(
                             tableSchema,
                             /*pushdownConfig=*/pushdownConfig,
-                            /*remainingFilter=*/"",
                             tableSchema,
                             {})
                         .planNode();

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -108,7 +108,6 @@ PlanBuilder& PlanBuilder::tableScan(
 PlanBuilder& PlanBuilder::tableScanWithPushDown(
     const RowTypePtr& outputType,
     const PushdownConfig& pushdownConfig,
-    const std::string& remainingFilter,
     const RowTypePtr& dataColumns,
     const connector::ColumnHandleMap& assignments) {
   return TableScanBuilder(*this)
@@ -116,9 +115,8 @@ PlanBuilder& PlanBuilder::tableScanWithPushDown(
       .outputType(outputType)
       .assignments(assignments)
       .dataColumns(dataColumns)
-
       .subfieldFiltersMap(pushdownConfig.subfieldFiltersMap)
-      .remainingFilter(remainingFilter)
+      .remainingFilter(pushdownConfig.remainingFilter)
       .endTableScan();
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -33,6 +33,7 @@ namespace facebook::velox::exec::test {
 
 struct PushdownConfig {
   common::SubfieldFilters subfieldFiltersMap;
+  std::string remainingFilter;
 };
 
 /// A builder class with fluent API for building query plans. Plans are built
@@ -175,14 +176,12 @@ class PlanBuilder {
   ///
   /// @param outputType List of column names and types to read from the table.
   /// @param PushdownConfig Contains pushdown configs for the table scan.
-  /// @param remainingFilter SQL expression for the additional conjunct.
   /// @param dataColumns Optional data columns that may differ from outputType.
   /// @param assignments Optional ColumnHandles.
 
   PlanBuilder& tableScanWithPushDown(
       const RowTypePtr& outputType,
       const PushdownConfig& pushdownConfig,
-      const std::string& remainingFilter = "",
       const RowTypePtr& dataColumns = nullptr,
       const connector::ColumnHandleMap& assignments = {});
 


### PR DESCRIPTION
Summary: Add remainingFilter into PushConfig so that TableEvolutionFuzzer use the same struct to conduct pushdown test

Differential Revision: D79188747


