### PR TITLE
feat: Add match column for the left index lookup join

### DIFF
--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -391,6 +391,7 @@ core::PlanNodePtr getTraceNode(
         indexLookupJoinNode->leftKeys(),
         indexLookupJoinNode->rightKeys(),
         indexLookupJoinNode->joinConditions(),
+        indexLookupJoinNode->includeMatchColumn(),
         std::make_shared<DummySourceNode>(
             indexLookupJoinNode->sources().front()->outputType()), // Probe side
         indexLookupJoinNode->lookupSource(), // Index side

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1213,6 +1213,9 @@ class PlanBuilder {
   /// condition column from left side or a constant but at least one of them
   /// must not be constant. They all have the same type.
   /// @param joinType Type of the join supported: inner, left.
+  /// @param includeMatchColumn if true, 'outputLayout' should include a boolean
+  /// column at the end to indicate if a join output row has a match or not.
+  /// This only applies for left join.
   ///
   /// See hashJoin method for the description of the other parameters.
   PlanBuilder& indexLookupJoin(
@@ -1220,6 +1223,7 @@ class PlanBuilder {
       const std::vector<std::string>& rightKeys,
       const core::TableScanNodePtr& right,
       const std::vector<std::string>& joinConditions,
+      bool includeMatchColumn,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 

--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -291,7 +291,13 @@ PyPlanBuilder& PyPlanBuilder::indexLookupJoin(
           std::dynamic_pointer_cast<const core::TableScanNode>(
               indexPlanSubtree.planNode())) {
     planBuilder_.indexLookupJoin(
-        leftKeys, rightKeys, tableScanNode, {}, output, joinType);
+        leftKeys,
+        rightKeys,
+        tableScanNode,
+        {},
+        /*includeMatchColumn=*/false,
+        output,
+        joinType);
   } else {
     throw std::runtime_error(
         "Index Loop Join subtree must be a single TableScanNode.");

--- a/velox/tool/trace/IndexLookupJoinReplayer.cpp
+++ b/velox/tool/trace/IndexLookupJoinReplayer.cpp
@@ -36,6 +36,7 @@ core::PlanNodePtr IndexLookupJoinReplayer::createPlanNode(
       indexLookupJoinNode->leftKeys(),
       indexLookupJoinNode->rightKeys(),
       indexLookupJoinNode->joinConditions(),
+      indexLookupJoinNode->includeMatchColumn(),
       source, // Probe side
       indexLookupJoinNode->lookupSource(), // Index side
       indexLookupJoinNode->outputType());

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -267,6 +267,7 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
               rightKeys,
               std::dynamic_pointer_cast<const core::TableScanNode>(indexScan),
               /*joinConditions=*/{},
+              /*includeMatchColumn=*/false,
               concat(probeType_, indexType_)->names(),
               core::JoinType::kInner)
           .capturePlanNodeId(traceNodeId_)


### PR DESCRIPTION
Summary: Support an optional match column for index lookup join operator to indicate if an output row has a match or not. If this option is set in the plan node, then we expect a boolean column at the end of the index join output, otherwise not. This only applies for left join type.

Differential Revision: D79839444


