### PR TITLE
misc: Remove lazy code option and make it default for ss client

### DIFF
--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -78,9 +78,6 @@ class IndexLookupJoin : public Operator {
   /// the raw data received from the remote storage lookup.
   static inline const std::string kClientLookupResultSize{
       "clientLookupResultSize"};
-  /// The number of lazy decoded result batches.
-  static inline const std::string kClientNumLazyDecodedResultBatches{
-      "clientNumLazyDecodedResultBatches"};
 
  private:
   using LookupResultIter = connector::IndexSource::LookupResultIterator;

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -2357,9 +2357,6 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
   ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientResultProcessTime), 0);
   ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientLookupResultSize), 0);
   ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientLookupResultRawSize), 0);
-  ASSERT_EQ(
-      runtimeStats.count(IndexLookupJoin::kClientNumLazyDecodedResultBatches),
-      0);
   ASSERT_THAT(
       operatorStats.toString(true, true),
       testing::MatchesRegex(".*Runtime stats.*connectorLookupWallNanos:.*"));


### PR DESCRIPTION
Summary: Make lazy decode the default and prevent the potential race condition of concurrent nimble decode which might cause data corruption with prefetch enabled.

Differential Revision: D79705068


