### PR TITLE
misc: Reduce Codeowners scope for assignUser

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,8 +24,9 @@
 
 # Build & CI
 CMake/ @assignUser @majetideepak
-*.cmake @assignUser @majetideepak
-**/CMakeLists.txt @assignUser @majetideepak
+/CMakeLists.txt @assignUser
+*.cmake @majetideepak
+**/CMakeLists.txt @majetideepak
 scripts/ @assignUser @majetideepak
 .github/ @assignUser @majetideepak
 


### PR DESCRIPTION
There is just too much activity in Velox these days for me to review each PR that touches CMake (allmost all of them). I hope #14211 will help with that. In the mean time I need to reduce the number of notifications I get and focus on the high impact ones.