### PR TITLE
misc: Remove duplicate registration for Spark url function

### DIFF
--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -64,10 +64,6 @@ void registerStringFunctions(const std::string& prefix) {
       {prefix + "replace"});
   registerFunction<FindInSetFunction, int32_t, Varchar, Varchar>(
       {prefix + "find_in_set"});
-  registerFunction<UrlEncodeFunction, Varchar, Varchar>(
-      {prefix + "url_encode"});
-  registerFunction<UrlDecodeFunction, Varchar, Varchar>(
-      {prefix + "url_decode"});
   registerFunction<sparksql::ChrFunction, Varchar, int64_t>({prefix + "chr"});
   registerFunction<AsciiFunction, int32_t, Varchar>({prefix + "ascii"});
   registerFunction<sparksql::LPadFunction, Varchar, Varchar, int32_t, Varchar>(


### PR DESCRIPTION
Same functions are also registered in https://github.com/facebookincubator/velox/blob/f2db819d053f4e7092efbef873ba23ea885fd1c3/velox/functions/sparksql/registration/RegisterUrl.cpp#L22