### PR TITLE
feat(build): Add support for Fedora

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
         os:
           - {runner: ubuntu-24.04-arm, platform: arm64}
           - {runner: ubuntu-24.04, platform: amd64}
-        target: [ci, pyvelox, ubuntu]
+        target: [ci, pyvelox, ubuntu, fedora]
 
     steps:
       - name: Free Disk Space
@@ -107,7 +107,7 @@ jobs:
           cd "$DIGEST_DIR" || exit 1
           # Add the target for any images that shouldn't be build as multi-platform
           # into the skip list
-          echo "$METADATA" | jq -r 'def skip: ["ubuntu"];
+          echo "$METADATA" | jq -r 'def skip: ["ubuntu", "fedora"];
             . | to_entries[] | .key | split("-")[0] |
             if . as $name | skip | index($name) != null then empty else . end' | \
             while read -r image_name; do

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Install Dependencies
         env:
           VELOX_BUILD_SHARED: "ON"
+          VELOX_ARROW_CMAKE_PATCH: ${{ github.workspace }}/CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
         run: |
           if git diff --name-only HEAD^1 HEAD | grep -q "scripts/setup-"; then
             # Overwrite old setup scripts with changed versions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,10 @@ if(ENABLE_ALL_WARNINGS)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.2.1")
       string(APPEND KNOWN_COMPILER_SPECIFIC_WARNINGS " -Wno-restrict")
     endif()
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
+      string(APPEND KNOWN_COMPILER_SPECIFIC_WARNINGS
+             " -Wno-error=template-id-cdtor")
+    endif()
   endif()
 
   set(KNOWN_WARNINGS

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -114,6 +114,19 @@ group "ubuntu-arm64" {
   targets = []
 }
 
+group "fedora-arm64" {
+  # We don't actually want to build the fedora arm image, this is a trick to simplify CI
+  # Empty targets don't fail the build.
+  targets = []
+}
+
+target "fedora-amd64" {
+  inherits   = ["base", "fedora"]
+  dockerfile = "scripts/docker/fedora.dockerfile"
+  cache-to   = cache-to-arch("fedora", "amd64")
+  cache-from = cache-from-arch("fedora", "amd64")
+}
+
 group "java" {
   # The main work is in the well cached download steps and the shared base stage,
   # so these can easily be run on the same node in ci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,3 +92,12 @@ services:
       args:
         - SPARK_VERSION=3.5.1
       dockerfile: scripts/docker/java.dockerfile
+
+  fedora:
+    extends: base-block
+    image: ghcr.io/facebookincubator/velox-dev:fedora
+    build:
+      dockerfile: scripts/docker/fedora.dockerfile
+      target: fedora
+    environment:
+      VELOX_BUILD_SHARED: "ON"

--- a/scripts/docker/fedora.dockerfile
+++ b/scripts/docker/fedora.dockerfile
@@ -1,0 +1,71 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+########################
+# Stage 1: Base Build  #
+########################
+ARG base=quay.io/fedora/fedora:42-x86_64
+FROM $base AS base-build
+
+COPY scripts/setup-helper-functions.sh /
+COPY scripts/setup-versions.sh /
+COPY scripts/setup-common.sh /
+COPY scripts/setup-centos9.sh /
+COPY scripts/setup-fedora.sh /
+COPY CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch /
+
+ARG VELOX_BUILD_SHARED=ON
+# Building libvelox.so requires folly and gflags to be built shared as well for now
+ENV VELOX_BUILD_SHARED=${VELOX_BUILD_SHARED}
+
+RUN mkdir build
+WORKDIR /build
+
+# We don't want UV symlinks to be copied into the following stages
+ENV UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_INSTALL_DIR=/usr/local/bin \
+    INSTALL_PREFIX=/deps
+
+# CMake 4.0 removed support for cmake minimums of <=3.5 and will fail builds, this overrides it
+ENV CMAKE_POLICY_VERSION_MINIMUM="3.5" \
+    VELOX_ARROW_CMAKE_PATCH=/cmake-compatibility.patch
+
+# Some CMake configs contain the hard coded prefix '/deps', we need to replace that with
+# the future location to avoid build errors in the base-image
+RUN bash /setup-fedora.sh && \
+    find $INSTALL_PREFIX/lib/cmake -type f -name '*.cmake' -exec sed -i 's|/deps/|/usr/local/|g' {} \;
+
+########################
+# Stage 2: Base Image  #
+########################
+FROM $base AS fedora
+
+COPY scripts/setup-helper-functions.sh /
+COPY scripts/setup-versions.sh /
+COPY scripts/setup-common.sh /
+COPY scripts/setup-centos9.sh /
+COPY scripts/setup-fedora.sh /
+
+# This way it's on the PATH and doesn't clash with the version installed in manylinux
+ENV UV_TOOL_BIN_DIR=/usr/local/bin \
+    UV_INSTALL_DIR=/usr/local/bin
+
+RUN /bin/bash -c 'source /setup-fedora.sh && \
+      install_build_prerequisites && \
+      install_velox_deps_from_dnf && \
+      dnf clean all'
+
+RUN ln -s $(which python3) /usr/bin/python
+
+COPY --from=base-build /deps /usr/local

--- a/scripts/setup-fedora.sh
+++ b/scripts/setup-fedora.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# shellcheck source-path=SCRIPT_DIR
+
+# This script documents setting up a Fedora host for Velox
+# development.  Running it should make you ready to compile.
+#
+# Environment variables:
+# * INSTALL_PREREQUISITES="N": Skip installation of packages for build.
+# * PROMPT_ALWAYS_RESPOND="n": Automatically respond to interactive prompts.
+#     Use "n" to never wipe directories.
+#
+# You can also run individual functions below by specifying them as arguments:
+# $ scripts/setup-fedora.sh install_googletest install_fmt
+#
+
+set -efx -o pipefail
+# Some of the packages must be build with the same compiler flags
+# so that some low level types are the same size. Also, disable warnings.
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+source "$SCRIPT_DIR"/setup-centos9.sh
+
+# Install packages required for build.
+function install_build_prerequisites {
+  dnf update -y
+  dnf_install dnf-plugins-core # For ccache, ninja
+  dnf_install autoconf automake ccache git g++-14 libtool \
+    ninja-build python3-pip python3-devel wget which
+
+  # Set up gcc alternatives
+  sudo alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 \
+    --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+    --slave /usr/bin/gcov gcov /usr/bin/gcov-14 \
+    --slave /usr/bin/gcc-ar gcc-ar /usr/bin/gcc-ar-14 \
+    --slave /usr/bin/gcc-ranlib gcc-ranlib /usr/bin/gcc-ranlib-14 \
+    --slave /usr/bin/gcc-nm gcc-nm /usr/bin/gcc-nm-14
+
+  install_uv
+  uv_install cmake
+
+  if [[ ${USE_CLANG} != "false" ]]; then
+    install_clang15
+  fi
+}
+
+(return 2>/dev/null) && return # If script was sourced, don't run commands.
+
+(
+  if [[ $# -ne 0 ]]; then
+    if [[ ${USE_CLANG} != "false" ]]; then
+      export CC=/usr/bin/clang-15
+      export CXX=/usr/bin/clang++-15
+    else
+      # Activate gcc 14
+      export CXX=/usr/bin/gcc-14
+      export CXX=/usr/bin/g++-14
+      set -u
+    fi
+
+    for cmd in "$@"; do
+      run_and_time "${cmd}"
+    done
+    echo "All specified dependencies installed!"
+  else
+    if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
+      echo "Installing build dependencies"
+      run_and_time install_build_prerequisites
+    else
+      echo "Skipping installation of build dependencies since INSTALL_PREREQUISITES is not set"
+    fi
+    if [[ ${USE_CLANG} != "false" ]]; then
+      export CC=/usr/bin/clang-15
+      export CXX=/usr/bin/clang++-15
+    else
+      # Activate gcc 14
+      export CXX=/usr/bin/gcc-14
+      export CXX=/usr/bin/g++-14
+      set -u
+    fi
+    install_velox_deps
+    echo "All dependencies for Velox installed!"
+    if [[ ${USE_CLANG} != "false" ]]; then
+      echo "To use clang for the Velox build set the CC and CXX environment variables in your session."
+      echo "  export CC=/usr/bin/clang-15"
+      echo "  export CXX=/usr/bin/clang++-15"
+    fi
+    dnf clean all
+  fi
+)

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -232,7 +232,7 @@ function wget_and_untar {
   # Use ${VAR:+"$VAR"} pattern to only include CURL_OPTIONS if it's not empty
   # as curl >=8.6.0 rejects empty arguments
   curl ${CURL_OPTIONS:+${CURL_OPTIONS}} -L "${URL}" -o "$2".tar.gz
-  tar -xz --strip-components=1 -f "$2".tar.gz
+  tar -xz --strip-components=1 --no-same-owner -f "$2".tar.gz
   popd || exit
   popd || exit
 }

--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -422,11 +422,15 @@ TEST_F(FlatMapVectorTest, sortedKeyIndices) {
 
 TEST_F(FlatMapVectorTest, toString) {
   auto vector = maker_.flatMapVectorNullable<int64_t, int64_t>({
-      {{}},
-      {std::nullopt},
-      {{{1, 0}}},
-      {{{1, 1}, {2, std::nullopt}}},
-      {{{0, 0}, {1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}}},
+      std::optional{std::vector<std::pair<int64_t, std::optional<int64_t>>>{}},
+      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+          std::nullopt},
+      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+          {{1, {0}}}},
+      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+          {{1, {1}}, {2, {std::nullopt}}}},
+      std::optional<std::vector<std::pair<int64_t, std::optional<int64_t>>>>{
+          {{0, {0}}, {1, {1}}, {2, {2}}, {3, {3}}, {4, {4}}, {5, {5}}}},
   });
 
   EXPECT_EQ(


### PR DESCRIPTION
Adds support for fedora images . Certain users use fedora as their base image internally at Meta, adding this docker image plus CI support will ensure that we always maintain compatibility here.

Fixes #14502

Co-authored-by: @assignUser 