### PR TITLE
misc: Use make_shared to create PeeledEncoding

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -26,7 +26,7 @@ namespace facebook::velox::exec {
     DecodedVector& decodedVector,
     bool canPeelsHaveNulls,
     std::vector<VectorPtr>& peeledVectors) {
-  auto peeledEncoding = std::make_shared<PeeledEncoding>();
+  auto peeledEncoding = std::make_shared<PeeledEncoding>(PrivateTag{});
   if (peeledEncoding->peelInternal(
           vectorsToPeel,
           rows,

--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -26,7 +26,7 @@ namespace facebook::velox::exec {
     DecodedVector& decodedVector,
     bool canPeelsHaveNulls,
     std::vector<VectorPtr>& peeledVectors) {
-  std::shared_ptr<PeeledEncoding> peeledEncoding(new PeeledEncoding());
+  auto peeledEncoding = std::make_shared<PeeledEncoding>();
   if (peeledEncoding->peelInternal(
           vectorsToPeel,
           rows,

--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -106,6 +106,10 @@ class LocalSelectivityVector;
 ///                    DictWithNulls(Dict3(Flat2))
 ///    peel: DictNoNulls
 class PeeledEncoding {
+  struct PrivateTag {
+    explicit PrivateTag() = default;
+  };
+
  public:
   /// Factory method for constructing a PeeledEncoding object only if peeling
   /// was successful. Takes a set of vectors and peels all the common encoding
@@ -178,9 +182,11 @@ class PeeledEncoding {
     });
   }
 
- private:
-  PeeledEncoding() = default;
+  // This constructor is public only for make_shared and can't be used,
+  // to create a PeeledEncoding use PeeledEncoding::peel(...)
+  explicit PeeledEncoding(PrivateTag) {}
 
+ private:
   // Contains the actual implementation of peeling. Return true is peeling was
   // successful.
   bool peelInternal(


### PR DESCRIPTION
PeeledEncoding sizeof is 32 bytes (small), so even if it's used with weak_ptr it doesn't make sense to allocate control block in separate allocation