### PR TITLE
feat(gcs): Add config to support registering custom GcsOAuthCredentialsProvider

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -93,6 +93,11 @@ std::optional<std::string> HiveConfig::gcsMaxRetryTime() const {
       config_->get<std::string>(kGcsMaxRetryTime));
 }
 
+std::optional<std::string> HiveConfig::gcsAuthAccessTokenProvider() const {
+  return static_cast<std::optional<std::string>>(
+      config_->get<std::string>(kGcsAuthAccessTokenProvider));
+}
+
 bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
   return session->get<bool>(
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -71,6 +71,9 @@ class HiveConfig {
   /// The GCS maximum time allowed to retry transient errors.
   static constexpr const char* kGcsMaxRetryTime = "hive.gcs.max-retry-time";
 
+  static constexpr const char* kGcsAuthAccessTokenProvider =
+      "hive.gcs.auth.access-token-provider";
+
   /// Maps table field names to file field names using names, not indices.
   // TODO: remove hive_orc_use_column_names since it doesn't exist in presto,
   // right now this is only used for testing.
@@ -210,6 +213,8 @@ class HiveConfig {
   std::optional<int> gcsMaxRetryCount() const;
 
   std::optional<std::string> gcsMaxRetryTime() const;
+
+  std::optional<std::string> gcsAuthAccessTokenProvider() const;
 
   bool isOrcUseColumnNames(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
@@ -36,12 +36,40 @@ using namespace connector::hive;
 namespace gcs = ::google::cloud::storage;
 namespace gc = ::google::cloud;
 
+namespace {
+
 auto constexpr kGcsInvalidPath = "File {} is not a valid gcs file";
+
+folly::Synchronized<
+    std::unordered_map<std::string, GcsOAuthCredentialsProviderFactory>>&
+credentialsProviderFactories() {
+  static folly::Synchronized<
+      std::unordered_map<std::string, GcsOAuthCredentialsProviderFactory>>
+      factories;
+  return factories;
+}
+
+std::shared_ptr<GcsOAuthCredentialsProvider> getCredentialsProviderByName(
+    const std::string& providerName,
+    const std::shared_ptr<connector::hive::HiveConfig>& hiveConfig) {
+  return credentialsProviderFactories().withRLock([&](const auto& factories) {
+    const auto it = factories.find(providerName);
+    VELOX_CHECK(
+        it != factories.end(),
+        "GcsOAuthCredentialsProviderFactory for '{}' not registered",
+        providerName);
+    const auto& factory = it->second;
+    return factory(hiveConfig);
+  });
+}
+
+} // namespace
 
 class GcsFileSystem::Impl {
  public:
-  Impl(const config::ConfigBase* config)
-      : hiveConfig_(std::make_shared<HiveConfig>(
+  Impl(const std::string& bucket, const config::ConfigBase* config)
+      : bucket_(bucket),
+        hiveConfig_(std::make_shared<HiveConfig>(
             std::make_shared<config::ConfigBase>(config->rawConfigsCopy()))) {}
 
   ~Impl() = default;
@@ -50,21 +78,28 @@ class GcsFileSystem::Impl {
   void initializeClient() {
     constexpr std::string_view kHttpsScheme{"https://"};
     auto options = gc::Options{};
-    auto endpointOverride = hiveConfig_->gcsEndpoint();
-    // Use secure credentials by default.
-    if (!endpointOverride.empty()) {
-      options.set<gcs::RestEndpointOption>(endpointOverride);
-      // Use Google default credentials if endpoint has https scheme.
-      if (endpointOverride.find(kHttpsScheme) == 0) {
-        options.set<gc::UnifiedCredentialsOption>(
-            gc::MakeGoogleDefaultCredentials());
+    if (auto tokenProvider = hiveConfig_->gcsAuthAccessTokenProvider()) {
+      auto credentialsProvider =
+          getCredentialsProviderByName(tokenProvider.value(), hiveConfig_);
+      auto credentials = credentialsProvider->getCredentials(bucket_);
+      options.set<gcs::Oauth2CredentialsOption>(credentials);
+    } else {
+      auto endpointOverride = hiveConfig_->gcsEndpoint();
+      // Use secure credentials by default.
+      if (!endpointOverride.empty()) {
+        options.set<gcs::RestEndpointOption>(endpointOverride);
+        // Use Google default credentials if endpoint has https scheme.
+        if (endpointOverride.find(kHttpsScheme) == 0) {
+          options.set<gc::UnifiedCredentialsOption>(
+              gc::MakeGoogleDefaultCredentials());
+        } else {
+          options.set<gc::UnifiedCredentialsOption>(
+              gc::MakeInsecureCredentials());
+        }
       } else {
         options.set<gc::UnifiedCredentialsOption>(
-            gc::MakeInsecureCredentials());
+            gc::MakeGoogleDefaultCredentials());
       }
-    } else {
-      options.set<gc::UnifiedCredentialsOption>(
-          gc::MakeGoogleDefaultCredentials());
     }
     options.set<gcs::UploadBufferSizeOption>(kUploadBufferSize);
 
@@ -107,13 +142,16 @@ class GcsFileSystem::Impl {
   }
 
  private:
+  const std::string bucket_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
   std::shared_ptr<gcs::Client> client_;
 };
 
-GcsFileSystem::GcsFileSystem(std::shared_ptr<const config::ConfigBase> config)
+GcsFileSystem::GcsFileSystem(
+    const std::string& bucket,
+    std::shared_ptr<const config::ConfigBase> config)
     : FileSystem(config) {
-  impl_ = std::make_shared<Impl>(config.get());
+  impl_ = std::make_shared<Impl>(bucket, config.get());
 }
 
 void GcsFileSystem::initializeClient() {
@@ -323,6 +361,21 @@ void GcsFileSystem::rmdir(std::string_view path) {
         bucket,
         metadata->name());
   }
+}
+
+void registerOAuthCredentialsProvider(
+    const std::string& providerName,
+    const GcsOAuthCredentialsProviderFactory& factory) {
+  VELOX_CHECK(
+      !providerName.empty(),
+      "GcsOAuthCredentialsProviderFactory name cannot be empty");
+  credentialsProviderFactories().withWLock([&](auto& factories) {
+    VELOX_CHECK(
+        factories.find(providerName) == factories.end(),
+        "GcsOAuthCredentialsProviderFactory '{}' already registered",
+        providerName);
+    factories.insert({providerName, factory});
+  });
 }
 
 } // namespace filesystems

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
@@ -52,9 +52,12 @@ credentialsProviderFactories() {
 std::shared_ptr<GcsOAuthCredentialsProvider> getCredentialsProviderByName(
     const std::string& providerName,
     const std::shared_ptr<connector::hive::HiveConfig>& hiveConfig) {
+  VELOX_USER_CHECK(
+      !providerName.empty(),
+      "GcsOAuthCredentialsProviderFactory name cannot be empty");
   return credentialsProviderFactories().withRLock([&](const auto& factories) {
     const auto it = factories.find(providerName);
-    VELOX_CHECK(
+    VELOX_USER_CHECK(
         it != factories.end(),
         "GcsOAuthCredentialsProviderFactory for '{}' not registered",
         providerName);

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GcsOAuthCredentialsProvider.h"
 
 namespace facebook::velox::filesystems {
 
@@ -26,7 +28,9 @@ namespace facebook::velox::filesystems {
 /// (register|generate)ReadFile and (register|generate)WriteFile functions.
 class GcsFileSystem : public FileSystem {
  public:
-  explicit GcsFileSystem(std::shared_ptr<const config::ConfigBase> config);
+  explicit GcsFileSystem(
+      const std::string& bucket,
+      std::shared_ptr<const config::ConfigBase> config);
 
   /// Initialize the google::cloud::storage::Client from the input Config
   /// parameters.
@@ -103,5 +107,13 @@ class GcsFileSystem : public FileSystem {
   class Impl;
   std::shared_ptr<Impl> impl_;
 };
+
+using GcsOAuthCredentialsProviderFactory =
+    std::function<std::shared_ptr<GcsOAuthCredentialsProvider>(
+        const std::shared_ptr<connector::hive::HiveConfig>& hiveConfig)>;
+
+void registerOAuthCredentialsProvider(
+    const std::string& providerName,
+    const GcsOAuthCredentialsProviderFactory& factory);
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/gcs/GcsOAuthCredentialsProvider.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsOAuthCredentialsProvider.h
@@ -22,6 +22,9 @@ namespace facebook::velox::filesystems {
 
 namespace gcs = ::google::cloud::storage;
 
+/// Interface for providing OAuth2 credentials for Google Cloud Storage (GCS).
+/// Implementations should return a GCS OAuth2 credential used for creating the
+/// GCS client for a specific bucket via `getCredentials`.
 class GcsOAuthCredentialsProvider {
  public:
   virtual ~GcsOAuthCredentialsProvider() = default;

--- a/velox/connectors/hive/storage_adapters/gcs/GcsOAuthCredentialsProvider.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsOAuthCredentialsProvider.h
@@ -16,26 +16,18 @@
 
 #pragma once
 
-#include <functional>
-#include <memory>
-#include <string>
-
-namespace facebook::velox::connector::hive {
-class HiveConfig;
-}
+#include <google/cloud/storage/oauth2/credentials.h>
 
 namespace facebook::velox::filesystems {
-class GcsOAuthCredentialsProvider;
 
-// Register the GCS filesystem.
-void registerGcsFileSystem();
+namespace gcs = ::google::cloud::storage;
 
-using GcsOAuthCredentialsProviderFactory =
-    std::function<std::shared_ptr<GcsOAuthCredentialsProvider>(
-        const std::shared_ptr<connector::hive::HiveConfig>& hiveConfig)>;
+class GcsOAuthCredentialsProvider {
+ public:
+  virtual ~GcsOAuthCredentialsProvider() = default;
 
-void registerGcsOAuthCredentialsProvider(
-    const std::string& providerName,
-    const GcsOAuthCredentialsProviderFactory& factory);
+  virtual std::shared_ptr<gcs::oauth2::Credentials> getCredentials(
+      const std::string& bucket) = 0;
+};
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include "velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.h"
+
 #ifdef VELOX_ENABLE_GCS
 #include "velox/common/config/Config.h"
 #include "velox/connectors/hive/HiveConfig.h"
@@ -75,9 +77,10 @@ gcsFileSystemGenerator() {
 
               std::shared_ptr<GcsFileSystem> fs;
               if (properties != nullptr) {
-                fs = std::make_shared<GcsFileSystem>(properties);
+                fs = std::make_shared<GcsFileSystem>(bucket, properties);
               } else {
                 fs = std::make_shared<GcsFileSystem>(
+                    bucket,
                     std::make_shared<config::ConfigBase>(
                         std::unordered_map<std::string, std::string>()));
               }
@@ -111,6 +114,14 @@ void registerGcsFileSystem() {
   registerFileSystem(isGcsFile, gcsFileSystemGenerator());
   dwio::common::FileSink::registerFactory(
       std::function(gcsWriteFileSinkGenerator));
+#endif
+}
+
+void registerGcsOAuthCredentialsProvider(
+    const std::string& providerName,
+    const GcsOAuthCredentialsProviderFactory& factory) {
+#ifdef VELOX_ENABLE_GCS
+  registerOAuthCredentialsProvider(providerName, factory);
 #endif
 }
 

--- a/velox/connectors/hive/storage_adapters/gcs/examples/GcsFileSystemExample.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/GcsFileSystemExample.cpp
@@ -16,6 +16,7 @@
 #include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GcsUtil.h"
 
 #include <folly/init/Init.h>
 #include <gflags/gflags.h>
@@ -45,7 +46,10 @@ int main(int argc, char** argv) {
     gflags::ShowUsageWithFlags(argv[0]);
     return 1;
   }
-  filesystems::GcsFileSystem gcfs(newConfiguration());
+  std::string bucket;
+  std::string object;
+  setBucketAndKeyFromGcsPath(FLAGS_gcs_path, bucket, object);
+  filesystems::GcsFileSystem gcfs(bucket, newConfiguration());
   gcfs.initializeClient();
   std::cout << "Opening file for read " << FLAGS_gcs_path << std::endl;
   std::unique_ptr<ReadFile> file_read = gcfs.openFileForRead(FLAGS_gcs_path);

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
@@ -103,7 +103,7 @@ class GcsEmulator : public testing::Environment {
     return std::make_shared<const config::ConfigBase>(std::move(config));
   }
 
-  std::string_view preexistingBucketName() {
+  const std::string& preexistingBucketName() {
     return bucketName_;
   }
 

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
@@ -277,23 +277,39 @@ TEST_F(GcsFileSystemTest, credentialsProvider) {
       };
   registerGcsOAuthCredentialsProvider("dummy_provider", providerFactory);
 
-  std::unordered_map<std::string, std::string> configOverride = {
-      {"hive.gcs.auth.access-token-provider", "dummy_provider"}};
-  auto hiveConfig = emulator_->hiveConfig(configOverride);
+  {
+    std::unordered_map<std::string, std::string> configOverride = {
+        {"hive.gcs.auth.access-token-provider", "dummy_provider"}};
+    auto hiveConfig = emulator_->hiveConfig(configOverride);
 
-  filesystems::GcsFileSystem gcfs(
-      emulator_->preexistingBucketName(), hiveConfig);
-  VELOX_ASSERT_THROW(
-      gcfs.initializeClient(),
-      "DummyGcsOAuthCredentialsProvider: Not implemented");
+    filesystems::GcsFileSystem gcfs(
+        emulator_->preexistingBucketName(), hiveConfig);
+    VELOX_ASSERT_THROW(
+        gcfs.initializeClient(),
+        "DummyGcsOAuthCredentialsProvider: Not implemented");
 
-  VELOX_ASSERT_THROW(
-      registerGcsOAuthCredentialsProvider("", providerFactory),
-      "GcsOAuthCredentialsProviderFactory name cannot be empty");
+    VELOX_ASSERT_THROW(
+        registerGcsOAuthCredentialsProvider("", providerFactory),
+        "GcsOAuthCredentialsProviderFactory name cannot be empty");
 
-  VELOX_ASSERT_THROW(
-      registerGcsOAuthCredentialsProvider("dummy_provider", providerFactory),
-      "GcsOAuthCredentialsProviderFactory 'dummy_provider' already registered");
+    VELOX_ASSERT_THROW(
+        registerGcsOAuthCredentialsProvider("dummy_provider", providerFactory),
+        "GcsOAuthCredentialsProviderFactory 'dummy_provider' already registered");
+  }
+
+  // Invalid provider name.
+  {
+    std::unordered_map<std::string, std::string> configOverride = {
+        {"hive.gcs.auth.access-token-provider", ""}};
+    auto hiveConfig = emulator_->hiveConfig(configOverride);
+
+    filesystems::GcsFileSystem gcfs(
+        emulator_->preexistingBucketName(), hiveConfig);
+
+    VELOX_ASSERT_THROW(
+        gcfs.initializeClient(),
+        "GcsOAuthCredentialsProviderFactory name cannot be empty");
+  }
 }
 
 TEST_F(GcsFileSystemTest, defaultCacheKey) {

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
@@ -27,6 +27,16 @@
 namespace facebook::velox::filesystems {
 namespace {
 
+class DummyGcsOAuthCredentialsProvider : public GcsOAuthCredentialsProvider {
+ public:
+  explicit DummyGcsOAuthCredentialsProvider() : GcsOAuthCredentialsProvider() {}
+
+  std::shared_ptr<gcs::oauth2::Credentials> getCredentials(
+      const std::string&) override {
+    VELOX_FAIL("DummyGcsOAuthCredentialsProvider: Not implemented");
+  }
+};
+
 class GcsFileSystemTest : public testing::Test {
  public:
   void SetUp() {
@@ -41,7 +51,8 @@ TEST_F(GcsFileSystemTest, readFile) {
   const auto gcsFile = gcsURI(
       emulator_->preexistingBucketName(), emulator_->preexistingObjectName());
 
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
   auto readFile = gcfs.openFileForRead(gcsFile);
   std::int64_t size = readFile->size();
@@ -78,7 +89,8 @@ TEST_F(GcsFileSystemTest, writeAndReadFile) {
   const std::string_view newFile = "readWriteFile.txt";
   const auto gcsFile = gcsURI(emulator_->preexistingBucketName(), newFile);
 
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
   auto writeFile = gcfs.openFileForWrite(gcsFile);
   std::string_view kDataContent =
@@ -104,13 +116,15 @@ TEST_F(GcsFileSystemTest, writeAndReadFile) {
   EXPECT_EQ(readFile->pread(0, size), kDataContent);
 
   // Opening an existing file for write must be an error.
-  filesystems::GcsFileSystem newGcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem newGcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   newGcfs.initializeClient();
   VELOX_ASSERT_THROW(newGcfs.openFileForWrite(gcsFile), "File already exists");
 }
 
 TEST_F(GcsFileSystemTest, rename) {
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
 
   const std::string_view oldFile = "oldTest.txt";
@@ -146,7 +160,8 @@ TEST_F(GcsFileSystemTest, rename) {
 TEST_F(GcsFileSystemTest, mkdir) {
   const std::string_view dir = "newDirectory";
   const auto gcsNewDirectory = gcsURI(emulator_->preexistingBucketName(), dir);
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
   gcfs.mkdir(gcsNewDirectory);
   const auto& results = gcfs.list(gcsNewDirectory);
@@ -156,7 +171,8 @@ TEST_F(GcsFileSystemTest, mkdir) {
 TEST_F(GcsFileSystemTest, rmdir) {
   const std::string_view dir = "Directory";
   const auto gcsDirectory = gcsURI(emulator_->preexistingBucketName(), dir);
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
 
   auto writeFile = gcfs.openFileForWrite(gcsDirectory);
@@ -176,7 +192,8 @@ TEST_F(GcsFileSystemTest, rmdir) {
 TEST_F(GcsFileSystemTest, missingFile) {
   const std::string_view file = "newTest.txt";
   const auto gcsFile = gcsURI(emulator_->preexistingBucketName(), file);
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
   VELOX_ASSERT_RUNTIME_THROW_CODE(
       gcfs.openFileForRead(gcsFile),
@@ -185,7 +202,8 @@ TEST_F(GcsFileSystemTest, missingFile) {
 }
 
 TEST_F(GcsFileSystemTest, missingBucket) {
-  filesystems::GcsFileSystem gcfs(emulator_->hiveConfig());
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), emulator_->hiveConfig());
   gcfs.initializeClient();
   const std::string_view gcsFile = "gs://dummy/foo.txt";
   VELOX_ASSERT_RUNTIME_THROW_CODE(
@@ -243,12 +261,39 @@ TEST_F(GcsFileSystemTest, credentialsConfig) {
       {"hive.gcs.json-key-file-path", jsonFile->getPath()}};
   auto hiveConfig = emulator_->hiveConfig(configOverride);
 
-  filesystems::GcsFileSystem gcfs(hiveConfig);
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), hiveConfig);
   gcfs.initializeClient();
   const auto gcsFile = gcsURI(
       emulator_->preexistingBucketName(), emulator_->preexistingObjectName());
   VELOX_ASSERT_THROW(
       gcfs.openFileForRead(gcsFile), "Invalid ServiceAccountCredentials");
+}
+
+TEST_F(GcsFileSystemTest, credentialsProvider) {
+  const auto providerFactory =
+      [](const std::shared_ptr<connector::hive::HiveConfig>&) {
+        return std::make_shared<DummyGcsOAuthCredentialsProvider>();
+      };
+  registerGcsOAuthCredentialsProvider("dummy_provider", providerFactory);
+
+  std::unordered_map<std::string, std::string> configOverride = {
+      {"hive.gcs.auth.access-token-provider", "dummy_provider"}};
+  auto hiveConfig = emulator_->hiveConfig(configOverride);
+
+  filesystems::GcsFileSystem gcfs(
+      emulator_->preexistingBucketName(), hiveConfig);
+  VELOX_ASSERT_THROW(
+      gcfs.initializeClient(),
+      "DummyGcsOAuthCredentialsProvider: Not implemented");
+
+  VELOX_ASSERT_THROW(
+      registerGcsOAuthCredentialsProvider("", providerFactory),
+      "GcsOAuthCredentialsProviderFactory name cannot be empty");
+
+  VELOX_ASSERT_THROW(
+      registerGcsOAuthCredentialsProvider("dummy_provider", providerFactory),
+      "GcsOAuthCredentialsProviderFactory 'dummy_provider' already registered");
 }
 
 TEST_F(GcsFileSystemTest, defaultCacheKey) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -914,6 +914,12 @@ These semantics are similar to the `Apache Hadoop-Aws module <https://hadoop.apa
      - string
      -
      - The GCS maximum time allowed to retry transient errors.
+   * - hive.gcs.auth.access-token-provider
+     - string
+     -
+     - A custom OAuth credential provider, if specified, will be used to create the client in favor of other
+       authentication mechanisms.
+       The provider must be registered using "registerGcsOAuthCredentialsProvider" before it can be used.
 
 ``Azure Blob Storage Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Currently, only a service account credential file is supported for creating the GCS client. In real-world scenarios, users may instead rely on provided OAuth credentials and manage their expiration according to external rules.

This patch adds a `GcsOAuthCredentialsProvider` interface for custom providers that generate OAuth credentials, a config entry `hive.gcs.auth.access-token-provider` to enable using a self-defined `GcsOAuthCredentialsProvider`, and adds a new API `registerGcsOAuthCredentialsProvider` for registering the factory to use the custom `GcsOAuthCredentialsProvider` implementation.