### PR TITLE
fix(fuzzer): Skip map_keys_by_top_n_values in fuzzer due to behavior mismatch

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -386,6 +386,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     // Skipping until the new signature is merged and released in Presto:
     // https://github.com/prestodb/presto/pull/25521
     "xxhash64(varbinary,bigint) -> varbinary",
+    "map_keys_by_top_n_values", // https://github.com/facebookincubator/velox/issues/14374
     "$internal$canonicalize",
     "$internal$contains",
 };


### PR DESCRIPTION
Summary: map_ley_by_top_n_values() has known behavior mismatch when wrapped in try() between Velox and Presto. https://github.com/facebookincubator/velox/issues/14374.

Differential Revision: D79862435


