### PR TITLE
fix: Revert ArraySortTransform and functions that necessitate it

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -353,6 +353,13 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "json_size", // https://github.com/facebookincubator/velox/issues/12371
     "json_extract_scalar", // https://github.com/facebookincubator/velox/issues/10698
     "json_array_contains", // https://github.com/facebookincubator/velox/issues/13685
+    // https://github.com/facebookincubator/velox/issues/14313
+    "array_intersect",
+    "array_except",
+    "array_duplicates",
+    "map_entries",
+    "map_keys",
+    "map_values",
     "clamp", // Function clamp not registered
     "current_date", // Non-deterministic
     "xxhash64_internal",

--- a/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
+++ b/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
@@ -41,9 +41,7 @@ class SortArrayTransformer : public ExprTransformer {
           type, facebook::velox::variant::null(type->kind()));
     } else {
       return std::make_shared<facebook::velox::core::CallTypedExpr>(
-          type,
-          std::vector<TypedExprPtr>{std::move(expr)},
-          "$internal$canonicalize");
+          type, std::vector<TypedExprPtr>{std::move(expr)}, "array_sort");
     }
   }
 


### PR DESCRIPTION
Summary: Fuzzer cannot compare arrays without first sorting them. This works for orderable types as we can use functions like array_sort in both Velox and Prestissimo. For non-orderable types, we fail. We could use internal sort `$internal$canonicalize`, but this only alleviates the Velox errors as Presto doesn't have this function. We will need to resolve this issue likely by using transforms, but in the meantime, to resolve errors, let's skip functions that require sort transform and revert our transform to use orderable-only sort.

Differential Revision: D79467638


