### PR TITLE
feat: Add LongEnumParameter to SignatureBinder

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -598,11 +598,12 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
         ...);
 
     for (const auto& constraint : constraints) {
-      VELOX_CHECK(
-          !constraint.constraint().empty(),
-          "Constraint must be set for variable {}",
-          constraint.name());
-
+      if (constraint.isIntegerParameter()) {
+        VELOX_CHECK(
+            !constraint.constraint().empty(),
+            "Constraint must be set for variable {}",
+            constraint.name());
+      }
       results.variablesInformation.erase(constraint.name());
       results.variablesInformation.emplace(constraint.name(), constraint);
     }

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -176,6 +176,7 @@ IPPREFIX                  ROW(HUGEINT,TINYINT)
 GEOMETRY                  VARBINARY
 TDIGEST                   VARBINARY
 QDIGEST                   VARBINARY
+BIGINT_ENUM               BIGINT
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
@@ -222,6 +223,16 @@ data for a given input set, and can be queried to retrieve approximate quantile 
 distribution. They may be merged without losing precision, and for storage and retrieval they may
 be cast to/from VARBINARY. The parameter type (BIGINT, REAL, or DOUBLE) represents
 the set of numbers that may be ingested by the quantile digest.
+
+BIGINT_ENUM(LongEnumParameter) type represents an enumerated value where the physical type is BIGINT.
+It takes one LongEnumParameter as parameter, which consists of a string name and a mapping of
+string keys to BIGINT values.
+There is a static cache which stores instances of different BIGINT_ENUM types. This is to treat each
+different enum type as a singleton. The LongEnumParameter is used as the key to retrieve the cached instance,
+and a new instance is only created if it has not been created with the given LongEnumParameter.
+Casting is permitted from any integer type to an enum type. Casting is only permitted from an enum type
+to a BIGINT type. Casting between different enum types is not permitted.
+Comparison operations are only allowed between values of the same enum type.
 
 Spark Types
 ~~~~~~~~~~~~

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -331,12 +331,15 @@ TypePtr sanitizeTryResolveType(
     const exec::TypeSignature& typeSignature,
     const std::unordered_map<std::string, SignatureVariable>& variables,
     const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
-    std::unordered_map<std::string, int>& integerVariablesBindings) {
+    std::unordered_map<std::string, int>& integerVariablesBindings,
+    const std::unordered_map<std::string, LongEnumParameter>&
+        longEnumParameterVariablesBindings) {
   return sanitize(SignatureBinder::tryResolveType(
       typeSignature,
       variables,
       typeVariablesBindings,
-      integerVariablesBindings));
+      integerVariablesBindings,
+      longEnumParameterVariablesBindings));
 }
 
 void setupMemory(

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -117,7 +117,9 @@ TypePtr sanitizeTryResolveType(
     const exec::TypeSignature& typeSignature,
     const std::unordered_map<std::string, SignatureVariable>& variables,
     const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
-    std::unordered_map<std::string, int>& integerVariablesBindings);
+    std::unordered_map<std::string, int>& integerVariablesBindings,
+    const std::unordered_map<std::string, LongEnumParameter>&
+        longEnumParameterVariablesBindings);
 
 // Invoked to set up memory system with arbitration.
 void setupMemory(

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -189,20 +189,21 @@ SignatureVariable::SignatureVariable(
     ParameterType type,
     bool knownTypesOnly,
     bool orderableTypesOnly,
-    bool comaprableTypesOnly)
+    bool comparableTypesOnly)
     : name_{std::move(name)},
       constraint_(constraint.has_value() ? std::move(constraint.value()) : ""),
       type_{type},
       knownTypesOnly_(knownTypesOnly),
       orderableTypesOnly_(orderableTypesOnly),
-      comparableTypesOnly_(comaprableTypesOnly) {
+      comparableTypesOnly_(comparableTypesOnly) {
   VELOX_CHECK(
       !(knownTypesOnly_ || orderableTypesOnly_ || comparableTypesOnly_) ||
           isTypeParameter(),
       "Non-Type variables cannot have the knownTypesOnly/orderableTypesOnly/comparableTypesOnly constraint");
 
   VELOX_CHECK(
-      isIntegerParameter() || (isTypeParameter() && constraint_.empty()),
+      (isIntegerParameter() || isEnumParameter() ||
+       (isTypeParameter() && constraint_.empty())),
       "Type variables cannot have constraints");
 }
 
@@ -267,7 +268,7 @@ FunctionSignatureBuilder& FunctionSignatureBuilder::knownTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ true,
           /*orderableTypesOnly*/ false,
-          /*comaprableTypesOnly*/ false));
+          /*comparableTypesOnly*/ false));
   return *this;
 }
 
@@ -281,7 +282,7 @@ FunctionSignatureBuilder& FunctionSignatureBuilder::orderableTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ false,
           /*orderableTypesOnly*/ true,
-          /*comaprableTypesOnly*/ true));
+          /*comparableTypesOnly*/ true));
   return *this;
 }
 
@@ -295,7 +296,7 @@ FunctionSignatureBuilder& FunctionSignatureBuilder::comparableTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ false,
           /*orderableTypesOnly*/ false,
-          /*comaprableTypesOnly*/ true));
+          /*comparableTypesOnly*/ true));
   return *this;
 }
 
@@ -322,7 +323,7 @@ AggregateFunctionSignatureBuilder::knownTypeVariable(const std::string& name) {
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ true,
           /*orderableTypesOnly*/ false,
-          /*comaprableTypesOnly*/ false));
+          /*comparableTypesOnly*/ false));
   return *this;
 }
 
@@ -337,7 +338,7 @@ AggregateFunctionSignatureBuilder::orderableTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ false,
           /*orderableTypesOnly*/ true,
-          /*comaprableTypesOnly*/ true));
+          /*comparableTypesOnly*/ true));
   return *this;
 }
 
@@ -352,7 +353,7 @@ AggregateFunctionSignatureBuilder::comparableTypeVariable(
           ParameterType::kTypeParameter,
           /*knownTypesOnly*/ false,
           /*orderableTypesOnly*/ false,
-          /*comaprableTypesOnly*/ true));
+          /*comparableTypesOnly*/ true));
   return *this;
 }
 

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -34,7 +34,11 @@ std::string sanitizeName(const std::string& name);
 /// Return a list of primitive type names.
 const std::vector<std::string> primitiveTypeNames();
 
-enum class ParameterType : int8_t { kTypeParameter, kIntegerParameter };
+enum class ParameterType : int8_t {
+  kTypeParameter,
+  kIntegerParameter,
+  kEnumParameter,
+};
 
 /// Canonical names for functions that have special treatments in pushdowns.
 enum class FunctionCanonicalName {
@@ -86,6 +90,10 @@ class SignatureVariable {
 
   bool isIntegerParameter() const {
     return type_ == ParameterType::kIntegerParameter;
+  }
+
+  bool isEnumParameter() const {
+    return type_ == ParameterType::kEnumParameter;
   }
 
   bool operator==(const SignatureVariable& rhs) const {
@@ -306,6 +314,15 @@ class FunctionSignatureBuilder {
     addVariable(
         variables_,
         SignatureVariable(name, constraint, ParameterType::kIntegerParameter));
+    return *this;
+  }
+
+  FunctionSignatureBuilder& enumVariable(
+      const std::string& name,
+      std::optional<std::string> constraint = std::nullopt) {
+    addVariable(
+        variables_,
+        SignatureVariable(name, constraint, ParameterType::kEnumParameter));
     return *this;
   }
 

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -53,6 +53,16 @@ class ReverseSignatureBinder : private SignatureBinderBase {
     return integerVariablesBindings_;
   }
 
+  /// Return the LongEnumParameter bindings produced by 'tryBind'. This
+  /// function should be called after 'tryBind' and only if 'tryBind' returns
+  /// true.
+  const std::unordered_map<std::string, LongEnumParameter>&
+  longEnumParameterBindings() const {
+    VELOX_CHECK(
+        tryBindSucceeded_, "tryBind() must be called first and succeed");
+    return longEnumVariablesBindings_;
+  }
+
  private:
   const TypePtr returnType_;
 

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -58,10 +58,18 @@ class SignatureBinderBase {
   /// Record concrete values that are bound to integer variables.
   std::unordered_map<std::string, int> integerVariablesBindings_;
 
+  /// Record concrete values that are bound to LongEnumParameter variables.
+  std::unordered_map<std::string, LongEnumParameter> longEnumVariablesBindings_;
+
  private:
   /// If the integer parameter is set, then it must match with value.
   /// Returns false if values do not match or the parameter does not exist.
   bool checkOrSetIntegerParameter(const std::string& parameterName, int value);
+
+  /// Try to bind the LongEnumParameter from the actualType.
+  bool checkOrSetLongEnumParameter(
+      const std::string& parameterName,
+      const LongEnumParameter& params);
 
   /// Try to bind the integer parameter from the actualType.
   bool tryBindIntegerParameters(
@@ -113,7 +121,8 @@ class SignatureBinder : private SignatureBinderBase {
         typeSignature,
         variables(),
         typeVariablesBindings_,
-        integerVariablesBindings_);
+        integerVariablesBindings_,
+        longEnumVariablesBindings_);
   }
 
   // Try resolve types for all specified signatures. Return empty list if some
@@ -140,8 +149,13 @@ class SignatureBinder : private SignatureBinderBase {
       const std::unordered_map<std::string, SignatureVariable>& variables,
       const std::unordered_map<std::string, TypePtr>& resolvedTypeVariables) {
     std::unordered_map<std::string, int> dummyEmpty;
+    std::unordered_map<std::string, LongEnumParameter> dummyEmpty2;
     return tryResolveType(
-        typeSignature, variables, resolvedTypeVariables, dummyEmpty);
+        typeSignature,
+        variables,
+        resolvedTypeVariables,
+        dummyEmpty,
+        dummyEmpty2);
   }
 
   // Given a pre-computed binding for type variables and integer variables,
@@ -151,7 +165,9 @@ class SignatureBinder : private SignatureBinderBase {
       const exec::TypeSignature& typeSignature,
       const std::unordered_map<std::string, SignatureVariable>& variables,
       const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
-      std::unordered_map<std::string, int>& integerVariablesBindings);
+      std::unordered_map<std::string, int>& integerVariablesBindings,
+      const std::unordered_map<std::string, LongEnumParameter>&
+          bigintEnumVariablesBindings);
 
  private:
   bool tryBind(bool allowCoercions, std::vector<Coercion>& coercions);

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.cpp
@@ -180,6 +180,7 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
 
     bindings_ = binder.bindings();
     integerBindings_ = binder.integerBindings();
+    longEnumParameterBindings_ = binder.longEnumParameterBindings();
   }
 
   const auto& formalArgs = signature_.argumentTypes();
@@ -195,7 +196,11 @@ bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {
       actualArg = randType();
     } else {
       actualArg = sanitizeTryResolveType(
-          formalArgs[i], variables(), bindings_, integerBindings_);
+          formalArgs[i],
+          variables(),
+          bindings_,
+          integerBindings_,
+          longEnumParameterBindings_);
       VELOX_CHECK(actualArg != nullptr);
     }
     argumentTypes_.push_back(actualArg);
@@ -230,7 +235,11 @@ TypePtr ArgumentTypeFuzzer::fuzzReturnType() {
     returnType_ = randType();
   } else {
     returnType_ = sanitizeTryResolveType(
-        returnType, variables(), bindings_, integerBindings_);
+        returnType,
+        variables(),
+        bindings_,
+        integerBindings_,
+        longEnumParameterBindings_);
   }
 
   VELOX_CHECK_NOT_NULL(returnType_);

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.h
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.h
@@ -113,6 +113,9 @@ class ArgumentTypeFuzzer {
 
   std::unordered_map<std::string, int> integerBindings_;
 
+  /// Bindings between LongEnumParameter variables and their actual types.
+  std::unordered_map<std::string, LongEnumParameter> longEnumParameterBindings_;
+
   /// RNG to generate random types for unbounded type variables when necessary.
   FuzzerGenerator& rng_;
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -236,6 +236,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
       "TDIGEST",
       "QDIGEST",
       "SFMSKETCH",
+      "BIGINT_ENUM",
   };
 #ifdef VELOX_ENABLE_GEO
   expectedTypes.insert("GEOMETRY");
@@ -277,6 +278,12 @@ TEST_F(CustomTypeTest, nullConstant) {
         checkNullConstant(
             type, fmt::format("QDIGEST({})", parameter->toString()));
       }
+    } else if (name == "BIGINT_ENUM") {
+      LongEnumParameter moodInfo(
+          "test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}});
+      auto type = getCustomType(name, {TypeParameter(moodInfo)});
+      checkNullConstant(
+          type, "test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0})");
     } else {
       auto type = getCustomType(name, {});
       checkNullConstant(type, type->toString());

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
@@ -59,7 +60,11 @@ std::string typeName(const TypePtr& type) {
       if (isBingTileType(type)) {
         return "bingtile";
       }
+      if (isBigintEnumType(*type)) {
+        return asBigintEnum(type)->enumName();
+      }
       return "bigint";
+
     case TypeKind::HUGEINT: {
       if (isUuidType(type)) {
         return "uuid";

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include "velox/functions/prestosql/IPAddressFunctions.h"
 #include "velox/functions/prestosql/UuidFunctions.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
 
 namespace facebook::velox::functions {
 
@@ -135,6 +136,9 @@ void registerBitwiseFunctions(const std::string& prefix) {
 }
 
 void registerAllScalarFunctions(const std::string& prefix) {
+  // TODO: move registerBigintEnumType to registerEnumTypeFunctions once the
+  // enum functions are implemented
+  registerBigintEnumType();
   registerArithmeticFunctions(prefix);
   registerCheckedArithmeticFunctions(prefix);
   registerComparisonFunctions(prefix);

--- a/velox/functions/prestosql/tests/BigintEnumCastTest.cpp
+++ b/velox/functions/prestosql/tests/BigintEnumCastTest.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox {
+namespace {
+
+class BigintEnumCastTest : public functions::test::CastBaseTest {
+ protected:
+  BigintEnumCastTest() {
+    registerBigintEnumType();
+    LongEnumParameter moodInfo(
+        "test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}});
+    moodEnum_ = BIGINT_ENUM(moodInfo);
+  }
+
+  BigintEnumTypePtr moodEnum_;
+};
+
+TEST_F(BigintEnumCastTest, castTo) {
+  // Cast different integer types to enum type.
+  testCast<int64_t, int64_t>(
+      BIGINT(), moodEnum_, {0, -2, std::nullopt}, {0, -2, std::nullopt});
+
+  testCast<int8_t, int64_t>(
+      TINYINT(), moodEnum_, {0, -2, std::nullopt}, {0, -2, std::nullopt});
+
+  testCast<int16_t, int64_t>(
+      SMALLINT(), moodEnum_, {0, -2, std::nullopt}, {0, -2, std::nullopt});
+
+  testCast<int32_t, int64_t>(
+      INTEGER(), moodEnum_, {0, -2, std::nullopt}, {0, -2, std::nullopt});
+
+  // Cast enum type to same enum type.
+  testCast<int64_t, int64_t>(
+      moodEnum_, moodEnum_, {0, -2, std::nullopt}, {0, -2, std::nullopt});
+}
+
+TEST_F(BigintEnumCastTest, invalidCastTo) {
+  // Cast is only permitted from integer types to enum type.
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          VARCHAR(),
+          moodEnum_,
+          makeRowVector({makeNullableFlatVector<StringView>(
+              {"a"_sv, "b"_sv, std::nullopt})})),
+      "Cannot cast VARCHAR to test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}).");
+
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BOOLEAN(),
+          moodEnum_,
+          makeRowVector(
+              {makeNullableFlatVector<bool>({true, false, std::nullopt})})),
+      "Cannot cast BOOLEAN to test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}).");
+
+  // Cast base type to enum type where the value does not exist in the enum.
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          BIGINT(),
+          moodEnum_,
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, BIGINT())})),
+      "No value '1' in test.enum.mood");
+
+  // Cast enum type to different enum type.
+  std::unordered_map<std::string, int64_t> differentMap = {
+      {"CURIOUS", -2}, {"HAPPY", 3}};
+  LongEnumParameter differentEnumInfo("someEnumType", differentMap);
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          moodEnum_,
+          BIGINT_ENUM(differentEnumInfo),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, moodEnum_)})),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to someEnumType:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 3}).");
+
+  // Cast enum type to different enum type with same name.
+  LongEnumParameter sameNameDifferentMap("test.enum.mood", differentMap);
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          moodEnum_,
+          BIGINT_ENUM(sameNameDifferentMap),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, moodEnum_)})),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 3})");
+}
+
+TEST_F(BigintEnumCastTest, fromBigintEnum) {
+  // Cast enum type to base type.
+  testCast<int64_t, int64_t>(
+      moodEnum_, BIGINT(), {0, -2, std::nullopt}, {0, -2, std::nullopt});
+
+  // Casting enum type to all other types including other integer types is not
+  // permitted.
+  auto enumInput = makeRowVector(
+      {makeNullableFlatVector<int64_t>({0, 1, std::nullopt}, moodEnum_)});
+  VELOX_ASSERT_THROW(
+      evaluateCast(moodEnum_, TINYINT(), enumInput),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to TINYINT.");
+
+  VELOX_ASSERT_THROW(
+      evaluateCast(moodEnum_, SMALLINT(), enumInput),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to SMALLINT.");
+
+  VELOX_ASSERT_THROW(
+      evaluateCast(moodEnum_, INTEGER(), enumInput),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to INTEGER.");
+
+  VELOX_ASSERT_THROW(
+      evaluateCast(moodEnum_, VARCHAR(), enumInput),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to VARCHAR.");
+
+  VELOX_ASSERT_THROW(
+      evaluateCast(
+          moodEnum_,
+          BOOLEAN(),
+          makeRowVector({makeNullableFlatVector<int64_t>(
+              {0, 1, std::nullopt}, moodEnum_)})),
+      "Cannot cast test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}) to BOOLEAN.");
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+namespace facebook::velox {
+namespace {
+class BigintEnumCastOperator : public exec::CastOperator {
+ public:
+  static const std::shared_ptr<const CastOperator>& get() {
+    static const std::shared_ptr<const CastOperator> kInstance =
+        std::make_shared<const BigintEnumCastOperator>();
+
+    return kInstance;
+  }
+
+  // Casting is supported from all integer types.
+  bool isSupportedFromType(const TypePtr& other) const override {
+    return BIGINT()->equivalent(*other) || TINYINT()->equivalent(*other) ||
+        SMALLINT()->equivalent(*other) || INTEGER()->equivalent(*other);
+  }
+
+  // Casting is only supported to BIGINT type.
+  bool isSupportedToType(const TypePtr& other) const override {
+    return BIGINT()->equivalent(*other);
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    switch (input.typeKind()) {
+      case TypeKind::TINYINT:
+        castFromInteger<int8_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::SMALLINT:
+        castFromInteger<int16_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::INTEGER:
+        castFromInteger<int32_t>(input, context, rows, resultType, result);
+        break;
+      case TypeKind::BIGINT:
+        castFromInteger<int64_t>(input, context, rows, resultType, result);
+        break;
+      default:
+        VELOX_UNREACHABLE(
+            "Cannot cast {} to {} type",
+            input.type()->toString(),
+            resultType->toString());
+    }
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<int64_t>>();
+    flatResult->copy(&input, rows, nullptr);
+  }
+
+ private:
+  template <typename T>
+  void castFromInteger(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<int64_t>>();
+    flatResult->clearNulls(rows);
+
+    auto enumType = asBigintEnum(resultType);
+    const auto* intVector = input.as<SimpleVector<T>>();
+    rows.applyToSelected([&](vector_size_t row) {
+      const int64_t intToCast = intVector->valueAt(row);
+      if (!enumType->containsValue(intToCast)) {
+        context.setStatus(
+            row,
+            Status::UserError(
+                "No value '{}' in {}", intToCast, enumType->enumName()));
+        return;
+      }
+      flatResult->set(row, intToCast);
+    });
+  }
+};
+
+class BigintEnumTypeFactory : public CustomTypeFactory {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK_EQ(
+        parameters.size(),
+        1,
+        "Expected exactly one type parameters for BigintEnumType");
+    VELOX_CHECK(
+        parameters[0].longEnumLiteral.has_value(),
+        "BigintEnumType parameter must be longEnumLiteral");
+    return BIGINT_ENUM(parameters[0].longEnumLiteral.value());
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return BigintEnumCastOperator::get();
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+} // namespace
+
+void registerBigintEnumType() {
+  registerCustomType(
+      "bigint_enum", std::make_unique<const BigintEnumTypeFactory>());
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumRegistration.h
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox {
+
+void registerBigintEnumType();
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumType.cpp
+++ b/velox/functions/prestosql/types/BigintEnumType.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Synchronized.h>
+
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+
+namespace facebook::velox {
+
+namespace {
+std::unordered_map<int64_t, std::string> toFlippedMap(
+    const std::unordered_map<std::string, int64_t>& map,
+    const std::string& name) {
+  std::unordered_map<int64_t, std::string> flippedMap;
+  for (const auto& [key, value] : map) {
+    bool ok = flippedMap.emplace(value, key).second;
+    VELOX_USER_CHECK(
+        ok, "Invalid enum type {}, contains duplicate value {}", name, value);
+  }
+  return flippedMap;
+}
+
+std::string flippedMapToString(
+    const std::unordered_map<int64_t, std::string>& flippedMap) {
+  std::ostringstream oss;
+  oss << "{";
+  std::map<std::string, int64_t> sortedMap;
+  for (const auto& [key, value] : flippedMap) {
+    sortedMap[value] = key;
+  }
+  for (auto it = sortedMap.begin(); it != sortedMap.end(); ++it) {
+    if (it != sortedMap.begin()) {
+      oss << ", ";
+    }
+    oss << "\"" << it->first << "\"" << ": " << it->second;
+  }
+  oss << "}";
+  return oss.str();
+}
+
+} // namespace
+
+// Should only be called from get() to create a new instance.
+BigintEnumType::BigintEnumType(const LongEnumParameter& parameters)
+    : parameters_{TypeParameter(parameters)},
+      name_{parameters.name},
+      flippedMap_{toFlippedMap(parameters.valuesMap, name_)} {}
+
+std::string BigintEnumType::toString() const {
+  return fmt::format(
+      "{}:BigintEnum({})", name_, flippedMapToString(flippedMap_));
+}
+
+// A thread-safe LRU cache to store instances of BigintEnumType.
+using Cache = folly::EvictingCacheMap<
+    LongEnumParameter,
+    BigintEnumTypePtr,
+    LongEnumParameter::Hash>;
+
+BigintEnumTypePtr BigintEnumType::get(const LongEnumParameter& parameter) {
+  static const int maxCacheSize = 1000;
+  static folly::Synchronized<Cache> kCache{Cache(maxCacheSize)};
+  return kCache.withWLock([&](auto& cache) -> BigintEnumTypePtr {
+    auto it = cache.find(parameter);
+    if (it != cache.end()) {
+      return it->second;
+    }
+    // Can't use std::make_shared because calling private ctor.
+    auto instance =
+        std::shared_ptr<const BigintEnumType>(new BigintEnumType(parameter));
+    cache.insert(parameter, instance);
+    return instance;
+  });
+}
+
+folly::dynamic BigintEnumType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "Type";
+  obj["type"] = name();
+  // parameters_[0].longEnumLiteral is assumed to have a value since it is
+  // constructed from a LongEnumParameter.
+  obj["kLongEnumParam"] =
+      parameters_[0].longEnumLiteral.value().serializeEnumParameter();
+  return obj;
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumType.h
+++ b/velox/functions/prestosql/types/BigintEnumType.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/container/EvictingCacheMap.h>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class BigintEnumType;
+using BigintEnumTypePtr = std::shared_ptr<const BigintEnumType>;
+
+/// Represents an enumerated value where the physical type is a bigint. Each
+/// enum type has a name and a set of string keys which map to bigint values,
+/// passed in as a LongEnumParameter TypeParameterKind.
+class BigintEnumType : public BigintType {
+ public:
+  static BigintEnumTypePtr get(const LongEnumParameter& parameter);
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "BIGINT_ENUM";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    return parameters_;
+  }
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  bool containsValue(int64_t value) const {
+    return flippedMap_.contains(value);
+  }
+
+  const std::string& enumName() const {
+    return name_;
+  }
+
+ private:
+  explicit BigintEnumType(const LongEnumParameter& parameters);
+
+  const std::vector<TypeParameter> parameters_;
+  const std::string name_;
+  const std::unordered_map<int64_t, std::string> flippedMap_;
+};
+
+inline BigintEnumTypePtr BIGINT_ENUM(const LongEnumParameter& parameter) {
+  return BigintEnumType::get(parameter);
+}
+
+FOLLY_ALWAYS_INLINE bool isBigintEnumType(const Type& type) {
+  return type.kind() == TypeKind::BIGINT &&
+      dynamic_cast<const BigintEnumType*>(&type) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE BigintEnumTypePtr asBigintEnum(const TypePtr& type) {
+  return std::dynamic_pointer_cast<const BigintEnumType>(type);
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -15,6 +15,8 @@
 add_subdirectory(parser)
 velox_add_library(
   velox_presto_types
+  BigintEnumRegistration.cpp
+  BigintEnumType.cpp
   BingTileRegistration.cpp
   BingTileType.cpp
   HyperLogLogRegistration.cpp

--- a/velox/functions/prestosql/types/parser/ParserUtil.cpp
+++ b/velox/functions/prestosql/types/parser/ParserUtil.cpp
@@ -65,4 +65,57 @@ std::pair<std::string, std::shared_ptr<const Type>> inferTypeWithSpaces(
       fieldName, typeFromString(allWords.substr(fieldName.size() + 1)));
 }
 
+// The values map of the enum type is passed into this function in the format:
+// "[["CURIOUS",-2], ["HAPPY",0]]" as an array of key-value pairs (as opposed to
+// a JSON map like "{"CURIOUS":-2, "HAPPY":0}") so that the function can fail
+// on duplicate keys and values. folly::parseJson on a JSON map will silently
+// drop duplicate elements.
+std::unordered_map<std::string, int64_t> parseMapFromString(
+    const std::string& input) {
+  folly::dynamic obj = folly::parseJson(input);
+  VELOX_CHECK(
+      obj.isArray(),
+      "Expected an array of key-value pairs for input: {}",
+      input);
+  std::unordered_map<std::string, int64_t> result;
+  std::unordered_set<int> seenValues;
+
+  for (const auto& pair : obj) {
+    VELOX_CHECK(
+        pair.isArray() && pair.size() == 2 && pair[0].isString() &&
+            pair[1].isInt(),
+        "Failed to parse map: {}, each element must be a [string key, int value] pair");
+
+    std::string key = pair[0].asString();
+    int64_t value = pair[1].asInt();
+
+    VELOX_CHECK(
+        !result.contains(key),
+        "Failed to parse map: {}, duplicate key found: {}",
+        input,
+        key);
+    VELOX_CHECK(
+        seenValues.insert(value).second,
+        "Failed to parse map: {}, duplicate value found: {}",
+        input,
+        value);
+
+    result[key] = value;
+  }
+  return result;
+}
+
+TypePtr getEnumType(
+    const std::string& enumType,
+    const std::string& enumName,
+    const std::string& valuesMap) {
+  std::vector<TypeParameter> params;
+  LongEnumParameter longEnumParameter(enumName, parseMapFromString(valuesMap));
+  params.emplace_back(TypeParameter(longEnumParameter));
+  if (enumType == "BigintEnum") {
+    return getType("BIGINT_ENUM", params);
+  }
+
+  VELOX_UNREACHABLE("Invalid type {}, expected BigintEnum", enumType);
+}
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/parser/ParserUtil.h
+++ b/velox/functions/prestosql/types/parser/ParserUtil.h
@@ -31,6 +31,16 @@ TypePtr customTypeWithChildren(
     const std::string& name,
     const std::vector<TypePtr>& children);
 
+/// Creates a LongEnumParameter with the enumName and valuesMap and passes it in
+/// as a parameter to BIGINT_ENUM type to return an enum Type.
+/// The valuesMap is assumed to have a format of "[["CURIOUS",-2], ["HAPPY",0]]"
+/// so that folly::parseJson can be used to parse and throw on duplicate keys
+/// and/or values.
+TypePtr getEnumType(
+    const std::string& enumType,
+    const std::string& enumName,
+    const std::string& valuesMap);
+
 /// Convert words with spaces to a Velox type.
 /// First check if all the words are a Velox type.
 /// Then check if the first word is a field name and the remaining words are a

--- a/velox/functions/prestosql/types/parser/TypeParser.yy
+++ b/velox/functions/prestosql/types/parser/TypeParser.yy
@@ -33,18 +33,18 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION DECIMAL
-%token <std::string> WORD VARIABLE QUOTED_ID
-%token <long long>   NUMBER
+%token               LPAREN RPAREN COMMA PERIOD COLON ARRAY MAP ROW FUNCTION DECIMAL LBRACE RBRACE
+%token <std::string> WORD VARIABLE QUOTED_ID WORD_WITH_PERIODS
+%token <long long>   NUMBER SIGNED_INT
 %token YYEOF         0
 
 %nterm <std::shared_ptr<const Type>> type type_single_word
-%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children
+%nterm <std::shared_ptr<const Type>> special_type function_type decimal_type row_type array_type map_type variable_type custom_type_with_children enum_type
 %nterm <RowArguments> type_list_opt_names
 %nterm <std::vector<std::shared_ptr<const Type>>> type_list
 %nterm <std::pair<std::string, std::shared_ptr<const Type>>> named_type
 %nterm <std::vector<std::string>> type_with_spaces
-%nterm <std::string> field_name
+%nterm <std::string> field_name enum_name enum_kind enum_map_entry enum_map_entries enum_map_entries_json
 
 %start type_spec
 
@@ -69,6 +69,7 @@ special_type : array_type     { $$ = $1; }
              | variable_type  { $$ = $1; }
              | decimal_type   { $$ = $1; }
              | custom_type_with_children { $$ = $1; }
+             | enum_type { $$ = $1; }
 
 /*
  * Types with spaces have at least two words. They are joined in an
@@ -148,6 +149,44 @@ named_type : type_single_word        { $$ = std::make_pair("", $1); }
            | type_with_spaces        { $$ = facebook::velox::functions::prestosql::inferTypeWithSpaces($1, false); }
            | QUOTED_ID type          { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
            ;
+
+/*
+ * Enum types have a format of:
+ * "test.enum.mood:BigintEnum(test.enum.mood{"CURIOUS":2, "HAPPY":0})"
+ * where "test.enum.mood" is the enum name, "BigintEnum" is the enum kind,
+ * and "CURIOUS":2, "HAPPY":0 are the enum values.
+ * These values are passed as parameters to BIGINT_ENUM type.
+ */
+enum_map_entries : enum_map_entry { $$ = $1; }
+            | enum_map_entries COMMA enum_map_entry { $$ = $1 + ", " + $3; }
+            ;
+
+/*
+ * Formats the values map like "[["CURIOUS",-2], ["HAPPY",0]]"
+ * so that it can be parsed as an array of pairs using folly::parseJson in getEnumType.
+ */
+enum_map_entries_json : LBRACE enum_map_entries RBRACE {$$ = "[" + $2 + "]"; }
+                    ;
+
+enum_map_entry : QUOTED_ID COLON SIGNED_INT {  $$ = "[" + $1 + "," + std::to_string($3) + "]"; }
+               | QUOTED_ID COLON NUMBER     {  $$ = "[" + $1 + "," + std::to_string($3) + "]"; }
+               ;
+
+enum_kind : WORD { if ($1 != "BigintEnum" && $1 != "VarcharEnum" )
+                    {
+                        std::string msg = "Invalid type " + $1 + ", expected BigintEnum or VarcharEnum";
+                        error(msg.c_str());
+                    }
+                $$ = $1; }
+                ;
+
+enum_name : WORD_WITH_PERIODS { $$ = $1; }
+          | WORD { $$ = $1; }
+          ;
+
+enum_type : enum_name COLON enum_kind LPAREN enum_name enum_map_entries_json RPAREN
+          { $$ = getEnumType($3, $1, $6); }
+          ;
 
 %%
 

--- a/velox/functions/prestosql/types/parser/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/parser/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_test(NAME velox_presto_type_parser_test
 target_link_libraries(
   velox_presto_type_parser_test
   velox_presto_type_parser
+  velox_presto_types
   velox_type
   GTest::gtest
   GTest::gtest_main

--- a/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/BigintEnumTypeTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox {
+namespace {
+class BigintEnumTypeTest : public testing::Test, public test::TypeTestBase {
+ protected:
+  BigintEnumTypeTest() {
+    registerBigintEnumType();
+    LongEnumParameter moodInfo(
+        "test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}});
+    moodEnum_ = BIGINT_ENUM(moodInfo);
+  }
+
+  BigintEnumTypePtr moodEnum_;
+};
+
+TEST_F(BigintEnumTypeTest, basic) {
+  ASSERT_TRUE(hasType("BIGINT_ENUM"));
+  LongEnumParameter moodInfo("test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}});
+  std::vector<TypeParameter> moodParams = {TypeParameter(moodInfo)};
+  ASSERT_EQ(getType("BIGINT_ENUM", moodParams), moodEnum_);
+
+  ASSERT_STREQ(moodEnum_->name(), "BIGINT_ENUM");
+  ASSERT_STREQ(moodEnum_->kindName(), "BIGINT");
+  ASSERT_EQ(moodEnum_->enumName(), "test.enum.mood");
+  ASSERT_EQ(moodEnum_->parameters().size(), 1);
+  ASSERT_EQ(
+      moodEnum_->toString(),
+      "test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0})");
+
+  // Different TypeParameters with different enumName, same enumMap
+  LongEnumParameter differentNameSameMap(
+      "test.enum.mood2", {{"CURIOUS", -2}, {"HAPPY", 0}});
+  ASSERT_NE(moodEnum_, BIGINT_ENUM(differentNameSameMap));
+  EXPECT_FALSE(moodEnum_->equivalent(*BIGINT_ENUM(differentNameSameMap)));
+
+  // Different TypeParameters with same enumName, different enumMap
+  LongEnumParameter sameNameDifferentMap(
+      "test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}, {"ANGRY", 1}});
+  ASSERT_NE(moodEnum_, BIGINT_ENUM(sameNameDifferentMap));
+  EXPECT_FALSE(moodEnum_->equivalent(*BIGINT_ENUM(sameNameDifferentMap)));
+
+  // Type Parameter with duplicate value in the enum map.
+  LongEnumParameter duplicateValuesInfo(
+      "duplicate.values.enum", {{"HAPPY", 0}, {"SAD", 0}, {"ANGRY", 0}});
+  VELOX_ASSERT_THROW(
+      BIGINT_ENUM(duplicateValuesInfo),
+      "Invalid enum type duplicate.values.enum, contains duplicate value 0");
+
+  // Different TypeParameters with same enumName and enumMap but in different
+  // order
+  LongEnumParameter differentOrderMapMoodInfo(
+      "test.enum.mood", {{"HAPPY", 0}, {"CURIOUS", -2}});
+  ASSERT_EQ(moodEnum_, BIGINT_ENUM(differentOrderMapMoodInfo));
+  EXPECT_TRUE(moodEnum_->equivalent(*BIGINT_ENUM(differentOrderMapMoodInfo)));
+}
+
+TEST_F(BigintEnumTypeTest, serde) {
+  testTypeSerde(moodEnum_);
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -68,6 +68,34 @@ const auto& typeKindNames() {
 }
 } // namespace
 
+folly::dynamic LongEnumParameter::serializeEnumParameter() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["enumName"] = name;
+  folly::dynamic follyMap = folly::dynamic::object;
+  for (const auto& [key, value] : valuesMap) {
+    follyMap[key] = value;
+  }
+  obj["valuesMap"] = follyMap;
+  return obj;
+}
+
+size_t LongEnumParameter::Hash::operator()(
+    const LongEnumParameter& param) const {
+  uint64_t nameHash = folly::Hash{}(param.name);
+
+  // Hash each key-value pair and combine using commutativeHashMix
+  // to ensure order independence.
+  uint64_t mapHash = facebook::velox::bits::kNullHash;
+  for (const auto& [key, value] : param.valuesMap) {
+    const auto elementHash = facebook::velox::bits::hashMix(
+        folly::Hash{}(key), folly::Hash{}(value));
+    mapHash = facebook::velox::bits::commutativeHashMix(mapHash, elementHash);
+  }
+
+  // Combine name hash with map hash.
+  return facebook::velox::bits::hashMix(nameHash, mapHash);
+}
+
 VELOX_DEFINE_ENUM_NAME(TypeKind, typeKindNames);
 
 std::pair<uint8_t, uint8_t> getDecimalPrecisionScale(const Type& type) {
@@ -103,6 +131,32 @@ namespace {
 std::vector<TypePtr> deserializeChildTypes(const folly::dynamic& obj) {
   return velox::ISerializable::deserialize<std::vector<Type>>(obj["cTypes"]);
 }
+
+template <typename ValueType>
+TypeParameter deserializeEnumParam(const folly::dynamic& obj) {
+  auto enumName = obj["enumName"].asString();
+  VELOX_CHECK(obj["valuesMap"].isObject());
+  auto valuesMap = obj["valuesMap"];
+
+  // Construct the values map
+  std::unordered_map<std::string, ValueType> map;
+  for (const auto& item : valuesMap.items()) {
+    std::string key = item.first.asString();
+    if constexpr (std::is_same_v<ValueType, int64_t>) {
+      int64_t value = item.second.asInt();
+      map.emplace(std::move(key), value);
+    } else {
+      VELOX_UNREACHABLE("Only int64_t value type is supported for enum types.");
+    }
+  }
+
+  // Construct the corresponding TypeParameter
+  if constexpr (std::is_same_v<ValueType, int64_t>) {
+    return TypeParameter(LongEnumParameter(enumName, map));
+  }
+  // TODO: Add the same deserialize logic for VarcharEnumType
+  VELOX_UNREACHABLE("Only int64_t value type is supported for enum types.");
+}
 } // namespace
 
 TypePtr Type::create(const folly::dynamic& obj) {
@@ -123,9 +177,14 @@ TypePtr Type::create(const folly::dynamic& obj) {
   // Checks if 'typeName' specifies a custom type.
   if (customTypeExists(typeName)) {
     std::vector<TypeParameter> params;
-    params.reserve(childTypes.size());
-    for (auto& child : childTypes) {
-      params.emplace_back(child);
+    if (obj.find("cTypes") != obj.items().end()) {
+      params.reserve(childTypes.size());
+      for (auto& child : childTypes) {
+        params.emplace_back(child);
+      }
+    }
+    if (obj.find("kLongEnumParam") != obj.items().end()) {
+      params.emplace_back(deserializeEnumParam<int64_t>(obj["kLongEnumParam"]));
     }
     return getCustomType(typeName, params);
   }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -393,6 +393,8 @@ using TypePtr = std::shared_ptr<const Type>;
 /// Represents the parameters for a BigintEnumType.
 /// Consists of the name of the enum and a map of string keys to bigint values.
 struct LongEnumParameter {
+  LongEnumParameter() = default;
+
   LongEnumParameter(
       std::string enumName,
       std::unordered_map<std::string, int64_t> enumValuesMap)

--- a/velox/type/parser/TypeParser.yy
+++ b/velox/type/parser/TypeParser.yy
@@ -34,7 +34,7 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION DECIMAL
+%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION DECIMAL LBRACE RBRACE
 %token <std::string> WORD VARIABLE QUOTED_ID
 %token <long long>   NUMBER
 %token YYEOF         0
@@ -149,7 +149,6 @@ named_type : type_single_word        { $$ = std::make_pair("", $1); }
            | type_with_spaces        { $$ = inferTypeWithSpaces($1, false); }
            | QUOTED_ID type          { $1.erase(0, 1); $1.pop_back(); $$ = std::make_pair($1, $2); }  // Remove the quotes.
            ;
-
 %%
 
 void facebook::velox::type::Parser::error(const std::string& msg) {


### PR DESCRIPTION
Added LongEnumParameter to SignatureBinder so that BigintEnum(LongEnumParameter) can be used as a function argument (for the enum_key function in a later PR)

Differential Revision: D78731080
