### PR TITLE
fix: Fix index join lookup flaky tests

### DIFF
--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -18,6 +18,7 @@
 #include "folly/experimental/EventCount.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest-matchers.h"
+#include "velox/common/base/PeriodicStatsReporter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/Connector.h"
@@ -97,9 +98,11 @@ class IndexLookupJoinTest : public IndexLookupJoinTestBase,
     probeType_ = ROW(
         {"t0", "t1", "t2", "t3", "t4", "t5"},
         {BIGINT(), BIGINT(), BIGINT(), BIGINT(), ARRAY(BIGINT()), VARCHAR()});
+    stopPeriodicStatsReporter();
   }
 
   void TearDown() override {
+    startPeriodicStatsReporter({});
     connector::unregisterConnectorFactory(kTestIndexConnectorName);
     connector::unregisterConnector(kTestIndexConnectorName);
     HiveConnectorTestBase::TearDown();
@@ -2373,9 +2376,6 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
 }
 
 TEST_P(IndexLookupJoinTest, barrier) {
-  if (!GetParam().serialExecution) {
-    GTEST_SKIP();
-  }
   SequenceTableData tableData;
   generateIndexTableData({100, 1, 1}, tableData, pool_);
   const int numProbeSplits{5};


### PR DESCRIPTION
Summary: There is race condition in async data cache which might cause real problem. We can't totally avoid it for performance without significant code change. Disable the background stats report for this unit test to prevent.

Differential Revision: D79698667


