### PR TITLE
fix: argument comment in velox/common/memory/tests/ArbitrationParticipantTest.cpp +12

### DIFF
--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -753,7 +753,7 @@ TEST_F(ArbitrationParticipantTest, getGrowTargets) {
     auto participant =
         ArbitrationParticipant::create(10, task->pool(), &config);
     auto scopedParticipant = participant->lock().value();
-    scopedParticipant->shrink(/*reclaimFromAll=*/true);
+    scopedParticipant->shrink(/*reclaimAll=*/true);
     ASSERT_EQ(scopedParticipant->capacity(), 0);
     void* buffer = task->allocate(testData.capacity);
     SCOPE_EXIT {
@@ -860,7 +860,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableFreeCapacityAndShrink) {
         ASSERT_EQ(scopedParticipant->pool()->peakBytes(), testData.peakBytes);
       }
 
-      scopedParticipant->shrink(/*reclaimFromAll=*/true);
+      scopedParticipant->shrink(/*reclaimAll=*/true);
       scopedParticipant->grow(testData.capacity, 0);
       ASSERT_EQ(scopedParticipant->capacity(), testData.capacity);
 
@@ -1020,7 +1020,7 @@ TEST_F(ArbitrationParticipantTest, reclaimableUsedCapacityAndReclaim) {
       ASSERT_EQ(scopedParticipant->pool()->peakBytes(), testData.peakBytes);
     }
 
-    scopedParticipant->shrink(/*reclaimFromAll=*/true);
+    scopedParticipant->shrink(/*reclaimAll=*/true);
     scopedParticipant->grow(testData.capacity, 0);
     ASSERT_EQ(scopedParticipant->capacity(), testData.capacity);
 

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
@@ -124,13 +124,13 @@ TEST_F(FuzzerConnectorTest, reproducible) {
   auto plan1 = PlanBuilder()
                    .startTableScan()
                    .outputType(type)
-                   .tableHandle(makeFuzzerTableHandle(/*fuzerSeed=*/1234))
+                   .tableHandle(makeFuzzerTableHandle(/*fuzzerSeed=*/1234))
                    .endTableScan()
                    .planNode();
   auto plan2 = PlanBuilder()
                    .startTableScan()
                    .outputType(type)
-                   .tableHandle(makeFuzzerTableHandle(/*fuzerSeed=*/1234))
+                   .tableHandle(makeFuzzerTableHandle(/*fuzzerSeed=*/1234))
                    .endTableScan()
                    .planNode();
 

--- a/velox/connectors/tpch/TpchConnectorSplit.h
+++ b/velox/connectors/tpch/TpchConnectorSplit.h
@@ -32,7 +32,7 @@ struct TpchConnectorSplit : public connector::ConnectorSplit {
       bool cacheable,
       size_t totalParts,
       size_t partNumber)
-      : ConnectorSplit(connectorId, /*splitWeight=*/0, cacheable),
+      : ConnectorSplit(connectorId, /*_splitWeight=*/0, cacheable),
         totalParts(totalParts),
         partNumber(partNumber) {
     VELOX_CHECK_GE(totalParts, 1, "totalParts must be >= 1");

--- a/velox/dwio/dwrf/test/E2EWriterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTest.cpp
@@ -980,7 +980,7 @@ TEST_F(E2EWriterTest, OversizeRows) {
       config,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
-      /*memoryBudget=*/std::numeric_limits<int64_t>::max(),
+      /*writerMemoryCap=*/std::numeric_limits<int64_t>::max(),
       false);
 }
 
@@ -1012,7 +1012,7 @@ TEST_F(E2EWriterTest, OversizeBatches) {
       config,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
-      /*memoryBudget=*/std::numeric_limits<int64_t>::max(),
+      /*writerMemoryCap=*/std::numeric_limits<int64_t>::max(),
       false);
 
   // Test splitting multiple huge batches.
@@ -1028,7 +1028,7 @@ TEST_F(E2EWriterTest, OversizeBatches) {
       config,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
-      /*memoryBudget=*/std::numeric_limits<int64_t>::max(),
+      /*writerMemoryCap=*/std::numeric_limits<int64_t>::max(),
       false);
 }
 
@@ -1088,7 +1088,7 @@ TEST_F(E2EWriterTest, OverflowLengthIncrements) {
       config,
       /*flushPolicyFactory=*/nullptr,
       /*layoutPlannerFactory=*/nullptr,
-      /*memoryBudget=*/std::numeric_limits<int64_t>::max(),
+      /*writerMemoryCap=*/std::numeric_limits<int64_t>::max(),
       false);
 }
 

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1575,7 +1575,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
             batch_num_values,
             batch_num_spaced_values,
             bits_buffer_->data(),
-            /*offset=*/0,
+            /*valid_bits_offset=*/0,
             /*num_levels=*/batch_size,
             null_count);
       } else {

--- a/velox/dwio/parquet/writer/arrow/Encoding.cpp
+++ b/velox/dwio/parquet/writer/arrow/Encoding.cpp
@@ -1738,7 +1738,7 @@ class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
     num_values_ = num_values;
     if (len == 0) {
       // Initialize dummy decoder to avoid crashes later on
-      idx_decoder_ = RleDecoder(data, len, /*bit_width=*/1);
+      idx_decoder_ = RleDecoder(data, len, /*bitWidth=*/1);
       return;
     }
     uint8_t bit_width = *data;

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
@@ -506,7 +506,7 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
   std::shared_ptr<DataPageV1> data_page = MakeDataPage<BooleanType>(
       &descr,
       values,
-      /*num_values=*/2,
+      /*num_vals=*/2,
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -600,7 +600,7 @@ TEST_F(TestPrimitiveReader, TestReadValuesMissingWithDictionary) {
   std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
       &descr,
       {},
-      /*num_values=*/2,
+      /*num_vals=*/2,
       Encoding::RLE_DICTIONARY,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -915,7 +915,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadRequired) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(def_levels.size()),
+      /*num_vals=*/static_cast<int>(def_levels.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -985,7 +985,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadOptional) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(def_levels.size()),
+      /*num_vals=*/static_cast<int>(def_levels.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1113,7 +1113,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadRequiredRepeated) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(def_levels.size()),
+      /*num_vals=*/static_cast<int>(def_levels.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1191,7 +1191,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadNullableRepeated) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(def_levels.size()),
+      /*num_vals=*/static_cast<int>(def_levels.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1320,7 +1320,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRequiredTopLevel) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(values.size()),
+      /*num_vals=*/static_cast<int>(values.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1371,7 +1371,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipOptional) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(values.size()),
+      /*num_vals=*/static_cast<int>(values.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1485,7 +1485,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeated) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(values.size()),
+      /*num_vals=*/static_cast<int>(values.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1590,7 +1590,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeatedConsumeBufferFirst) {
   std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
       descr_,
       values,
-      /*num_values=*/static_cast<int>(values.size()),
+      /*num_vals=*/static_cast<int>(values.size()),
       Encoding::PLAIN,
       /*indices=*/{},
       /*indices_size=*/0,
@@ -1647,7 +1647,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{10, 20, 20, 20},
-        /*num_values=*/4,
+        /*num_vals=*/4,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,
@@ -1663,7 +1663,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{20, 20},
-        /*num_values=*/2,
+        /*num_vals=*/2,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,
@@ -1679,7 +1679,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{20, 30},
-        /*num_values=*/2,
+        /*num_vals=*/2,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,
@@ -1751,7 +1751,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{10, 20, 20, 20},
-        /*num_values=*/4,
+        /*num_vals=*/4,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,
@@ -1767,7 +1767,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{20, 20},
-        /*num_values=*/2,
+        /*num_vals=*/2,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,
@@ -1783,7 +1783,7 @@ TEST_P(RecordReaderPrimitiveTypeTest, SkipPartialRecord) {
     std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
         descr_,
         /*values=*/{20, 30},
-        /*num_values=*/2,
+        /*num_vals=*/2,
         Encoding::PLAIN,
         /*indices=*/{},
         /*indices_size=*/0,

--- a/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
@@ -1706,7 +1706,7 @@ class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
     num_values_ = num_values;
     if (len == 0) {
       // Initialize dummy decoder to avoid crashes later on
-      idx_decoder_ = RleDecoder(data, len, /*bit_width=*/1);
+      idx_decoder_ = RleDecoder(data, len, /*bitWidth=*/1);
       return;
     }
     uint8_t bit_width = *data;
@@ -3411,7 +3411,7 @@ class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
           num_bytes,
           /*bit_width=*/1);
     } else {
-      decoder_->Reset(decoder_data, num_bytes, /*bit_width=*/1);
+      decoder_->Reset(decoder_data, num_bytes, /*bitWidth=*/1);
     }
   }
 

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -59,7 +59,7 @@ class OperatorTraceInputWriter {
       true,
       common::CompressionKind::CompressionKind_ZSTD,
       0.8,
-      /*nullsFirst=*/true};
+      /*_nullsFirst=*/true};
   const std::shared_ptr<filesystems::FileSystem> fs_;
   memory::MemoryPool* const pool_;
   VectorSerde* const serde_;

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -242,7 +242,7 @@ uint64_t SpillWriter::write(
           kDefaultUseLosslessTimestamp,
           compressionKind_,
           0.8,
-          /*nullsFirst=*/true};
+          /*_nullsFirst=*/true};
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(
           std::static_pointer_cast<const RowType>(rows->type()),
@@ -327,7 +327,7 @@ SpillReadFile::SpillReadFile(
           kDefaultUseLosslessTimestamp,
           compressionKind_,
           0.8,
-          /*nullsFirst=*/true},
+          /*_nullsFirst=*/true},
       pool_(pool),
       serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),
       stats_(stats) {

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -1181,7 +1181,7 @@ TEST_P(IndexLookupJoinTest, betweenJoinCondition) {
         GetParam().hasNullKeys,
         {},
         {{"t2", "t3"}},
-        /*eqaulityMatchPct=*/80,
+        /*equalMatchPct=*/80,
         /*inColumns=*/std::nullopt,
         testData.betweenMatchPct);
     std::vector<std::shared_ptr<TempFilePath>> probeFiles =
@@ -1505,7 +1505,7 @@ TEST_P(IndexLookupJoinTest, inJoinCondition) {
         GetParam().hasNullKeys,
         {{"t4"}},
         {},
-        /*eqaulityMatchPct=*/80,
+        /*equalMatchPct=*/80,
         testData.inMatchPct);
     std::vector<std::shared_ptr<TempFilePath>> probeFiles =
         createProbeFiles(probeVectors);
@@ -1765,7 +1765,7 @@ TEST_P(IndexLookupJoinTest, prefixKeysbetweenJoinCondition) {
         GetParam().hasNullKeys,
         {},
         {{"t1", "t2"}},
-        /*eqaulityMatchPct=*/80,
+        /*equalMatchPct=*/80,
         /*inColumns=*/std::nullopt,
         testData.betweenMatchPct);
     std::vector<std::shared_ptr<TempFilePath>> probeFiles =
@@ -1889,7 +1889,7 @@ TEST_P(IndexLookupJoinTest, prefixInJoinCondition) {
         GetParam().hasNullKeys,
         {{"t4"}},
         {},
-        /*eqaulityMatchPct=*/80,
+        /*equalMatchPct=*/80,
         testData.inMatchPct);
     std::vector<std::shared_ptr<TempFilePath>> probeFiles =
         createProbeFiles(probeVectors);

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -762,7 +762,7 @@ TEST_F(OperatorTraceTest, traceSplitRoundTrip) {
   for (int i = 0; i < 3; ++i) {
     const auto opTraceDir = getOpTraceDirectory(
         taskTraceDir,
-        /*planNodeId=*/"0",
+        /*nodeId=*/"0",
         /*pipelineId=*/0,
         /*driverId=*/i);
     const auto summaryFilePath = getOpTraceSummaryFilePath(opTraceDir);
@@ -828,7 +828,7 @@ TEST_F(OperatorTraceTest, traceSplitPartial) {
   for (int i = 0; i < 3; ++i) {
     const auto opTraceDir = getOpTraceDirectory(
         taskTraceDir,
-        /*planNodeId=*/"0",
+        /*nodeId=*/"0",
         /*pipelineId=*/0,
         /*driverId=*/i);
     const auto summaryFilePath = getOpTraceSummaryFilePath(opTraceDir);
@@ -917,7 +917,7 @@ TEST_F(OperatorTraceTest, traceSplitCorrupted) {
   for (int i = 0; i < 3; ++i) {
     const auto opTraceDir = getOpTraceDirectory(
         taskTraceDir,
-        /*planNodeId=*/"0",
+        /*nodeId=*/"0",
         /*pipelineId=*/0,
         /*driverId=*/i);
     const auto summaryFilePath = getOpTraceSummaryFilePath(opTraceDir);


### PR DESCRIPTION
Summary:
Argument comments ensure that the correct values are assigned to the correct arguments.

This diff is a manual fix (assisted by the script in D78190897) of one or more argument comments in velox/common/memory/tests/ArbitrationParticipantTest.cpp. Once existing violations are drawn down we will make mismatches between argument comments and argument names an error.

Reviewed By: dtolnay

Differential Revision: D78191303


