### PR TITLE
fix: An unloaded lazy vector cannot be wrapped by two different top level vectors

### DIFF
--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -76,7 +76,13 @@ class RowVector : public BaseVector {
       std::shared_ptr<const Type> type,
       velox::memory::MemoryPool* pool);
 
-  virtual ~RowVector() override {}
+  ~RowVector() override {
+    for (auto children : children_) {
+      if (children) {
+        children->clearContainingLazyAndWrapped();
+      }
+    }
+  }
 
   bool containsNullAt(vector_size_t idx) const override;
 
@@ -202,9 +208,9 @@ class RowVector : public BaseVector {
 
   /// For backwards compatibility.
   /// TODO Remove after updating callsites.
-  [[deprecated]]
-  std::string deprecatedToString(vector_size_t index, vector_size_t limit)
-      const;
+  [[deprecated]] std::string deprecatedToString(
+      vector_size_t index,
+      vector_size_t limit) const;
 
   void ensureWritable(const SelectivityVector& rows) override;
 


### PR DESCRIPTION
We identified a bug in MergeJoin that leads to the following exception:

```
E0730 23:25:42.630664 2006023 Exceptions.h:66] Line: /mnt/DP_disk3/jk/projects/fb-velox/velox/./velox/vector/DictionaryVector-inl.h:35, Function:setInternalState, Expression: dictionaryValues_->markAsContainingLazyAndWrapped() An unloaded lazy vector cannot be wrapped by two different top level vectors., Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: An unloaded lazy vector cannot be wrapped by two different top level vectors.
Retriable: False
Expression: dictionaryValues_->markAsContainingLazyAndWrapped()
Context: Operator: MergeJoin[2] 1
Function: setInternalState
File: /mnt/DP_disk3/jk/projects/fb-velox/velox/./velox/vector/DictionaryVector-inl.h
Line: 35
Stack trace:
# 0  std::shared_ptr<facebook::velox::VeloxException::State const> facebook::velox::VeloxException::State::make<facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1}>(facebook::velox::VeloxException::Type, facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1})
# 1  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 2  facebook::velox::VeloxRuntimeError::VeloxRuntimeError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, std::basic_string_view<char, std::char_traits<char> >)
# 3  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, char const*>(facebook::velox::detail::VeloxCheckFailArgs const&, char const*)
# 4  facebook::velox::DictionaryVector<int>::setInternalState()
# 5  facebook::velox::DictionaryVector<int>::DictionaryVector(facebook::velox::memory::MemoryPool*, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer>, facebook::velox::SimpleVectorStats<int> const&, std::optional<int>, std::optional<int>, std::optional<bool>, std::optional<int>, std::optional<int>)
# 6  decltype (::new ((void*)(0)) facebook::velox::DictionaryVector<int>((declval<facebook::velox::memory::MemoryPool*&>)(), (declval<boost::intrusive_ptr<facebook::velox::Buffer> >)(), (declval<unsigned long&>)(), (declval<std::shared_ptr<facebook::velox::BaseVector> >)(), (declval<boost::intrusive_ptr<facebook::velox::Buffer> >)())) std::construct_at<facebook::velox::DictionaryVector<int>, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(facebook::velox::DictionaryVector<int>*, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 7  void std::allocator_traits<std::allocator<facebook::velox::DictionaryVector<int> > >::construct<facebook::velox::DictionaryVector<int>, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(std::allocator<facebook::velox::DictionaryVector<int> >&, facebook::velox::DictionaryVector<int>*, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 8  std::_Sp_counted_ptr_inplace<facebook::velox::DictionaryVector<int>, std::allocator<facebook::velox::DictionaryVector<int> >, (__gnu_cxx::_Lock_policy)2>::_Sp_counted_ptr_inplace<facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(std::allocator<facebook::velox::DictionaryVector<int> >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 9  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<facebook::velox::DictionaryVector<int>, std::allocator<facebook::velox::DictionaryVector<int> >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(facebook::velox::DictionaryVector<int>*&, std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::DictionaryVector<int> > >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 10 std::__shared_ptr<facebook::velox::DictionaryVector<int>, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<facebook::velox::DictionaryVector<int> >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::DictionaryVector<int> > >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 11 std::shared_ptr<facebook::velox::DictionaryVector<int> >::shared_ptr<std::allocator<facebook::velox::DictionaryVector<int> >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::DictionaryVector<int> > >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 12 std::shared_ptr<facebook::velox::DictionaryVector<int> > std::allocate_shared<facebook::velox::DictionaryVector<int>, std::allocator<facebook::velox::DictionaryVector<int> >, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(std::allocator<facebook::velox::DictionaryVector<int> > const&, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 13 std::shared_ptr<facebook::velox::DictionaryVector<int> > std::make_shared<facebook::velox::DictionaryVector<int>, facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>, boost::intrusive_ptr<facebook::velox::Buffer> >(facebook::velox::memory::MemoryPool*&, boost::intrusive_ptr<facebook::velox::Buffer>&&, unsigned long&, std::shared_ptr<facebook::velox::BaseVector>&&, boost::intrusive_ptr<facebook::velox::Buffer>&&)
# 14 std::shared_ptr<facebook::velox::BaseVector> facebook::velox::addDictionary<(facebook::velox::TypeKind)3>(boost::intrusive_ptr<facebook::velox::Buffer>, boost::intrusive_ptr<facebook::velox::Buffer>, unsigned long, std::shared_ptr<facebook::velox::BaseVector>)
# 15 facebook::velox::BaseVector::wrapInDictionary(boost::intrusive_ptr<facebook::velox::Buffer>, boost::intrusive_ptr<facebook::velox::Buffer>, int, std::shared_ptr<facebook::velox::BaseVector>, bool)::{lambda()#1}::operator()() const::{lambda()#1}::operator()() const
# 16 facebook::velox::BaseVector::wrapInDictionary(boost::intrusive_ptr<facebook::velox::Buffer>, boost::intrusive_ptr<facebook::velox::Buffer>, int, std::shared_ptr<facebook::velox::BaseVector>, bool)::{lambda()#1}::operator()() const
# 17 facebook::velox::BaseVector::wrapInDictionary(boost::intrusive_ptr<facebook::velox::Buffer>, boost::intrusive_ptr<facebook::velox::Buffer>, int, std::shared_ptr<facebook::velox::BaseVector>, bool)
# 18 facebook::velox::exec::MergeJoin::prepareOutput(std::shared_ptr<facebook::velox::RowVector> const&, std::shared_ptr<facebook::velox::RowVector> const&)
# 19 facebook::velox::exec::MergeJoin::addToOutputForLeftJoin()
# 20 facebook::velox::exec::MergeJoin::addToOutput()
# 21 facebook::velox::exec::MergeJoin::doGetOutput()
# 22 facebook::velox::exec::MergeJoin::getOutput()
# 23 facebook::velox::exec::(anonymous namespace)::getOutput(facebook::velox::exec::Operator*, std::shared_ptr<facebook::velox::RowVector>&)
# 24 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}::operator()() const
# 25 void facebook::velox::exec::Driver::withDeltaCpuWallTimer<facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}>(facebook::velox::exec::Operator*, facebook::velox::CpuWallTiming facebook::velox::exec::OperatorStats::*, facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::{lambda()#10}&&)
# 26 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 27 facebook::velox::exec::Driver::next(folly::SemiFuture<folly::Unit>*, facebook::velox::exec::Operator*&, facebook::velox::exec::BlockingReason&)
# 28 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
# 29 facebook::velox::exec::SingleThreadedTaskCursor::hasNext()
# 30 facebook::velox::exec::SingleThreadedTaskCursor::moveNext()
# 31 facebook::velox::exec::test::readCursor(facebook::velox::exec::CursorParameters const&, std::function<void (facebook::velox::exec::TaskCursor*)>, unsigned long)
# 32 facebook::velox::exec::test::AssertQueryBuilder::readCursor()
# 33 facebook::velox::exec::test::AssertQueryBuilder::assertResults(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::optional<std::vector<unsigned int, std::allocator<unsigned int> > > const&)
# 34 MergeJoinTest_barrier_Test::TestBody()
# 35 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
# 36 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)
# 37 testing::Test::Run()
# 38 testing::TestInfo::Run()
# 39 testing::TestSuite::Run()
# 40 testing::internal::UnitTestImpl::RunAllTests()
# 41 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
# 42 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)
# 43 testing::UnitTest::Run()
# 44 RUN_ALL_TESTS()
# 45 main
# 46 __libc_start_main
# 47 _start
" thrown in the test body.
```

The root cause is that when input_ differs from currentLeft_ in the prepareOutput method, the current output_ is returned and then re-initialized. However, if right_ is the same as currentRight_, it may result in right_ being wrapped multiple times, which can cause unexpected behavior [code](https://github.com/facebookincubator/velox/blob/f2db819d053f4e7092efbef873ba23ea885fd1c3/velox/exec/MergeJoin.cpp#L456-L472). This PR addresses the issue by invoking `clearContainingLazyAndWrapped` on each child vector in the RowVector destructor, ensuring that the vector can be safely wrapped multiple times.