### PR TITLE
fix: Reduce memory usage of constant expression

### DIFF
--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -30,10 +30,7 @@ class ConstantExpr : public SpecialForm {
             false /* trackCpuUsage */),
         needToSetIsAscii_{value->type()->isVarchar()} {
     VELOX_CHECK_EQ(value->encoding(), VectorEncoding::Simple::CONSTANT);
-    // sharedConstantValue_ may be modified so we should take our own copy to
-    // prevent sharing across threads.
-    sharedConstantValue_ =
-        BaseVector::wrapInConstant(1, 0, std::move(value), true);
+    sharedConstantValue_ = std::move(value);
   }
 
   void evalSpecialForm(

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -131,9 +131,8 @@ TEST_F(ExpressionRunnerUnitTest, persistAndReproComplexSql) {
   auto reproExprs = ExpressionRunner::parseSql(
       reproSql, nullptr, pool_.get(), reproComplexConstants);
   ASSERT_EQ(reproExprs.size(), 1);
-  // Note that ConstantExpr makes a copy of sharedConstantValue_ to guard
-  // against race conditions, which in effect falttens the array.
-  ASSERT_EQ(reproExprs[0]->toString(), "{3, 5, 1, 2}");
+  // Restored vector should have the exact same structure as the original one.
+  ASSERT_EQ(reproExprs[0]->toString(), constantExpr->toString());
 }
 
 TEST_F(ExpressionRunnerUnitTest, primitiveConstantsInexpressibleInSql) {

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -199,11 +199,8 @@ VectorPtr BaseVector::wrapInSequence(
 }
 
 template <TypeKind kind>
-static VectorPtr addConstant(
-    vector_size_t size,
-    vector_size_t index,
-    VectorPtr vector,
-    bool copyBase) {
+static VectorPtr
+addConstant(vector_size_t size, vector_size_t index, VectorPtr vector) {
   using T = typename KindToFlatVector<kind>::WrapperType;
 
   auto* pool = vector->pool();
@@ -242,13 +239,6 @@ static VectorPtr addConstant(
     }
   }
 
-  if (copyBase) {
-    VectorPtr copy = BaseVector::create(vector->type(), 1, pool);
-    copy->copy(vector.get(), 0, index, 1);
-    return std::make_shared<ConstantVector<T>>(
-        pool, size, 0, std::move(copy), SimpleVectorStats<T>{});
-  }
-
   return std::make_shared<ConstantVector<T>>(
       pool, size, index, std::move(vector), SimpleVectorStats<T>{});
 }
@@ -257,11 +247,10 @@ static VectorPtr addConstant(
 VectorPtr BaseVector::wrapInConstant(
     vector_size_t length,
     vector_size_t index,
-    VectorPtr vector,
-    bool copyBase) {
+    VectorPtr vector) {
   const auto kind = vector->typeKind();
   return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
-      addConstant, kind, length, index, std::move(vector), copyBase);
+      addConstant, kind, length, index, std::move(vector));
 }
 
 std::optional<bool> BaseVector::equalValueAt(

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -628,14 +628,9 @@ class BaseVector {
   /// before making a new ConstantVector. The result vector is either a
   /// ConstantVector holding a scalar value or a ConstantVector wrapping flat or
   /// lazy vector. The result cannot be a wrapping over another constant or
-  /// dictionary vector. If copyBase is true and the result vector wraps a
-  /// vector, the wrapped vector is newly constructed by copying the value from
-  /// the original, guaranteeing no Vectors are shared with 'vector'.
-  static VectorPtr wrapInConstant(
-      vector_size_t length,
-      vector_size_t index,
-      VectorPtr vector,
-      bool copyBase = false);
+  /// dictionary vector.
+  static VectorPtr
+  wrapInConstant(vector_size_t length, vector_size_t index, VectorPtr vector);
 
   /// Makes 'result' writable for 'rows'. A wrapper (e.g. dictionary, constant,
   /// sequence) is flattened and a multiply referenced flat vector is copied.


### PR DESCRIPTION
Summary:
In `ConstantExpr` we are making deep copy of the constant vector.  This
was done to avoid multi-threaded (MT) access to `computeAndSetIsAscii`, but that
function was changed to be MT-safe later, so we can drop the deep copy to reduce
memory usage and initialization cost.

Differential Revision: D79177296


