### PR TITLE
feat: Add an option in duck parser to parse IN list values as individual arguments

### DIFF
--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -33,6 +33,9 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+  // Whether to parse the values in an IN list as separate arguments or as a
+  // single array argument.
+  bool parseInListAsArray = true;
 
   /// SQL functions could be registered with different prefixes by the user.
   /// This parameter is the registered prefix of presto or spark functions,

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -197,6 +197,22 @@ TEST(DuckParserTest, in) {
       parseExpr("col1 in ('a', null, 'b', 'c')")->toString());
 }
 
+TEST(DuckParserTest, inListAsArray) {
+  ParseOptions parseOptions{.parseInListAsArray = false, .functionPrefix = ""};
+  EXPECT_EQ(
+      "in(\"col1\",1,2,3)",
+      parseExpr("col1 in (1, 2, 3)", parseOptions)->toString());
+  EXPECT_EQ(
+      "in(\"col1\",1,2,null,3)",
+      parseExpr("col1 in (1, 2, null, 3)", parseOptions)->toString());
+  EXPECT_EQ(
+      "in(\"col1\",a,b,c)",
+      parseExpr("col1 in ('a', 'b', 'c')", parseOptions)->toString());
+  EXPECT_EQ(
+      "in(\"col1\",a,null,b,c)",
+      parseExpr("col1 in ('a', null, 'b', 'c')", parseOptions)->toString());
+}
+
 TEST(DuckParserTest, notIn) {
   EXPECT_EQ(
       "not(in(\"col1\",{1, 2, 3}))",
@@ -229,6 +245,42 @@ TEST(DuckParserTest, notIn) {
   EXPECT_EQ(
       "not(in(\"col1\",{a, null, b, c}))",
       parseExpr("not(col1 in ('a', null, 'b', 'c'))")->toString());
+}
+
+TEST(DuckParserTest, notInListAsArray) {
+  ParseOptions parseOptions{.parseInListAsArray = false, .functionPrefix = ""};
+  EXPECT_EQ(
+      "not(in(\"col1\",1,2,3))",
+      parseExpr("col1 not in (1, 2, 3)", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",1,2,3))",
+      parseExpr("not(col1 in (1, 2, 3))", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",1,2,null,3))",
+      parseExpr("col1 not in (1, 2, null, 3)", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",1,2,null,3))",
+      parseExpr("not(col1 in (1, 2, null, 3))", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",a,b,c))",
+      parseExpr("col1 not in ('a', 'b', 'c')", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",a,b,c))",
+      parseExpr("not(col1 in ('a', 'b', 'c'))", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",a,null,b,c))",
+      parseExpr("col1 not in ('a', null, 'b', 'c')", parseOptions)->toString());
+
+  EXPECT_EQ(
+      "not(in(\"col1\",a,null,b,c))",
+      parseExpr("not(col1 in ('a', null, 'b', 'c'))", parseOptions)
+          ->toString());
 }
 
 TEST(DuckParserTest, expressions) {

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -22,6 +22,7 @@ core::ExprPtr parseExpr(const std::string& expr, const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
+  duckConversionOptions.parseInListAsArray = options.parseInListAsArray;
   duckConversionOptions.functionPrefix = options.functionPrefix;
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -24,6 +24,9 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+  // Controls whether to parse the values in an IN list as separate arguments or
+  // as a single array argument.
+  bool parseInListAsArray = true;
 
   /// SQL functions could be registered with different prefixes by the user.
   /// This parameter is the registered prefix of presto or spark functions,


### PR DESCRIPTION
Summary: Add an option to choose the parser output of IN List, with the values to be in an array or separate arguments.

Differential Revision: D79934869


