### PR TITLE
feat(type): Add VarcharN and VarbinaryN type

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -83,6 +83,29 @@ std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type) {
   VELOX_FAIL("Type is not Decimal");
 }
 
+uint32_t getVarcharLength(const Type& type) {
+  if (type.isVarcharN()) {
+    return type.asVarcharN().length();
+  }
+  return kVaryingLengthScalarTypeUnboundedLength;
+}
+
+uint32_t getVarbinaryLength(const Type& type) {
+  if (type.isVarbinaryN()) {
+    return type.asVarbinaryN().length();
+  }
+  return kVaryingLengthScalarTypeUnboundedLength;
+}
+
+uint32_t getVaryingLengthScalarTypeLength(const Type& type) {
+  if (type.kind() == TypeKind::VARCHAR) {
+    return getVarcharLength(type);
+  } else if (type.kind() == TypeKind::VARBINARY) {
+    return getVarbinaryLength(type);
+  }
+  VELOX_FAIL("Type is not VarcharN or VarbinaryN");
+}
+
 namespace {
 struct OpaqueSerdeRegistry {
   struct Entry {
@@ -202,6 +225,18 @@ TypePtr Type::create(const folly::dynamic& obj) {
   auto typeName = obj["type"].asString();
   if (isDecimalName(typeName)) {
     return DECIMAL(obj["precision"].asInt(), obj["scale"].asInt());
+  }
+  if (isVarcharName(typeName)) {
+    if (obj.find("length") != obj.items().end()) {
+      return VARCHAR(obj["length"].asInt());
+    }
+    return VARCHAR();
+  }
+  if (isVarbinaryName(typeName)) {
+    if (obj.find("length") != obj.items().end()) {
+      return VARBINARY(obj["length"].asInt());
+    }
+    return VARBINARY();
   }
   // Checks if 'typeName' specifies a custom type.
   if (customTypeExists(typeName)) {
@@ -1027,6 +1062,38 @@ std::string LongDecimalType::toString(int128_t value, const Type& type) {
   return DecimalUtil::toString(value, type);
 }
 
+template <>
+// static
+TypePtr VarcharNType::create() {
+  return std::make_shared<const VarcharNType>();
+}
+
+template <>
+// static
+TypePtr VarcharNType::create(uint32_t length) {
+  return std::make_shared<const VarcharNType>(length);
+}
+
+TypePtr VARCHAR(uint32_t length) {
+  return VarcharNType::create(length);
+}
+
+template <>
+// static
+TypePtr VarbinaryNType::create() {
+  return std::make_shared<const VarbinaryNType>();
+}
+
+template <>
+// static
+TypePtr VarbinaryNType::create(uint32_t length) {
+  return std::make_shared<const VarbinaryNType>(length);
+}
+
+TypePtr VARBINARY(uint32_t length) {
+  return VarbinaryNType::create(length);
+}
+
 TypePtr createScalarType(TypeKind kind) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(createScalarType, kind);
 }
@@ -1433,6 +1500,24 @@ class FunctionParametricType {
   }
 };
 
+template <TypeKind KIND>
+class VaryingLengthParametricType {
+ public:
+  static TypePtr create(const std::vector<TypeParameter>& parameters) {
+    VELOX_USER_CHECK_EQ(1, parameters.size());
+    VELOX_USER_CHECK(parameters[0].kind == TypeParameterKind::kLongLiteral);
+    VELOX_USER_CHECK(parameters[0].longLiteral.has_value());
+
+    if constexpr (KIND == TypeKind::VARCHAR) {
+      return VARCHAR(parameters[0].longLiteral.value());
+    } else if constexpr (KIND == TypeKind::VARBINARY) {
+      return VARBINARY(parameters[0].longLiteral.value());
+    } else {
+      VELOX_UNSUPPORTED("Unknown TypeKind for varying length parametric type.");
+    }
+  }
+};
+
 using ParametricTypeMap = std::unordered_map<
     std::string,
     std::function<TypePtr(const std::vector<TypeParameter>& parameters)>>;
@@ -1444,6 +1529,8 @@ const ParametricTypeMap& parametricBuiltinTypes() {
       {"MAP", MapParametricType::create},
       {"ROW", RowParametricType::create},
       {"FUNCTION", FunctionParametricType::create},
+      {"VARCHAR", VaryingLengthParametricType<TypeKind::VARCHAR>::create},
+      {"VARBINARY", VaryingLengthParametricType<TypeKind::VARBINARY>::create},
   };
   return kTypes;
 }
@@ -1469,11 +1556,11 @@ bool hasType(const std::string& name) {
 TypePtr getType(
     const std::string& name,
     const std::vector<TypeParameter>& parameters) {
-  if (singletonBuiltInTypes().count(name)) {
+  if (parameters.size() == 0 && singletonBuiltInTypes().count(name)) {
     return singletonBuiltInTypes().at(name);
   }
 
-  if (parametricBuiltinTypes().count(name)) {
+  if (parameters.size() > 0 && parametricBuiltinTypes().count(name)) {
     return parametricBuiltinTypes().at(name)(parameters);
   }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -97,6 +97,10 @@ VELOX_DECLARE_ENUM_NAME(TypeKind);
 
 template <TypeKind KIND>
 class ScalarType;
+template <TypeKind KIND>
+class VaryingLengthScalarType;
+using VarcharNType = VaryingLengthScalarType<TypeKind::VARCHAR>;
+using VarbinaryNType = VaryingLengthScalarType<TypeKind::VARBINARY>;
 class ShortDecimalType;
 class LongDecimalType;
 class ArrayType;
@@ -633,8 +637,12 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   const ShortDecimalType& asShortDecimal() const;
   const LongDecimalType& asLongDecimal() const;
+  const VarcharNType& asVarcharN() const;
+  const VarbinaryNType& asVarbinaryN() const;
   bool isShortDecimal() const;
   bool isLongDecimal() const;
+  bool isVarcharN() const;
+  bool isVarbinaryN() const;
   bool isDecimal() const;
   bool isIntervalYearMonth() const;
 
@@ -964,6 +972,108 @@ class UnknownType : public CanProvideCustomComparisonType<TypeKind::UNKNOWN> {
     return obj;
   }
 };
+
+static const uint32_t kVaryingLengthScalarTypeUnboundedLength =
+    std::numeric_limits<int32_t>::max();
+static const std::string kVaryingLengthScalarTypeUnboundedLengthStr =
+    std::to_string(kVaryingLengthScalarTypeUnboundedLength);
+
+template <TypeKind KIND>
+class VaryingLengthScalarType : public ScalarType<KIND> {
+ public:
+  explicit VaryingLengthScalarType(
+      const std::optional<uint32_t> length = std::nullopt) {
+    if (length.has_value()) {
+      VELOX_CHECK_LE(
+          length.value(),
+          kVaryingLengthScalarTypeUnboundedLength,
+          "Maximum length of varying string or binary type cannot exceed {}",
+          kVaryingLengthScalarTypeUnboundedLengthStr);
+      parameters_.emplace_back(TypeParameter(length.value()));
+    } else {
+      parameters_.emplace_back(
+          TypeParameter(kVaryingLengthScalarTypeUnboundedLength));
+    }
+  }
+
+  FOLLY_NOINLINE static TypePtr create();
+
+  FOLLY_NOINLINE static TypePtr create(uint32_t length);
+
+  inline uint32_t length() const {
+    return parameters_[0].longLiteral.value();
+  }
+
+  inline bool equivalent(const Type& other) const override {
+    if (!Type::hasSameTypeId(other)) {
+      return false;
+    }
+    const auto& otherType =
+        static_cast<const VaryingLengthScalarType<KIND>&>(other);
+    return (otherType.length() == length());
+  }
+
+  const char* name() const override {
+    return TypeTraits<KIND>::name;
+  }
+
+  std::string toString() const override {
+    if (length() == kVaryingLengthScalarTypeUnboundedLength) {
+      return std::string(name());
+    }
+    return fmt::format("{}({})", name(), length());
+  }
+
+  folly::dynamic serialize() const override {
+    auto obj = ScalarType<KIND>::serialize();
+    obj["type"] = name();
+    obj["length"] = length();
+    return obj;
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    return parameters_;
+  }
+
+ private:
+  std::vector<TypeParameter> parameters_;
+};
+
+// Functions for Varchar.
+FOLLY_ALWAYS_INLINE const VarcharNType& Type::asVarcharN() const {
+  return dynamic_cast<const VarcharNType&>(*this);
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isVarcharN() const {
+  return dynamic_cast<const VarcharNType*>(this) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE bool isVarcharName(std::string_view name) {
+  return (name == "VARCHAR");
+}
+
+uint32_t getVarcharLength(const Type& type);
+
+// Functions for Varbinary.
+FOLLY_ALWAYS_INLINE const VarbinaryNType& Type::asVarbinaryN() const {
+  return dynamic_cast<const VarbinaryNType&>(*this);
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isVarbinaryN() const {
+  return dynamic_cast<const VarbinaryNType*>(this) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE bool isVarbinaryName(const std::string& name) {
+  return (name == "VARBINARY");
+}
+
+uint32_t getVarbinaryLength(const Type& type);
+
+uint32_t getVaryingLengthScalarTypeLength(const Type& type);
+
+FOLLY_ALWAYS_INLINE bool isVaryingLengthScalarType(const TypePtr& type) {
+  return (type->isVarcharN() || type->isVarbinaryN());
+}
 
 class ArrayType : public TypeBase<TypeKind::ARRAY> {
  public:
@@ -2108,6 +2218,9 @@ VELOX_SCALAR_ACCESSOR(DOUBLE);
 VELOX_SCALAR_ACCESSOR(TIMESTAMP);
 VELOX_SCALAR_ACCESSOR(VARCHAR);
 VELOX_SCALAR_ACCESSOR(VARBINARY);
+
+TypePtr VARCHAR(uint32_t length);
+TypePtr VARBINARY(uint32_t length);
 
 TypePtr UNKNOWN();
 


### PR DESCRIPTION
This change adds the base for a parametric scalar type and implementations for VarcharN and VarbinaryN.
In addition, Cast is updated to handle the new type information.

What is not yet included is using this type in metadata or function signatures. That is a separate commit.