### PR TITLE
feat: Remove deprecated queryTraceNodeIds

### DIFF
--- a/velox/common/base/TraceConfig.cpp
+++ b/velox/common/base/TraceConfig.cpp
@@ -32,6 +32,6 @@ TraceConfig::TraceConfig(
       updateAndCheckTraceLimitCB(std::move(_updateAndCheckTraceLimitCB)),
       taskRegExp(std::move(_taskRegExp)),
       dryRun(_dryRun) {
-  VELOX_CHECK(!queryNodeId.empty(), "Query trace nodes cannot be empty");
+  VELOX_CHECK(!queryNodeId.empty(), "The query trace node cannot be empty");
 }
 } // namespace facebook::velox

--- a/velox/common/base/TraceConfig.h
+++ b/velox/common/base/TraceConfig.h
@@ -38,7 +38,7 @@ namespace facebook::velox {
 using UpdateAndCheckTraceLimitCB = std::function<void(uint64_t)>;
 
 struct TraceConfig {
-  /// Target query trace nodes.
+  /// Target query trace node id.
   std::string queryNodeId;
   /// Base dir of query trace.
   std::string queryTraceDir;
@@ -51,7 +51,7 @@ struct TraceConfig {
   bool dryRun{false};
 
   TraceConfig(
-      std::string queryNodeIds,
+      std::string queryNodeId,
       std::string queryTraceDir,
       UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB,
       std::string taskRegExp,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -466,11 +466,6 @@ class QueryConfig {
   /// Base dir of a query to store tracing data.
   static constexpr const char* kQueryTraceDir = "query_trace_dir";
 
-  /// @Deprecated. Do not use. Remove once existing call sites are updated.
-  /// The plan node id whose input data will be traced.
-  /// Empty string if only want to trace the query metadata.
-  static constexpr const char* kQueryTraceNodeIds = "query_trace_node_id";
-
   /// The plan node id whose input data will be traced.
   /// Empty string if only want to trace the query metadata.
   static constexpr const char* kQueryTraceNodeId = "query_trace_node_id";
@@ -987,12 +982,6 @@ class QueryConfig {
   std::string queryTraceDir() const {
     // The default query trace dir, empty by default.
     return get<std::string>(kQueryTraceDir, "");
-  }
-
-  /// @Deprecated. Do not use. Remove once existing call sites are updated.
-  std::string queryTraceNodeIds() const {
-    // Use the new config kQueryTraceNodeId.
-    return get<std::string>(kQueryTraceNodeId, "");
   }
 
   std::string queryTraceNodeId() const {


### PR DESCRIPTION
Summary: QueryTraceNodeId is taking place of deprecated queryTraceNodeIds, which should be removed to avoid confusing.

Differential Revision: D80040603


