### PR TITLE
misc: Add Spark function code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,3 +46,6 @@ velox/connectors/ @majetideepak
 
 # Caching
 velox/common/caching/ @majetideepak
+
+# Spark Functions
+velox/functions/sparksql/ @jinchengchenghh @rui-mo @zhli1142015


### PR DESCRIPTION
Setup the Spark function maintainer as code owners so it automatically requests 
a review from us on changes to the Spark functions in Velox.