### PR TITLE
fix(fuzzer): Disable decimal type when running fuzzer with Presto SOT

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1163,7 +1163,6 @@ jobs:
                 --duration_sec $DURATION \
                 --enable_variadic_signatures \
                 --velox_fuzzer_enable_complex_types \
-                --velox_fuzzer_enable_decimal_type \
                 --velox_fuzzer_enable_column_reuse \
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \


### PR DESCRIPTION
Summary:
Dwrf doesn't support writing Decimal type to file directly, which leads to failure with 
running fuzzer with reference DB. Disable it until we add intermediate type 
transformation for decimal type.

```
I20250730 14:07:36.587884   626 HiveConnector.cpp:53] Hive connector test-hive created with maximum of 1000 cached file handles with expiration of 0ms.
I20250730 14:07:36.588048   626 ExpressionFuzzerVerifier.cpp:389] ==============================> Started iteration 0 (seed: 23779)
I20250730 14:07:36.588622   626 ExpressionVerifier.cpp:245] Executing expression 0 : negate(greatest(floor(73.48892937003764484402659582),202,828,892,"c0"))
I20250730 14:07:36.590449   626 ExpressionVerifier.cpp:377] Common eval succeeded.
I20250730 14:07:36.618371   626 PrestoQueryRunner.cpp:449] Execute presto sql: CREATE TABLE t_5afac645_66b1_420c_b5c3_87a90589d435(c0, row_number) WITH (format = 'DWRF') AS SELECT cast(null as DECIMAL(3, 0)), cast(null as BIGINT)
E20250730 14:07:37.946817   626 Exceptions.h:66] Line: /__w/velox/velox/velox/velox/exec/fuzzer/PrestoQueryRunner.cpp:108, Function:throwIfFailed, Expression:  Presto query failed: 65536 DWRF does not support decimal(3,0) type, Source: RUNTIME, ErrorCode: INVALID_STATE
W20250730 14:07:37.948414   626 PrestoQueryRunner.cpp:427] Query failed in Presto
```

Differential Revision: D79299153


