### PR TITLE
feat: Add Spark get_array_struct_fields function

### DIFF
--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -19,7 +19,7 @@ Miscellaneous Functions
 
     Extracts the ``ordinal``-th fields of all array elements, and returns them as a new array.
     The first input must be of array(strcut) type and nested complex type is allowed.
-    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
+    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or no less than
     the children size of strcut, exception is thrown. ::
 
         SELECT items.col1 FROM VALUES (array(struct(100,'foo'), struct(200,'bar'))) AS t(items); -- array(100, 200)
@@ -29,7 +29,7 @@ Miscellaneous Functions
 
     Returns the value of nested subfield at position ``ordinal`` in the input ``struct``.
     The input must be of row type and nested complex type is allowed.
-    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or no less than
+    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
     the children size of ``struct``, exception is thrown. ::
 
         SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').a; -- 1

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -22,13 +22,14 @@ Miscellaneous Functions
     The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
     the children size of strcut, exception is thrown. ::
 
-        SELECT from_json('[{"name":"Alice"}, {"name":"Bob"}, {"name":"Charlie"}]', 'array<struct<name:string>>' ).name; -- array("Alice", "Bob", "Charlie")
+        SELECT items.col1 FROM VALUES (array(struct(100,'foo'), struct(200,'bar'))) AS t(items); -- array(100, 200)
+        SELECT items.col2 FROM VALUES (array(struct(100,'foo'), struct(200,'bar'))) AS t(items); -- array('foo', 'bar')
 
 .. spark:function:: get_struct_field(struct, ordinal) -> T
 
     Returns the value of nested subfield at position ``ordinal`` in the input ``struct``.
     The input must be of row type and nested complex type is allowed.
-    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
+    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or no less than
     the children size of ``struct``, exception is thrown. ::
 
         SELECT from_json('{"a": 1, "b": [1, 2, 3]}', 'a INT, b ARRAY<INT>').a; -- 1

--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -15,6 +15,15 @@ Miscellaneous Functions
         SELECT at_least_n_non_nulls(2, 0, 1.0, NULL);  -- true
         SELECT at_least_n_non_nulls(2, 0, array(NULL), NULL);  -- true
 
+.. spark:function:: get_array_struct_fields(array, ordinal) -> array(T)
+
+    Extracts the ``ordinal``-th fields of all array elements, and returns them as a new array.
+    The first input must be of array(strcut) type and nested complex type is allowed.
+    The ``ordinal`` is 0-based, and if ``ordinal`` is negative or greater than or equal to
+    the children size of strcut, exception is thrown. ::
+
+        SELECT from_json('[{"name":"Alice"}, {"name":"Bob"}, {"name":"Charlie"}]', 'array<struct<name:string>>' ).name; -- array("Alice", "Bob", "Charlie")
+
 .. spark:function:: get_struct_field(struct, ordinal) -> T
 
     Returns the value of nested subfield at position ``ordinal`` in the input ``struct``.

--- a/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
+++ b/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/sparksql/specialforms/AtLeastNNonNulls.h"
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/functions/sparksql/specialforms/FromJson.h"
+#include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/functions/sparksql/specialforms/GetStructField.h"
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
 #include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
@@ -51,6 +52,9 @@ void registerSpecialFormGeneralFunctions(const std::string& prefix) {
       std::make_unique<FromJsonCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       "get_struct_field", std::make_unique<GetStructFieldCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
+      std::make_unique<GetArrayStructFieldsCallToSpecialForm>());
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   AtLeastNNonNulls.cpp
   DecimalRound.cpp
   FromJson.cpp
+  GetArrayStructFields.cpp
   GetStructField.cpp
   MakeDecimal.cpp
   SparkCastExpr.cpp

--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
+#include "velox/expression/ConstantExpr.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+class GetArrayStructFieldsFunction : public exec::VectorFunction {
+ public:
+  explicit GetArrayStructFieldsFunction(int32_t ordinal) : ordinal_(ordinal) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /*resultType*/,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    // Decode input array vector
+    exec::LocalDecodedVector decoded(context, *args[0], rows);
+    auto arrayVec = decoded->base()->as<ArrayVector>();
+
+    DecodedVector decodedElement(*arrayVec->elements());
+    auto elements = decodedElement.base()->as<RowVector>();
+    auto fieldVec = elements->childAt(ordinal_);
+
+    VectorPtr fieldResult;
+    if (elements->mayHaveNulls()) {
+      auto indices = AlignedBuffer::allocate<vector_size_t>(
+          elements->size(), context.pool(), 0);
+      auto rawIndices = indices->asMutable<vector_size_t>();
+      for (int32_t i = 0; i < elements->size(); ++i) {
+        rawIndices[i] = i;
+      }
+      fieldResult = BaseVector::wrapInDictionary(
+          elements->nulls(), indices, elements->size(), fieldVec);
+    } else {
+      fieldResult = fieldVec;
+    }
+    if (!decodedElement.isIdentityMapping()) {
+      fieldResult = decodedElement.wrap(
+          fieldResult, *arrayVec->elements(), decodedElement.size());
+    }
+
+    auto tempResult = std::make_shared<ArrayVector>(
+        context.pool(),
+        ARRAY(fieldVec->type()),
+        arrayVec->nulls(),
+        arrayVec->size(),
+        arrayVec->offsets(),
+        arrayVec->sizes(),
+        fieldResult);
+
+    if (decoded->isIdentityMapping()) {
+      result = tempResult;
+    } else {
+      result = decoded->wrap(tempResult, *args[0], decoded->size());
+    }
+  }
+
+ private:
+  // The position to select subfield from the struct.
+  const int32_t ordinal_;
+};
+
+} // namespace
+
+TypePtr GetArrayStructFieldsCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& /*argTypes*/) {
+  VELOX_FAIL("GetArrayStructFields function does not support type resolution.");
+}
+
+exec::ExprPtr GetArrayStructFieldsCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<exec::ExprPtr>&& args,
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
+  VELOX_USER_CHECK_EQ(
+      args.size(), 2, "get_array_struct_fields expects two arguments.");
+
+  VELOX_USER_CHECK(
+      args[0]->type()->kind() == TypeKind::ARRAY &&
+          args[0]->type()->asArray().elementType()->kind() == TypeKind::ROW,
+      "The first argument of get_array_struct_fields should be of array(row) type.");
+
+  VELOX_USER_CHECK_EQ(
+      args[1]->type()->kind(),
+      TypeKind::INTEGER,
+      "The second argument of get_array_struct_fields should be of integer type.");
+
+  auto constantExpr = std::dynamic_pointer_cast<exec::ConstantExpr>(args[1]);
+  VELOX_USER_CHECK_NOT_NULL(
+      constantExpr,
+      "The second argument of get_array_struct_fields should be constant expression.");
+  VELOX_USER_CHECK(
+      constantExpr->value()->isConstantEncoding(),
+      "The second argument of get_array_struct_fields should be wrapped in constant vector.");
+  auto constantVector =
+      constantExpr->value()->asUnchecked<ConstantVector<int32_t>>();
+  VELOX_USER_CHECK(
+      !constantVector->isNullAt(0),
+      "The second argument of get_array_struct_fields should be non-nullable.");
+
+  auto ordinal = constantVector->valueAt(0);
+
+  VELOX_USER_CHECK_GE(ordinal, 0, "Invalid ordinal. Should be greater than 0.");
+  auto numFields = args[0]->type()->asArray().elementType()->asRow().size();
+  VELOX_USER_CHECK_LT(
+      ordinal,
+      numFields,
+      "Invalid ordinal {} for struct with {} fields.",
+      ordinal,
+      numFields);
+  auto getArrayStructFieldsFunction =
+      std::make_shared<GetArrayStructFieldsFunction>(ordinal);
+
+  return std::make_shared<exec::Expr>(
+      type,
+      std::move(args),
+      std::move(getArrayStructFieldsFunction),
+      exec::VectorFunctionMetadata{},
+      kGetArrayStructFields,
+      trackCpuUsage);
+}
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
@@ -121,7 +121,8 @@ exec::ExprPtr GetArrayStructFieldsCallToSpecialForm::constructSpecialForm(
 
   auto ordinal = constantVector->valueAt(0);
 
-  VELOX_USER_CHECK_GE(ordinal, 0, "Invalid ordinal. Should be greater than 0.");
+  VELOX_USER_CHECK_GE(
+      ordinal, 0, "Invalid ordinal. Should be greater than or equal to 0.");
   auto numFields = args[0]->type()->asArray().elementType()->asRow().size();
   VELOX_USER_CHECK_LT(
       ordinal,

--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.h
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/FunctionCallToSpecialForm.h"
+
+namespace facebook::velox::functions::sparksql {
+
+class GetArrayStructFieldsCallToSpecialForm
+    : public exec::FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  /// Returns an expression for get_array_struct_fields special form. The
+  /// expression is a regular expression based on a custom VectorFunction
+  /// implementation.
+  exec::ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<exec::ExprPtr>&& args,
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
+
+  static constexpr const char* kGetArrayStructFields =
+      "get_array_struct_fields";
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   FactorialTest.cpp
   FromJsonTest.cpp
   FromToJsonRoundTripTest.cpp
+  GetArrayStructFieldsTest.cpp
   GetJsonObjectTest.cpp
   GetStructFieldTest.cpp
   HashTest.cpp

--- a/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
+++ b/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <gtest/gtest.h>
-#include <optional>
-
+#include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
-#include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
+++ b/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include <optional>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
+#include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class GetArrayStructFieldsTest : public SparkFunctionBaseTest {
+ protected:
+  void testGetArrayStructFields(
+      const VectorPtr& input,
+      int ordinal,
+      const VectorPtr& expected) {
+    std::vector<core::TypedExprPtr> inputs = {
+        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal))};
+    auto expr = std::make_shared<const core::CallTypedExpr>(
+        expected->type(),
+        std::move(inputs),
+        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields);
+
+    // Input is flat.
+    auto result = evaluate(expr, makeRowVector({input}));
+    assertEqualVectors(expected, result);
+
+    // Input is dictionary or constant encoding.
+    testEncodings(expr, {input}, expected);
+  }
+};
+
+TEST_F(GetArrayStructFieldsTest, simpleType) {
+  std::vector<vector_size_t> offsets{0, 1, 3};
+  auto colInt = makeFlatVector<int32_t>({1, 2, 3, 4});
+  auto colString = makeNullableFlatVector<std::string>(
+      {"hello", "world", std::nullopt, "test"});
+  auto colIntWithNull =
+      makeNullableFlatVector<int32_t>({11, std::nullopt, 13, 14});
+  auto elementVector = makeRowVector({colInt, colString, colIntWithNull});
+  auto data = makeArrayVector(offsets, elementVector);
+
+  testGetArrayStructFields(data, 0, makeArrayVector(offsets, colInt));
+  testGetArrayStructFields(data, 1, makeArrayVector(offsets, colString));
+  testGetArrayStructFields(data, 2, makeArrayVector(offsets, colIntWithNull));
+}
+
+TEST_F(GetArrayStructFieldsTest, complexType) {
+  std::vector<vector_size_t> offsets{0, 1, 2};
+  std::vector<vector_size_t> nulls{1};
+  auto colArray = makeNullableArrayVector<int32_t>(
+      {{1, 2, std::nullopt},
+       {3, std::nullopt, 4},
+       {5, std::nullopt, std::nullopt},
+       {6, 7, 8}});
+  auto colMap = makeMapVector<std::string, int32_t>(
+      {{{"a", 0}, {"b", 1}},
+       {{"c", 3}, {"d", 4}},
+       {{"e", 5}, {"f", 6}},
+       {{"g", 7}, {"h", 8}}});
+  auto colRow = makeRowVector(
+      {makeNullableArrayVector<int32_t>(
+           {{100, 101, std::nullopt},
+            {std::nullopt},
+            {200, std::nullopt, 202},
+            {300, 301, 302}}),
+       makeNullableFlatVector<std::string>({"a", "b", std::nullopt, "c"})});
+  auto elementVector = makeRowVector({colArray, colMap, colRow});
+  auto data = makeArrayVector(offsets, elementVector, nulls);
+
+  // Get array field array.
+  testGetArrayStructFields(data, 0, makeArrayVector(offsets, colArray, nulls));
+
+  // Get map field array.
+  testGetArrayStructFields(data, 1, makeArrayVector(offsets, colMap, nulls));
+
+  // Get row field array.
+  testGetArrayStructFields(data, 2, makeArrayVector(offsets, colRow, nulls));
+}
+
+TEST_F(GetArrayStructFieldsTest, nullElement) {
+  std::vector<vector_size_t> offsets{0, 1, 3};
+  auto colInt = makeFlatVector<int32_t>({1, 2, 3, 4});
+  auto colIntWithNull =
+      makeNullableFlatVector<int32_t>({11, std::nullopt, 13, 14});
+  auto elementVector = makeRowVector({colInt, colIntWithNull}, nullEvery(2));
+  auto data = makeArrayVector(offsets, elementVector);
+  testGetArrayStructFields(
+      data,
+      0,
+      makeArrayVector(
+          offsets,
+          makeNullableFlatVector<int32_t>({std::nullopt, 2, std::nullopt, 4})));
+  testGetArrayStructFields(
+      data,
+      1,
+      makeArrayVector(
+          offsets,
+          makeNullableFlatVector<int32_t>(
+              {std::nullopt, std::nullopt, std::nullopt, 14})));
+}
+
+TEST_F(GetArrayStructFieldsTest, decodeElement) {
+  std::vector<vector_size_t> offsets{0, 1, 3};
+  auto colInt = makeFlatVector<int32_t>({1, 2, 3, 4});
+  auto elementVector =
+      makeRowVector({wrapInDictionary(makeIndices({1, 0, 2, 3}), colInt)});
+  auto data = makeArrayVector(
+      offsets, wrapInDictionary(makeIndicesInReverse(4), elementVector));
+  testGetArrayStructFields(
+      data, 0, makeArrayVector(offsets, makeFlatVector<int32_t>({4, 3, 1, 2})));
+}
+
+TEST_F(GetArrayStructFieldsTest, invalidOrdinal) {
+  std::vector<vector_size_t> offsets{0};
+  auto colInt = makeFlatVector<int32_t>({1, 2, 3, 4});
+  auto elementVector = makeRowVector({colInt});
+  auto data = makeArrayVector(offsets, elementVector);
+
+  VELOX_ASSERT_USER_THROW(
+      testGetArrayStructFields(
+          elementVector, -1, makeArrayVector(offsets, colInt)),
+      "The first argument of get_array_struct_fields should be of array(row) type.");
+
+  VELOX_ASSERT_USER_THROW(
+      testGetArrayStructFields(data, -1, makeArrayVector(offsets, colInt)),
+      "Invalid ordinal. Should be greater than 0.");
+
+  VELOX_ASSERT_USER_THROW(
+      testGetArrayStructFields(data, 2, makeArrayVector(offsets, colInt)),
+      fmt::format("(2 vs. 1) Invalid ordinal 2 for struct with 1 fields."));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Extracts the ``ordinal``-th fields of all array elements from array(struct), 
and returns them as a new array.

Spark source code: https://github.com/apache/spark/blob/800d3729c9c2c1b1bf2d4c326d1ade610a7f2ada/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/complexTypeExtractors.scala#L203