### PR TITLE
fix: Make Spark abs function ansi-compliant

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -2,12 +2,17 @@
 Mathematical Functions
 ======================
 
-.. spark:function:: abs(x) -> [same as x]
+.. spark:function:: abs(x) -> [same as x] (ANSI compliant)
 
-    *ANSI compliant* - Returns the absolute value of ``x``. When ``x`` is negative minimum
+    Returns the absolute value of ``x``. When ``x`` is negative minimum
     value of integral type returns the same value as ``x`` following
     the behavior when Spark ANSI mode is disabled and throws exception
-    when Spark ANSI mode is enabled.
+    when Spark ANSI mode is enabled. ::
+
+        SELECT abs(-42); -- 42
+        SELECT abs(3.14); -- 3.14
+        SELECT abs(-128); -- 128 (with ANSI mode disabled)
+        -- abs(-128) throws overflow exception with ANSI mode enabled for TINYINT
 
 .. spark:function:: acos(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -7,7 +7,7 @@ Mathematical Functions
     Returns the absolute value of ``x``. When ``x`` is negative minimum
     value of integral type returns the same value as ``x`` following
     the behavior when Spark ANSI mode is disabled and throws exception
-    when spark ansi mode is enabled.
+    when Spark ANSI mode is enabled.
 
 .. spark:function:: acos(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -12,7 +12,7 @@ Mathematical Functions
         SELECT abs(-42); -- 42
         SELECT abs(3.14); -- 3.14
         SELECT abs(-128); -- 128 (with ANSI mode disabled)
-        -- abs(-128) throws overflow exception with ANSI mode enabled for TINYINT
+        SELECT abs(-128); throws overflow exception with ANSI mode enabled for TINYINT
 
 .. spark:function:: acos(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -4,7 +4,7 @@ Mathematical Functions
 
 .. spark:function:: abs(x) -> [same as x]
 
-    Returns the absolute value of ``x``. When ``x`` is negative minimum
+    *ANSI compliant* - Returns the absolute value of ``x``. When ``x`` is negative minimum
     value of integral type returns the same value as ``x`` following
     the behavior when Spark ANSI mode is disabled and throws exception
     when Spark ANSI mode is enabled.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -12,8 +12,7 @@ Mathematical Functions
         SELECT abs(-42); -- 42
         SELECT abs(3.14); -- 3.14
         SELECT abs(-128); -- 128 (with ANSI mode disabled)
-        SELECT abs(-128); throws overflow exception with ANSI mode enabled for TINYINT
-
+        SELECT abs(-128); -- Overflow exception (with ANSI mode enabled for TINYINT)
 .. spark:function:: acos(x) -> double
 
     Returns the inverse cosine (a.k.a. arc cosine) of ``x``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -5,8 +5,9 @@ Mathematical Functions
 .. spark:function:: abs(x) -> [same as x]
 
     Returns the absolute value of ``x``. When ``x`` is negative minimum
-    value of integral type, returns the same value as ``x`` following
-    the behavior when Spark ANSI mode is disabled.
+    value of integral type returns the same value as ``x`` following
+    the behavior when Spark ANSI mode is disabled and throws exception
+    when spark ansi mode is enabled.
 
 .. spark:function:: acos(x) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -48,10 +48,10 @@ struct AbsFunction {
     if constexpr (std::is_integral_v<T>) {
       if (FOLLY_UNLIKELY(a == std::numeric_limits<T>::min())) {
         if (ansiEnabled_) {
-          // In ANSI mode, throws an overflow error
+          // In ANSI mode, throws an overflow error.
           VELOX_USER_FAIL("Arithmetic overflow: abs({})", a);
         }
-        // In ANSI off mode, returns the same negative minimum value
+        // In ANSI off mode, returns the same negative minimum value.
         result = a;
         return;
       }

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -32,9 +32,9 @@ namespace facebook::velox::functions::sparksql {
 template <typename TExec>
 struct AbsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
-  
+
   bool ansiEnabled_ = false;
-  
+
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -31,13 +31,11 @@ namespace facebook::velox::functions::sparksql {
 // The abs implementation is used for primitive types except for decimal type.
 template <typename TExec>
 struct AbsFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(TExec);
-
-  template <typename TInput>
+  template <typename T>
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
-      const TInput* /*a*/) {
+      const T* /*a*/) {
     ansiEnabled_ = config.sparkAnsiEnabled();
   }
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -38,14 +38,14 @@ struct AbsFunction {
       const std::vector<TypePtr>& /*inputTypes*/,
       const core::QueryConfig& config,
       const TInput* /*a*/) {
-    ansiEnabled = config.sparkAnsiEnabled();
+    ansiEnabled_ = config.sparkAnsiEnabled();
   }
 
   template <typename T>
   FOLLY_ALWAYS_INLINE Status call(T& result, const T& a) {
     if constexpr (std::is_integral_v<T>) {
       if (FOLLY_UNLIKELY(a == std::numeric_limits<T>::min())) {
-        if (ansiEnabled) {
+        if (ansiEnabled_) {
           // In ANSI mode, returns an overflow error.
           if (threadSkipErrorDetails()) {
             return Status::UserError();
@@ -61,7 +61,8 @@ struct AbsFunction {
     return Status::OK();
   }
 
-  bool ansiEnabled = false;
+ private:
+  bool ansiEnabled_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -48,15 +48,12 @@ struct AbsFunction {
     if constexpr (std::is_integral_v<T>) {
       if (FOLLY_UNLIKELY(a == std::numeric_limits<T>::min())) {
         if (ansiEnabled_) {
-          // In ANSI mode, throw an overflow error
+          // In ANSI mode, throws an overflow error
           VELOX_USER_FAIL("Arithmetic overflow: abs({})", a);
-        } else {
-          // To be compatible with Spark's ANSI off mode, when the input is
-          // negative minimum value, returns the same value as input instead of
-          // throwing an error.
-          result = a;
-          return;
         }
+        // In ANSI off mode, returns the same negative minimum value
+        result = a;
+        return;
       }
     }
     result = std::abs(a);

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -761,6 +761,42 @@ TEST_F(ArithmeticTest, abs) {
       std::numeric_limits<double>::max());
 }
 
+TEST_F(ArithmeticTest, absAnsiMode) {
+  // Enable ANSI mode
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
+
+  // Normal cases should still work
+  EXPECT_EQ(abs<int8_t>(-127), 127);
+  EXPECT_EQ(abs<int16_t>(-32767), 32767);
+  EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
+  EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
+
+  // Minimum values should throw in ANSI mode
+  EXPECT_THROW(
+      abs<int8_t>(std::numeric_limits<int8_t>::min()),
+      VeloxUserError);
+  EXPECT_THROW(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()),
+      VeloxUserError);
+  EXPECT_THROW(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()),
+      VeloxUserError);
+  EXPECT_THROW(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()),
+      VeloxUserError);
+
+  // Floating point should still work normally (no overflow for floats)
+  EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
+  EXPECT_EQ(
+      abs<float>(std::numeric_limits<float>::lowest()),
+      std::numeric_limits<float>::max());
+  EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
+  EXPECT_EQ(
+      abs<double>(std::numeric_limits<double>::lowest()),
+      std::numeric_limits<double>::max());
+}
+
 class LogNTest : public SparkFunctionBaseTest {
  protected:
   static constexpr double kInf = std::numeric_limits<double>::infinity();

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -777,13 +777,13 @@ TEST_F(ArithmeticTest, absMinValueOverflow) {
   queryCtx_->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
-  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
+  VELOX_ASSERT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()), "Arithmetic overflow");
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -778,7 +778,7 @@ TEST_F(ArithmeticTest, absMinValueOverflow) {
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
   VELOX_ASSERT_THROW(
-    abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
+      abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
   VELOX_ASSERT_THROW(
       abs<int16_t>(std::numeric_limits<int16_t>::min()), "Arithmetic overflow");
   VELOX_ASSERT_THROW(

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -774,17 +774,13 @@ TEST_F(ArithmeticTest, absAnsiMode) {
 
   // Minimum values should throw in ANSI mode
   EXPECT_THROW(
-      abs<int8_t>(std::numeric_limits<int8_t>::min()),
-      VeloxUserError);
+      abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int16_t>(std::numeric_limits<int16_t>::min()),
-      VeloxUserError);
+      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int32_t>(std::numeric_limits<int32_t>::min()),
-      VeloxUserError);
+      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int64_t>(std::numeric_limits<int64_t>::min()),
-      VeloxUserError);
+      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
 
   // Floating point should still work normally (no overflow for floats)
   EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -756,7 +756,7 @@ TEST_F(ArithmeticTest, abs) {
 }
 
 TEST_F(ArithmeticTest, absMinValueOverflow) {
-  //Test abs with ANSI off.
+  // Test abs with ANSI off.
   queryCtx_->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSparkAnsiEnabled, "false"}});
 
@@ -773,22 +773,17 @@ TEST_F(ArithmeticTest, absMinValueOverflow) {
       abs<int64_t>(std::numeric_limits<int64_t>::min()),
       std::numeric_limits<int64_t>::min());
 
-  //Test abs with ANSI on.
+  // Test abs with ANSI on.
   queryCtx_->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
+  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int8_t>(std::numeric_limits<int8_t>::min()),
-      VeloxUserError);
+      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int16_t>(std::numeric_limits<int16_t>::min()),
-      VeloxUserError);
+      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int32_t>(std::numeric_limits<int32_t>::min()),
-      VeloxUserError);
-  EXPECT_THROW(
-      abs<int64_t>(std::numeric_limits<int64_t>::min()),
-      VeloxUserError);
+      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <limits>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -773,8 +773,7 @@ TEST_F(ArithmeticTest, absAnsiMode) {
   EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
 
   // Minimum values should throw in ANSI mode
-  EXPECT_THROW(
-      abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
+  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
   EXPECT_THROW(
       abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
   EXPECT_THROW(

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -773,24 +773,16 @@ TEST_F(ArithmeticTest, absAnsiMode) {
   EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
 
   // Minimum values should throw in ANSI mode
-  EXPECT_THROW(
-      abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
-  EXPECT_THROW(
-      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
+  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
+  EXPECT_THROW(abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
+  EXPECT_THROW(abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
+  EXPECT_THROW(abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
 
   // Floating point should still work normally (no overflow for floats)
   EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
-  EXPECT_EQ(
-      abs<float>(std::numeric_limits<float>::lowest()),
-      std::numeric_limits<float>::max());
+  EXPECT_EQ(abs<float>(std::numeric_limits<float>::lowest()),std::numeric_limits<float>::max());
   EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
-  EXPECT_EQ(
-      abs<double>(std::numeric_limits<double>::lowest()),
-      std::numeric_limits<double>::max());
+  EXPECT_EQ(abs<double>(std::numeric_limits<double>::lowest()),std::numeric_limits<double>::max());
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -777,7 +777,8 @@ TEST_F(ArithmeticTest, absMinValueOverflow) {
   queryCtx_->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
-  VELOX_ASSERT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(
+    abs<int8_t>(std::numeric_limits<int8_t>::min()), "Arithmetic overflow");
   VELOX_ASSERT_THROW(
       abs<int16_t>(std::numeric_limits<int16_t>::min()), "Arithmetic overflow");
   VELOX_ASSERT_THROW(

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -767,9 +767,6 @@ TEST_F(ArithmeticTest, absAnsiMode) {
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
   // Normal cases should still work
-  EXPECT_EQ(abs<int8_t>(-127), 127);
-  EXPECT_EQ(abs<int16_t>(-32767), 32767);
-  EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
   EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
 
   // Minimum values should throw in ANSI mode

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -773,16 +773,24 @@ TEST_F(ArithmeticTest, absAnsiMode) {
   EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
 
   // Minimum values should throw in ANSI mode
-  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
-  EXPECT_THROW(abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
-  EXPECT_THROW(abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
-  EXPECT_THROW(abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
+  EXPECT_THROW(
+      abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
+  EXPECT_THROW(
+      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
+  EXPECT_THROW(
+      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
+  EXPECT_THROW(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
 
   // Floating point should still work normally (no overflow for floats)
   EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
-  EXPECT_EQ(abs<float>(std::numeric_limits<float>::lowest()),std::numeric_limits<float>::max());
+  EXPECT_EQ(
+      abs<float>(std::numeric_limits<float>::lowest()),
+      std::numeric_limits<float>::max());
   EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
-  EXPECT_EQ(abs<double>(std::numeric_limits<double>::lowest()),std::numeric_limits<double>::max());
+  EXPECT_EQ(
+      abs<double>(std::numeric_limits<double>::lowest()),
+      std::numeric_limits<double>::max());
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -735,58 +735,60 @@ TEST_F(ArithmeticTest, checkedDivide) {
 }
 
 TEST_F(ArithmeticTest, abs) {
-  EXPECT_EQ(abs<int8_t>(-127), 127);
+  for (const auto& ansiEnabled : {"false", "true"}) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kSparkAnsiEnabled, ansiEnabled}});
+
+    EXPECT_EQ(abs<int8_t>(-127), 127);
+    EXPECT_EQ(abs<int16_t>(-32767), 32767);
+    EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
+    EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
+
+    EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
+    EXPECT_EQ(
+        abs<float>(std::numeric_limits<float>::lowest()),
+        std::numeric_limits<float>::max());
+    EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
+    EXPECT_EQ(
+        abs<double>(std::numeric_limits<double>::lowest()),
+        std::numeric_limits<double>::max());
+  }
+}
+
+TEST_F(ArithmeticTest, absMinValueOverflow) {
+  //Test abs with ANSI off.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kSparkAnsiEnabled, "false"}});
+
   EXPECT_EQ(
       abs<int8_t>(std::numeric_limits<int8_t>::min()),
       std::numeric_limits<int8_t>::min());
-  EXPECT_EQ(abs<int16_t>(-32767), 32767);
   EXPECT_EQ(
       abs<int16_t>(std::numeric_limits<int16_t>::min()),
       std::numeric_limits<int16_t>::min());
-  EXPECT_EQ(abs<int32_t>(-2147483647), 2147483647);
   EXPECT_EQ(
       abs<int32_t>(std::numeric_limits<int32_t>::min()),
       std::numeric_limits<int32_t>::min());
-  EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
   EXPECT_EQ(
       abs<int64_t>(std::numeric_limits<int64_t>::min()),
       std::numeric_limits<int64_t>::min());
-  EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
-  EXPECT_EQ(
-      abs<float>(std::numeric_limits<float>::lowest()),
-      std::numeric_limits<float>::max());
-  EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
-  EXPECT_EQ(
-      abs<double>(std::numeric_limits<double>::lowest()),
-      std::numeric_limits<double>::max());
-}
 
-TEST_F(ArithmeticTest, absAnsiMode) {
-  // Enable ANSI mode
+  //Test abs with ANSI on.
   queryCtx_->testingOverrideConfigUnsafe(
       {{core::QueryConfig::kSparkAnsiEnabled, "true"}});
 
-  // Normal cases should still work
-  EXPECT_EQ(abs<int64_t>(-9223372036854775807), 9223372036854775807);
-
-  // Minimum values should throw in ANSI mode
-  EXPECT_THROW(abs<int8_t>(std::numeric_limits<int8_t>::min()), VeloxUserError);
   EXPECT_THROW(
-      abs<int16_t>(std::numeric_limits<int16_t>::min()), VeloxUserError);
+      abs<int8_t>(std::numeric_limits<int8_t>::min()),
+      VeloxUserError);
   EXPECT_THROW(
-      abs<int32_t>(std::numeric_limits<int32_t>::min()), VeloxUserError);
+      abs<int16_t>(std::numeric_limits<int16_t>::min()),
+      VeloxUserError);
   EXPECT_THROW(
-      abs<int64_t>(std::numeric_limits<int64_t>::min()), VeloxUserError);
-
-  // Floating point should still work normally (no overflow for floats)
-  EXPECT_EQ(abs<float>(-99999.9999f), 99999.9999f);
-  EXPECT_EQ(
-      abs<float>(std::numeric_limits<float>::lowest()),
-      std::numeric_limits<float>::max());
-  EXPECT_EQ(abs<double>(-99999.9999), 99999.9999);
-  EXPECT_EQ(
-      abs<double>(std::numeric_limits<double>::lowest()),
-      std::numeric_limits<double>::max());
+      abs<int32_t>(std::numeric_limits<int32_t>::min()),
+      VeloxUserError);
+  EXPECT_THROW(
+      abs<int64_t>(std::numeric_limits<int64_t>::min()),
+      VeloxUserError);
 }
 
 class LogNTest : public SparkFunctionBaseTest {


### PR DESCRIPTION
This PR supports ansi-compliant behavior for the Spark abs function.
Fixes #14345.

