### PR TITLE
fix: SubscriptUtil doesn't respect map offset when caching complex keys

### DIFF
--- a/velox/functions/lib/SubscriptUtil.cpp
+++ b/velox/functions/lib/SubscriptUtil.cpp
@@ -255,7 +255,9 @@ VectorPtr applyMapComplexType(
       auto numKeys = rawSizes[0];
       hashMapPtr->reserve(numKeys * 1.3);
       for (auto i = 0; i < numKeys; ++i) {
-        hashMapPtr->insert(detail::MapKey{mapKeysBase, mapKeysIndices[i], i});
+        const vector_size_t offset = rawOffsets[0] + i;
+        hashMapPtr->insert(
+            detail::MapKey{mapKeysBase, mapKeysIndices[offset], offset});
       }
     }
 


### PR DESCRIPTION
Summary:
In the Velox UDFs for map subscript and element_at we use the SubscriptUtil library for the
implementation.

In the implementation in SubscriptUtil when we enable caching and the key is a ComplexType 
we create a HashMap where the key is a structure that contains the key's base Vector and an 
index into it. Currently we assume that index starts from 0, but it should really be based on 
the offsets in the MapVector.

This change corrects this.

This addresses https://github.com/facebookincubator/velox/issues/14395

Differential Revision: D80021449


