### PR TITLE
feat: Add a configuration property for Spark ANSI mode

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -363,9 +363,11 @@ class QueryConfig {
   static constexpr const char* kPrestoArrayAggIgnoreNulls =
       "presto.array_agg.ignore_nulls";
 
-  /// If true, Velox will use an ANSI-compliant dialect. For example, Velox will
-  /// throw a runtime exception instead of returning null results when the
-  /// inputs to a SQL operator or function are invalid.
+  /// If true, Spark function's behavior is ANSI-compliant, e.g. throws runtime
+  /// exception instead of returning null on invalid inputs.
+  /// Note: This feature is still under development to achieve full ANSI
+  /// compliance. Users can refer to the Spark function documentation to verify
+  /// the current support status of a specific function.
   static constexpr const char* kSparkAnsiEnabled = "spark.ansi_enabled";
 
   /// The default number of expected items for the bloomfilter.

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -36,11 +36,6 @@ class QueryConfig {
   static constexpr const char* kQueryMaxMemoryPerNode =
       "query_max_memory_per_node";
 
-  /// If true, Velox will use an ANSI-compliant dialect. For example, Velox will
-  /// throw a runtime exception instead of returning null results when the inputs
-  /// to a SQL operator or function are invalid.
-  static constexpr const char* kAnsiEnabled = "ansi_enabled";
-
   /// User provided session timezone. Stores a string with the actual timezone
   /// name, e.g: "America/Los_Angeles".
   static constexpr const char* kSessionTimezone = "session_timezone";
@@ -367,6 +362,11 @@ class QueryConfig {
   /// If true, array_agg() aggregation function will ignore nulls in the input.
   static constexpr const char* kPrestoArrayAggIgnoreNulls =
       "presto.array_agg.ignore_nulls";
+
+  /// If true, Velox will use an ANSI-compliant dialect. For example, Velox will
+  /// throw a runtime exception instead of returning null results when the
+  /// inputs to a SQL operator or function are invalid.
+  static constexpr const char* kSparkAnsiEnabled = "spark.ansi_enabled";
 
   /// The default number of expected items for the bloomfilter.
   static constexpr const char* kSparkBloomFilterExpectedNumItems =
@@ -869,10 +869,6 @@ class QueryConfig {
     return get<uint64_t>(kExprMaxCompiledRegexes, 100);
   }
 
-  bool ansiEnabled() const {
-    return get<bool>(kAnsiEnabled, false);
-  }
-
   bool adjustTimestampToTimezone() const {
     return get<bool>(kAdjustTimestampToTimezone, false);
   }
@@ -1028,6 +1024,10 @@ class QueryConfig {
 
   bool prestoArrayAggIgnoreNulls() const {
     return get<bool>(kPrestoArrayAggIgnoreNulls, false);
+  }
+
+  bool sparkAnsiEnabled() const {
+    return get<bool>(kSparkAnsiEnabled, false);
   }
 
   int64_t sparkBloomFilterExpectedNumItems() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -36,6 +36,11 @@ class QueryConfig {
   static constexpr const char* kQueryMaxMemoryPerNode =
       "query_max_memory_per_node";
 
+  /// If true, Velox will use an ANSI-compliant dialect. For example, Velox will
+  /// throw a runtime exception instead of returning null results when the inputs
+  /// to a SQL operator or function are invalid.
+  static constexpr const char* kAnsiEnabled = "ansi_enabled";
+
   /// User provided session timezone. Stores a string with the actual timezone
   /// name, e.g: "America/Los_Angeles".
   static constexpr const char* kSessionTimezone = "session_timezone";
@@ -862,6 +867,10 @@ class QueryConfig {
 
   uint64_t exprMaxCompiledRegexes() const {
     return get<uint64_t>(kExprMaxCompiledRegexes, 100);
+  }
+
+  bool ansiEnabled() const {
+    return get<bool>(kAnsiEnabled, false);
   }
 
   bool adjustTimestampToTimezone() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -43,6 +43,11 @@ Generic Configuration
      - integer
      - 80
      - Abandons partial TopNRowNumber if number of output rows equals or exceeds this percentage of the number of input rows.
+   * - ansi_enabled
+     - bool
+     - false
+     - If true, Velox will use an ANSI-compliant dialect. For example, Velox will throw a runtime exception instead of
+       returning null results when the inputs to a SQL operator or function are invalid.
    * - session_timezone
      - string
      -

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -980,8 +980,11 @@ Spark-specific Configuration
    * - spark.ansi_enabled
      - bool
      - false
-     - If true, Velox will use an ANSI-compliant dialect. For example, Velox will throw a runtime exception instead of
-       returning null results when the inputs to a SQL operator or function are invalid.
+     - If true, Spark function's behavior is ANSI-compliant, e.g. throws runtime exception instead
+       of returning null on invalid inputs.
+       Note: This feature is still under development to achieve full ANSI compliance. Users can
+       refer to the Spark function documentation to verify the current support status of a specific
+       function.
    * - spark.legacy_size_of_null
      - bool
      - true

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -43,11 +43,6 @@ Generic Configuration
      - integer
      - 80
      - Abandons partial TopNRowNumber if number of output rows equals or exceeds this percentage of the number of input rows.
-   * - ansi_enabled
-     - bool
-     - false
-     - If true, Velox will use an ANSI-compliant dialect. For example, Velox will throw a runtime exception instead of
-       returning null results when the inputs to a SQL operator or function are invalid.
    * - session_timezone
      - string
      -
@@ -982,6 +977,11 @@ Spark-specific Configuration
      - Type
      - Default Value
      - Description
+   * - spark.ansi_enabled
+     - bool
+     - false
+     - If true, Velox will use an ANSI-compliant dialect. For example, Velox will throw a runtime exception instead of
+       returning null results when the inputs to a SQL operator or function are invalid.
    * - spark.legacy_size_of_null
      - bool
      - true


### PR DESCRIPTION
This change prepares for supporting an ANSI-compliant dialect in Velox. The added
configuration property allows function implementations to adapt based on the user's
ANSI mode setting.

See ANSI support discussion: https://github.com/facebookincubator/velox/issues/3869.