### PR TITLE
fix: Fix approximateTypeEncodingwidth to count Row with one in width

### DIFF
--- a/velox/type/TypeEncodingUtil.cpp
+++ b/velox/type/TypeEncodingUtil.cpp
@@ -34,16 +34,16 @@ size_t approximateTypeEncodingwidth(const TypePtr& type) {
 
   switch (type->kind()) {
     case TypeKind::ARRAY:
-      return 1 + approximateTypeEncodingwidth(type->asArray().elementType());
+      return approximateTypeEncodingwidth(type->asArray().elementType()) + 1;
     case TypeKind::MAP:
-      return 1 + approximateTypeEncodingwidth(type->asMap().keyType()) +
-          approximateTypeEncodingwidth(type->asMap().valueType());
+      return approximateTypeEncodingwidth(type->asMap().keyType()) +
+          approximateTypeEncodingwidth(type->asMap().valueType()) + 1;
     case TypeKind::ROW: {
       size_t fieldWidth = 0;
       for (const auto& child : type->asRow().children()) {
         fieldWidth += approximateTypeEncodingwidth(child);
       }
-      return fieldWidth;
+      return fieldWidth + 1;
     }
     default:
       VELOX_UNREACHABLE("Unsupported type: {}", type->toString());

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -454,7 +454,7 @@ TEST(TypeTest, row) {
     seen++;
   }
   ASSERT_EQ(seen, 2);
-  ASSERT_EQ(approximateTypeEncodingwidth(row0), 2);
+  ASSERT_EQ(approximateTypeEncodingwidth(row0), 4);
 
   EXPECT_STREQ(row0->name(), "ROW");
   ASSERT_EQ(row0->parameters().size(), 2);
@@ -471,12 +471,12 @@ TEST(TypeTest, row) {
   ASSERT_EQ(row1->nameOf(0), "a,b");
   ASSERT_EQ(row1->nameOf(1), R"(my "column")");
   ASSERT_EQ(row1->childAt(1)->toString(), R"(ROW<"#1":BIGINT>)");
-  ASSERT_EQ(approximateTypeEncodingwidth(row1), 2);
+  ASSERT_EQ(approximateTypeEncodingwidth(row1), 4);
 
   const auto row2 = ROW({{"", INTEGER()}});
   ASSERT_EQ(row2->toString(), R"(ROW<"":INTEGER>)");
   ASSERT_EQ(row2->nameOf(0), "");
-  ASSERT_EQ(approximateTypeEncodingwidth(row2), 1);
+  ASSERT_EQ(approximateTypeEncodingwidth(row2), 2);
 
   VELOX_ASSERT_THROW(createScalarType(TypeKind::ROW), "not a scalar type");
   VELOX_ASSERT_THROW(

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -994,7 +994,7 @@ TEST_F(VectorFuzzerTest, randTypeByWidth) {
   ASSERT_EQ(approximateTypeEncodingwidth(type), 4);
   type = ROW(
       {INTEGER(), ARRAY(BIGINT()), MAP(VARCHAR(), DOUBLE()), ROW({TINYINT()})});
-  ASSERT_EQ(approximateTypeEncodingwidth(type), 7);
+  ASSERT_EQ(approximateTypeEncodingwidth(type), 9);
 
   // Test randType by width. Results should be at least a RowType with one
   // field, so the minimal type width is 2.


### PR DESCRIPTION
Summary: The approximateTypeEncodingwidth() method should count the Row-type layer itself as 1 in width. Failing to do so could cause unit test failure of VectorFuzzerTest.randTypeByWidth.

Differential Revision: D79829209


