### PR TITLE
fix: Remove unused exception parameter from velox/common/memory/tests/ArbitrationParticipantTest.cpp

### DIFF
--- a/velox/common/memory/tests/ArbitrationParticipantTest.cpp
+++ b/velox/common/memory/tests/ArbitrationParticipantTest.cpp
@@ -1335,7 +1335,7 @@ TEST_F(ArbitrationParticipantTest, abort) {
     const std::string abortReason = "test abort";
     try {
       VELOX_FAIL(abortReason);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(
           scopedParticipant->abort(std::current_exception()),
           testData.expectedReclaimCapacity);
@@ -1351,7 +1351,7 @@ TEST_F(ArbitrationParticipantTest, abort) {
 
     try {
       VELOX_FAIL(abortReason);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(scopedParticipant->abort(std::current_exception()), 0);
     }
     ASSERT_EQ(scopedParticipant->stats().numShrinks, prevNumShrunks + 1);
@@ -1431,7 +1431,7 @@ DEBUG_ONLY_TEST_F(ArbitrationParticipantTest, reclaimLock) {
     const std::string abortReason = "test abort";
     try {
       VELOX_FAIL(abortReason);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(scopedParticipant->abort(std::current_exception()), 32 * MB);
     }
     abortCompletedFlag = true;
@@ -1508,7 +1508,7 @@ DEBUG_ONLY_TEST_F(ArbitrationParticipantTest, abortedCheck) {
     const std::string abortReason = "test abort1";
     try {
       VELOX_FAIL(abortReason);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(scopedParticipant->abort(std::current_exception()), MB);
     }
   });
@@ -1517,7 +1517,7 @@ DEBUG_ONLY_TEST_F(ArbitrationParticipantTest, abortedCheck) {
     const std::string abortReason = "test abort2";
     try {
       VELOX_FAIL(abortReason);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(scopedParticipant->abort(std::current_exception()), 0);
     }
   });
@@ -1579,7 +1579,7 @@ DEBUG_ONLY_TEST_F(ArbitrationParticipantTest, concurrentAbort) {
   // Second abort uses main thread.
   try {
     VELOX_FAIL("test abort 2");
-  } catch (const VeloxRuntimeError& e) {
+  } catch (const VeloxRuntimeError&) {
     ASSERT_EQ(scopedParticipant->abort(std::current_exception()), 32 * MB);
   }
 
@@ -1732,7 +1732,7 @@ TEST_F(ArbitrationParticipantTest, arbitrationOperation) {
     ASSERT_FALSE(abortOp.aborted());
     try {
       VELOX_FAIL("abort op");
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       ASSERT_EQ(scopedParticipant->abort(std::current_exception()), 0);
     }
     ASSERT_TRUE(abortOp.aborted());

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -65,7 +65,7 @@ TEST_F(MemoryManagerTest, ctor) {
     ASSERT_NE(sysPool->reclaimer(), nullptr);
     try {
       VELOX_FAIL("Trigger Error");
-    } catch (const velox::VeloxRuntimeError& e) {
+    } catch (const velox::VeloxRuntimeError&) {
       VELOX_ASSERT_THROW(
           sysPool->reclaimer()->abort(
               &manager.deprecatedSysRootPool(), std::current_exception()),

--- a/velox/core/tests/QueryCtxTest.cpp
+++ b/velox/core/tests/QueryCtxTest.cpp
@@ -39,7 +39,7 @@ TEST_F(QueryCtxTest, withSysRootPool) {
   ASSERT_NE(queryPool->reclaimer(), nullptr);
   try {
     VELOX_FAIL("Trigger Error");
-  } catch (const velox::VeloxRuntimeError& e) {
+  } catch (const velox::VeloxRuntimeError&) {
     VELOX_ASSERT_THROW(
         queryPool->reclaimer()->abort(queryPool, std::current_exception()),
         "SysMemoryReclaimer::abort is not supported");

--- a/velox/exec/ParallelProject.cpp
+++ b/velox/exec/ParallelProject.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<ParallelProject::WorkResult> ParallelProject::doWork(
       results[projection.outputChannel] =
           std::move(localResults[projection.inputChannel]);
     }
-  } catch (const std::exception& e) {
+  } catch (const std::exception&) {
     return std::make_unique<WorkResult>(std::current_exception());
   }
   return std::make_unique<WorkResult>(nullptr);

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -2414,7 +2414,7 @@ DEBUG_ONLY_TEST_P(
   std::thread failThread([&]() {
     try {
       VELOX_FAIL("Test terminate task");
-    } catch (const VeloxException& e) {
+    } catch (const VeloxException&) {
       task->setError(std::current_exception());
     }
   });
@@ -2820,7 +2820,7 @@ TEST_P(MultiFragmentTest, earlyTaskFailure) {
     if (internalFailure) {
       try {
         VELOX_FAIL("memoryAbortTest");
-      } catch (const VeloxRuntimeError& e) {
+      } catch (const VeloxRuntimeError&) {
         finalSortTask->pool()->abort(std::current_exception());
       }
     } else {

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunner.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunner.cpp
@@ -159,7 +159,7 @@ SparkQueryRunner::executeAndReturnVector(const core::PlanNodePtr& plan) {
       // Run the query.
       return std::make_pair(
           execute(*sql), exec::test::ReferenceQueryErrorCode::kSuccess);
-    } catch (const VeloxRuntimeError& e) {
+    } catch (const VeloxRuntimeError&) {
       throw;
     } catch (...) {
       LOG(WARNING) << "Query failed in Spark";


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968869


