### PR TITLE
Use fast path for Spark split with simple delimiter

### DIFF
--- a/velox/functions/sparksql/tests/SplitTest.cpp
+++ b/velox/functions/sparksql/tests/SplitTest.cpp
@@ -253,5 +253,14 @@ TEST_F(SplitTest, regexDelimiter) {
   };
   testSplit(input, "🙂", -1, numRows, expected);
 }
+
+TEST_F(SplitTest, singleMetaCharacterDelimiter) {
+  auto input = std::vector<std::string>{"abc", ""};
+  auto expected = std::vector<std::vector<std::string>>({
+      {"", "", "", ""},
+      {""},
+  });
+  testSplit(input, ".", std::nullopt, 2, expected);
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
#### Summary

Avoids invoking RE2 when the Spark split delimiter is a single non-regex character by switching to std::string_view::find for faster substring searches

Adds specialized helpers to split on a single character and to detect regex metacharacters, further streamlining simple split operations

Introduces a unit test confirming that a regex metacharacter (".") still triggers regex semantics rather than the fast path