### PR TITLE
remove CppToType for VARBINARY

### DIFF
--- a/velox/type/CppToType.h
+++ b/velox/type/CppToType.h
@@ -67,6 +67,8 @@ template <>
 struct CppToType<folly::StringPiece> : public CppToTypeBase<TypeKind::VARCHAR> {
 };
 
+// VARBINARY also uses StringView as the native type but its CppToType template
+// is omitted to avoid conflict with VARCHAR.
 template <>
 struct CppToType<velox::StringView> : public CppToTypeBase<TypeKind::VARCHAR> {
 };
@@ -79,10 +81,6 @@ struct CppToType<std::string> : public CppToTypeBase<TypeKind::VARCHAR> {};
 
 template <>
 struct CppToType<const char*> : public CppToTypeBase<TypeKind::VARCHAR> {};
-
-template <>
-struct CppToType<folly::ByteRange> : public CppToTypeBase<TypeKind::VARBINARY> {
-};
 
 template <>
 struct CppToType<float> : public CppToTypeBase<TypeKind::REAL> {};

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -771,7 +771,6 @@ TEST(TypeTest, cpp2Type) {
   EXPECT_EQ(*CppToType<int8_t>::create(), *TINYINT());
   EXPECT_EQ(*CppToType<velox::StringView>::create(), *VARCHAR());
   EXPECT_EQ(*CppToType<std::string>::create(), *VARCHAR());
-  EXPECT_EQ(*CppToType<folly::ByteRange>::create(), *VARBINARY());
   EXPECT_EQ(*CppToType<float>::create(), *REAL());
   EXPECT_EQ(*CppToType<double>::create(), *DOUBLE());
   EXPECT_EQ(*CppToType<bool>::create(), *BOOLEAN());


### PR DESCRIPTION
Summary:
Existing CppToType for VARBINARY is folly::ByteRange, but in [TypeTraits](https://www.internalfb.com/code/fbsource/[9fccaf94219d]/fbcode/velox/type/Type.h?lines=293) it's NativeType is  defined as velox::StringView. 

The c++ type for VARBINARY should be velox::StringView, but if so, it'll conflict with VARCHAR: 

```
template <>
struct CppToType<velox::StringView> : public CppToTypeBase<TypeKind::VARCHAR> {};

template <>
struct CppToType<velox::StringView> : public CppToTypeBase<TypeKind::VARBINARY> {}; // Redefinition 
```

This diff removes CppToType for VARBINARY to avoid confusion.

Reviewed By: xiaoxmeng

Differential Revision: D79598361


