### PR TITLE
misc(fuzzer): Skip numeric_histogram in aggregation and window fuzzers

### DIFF
--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -156,6 +156,8 @@ int main(int argc, char** argv) {
       "noisy_approx_set_sfm_from_index_and_zeros",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
+      // https://github.com/facebookincubator/velox/issues/14423
+      "numeric_histogram",
   };
 
   static const std::unordered_set<std::string> functionsRequireSortedInput = {

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -136,6 +136,8 @@ int main(int argc, char** argv) {
       "noisy_approx_set_sfm_from_index_and_zeros",
       // https://github.com/facebookincubator/velox/issues/13547
       "merge",
+      // https://github.com/facebookincubator/velox/issues/14423
+      "numeric_histogram",
   };
 
   if (!FLAGS_presto_url.empty()) {


### PR DESCRIPTION
Summary: Skip numeric_histogram in aggregation and window fuzzers due to a known bug https://github.com/facebookincubator/velox/issues/14423.

Differential Revision: D80022571


