### PR TITLE
fix: Fix install stemmer in macOS

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -232,9 +232,7 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-"${STEMMER_VERSION}".tar.gz stemmer
   (
     cd "${DEPENDENCY_DIR}"/stemmer || exit
-    if [[ "$(uname)" != "Darwin" ]]; then
-      sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
-    fi
+    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a "${INSTALL_PREFIX}"/lib/
     ${SUDO} cp include/libstemmer.h "${INSTALL_PREFIX}"/include/

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -171,6 +171,16 @@ function install_faiss {
   fi
 }
 
+function install_stemmer {
+  wget_and_untar https://snowballstem.org/dist/libstemmer_c-"${STEMMER_VERSION}".tar.gz stemmer
+  (
+    cd "${DEPENDENCY_DIR}"/stemmer || exit
+    make clean && make "-j${NPROC}"
+    ${SUDO} cp libstemmer.a "${INSTALL_PREFIX}"/lib/
+    ${SUDO} cp include/libstemmer.h "${INSTALL_PREFIX}"/include/
+  )
+}
+
 function install_velox_deps {
   run_and_time install_velox_deps_from_brew
   run_and_time install_ranges_v3


### PR DESCRIPTION
Fix error `sed: 1: "Makefile": invalid command code M`.
On macOS, the sed command has some differences from the GNU sed found on Linux systems. macOS does not require the PIC flag.

