### PR TITLE
feat(function): Add fast path for Spark split function

### DIFF
--- a/velox/functions/sparksql/Split.h
+++ b/velox/functions/sparksql/Split.h
@@ -47,9 +47,13 @@ struct Split {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const arg_type<Varchar>* /*input*/,
-      const arg_type<Varchar>* /*delimiter*/,
+      const arg_type<Varchar>* delimiter,
       const arg_type<int32_t>* /*limit*/) {
     cache_.setMaxCompiledRegexes(config.exprMaxCompiledRegexes());
+    if (delimiter) {
+      initializeFastPath(delimiter->data(), delimiter->size());
+      isConstantDelimiter_ = true;
+    }
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -72,12 +76,32 @@ struct Split {
       out_type<Array<Varchar>>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& delimiter,
-      int32_t limit) const {
+      int32_t limit) {
     if (delimiter.empty()) {
       splitEmptyDelimiter(result, input, limit);
     } else {
       split(result, input, delimiter, limit);
     }
+  }
+
+  // Checks if a string represents an octal-escaped ascii character (e.g.,
+  // \123). If valid, converts it to its decimal value.
+  bool isOctalString(const char* str, char& decimal, size_t size) const {
+    if (size > 4 || str[0] != '\\') {
+      return false;
+    }
+    for (int i = 1; i < size; ++i) {
+      char ch = str[i];
+      if (ch < '0' || ch > '7') {
+        return false;
+      }
+    }
+    // The ascii octal number should not exceed 177.
+    if (std::stoi(str + 1) > 177) {
+      return false;
+    }
+    decimal = std::stoi(str + 1, nullptr, 8);
+    return true;
   }
 
   // When pattern is empty, split each character out. Since Spark 3.4, when
@@ -113,6 +137,33 @@ struct Split {
     }
   }
 
+  // Fast path if the delimiter is a
+  // (1)one-char String and this character is not one of the RegEx's meta
+  // characters ".$|()[{^?*+\\", or
+  // (2)two-char String and the first char is the backslash and the second is
+  // not the ascii digit or ascii letter, or
+  // (3)octal string.
+  void initializeFastPath(const char* delimiterStr, size_t delimiterSize) {
+    const std::string reservedChars = ".$|()[{^?*+\\";
+    if (delimiterSize == 1) {
+      singleCharDelimiter_ = delimiterStr[0];
+      if (reservedChars.find(singleCharDelimiter_) == std::string::npos) {
+        fastPath_ = true;
+      }
+    } else if (delimiterSize == 2 && delimiterStr[0] == '\\') {
+      singleCharDelimiter_ = delimiterStr[1];
+      if (!std::isdigit(singleCharDelimiter_) &&
+          !std::isalpha(singleCharDelimiter_)) {
+        fastPath_ = true;
+      }
+    } else if (isOctalString(
+                   delimiterStr, singleCharDelimiter_, delimiterSize)) {
+      fastPath_ = true;
+    } else {
+      fastPath_ = false;
+    }
+  }
+
   // Split with a non-empty delimiter. If limit > 0, The resulting array's
   // length will not be more than limit and the resulting array's last entry
   // will contain all input beyond the last matched regex. If limit <= 0,
@@ -122,7 +173,7 @@ struct Split {
       out_type<Array<Varchar>>& result,
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& delimiter,
-      int32_t limit) const {
+      int32_t limit) {
     VELOX_DCHECK(!delimiter.empty(), "Non-empty delimiter is expected");
 
     // Trivial case of converting string to array with 1 element.
@@ -134,52 +185,69 @@ struct Split {
     // Splits input string using the delimiter and adds the cutting-off pieces
     // to elements vector until the string's end or the limit is reached.
     int32_t addedElements{0};
-    auto* re = cache_.findOrCompile(delimiter);
     const size_t end = input.size();
     const char* start = input.data();
-    const auto re2String = re2::StringPiece(start, end);
     size_t pos = 0;
 
-    re2::StringPiece subMatches[1];
-    // Matches a regular expression against a portion of the input string,
-    // starting from 'pos' to the end of the input string. The match is not
-    // anchored, which means it can start at any position in the string. If a
-    // match is found, the matched portion of the string is stored in
-    // 'subMatches'. The '1' indicates that we are only interested in the first
-    // match found from the current position 'pos' in each iteration of the
-    // loop.
-    while (re->Match(
-        re2String, pos, end, RE2::Anchor::UNANCHORED, subMatches, 1)) {
-      const auto fullMatch = subMatches[0];
-      auto offset = fullMatch.data() - start;
-      const auto size = fullMatch.size();
-      if (offset >= end) {
-        break;
-      }
+    if (!isConstantDelimiter_) {
+      initializeFastPath(delimiter.data(), delimiter.size());
+    }
 
-      // When hitting an empty match, split the character at the current 'pos'
-      // of the input string and put it into the result array, followed by an
-      // empty tail string at last, e.g., the result array for split('abc','d|')
-      // is ["a","b","c",""].
-      if (size == 0) {
-        int32_t codePoint;
-        auto charLength =
-            tryGetUtf8CharLength(start + pos, end - pos, codePoint);
-        if (charLength <= 0) {
-          // Invalid UTF-8 character, the length of the invalid
-          // character is the absolute value of result of
-          // `tryGetUtf8CharLength`.
-          charLength = -charLength;
+    if (fastPath_) {
+      for (size_t i = 0; i < end; ++i) {
+        if (start[i] == singleCharDelimiter_) {
+          result.add_item().setNoCopy(StringView(start + pos, i - pos));
+          pos = i + 1;
+          ++addedElements;
+          if (addedElements + 1 == limit) {
+            break;
+          }
         }
-        offset += charLength;
       }
-      result.add_item().setNoCopy(StringView(start + pos, offset - pos));
-      pos = offset + size;
+    } else {
+      auto* re = cache_.findOrCompile(delimiter);
+      const auto re2String = re2::StringPiece(start, end);
+      re2::StringPiece subMatches[1];
+      // Matches a regular expression against a portion of the input string,
+      // starting from 'pos' to the end of the input string. The match is not
+      // anchored, which means it can start at any position in the string. If a
+      // match is found, the matched portion of the string is stored in
+      // 'subMatches'. The '1' indicates that we are only interested in the
+      // first match found from the current position 'pos' in each iteration of
+      // the loop.
+      while (re->Match(
+          re2String, pos, end, RE2::Anchor::UNANCHORED, subMatches, 1)) {
+        const auto fullMatch = subMatches[0];
+        auto offset = fullMatch.data() - start;
+        const auto size = fullMatch.size();
+        if (offset >= end) {
+          break;
+        }
 
-      ++addedElements;
-      // If the next element should be the last, leave the loop.
-      if (addedElements + 1 == limit) {
-        break;
+        // When hitting an empty match, split the character at the current 'pos'
+        // of the input string and put it into the result array, followed by an
+        // empty tail string at last, e.g., the result array for
+        // split('abc','d|') is ["a","b","c",""].
+        if (size == 0) {
+          int32_t codePoint;
+          auto charLength =
+              tryGetUtf8CharLength(start + pos, end - pos, codePoint);
+          if (charLength <= 0) {
+            // Invalid UTF-8 character, the length of the invalid
+            // character is the absolute value of result of
+            // `tryGetUtf8CharLength`.
+            charLength = -charLength;
+          }
+          offset += charLength;
+        }
+        result.add_item().setNoCopy(StringView(start + pos, offset - pos));
+        pos = offset + size;
+
+        ++addedElements;
+        // If the next element should be the last, leave the loop.
+        if (addedElements + 1 == limit) {
+          break;
+        }
       }
     }
 
@@ -189,5 +257,9 @@ struct Split {
   }
 
   mutable facebook::velox::functions::detail::ReCache cache_;
+  bool fastPath_{false};
+  // Single character delimiter for fast path.
+  char singleCharDelimiter_;
+  bool isConstantDelimiter_{false};
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Split.h
+++ b/velox/functions/sparksql/Split.h
@@ -138,13 +138,17 @@ struct Split {
   }
 
   // Fast path if the delimiter is a
-  // (1)one-char String and this character is not one of the RegEx's meta
+  // (1)one-char string and this character is not one of the RegEx's meta
   // characters ".$|()[{^?*+\\", or
-  // (2)two-char String and the first char is the backslash and the second is
+  // (2)two-char string and the first char is the backslash and the second is
   // not the ascii digit or ascii letter, or
-  // (3)octal string.
+  // (3)octal string that falls within the range of ASCII characters.
   void initializeFastPath(const char* delimiterStr, size_t delimiterSize) {
+    // Referencing from
+    // https://github.com/openjdk/jdk8/blob/master/jdk/src/share/classes/java/lang/String.java#L2325
+    // to align with Spark.
     const std::string reservedChars = ".$|()[{^?*+\\";
+
     if (delimiterSize == 1) {
       singleCharDelimiter_ = delimiterStr[0];
       if (reservedChars.find(singleCharDelimiter_) == std::string::npos) {

--- a/velox/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/velox/functions/sparksql/benchmarks/CMakeLists.txt
@@ -47,3 +47,12 @@ target_link_libraries(
   velox_parse_utils
   Folly::folly
   Folly::follybenchmark)
+
+add_executable(velox_sparksql_benchmarks_split SplitBenchmark.cpp)
+target_link_libraries(
+  velox_sparksql_benchmarks_split
+  velox_functions_spark
+  velox_benchmark_builder
+  velox_vector_test_lib
+  velox_vector_fuzzer
+  velox_functions_lib)

--- a/velox/functions/sparksql/benchmarks/SplitBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/SplitBenchmark.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/sparksql/registration/Register.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class SplitBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  SplitBenchmark(uint32_t seed) : FunctionBenchmarkBase(), seed_{seed} {
+    parse::registerTypeResolver();
+    functions::sparksql::registerFunctions("");
+    generateData();
+  }
+
+  void generateData() {
+    VectorFuzzer::Options options;
+    options.vectorSize = 10000;
+    options.stringVariableLength = true;
+    options.stringLength = 10;
+
+    VectorFuzzer fuzzer(options, pool(), seed_);
+
+    auto vector = vectorMaker_.rowVector(
+        {fuzzer.fuzzFlat(VARCHAR()),
+         fuzzer.fuzzFlat(VARCHAR()),
+         fuzzer.fuzzFlat(VARCHAR()),
+         fuzzer.fuzzFlat(VARCHAR()),
+         fuzzer.fuzzFlat(VARCHAR())});
+    data_ = vectorMaker_.rowVector({evaluateOnce(kConcatExpression, vector)});
+  }
+
+  VectorPtr evaluateOnce(
+      const std::string& expression,
+      const RowVectorPtr& data) {
+    auto exprSet = compileExpression(expression, asRowType(data->type()));
+    return evaluate(exprSet, data);
+  }
+
+  size_t run(size_t times, const std::string& expression) {
+    folly::BenchmarkSuspender suspender;
+    auto exprSet = compileExpression(expression, asRowType(data_->type()));
+    suspender.dismiss();
+
+    return doRun(exprSet, data_, times);
+  }
+
+  size_t doRun(ExprSet& exprSet, const RowVectorPtr& rowVector, size_t times) {
+    int cnt = 0;
+    for (auto i = 0; i < times * 1'000; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    return cnt;
+  }
+
+  static const std::string kSplitExpression;
+
+ private:
+  static const std::string kConcatExpression;
+  RowVectorPtr data_ = nullptr;
+
+  const uint32_t seed_;
+};
+
+const std::string SplitBenchmark::kSplitExpression = "split(c0, '\\044')";
+const std::string SplitBenchmark::kConcatExpression =
+    "concat(c0, '$', c1, '$', c2, '$', c3, '$', c4)";
+
+const uint32_t seed = folly::Random::rand32();
+
+std::unique_ptr<SplitBenchmark> benchmark;
+
+BENCHMARK_RELATIVE(split, n) {
+  benchmark->run(n, SplitBenchmark::kSplitExpression);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  LOG(ERROR) << "Seed: " << seed;
+  benchmark = std::make_unique<SplitBenchmark>(seed);
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/functions/sparksql/benchmarks/SplitBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/SplitBenchmark.cpp
@@ -100,7 +100,7 @@ BENCHMARK_RELATIVE(split, n) {
 int main(int argc, char** argv) {
   folly::Init init{&argc, &argv};
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
-  LOG(ERROR) << "Seed: " << seed;
+  LOG(INFO) << "Seed: " << seed;
   benchmark = std::make_unique<SplitBenchmark>(seed);
   folly::runBenchmarks();
   benchmark.reset();

--- a/velox/functions/sparksql/tests/SplitTest.cpp
+++ b/velox/functions/sparksql/tests/SplitTest.cpp
@@ -306,6 +306,17 @@ TEST_F(SplitTest, fastPath) {
   // Single character delimiter.
   testSplit(input, "<", std::nullopt, 1, expected);
   testSplitConstantDelim(input, "<", std::nullopt, 1, expected);
+
+  input = std::vector<std::string>{
+      {"I©he©she©they"}, // Simple
+      {"one©©©four©"}, // Empty strings
+      {"a©\xED©\xA0©123"}, // Not a well-formed UTF-8 string
+      {""}, // The whole string is empty
+  };
+
+  // Octal string delimiter that is outside the range of ASCII characters.
+  testSplit(input, "\\251", std::nullopt, 1, expected);
+  testSplitConstantDelim(input, "\\251", std::nullopt, 1, expected);
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/SplitTest.cpp
+++ b/velox/functions/sparksql/tests/SplitTest.cpp
@@ -42,7 +42,27 @@ class SplitTest : public SparkFunctionBaseTest {
       result = evaluate("split(c0, c1)", input);
     }
     assertEqualVectors(expectedResult, result);
-  };
+  }
+
+  void testSplitConstantDelim(
+      const std::vector<std::string>& input,
+      const std::string& delim,
+      std::optional<int32_t> limit,
+      size_t numRows,
+      const std::vector<std::vector<std::string>>& expected) {
+    auto strings = makeFlatVector(input);
+    auto expectedResult = makeArrayVector(expected);
+    VectorPtr result;
+    if (limit.has_value()) {
+      auto limits = makeConstant<int32_t>(limit.value(), numRows);
+      auto input = makeRowVector({strings, limits});
+      result = evaluate("split(c0, '" + delim + "', c1)", input);
+    } else {
+      auto input = makeRowVector({strings});
+      result = evaluate("split(c0, '" + delim + "')", input);
+    }
+    assertEqualVectors(expectedResult, result);
+  }
 };
 
 TEST_F(SplitTest, basic) {
@@ -252,6 +272,40 @@ TEST_F(SplitTest, regexDelimiter) {
       {""},
   };
   testSplit(input, "🙂", -1, numRows, expected);
+}
+
+TEST_F(SplitTest, fastPath) {
+  auto input = std::vector<std::string>{
+      {"I$he$she$they"}, // Simple
+      {"one$$$four$"}, // Empty strings
+      {"a$\xED$\xA0$123"}, // Not a well-formed UTF-8 string
+      {""}, // The whole string is empty
+  };
+  auto expected = std::vector<std::vector<std::string>>({
+      {"I", "he", "she", "they"},
+      {"one", "", "", "four", ""},
+      {"a", "\xED", "\xA0", "123"},
+      {""},
+  });
+
+  // Escaped delimiter.
+  testSplit(input, "\\$", std::nullopt, 1, expected);
+  testSplitConstantDelim(input, "\\$", std::nullopt, 1, expected);
+
+  // Octal string delimiter.
+  testSplit(input, "\\044", std::nullopt, 1, expected);
+  testSplitConstantDelim(input, "\\044", std::nullopt, 1, expected);
+
+  input = std::vector<std::string>{
+      {"I<he<she<they"}, // Simple
+      {"one<<<four<"}, // Empty strings
+      {"a<\xED<\xA0<123"}, // Not a well-formed UTF-8 string
+      {""}, // The whole string is empty
+  };
+
+  // Single character delimiter.
+  testSplit(input, "<", std::nullopt, 1, expected);
+  testSplitConstantDelim(input, "<", std::nullopt, 1, expected);
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Add a fast path that locates the delimiter by iterating string instead of
using re2 library for Spark split function. The microbenchmark shows
there is a 5x performance gain.

```
============================================================================
[...]parksql/benchmarks/SplitBenchmark.cpp     relative  time/iter   iters/s
============================================================================
baseline_old                                                29.14s    34.32m
split_new                                       514.54%      5.66s   176.60m
```

Fixes [#14262](https://github.com/facebookincubator/velox/issues/14262)