### PR TITLE
Fix microsecond getting truncated when using to_timestamp casting from String to Timestamp in Spark

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.h
+++ b/velox/functions/lib/DateTimeFormatter.h
@@ -184,11 +184,13 @@ class DateTimeFormatter {
       std::unique_ptr<char[]>&& literalBuf,
       size_t bufSize,
       std::vector<DateTimeToken>&& tokens,
-      DateTimeFormatterType type)
+      DateTimeFormatterType type,
+      bool truncateFractionOfSecondToMillis)
       : literalBuf_(std::move(literalBuf)),
         bufSize_(bufSize),
         tokens_(std::move(tokens)),
-        type_(type) {}
+        type_(type),
+        truncateFractionOfSecondToMillis_(truncateFractionOfSecondToMillis) {}
 
   const std::unique_ptr<char[]>& literalBuf() const {
     return literalBuf_;
@@ -233,13 +235,15 @@ class DateTimeFormatter {
   size_t bufSize_;
   std::vector<DateTimeToken> tokens_;
   DateTimeFormatterType type_;
+  bool truncateFractionOfSecondToMillis_;
 };
 
 Expected<std::shared_ptr<DateTimeFormatter>> buildMysqlDateTimeFormatter(
     const std::string_view& format);
 
 Expected<std::shared_ptr<DateTimeFormatter>> buildJodaDateTimeFormatter(
-    const std::string_view& format);
+    const std::string_view& format,
+    bool truncateFractionOfSecondToMillis = true);
 
 Expected<std::shared_ptr<DateTimeFormatter>> buildSimpleDateTimeFormatter(
     const std::string_view& format,

--- a/velox/functions/lib/DateTimeFormatterBuilder.cpp
+++ b/velox/functions/lib/DateTimeFormatterBuilder.cpp
@@ -173,6 +173,12 @@ DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendFractionOfSecond(
   return *this;
 }
 
+DateTimeFormatterBuilder&
+DateTimeFormatterBuilder::truncateFractionOfSecondToMillis(bool truncate) {
+  truncateFractionOfSecondToMillis_ = truncate;
+  return *this;
+}
+
 DateTimeFormatterBuilder& DateTimeFormatterBuilder::appendTimeZone(
     size_t minDigits) {
   tokens_.emplace_back(
@@ -219,7 +225,11 @@ DateTimeFormatterBuilder& DateTimeFormatterBuilder::setType(
 std::shared_ptr<DateTimeFormatter> DateTimeFormatterBuilder::build() {
   VELOX_CHECK_NE(type_, DateTimeFormatterType::UNKNOWN);
   return std::make_shared<DateTimeFormatter>(
-      std::move(literalBuf_), bufEnd_, std::move(tokens_), type_);
+      std::move(literalBuf_),
+      bufEnd_,
+      std::move(tokens_),
+      type_,
+      truncateFractionOfSecondToMillis_);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/DateTimeFormatterBuilder.h
+++ b/velox/functions/lib/DateTimeFormatterBuilder.h
@@ -248,6 +248,8 @@ class DateTimeFormatterBuilder {
   /// be 9870, with digit being 6 the formatted result will be 987000
   DateTimeFormatterBuilder& appendFractionOfSecond(size_t digits);
 
+  DateTimeFormatterBuilder& truncateFractionOfSecondToMillis(bool truncate);
+
   /// Appends time zone to formatter builder, e.g: 'Pacific Standard Time' or
   /// 'PST'
   ///
@@ -281,6 +283,7 @@ class DateTimeFormatterBuilder {
   size_t bufEnd_{0};
   std::vector<DateTimeToken> tokens_;
   DateTimeFormatterType type_{DateTimeFormatterType::UNKNOWN};
+  bool truncateFractionOfSecondToMillis_{true};
 };
 
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -36,7 +36,8 @@ Expected<std::shared_ptr<DateTimeFormatter>> getDateTimeFormatter(
       return buildSimpleDateTimeFormatter(format, /*lenient=*/true);
     default:
       return buildJodaDateTimeFormatter(
-          std::string_view(format.data(), format.size()));
+          std::string_view(format.data(), format.size()),
+          /* truncateFractionOfSecondToMillis */ false);
   }
 }
 

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -784,6 +784,27 @@ TEST_F(DateTimeFunctionsTest, getTimestamp) {
           const std::string& format) {
         return getTimestamp(dateString, format)->toString();
       };
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.123456", "yyyy-MM-dd HH:mm:ss.SSS"),
+      std::nullopt);
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.123456", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 123456000));
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.12345", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 123450000));
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.1234", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 123400000));
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.123", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 123000000));
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.12", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 120000000));
+  EXPECT_EQ(
+      getTimestamp("1970-01-01 00:00:00.1", "yyyy-MM-dd HH:mm:ss.SSSSSS"),
+      Timestamp(0, 100000000));
 
   EXPECT_EQ(getTimestamp("1970-01-01", "yyyy-MM-dd"), Timestamp(0, 0));
   EXPECT_EQ(


### PR DESCRIPTION
Spark function `to_timestamp` currently truncates microseconds part.
This gives different result compares to Vanilla spark.

Issue: https://github.com/apache/incubator-gluten/issues/10314