### PR TITLE
fix: print bucket and key in s3 object already exists error message

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -57,7 +57,8 @@ class S3WriteFile::Impl {
       }
       RECORD_METRIC_VALUE(
           kMetricS3GetObjectRetries, objectMetadata.GetRetryCount());
-      VELOX_CHECK(!objectMetadata.IsSuccess(), "S3 object already exists");
+      VELOX_CHECK(!objectMetadata.IsSuccess(),
+          "S3 object already exists: bucket={}, key={}", bucket_, key_);
     }
 
     // Create bucket if not present.


### PR DESCRIPTION
When I used the TableWrite operator of velox, a logic error caused the same file to be uploaded to the object storage multiple times. S3WriteFile discovered this error, but I found that I could not tell from the log which object was uploaded multiple times. This PR enhances the error printing to deal with this scenario.