### PR TITLE
fix: Clear sortBuffer to avoid OOM when there is so many OrderBy operator

### DIFF
--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -100,6 +100,12 @@ RowVectorPtr OrderBy::getOutput() {
     return nullptr;
   }
 
+  auto guard = folly::makeGuard([&](){
+    if (finished_) {
+      sortBuffer_.reset();
+    }
+  });
+
   RowVectorPtr output = sortBuffer_->getOutput(maxOutputRows_);
   finished_ = (output == nullptr);
   return output;


### PR DESCRIPTION
When there are a large number of Window calculation functions, Out of Memory (OOM) is a common occurrence. We observed that many OrderBy operators were consuming a large amount of memory. However, OrderBy operators are blocking operators, and a maximum of two OrderBy operators should occupy memory throughout the entire pipeline. Investigation revealed that the sortBuffer was only cleared during OrderBy::close(), which is unreasonable. Clearing the sortBuffer earlier could have reduced peak memory usage.
```
  node.0 usage 0B reserved 0B peak 0B
      op.0.0.0.ValueStream usage 0B reserved 0B peak 0B
  node.1 usage 408.00MB reserved 408.00MB peak 432.00MB
      op.1.0.0.OrderBy usage 403.88MB reserved 408.00MB peak 404.52MB      
  node.2 usage 304.00MB reserved 304.00MB peak 304.00MB
      op.2.0.0.Window usage 255.25MB reserved 304.00MB peak 263.92MB
   node.3 usage 1.00MB reserved 1.00MB peak 2.00MB
      op.3.0.0.FilterProject usage 70.19KB reserved 1.00MB peak 1.78MB
  node.4 usage 496.00MB reserved 496.00MB peak 512.00MB
      op.4.0.0.OrderBy usage 493.77MB reserved 496.00MB peak 494.46MB
  node.5 usage 304.00MB reserved 304.00MB peak 312.00MB
      op.5.0.0.Window usage 299.25MB reserved 304.00MB peak 309.58MB      
  node.6 usage 12.00MB reserved 12.00MB peak 616.00MB
      op.6.0.0.OrderBy usage 11.90MB reserved 12.00MB peak 512.84MB
  node.7 usage 320.00MB reserved 320.00MB peak 328.00MB
      op.7.0.0.Window usage 317.25MB reserved 320.00MB peak 327.96MB
  node.8 usage 20.00MB reserved 20.00MB peak 240.00MB
      op.8.0.0.OrderBy usage 16.78MB reserved 20.00MB peak 210.50MB      
  node.9 usage 336.00MB reserved 336.00MB peak 344.00MB
      op.9.0.0.Window usage 329.25MB reserved 336.00MB peak 340.34MB
  node.10 usage 128.00MB reserved 128.00MB peak 128.00MB
      op.10.0.0.OrderBy usage 126.69MB reserved 128.00MB peak 126.70MB      
  node.11 usage 96.00MB reserved 96.00MB peak 96.00MB
      op.11.0.0.Window usage 95.25MB reserved 96.00MB peak 95.25MB      
  node.12 usage 0B reserved 0B peak 35.00MB
      op.12.0.0.OrderBy usage 0B reserved 0B peak 12.50MB
  node.13 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.13.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB      
  node.14 usage 0B reserved 0B peak 0B
      op.14.0.0.OrderBy usage 0B reserved 0B peak 0B
  node.15 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.15.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB      
  node.16 usage 0B reserved 0B peak 0B
      op.16.0.0.OrderBy usage 0B reserved 0B peak 0B
  node.17 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.17.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB      
  node.18 usage 0B reserved 0B peak 0B
      op.18.0.0.OrderBy usage 0B reserved 0B peak 0B      
  node.19 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.19.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB      
  node.20 usage 0B reserved 0B peak 0B
      op.20.0.0.OrderBy usage 0B reserved 0B peak 0B
  node.21 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.21.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB      
  node.22 usage 0B reserved 0B peak 0B
      op.22.0.0.OrderBy usage 0B reserved 0B peak 0B 
  node.23 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.23.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB 
  node.24 usage 0B reserved 0B peak 0B
      op.24.0.0.OrderBy usage 0B reserved 0B peak 0B                                   
  node.25 usage 1.00MB reserved 1.00MB peak 1.00MB
      op.25.0.0.Window usage 768.00KB reserved 1.00MB peak 768.00KB  
  node.26 usage 0B reserved 0B peak 0B
      op.26.0.0.FilterProject usage 0B reserved 0B peak 0B
```