### PR TITLE
fix: Remove call to deprecated CUDA function

### DIFF
--- a/velox/experimental/gpu/tests/HashTableTest.cu
+++ b/velox/experimental/gpu/tests/HashTableTest.cu
@@ -710,8 +710,6 @@ void runPartitioned() {
       shuffledKeys.get(),
       tmp.get(),
       tmpSize);
-  CUDA_CHECK_FATAL(
-      cudaDeviceSetSharedMemConfig(cudaSharedMemBankSizeEightByte));
   CUDA_CHECK_FATAL(cudaFuncSetAttribute(
       probePartitioned<kUseTags>,
       cudaFuncAttributeMaxDynamicSharedMemorySize,


### PR DESCRIPTION
Remove call to `cudaDeviceSetSharedMemConfig` which has been deprecated since CUDA 12.4.

This function apparently does nothing on any modern GPU architecture, and only had effect on Kepler, so the call can safely be removed, thus squashing some build warnings when tests are enabled.

https://stackoverflow.com/questions/78211209/cudafuncsetsharedmemconfig-is-deprecated-in-12-4-why
