### PR TITLE
feat: Add Spark timestampadd function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -271,6 +271,20 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT second('2009-07-30 12:58:59'); -- 59
 
+.. spark:function:: timestampadd(unit, value, timestamp) -> timestamp
+
+    Adds an interval ``value`` of type ``unit`` to ``timestamp``.
+    Subtraction can be performed by using a negative value.
+    Throws exception if ``unit`` is invalid.
+    ``unit`` is case insensitive and must be one of the following:
+    ``YEAR``, ``QUARTER``, ``MONTH``, ``WEEK``, ``DAY``, ``DAYOFYEAR``, ``HOUR``, ``MINUTE``, ``SECOND``,
+    ``MILLISECOND``, ``MICROSECOND``. ::
+
+        SELECT timestampadd(YEAR, 1, '2030-02-28 10:00:00.500'); -- 2031-02-28 10:00:00.500
+        SELECT timestampadd(DAY, 1, '2020-02-29 10:00:00.500'); -- 2020-03-01 10:00:00.500
+        SELECT timestampadd(SECOND, 10, '2019-03-01 10:00:00.500'); -- 2019-03-01 10:00:10.500
+        SELECT timestampadd(MICROSECOND, 500, '2019-02-28 10:01:00.500999'); -- 2019-02-28 10:01:00.501499
+
 .. spark:function:: timestampdiff(unit, timestamp1, timestamp2) -> bigint
 
     Returns ``timestamp2`` - ``timestamp1`` expressed in terms of ``unit``, the fraction

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -274,7 +274,7 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: timestampadd(unit, value, timestamp) -> timestamp
 
     Adds an interval ``value`` of type ``unit`` to ``timestamp``.
-    Subtraction can be performed by using a negative value.
+    Subtraction can be performed by using a negative ``value``.
     Throws exception if ``unit`` is invalid.
     ``unit`` is case insensitive and must be one of the following:
     ``YEAR``, ``QUARTER``, ``MONTH``, ``WEEK``, ``DAY``, ``DAYOFYEAR``, ``HOUR``, ``MINUTE``, ``SECOND``,
@@ -282,6 +282,7 @@ These functions support TIMESTAMP and DATE input types.
 
         SELECT timestampadd(YEAR, 1, '2030-02-28 10:00:00.500'); -- 2031-02-28 10:00:00.500
         SELECT timestampadd(DAY, 1, '2020-02-29 10:00:00.500'); -- 2020-03-01 10:00:00.500
+        SELECT timestampadd(DAYOFYEAR, 1, '2020-02-29 10:00:00.500'); -- 2020-03-01 10:00:00.500
         SELECT timestampadd(SECOND, 10, '2019-03-01 10:00:00.500'); -- 2019-03-01 10:00:10.500
         SELECT timestampadd(MICROSECOND, 500, '2019-02-28 10:01:00.500999'); -- 2019-02-28 10:01:00.501499
 

--- a/velox/functions/lib/DateTimeUtil.h
+++ b/velox/functions/lib/DateTimeUtil.h
@@ -277,8 +277,10 @@ addToTimestamp(const Timestamp& timestamp, DateTimeUnit unit, int32_t value) {
         std::chrono::microseconds(timestamp.toMicros()));
     const std::chrono::time_point<std::chrono::system_clock> outMicroTimestamp =
         inMicroTimestamp + std::chrono::microseconds(value);
-    const Timestamp microTimestamp =
-        Timestamp::fromMicros(outMicroTimestamp.time_since_epoch().count());
+    const Timestamp microTimestamp = Timestamp::fromMicros(
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            outMicroTimestamp.time_since_epoch())
+            .count());
     return Timestamp(
         microTimestamp.getSeconds(),
         microTimestamp.getNanos() +

--- a/velox/functions/lib/DateTimeUtil.h
+++ b/velox/functions/lib/DateTimeUtil.h
@@ -21,12 +21,6 @@
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
-namespace {
-constexpr double kNanosecondsInSecond = 1'000'000'000;
-constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
-constexpr int64_t kNanosecondsInMicrosecond = 1'000;
-constexpr int64_t kMillisecondsInSecond = 1'000;
-} // namespace
 
 /// Returns toTimestamp - fromTimestamp expressed in terms of unit.
 /// @param respectLastDay If true, the last day of a year-month is respected.
@@ -284,7 +278,7 @@ addToTimestamp(const Timestamp& timestamp, DateTimeUnit unit, int32_t value) {
     return Timestamp(
         microTimestamp.getSeconds(),
         microTimestamp.getNanos() +
-            timestamp.getNanos() % kNanosecondsInMicrosecond);
+            timestamp.getNanos() % Timestamp::kNanosecondsInMicrosecond);
   }
 
   const std::chrono::
@@ -342,7 +336,7 @@ addToTimestamp(const Timestamp& timestamp, DateTimeUnit unit, int32_t value) {
   return Timestamp(
       milliTimestamp.getSeconds(),
       milliTimestamp.getNanos() +
-          timestamp.getNanos() % kNanosecondsInMillisecond);
+          timestamp.getNanos() % Timestamp::kNanosecondsInMillisecond);
 }
 
 FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(

--- a/velox/functions/lib/DateTimeUtil.h
+++ b/velox/functions/lib/DateTimeUtil.h
@@ -18,8 +18,15 @@
 #include "velox/external/date/date.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/type/Timestamp.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
+namespace {
+constexpr double kNanosecondsInSecond = 1'000'000'000;
+constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
+constexpr int64_t kMicrosecondsInNanoseconds = 1'000;
+constexpr int64_t kMillisecondsInSecond = 1'000;
+} // namespace
 
 /// Returns toTimestamp - fromTimestamp expressed in terms of unit.
 /// @param respectLastDay If true, the last day of a year-month is respected.
@@ -202,6 +209,172 @@ FOLLY_ALWAYS_INLINE int64_t diffTimestamp(
         unit, fromZonedTimestamp, toZonedTimestamp, respectLastDay);
   }
   return diffTimestamp(unit, fromTimestamp, toTimestamp, respectLastDay);
+}
+
+/// Year, quarter or month are not uniformly incremented. Months have different
+/// total days, and leap years have more days than the rest. If the new year,
+/// quarter or month has less total days than the given one, it will be coerced
+/// to use the valid last day of the new month. This could result in weird
+/// arithmetic behavior. For example,
+///
+/// 2022-01-30 + (1 month) = 2022-02-28
+/// 2022-02-28 - (1 month) = 2022-01-28
+///
+/// 2022-08-31 + (1 quarter) = 2022-11-30
+/// 2022-11-30 - (1 quarter) = 2022-08-30
+///
+/// 2020-02-29 + (1 year) = 2021-02-28
+/// 2021-02-28 - (1 year) = 2020-02-28
+FOLLY_ALWAYS_INLINE
+int32_t addToDate(int32_t input, DateTimeUnit unit, int32_t value) {
+  // TODO: Handle overflow and underflow with 64-bit representation
+  if (value == 0) {
+    return input;
+  }
+
+  const std::chrono::time_point<std::chrono::system_clock, date::days> inDate{
+      date::days(input)};
+  std::chrono::time_point<std::chrono::system_clock, date::days> outDate;
+
+  if (unit == DateTimeUnit::kDay) {
+    outDate = inDate + date::days(value);
+  } else if (unit == DateTimeUnit::kWeek) {
+    outDate = inDate + date::days(value * 7);
+  } else {
+    const date::year_month_day inCalDate(inDate);
+    date::year_month_day outCalDate;
+
+    if (unit == DateTimeUnit::kMonth) {
+      outCalDate = inCalDate + date::months(value);
+    } else if (unit == DateTimeUnit::kQuarter) {
+      outCalDate = inCalDate + date::months(3 * value);
+    } else if (unit == DateTimeUnit::kYear) {
+      outCalDate = inCalDate + date::years(value);
+    } else {
+      VELOX_UNREACHABLE();
+    }
+
+    if (!outCalDate.ok()) {
+      outCalDate = outCalDate.year() / outCalDate.month() / date::last;
+    }
+    outDate = date::sys_days{outCalDate};
+  }
+
+  return outDate.time_since_epoch().count();
+}
+
+FOLLY_ALWAYS_INLINE Timestamp
+addToTimestamp(const Timestamp& timestamp, DateTimeUnit unit, int32_t value) {
+  // TODO: Handle overflow and underflow with 64-bit representation.
+  if (value == 0) {
+    return timestamp;
+  }
+
+  // The microsecond unit is handled independently to prevent overflow while
+  // converting all timestamps to microseconds for each unit.
+  if (unit == DateTimeUnit::kMicrosecond) {
+    const std::chrono::time_point<std::chrono::system_clock> inTimestamp(
+        std::chrono::microseconds(timestamp.toMicros()));
+    std::chrono::time_point<std::chrono::system_clock> outTimestamp =
+        inTimestamp + std::chrono::microseconds(value);
+    Timestamp microTimestamp =
+        Timestamp::fromMicros(outTimestamp.time_since_epoch().count());
+    return Timestamp(
+        microTimestamp.getSeconds(),
+        microTimestamp.getNanos() +
+            timestamp.getNanos() % kMicrosecondsInNanoseconds);
+  }
+
+  const std::chrono::
+      time_point<std::chrono::system_clock, std::chrono::milliseconds>
+          inTimestamp(std::chrono::milliseconds(timestamp.toMillis()));
+  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
+      outTimestamp;
+
+  switch (unit) {
+    // Year, quarter or month are not uniformly incremented in terms of number
+    // of days. So we treat them differently.
+    case DateTimeUnit::kYear:
+    case DateTimeUnit::kQuarter:
+    case DateTimeUnit::kMonth:
+    case DateTimeUnit::kDay: {
+      const int32_t inDate =
+          std::chrono::duration_cast<date::days>(inTimestamp.time_since_epoch())
+              .count();
+      const int32_t outDate = addToDate(inDate, unit, value);
+      outTimestamp =
+          inTimestamp + date::days(checkedMinus<int32_t>(outDate, inDate));
+      break;
+    }
+    case DateTimeUnit::kHour: {
+      outTimestamp = inTimestamp + std::chrono::hours(value);
+      break;
+    }
+    case DateTimeUnit::kMinute: {
+      outTimestamp = inTimestamp + std::chrono::minutes(value);
+      break;
+    }
+    case DateTimeUnit::kSecond: {
+      outTimestamp = inTimestamp + std::chrono::seconds(value);
+      break;
+    }
+    case DateTimeUnit::kMillisecond: {
+      outTimestamp = inTimestamp + std::chrono::milliseconds(value);
+      break;
+    }
+    case DateTimeUnit::kWeek: {
+      const int32_t inDate =
+          std::chrono::duration_cast<date::days>(inTimestamp.time_since_epoch())
+              .count();
+      const int32_t outDate = addToDate(inDate, DateTimeUnit::kDay, 7 * value);
+
+      outTimestamp = inTimestamp + date::days(outDate - inDate);
+      break;
+    }
+    default:
+      VELOX_UNREACHABLE("Unsupported datetime unit");
+  }
+
+  Timestamp milliTimestamp =
+      Timestamp::fromMillis(outTimestamp.time_since_epoch().count());
+  return Timestamp(
+      milliTimestamp.getSeconds(),
+      milliTimestamp.getNanos() +
+          timestamp.getNanos() % kNanosecondsInMillisecond);
+}
+
+FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
+    DateTimeUnit unit,
+    int32_t value,
+    const Timestamp& timestamp,
+    const tz::TimeZone* timeZone) {
+  Timestamp result;
+  if (LIKELY(timeZone != nullptr)) {
+    // timeZone not null means that the config
+    // adjust_timestamp_to_timezone is on.
+    Timestamp zonedTimestamp = timestamp;
+    zonedTimestamp.toTimezone(*timeZone);
+
+    Timestamp resultTimestamp = addToTimestamp(zonedTimestamp, unit, value);
+
+    if (isTimeUnit(unit)) {
+      const int64_t offset = static_cast<Timestamp>(timestamp).getSeconds() -
+          zonedTimestamp.getSeconds();
+      result = Timestamp(
+          resultTimestamp.getSeconds() + offset, resultTimestamp.getNanos());
+    } else {
+      result = Timestamp(
+          timeZone
+              ->correct_nonexistent_time(
+                  std::chrono::seconds(resultTimestamp.getSeconds()))
+              .count(),
+          resultTimestamp.getNanos());
+      result.toGMT(*timeZone);
+    }
+  } else {
+    result = addToTimestamp(timestamp, unit, value);
+  }
+  return result;
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -44,7 +44,7 @@ struct ToUnixtimeFunction {
       double& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     const auto milliseconds = unpackMillisUtc(*timestampWithTimezone);
-    result = (double)milliseconds / kMillisecondsInSecond;
+    result = (double)milliseconds / Timestamp::kMillisecondsInSecond;
   }
 };
 
@@ -852,7 +852,7 @@ struct MillisecondFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<Timestamp>& timestamp) {
-    result = timestamp.getNanos() / kNanosecondsInMillisecond;
+    result = timestamp.getNanos() / Timestamp::kNanosecondsInMillisecond;
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -866,7 +866,7 @@ struct MillisecondFunction : public TimestampWithTimezoneSupport<T> {
       int64_t& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
-    result = timestamp.getNanos() / kNanosecondsInMillisecond;
+    result = timestamp.getNanos() / Timestamp::kNanosecondsInMillisecond;
   }
 };
 
@@ -877,7 +877,7 @@ struct MillisecondFromIntervalFunction {
   FOLLY_ALWAYS_INLINE void call(
       int64_t& result,
       const arg_type<IntervalDayTime>& millis) {
-    result = millis % kMillisecondsInSecond;
+    result = millis % Timestamp::kMillisecondsInSecond;
   }
 };
 

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -29,7 +29,8 @@ namespace facebook::velox::functions {
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {
   double result = timestamp.getSeconds();
-  result += static_cast<double>(timestamp.getNanos()) / kNanosecondsInSecond;
+  result +=
+      static_cast<double>(timestamp.getNanos()) / Timestamp::kNanosInSecond;
   return result;
 }
 
@@ -58,7 +59,8 @@ FOLLY_ALWAYS_INLINE Timestamp fromUnixtime(double unixtime) {
     ++seconds;
     milliseconds = 0;
   }
-  return Timestamp(seconds, milliseconds * kNanosecondsInMillisecond);
+  return Timestamp(
+      seconds, milliseconds * Timestamp::kNanosecondsInMillisecond);
 }
 
 FOLLY_ALWAYS_INLINE boost::int64_t fromUnixtime(
@@ -83,7 +85,8 @@ FOLLY_ALWAYS_INLINE boost::int64_t fromUnixtime(
                         : pack(std::numeric_limits<int64_t>::max(), timeZoneId);
   }
 
-  return pack(std::llround(unixtime * kMillisecondsInSecond), timeZoneId);
+  return pack(
+      std::llround(unixtime * Timestamp::kMillisecondsInSecond), timeZoneId);
 }
 
 // If time zone is provided, use it for the arithmetic operation (convert to it,

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -16,10 +16,8 @@
 #pragma once
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <chrono>
 #include <optional>
 #include "velox/common/base/Doubles.h"
-#include "velox/external/date/date.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/DateTimeUtil.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -28,11 +26,6 @@
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions {
-namespace {
-constexpr double kNanosecondsInSecond = 1'000'000'000;
-constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
-constexpr int64_t kMillisecondsInSecond = 1'000;
-} // namespace
 
 FOLLY_ALWAYS_INLINE double toUnixtime(const Timestamp& timestamp) {
   double result = timestamp.getSeconds();
@@ -91,126 +84,6 @@ FOLLY_ALWAYS_INLINE boost::int64_t fromUnixtime(
   }
 
   return pack(std::llround(unixtime * kMillisecondsInSecond), timeZoneId);
-}
-
-// Year, quarter or month are not uniformly incremented. Months have different
-// total days, and leap years have more days than the rest. If the new year,
-// quarter or month has less total days than the given one, it will be coerced
-// to use the valid last day of the new month. This could result in weird
-// arithmetic behavior. For example,
-//
-// 2022-01-30 + (1 month) = 2022-02-28
-// 2022-02-28 - (1 month) = 2022-01-28
-//
-// 2022-08-31 + (1 quarter) = 2022-11-30
-// 2022-11-30 - (1 quarter) = 2022-08-30
-//
-// 2020-02-29 + (1 year) = 2021-02-28
-// 2021-02-28 - (1 year) = 2020-02-28
-FOLLY_ALWAYS_INLINE
-int32_t
-addToDate(const int32_t input, const DateTimeUnit unit, const int32_t value) {
-  // TODO(gaoge): Handle overflow and underflow with 64-bit representation
-  if (value == 0) {
-    return input;
-  }
-
-  const std::chrono::time_point<std::chrono::system_clock, date::days> inDate{
-      date::days(input)};
-  std::chrono::time_point<std::chrono::system_clock, date::days> outDate;
-
-  if (unit == DateTimeUnit::kDay) {
-    outDate = inDate + date::days(value);
-  } else if (unit == DateTimeUnit::kWeek) {
-    outDate = inDate + date::days(value * 7);
-  } else {
-    const date::year_month_day inCalDate(inDate);
-    date::year_month_day outCalDate;
-
-    if (unit == DateTimeUnit::kMonth) {
-      outCalDate = inCalDate + date::months(value);
-    } else if (unit == DateTimeUnit::kQuarter) {
-      outCalDate = inCalDate + date::months(3 * value);
-    } else if (unit == DateTimeUnit::kYear) {
-      outCalDate = inCalDate + date::years(value);
-    } else {
-      VELOX_UNREACHABLE();
-    }
-
-    if (!outCalDate.ok()) {
-      outCalDate = outCalDate.year() / outCalDate.month() / date::last;
-    }
-    outDate = date::sys_days{outCalDate};
-  }
-
-  return outDate.time_since_epoch().count();
-}
-
-FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
-    const Timestamp& timestamp,
-    const DateTimeUnit unit,
-    const int32_t value) {
-  // TODO(gaoge): Handle overflow and underflow with 64-bit representation
-  if (value == 0) {
-    return timestamp;
-  }
-
-  const std::chrono::
-      time_point<std::chrono::system_clock, std::chrono::milliseconds>
-          inTimestamp(std::chrono::milliseconds(timestamp.toMillis()));
-  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
-      outTimestamp;
-
-  switch (unit) {
-    // Year, quarter or month are not uniformly incremented in terms of number
-    // of days. So we treat them differently.
-    case DateTimeUnit::kYear:
-    case DateTimeUnit::kQuarter:
-    case DateTimeUnit::kMonth:
-    case DateTimeUnit::kDay: {
-      const int32_t inDate =
-          std::chrono::duration_cast<date::days>(inTimestamp.time_since_epoch())
-              .count();
-      const int32_t outDate = addToDate(inDate, unit, value);
-      outTimestamp =
-          inTimestamp + date::days(checkedMinus<int32_t>(outDate, inDate));
-      break;
-    }
-    case DateTimeUnit::kHour: {
-      outTimestamp = inTimestamp + std::chrono::hours(value);
-      break;
-    }
-    case DateTimeUnit::kMinute: {
-      outTimestamp = inTimestamp + std::chrono::minutes(value);
-      break;
-    }
-    case DateTimeUnit::kSecond: {
-      outTimestamp = inTimestamp + std::chrono::seconds(value);
-      break;
-    }
-    case DateTimeUnit::kMillisecond: {
-      outTimestamp = inTimestamp + std::chrono::milliseconds(value);
-      break;
-    }
-    case DateTimeUnit::kWeek: {
-      const int32_t inDate =
-          std::chrono::duration_cast<date::days>(inTimestamp.time_since_epoch())
-              .count();
-      const int32_t outDate = addToDate(inDate, DateTimeUnit::kDay, 7 * value);
-
-      outTimestamp = inTimestamp + date::days(outDate - inDate);
-      break;
-    }
-    default:
-      VELOX_UNREACHABLE("Unsupported datetime unit");
-  }
-
-  Timestamp milliTimestamp =
-      Timestamp::fromMillis(outTimestamp.time_since_epoch().count());
-  return Timestamp(
-      milliTimestamp.getSeconds(),
-      milliTimestamp.getNanos() +
-          timestamp.getNanos() % kNanosecondsInMillisecond);
 }
 
 // If time zone is provided, use it for the arithmetic operation (convert to it,

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -986,4 +986,39 @@ struct TimestampDiffFunction {
   std::optional<DateTimeUnit> unit_ = std::nullopt;
 };
 
+template <typename T>
+struct TimestampAddFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* unitString,
+      const int32_t* /*value*/,
+      const arg_type<Timestamp>* /*timestamp*/) {
+    VELOX_USER_CHECK_NOT_NULL(unitString);
+    if (boost::algorithm::to_lower_copy(StringView(*unitString).str()) ==
+        "dayofyear") {
+      unit_ = DateTimeUnit::kDay;
+    } else {
+      unit_ = fromDateTimeUnitString(
+          *unitString, /*throwIfInvalid=*/true, /*allowMicro=*/true);
+    }
+    sessionTimeZone_ = getTimeZoneFromConfig(config);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Timestamp>& result,
+      const arg_type<Varchar>& /*unitString*/,
+      const int32_t value,
+      const arg_type<Timestamp>& timestamp) {
+    const auto unit = unit_.value();
+    result = addToTimestamp(unit, value, timestamp, sessionTimeZone_);
+  }
+
+ private:
+  const tz::TimeZone* sessionTimeZone_ = nullptr;
+  std::optional<DateTimeUnit> unit_ = std::nullopt;
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -997,8 +997,9 @@ struct TimestampAddFunction {
       const int32_t* /*value*/,
       const arg_type<Timestamp>* /*timestamp*/) {
     VELOX_USER_CHECK_NOT_NULL(unitString);
-    if (boost::algorithm::to_lower_copy(StringView(*unitString).str()) ==
-        "dayofyear") {
+    std::string unitStr(*unitString);
+    folly::toLowerAscii(unitStr);
+    if (unitStr == "dayofyear") {
       unit_ = DateTimeUnit::kDay;
     } else {
       unit_ = fromDateTimeUnitString(

--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -101,6 +101,12 @@ void registerDatetimeFunctions(const std::string& prefix) {
       Varchar,
       Timestamp,
       Timestamp>({prefix + "timestampdiff"});
+  registerFunction<
+      TimestampAddFunction,
+      Timestamp,
+      Varchar,
+      int32_t,
+      Timestamp>({prefix + "timestampadd"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1573,11 +1573,11 @@ TEST_F(DateTimeFunctionsTest, timestampadd) {
         fmt::format("timestampadd('{}', c0, c1)", unit), value, timestamp);
   };
 
-  // Check null behaviors
+  // Check null behaviors.
   EXPECT_EQ(std::nullopt, timestampadd("second", 1, std::nullopt));
   EXPECT_EQ(std::nullopt, timestampadd("month", std::nullopt, Timestamp(0, 0)));
 
-  // Check invalid units
+  // Check invalid units.
   VELOX_ASSERT_THROW(
       timestampadd("invalid_unit", 1, Timestamp(0, 0)),
       "Unsupported datetime unit: invalid_unit");
@@ -1645,6 +1645,32 @@ TEST_F(DateTimeFunctionsTest, timestampadd) {
           "year",
           1,
           Timestamp(1551348000, 500'999'999) /*2019-02-28 10:00:00.500*/));
+
+  // Test for coercing to the last day of a year-month.
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      timestampadd(
+          "day",
+          365 + 30,
+          Timestamp(1548842400, 500'999'999) /*2019-01-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      timestampadd(
+          "month",
+          12 + 1,
+          Timestamp(1548842400, 500'999'999) /*2019-01-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/,
+      timestampadd(
+          "quarter",
+          1,
+          Timestamp(1575108000, 500'999'999) /*2019-11-30 10:00:00.500*/));
+  EXPECT_EQ(
+      Timestamp(1898503200, 500'999'999) /*2030-02-28 10:00:00.500*/,
+      timestampadd(
+          "year",
+          10,
+          Timestamp(1582970400, 500'999'999) /*2020-02-29 10:00:00.500*/));
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Adds Spark timestampadd function.  Extracts `addToDate` and `addToTimestamp` 
functions to 'velox/functions/lib' for reuse between Presto and Spark. Adds the 
support of microsecond in `addToTimestamp` for Spark. The 'dayofyear' unit is 
supported in the timestampadd function.

Spark's implementation:
https://github.com/apache/spark/blob/303c18c74664f161b9b969ac343784c088b47593/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L3126-L3206