### PR TITLE
fix: Do not keep reference to input vector in FilterProject longer than needed

### DIFF
--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -83,11 +83,6 @@ class FilterProject : public Operator {
   OperatorStats stats(bool clear) override;
 
  private:
-  // Tests if 'numProcessedRows_' equals to the length of input_ and clears
-  // outstanding references to input_ if done. Returns true if getOutput
-  // should return nullptr.
-  bool allInputProcessed();
-
   // Evaluate filter on all rows. Return number of rows that passed the filter.
   // Populate filterEvalCtx_.selectedBits and selectedIndices with the indices
   // of the passing rows if only some rows pass the filter. If all or no rows
@@ -114,8 +109,6 @@ class FilterProject : public Operator {
   int32_t numExprs_;
 
   FilterEvalCtx filterEvalCtx_;
-
-  vector_size_t numProcessedInputRows_{0};
 
   // Indices for fields/input columns that are both an identity projection and
   // are referenced by either a filter or project expression. This is used to


### PR DESCRIPTION
Summary:
`FilterProject` always consumes all the input by the time we return
from `getOutput`, so there is no need to track number of rows consumed.  In the
current implementation, this was causing us to hold on to the input after
`getOutput` is returned and preventing memory reusing when the batch is processed by downstream operators.

Differential Revision: D79174768


