### PR TITLE
fix: Fix ~UnknownType() used before its definition

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1486,7 +1486,7 @@ struct TypeFactory {
 template <>
 struct TypeFactory<TypeKind::UNKNOWN> {
   FOLLY_NOINLINE static std::shared_ptr<const UnknownType> create() {
-    static constexpr UnknownType kInstance;
+    static const UnknownType kInstance;
     return {std::shared_ptr<const UnknownType>{}, &kInstance};
   }
 };


### PR DESCRIPTION
Addressing the following build error:

```
[ 56%] Building CXX object _deps/velox-build/velox/buffer/CMakeFiles/velox.dir/__/common/caching/SsdCache.cpp.o
In file included from /velox4j/src/main/cpp/build/_deps/velox-src/./velox/common/memory/ByteStream.h:20,
                 from /velox4j/src/main/cpp/build/_deps/velox-src/./velox/common/memory/HashStringAllocator.h:20,
                 from /velox4j/src/main/cpp/build/_deps/velox-src/./velox/common/base/BigintIdMap.h:22,
                 from /velox4j/src/main/cpp/build/_deps/velox-src/velox/common/base/BigintIdMap.cpp:17:
/velox4j/src/main/cpp/build/_deps/velox-src/./velox/type/Type.h: In static member function 'static std::shared_ptr<const facebook::velox::UnknownType> facebook::velox::TypeFactory<facebook::velox::TypeKind::UNKNOWN>::create()':
/velox4j/src/main/cpp/build/_deps/velox-src/./velox/type/Type.h:1489:34: error: 'virtual constexpr facebook::velox::UnknownType::~UnknownType()' used before its definition
 1489 |     static constexpr UnknownType kInstance;
      |                                  ^~~~~~~~~
gmake[3]: *** [_deps/velox-build/velox/buffer/CMakeFiles/velox.dir/__/common/base/BigintIdMap.cpp.o] Error 1
```

Fixes https://github.com/facebookincubator/velox/issues/14309

Caused by https://github.com/facebookincubator/velox/pull/14177