### PR TITLE
refactor: Align toString() output for typed and untyped expressions

### DIFF
--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -609,7 +609,7 @@ TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {
   // Change these once HUGEINT filter merge is fixed.
   ASSERT_TRUE(remaining);
   ASSERT_EQ(
-      remaining->toString(), "not(lt(ROW[\"c2\"],cast 0 as DECIMAL(20, 0)))");
+      remaining->toString(), "not(lt(ROW[\"c2\"],cast(0 as DECIMAL(20, 0))))");
 }
 
 TEST_F(HiveConnectorTest, prestoTableSampling) {

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -43,8 +43,8 @@ TEST(DuckParserTest, constants) {
   EXPECT_EQ("-303.1234", parseExpr("-303.1234")->toString());
 
   // Strings.
-  EXPECT_EQ("\"\"", parseExpr("''")->toString());
-  EXPECT_EQ("\"hello world\"", parseExpr("'hello world'")->toString());
+  EXPECT_EQ("", parseExpr("''")->toString());
+  EXPECT_EQ("hello world", parseExpr("'hello world'")->toString());
 
   // Nulls
   EXPECT_EQ("null", parseExpr("NULL")->toString());
@@ -57,16 +57,15 @@ TEST(DuckParserTest, constants) {
 
 TEST(DuckParserTest, arrays) {
   // Literal arrays with different types.
-  EXPECT_EQ("[1,2,-33]", parseExpr("ARRAY[1, 2, -33]")->toString());
+  EXPECT_EQ("{1, 2, -33}", parseExpr("ARRAY[1, 2, -33]")->toString());
   EXPECT_EQ(
-      "[1.99,-8.3,0.878]", parseExpr("ARRAY[1.99, -8.3, 0.878]")->toString());
+      "{1.99, -8.3, 0.878}", parseExpr("ARRAY[1.99, -8.3, 0.878]")->toString());
   EXPECT_EQ(
-      "[\"asd\",\"qwe\",\"ewqq\"]",
-      parseExpr("ARRAY['asd', 'qwe', 'ewqq']")->toString());
-  EXPECT_EQ("[null,1]", parseExpr("ARRAY[NULL, 1]")->toString());
+      "{asd, qwe, ewqq}", parseExpr("ARRAY['asd', 'qwe', 'ewqq']")->toString());
+  EXPECT_EQ("{null, 1}", parseExpr("ARRAY[NULL, 1]")->toString());
 
   // Empty array.
-  EXPECT_EQ("[]", parseExpr("ARRAY[]")->toString());
+  EXPECT_EQ("<empty>", parseExpr("ARRAY[]")->toString());
 
   // Expressions with variables and without.
   EXPECT_EQ(
@@ -92,8 +91,7 @@ TEST(DuckParserTest, variables) {
 
 TEST(DuckParserTest, functions) {
   EXPECT_EQ("avg(\"col1\")", parseExpr("avg(col1)")->toString());
-  EXPECT_EQ(
-      "func(1,3.4,\"str\")", parseExpr("func(1, 3.4, 'str')")->toString());
+  EXPECT_EQ("func(1,3.4,str)", parseExpr("func(1, 3.4, 'str')")->toString());
 
   // Nested calls.
   EXPECT_EQ(
@@ -172,11 +170,10 @@ TEST(DuckParserTest, subscript) {
       "subscript(\"col\",plus(10,99))", parseExpr("col[10 + 99]")->toString());
   EXPECT_EQ("subscript(\"m1\",34)", parseExpr("m1[34]")->toString());
   EXPECT_EQ(
-      "subscript(\"m2\",\"key str\")", parseExpr("m2['key str']")->toString());
+      "subscript(\"m2\",key str)", parseExpr("m2['key str']")->toString());
 
   EXPECT_EQ(
-      "subscript(func(),\"key str\")",
-      parseExpr("func()['key str']")->toString());
+      "subscript(func(),key str)", parseExpr("func()['key str']")->toString());
 }
 
 TEST(DuckParserTest, coalesce) {
@@ -187,49 +184,50 @@ TEST(DuckParserTest, coalesce) {
 }
 
 TEST(DuckParserTest, in) {
-  EXPECT_EQ("in(\"col1\",[1,2,3])", parseExpr("col1 in (1, 2, 3)")->toString());
   EXPECT_EQ(
-      "in(\"col1\",[1,2,null,3])",
+      "in(\"col1\",{1, 2, 3})", parseExpr("col1 in (1, 2, 3)")->toString());
+  EXPECT_EQ(
+      "in(\"col1\",{1, 2, null, 3})",
       parseExpr("col1 in (1, 2, null, 3)")->toString());
   EXPECT_EQ(
-      "in(\"col1\",[\"a\",\"b\",\"c\"])",
+      "in(\"col1\",{a, b, c})",
       parseExpr("col1 in ('a', 'b', 'c')")->toString());
   EXPECT_EQ(
-      "in(\"col1\",[\"a\",null,\"b\",\"c\"])",
+      "in(\"col1\",{a, null, b, c})",
       parseExpr("col1 in ('a', null, 'b', 'c')")->toString());
 }
 
-TEST(DuckParserTest, notin) {
+TEST(DuckParserTest, notIn) {
   EXPECT_EQ(
-      "not(in(\"col1\",[1,2,3]))",
+      "not(in(\"col1\",{1, 2, 3}))",
       parseExpr("col1 not in (1, 2, 3)")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[1,2,3]))",
+      "not(in(\"col1\",{1, 2, 3}))",
       parseExpr("not(col1 in (1, 2, 3))")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[1,2,null,3]))",
+      "not(in(\"col1\",{1, 2, null, 3}))",
       parseExpr("col1 not in (1, 2, null, 3)")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[1,2,null,3]))",
+      "not(in(\"col1\",{1, 2, null, 3}))",
       parseExpr("not(col1 in (1, 2, null, 3))")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[\"a\",\"b\",\"c\"]))",
+      "not(in(\"col1\",{a, b, c}))",
       parseExpr("col1 not in ('a', 'b', 'c')")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[\"a\",\"b\",\"c\"]))",
+      "not(in(\"col1\",{a, b, c}))",
       parseExpr("not(col1 in ('a', 'b', 'c'))")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[\"a\",null,\"b\",\"c\"]))",
+      "not(in(\"col1\",{a, null, b, c}))",
       parseExpr("col1 not in ('a', null, 'b', 'c')")->toString());
 
   EXPECT_EQ(
-      "not(in(\"col1\",[\"a\",null,\"b\",\"c\"]))",
+      "not(in(\"col1\",{a, null, b, c}))",
       parseExpr("not(col1 in ('a', null, 'b', 'c'))")->toString());
 }
 
@@ -334,36 +332,34 @@ TEST(DuckParserTest, intervalYearMonth) {
 }
 
 TEST(DuckParserTest, cast) {
+  EXPECT_EQ("cast(1 as BIGINT)", parseExpr("cast('1' as bigint)")->toString());
   EXPECT_EQ(
-      "cast(\"1\", BIGINT)", parseExpr("cast('1' as bigint)")->toString());
+      "cast(0.99 as INTEGER)", parseExpr("cast(0.99 as integer)")->toString());
   EXPECT_EQ(
-      "cast(0.99, INTEGER)", parseExpr("cast(0.99 as integer)")->toString());
+      "cast(0.99 as SMALLINT)",
+      parseExpr("cast(0.99 as smallint)")->toString());
   EXPECT_EQ(
-      "cast(0.99, SMALLINT)", parseExpr("cast(0.99 as smallint)")->toString());
+      "cast(0.99 as TINYINT)", parseExpr("cast(0.99 as tinyint)")->toString());
+  EXPECT_EQ("cast(1 as DOUBLE)", parseExpr("cast(1 as double)")->toString());
   EXPECT_EQ(
-      "cast(0.99, TINYINT)", parseExpr("cast(0.99 as tinyint)")->toString());
-  EXPECT_EQ("cast(1, DOUBLE)", parseExpr("cast(1 as double)")->toString());
+      "cast(\"col1\" as REAL)", parseExpr("cast(col1 as real)")->toString());
   EXPECT_EQ(
-      "cast(\"col1\", REAL)", parseExpr("cast(col1 as real)")->toString());
+      "cast(\"col1\" as REAL)", parseExpr("cast(col1 as float)")->toString());
   EXPECT_EQ(
-      "cast(\"col1\", REAL)", parseExpr("cast(col1 as float)")->toString());
+      "cast(0.99 as VARCHAR)", parseExpr("cast(0.99 as string)")->toString());
   EXPECT_EQ(
-      "cast(0.99, VARCHAR)", parseExpr("cast(0.99 as string)")->toString());
+      "cast(0.99 as VARCHAR)", parseExpr("cast(0.99 as varchar)")->toString());
+  EXPECT_EQ("abc", parseExpr("cast('abc' as varbinary)")->toString());
   EXPECT_EQ(
-      "cast(0.99, VARCHAR)", parseExpr("cast(0.99 as varchar)")->toString());
-  // Cast varchar to varbinary produces a varbinary value which is serialized
-  // using base64 encoding.
-  EXPECT_EQ("\"YWJj\"", parseExpr("cast('abc' as varbinary)")->toString());
-  EXPECT_EQ(
-      "cast(\"str_col\", TIMESTAMP)",
+      "cast(\"str_col\" as TIMESTAMP)",
       parseExpr("cast(str_col as timestamp)")->toString());
 
   EXPECT_EQ(
-      "cast(\"str_col\", DATE)",
+      "cast(\"str_col\" as DATE)",
       parseExpr("cast(str_col as date)")->toString());
 
   EXPECT_EQ(
-      "cast(\"str_col\", INTERVAL DAY TO SECOND)",
+      "cast(\"str_col\" as INTERVAL DAY TO SECOND)",
       parseExpr("cast(str_col as interval day to second)")->toString());
 
   // Unsupported casts for now.
@@ -371,39 +367,39 @@ TEST(DuckParserTest, cast) {
 
   // Complex types.
   EXPECT_EQ(
-      "cast(\"c0\", ARRAY<BIGINT>)", parseExpr("c0::bigint[]")->toString());
+      "cast(\"c0\" as ARRAY<BIGINT>)", parseExpr("c0::bigint[]")->toString());
   EXPECT_EQ(
-      "cast(\"c0\", ARRAY<BIGINT>)",
+      "cast(\"c0\" as ARRAY<BIGINT>)",
       parseExpr("cast(c0 as bigint[])")->toString());
 
   EXPECT_EQ(
-      "cast(\"c0\", MAP<VARCHAR,BIGINT>)",
+      "cast(\"c0\" as MAP<VARCHAR,BIGINT>)",
       parseExpr("c0::map(varchar, bigint)")->toString());
   EXPECT_EQ(
-      "cast(\"c0\", MAP<VARCHAR,BIGINT>)",
+      "cast(\"c0\" as MAP<VARCHAR,BIGINT>)",
       parseExpr("cast(c0 as map(varchar, bigint))")->toString());
 
   EXPECT_EQ(
-      "cast(\"c0\", ROW<a:BIGINT,b:REAL,c:VARCHAR>)",
+      "cast(\"c0\" as ROW<a:BIGINT,b:REAL,c:VARCHAR>)",
       parseExpr("c0::struct(a bigint, b real, c varchar)")->toString());
   EXPECT_EQ(
-      "cast(\"c0\", ROW<a:BIGINT,b:REAL,c:VARCHAR>)",
+      "cast(\"c0\" as ROW<a:BIGINT,b:REAL,c:VARCHAR>)",
       parseExpr("cast(c0 as struct(a bigint, b real, c varchar))")->toString());
 }
 
 TEST(DuckParserTest, castToJson) {
   registerJsonType();
-  EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as json)")->toString());
-  EXPECT_EQ("cast(\"c0\", JSON)", parseExpr("cast(c0 as JSON)")->toString());
+  EXPECT_EQ("cast(\"c0\" as JSON)", parseExpr("cast(c0 as json)")->toString());
+  EXPECT_EQ("cast(\"c0\" as JSON)", parseExpr("cast(c0 as JSON)")->toString());
 }
 
 TEST(DuckParserTest, castToTimestampWithTimeZone) {
   registerTimestampWithTimeZoneType();
   EXPECT_EQ(
-      "cast(\"c0\", TIMESTAMP WITH TIME ZONE)",
+      "cast(\"c0\" as TIMESTAMP WITH TIME ZONE)",
       parseExpr("cast(c0 as timestamp with time zone)")->toString());
   EXPECT_EQ(
-      "cast(\"c0\", TIMESTAMP WITH TIME ZONE)",
+      "cast(\"c0\" as TIMESTAMP WITH TIME ZONE)",
       parseExpr("cast(c0 as TIMESTAMP WITH TIME ZONE)")->toString());
 }
 
@@ -434,7 +430,7 @@ TEST(DuckParserTest, switchCase) {
       parseExpr("case when a > 0 then 1 when a < 0 then -1end")->toString());
 
   EXPECT_EQ(
-      "switch(eq(\"a\",1),\"x\",eq(\"a\",5),\"y\",\"z\")",
+      "switch(eq(\"a\",1),x,eq(\"a\",5),y,z)",
       parseExpr("case a when 1 then 'x' when 5 then 'y' else 'z' end")
           ->toString());
 }
@@ -475,24 +471,23 @@ TEST(DuckParserTest, alias) {
       "gt(\"a\",\"b\") AS result", parseExpr("a > b AS result")->toString());
   EXPECT_EQ("2 AS multiplier", parseExpr("2 AS multiplier")->toString());
   EXPECT_EQ(
-      "cast(\"a\", DOUBLE) AS a_double",
+      "cast(\"a\" as DOUBLE) AS a_double",
       parseExpr("cast(a AS DOUBLE) AS a_double")->toString());
   EXPECT_EQ("\"a\" AS b", parseExpr("a AS b")->toString());
 }
 
 TEST(DuckParserTest, like) {
-  EXPECT_EQ("like(\"name\",\"%b%\")", parseExpr("name LIKE '%b%'")->toString());
+  EXPECT_EQ("like(\"name\",%b%)", parseExpr("name LIKE '%b%'")->toString());
   EXPECT_EQ(
-      "like(\"name\",\"%#_%\",\"#\")",
+      "like(\"name\",%#_%,#)",
       parseExpr("name LIKE '%#_%' ESCAPE '#'")->toString());
 }
 
 TEST(DuckParserTest, notLike) {
   EXPECT_EQ(
-      "not(like(\"name\",\"%b%\"))",
-      parseExpr("name NOT LIKE '%b%'")->toString());
+      "not(like(\"name\",%b%))", parseExpr("name NOT LIKE '%b%'")->toString());
   EXPECT_EQ(
-      "not(like(\"name\",\"%#_%\",\"#\"))",
+      "not(like(\"name\",%#_%,#))",
       parseExpr("name NOT LIKE '%#_%' ESCAPE '#'")->toString());
 }
 
@@ -680,13 +675,13 @@ TEST(DuckParserTest, parseWithPrefix) {
   ParseOptions options;
   options.functionPrefix = "prefix.";
   EXPECT_EQ(
-      "prefix.in(\"col1\",[1,2,3])",
+      "prefix.in(\"col1\",{1, 2, 3})",
       parseExpr("col1 in (1, 2, 3)", options)->toString());
   EXPECT_EQ(
-      "prefix.like(\"name\",\"%b%\")",
+      "prefix.like(\"name\",%b%)",
       parseExpr("name LIKE '%b%'", options)->toString());
   EXPECT_EQ(
-      "prefix.not(prefix.like(\"name\",\"%b%\"))",
+      "prefix.not(prefix.like(\"name\",%b%))",
       parseExpr("name NOT LIKE '%b%'", options)->toString());
 
   // Arithmetic operators.
@@ -742,7 +737,7 @@ TEST(DuckParserTest, parseWithPrefix) {
   EXPECT_EQ(
       "coalesce(null,0)", parseExpr("coalesce(NULL, 0)", options)->toString());
   EXPECT_EQ(
-      "cast(\"1\", BIGINT)",
+      "cast(1 as BIGINT)",
       parseExpr("cast('1' as bigint)", options)->toString());
   EXPECT_EQ(
       "try(prefix.plus(\"c0\",\"c1\"))",

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -75,16 +75,16 @@ TEST_F(PlanNodeToStringTest, recursive) {
 
 TEST_F(PlanNodeToStringTest, detailed) {
   ASSERT_EQ(
-      "-- Project[4][expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n",
+      "-- Project[4][expressions: (out3:BIGINT, plus(cast(ROW[\"out1\"] as BIGINT),10))] -> out3:BIGINT\n",
       plan_->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, recursiveAndDetailed) {
   ASSERT_EQ(
-      "-- Project[4][expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
-      "  -- Filter[3][expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)] -> out1:SMALLINT, out2:BIGINT\n"
-      "    -- Project[2][expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))] -> out1:SMALLINT, out2:BIGINT\n"
-      "      -- Filter[1][expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
+      "-- Project[4][expressions: (out3:BIGINT, plus(cast(ROW[\"out1\"] as BIGINT),10))] -> out3:BIGINT\n"
+      "  -- Filter[3][expression: lt(mod(cast(ROW[\"out1\"] as BIGINT),10),8)] -> out1:SMALLINT, out2:BIGINT\n"
+      "    -- Project[2][expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast(ROW[\"c0\"] as BIGINT),100),mod(cast(ROW[\"c1\"] as BIGINT),50)))] -> out1:SMALLINT, out2:BIGINT\n"
+      "      -- Filter[1][expression: lt(mod(cast(ROW[\"c0\"] as BIGINT),10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
       "        -- Values[0][5 rows in 1 vectors] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n",
       plan_->toString(true, true));
 }
@@ -102,7 +102,7 @@ TEST_F(PlanNodeToStringTest, withContext) {
       plan_->toString(false, false, addContext));
 
   ASSERT_EQ(
-      "-- Project[4][expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
+      "-- Project[4][expressions: (out3:BIGINT, plus(cast(ROW[\"out1\"] as BIGINT),10))] -> out3:BIGINT\n"
       "   Context for 4\n",
       plan_->toString(true, false, addContext));
 
@@ -120,13 +120,13 @@ TEST_F(PlanNodeToStringTest, withContext) {
       plan_->toString(false, true, addContext));
 
   ASSERT_EQ(
-      "-- Project[4][expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
+      "-- Project[4][expressions: (out3:BIGINT, plus(cast(ROW[\"out1\"] as BIGINT),10))] -> out3:BIGINT\n"
       "   Context for 4\n"
-      "  -- Filter[3][expression: lt(mod(cast ROW[\"out1\"] as BIGINT,10),8)] -> out1:SMALLINT, out2:BIGINT\n"
+      "  -- Filter[3][expression: lt(mod(cast(ROW[\"out1\"] as BIGINT),10),8)] -> out1:SMALLINT, out2:BIGINT\n"
       "     Context for 3\n"
-      "    -- Project[2][expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast ROW[\"c0\"] as BIGINT,100),mod(cast ROW[\"c1\"] as BIGINT,50)))] -> out1:SMALLINT, out2:BIGINT\n"
+      "    -- Project[2][expressions: (out1:SMALLINT, ROW[\"c0\"]), (out2:BIGINT, plus(mod(cast(ROW[\"c0\"] as BIGINT),100),mod(cast(ROW[\"c1\"] as BIGINT),50)))] -> out1:SMALLINT, out2:BIGINT\n"
       "       Context for 2\n"
-      "      -- Filter[1][expression: lt(mod(cast ROW[\"c0\"] as BIGINT,10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
+      "      -- Filter[1][expression: lt(mod(cast(ROW[\"c0\"] as BIGINT),10),9)] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
       "         Context for 1\n"
       "        -- Values[0][5 rows in 1 vectors] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT\n"
       "           Context for 0\n",
@@ -148,7 +148,7 @@ TEST_F(PlanNodeToStringTest, withMultiLineContext) {
       plan_->toString(false, false, addContext));
 
   ASSERT_EQ(
-      "-- Project[4][expressions: (out3:BIGINT, plus(cast ROW[\"out1\"] as BIGINT,10))] -> out3:BIGINT\n"
+      "-- Project[4][expressions: (out3:BIGINT, plus(cast(ROW[\"out1\"] as BIGINT),10))] -> out3:BIGINT\n"
       "   Context for 4: line 1\n"
       "   Context for 4: line 2\n",
       plan_->toString(true, false, addContext));

--- a/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToSummaryStringTest.cpp
@@ -77,7 +77,7 @@ TEST_F(PlanNodeToSummaryStringTest, basic) {
       "        expressions: call: 8, cast: 2, constant: 5, field: 3\n"
       "        functions: and: 2, cardinality: 1, gt: 3, plus: 1, subscript: 1\n"
       "        constants: BIGINT: 5\n"
-      "        filter: and(and(gt(cast ROW[\"a\"] as BIGINT,10),gt(cardinal...\n"
+      "        filter: and(and(gt(cast(ROW[\"a\"] as BIGINT),10),gt(cardina...\n"
       "    -- TableScan[0]: 3 fields: a INTEGER, b ARRAY, c MAP\n"
       "          table: hive_table\n",
       plan->toSummaryString());
@@ -88,15 +88,15 @@ TEST_F(PlanNodeToSummaryStringTest, basic) {
       "      functions: plus: 3, subscript: 6\n"
       "      constants: BIGINT: 9\n"
       "      projections: 7 out of 7\n"
-      "         p0: plus(cast ROW[\"a\"] as BIGINT,1)\n"
-      "         p1: subscript(ROW[\"b\"],cast 1 as INTEGER)\n"
+      "         p0: plus(cast(ROW[\"a\"] as BIGINT),1)\n"
+      "         p1: subscript(ROW[\"b\"],cast(1 as INTEGER))\n"
       "         ... 5 more\n"
       "      dereferences: 0 out of 7\n"
       "  -- Filter[1]: 3 fields: a INTEGER, b ARRAY(BIGINT), c MAP(TINYINT, BIGINT)\n"
       "        expressions: call: 8, cast: 2, constant: 5, field: 3\n"
       "        functions: and: 2, cardinality: 1, gt: 3, plus: 1, subscript: 1\n"
       "        constants: BIGINT: 5\n"
-      "        filter: and(and(gt(cast ROW[\"a\"] as BIGINT,10),gt(cardinal...\n"
+      "        filter: and(and(gt(cast(ROW[\"a\"] as BIGINT),10),gt(cardina...\n"
       "    -- TableScan[0]: 3 fields: a INTEGER, b ARRAY(BIGINT), c MAP(TINYINT, BIGINT)\n"
       "          table: hive_table\n",
       plan->toSummaryString({

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -49,7 +49,11 @@ std::string CallExpr::toString() const {
 
 std::string CastExpr::toString() const {
   return appendAliasIfExists(
-      "cast(" + input()->toString() + ", " + type_->toString() + ")");
+      "cast(" + input()->toString() + " as " + type_->toString() + ")");
+}
+
+std::string ConstantExpr::toString() const {
+  return appendAliasIfExists(value_.toStringAsVector(type_));
 }
 
 std::string LambdaExpr::toString() const {

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -89,9 +89,7 @@ class ConstantExpr : public IExpr,
         type_{std::move(type)},
         value_{std::move(value)} {}
 
-  std::string toString() const override {
-    return appendAliasIfExists(variant{value_}.toJson(type_));
-  }
+  std::string toString() const override;
 
   const variant& value() const {
     return value_;

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -54,8 +54,8 @@ std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
 }
 } // namespace
 
-std::string DecimalUtil::toString(int128_t value, const TypePtr& type) {
-  auto [precision, scale] = getDecimalPrecisionScale(*type);
+std::string DecimalUtil::toString(int128_t value, const Type& type) {
+  auto [precision, scale] = getDecimalPrecisionScale(type);
   return formatDecimal(scale, value);
 }
 

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -102,7 +102,12 @@ class DecimalUtil {
   }
 
   /// Helper function to convert a decimal value to string.
-  static std::string toString(int128_t value, const TypePtr& type);
+  static std::string toString(int128_t value, const Type& type);
+
+  // TODO Remove.
+  static std::string toString(int128_t value, const TypePtr& type) {
+    return toString(value, *type);
+  }
 
   template <typename T>
   inline static void fillDecimals(

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -437,6 +437,10 @@ class Variant {
   /// Returns a string of the Variant value.
   std::string toString(const TypePtr& type) const;
 
+  /// Returns a string representation identical to
+  /// BaseVector::createConstant(type, *this)->toString(0).
+  std::string toStringAsVector(const TypePtr& type) const;
+
   folly::dynamic serialize() const;
 
   static Variant create(const folly::dynamic& obj);

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -28,35 +28,6 @@
 
 namespace facebook::velox {
 
-std::string ArrayVectorBase::stringifyTruncatedElementList(
-    vector_size_t size,
-    const std::function<void(std::stringstream&, vector_size_t)>&
-        stringifyElement,
-    vector_size_t limit) {
-  if (size == 0) {
-    return "<empty>";
-  }
-
-  VELOX_CHECK_GT(limit, 0);
-
-  const vector_size_t limitedSize = std::min(size, limit);
-
-  std::stringstream out;
-  out << "{";
-  for (vector_size_t i = 0; i < limitedSize; ++i) {
-    if (i > 0) {
-      out << ", ";
-    }
-    stringifyElement(out, i);
-  }
-
-  if (size > limitedSize) {
-    out << ", ..." << (size - limitedSize) << " more";
-  }
-  out << "}";
-  return out.str();
-}
-
 // static
 std::shared_ptr<RowVector> RowVector::createEmpty(
     std::shared_ptr<const Type> type,
@@ -413,7 +384,7 @@ std::string RowVector::deprecatedToString(
     return std::string(BaseVector::kNullValueString);
   }
 
-  return ArrayVectorBase::stringifyTruncatedElementList(
+  return stringifyTruncatedElementList(
       children_.size(),
       [&](auto& out, auto i) {
         out << (children_[i] ? children_[i]->toString(index) : "<not set>");

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -396,19 +396,6 @@ struct ArrayVectorBase : BaseVector {
   /// buffers are mutable (e.g. singly referenced).
   void ensureNullRowsEmpty();
 
-  /// Return a string representation of a limited number of elements at the
-  /// start of the array or map.
-  ///
-  /// @param size Total number of elements.
-  /// @param stringifyElement Function to call to append individual elements.
-  /// Will be called up to 'limit' times.
-  /// @param limit Maximum number of elements to include in the result.
-  static std::string stringifyTruncatedElementList(
-      vector_size_t size,
-      const std::function<void(std::stringstream&, vector_size_t)>&
-          stringifyElement,
-      vector_size_t limit = 5);
-
  protected:
   ArrayVectorBase(
       velox::memory::MemoryPool* pool,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -347,7 +347,7 @@ class ConstantVector final : public SimpleVector<T> {
     if (isNull_) {
       return std::string(BaseVector::kNullValueString);
     } else {
-      return SimpleVector<T>::valueToString(BaseVector::type(), value());
+      return BaseVector::type()->template valueToString<T>(value());
     }
   }
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -244,36 +244,13 @@ class SimpleVector : public BaseVector {
 
   using BaseVector::toString;
 
-  static std::string valueToString(const TypePtr& type, T value) {
-    if constexpr (std::is_same_v<T, bool>) {
-      return value ? "true" : "false";
-    } else if constexpr (std::is_same_v<T, std::shared_ptr<void>>) {
-      return "<opaque>";
-    } else if constexpr (
-        std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
-      if (type->isDecimal()) {
-        return DecimalUtil::toString(value, type);
-      } else {
-        return velox::to<std::string>(value);
-      }
-    } else if constexpr (std::is_same_v<T, int32_t>) {
-      if (type->isDate()) {
-        return DATE()->toString(value);
-      } else {
-        return velox::to<std::string>(value);
-      }
-    } else {
-      return velox::to<std::string>(value);
-    }
-  }
-
   std::string toString(vector_size_t index) const override {
     VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
     std::stringstream out;
     if (isNullAt(index)) {
       out << kNullValueString;
     } else {
-      out << valueToString(type(), valueAt(index));
+      out << type()->valueToString(valueAt(index));
     }
     return out.str();
   }

--- a/velox/vector/tests/ToStringUtilityTest.cpp
+++ b/velox/vector/tests/ToStringUtilityTest.cpp
@@ -15,34 +15,24 @@
  */
 
 #include <gtest/gtest.h>
-#include <sstream>
-#include "folly/Conv.h"
-#include "velox/vector/ComplexVector.h"
-#include "velox/vector/TypeAliases.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox {
 namespace {
 TEST(ToStringUtil, stringifyTruncatedElementList) {
-  const auto indexAsString = [](std::stringstream& ss, vector_size_t i) {
+  const auto indexAsString = [](std::stringstream& ss, size_t i) {
     ss << folly::to<std::string>(i);
   };
 
   // no item
-  EXPECT_EQ(
-      ArrayVectorBase::stringifyTruncatedElementList(0, indexAsString),
-      "<empty>");
+  EXPECT_EQ(stringifyTruncatedElementList(0, indexAsString), "<empty>");
   // exact item
-  EXPECT_EQ(
-      ArrayVectorBase::stringifyTruncatedElementList(5, indexAsString),
-      "{0, 1, 2, 3, 4}");
+  EXPECT_EQ(stringifyTruncatedElementList(5, indexAsString), "{0, 1, 2, 3, 4}");
   // more items
   EXPECT_EQ(
-      ArrayVectorBase::stringifyTruncatedElementList(5, indexAsString, 2),
-      "{0, 1, ...3 more}");
+      stringifyTruncatedElementList(5, indexAsString, 2), "{0, 1, ...3 more}");
   // less items
-  EXPECT_EQ(
-      ArrayVectorBase::stringifyTruncatedElementList(3, indexAsString),
-      "{0, 1, 2}");
+  EXPECT_EQ(stringifyTruncatedElementList(3, indexAsString), "{0, 1, 2}");
 }
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
- Change ConstantExpr::toString() to match ConstantTypedExpr::toString.
- Change CastTypedExpr::toString() to match CastExpr::toString()
  - cast x as bigint => cast(x as bigint)

Move toString logic for Variant and BaseVector::toString(index) to velox/type.
- Move valueToString static method from SimpleVector<T> to Type.
- Move stringifyTruncatedElementList from ArrayVectorBase to Type.h
- Move logic from ConstantTypedExpr::toString to Variant::toStringAsVector.

This is useful for comparing XxxTypedExpr with hard-coded SQL string in PlanMatcher in Verax: https://github.com/facebookexperimental/verax/pull/115

A desired follow-up would be to add toSql() method to both XxxExpr and XxxTypedExpr and have these methods produce same results.

Fixes https://github.com/facebookincubator/velox/issues/14353

Differential Revision: D79720451
