### PR TITLE
feat: Add barrier support for Limit operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3963,6 +3963,10 @@ class LimitNode : public PlanNode {
     std::optional<PlanNodePtr> source_;
   };
 
+  bool supportsBarrier() const override {
+    return true;
+  }
+
   const RowTypePtr& outputType() const override {
     return sources_[0]->outputType();
   }

--- a/velox/exec/Limit.cpp
+++ b/velox/exec/Limit.cpp
@@ -37,6 +37,10 @@ Limit::Limit(
   }
 }
 
+bool Limit::startDrain() {
+  return false;
+}
+
 bool Limit::needsInput() const {
   return !finished_ && input_ == nullptr;
 }
@@ -47,15 +51,19 @@ void Limit::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr Limit::getOutput() {
-  if (input_ == nullptr || (remainingOffset_ == 0 && remainingLimit_ == 0)) {
+  VELOX_DCHECK(!isDraining());
+
+  if ((input_ == nullptr) || (remainingOffset_ == 0 && remainingLimit_ == 0)) {
     return nullptr;
   }
 
+  SCOPE_EXIT {
+    input_ = nullptr;
+  };
   const auto inputSize = input_->size();
 
   if (remainingOffset_ >= inputSize) {
     remainingOffset_ -= inputSize;
-    input_ = nullptr;
     return nullptr;
   }
 
@@ -71,7 +79,6 @@ RowVectorPtr Limit::getOutput() {
     auto output = fillOutput(outputSize, indices);
     remainingOffset_ = 0;
     remainingLimit_ -= outputSize;
-    input_ = nullptr;
     if (remainingLimit_ == 0) {
       finished_ = true;
     }
@@ -85,7 +92,6 @@ RowVectorPtr Limit::getOutput() {
   if (remainingLimit_ >= inputSize) {
     remainingLimit_ -= inputSize;
     auto output = input_;
-    input_.reset();
     return output;
   }
 
@@ -95,7 +101,6 @@ RowVectorPtr Limit::getOutput() {
       input_->nulls(),
       remainingLimit_,
       input_->children());
-  input_.reset();
   remainingLimit_ = 0;
   return output;
 }

--- a/velox/exec/Limit.h
+++ b/velox/exec/Limit.h
@@ -28,6 +28,8 @@ class Limit : public Operator {
 
   void addInput(RowVectorPtr input) override;
 
+  bool startDrain() override;
+
   RowVectorPtr getOutput() override;
 
   BlockingReason isBlocked(ContinueFuture* /*future*/) override {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1277,7 +1277,7 @@ PlanBuilder& PlanBuilder::topN(
 PlanBuilder& PlanBuilder::limit(int64_t offset, int64_t count, bool isPartial) {
   planNode_ = std::make_shared<core::LimitNode>(
       nextPlanNodeId(), offset, count, isPartial, planNode_);
-  VELOX_CHECK(!planNode_->supportsBarrier());
+  VELOX_CHECK(planNode_->supportsBarrier());
   return *this;
 }
 


### PR DESCRIPTION
Summary: Add task barrier support for Limit operator

This changes make limit to support barrier. Since limit doesn't buffer any data, it just needs to tell the driver framework (1) it supports barrier; (2) there is no need for draining processing.

Differential Revision: D79499011


