### PR TITLE
feat(geo): Implement NLJ-version of SpatialJoinBuild/Probe Operators

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3064,9 +3064,6 @@ PlanNodePtr PartitionedOutputNode::create(
       deserializeSingleSource(obj, context));
 }
 
-// static
-const JoinType SpatialJoinNode::kDefaultJoinType = JoinType::kInner;
-
 SpatialJoinNode::SpatialJoinNode(
     const PlanNodeId& id,
     JoinType joinType,

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3955,7 +3955,7 @@ class SpatialJoinNode : public PlanNode {
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
-  static const JoinType kDefaultJoinType;
+  constexpr static JoinType kDefaultJoinType = JoinType::kInner;
 
   void addDetails(std::stringstream& stream) const override;
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -56,6 +56,8 @@ velox_add_library(
   MergeSource.cpp
   NestedLoopJoinBuild.cpp
   NestedLoopJoinProbe.cpp
+  SpatialJoinBuild.cpp
+  SpatialJoinProbe.cpp
   Operator.cpp
   OperatorUtils.cpp
   OrderBy.cpp

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -818,6 +818,10 @@ struct DriverFactory {
   /// based on this pipeline.
   std::vector<core::PlanNodeId> needsNestedLoopJoinBridges() const;
 
+  /// Returns plan node IDs for which Spatial Join Bridges must be created
+  /// based on this pipeline.
+  std::vector<core::PlanNodeId> needsSpatialJoinBridges() const;
+
   static std::vector<DriverAdapter> adapters;
 };
 

--- a/velox/exec/SpatialJoinBuild.cpp
+++ b/velox/exec/SpatialJoinBuild.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SpatialJoinBuild.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+void SpatialJoinBridge::setData(std::vector<RowVectorPtr> buildVectors) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(!buildVectors_.has_value(), "setData must be called only once");
+    buildVectors_ = std::move(buildVectors);
+    promises = std::move(promises_);
+  }
+  notify(std::move(promises));
+}
+
+std::optional<std::vector<RowVectorPtr>> SpatialJoinBridge::dataOrFuture(
+    ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(!cancelled_, "Getting data after the build side is aborted");
+  if (buildVectors_.has_value()) {
+    return buildVectors_;
+  }
+  promises_.emplace_back("SpatialJoinBridge::tableOrFuture");
+  *future = promises_.back().getSemiFuture();
+  return std::nullopt;
+}
+
+SpatialJoinBuild::SpatialJoinBuild(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    std::shared_ptr<const core::SpatialJoinNode> joinNode)
+    : Operator(
+          driverCtx,
+          nullptr,
+          operatorId,
+          joinNode->id(),
+          "SpatialJoinBuild") {}
+
+void SpatialJoinBuild::addInput(RowVectorPtr input) {
+  if (input->size() > 0) {
+    // Load lazy vectors before storing.
+    for (auto& child : input->children()) {
+      child->loadedVector();
+    }
+    dataVectors_.emplace_back(std::move(input));
+  }
+}
+
+BlockingReason SpatialJoinBuild::isBlocked(ContinueFuture* future) {
+  if (!future_.valid()) {
+    return BlockingReason::kNotBlocked;
+  }
+  *future = std::move(future_);
+  return BlockingReason::kWaitForJoinBuild;
+}
+
+// Merge adjacent vectors to larger vectors as long as the result do not exceed
+// the size limit.  This is important for performance because each small vector
+// here would be duplicated by the number of rows on probe side, result in huge
+// number of small vectors in the output.
+std::vector<RowVectorPtr> SpatialJoinBuild::mergeDataVectors() const {
+  const auto maxBatchRows =
+      operatorCtx_->task()->queryCtx()->queryConfig().maxOutputBatchRows();
+  std::vector<RowVectorPtr> merged;
+  for (size_t i = 0; i < dataVectors_.size();) {
+    // convert int32_t to int64_t to avoid sum overflow
+    int64_t batchSize = static_cast<int64_t>(dataVectors_[i]->size());
+    auto j = i + 1;
+    while (j < dataVectors_.size() &&
+           batchSize + dataVectors_[j]->size() <= maxBatchRows) {
+      batchSize += dataVectors_[j++]->size();
+    }
+    if (j == i + 1) {
+      merged.push_back(dataVectors_[i++]);
+    } else {
+      auto batch = BaseVector::create<RowVector>(
+          dataVectors_[i]->type(),
+          static_cast<vector_size_t>(batchSize),
+          pool());
+      batchSize = 0;
+      while (i < j) {
+        auto* source = dataVectors_[i++].get();
+        batch->copy(
+            source, static_cast<vector_size_t>(batchSize), 0, source->size());
+        batchSize += source->size();
+      }
+      merged.push_back(std::move(batch));
+    }
+  }
+  return merged;
+}
+
+void SpatialJoinBuild::noMoreInput() {
+  Operator::noMoreInput();
+  std::vector<ContinuePromise> promises;
+  std::vector<std::shared_ptr<Driver>> peers;
+  // The last Driver to hit SpatialJoinBuild::finish gathers the data from
+  // all build Drivers and hands it over to the probe side. At this
+  // point all build Drivers are continued and will free their
+  // state. allPeersFinished is true only for the last Driver of the
+  // build pipeline.
+  if (!operatorCtx_->task()->allPeersFinished(
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    return;
+  }
+
+  {
+    auto promisesGuard = folly::makeGuard([&]() {
+      // Realize the promises so that the other Drivers (which were not
+      // the last to finish) can continue from the barrier and finish.
+      peers.clear();
+      for (auto& promise : promises) {
+        promise.setValue();
+      }
+    });
+
+    for (auto& peer : peers) {
+      auto op = peer->findOperator(planNodeId());
+      auto* build = dynamic_cast<SpatialJoinBuild*>(op);
+      VELOX_CHECK_NOT_NULL(build);
+      dataVectors_.insert(
+          dataVectors_.end(),
+          std::make_move_iterator(build->dataVectors_.begin()),
+          std::make_move_iterator(build->dataVectors_.end()));
+    }
+  }
+
+  dataVectors_ = mergeDataVectors();
+  operatorCtx_->task()
+      ->getSpatialJoinBridge(
+          operatorCtx_->driverCtx()->splitGroupId, planNodeId())
+      ->setData(std::move(dataVectors_));
+}
+
+bool SpatialJoinBuild::isFinished() {
+  return !future_.valid() && noMoreInput_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/SpatialJoinBuild.h
+++ b/velox/exec/SpatialJoinBuild.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/JoinBridge.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class SpatialJoinBridge : public JoinBridge {
+ public:
+  void setData(std::vector<RowVectorPtr> buildVectors);
+
+  std::optional<std::vector<RowVectorPtr>> dataOrFuture(ContinueFuture* future);
+
+ private:
+  std::optional<std::vector<RowVectorPtr>> buildVectors_;
+};
+
+class SpatialJoinBuild : public Operator {
+ public:
+  SpatialJoinBuild(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      std::shared_ptr<const core::SpatialJoinNode> joinNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override {
+    return nullptr;
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void noMoreInput() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+  void close() override {
+    dataVectors_.clear();
+    Operator::close();
+  }
+
+  std::vector<RowVectorPtr> mergeDataVectors() const;
+
+ private:
+  std::vector<RowVectorPtr> dataVectors_;
+
+  // Future for synchronizing with other Drivers of the same pipeline. All build
+  // Drivers must be completed before making data available for the probe side.
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SpatialJoinProbe.cpp
+++ b/velox/exec/SpatialJoinProbe.cpp
@@ -1,0 +1,471 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SpatialJoinProbe.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/SpatialJoinBuild.h"
+#include "velox/exec/Task.h"
+#include "velox/expression/FieldReference.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+bool needsProbeMismatch(core::JoinType joinType) {
+  return isLeftJoin(joinType);
+}
+
+std::vector<IdentityProjection> extractProjections(
+    const RowTypePtr& srcType,
+    const RowTypePtr& destType) {
+  std::vector<IdentityProjection> projections;
+  for (auto i = 0; i < srcType->size(); ++i) {
+    auto name = srcType->nameOf(i);
+    auto outIndex = destType->getChildIdxIfExists(name);
+    if (outIndex.has_value()) {
+      projections.emplace_back(i, outIndex.value());
+    }
+  }
+  return projections;
+}
+
+} // namespace
+
+SpatialJoinProbe::SpatialJoinProbe(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::SpatialJoinNode>& joinNode)
+    : Operator(
+          driverCtx,
+          joinNode->outputType(),
+          operatorId,
+          joinNode->id(),
+          "SpatialJoinProbe"),
+      joinType_(joinNode->joinType()),
+      outputBatchSize_{outputBatchRows()},
+      joinNode_(joinNode) {
+  auto probeType = joinNode_->sources()[0]->outputType();
+  auto buildType = joinNode_->sources()[1]->outputType();
+  identityProjections_ = extractProjections(probeType, outputType_);
+  buildProjections_ = extractProjections(buildType, outputType_);
+}
+
+void SpatialJoinProbe::initialize() {
+  Operator::initialize();
+
+  VELOX_CHECK(joinNode_ != nullptr);
+  if (joinNode_->joinCondition() != nullptr) {
+    initializeFilter(
+        joinNode_->joinCondition(),
+        joinNode_->sources()[0]->outputType(),
+        joinNode_->sources()[1]->outputType());
+  }
+
+  joinNode_.reset();
+}
+
+void SpatialJoinProbe::initializeFilter(
+    const core::TypedExprPtr& filter,
+    const RowTypePtr& probeType,
+    const RowTypePtr& buildType) {
+  VELOX_CHECK_NULL(joinCondition_);
+
+  std::vector<core::TypedExprPtr> filters = {filter};
+  joinCondition_ =
+      std::make_unique<ExprSet>(std::move(filters), operatorCtx_->execCtx());
+
+  column_index_t filterChannel = 0;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  const auto numFields = joinCondition_->expr(0)->distinctFields().size();
+  names.reserve(numFields);
+  types.reserve(numFields);
+
+  for (const auto& field : joinCondition_->expr(0)->distinctFields()) {
+    const auto& name = field->field();
+    auto channel = probeType->getChildIdxIfExists(name);
+    if (channel.has_value()) {
+      auto channelValue = channel.value();
+      filterProbeProjections_.emplace_back(channelValue, filterChannel++);
+      names.emplace_back(probeType->nameOf(channelValue));
+      types.emplace_back(probeType->childAt(channelValue));
+      continue;
+    }
+    channel = buildType->getChildIdxIfExists(name);
+    if (channel.has_value()) {
+      auto channelValue = channel.value();
+      filterBuildProjections_.emplace_back(channelValue, filterChannel++);
+      names.emplace_back(buildType->nameOf(channelValue));
+      types.emplace_back(buildType->childAt(channelValue));
+      continue;
+    }
+    VELOX_FAIL(
+        "Spatial join filter field {} not in probe or build input, filter: {}",
+        field->toString(),
+        filter->toString());
+  }
+
+  filterInputType_ = ROW(std::move(names), std::move(types));
+}
+
+BlockingReason SpatialJoinProbe::isBlocked(ContinueFuture* future) {
+  switch (state_) {
+    case ProbeOperatorState::kRunning:
+      [[fallthrough]];
+    case ProbeOperatorState::kFinish:
+      return BlockingReason::kNotBlocked;
+    case ProbeOperatorState::kWaitForPeers:
+      if (future_.valid()) {
+        *future = std::move(future_);
+        return BlockingReason::kWaitForJoinProbe;
+      }
+      setState(ProbeOperatorState::kFinish);
+      return BlockingReason::kNotBlocked;
+    case ProbeOperatorState::kWaitForBuild: {
+      VELOX_CHECK(!buildVectors_.has_value());
+      if (!getBuildData(future)) {
+        return BlockingReason::kWaitForJoinBuild;
+      }
+      VELOX_CHECK(buildVectors_.has_value());
+      setState(ProbeOperatorState::kRunning);
+      return BlockingReason::kNotBlocked;
+    }
+    default:
+      VELOX_UNREACHABLE(probeOperatorStateName(state_));
+  }
+}
+
+void SpatialJoinProbe::close() {
+  if (joinCondition_ != nullptr) {
+    joinCondition_->clear();
+  }
+  buildVectors_.reset();
+  Operator::close();
+}
+
+void SpatialJoinProbe::addInput(RowVectorPtr input) {
+  VELOX_CHECK_NULL(input_);
+
+  // In getOutput(), we are going to wrap input in dictionaries a few rows at a
+  // time. Since lazy vectors cannot be wrapped in different dictionaries, we
+  // are going to load them here.
+  for (auto& child : input->children()) {
+    child->loadedVector();
+  }
+  input_ = std::move(input);
+  if (input_->size() > 0) {
+    probeSideEmpty_ = false;
+  }
+  VELOX_CHECK_EQ(buildIndex_, 0);
+}
+
+void SpatialJoinProbe::noMoreInput() {
+  Operator::noMoreInput();
+  if (state_ != ProbeOperatorState::kRunning || input_ != nullptr) {
+    return;
+  }
+  setState(ProbeOperatorState::kFinish);
+  return;
+}
+
+bool SpatialJoinProbe::getBuildData(ContinueFuture* future) {
+  VELOX_CHECK(!buildVectors_.has_value());
+
+  auto buildData =
+      operatorCtx_->task()
+          ->getSpatialJoinBridge(
+              operatorCtx_->driverCtx()->splitGroupId, planNodeId())
+          ->dataOrFuture(future);
+  if (!buildData.has_value()) {
+    return false;
+  }
+
+  buildVectors_ = std::move(buildData);
+  return true;
+}
+
+RowVectorPtr SpatialJoinProbe::getOutput() {
+  if (state_ == ProbeOperatorState::kFinish ||
+      state_ == ProbeOperatorState::kWaitForPeers) {
+    return nullptr;
+  }
+  RowVectorPtr output{nullptr};
+  while (output == nullptr) {
+    // Need more input.
+    if (input_ == nullptr) {
+      break;
+    }
+
+    // Generate actual join output by processing probe and build matches, and
+    // probe mismaches (for left joins).
+    output = generateOutput();
+  }
+  return output;
+}
+
+RowVectorPtr SpatialJoinProbe::generateOutput() {
+  // If addToOutput() returns false, output_ is filled. Need to produce it.
+  if (!addToOutput()) {
+    VELOX_CHECK_GT(output_->size(), 0);
+    return std::move(output_);
+  }
+
+  // Try to advance the probe cursor; call finish if no more probe input.
+  if (advanceProbe()) {
+    finishProbeInput();
+    if (numOutputRows_ == 0) {
+      // output_ can only be re-used across probe rows within the same input_.
+      // Here we have to abandon the emtpy non-null output_ before we advance to
+      // the next probe input.
+      output_ = nullptr;
+    }
+  }
+
+  if (!readyToProduceOutput()) {
+    return nullptr;
+  }
+
+  output_->resize(numOutputRows_);
+  return std::move(output_);
+}
+
+bool SpatialJoinProbe::readyToProduceOutput() {
+  if (!output_ || numOutputRows_ == 0) {
+    return false;
+  }
+
+  // If the input_ has no remaining rows or the output_ is fully filled,
+  // it's right time for output.
+  return !input_ || numOutputRows_ >= outputBatchSize_;
+}
+
+bool SpatialJoinProbe::advanceProbe() {
+  if (hasProbedAllBuildData()) {
+    probeRow_ += 1;
+    probeRowHasMatch_ = false;
+    buildIndex_ = 0;
+
+    // If we finished processing the probe side.
+    if (probeRow_ >= input_->size()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool SpatialJoinProbe::addToOutput() {
+  VELOX_CHECK_NOT_NULL(input_);
+  prepareOutput();
+
+  while (!hasProbedAllBuildData()) {
+    const auto& currentBuild = buildVectors_.value()[buildIndex_];
+
+    // Empty build vector; move to the next.
+    if (currentBuild->size() == 0) {
+      ++buildIndex_;
+      buildRow_ = 0;
+      continue;
+    }
+
+    // Only re-calculate the filter if we have a new build vector.
+    if (buildRow_ == 0) {
+      evaluateSpatialJoinFilter(currentBuild);
+    }
+
+    // Iterate over the filter results. For each match, add an output record.
+    for (vector_size_t i = buildRow_; i < decodedFilterResult_.size(); ++i) {
+      if (!isSpatialJoinConditionMatch(i)) {
+        continue;
+      }
+
+      addOutputRow(i);
+      ++numOutputRows_;
+      probeRowHasMatch_ = true;
+
+      // If the buffer is full, save state and produce it as output.
+      if (numOutputRows_ == outputBatchSize_) {
+        buildRow_ = i + 1;
+        copyBuildValues(currentBuild);
+        return false;
+      }
+    }
+
+    // Before moving to the next build vector, copy the needed ranges.
+    copyBuildValues(currentBuild);
+    ++buildIndex_;
+    buildRow_ = 0;
+  }
+
+  // Check if the current probed row needs to be added as a mismatch (for left
+  // and full outer joins).
+  checkProbeMismatchRow();
+
+  // Signals that all input has been generated for the probeRow and build
+  // vectors; safe to move to the next probe record.
+  return true;
+}
+
+void SpatialJoinProbe::prepareOutput() {
+  if (output_ != nullptr) {
+    return;
+  }
+
+  std::vector<VectorPtr> localColumns(outputType_->size());
+
+  probeOutputIndices_ = allocateIndices(outputBatchSize_, pool());
+  rawProbeOutputIndices_ = probeOutputIndices_->asMutable<vector_size_t>();
+
+  for (const auto& projection : identityProjections_) {
+    localColumns[projection.outputChannel] = BaseVector::wrapInDictionary(
+        {},
+        probeOutputIndices_,
+        outputBatchSize_,
+        input_->childAt(projection.inputChannel));
+  }
+
+  // For other join types, add build side projections
+  for (const auto& projection : buildProjections_) {
+    localColumns[projection.outputChannel] = BaseVector::create(
+        outputType_->childAt(projection.outputChannel),
+        outputBatchSize_,
+        operatorCtx_->pool());
+  }
+
+  numOutputRows_ = 0;
+  output_ = std::make_shared<RowVector>(
+      pool(), outputType_, nullptr, outputBatchSize_, std::move(localColumns));
+}
+
+void SpatialJoinProbe::evaluateSpatialJoinFilter(
+    const RowVectorPtr& buildVector) {
+  // First step to process is to get a batch so we can evaluate the join
+  // filter.
+  auto filterInput = getNextCrossProductBatch(
+      buildVector,
+      filterInputType_,
+      filterProbeProjections_,
+      filterBuildProjections_);
+
+  if (filterInputRows_.size() != filterInput->size()) {
+    filterInputRows_.resizeFill(filterInput->size(), true);
+  }
+  VELOX_CHECK(filterInputRows_.isAllSelected());
+
+  std::vector<VectorPtr> filterResult;
+  EvalCtx evalCtx(
+      operatorCtx_->execCtx(), joinCondition_.get(), filterInput.get());
+  joinCondition_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult);
+  VELOX_CHECK_GT(filterResult.size(), 0);
+  filterOutput_ = filterResult[0];
+  decodedFilterResult_.decode(*filterOutput_, filterInputRows_);
+}
+
+RowVectorPtr SpatialJoinProbe::getNextCrossProductBatch(
+    const RowVectorPtr& buildVector,
+    const RowTypePtr& outputType,
+    const std::vector<IdentityProjection>& probeProjections,
+    const std::vector<IdentityProjection>& buildProjections) {
+  VELOX_CHECK_GT(buildVector->size(), 0);
+
+  return genCrossProductMultipleBuildVectors(
+      buildVector, outputType, probeProjections, buildProjections);
+}
+
+RowVectorPtr SpatialJoinProbe::genCrossProductMultipleBuildVectors(
+    const RowVectorPtr& buildVector,
+    const RowTypePtr& outputType,
+    const std::vector<IdentityProjection>& probeProjections,
+    const std::vector<IdentityProjection>& buildProjections) {
+  std::vector<VectorPtr> projectedChildren(outputType->size());
+  const vector_size_t numOutputRows = buildVector->size();
+
+  // Project columns from the build side.
+  projectChildren(
+      projectedChildren, buildVector, buildProjections, numOutputRows, nullptr);
+
+  // Wrap projections from the probe side as constants.
+  for (const auto [inputChannel, outputChannel] : probeProjections) {
+    projectedChildren[outputChannel] = BaseVector::wrapInConstant(
+        numOutputRows, probeRow_, input_->childAt(inputChannel));
+  }
+
+  return std::make_shared<RowVector>(
+      pool(), outputType, nullptr, numOutputRows, std::move(projectedChildren));
+}
+
+void SpatialJoinProbe::addOutputRow(vector_size_t buildRow) {
+  // Probe side is always a dictionary; just populate the index.
+  rawProbeOutputIndices_[numOutputRows_] = probeRow_;
+
+  // For the build side, we accumulate the ranges to copy, then copy all of them
+  // at once. If records are consecutive and can have a single copy range run.
+  if (!buildCopyRanges_.empty() &&
+      (buildCopyRanges_.back().sourceIndex + buildCopyRanges_.back().count) ==
+          buildRow) {
+    ++buildCopyRanges_.back().count;
+  } else {
+    buildCopyRanges_.push_back({buildRow, numOutputRows_, 1});
+  }
+}
+
+void SpatialJoinProbe::copyBuildValues(const RowVectorPtr& buildVector) {
+  if (buildCopyRanges_.empty() || isLeftSemiProjectJoin(joinType_)) {
+    return;
+  }
+
+  for (const auto& projection : buildProjections_) {
+    const auto& buildChild = buildVector->childAt(projection.inputChannel);
+    const auto& outputChild = output_->childAt(projection.outputChannel);
+    outputChild->copyRanges(buildChild.get(), buildCopyRanges_);
+  }
+  buildCopyRanges_.clear();
+}
+
+void SpatialJoinProbe::checkProbeMismatchRow() {
+  // If we are processing the last batch of the build side, check if we need
+  // to add a probe mismatch record.
+  if (needsProbeMismatch(joinType_) && hasProbedAllBuildData() &&
+      !probeRowHasMatch_) {
+    prepareOutput();
+    addProbeMismatchRow();
+    ++numOutputRows_;
+  }
+}
+
+void SpatialJoinProbe::addProbeMismatchRow() {
+  // Probe side is always a dictionary; just populate the index.
+  rawProbeOutputIndices_[numOutputRows_] = probeRow_;
+
+  // Null out build projections.
+  for (const auto& projection : buildProjections_) {
+    const auto& outputChild = output_->childAt(projection.outputChannel);
+    outputChild->setNull(numOutputRows_, true);
+  }
+}
+
+void SpatialJoinProbe::finishProbeInput() {
+  VELOX_CHECK_NOT_NULL(input_);
+  input_.reset();
+  buildIndex_ = 0;
+  probeRow_ = 0;
+
+  if (!noMoreInput_) {
+    return;
+  }
+
+  setState(ProbeOperatorState::kFinish);
+  return;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SpatialJoinProbe.h
+++ b/velox/exec/SpatialJoinProbe.h
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/ProbeOperatorState.h"
+
+namespace facebook::velox::exec {
+
+/// Implements a Spatial Join between records from the probe (input_)
+/// and build (SpatialJoinBridge) sides. It supports inner, left, right and
+/// full outer joins.
+///
+/// This class is designed to evaluate spatial join conditions (e.g.
+/// ST_INTERSECTS, ST_CONTAINS, ST_WITHIN) between geometric data types. It can
+/// also implement spatial cross-join semantics if joinCondition is nullptr.
+///
+/// The output follows the order of the probe side rows (for inner and left
+/// joins). All build vectors are materialized upfront (check buildVectors_),
+/// but probe batches are processed one-by-one as a stream.
+///
+/// To produce output, the operator processes each probe record from probe
+/// input, using the following steps:
+///
+/// 1. Materialize a cross-product batch across probe and build.
+/// 2. Evaluate the spatial join condition.
+/// 3. Add spatial matches to the output.
+/// 4. Once all build vectors are processed for a particular probe row, check if
+///    a probe mismatch is needed (only for left and full outer joins).
+/// 5. Once all probe and build inputs are processed, check if build mismatches
+///    are needed (only for right and full outer joins).
+/// 6. If so, signal other peer operators; only a single operator instance will
+///    collect all build matches at the end, and emit any records that haven't
+///    been matched by any of the peers.
+///
+/// Spatial joins typically use spatial indexing for performance optimization,
+/// but this implementation follows the nested loop pattern for compatibility
+/// with the existing join framework.
+class SpatialJoinProbe : public Operator {
+ public:
+  SpatialJoinProbe(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::SpatialJoinNode>& joinNode);
+
+  void initialize() override;
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  bool needsInput() const override {
+    return state_ == ProbeOperatorState::kRunning && input_ == nullptr &&
+        !noMoreInput_;
+  }
+
+  void noMoreInput() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override {
+    return state_ == ProbeOperatorState::kFinish;
+  }
+
+  void close() override;
+
+ private:
+  // Initialize spatial filter for evaluating spatial join conditions.
+  void initializeFilter(
+      const core::TypedExprPtr& filter,
+      const RowTypePtr& leftType,
+      const RowTypePtr& rightType);
+
+  // Materializes build data from spatial join bridge into `buildVectors_`.
+  // Returns whether the data has been materialized and is ready for use.
+  // Spatial join requires all build data to be materialized and available in
+  // `buildVectors_` before it can produce output.
+  bool getBuildData(ContinueFuture* future);
+
+  // Generates output from spatial join matches between probe and build sides,
+  // as well as probe mismatches (for left and full outer joins). As much as
+  // possible, generates outputs `outputBatchSize_` records at a time, but
+  // batches may be smaller in some cases - outputs follow the probe side buffer
+  // boundaries.
+  RowVectorPtr generateOutput();
+
+  // For non cross-join mode, the `output_` can be reused across multiple probe
+  // rows. If the input_ has remaining rows and the output_ is not fully filled,
+  // it returns false here.
+  bool readyToProduceOutput();
+
+  // Fill in joined output to `output_` by matching the current probeRow_ and
+  // successive build vectors (using getNextCrossProductBatch()). Stops when
+  // either all build vectors were matched for the current probeRow (returns
+  // true), or if the output is full (returns false). If it returns false, a
+  // valid vector with more than zero records will be available at `output_`;
+  // if it returns true, either nullptr or zero records may be placed at
+  // `output_`. Also if it returns true, it's the caller's responsibility to
+  // decide when to set `output_` size.
+  //
+  // Also updates `buildMatched_` if the build records that received a match, so
+  // that they can be used to implement right and full outer join semantic once
+  // all probe data has been processed.
+  bool addToOutput();
+
+  // Advances 'probeRow_' and resets required state information. Returns true
+  // if there is no more probe data to be processed in the current `input_`
+  // (and hence a new probe input is required). False otherwise.
+  bool advanceProbe();
+
+  // Ensures a new batch of records is available at `output_` and ready to
+  // receive rows. Batches have space for `outputBatchSize_`.
+  void prepareOutput();
+
+  // Evaluates the spatial joinCondition for a given build vector. This method
+  // sets `filterOutput_` and `decodedFilterResult_`, which will be ready to be
+  // used by `isSpatialJoinConditionMatch(buildRow)` below.
+  void evaluateSpatialJoinFilter(const RowVectorPtr& buildVector);
+
+  // Checks if the spatial join condition matched for a particular row.
+  bool isSpatialJoinConditionMatch(vector_size_t i) const {
+    return (
+        !decodedFilterResult_.isNullAt(i) &&
+        decodedFilterResult_.valueAt<bool>(i));
+  }
+
+  // Generates the next batch of a cross product between probe and build. It
+  // should be used as the entry point, and will internally delegate to one of
+  // the three functions below.
+  //
+  // Output projections can be specified so that this function can be used to
+  // generate both filter input and actual output (in case there is no join
+  // filter - cross join).
+  RowVectorPtr getNextCrossProductBatch(
+      const RowVectorPtr& buildVector,
+      const RowTypePtr& outputType,
+      const std::vector<IdentityProjection>& probeProjections,
+      const std::vector<IdentityProjection>& buildProjections);
+
+  // As a fallback, process the current probe row to as much build data as
+  // possible (probe row as constant, and flat copied data for build records).
+  RowVectorPtr genCrossProductMultipleBuildVectors(
+      const RowVectorPtr& buildVector,
+      const RowTypePtr& outputType,
+      const std::vector<IdentityProjection>& probeProjections,
+      const std::vector<IdentityProjection>& buildProjections);
+
+  // Add a single record to `output_` based on buildRow from buildVector, and
+  // the current probeRow and probe vector (input_). Probe side projections are
+  // zero-copy (dictionary indices), and build side projections are marked to be
+  // copied using `buildCopyRanges_`; they will be copied later on by
+  // `copyBuildValues()`.
+  void addOutputRow(vector_size_t buildRow);
+
+  // Copies the ranges from buildVector specified by `buildCopyRanges_` to
+  // `output_`, one projected column at a time. Clears buildCopyRanges_.
+  void copyBuildValues(const RowVectorPtr& buildVector);
+
+  // Checks if it is required to add a probe mismatch row, and does it if
+  // needed. The caller needs to ensure there is available space in `output_`
+  // for the new record, which has nulled out build projections.
+  void checkProbeMismatchRow();
+
+  // Add a probe mismatch (only for left/full outer joins). The record is based
+  // on the current probeRow and vector (input_) and build projections are null.
+  void addProbeMismatchRow();
+
+  // Called when we are done processing the current probe batch, to signal we
+  // are ready for the next one.
+  //
+  // If this is the last probe batch (and this is a right or full outer join),
+  // change the operator state to signal peers.
+  void finishProbeInput();
+
+  // Whether we have processed all build data for the current probe row (based
+  // on buildIndex_'s value).
+  bool hasProbedAllBuildData() const {
+    return (buildIndex_ >= buildVectors_.value().size());
+  }
+
+  // If build has a single vector, we can wrap probe and build batches into
+  // dictionaries and produce as many combinations of probe and build rows,
+  // until `numOutputRows_` is filled.
+  bool isSingleBuildVector() const {
+    return buildVectors_->size() == 1;
+  }
+
+  // If there are no incoming records in the build side.
+  bool isBuildSideEmpty() const {
+    return buildVectors_->empty();
+  }
+
+  // If build has a single row, we can simply add it as a constant to probe
+  // batches.
+  bool isSingleBuildRow() const {
+    return isSingleBuildVector() && buildVectors_->front()->size() == 1;
+  }
+
+  // TODO: Add state transition check.
+  void setState(ProbeOperatorState state) {
+    state_ = state;
+  }
+
+  const core::JoinType joinType_;
+
+  // Output buffer members.
+
+  // Maximum number of rows in the output batch.
+  const vector_size_t outputBatchSize_;
+
+  // The current output batch being populated.
+  RowVectorPtr output_;
+
+  // Number of output rows in the current output batch.
+  vector_size_t numOutputRows_{0};
+
+  // Dictionary indices for probe columns used to generate cross-product.
+  BufferPtr probeIndices_;
+
+  // Dictionary indices for probe columns for output vector.
+  BufferPtr probeOutputIndices_;
+  vector_size_t* rawProbeOutputIndices_{};
+
+  // Dictionary indices for build columns.
+  BufferPtr buildIndices_;
+
+  // Spatial join condition expression.
+
+  // Must not be null
+  std::unique_ptr<ExprSet> joinCondition_;
+
+  // Input type for the spatial join condition expression.
+  RowTypePtr filterInputType_;
+
+  // Spatial join condition evaluation state that need to persisted across the
+  // generation of successive output buffers.
+  SelectivityVector filterInputRows_;
+  VectorPtr filterOutput_;
+  DecodedVector decodedFilterResult_;
+
+  // Join metadata and state.
+  std::shared_ptr<const core::SpatialJoinNode> joinNode_;
+
+  ProbeOperatorState state_{ProbeOperatorState::kWaitForBuild};
+  ContinueFuture future_{ContinueFuture::makeEmpty()};
+
+  // Probe side state.
+
+  // Probe row being currently processed (related to `input_`).
+  vector_size_t probeRow_{0};
+
+  // Whether the current probeRow_ has produces a match. Used for left and full
+  // outer joins.
+  bool probeRowHasMatch_{false};
+
+  // Indicate if the probe side has empty input or not. For the last probe,
+  // this indicates if all the probe sides are empty or not. This flag is used
+  // for mismatched output producing.
+  bool probeSideEmpty_{true};
+
+  // Build side state.
+
+  // Stores the data for build vectors (right side of the join).
+  std::optional<std::vector<RowVectorPtr>> buildVectors_;
+
+  // Index into `buildVectors_` for the build vector being currently processed.
+  size_t buildIndex_{0};
+
+  // Row being currently processed from `buildVectors_[buildIndex_]`.
+  vector_size_t buildRow_{0};
+
+  // Stores the ranges of build values to be copied to the output vector (we
+  // batch them and copy once, instead of copying them row-by-row).
+  std::vector<BaseVector::CopyRange> buildCopyRanges_;
+
+  // List of output projections from the build side. Note that the list of
+  // projections from the probe side is available at `identityProjections_`.
+  std::vector<IdentityProjection> buildProjections_;
+
+  // Projections needed as input to the filter to evaluation spatial join filter
+  // conditions. Note that if this is a cross-join, filter projections are the
+  // same as output projections.
+  std::vector<IdentityProjection> filterProbeProjections_;
+  std::vector<IdentityProjection> filterBuildProjections_;
+
+  BufferPtr buildOutMapping_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -34,6 +34,7 @@ class OutputBufferManager;
 
 class HashJoinBridge;
 class NestedLoopJoinBridge;
+class SpatialJoinBridge;
 class SplitListener;
 
 using ConnectorSplitPreloadFunc =
@@ -555,6 +556,11 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const std::vector<core::PlanNodeId>& planNodeIds);
 
+  /// Adds SpatialJoinBridge's for all the specified plan node IDs.
+  void addSpatialJoinBridgesLocked(
+      uint32_t splitGroupId,
+      const std::vector<core::PlanNodeId>& planNodeIds);
+
   /// Adds custom join bridges for all the specified plan nodes.
   void addCustomJoinBridgesLocked(
       uint32_t splitGroupId,
@@ -574,6 +580,11 @@ class Task : public std::enable_shared_from_this<Task> {
 
   /// Returns a NestedLoopJoinBridge for 'planNodeId'.
   std::shared_ptr<NestedLoopJoinBridge> getNestedLoopJoinBridge(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
+  /// Returns a SpatialJoinBridge for 'planNodeId'.
+  std::shared_ptr<SpatialJoinBridge> getSpatialJoinBridge(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -108,6 +108,10 @@ add_executable(
   WriterFuzzerUtilTest.cpp
 )
 
+if(VELOX_ENABLE_GEO)
+  target_sources(velox_exec_test PRIVATE SpatialJoinTest.cpp)
+endif()
+
 add_executable(
   velox_exec_infra_test
   AssertQueryBuilderTest.cpp

--- a/velox/exec/tests/SpatialJoinTest.cpp
+++ b/velox/exec/tests/SpatialJoinTest.cpp
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/PlanFragment.h"
+#include "velox/core/PlanNode.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::exec::test {
+
+class SpatialJoinTest : public OperatorTestBase {
+ public:
+  /* The polygons below have the following relations:
+   * [Legend: = equals, v overlap, / disjoint]
+   *
+   *   A  B  C  D
+   * A =  v  /  /
+   * B v  =  /  /
+   * C /  /  =  /
+   * D /  /  /  =
+   *
+   * Overlap means geometries share interior points (for full definition see
+   * (DE-9IM)[https://en.wikipedia.org/wiki/DE-9IM]), but neither contains the
+   * other.
+   */
+  static constexpr std::string_view kPolygonA =
+      "POLYGON ((0 0, -0.5 2.5, 0 5, 2.5 5.5, 5 5, 5.5 2.5, 5 0, 2.5 -0.5, 0 0))";
+  static constexpr std::string_view kPolygonB =
+      "POLYGON ((4 4, 3.5 7, 4 10, 7 10.5, 10 10, 10.5 7, 10 4, 7 3.5, 4 4))";
+  static constexpr std::string_view kPolygonC =
+      "POLYGON ((15 15, 15 14, 14 14, 14 15, 15 15))";
+  static constexpr std::string_view kPolygonD =
+      "POLYGON ((18 18, 18 19, 19 19, 19 18, 18 18))";
+
+  // A set of points: X in A, Y in A and B, Z in B, W outside of A and B
+  static constexpr std::string_view kPointX = "POINT (1 1)";
+  static constexpr std::string_view kPointY = "POINT (4.5 4.5)";
+  static constexpr std::string_view kPointZ = "POINT (6 6)";
+  static constexpr std::string_view kPointW = "POINT (20 20)";
+  static constexpr std::string_view kPointV = "POINT (15 15)";
+  static constexpr std::string_view kPointS = "POINT (18 18)";
+  static constexpr std::string_view kPointQ = "POINT (28 28)";
+  static constexpr std::string_view kMultipointU = "MULTIPOINT (15 15)";
+  static constexpr std::string_view kMultipointT =
+      "MULTIPOINT (14.5 14.5, 16 16)";
+  static constexpr std::string_view kMultipointR = "MULTIPOINT (15 15, 19 19)";
+
+ protected:
+  void runTest(
+      const std::vector<std::optional<std::string_view>>& probeWkts,
+      const std::vector<std::optional<std::string_view>>& buildWkts,
+      const std::string& predicate,
+      core::JoinType joinType,
+      const std::vector<std::optional<std::string_view>>& expectedLeftWkts,
+      const std::vector<std::optional<std::string_view>>& expectedRightWkts) {
+    runTestWithDrivers(
+        probeWkts,
+        buildWkts,
+        predicate,
+        joinType,
+        expectedLeftWkts,
+        expectedRightWkts,
+        1,
+        false);
+    runTestWithDrivers(
+        probeWkts,
+        buildWkts,
+        predicate,
+        joinType,
+        expectedLeftWkts,
+        expectedRightWkts,
+        1,
+        true);
+    runTestWithDrivers(
+        probeWkts,
+        buildWkts,
+        predicate,
+        joinType,
+        expectedLeftWkts,
+        expectedRightWkts,
+        4,
+        false);
+    runTestWithDrivers(
+        probeWkts,
+        buildWkts,
+        predicate,
+        joinType,
+        expectedLeftWkts,
+        expectedRightWkts,
+        4,
+        true);
+  }
+
+  void runTestWithDrivers(
+      const std::vector<std::optional<std::string_view>>& probeWkts,
+      const std::vector<std::optional<std::string_view>>& buildWkts,
+      const std::string& predicate,
+      core::JoinType joinType,
+      const std::vector<std::optional<std::string_view>>& expectedLeftWkts,
+      const std::vector<std::optional<std::string_view>>& expectedRightWkts,
+      int32_t maxDrivers,
+      bool separateBatches) {
+    std::vector<std::optional<std::string>> probeWktsStr(
+        probeWkts.begin(), probeWkts.end());
+    std::vector<std::optional<std::string>> buildWktsStr(
+        buildWkts.begin(), buildWkts.end());
+    std::vector<std::optional<std::string>> expectedLeftWktsStr(
+        expectedLeftWkts.begin(), expectedLeftWkts.end());
+    std::vector<std::optional<std::string>> expectedRightWktsStr(
+        expectedRightWkts.begin(), expectedRightWkts.end());
+
+    std::vector<RowVectorPtr> probeBatches;
+    std::vector<RowVectorPtr> buildBatches;
+    if (separateBatches) {
+      for (const auto& wkt : probeWktsStr) {
+        probeBatches.push_back(makeRowVector(
+            {"left_g"}, {makeNullableFlatVector<std::string>({wkt})}));
+      }
+      for (const auto& wkt : buildWktsStr) {
+        buildBatches.push_back(makeRowVector(
+            {"right_g"}, {makeNullableFlatVector<std::string>({wkt})}));
+      }
+    } else {
+      probeBatches.push_back(makeRowVector(
+          {"left_g"}, {makeNullableFlatVector<std::string>(probeWktsStr)}));
+      buildBatches.push_back(makeRowVector(
+          {"right_g"}, {makeNullableFlatVector<std::string>(buildWktsStr)}));
+    }
+    auto expectedRows = makeRowVector(
+        {"left_g", "right_g"},
+        {makeNullableFlatVector<std::string>(expectedLeftWktsStr),
+         makeNullableFlatVector<std::string>(expectedRightWktsStr)});
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values(probeBatches)
+            .project({"ST_GeometryFromText(left_g) AS left_g"})
+            .localPartitionRoundRobinRow()
+            .spatialJoin(
+                PlanBuilder(planNodeIdGenerator)
+                    .values(buildBatches)
+                    .project({"ST_GeometryFromText(right_g) AS right_g"})
+                    .localPartition({})
+                    .planNode(),
+                predicate,
+                {"left_g", "right_g"},
+                joinType)
+            .project(
+                {"ST_AsText(left_g) AS left_g",
+                 "ST_AsText(right_g) AS right_g"})
+            .planNode();
+    AssertQueryBuilder builder{plan};
+    builder.maxDrivers(maxDrivers).assertResults({expectedRows});
+  }
+};
+TEST_F(SpatialJoinTest, simpleSpatialJoin) {
+  runTest(
+      {"POINT (1 1)", "POINT (1 2)"},
+      {"POINT (1 1)", "POINT (2 1)"},
+      "ST_Intersects(left_g, right_g)",
+      core::JoinType::kInner,
+      {"POINT (1 1)"},
+      {"POINT (1 1)"});
+  runTest(
+      {"POINT (1 1)", "POINT (1 2)"},
+      {"POINT (1 1)", "POINT (2 1)"},
+      "ST_Intersects(left_g, right_g)",
+      core::JoinType::kLeft,
+      {"POINT (1 1)", "POINT (1 2)"},
+      {"POINT (1 1)", std::nullopt});
+}
+
+TEST_F(SpatialJoinTest, selfSpatialJoin) {
+  std::vector<std::optional<std::string_view>> inputWkts = {
+      kPolygonA, kPolygonB, kPolygonC, kPolygonD};
+  std::vector<std::optional<std::string_view>> leftOutputWkts = {
+      kPolygonA, kPolygonA, kPolygonB, kPolygonB, kPolygonC, kPolygonD};
+  std::vector<std::optional<std::string_view>> rightOutputWkts = {
+      kPolygonA, kPolygonB, kPolygonA, kPolygonB, kPolygonC, kPolygonD};
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Intersects(left_g, right_g)",
+      core::JoinType::kInner,
+      leftOutputWkts,
+      rightOutputWkts);
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Intersects(left_g, right_g)",
+      core::JoinType::kLeft,
+      leftOutputWkts,
+      rightOutputWkts);
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Overlaps(left_g, right_g)",
+      core::JoinType::kInner,
+      {kPolygonA, kPolygonB},
+      {kPolygonB, kPolygonA});
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Intersects(left_g, right_g) AND ST_Overlaps(left_g, right_g)",
+      core::JoinType::kInner,
+      {kPolygonA, kPolygonB},
+      {kPolygonB, kPolygonA});
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Overlaps(left_g, right_g)",
+      core::JoinType::kLeft,
+      {kPolygonA, kPolygonB, kPolygonC, kPolygonD},
+      {kPolygonB, kPolygonA, std::nullopt, std::nullopt});
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Equals(left_g, right_g)",
+      core::JoinType::kInner,
+      inputWkts,
+      inputWkts);
+
+  runTest(
+      inputWkts,
+      inputWkts,
+      "ST_Equals(left_g, right_g)",
+      core::JoinType::kLeft,
+      inputWkts,
+      inputWkts);
+}
+
+TEST_F(SpatialJoinTest, pointPolygonSpatialJoin) {
+  std::vector<std::optional<std::string_view>> polygonWkts = {
+      kPolygonA, kPolygonB, kPolygonC, kPolygonD};
+  std::vector<std::optional<std::string_view>> pointWkts = {
+      kPointX,
+      kPointY,
+      kPointZ,
+      kPointW,
+      kPointV,
+      kPointS,
+      kPointQ,
+      kMultipointU,
+      kMultipointT,
+      kMultipointR};
+
+  std::vector<std::optional<std::string_view>> pointOutputWkts = {
+      kPointX,
+      kPointY,
+      kPointY,
+      kPointZ,
+      kPointV,
+      kPointS,
+      kMultipointU,
+      kMultipointR,
+      kMultipointR,
+      kMultipointT};
+  std::vector<std::optional<std::string_view>> polygonOutputWkts = {
+      kPolygonA,
+      kPolygonA,
+      kPolygonB,
+      kPolygonB,
+      kPolygonC,
+      kPolygonD,
+      kPolygonC,
+      kPolygonC,
+      kPolygonD,
+      kPolygonC};
+  runTest(
+      pointWkts,
+      polygonWkts,
+      "ST_Intersects(left_g, right_g)",
+      core::JoinType::kInner,
+      pointOutputWkts,
+      polygonOutputWkts);
+}
+
+TEST_F(SpatialJoinTest, failOnGroupedExecution) {
+  std::vector<RowVectorPtr> batches{
+      makeRowVector({"wkt"}, {makeFlatVector<std::string>({"POINT(0 0)"})})};
+  core::PlanNodeId groupedScanNodeId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto planFragment =
+      PlanBuilder(planNodeIdGenerator)
+          .values(batches)
+          .capturePlanNodeId(groupedScanNodeId)
+          .project({"ST_GeometryFromText(wkt) AS left_g"})
+          .spatialJoin(
+              PlanBuilder(planNodeIdGenerator)
+                  .values(batches)
+                  .project({"ST_GeometryFromText(wkt) AS right_g"})
+                  .localPartition({})
+                  .planNode(),
+              "ST_Intersects(left_g, right_g)",
+              {"left_g", "right_g"},
+              core::JoinType::kInner)
+          .project(
+              {"ST_AsText(left_g) AS left_g", "ST_AsText(right_g) AS right_g"})
+          .planFragment();
+  planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
+  planFragment.groupedExecutionLeafNodeIds.emplace(groupedScanNodeId);
+  auto task = Task::create(
+      "task-grouped-join",
+      std::move(planFragment),
+      0,
+      core::QueryCtx::create(driverExecutor_.get()),
+      Task::ExecutionMode::kParallel);
+
+  VELOX_ASSERT_THROW(
+      task->start(1), "Spatial joins do not support grouped execution.");
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1213,6 +1213,21 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 
+  /// Add a SpatialJoinNode to join two inputs using spatial join condition.
+  ///
+  /// @param right Right-side input. Typically, to reduce memory usage, the
+  /// smaller input is placed on the right-side.
+  /// @param joinCondition SQL expression as the spatial join condition. Can
+  /// use columns from both probe and build sides of the join.
+  /// @param outputLayout Output layout consisting of columns from probe and
+  /// build sides.
+  /// @param joinType Type of the join: inner (only one supported for now
+  PlanBuilder& spatialJoin(
+      const core::PlanNodePtr& right,
+      const std::string& joinCondition,
+      const std::vector<std::string>& outputLayout,
+      core::JoinType joinType = core::JoinType::kInner);
+
   static core::IndexLookupConditionPtr parseIndexJoinCondition(
       const std::string& joinCondition,
       const RowTypePtr& rowType,


### PR DESCRIPTION
Summary:
Implement a simple version of SpatialJoin that is really just a NLJ in
disguise.  This fills out the operator skeleton in exec and allows us to test
correctness.  We could in theory run spatial queries with these, although they
would be very inefficient.

Later commits will replace the SpatialJoinOperators with more efficient
versions with SpatialIndexes, as well as implement Left Joins.

Differential Revision: D79613518


