### PR TITLE
refactor: Avoid extra overhead call sanitizeName and find

### DIFF
--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -85,6 +85,25 @@ const SignatureMap* getSignatureMap(
 }
 } // namespace
 
+std::unordered_map<std::string, std::vector<const FunctionSignature*>>
+SimpleFunctionRegistry::getFunctionSignatureMap() const {
+  std::unordered_map<std::string, std::vector<const FunctionSignature*>> result;
+  registeredFunctions_.withRLock([&](const auto& map) {
+    result.reserve(map.size());
+
+    for (const auto& entry : map) {
+      std::vector<const FunctionSignature*> signatures;
+      const auto signatureMap = &entry.second;
+      signatures.reserve(signatureMap->size());
+      for (const auto& pair : *signatureMap) {
+        signatures.emplace_back(&pair.first);
+      }
+      result[entry.first] = signatures;
+    }
+  });
+  return result;
+}
+
 std::vector<const FunctionSignature*>
 SimpleFunctionRegistry::getFunctionSignatures(const std::string& name) const {
   std::vector<const FunctionSignature*> signatures;

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -109,6 +109,9 @@ class SimpleFunctionRegistry {
     registeredFunctions_.withWLock([&](auto& map) { map.clear(); });
   }
 
+  std::unordered_map<std::string, std::vector<const exec::FunctionSignature*>>
+  getFunctionSignatureMap() const;
+
   std::vector<const FunctionSignature*> getFunctionSignatures(
       const std::string& name) const;
 

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -32,13 +32,6 @@
 namespace facebook::velox {
 namespace {
 
-void populateSimpleFunctionSignatures(FunctionSignatureMap& map) {
-  const auto& simpleFunctions = exec::simpleFunctions();
-  for (const auto& functionName : simpleFunctions.getFunctionNames()) {
-    map[functionName] = simpleFunctions.getFunctionSignatures(functionName);
-  }
-}
-
 void populateVectorFunctionSignatures(FunctionSignatureMap& map) {
   auto vectorFunctions = exec::vectorFunctionFactories();
   vectorFunctions.withRLock([&map](const auto& locked) {
@@ -58,8 +51,8 @@ void populateVectorFunctionSignatures(FunctionSignatureMap& map) {
 } // namespace
 
 FunctionSignatureMap getFunctionSignatures() {
-  FunctionSignatureMap result;
-  populateSimpleFunctionSignatures(result);
+  const auto& simpleFunctions = exec::simpleFunctions();
+  FunctionSignatureMap result = simpleFunctions.getFunctionSignatureMap();
   populateVectorFunctionSignatures(result);
   return result;
 }

--- a/velox/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/velox/functions/sparksql/benchmarks/CMakeLists.txt
@@ -56,3 +56,12 @@ target_link_libraries(
   velox_vector_test_lib
   velox_vector_fuzzer
   velox_functions_lib)
+
+add_executable(velox_sparksql_benchmarks_get_funcs FunctionBenchmark.cpp)
+target_link_libraries(
+  velox_sparksql_benchmarks_get_funcs
+  velox_functions_spark
+  velox_exec_test_lib
+  velox_parse_utils
+  Folly::folly
+  Folly::follybenchmark)

--- a/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <functions/FunctionRegistry.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/sparksql/registration/Register.h"
+
+using namespace facebook::velox;
+class FunctionBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  FunctionBenchmark() : FunctionBenchmarkBase() {
+    functions::sparksql::registerFunctions("");
+  }
+
+  void run() {
+    volatile int total = 0;
+    for (auto i = 0; i < 1000; i++) {
+      auto functions = getFunctionSignatures();
+      auto size = functions.size();
+      total += size;
+    }
+    std::cout << total << std::endl;
+  }
+};
+
+BENCHMARK(get_function_signatures_1000) {
+  FunctionBenchmark benchmark;
+  benchmark.run();
+}
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Fixes: https://github.com/facebookincubator/velox/issues/14377

This PR proposes to add `getFunctionSignatureMap`.
So we can avoid the overhead of extra loop (`for (const auto& functionName : simpleFunctions.getFunctionNames())`) and the overhead of calling `getSignatureMap`.

This PR also adds a benchmark named `velox_sparksql_benchmarks_get_funcs`.
Before this PR, the output of benchmark show below.

```
cmake-build-debug/velox/functions/sparksql/benchmarks/velox_sparksql_benchmarks_get_funcs
WARNING: Benchmark running in DEBUG mode
225000
225000
225000
225000
============================================================================
[...]ksql/benchmarks/FunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
get_function_signatures_1000                              256.17ms      3.90
WARNING: Benchmark running in DEBUG mode
```

After this PR, the output of benchmark show below.

```
cmake-build-debug/velox/functions/sparksql/benchmarks/velox_sparksql_benchmarks_get_funcs
WARNING: Benchmark running in DEBUG mode
225000
225000
225000
225000
225000
============================================================================
[...]ksql/benchmarks/FunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
get_function_signatures_1000                              209.14ms      4.78
WARNING: Benchmark running in DEBUG mode
```