### PR TITLE
fix: Support BSD sed

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -232,7 +232,11 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-"${STEMMER_VERSION}".tar.gz stemmer
   (
     cd "${DEPENDENCY_DIR}"/stemmer || exit
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    if [[ $OSTYPE == "darwin"* ]]; then
+      sed -i '' '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    else
+      sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    fi
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a "${INSTALL_PREFIX}"/lib/
     ${SUDO} cp include/libstemmer.h "${INSTALL_PREFIX}"/include/


### PR DESCRIPTION
While I building velox with gluten, I found the failure show below.
```
stemmer already exists. Delete? [Y, n] Y
+ rm -rf stemmer
+ mkdir -p stemmer
+ pushd stemmer
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download/stemmer ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ curl -L https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz -o stemmer.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  219k  100  219k    0     0   172k      0  0:00:01  0:00:01 --:--:--  172k
+ tar -xz --strip-components=1 -f stemmer.tar.gz
+ popd
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ popd
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ cd /Users/game-netease/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download/stemmer
+ sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
sed: 1: "Makefile": invalid command code M
```

After this PR, the output show below.
```
stemmer already exists. Delete? [Y, n] Y
+ rm -rf stemmer
+ mkdir -p stemmer
+ pushd stemmer
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download/stemmer ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ curl -L https://snowballstem.org/dist/libstemmer_c-2.2.0.tar.gz -o stemmer.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  219k  100  219k    0     0   229k      0 --:--:-- --:--:-- --:--:--  229k
+ tar -xz --strip-components=1 -f stemmer.tar.gz
+ popd
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download ~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ popd
~/git-repo/forks/gluten/ep/build-velox/build/velox_ep
+ cd /Users/game-netease/git-repo/forks/gluten/ep/build-velox/build/velox_ep/deps-download/stemmer
+ [[ darwin24 == \d\a\r\w\i\n* ]]
+ sed -i '' '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+ make clean
rm -f stemwords libstemmer.a *.o src_c/*.o examples/*.o runtime/*.o libstemmer/*.o
+ make -j8
cc -O2 -Iinclude -fPIC  -c -o src_c/stem_UTF_8_arabic.o src_c/stem_UTF_8_arabic.c
```