### PR TITLE
feat: Implement SpatialJoin nodes

### DIFF
--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
@@ -106,6 +106,11 @@ class DuckQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
       const core::NestedLoopJoinNode& node,
       core::PlanNodeVisitorContext& ctx) const override;
 
+  void visit(const core::SpatialJoinNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::OrderByNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
@@ -132,6 +132,12 @@ class PrestoQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
   void visit(const core::RowNumberNode& node, core::PlanNodeVisitorContext& ctx)
       const override;
 
+  void visit(
+      const core::SpatialJoinNode& node,
+      core::PlanNodeVisitorContext& ctx) const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::TableScanNode& node, core::PlanNodeVisitorContext& ctx)
       const override {
     PrestoSqlPlanNodeVisitor::visit(node, ctx);

--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -598,6 +598,12 @@ void PrestoSqlPlanNodeVisitor::visit(
   visitorContext.sql = sql.str();
 }
 
+void PrestoSqlPlanNodeVisitor::visit(
+    const core::SpatialJoinNode& node,
+    core::PlanNodeVisitorContext& ctx) const {
+  VELOX_NYI("SpatialJoinNode is not yet supported in SQL conversion");
+}
+
 std::optional<std::string> PrestoSqlPlanNodeVisitor::toSql(
     const core::PlanNodePtr& node) const {
   PrestoSqlPlanNodeVisitorContext sourceContext;

--- a/velox/exec/fuzzer/PrestoSql.h
+++ b/velox/exec/fuzzer/PrestoSql.h
@@ -70,6 +70,10 @@ class PrestoSqlPlanNodeVisitor : public core::PlanNodeVisitor {
       const core::NestedLoopJoinNode& node,
       core::PlanNodeVisitorContext& ctx) const override;
 
+  void visit(
+      const core::SpatialJoinNode& node,
+      core::PlanNodeVisitorContext& ctx) const override;
+
   void visit(const core::TableScanNode& node, core::PlanNodeVisitorContext& ctx)
       const override;
 

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
@@ -132,6 +132,12 @@ class SparkQueryRunnerToSqlPlanNodeVisitor
     VELOX_NYI();
   }
 
+  void visit(
+      const core::SpatialJoinNode& node,
+      core::PlanNodeVisitorContext& ctx) const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::TableScanNode& node, core::PlanNodeVisitorContext& ctx)
       const override {
     PrestoSqlPlanNodeVisitor::visit(node, ctx);


### PR DESCRIPTION
Summary:
As part of supporting Spatial Joins, implement SpatialJoinNode in PlanNode.
These don't yet have the operators: that will come in the next diff.

Reviewed By: kgpai

Differential Revision: D79589206


