### PR TITLE
fix: Unused-local-typedef issue in velox/.../MapInputBenchmark.cpp +1

### DIFF
--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -166,8 +166,6 @@ class NestedMapWithMapView : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     LocalDecodedVector decoded_(context, *args[0], rows);
-    using exec_in_t = typename VectorExec::template resolver<
-        Map<int64_t, Map<int64_t, int64_t>>>::in_type;
     VectorReader<Map<int64_t, Map<int64_t, int64_t>>> reader{decoded_.get()};
 
     // Prepare results


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-local-typedef` which we are enabling to remove unused code. This has the side-effect of making it easier to do refactors should as removing unnecessary includes.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: pedroerp

Differential Revision: D79834771


