### PR TITLE
fix: Add sudo while moving ccache

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,6 +80,7 @@ jobs:
             brew uninstall cmake
             pipx install --force cmake==3.31
           fi
+          echo "$INSTALL_PREFIX/bin" >> $GITHUB_PATH
 
       - name: Cache ccache
         uses: apache/infrastructure-actions/stash/restore@3354c1565d4b0e335b78a76aedd82153a9e144d4
@@ -93,7 +94,7 @@ jobs:
           faiss_SOURCE: BUNDLED #brew faiss is not supported
           CMAKE_POLICY_VERSION_MINIMUM: '3.5'
         run: |
-          ${{ env.INSTALL_PREFIX }}/bin/ccache -sz -M 5Gi
+          ccache -sz -M 5Gi
           cmake \
               -B _build/$BUILD_TYPE \
               -GNinja \
@@ -108,7 +109,7 @@ jobs:
       - name: Build
         run: |
           cmake --build _build/$BUILD_TYPE -j $NJOBS
-          ${{ env.INSTALL_PREFIX }}/bin/ccache -s
+          ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -93,7 +93,7 @@ jobs:
           faiss_SOURCE: BUNDLED #brew faiss is not supported
           CMAKE_POLICY_VERSION_MINIMUM: '3.5'
         run: |
-          ccache -sz -M 5Gi
+          ${{ env.INSTALL_PREFIX }}/bin/ccache -sz -M 5Gi
           cmake \
               -B _build/$BUILD_TYPE \
               -GNinja \
@@ -108,7 +108,7 @@ jobs:
       - name: Build
         run: |
           cmake --build _build/$BUILD_TYPE -j $NJOBS
-          ccache -s
+          ${{ env.INSTALL_PREFIX }}/bin/ccache -s
 
       - uses: apache/infrastructure-actions/stash/save@3354c1565d4b0e335b78a76aedd82153a9e144d4
         with:

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -92,7 +92,8 @@ function install_build_prerequisites {
   # Install ccache
   curl -L https://github.com/ccache/ccache/releases/download/v"${CCACHE_VERSION}"/ccache-"${CCACHE_VERSION}"-darwin.tar.gz -o ccache.tar.gz
   tar -xf ccache.tar.gz
-  mv ccache-"${CCACHE_VERSION}"-darwin/ccache /usr/local/bin/
+  $SUDO mkdir -p "$INSTALL_PREFIX"/bin
+  $SUDO mv ccache-"${CCACHE_VERSION}"-darwin/ccache "$INSTALL_PREFIX"/bin
   rm -rf ccache-"${CCACHE_VERSION}"-darwin ccache.tar.gz
 }
 


### PR DESCRIPTION
While I building velox with gluten, I found the failure show below.

```
+ curl -L https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-darwin.tar.gz -o ccache.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1954k  100 1954k    0     0  2986k      0 --:--:-- --:--:-- --:--:-- 2986k
+ tar -xf ccache.tar.gz
+ mv ccache-4.11.3-darwin/ccache /usr/local/bin/
mv: rename ccache-4.11.3-darwin/ccache to /usr/local/bin/ccache: Permission denied
```

After this PR, the output show below.
```
+ curl -L https://github.com/ccache/ccache/releases/download/v4.11.3/ccache-4.11.3-darwin.tar.gz -o ccache.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 1954k  100 1954k    0     0  1761k      0  0:00:01  0:00:01 --:--:-- 3916k
+ tar -xf ccache.tar.gz
+ sudo mv ccache-4.11.3-darwin/ccache /usr/local/bin/
Password:
+ rm -rf ccache-4.11.3-darwin ccache.tar.gz

real	0m8.720s
user	0m0.605s
sys	0m0.207s
```