### PR TITLE
fix: Use internal sort_array for Presto fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
+++ b/velox/functions/prestosql/fuzzer/SortArrayTransformer.h
@@ -41,7 +41,9 @@ class SortArrayTransformer : public ExprTransformer {
           type, facebook::velox::variant::null(type->kind()));
     } else {
       return std::make_shared<facebook::velox::core::CallTypedExpr>(
-          type, std::vector<TypedExprPtr>{std::move(expr)}, "array_sort");
+          type,
+          std::vector<TypedExprPtr>{std::move(expr)},
+          "$internal$canonicalize");
     }
   }
 


### PR DESCRIPTION
Summary:
Presto fuzzer requires internal array_sort: https://github.com/facebookincubator/velox/actions/runs/16737201668/job/47380292858

These functions are skipped on SOT test, so we don't have to be concerned about Presto executing a function that doesn't exist.

Differential Revision: D79618317


