### PR TITLE
fix: Make access O(1) instead of O(n), it should reduce overhead for large projections

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -126,7 +126,7 @@ jobs:
           INPUT_REF: ${{ inputs.ref || 'main' }}
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
         id: get-merge-base
         run: |
           if [ '${{ github.event_name == 'push' }}' == "true" ]; then
@@ -135,7 +135,7 @@ jobs:
           elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
             # Get the merge base from the api
             head_main=$(gh api -q '.merge_base_commit.sha' \
-              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_AUTHOR:$HEAD_REF \
+              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_OWNER:$HEAD_REF \
             )
           else
             head_main=$INPUT_REF

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -410,14 +410,49 @@ RowType::RowType(std::vector<std::string>&& names, std::vector<TypePtr>&& types)
 }
 
 RowType::~RowType() {
-  if (auto* parameters = parameters_.load()) {
-    delete parameters;
-  }
+  auto* parameters = parameters_.load(std::memory_order_acquire);
+  delete parameters;
+
+  auto* nameToIndex = nameToIndex_.load(std::memory_order_acquire);
+  delete nameToIndex;
 }
 
-std::unique_ptr<std::vector<TypeParameter>> RowType::makeParameters() const {
-  return std::make_unique<std::vector<TypeParameter>>(
+const std::vector<TypeParameter>* RowType::ensureParameters() const {
+  auto newParameters = std::make_unique<std::vector<TypeParameter>>(
       createTypeParameters(children_));
+
+  std::vector<TypeParameter>* oldParameters = nullptr;
+  if (!parameters_.compare_exchange_strong(
+          oldParameters,
+          newParameters.get(),
+          std::memory_order_acq_rel,
+          std::memory_order_acquire)) {
+    return oldParameters;
+  }
+
+  return newParameters.release();
+}
+
+const RowType::NameToIndex* RowType::ensureNameToIndex() const {
+  auto newNameToIndex = std::make_unique<NameToIndex>();
+  newNameToIndex->reserve(names_.size());
+  for (uint32_t i = 0; const auto& name : names_) {
+    if (auto* oldNameToIndex = nameToIndex_.load(std::memory_order_acquire)) {
+      return oldNameToIndex;
+    }
+    newNameToIndex->emplace(NameIndex{name, i++});
+  }
+
+  NameToIndex* oldNameToIndex = nullptr;
+  if (!nameToIndex_.compare_exchange_strong(
+          oldNameToIndex,
+          newNameToIndex.get(),
+          std::memory_order_acq_rel,
+          std::memory_order_acquire)) {
+    return oldNameToIndex;
+  }
+
+  return newNameToIndex.release();
 }
 
 namespace {
@@ -448,10 +483,8 @@ std::string makeFieldNotFoundErrorMessage(
 } // namespace
 
 const TypePtr& RowType::findChild(folly::StringPiece name) const {
-  for (uint32_t i = 0; i < names_.size(); ++i) {
-    if (names_.at(i) == name) {
-      return children_.at(i);
-    }
+  if (auto i = getChildIdxIfExists(name)) {
+    return children_[*i];
   }
   VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
 }
@@ -471,7 +504,7 @@ bool RowType::isComparable() const {
 }
 
 bool RowType::containsChild(std::string_view name) const {
-  return std::find(names_.begin(), names_.end(), name) != names_.end();
+  return nameToIndex().contains(NameIndex{name, 0});
 }
 
 uint32_t RowType::getChildIdx(std::string_view name) const {
@@ -484,10 +517,10 @@ uint32_t RowType::getChildIdx(std::string_view name) const {
 
 std::optional<uint32_t> RowType::getChildIdxIfExists(
     std::string_view name) const {
-  for (uint32_t i = 0; i < names_.size(); i++) {
-    if (names_.at(i) == name) {
-      return i;
-    }
+  const auto& nameToIndex = this->nameToIndex();
+  auto it = nameToIndex.find(NameIndex{name, 0});
+  if (it != nameToIndex.end()) {
+    return it->index;
   }
   return std::nullopt;
 }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -426,7 +426,7 @@ const std::vector<TypeParameter>* RowType::ensureParameters() const {
           oldParameters,
           newParameters.get(),
           std::memory_order_acq_rel,
-          std::memory_order_acquire)) {
+          std::memory_order_acquire)) [[unlikely]] {
     return oldParameters;
   }
 
@@ -437,7 +437,8 @@ const RowType::NameToIndex* RowType::ensureNameToIndex() const {
   auto newNameToIndex = std::make_unique<NameToIndex>();
   newNameToIndex->reserve(names_.size());
   for (uint32_t i = 0; const auto& name : names_) {
-    if (auto* oldNameToIndex = nameToIndex_.load(std::memory_order_acquire)) {
+    if (auto* oldNameToIndex = nameToIndex_.load(std::memory_order_acquire))
+        [[unlikely]] {
       return oldNameToIndex;
     }
     newNameToIndex->emplace(NameIndex{name, i++});
@@ -448,7 +449,7 @@ const RowType::NameToIndex* RowType::ensureNameToIndex() const {
           oldNameToIndex,
           newNameToIndex.get(),
           std::memory_order_acq_rel,
-          std::memory_order_acquire)) {
+          std::memory_order_acquire)) [[unlikely]] {
     return oldNameToIndex;
   }
 


### PR DESCRIPTION
…and keep it similar for small.

Memory overhead is just additional ~16.125 bytes per type in row.

Also I don't think lazy is good here, but I made it this way because it was TODO in previous attempt


It will be nice if exists some benchmarks for this

Context: https://github.com/facebookexperimental/verax/pull/118#discussion_r2264184373
