### PR TITLE
refactor: Use TypeKindName helpers

### DIFF
--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -19,23 +19,23 @@
 
 namespace facebook::velox::connector::hive {
 
-#define PARTITION_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)               \
-  [&]() {                                                                   \
-    switch (typeKind) {                                                     \
-      case TypeKind::BOOLEAN:                                               \
-      case TypeKind::TINYINT:                                               \
-      case TypeKind::SMALLINT:                                              \
-      case TypeKind::INTEGER:                                               \
-      case TypeKind::BIGINT:                                                \
-      case TypeKind::VARCHAR:                                               \
-      case TypeKind::VARBINARY:                                             \
-      case TypeKind::TIMESTAMP:                                             \
-        return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                          \
-            TEMPLATE_FUNC, typeKind, __VA_ARGS__);                          \
-      default:                                                              \
-        VELOX_UNSUPPORTED(                                                  \
-            "Unsupported partition type: {}", mapTypeKindToName(typeKind)); \
-    }                                                                       \
+#define PARTITION_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                  \
+  [&]() {                                                                      \
+    switch (typeKind) {                                                        \
+      case TypeKind::BOOLEAN:                                                  \
+      case TypeKind::TINYINT:                                                  \
+      case TypeKind::SMALLINT:                                                 \
+      case TypeKind::INTEGER:                                                  \
+      case TypeKind::BIGINT:                                                   \
+      case TypeKind::VARCHAR:                                                  \
+      case TypeKind::VARBINARY:                                                \
+      case TypeKind::TIMESTAMP:                                                \
+        return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                             \
+            TEMPLATE_FUNC, typeKind, __VA_ARGS__);                             \
+      default:                                                                 \
+        VELOX_UNSUPPORTED(                                                     \
+            "Unsupported partition type: {}", TypeKindName::toName(typeKind)); \
+    }                                                                          \
   }()
 
 namespace {

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -97,7 +97,7 @@ class HivePartitionFunctionBenchmark
   void run(HivePartitionFunction* function) {
     if (rowVectors_.find(KIND) == rowVectors_.end()) {
       throw std::runtime_error(
-          fmt::format("Unsupported type {}.", mapTypeKindToName(KIND)));
+          fmt::format("Unsupported type {}.", TypeKindName::toName(KIND)));
     }
     function->partition(*rowVectors_[KIND], partitions_);
   }

--- a/velox/dwio/common/TypeUtils.cpp
+++ b/velox/dwio/common/TypeUtils.cpp
@@ -134,8 +134,8 @@ void checkTypeCompatibility(
     VELOX_SCHEMA_MISMATCH_ERROR(fmt::format(
         "{}, From Kind: {}, To Kind: {}",
         exceptionMessageCreator ? exceptionMessageCreator() : "Schema mismatch",
-        mapTypeKindToName(from.kind()),
-        mapTypeKindToName(kind(to))));
+        TypeKindName::toName(from.kind()),
+        TypeKindName::toName(kind(to))));
   }
 
   if (recurse) {

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -152,7 +152,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     default:
       VELOX_FAIL(
           "buildReader unhandled type: " +
-          mapTypeKindToName(fileType->type()->kind()));
+          std::string(TypeKindName::toName(fileType->type()->kind())));
   }
 }
 

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -2119,7 +2119,7 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
           "MAP_FLAT_COLS contains column {}, but the root type of this column is {}."
           " Column root types must be of type MAP",
           type.column(),
-          mapTypeKindToName(type.type()->kind()));
+          TypeKindName::toName(type.type()->kind()));
     }
     const auto structColumnKeys =
         context.getConfig(Config::MAP_FLAT_COLS_STRUCT_KEYS);
@@ -2212,7 +2212,7 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
     }
     default:
       VELOX_FAIL(
-          "not supported yet: {}", mapTypeKindToName(type.type()->kind()));
+          "not supported yet: {}", TypeKindName::toName(type.type()->kind()));
   }
 }
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -97,7 +97,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     default:
       VELOX_FAIL(
           "buildReader unhandled type: " +
-          mapTypeKindToName(fileType->type()->kind()));
+          std::string(TypeKindName::toName(fileType->type()->kind())));
   }
 }
 

--- a/velox/dwio/text/writer/TextWriter.cpp
+++ b/velox/dwio/text/writer/TextWriter.cpp
@@ -348,7 +348,7 @@ void TextWriter::writeCellValue(
       [[fallthrough]];
     default:
       VELOX_NYI(
-          "Text writer does not support type {}", mapTypeKindToName(type));
+          "Text writer does not support type {}", TypeKindName::toName(type));
   }
 
   VELOX_CHECK(

--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -101,7 +101,7 @@ FOLLY_ALWAYS_INLINE void extractRowColumnToPrefix(
     default:
       VELOX_UNSUPPORTED(
           "prefix-sort does not support type kind: {}",
-          mapTypeKindToName(typeKind));
+          TypeKindName::toName(typeKind));
   }
 }
 

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -23,35 +23,35 @@
 
 namespace facebook::velox::exec {
 
-#define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)             \
-  [&]() {                                                                \
-    switch (typeKind) {                                                  \
-      case TypeKind::BOOLEAN: {                                          \
-        return TEMPLATE_FUNC<TypeKind::BOOLEAN>(__VA_ARGS__);            \
-      }                                                                  \
-      case TypeKind::TINYINT: {                                          \
-        return TEMPLATE_FUNC<TypeKind::TINYINT>(__VA_ARGS__);            \
-      }                                                                  \
-      case TypeKind::SMALLINT: {                                         \
-        return TEMPLATE_FUNC<TypeKind::SMALLINT>(__VA_ARGS__);           \
-      }                                                                  \
-      case TypeKind::INTEGER: {                                          \
-        return TEMPLATE_FUNC<TypeKind::INTEGER>(__VA_ARGS__);            \
-      }                                                                  \
-      case TypeKind::BIGINT: {                                           \
-        return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);             \
-      }                                                                  \
-      case TypeKind::VARCHAR:                                            \
-      case TypeKind::VARBINARY: {                                        \
-        return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);            \
-      }                                                                  \
-      case TypeKind::TIMESTAMP: {                                        \
-        return TEMPLATE_FUNC<TypeKind::TIMESTAMP>(__VA_ARGS__);          \
-      }                                                                  \
-      default:                                                           \
-        VELOX_UNREACHABLE(                                               \
-            "Unsupported value ID type: ", mapTypeKindToName(typeKind)); \
-    }                                                                    \
+#define VALUE_ID_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                \
+  [&]() {                                                                   \
+    switch (typeKind) {                                                     \
+      case TypeKind::BOOLEAN: {                                             \
+        return TEMPLATE_FUNC<TypeKind::BOOLEAN>(__VA_ARGS__);               \
+      }                                                                     \
+      case TypeKind::TINYINT: {                                             \
+        return TEMPLATE_FUNC<TypeKind::TINYINT>(__VA_ARGS__);               \
+      }                                                                     \
+      case TypeKind::SMALLINT: {                                            \
+        return TEMPLATE_FUNC<TypeKind::SMALLINT>(__VA_ARGS__);              \
+      }                                                                     \
+      case TypeKind::INTEGER: {                                             \
+        return TEMPLATE_FUNC<TypeKind::INTEGER>(__VA_ARGS__);               \
+      }                                                                     \
+      case TypeKind::BIGINT: {                                              \
+        return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);                \
+      }                                                                     \
+      case TypeKind::VARCHAR:                                               \
+      case TypeKind::VARBINARY: {                                           \
+        return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);               \
+      }                                                                     \
+      case TypeKind::TIMESTAMP: {                                           \
+        return TEMPLATE_FUNC<TypeKind::TIMESTAMP>(__VA_ARGS__);             \
+      }                                                                     \
+      default:                                                              \
+        VELOX_UNREACHABLE(                                                  \
+            "Unsupported value ID type: ", TypeKindName::toName(typeKind)); \
+    }                                                                       \
   }()
 
 namespace {

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -21,6 +21,7 @@
 #include "velox/duckdb/conversion/DuckConversion.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/type/Type.h"
 #include "velox/vector/VariantToVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
@@ -709,7 +710,7 @@ std::string toTypeString(const MaterializedRow& row) {
     if (i > 0) {
       out << ", ";
     }
-    out << mapTypeKindToName(row[i].kind());
+    out << TypeKindName::toName(row[i].kind());
   }
   out << ")";
   return out.str();

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -122,7 +122,7 @@ cudf::ast::literal makeScalarAndLiteral(
     // TODO for non-numeric types too.
     VELOX_NYI(
         "Non-numeric types not yet implemented for kind " +
-        mapTypeKindToName(kind));
+        std::string(TypeKindName::toName(kind)));
   }
 }
 

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -84,7 +84,9 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type) {
     // case TypeKind::OPAQUE: return cudf::type_id::EMPTY;
     // case TypeKind::INVALID: return cudf::type_id::EMPTY;
     default:
-      CUDF_FAIL("Unsupported Velox type: " + mapTypeKindToName(type->kind()));
+      CUDF_FAIL(
+          "Unsupported Velox type: " +
+          std::string(TypeKindName::toName(type->kind())));
       return cudf::type_id::EMPTY;
   }
 }

--- a/velox/functions/lib/CheckNestedNulls.cpp
+++ b/velox/functions/lib/CheckNestedNulls.cpp
@@ -34,7 +34,7 @@ bool checkNestedNulls(
     VELOX_USER_CHECK(
         !decoded.base()->containsNullAt(indices[index]),
         "{} comparison not supported for values that contain nulls",
-        mapTypeKindToName(decoded.base()->typeKind()));
+        TypeKindName::toName(decoded.base()->typeKind()));
   }
 
   return false;

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1709,7 +1709,7 @@ std::shared_ptr<exec::VectorFunction> makeRe2Extract(
             groupIdTypeKind == TypeKind::BIGINT,
         "{} requires third argument of type INTEGER or BIGINT, but got {}",
         name,
-        mapTypeKindToName(groupIdTypeKind));
+        TypeKindName::toName(groupIdTypeKind));
   }
 
   BaseVector* constantPattern = inputArgs[1].constantValue.get();
@@ -2360,7 +2360,7 @@ std::shared_ptr<exec::VectorFunction> makeRe2ExtractAll(
             groupIdTypeKind == TypeKind::BIGINT,
         "{} requires third argument of type INTEGER or BIGINT, but got {}",
         name,
-        mapTypeKindToName(groupIdTypeKind));
+        TypeKindName::toName(groupIdTypeKind));
   }
 
   BaseVector* constantPattern = inputArgs[1].constantValue.get();

--- a/velox/functions/lib/Slice.cpp
+++ b/velox/functions/lib/Slice.cpp
@@ -54,7 +54,7 @@ class SliceFunction : public exec::VectorFunction {
     VELOX_CHECK(
         kind == TypeKind::BIGINT || kind == TypeKind::INTEGER,
         "Unsupported parameter type {} to register slice function",
-        mapTypeKindToName(kind));
+        TypeKindName::toName(kind));
   }
 
   void apply(
@@ -71,7 +71,7 @@ class SliceFunction : public exec::VectorFunction {
         args[1]->typeKind(),
         kind_,
         "Function slice() requires second argument of type {}",
-        mapTypeKindToName(kind_));
+        TypeKindName::toName(kind_));
     VELOX_USER_CHECK_EQ(
         args[1]->typeKind(),
         args[2]->typeKind(),
@@ -213,7 +213,7 @@ class SliceFunction : public exec::VectorFunction {
 
 // @param kind The type kind of start and length.
 void registerSliceFunction(const std::string& prefix, TypeKind kind) {
-  auto kindName = exec::sanitizeName(mapTypeKindToName(kind));
+  auto kindName = exec::sanitizeName(std::string(TypeKindName::toName(kind)));
 
   std::vector<std::shared_ptr<exec::FunctionSignature>> signatures = {
       exec::FunctionSignatureBuilder()

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -277,7 +277,7 @@ class SubscriptImpl : public exec::Subscript {
       default:
         VELOX_UNSUPPORTED(
             "Unsupported type for element_at index {}",
-            mapTypeKindToName(indexArg->typeKind()));
+            TypeKindName::toName(indexArg->typeKind()));
     }
   }
 

--- a/velox/functions/lib/aggregates/Compare.cpp
+++ b/velox/functions/lib/aggregates/Compare.cpp
@@ -28,7 +28,7 @@ int32_t compare(
       result.has_value(),
       fmt::format(
           "{} comparison not supported for values that contain nulls",
-          mapTypeKindToName(decoded.base()->typeKind())));
+          TypeKindName::toName(decoded.base()->typeKind())));
   return result.value();
 }
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/window/NthValue.cpp
+++ b/velox/functions/lib/window/NthValue.cpp
@@ -312,7 +312,7 @@ void registerNthValue(const std::string& name, TypeKind offsetTypeKind) {
           .typeVariable("T")
           .returnType("T")
           .argumentType("T")
-          .argumentType(mapTypeKindToName(offsetTypeKind))
+          .argumentType(std::string(TypeKindName::toName(offsetTypeKind)))
           .build(),
   };
 

--- a/velox/functions/lib/window/RowNumber.cpp
+++ b/velox/functions/lib/window/RowNumber.cpp
@@ -68,7 +68,7 @@ class RowNumberFunction : public exec::WindowFunction {
 void registerRowNumber(const std::string& name, TypeKind resultTypeKind) {
   std::vector<exec::FunctionSignaturePtr> signatures{
       exec::FunctionSignatureBuilder()
-          .returnType(mapTypeKindToName(resultTypeKind))
+          .returnType(std::string(TypeKindName::toName(resultTypeKind)))
           .build(),
   };
 

--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -71,7 +71,7 @@ class MapKeysFunction : public MapKeyValueFunction {
     VELOX_CHECK(
         arg->typeKind() == TypeKind::MAP,
         "Unsupported type for map_keys function {}",
-        mapTypeKindToName(arg->typeKind()));
+        TypeKindName::toName(arg->typeKind()));
 
     auto mapVector = arg->as<MapVector>();
     auto mapKeys = mapVector->mapKeys();
@@ -108,7 +108,7 @@ class MapValuesFunction : public MapKeyValueFunction {
     VELOX_CHECK(
         arg->typeKind() == TypeKind::MAP,
         "Unsupported type for map_values function {}",
-        mapTypeKindToName(arg->typeKind()));
+        TypeKindName::toName(arg->typeKind()));
 
     auto mapVector = arg->as<MapVector>();
     auto mapValues = mapVector->mapValues();

--- a/velox/functions/prestosql/Split.cpp
+++ b/velox/functions/prestosql/Split.cpp
@@ -85,7 +85,7 @@ class SplitFunction : public exec::VectorFunction {
       default:
         VELOX_FAIL(
             "Unsupported type for 'limit' argument of 'split' function: {}",
-            mapTypeKindToName(limitType));
+            TypeKindName::toName(limitType));
     }
   }
 

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -225,7 +225,7 @@ void registerMapAggAggregate(
             return std::make_unique<MapAggAggregate<int32_t>>(resultType);
           default:
             VELOX_UNREACHABLE(
-                "Unexpected type {}", mapTypeKindToName(typeKind));
+                "Unexpected type {}", TypeKindName::toName(typeKind));
         }
       },
       withCompanionFunctions,

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -232,7 +232,7 @@ std::unique_ptr<exec::Aggregate> createMapAggregate(const TypePtr& resultType) {
     case TypeKind::UNKNOWN:
       return std::make_unique<TAggregate<int32_t>>(resultType);
     default:
-      VELOX_UNREACHABLE("Unexpected type {}", mapTypeKindToName(typeKind));
+      VELOX_UNREACHABLE("Unexpected type {}", TypeKindName::toName(typeKind));
   }
 }
 

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -481,7 +481,7 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
       return std::make_unique<MapUnionSumAggregate<K, double>>(resultType);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected value type {}", mapTypeKindToName(valueKind));
+          "Unexpected value type {}", TypeKindName::toName(valueKind));
   }
 }
 
@@ -563,7 +563,7 @@ void registerMapUnionSumAggregate(
                   valueTypeKind, resultType);
             }
             VELOX_UNREACHABLE(
-                "Unexpected key type {}", mapTypeKindToName(keyTypeKind));
+                "Unexpected key type {}", TypeKindName::toName(keyTypeKind));
         }
       },
       withCompanionFunctions,

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -666,7 +666,7 @@ void registerMultiMapAggAggregate(
             return std::make_unique<MultiMapAggAggregate<int32_t>>(resultType);
           default:
             VELOX_UNREACHABLE(
-                "Unexpected type {}", mapTypeKindToName(typeKind));
+                "Unexpected type {}", TypeKindName::toName(typeKind));
         }
       },
       withCompanionFunctions,

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -213,7 +213,7 @@ std::unique_ptr<exec::Aggregate> create(
       return std::make_unique<Aggregate<UnknownValue>>(resultType);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected type {}", mapTypeKindToName(inputType->kind()));
+          "Unexpected type {}", TypeKindName::toName(inputType->kind()));
   }
 }
 
@@ -309,7 +309,7 @@ void registerSetAggAggregate(
             return std::make_unique<SetAggAggregate<UnknownValue>>(resultType);
           default:
             VELOX_UNREACHABLE(
-                "Unexpected type {}", mapTypeKindToName(typeKind));
+                "Unexpected type {}", TypeKindName::toName(typeKind));
         }
       },
       withCompanionFunctions,
@@ -427,7 +427,7 @@ void registerCountDistinctAggregate(
                 resultType, argTypes[0]);
           default:
             VELOX_UNREACHABLE(
-                "Unexpected type {}", mapTypeKindToName(typeKind));
+                "Unexpected type {}", TypeKindName::toName(typeKind));
         }
       },
       withCompanionFunctions,

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -59,82 +59,82 @@ std::vector<TestParam> getTestParams() {
   return params;
 }
 
-#define EXECUTE_TEST_BY_VALUE_TYPE(testFunc, valueType)              \
-  do {                                                               \
-    switch (GetParam().comparisonType) {                             \
-      case TypeKind::BOOLEAN:                                        \
-        testFunc<valueType, bool>();                                 \
-        break;                                                       \
-      case TypeKind::TINYINT:                                        \
-        testFunc<valueType, int8_t>();                               \
-        break;                                                       \
-      case TypeKind::SMALLINT:                                       \
-        testFunc<valueType, int16_t>();                              \
-        break;                                                       \
-      case TypeKind::INTEGER:                                        \
-        testFunc<valueType, int32_t>();                              \
-        break;                                                       \
-      case TypeKind::BIGINT:                                         \
-        testFunc<valueType, int64_t>();                              \
-        break;                                                       \
-      case TypeKind::HUGEINT:                                        \
-        testFunc<valueType, int128_t>();                             \
-        break;                                                       \
-      case TypeKind::REAL:                                           \
-        testFunc<valueType, float>();                                \
-        break;                                                       \
-      case TypeKind::DOUBLE:                                         \
-        testFunc<valueType, double>();                               \
-        break;                                                       \
-      case TypeKind::VARCHAR:                                        \
-        testFunc<valueType, StringView>();                           \
-        break;                                                       \
-      case TypeKind::TIMESTAMP:                                      \
-        testFunc<valueType, Timestamp>();                            \
-        break;                                                       \
-      default:                                                       \
-        LOG(FATAL) << "Unsupported comparison type of minmax_by(): " \
-                   << mapTypeKindToName(GetParam().comparisonType);  \
-    }                                                                \
+#define EXECUTE_TEST_BY_VALUE_TYPE(testFunc, valueType)                \
+  do {                                                                 \
+    switch (GetParam().comparisonType) {                               \
+      case TypeKind::BOOLEAN:                                          \
+        testFunc<valueType, bool>();                                   \
+        break;                                                         \
+      case TypeKind::TINYINT:                                          \
+        testFunc<valueType, int8_t>();                                 \
+        break;                                                         \
+      case TypeKind::SMALLINT:                                         \
+        testFunc<valueType, int16_t>();                                \
+        break;                                                         \
+      case TypeKind::INTEGER:                                          \
+        testFunc<valueType, int32_t>();                                \
+        break;                                                         \
+      case TypeKind::BIGINT:                                           \
+        testFunc<valueType, int64_t>();                                \
+        break;                                                         \
+      case TypeKind::HUGEINT:                                          \
+        testFunc<valueType, int128_t>();                               \
+        break;                                                         \
+      case TypeKind::REAL:                                             \
+        testFunc<valueType, float>();                                  \
+        break;                                                         \
+      case TypeKind::DOUBLE:                                           \
+        testFunc<valueType, double>();                                 \
+        break;                                                         \
+      case TypeKind::VARCHAR:                                          \
+        testFunc<valueType, StringView>();                             \
+        break;                                                         \
+      case TypeKind::TIMESTAMP:                                        \
+        testFunc<valueType, Timestamp>();                              \
+        break;                                                         \
+      default:                                                         \
+        LOG(FATAL) << "Unsupported comparison type of minmax_by(): "   \
+                   << TypeKindName::toName(GetParam().comparisonType); \
+    }                                                                  \
   } while (0);
 
-#define EXECUTE_TEST(testFunc)                                  \
-  do {                                                          \
-    switch (GetParam().valueType) {                             \
-      case TypeKind::BOOLEAN:                                   \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, bool);             \
-        break;                                                  \
-      case TypeKind::TINYINT:                                   \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int8_t);           \
-        break;                                                  \
-      case TypeKind::SMALLINT:                                  \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int16_t);          \
-        break;                                                  \
-      case TypeKind::INTEGER:                                   \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int32_t);          \
-        break;                                                  \
-      case TypeKind::BIGINT:                                    \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int64_t);          \
-        break;                                                  \
-      case TypeKind::HUGEINT:                                   \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int128_t);         \
-        break;                                                  \
-      case TypeKind::REAL:                                      \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, float);            \
-        break;                                                  \
-      case TypeKind::DOUBLE:                                    \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, double);           \
-        break;                                                  \
-      case TypeKind::VARCHAR:                                   \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, StringView);       \
-        break;                                                  \
-      case TypeKind::TIMESTAMP:                                 \
-        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, Timestamp);        \
-        break;                                                  \
-      default:                                                  \
-        LOG(FATAL) << "Unsupported value type of minmax_by(): " \
-                   << mapTypeKindToName(GetParam().valueType);  \
-    }                                                           \
+#define EXECUTE_TEST(testFunc)                                    \
+  do {                                                            \
+    switch (GetParam().valueType) {                               \
+      case TypeKind::BOOLEAN:                                     \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, bool);               \
+        break;                                                    \
+      case TypeKind::TINYINT:                                     \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int8_t);             \
+        break;                                                    \
+      case TypeKind::SMALLINT:                                    \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int16_t);            \
+        break;                                                    \
+      case TypeKind::INTEGER:                                     \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int32_t);            \
+        break;                                                    \
+      case TypeKind::BIGINT:                                      \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int64_t);            \
+        break;                                                    \
+      case TypeKind::HUGEINT:                                     \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, int128_t);           \
+        break;                                                    \
+      case TypeKind::REAL:                                        \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, float);              \
+        break;                                                    \
+      case TypeKind::DOUBLE:                                      \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, double);             \
+        break;                                                    \
+      case TypeKind::VARCHAR:                                     \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, StringView);         \
+        break;                                                    \
+      case TypeKind::TIMESTAMP:                                   \
+        EXECUTE_TEST_BY_VALUE_TYPE(testFunc, Timestamp);          \
+        break;                                                    \
+      default:                                                    \
+        LOG(FATAL) << "Unsupported value type of minmax_by(): "   \
+                   << TypeKindName::toName(GetParam().valueType); \
+    }                                                             \
   } while (0);
 
 template <typename T>
@@ -194,7 +194,7 @@ class MinMaxByAggregationTestBase : public AggregationTestBase {
     }
     VELOX_FAIL(
         "Type {} is not found in rowType_: ",
-        mapTypeKindToName(kind),
+        TypeKindName::toName(kind),
         rowType_->toString());
   }
 
@@ -305,7 +305,7 @@ VectorPtr MinMaxByAggregationTestBase::buildDataVector(
       return buildDataVector<Timestamp>(size, values);
     default:
       LOG(FATAL) << "Unsupported value/comparison type of minmax_by(): "
-                 << mapTypeKindToName(kind);
+                 << TypeKindName::toName(kind);
   }
 }
 
@@ -369,7 +369,7 @@ void MinMaxByAggregationTestBase::SetUp() {
             type, buildDataVector<StringView>(numValues_));
         break;
       default:
-        LOG(FATAL) << "Unsupported data type: " << mapTypeKindToName(type);
+        LOG(FATAL) << "Unsupported data type: " << TypeKindName::toName(type);
     }
   }
   ASSERT_EQ(dataVectorsByType_.size(), kSupportedTypes.size());

--- a/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
         .addBenchmarkSet(
             fmt::format(
                 "array_constructor_{}_{}{}",
-                mapTypeKindToName(type->kind()),
+                TypeKindName::toName(type->kind()),
                 withNulls ? "nulls" : "nullfree",
                 suffix),
             input)

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -224,7 +224,8 @@ class ArraySortTest : public FunctionBaseTest,
         break;
       default:
         VELOX_FAIL(
-            "Unsupported data type of sort_array: {}", mapTypeKindToName(kind));
+            "Unsupported data type of sort_array: {}",
+            TypeKindName::toName(kind));
     }
   }
 
@@ -367,7 +368,8 @@ void ArraySortTest::SetUp() {
         break;
       default:
         VELOX_FAIL(
-            "Unsupported data type of sort_array: {}", mapTypeKindToName(type));
+            "Unsupported data type of sort_array: {}",
+            TypeKindName::toName(type));
     }
   }
   ASSERT_LE(dataVectorsByType_.size(), kSupportedTypes.size());

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -103,7 +103,7 @@ void registerCollectSetAggAggregate(
                 resultType);
           default:
             VELOX_UNSUPPORTED(
-                "Unsupported type {}", mapTypeKindToName(typeKind));
+                "Unsupported type {}", TypeKindName::toName(typeKind));
         }
       },
       withCompanionFunctions,

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -455,7 +455,7 @@ int32_t CompactRow::variableWidthRowSize(vector_size_t index) const {
       return rowRowSize(index);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+          "Unexpected type kind: {}", TypeKindName::toName(typeKind_));
   };
 }
 
@@ -718,7 +718,7 @@ int32_t CompactRow::serializeVariableWidth(vector_size_t index, char* buffer)
       return serializeRow(index, buffer);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+          "Unexpected type kind: {}", TypeKindName::toName(typeKind_));
   };
 }
 

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -161,7 +161,7 @@ int32_t UnsafeRowFast::variableWidthRowSize(vector_size_t index) const {
       return rowRowSize(index);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+          "Unexpected type kind: {}", TypeKindName::toName(typeKind_));
   };
 }
 
@@ -228,7 +228,7 @@ int32_t UnsafeRowFast::serializeVariableWidth(vector_size_t index, char* buffer)
       return serializeRow(index, buffer);
     default:
       VELOX_UNREACHABLE(
-          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+          "Unexpected type kind: {}", TypeKindName::toName(typeKind_));
   };
 }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -90,21 +90,6 @@ enum class TypeKind : int8_t {
 
 VELOX_DECLARE_ENUM_NAME(TypeKind);
 
-/// Deprecated.
-inline TypeKind mapNameToTypeKind(const std::string& name) {
-  return TypeKindName::toTypeKind(name);
-}
-
-[[deprecated("Use TypeKindName::tryToTypeKind")]]
-inline std::optional<TypeKind> tryMapNameToTypeKind(const std::string& name) {
-  return TypeKindName::tryToTypeKind(name);
-}
-
-/// Deprecated.
-inline std::string mapTypeKindToName(const TypeKind& typeKind) {
-  return std::string(TypeKindName::toName(typeKind));
-}
-
 std::ostream& operator<<(std::ostream& os, const TypeKind& kind);
 
 template <TypeKind KIND>
@@ -1583,62 +1568,62 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
       }                                                                       \
       default:                                                                \
         VELOX_FAIL(                                                           \
-            "not a scalar type! kind: {}", mapTypeKindToName(typeKind));      \
+            "not a scalar type! kind: {}", TypeKindName::toName(typeKind));   \
     }                                                                         \
   }()
 
-#define VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(                     \
-    TEMPLATE_FUNC, T, typeKind, ...)                                     \
-  [&]() {                                                                \
-    switch (typeKind) {                                                  \
-      case ::facebook::velox::TypeKind::BOOLEAN: {                       \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::BOOLEAN>(   \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::INTEGER: {                       \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::INTEGER>(   \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::TINYINT: {                       \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::TINYINT>(   \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::SMALLINT: {                      \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::SMALLINT>(  \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::BIGINT: {                        \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::BIGINT>(    \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::HUGEINT: {                       \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::HUGEINT>(   \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::REAL: {                          \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::REAL>(      \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::DOUBLE: {                        \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::DOUBLE>(    \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::VARCHAR: {                       \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::VARCHAR>(   \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::VARBINARY: {                     \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::VARBINARY>( \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      case ::facebook::velox::TypeKind::TIMESTAMP: {                     \
-        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::TIMESTAMP>( \
-            __VA_ARGS__);                                                \
-      }                                                                  \
-      default:                                                           \
-        VELOX_FAIL(                                                      \
-            "not a scalar type! kind: {}", mapTypeKindToName(typeKind)); \
-    }                                                                    \
+#define VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(                        \
+    TEMPLATE_FUNC, T, typeKind, ...)                                        \
+  [&]() {                                                                   \
+    switch (typeKind) {                                                     \
+      case ::facebook::velox::TypeKind::BOOLEAN: {                          \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::BOOLEAN>(      \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::INTEGER: {                          \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::INTEGER>(      \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::TINYINT: {                          \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::TINYINT>(      \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::SMALLINT: {                         \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::SMALLINT>(     \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::BIGINT: {                           \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::BIGINT>(       \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::HUGEINT: {                          \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::HUGEINT>(      \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::REAL: {                             \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::REAL>(         \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::DOUBLE: {                           \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::DOUBLE>(       \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::VARCHAR: {                          \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::VARCHAR>(      \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::VARBINARY: {                        \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::VARBINARY>(    \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      case ::facebook::velox::TypeKind::TIMESTAMP: {                        \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::TIMESTAMP>(    \
+            __VA_ARGS__);                                                   \
+      }                                                                     \
+      default:                                                              \
+        VELOX_FAIL(                                                         \
+            "not a scalar type! kind: {}", TypeKindName::toName(typeKind)); \
+    }                                                                       \
   }()
 
 #define VELOX_DYNAMIC_TEMPLATE_TYPE_DISPATCH(TEMPLATE_FUNC, T, typeKind, ...) \
@@ -1701,7 +1686,8 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
             __VA_ARGS__);                                                     \
       }                                                                       \
       default:                                                                \
-        VELOX_FAIL("not a known type kind: {}", mapTypeKindToName(typeKind)); \
+        VELOX_FAIL(                                                           \
+            "not a known type kind: {}", TypeKindName::toName(typeKind));     \
     }                                                                         \
   }()
 
@@ -1788,7 +1774,8 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
         return PREFIX<::facebook::velox::TypeKind::ROW> SUFFIX(__VA_ARGS__);   \
       }                                                                        \
       default:                                                                 \
-        VELOX_FAIL("not a known type kind: {}", mapTypeKindToName(typeKind));  \
+        VELOX_FAIL(                                                            \
+            "not a known type kind: {}", TypeKindName::toName(typeKind));      \
     }                                                                          \
   }()
 
@@ -1830,51 +1817,52 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
 #define VELOX_SCALAR_ACCESSOR(KIND) \
   std::shared_ptr<const ScalarType<TypeKind::KIND>> KIND()
 
-#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind)           \
-  [&]() {                                                                     \
-    switch (typeKind) {                                                       \
-      case ::facebook::velox::TypeKind::BOOLEAN: {                            \
-        return CLASS<::facebook::velox::TypeKind::BOOLEAN>::FIELD;            \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::INTEGER: {                            \
-        return CLASS<::facebook::velox::TypeKind::INTEGER>::FIELD;            \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::TINYINT: {                            \
-        return CLASS<::facebook::velox::TypeKind::TINYINT>::FIELD;            \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::SMALLINT: {                           \
-        return CLASS<::facebook::velox::TypeKind::SMALLINT>::FIELD;           \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::BIGINT: {                             \
-        return CLASS<::facebook::velox::TypeKind::BIGINT>::FIELD;             \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::REAL: {                               \
-        return CLASS<::facebook::velox::TypeKind::REAL>::FIELD;               \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::DOUBLE: {                             \
-        return CLASS<::facebook::velox::TypeKind::DOUBLE>::FIELD;             \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::VARCHAR: {                            \
-        return CLASS<::facebook::velox::TypeKind::VARCHAR>::FIELD;            \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::VARBINARY: {                          \
-        return CLASS<::facebook::velox::TypeKind::VARBINARY>::FIELD;          \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::TIMESTAMP: {                          \
-        return CLASS<::facebook::velox::TypeKind::TIMESTAMP>::FIELD;          \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::ARRAY: {                              \
-        return CLASS<::facebook::velox::TypeKind::ARRAY>::FIELD;              \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::MAP: {                                \
-        return CLASS<::facebook::velox::TypeKind::MAP>::FIELD;                \
-      }                                                                       \
-      case ::facebook::velox::TypeKind::ROW: {                                \
-        return CLASS<::facebook::velox::TypeKind::ROW>::FIELD;                \
-      }                                                                       \
-      default:                                                                \
-        VELOX_FAIL("not a known type kind: {}", mapTypeKindToName(typeKind)); \
-    }                                                                         \
+#define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH(CLASS, FIELD, typeKind)       \
+  [&]() {                                                                 \
+    switch (typeKind) {                                                   \
+      case ::facebook::velox::TypeKind::BOOLEAN: {                        \
+        return CLASS<::facebook::velox::TypeKind::BOOLEAN>::FIELD;        \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::INTEGER: {                        \
+        return CLASS<::facebook::velox::TypeKind::INTEGER>::FIELD;        \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::TINYINT: {                        \
+        return CLASS<::facebook::velox::TypeKind::TINYINT>::FIELD;        \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::SMALLINT: {                       \
+        return CLASS<::facebook::velox::TypeKind::SMALLINT>::FIELD;       \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::BIGINT: {                         \
+        return CLASS<::facebook::velox::TypeKind::BIGINT>::FIELD;         \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::REAL: {                           \
+        return CLASS<::facebook::velox::TypeKind::REAL>::FIELD;           \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::DOUBLE: {                         \
+        return CLASS<::facebook::velox::TypeKind::DOUBLE>::FIELD;         \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::VARCHAR: {                        \
+        return CLASS<::facebook::velox::TypeKind::VARCHAR>::FIELD;        \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::VARBINARY: {                      \
+        return CLASS<::facebook::velox::TypeKind::VARBINARY>::FIELD;      \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::TIMESTAMP: {                      \
+        return CLASS<::facebook::velox::TypeKind::TIMESTAMP>::FIELD;      \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::ARRAY: {                          \
+        return CLASS<::facebook::velox::TypeKind::ARRAY>::FIELD;          \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::MAP: {                            \
+        return CLASS<::facebook::velox::TypeKind::MAP>::FIELD;            \
+      }                                                                   \
+      case ::facebook::velox::TypeKind::ROW: {                            \
+        return CLASS<::facebook::velox::TypeKind::ROW>::FIELD;            \
+      }                                                                   \
+      default:                                                            \
+        VELOX_FAIL(                                                       \
+            "not a known type kind: {}", TypeKindName::toName(typeKind)); \
+    }                                                                     \
   }()
 
 #define VELOX_STATIC_FIELD_DYNAMIC_DISPATCH_ALL(CLASS, FIELD, typeKind)   \
@@ -2303,7 +2291,7 @@ class FormatValue<facebook::velox::TypeKind> {
   template <typename FormatCallback>
   void format(FormatArg& arg, FormatCallback& cb) const {
     return format_value::formatString(
-        facebook::velox::mapTypeKindToName(type_), arg, cb);
+        facebook::velox::TypeKindName::toName(type_), arg, cb);
   }
 
  private:
@@ -2335,7 +2323,7 @@ struct fmt::formatter<facebook::velox::TypeKind> : fmt::formatter<string_view> {
   template <typename FormatContext>
   auto format(facebook::velox::TypeKind k, FormatContext& ctx) const {
     return formatter<string_view>::format(
-        facebook::velox::mapTypeKindToName(k), ctx);
+        facebook::velox::TypeKindName::toName(k), ctx);
   }
 };
 

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -183,8 +183,8 @@ std::string stringifyFloatingPointerValue(T val) {
 void Variant::throwCheckIsKindError(TypeKind kind) const {
   throw std::invalid_argument{fmt::format(
       "wrong kind! {} != {}",
-      mapTypeKindToName(kind_),
-      mapTypeKindToName(kind))};
+      TypeKindName::toName(kind_),
+      TypeKindName::toName(kind))};
 }
 
 void Variant::throwCheckPtrError() const {
@@ -398,7 +398,8 @@ std::string Variant::toJson(const TypePtr& type) const {
   }
 
   VELOX_UNSUPPORTED(
-      "Unsupported: given type {} is not json-ready", mapTypeKindToName(kind_));
+      "Unsupported: given type {} is not json-ready",
+      TypeKindName::toName(kind_));
 }
 
 // This is the unsafe older implementation of toJson. It is kept here for
@@ -524,7 +525,8 @@ std::string Variant::toJsonUnsafe(const TypePtr& type) const {
   }
 
   VELOX_UNSUPPORTED(
-      "Unsupported: given type {} is not json-ready", mapTypeKindToName(kind_));
+      "Unsupported: given type {} is not json-ready",
+      TypeKindName::toName(kind_));
 }
 
 void serializeOpaque(
@@ -546,7 +548,7 @@ void serializeOpaque(
 folly::dynamic Variant::serialize() const {
   folly::dynamic variantObj = folly::dynamic::object;
 
-  variantObj["type"] = mapTypeKindToName(kind_);
+  variantObj["type"] = std::string(TypeKindName::toName(kind_));
   auto& objValue = variantObj["value"];
   if (isNull()) {
     objValue = nullptr;
@@ -657,7 +659,7 @@ Variant deserializeOpaque(const folly::dynamic& variantobj) {
 }
 
 Variant Variant::create(const folly::dynamic& variantobj) {
-  TypeKind kind = mapNameToTypeKind(variantobj["type"].asString());
+  TypeKind kind = TypeKindName::toTypeKind(variantobj["type"].asString());
   const folly::dynamic& obj = variantobj["value"];
 
   if (obj.isNull()) {

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -155,7 +155,9 @@ Result HiveTypeParser::parseType() {
         return Result{velox::ARRAY(resultList.typelist.at(0))};
       }
       default:
-        VELOX_FAIL("unsupported kind: " + mapTypeKindToName(nt.typeKind()));
+        VELOX_FAIL(
+            "unsupported kind: " +
+            std::string(TypeKindName::toName(nt.typeKind())));
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/facebookincubator/velox/issues/14096

Removed legacy type-conversion helpers in Type.h, consolidating enum name translation under TypeKindName for a single source of truth

Updated variant serialization to resolve type names and kinds through TypeKindName instead of deprecated mapping utilities

Revised error handling and validation, such as subscript index checks, to use TypeKindName::toName across the codebase