### PR TITLE
docs: Update Presto functions coverage map

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -66,99 +66,135 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     :widths: auto
     :class: rows
 
-    ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
-    Scalar Functions                                                                                                                  Aggregate Functions                           Window Functions
-    ============================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`$internal$split_to_map`            :func:`format_datetime`                   :func:`plus`                                  :func:`any_value`                             :func:`cume_dist`
-    :func:`abs`                               :func:`from_base`                         :func:`poisson_cdf`                           :func:`approx_distinct`                       :func:`dense_rank`
-    :func:`acos`                              :func:`from_base64`                       :func:`pow`                                   :func:`approx_most_frequent`                  :func:`first_value`
-    :func:`all_keys_match`                    :func:`from_base64url`                    :func:`power`                                 :func:`approx_percentile`                     :func:`lag`
-    :func:`all_match`                         :func:`from_big_endian_32`                :func:`quarter`                               :func:`approx_set`                            :func:`last_value`
-    :func:`any_keys_match`                    :func:`from_big_endian_64`                :func:`radians`                               :func:`arbitrary`                             :func:`lead`
-    :func:`any_match`                         :func:`from_hex`                          :func:`rand`                                  :func:`array_agg`                             :func:`nth_value`
-    :func:`any_values_match`                  :func:`from_ieee754_32`                   :func:`random`                                :func:`avg`                                   :func:`ntile`
-    :func:`array_average`                     :func:`from_ieee754_64`                   :func:`reduce`                                :func:`bitwise_and_agg`                       :func:`percent_rank`
-    :func:`array_constructor`                 :func:`from_iso8601_date`                 :func:`regexp_extract`                        :func:`bitwise_or_agg`                        :func:`rank`
-    :func:`array_cum_sum`                     :func:`from_iso8601_timestamp`            :func:`regexp_extract_all`                    :func:`bitwise_xor_agg`                       :func:`row_number`
-    :func:`array_distinct`                    :func:`from_unixtime`                     :func:`regexp_like`                           :func:`bool_and`
-    :func:`array_duplicates`                  :func:`from_utf8`                         :func:`regexp_replace`                        :func:`bool_or`
-    :func:`array_except`                      :func:`gamma_cdf`                         :func:`regexp_split`                          :func:`checksum`
-    :func:`array_frequency`                   :func:`greatest`                          :func:`remove_nulls`                          :func:`classification_fall_out`
-    :func:`array_has_duplicates`              :func:`gt`                                :func:`repeat`                                :func:`classification_miss_rate`
-    :func:`array_intersect`                   :func:`gte`                               :func:`replace`                               :func:`classification_precision`
-    :func:`array_join`                        :func:`hamming_distance`                  :func:`replace_first`                         :func:`classification_recall`
-    :func:`array_max`                         :func:`hmac_md5`                          :func:`reverse`                               :func:`classification_thresholds`
-    :func:`array_min`                         :func:`hmac_sha1`                         :func:`round`                                 :func:`corr`
-    :func:`array_normalize`                   :func:`hmac_sha256`                       :func:`rpad`                                  :func:`count`
-    :func:`array_position`                    :func:`hmac_sha512`                       :func:`rtrim`                                 :func:`count_if`
-    :func:`array_remove`                      :func:`hour`                              :func:`second`                                :func:`covar_pop`
-    :func:`array_sort`                        in                                        :func:`secure_rand`                           :func:`covar_samp`
-    :func:`array_sort_desc`                   :func:`infinity`                          :func:`secure_random`                         :func:`entropy`
-    :func:`array_sum`                         :func:`inverse_beta_cdf`                  :func:`sequence`                              :func:`every`
-    :func:`array_sum_propagate_element_null`  :func:`inverse_cauchy_cdf`                :func:`sha1`                                  :func:`geometric_mean`
-    :func:`array_union`                       :func:`inverse_laplace_cdf`               :func:`sha256`                                :func:`histogram`
-    :func:`arrays_overlap`                    :func:`inverse_normal_cdf`                :func:`sha512`                                :func:`kurtosis`
-    :func:`asin`                              :func:`inverse_weibull_cdf`               :func:`shuffle`                               :func:`map_agg`
-    :func:`at_timezone`                       :func:`ip_prefix`                         :func:`sign`                                  :func:`map_union`
-    :func:`atan`                              :func:`is_finite`                         :func:`sin`                                   :func:`map_union_sum`
-    :func:`atan2`                             :func:`is_infinite`                       :func:`slice`                                 :func:`max`
-    :func:`beta_cdf`                          :func:`is_json_scalar`                    :func:`split`                                 :func:`max_by`
-    :func:`between`                           :func:`is_nan`                            :func:`split_part`                            :func:`max_data_size_for_stats`
-    :func:`binomial_cdf`                      :func:`is_null`                           :func:`split_to_map`                          :func:`merge`
-    :func:`bit_count`                         :func:`json_array_contains`               :func:`spooky_hash_v2_32`                     :func:`min`
-    :func:`bitwise_and`                       :func:`json_array_get`                    :func:`spooky_hash_v2_64`                     :func:`min_by`
-    :func:`bitwise_arithmetic_shift_right`    :func:`json_array_length`                 :func:`sqrt`                                  :func:`multimap_agg`
-    :func:`bitwise_left_shift`                :func:`json_extract`                      :func:`starts_with`                           :func:`reduce_agg`
-    :func:`bitwise_logical_shift_right`       :func:`json_extract_scalar`               :func:`strpos`                                :func:`regr_avgx`
-    :func:`bitwise_not`                       :func:`json_format`                       :func:`strrpos`                               :func:`regr_avgy`
-    :func:`bitwise_or`                        :func:`json_parse`                        :func:`subscript`                             :func:`regr_count`
-    :func:`bitwise_right_shift`               :func:`json_size`                         :func:`substr`                                :func:`regr_intercept`
-    :func:`bitwise_right_shift_arithmetic`    :func:`laplace_cdf`                       :func:`tan`                                   :func:`regr_r2`
-    :func:`bitwise_shift_left`                :func:`last_day_of_month`                 :func:`tanh`                                  :func:`regr_slope`
-    :func:`bitwise_xor`                       :func:`least`                             :func:`timezone_hour`                         :func:`regr_sxx`
-    :func:`cardinality`                       :func:`length`                            :func:`timezone_minute`                       :func:`regr_sxy`
-    :func:`cauchy_cdf`                        :func:`levenshtein_distance`              :func:`to_base`                               :func:`regr_syy`
-    :func:`cbrt`                              :func:`like`                              :func:`to_base64`                             :func:`set_agg`
-    :func:`ceil`                              :func:`ln`                                :func:`to_base64url`                          :func:`set_union`
-    :func:`ceiling`                           :func:`log10`                             :func:`to_big_endian_32`                      :func:`skewness`
-    :func:`chi_squared_cdf`                   :func:`log2`                              :func:`to_big_endian_64`                      :func:`stddev`
-    :func:`chr`                               :func:`lower`                             :func:`to_hex`                                :func:`stddev_pop`
-    :func:`clamp`                             :func:`lpad`                              :func:`to_ieee754_32`                         :func:`stddev_samp`
-    :func:`codepoint`                         :func:`lt`                                :func:`to_ieee754_64`                         :func:`sum`
-    :func:`combinations`                      :func:`lte`                               :func:`to_iso8601`                            :func:`sum_data_size_for_stats`
-    :func:`concat`                            :func:`ltrim`                             :func:`to_milliseconds`                       :func:`var_pop`
-    :func:`contains`                          :func:`map`                               :func:`to_unixtime`                           :func:`var_samp`
-    :func:`cos`                               :func:`map_concat`                        :func:`to_utf8`                               :func:`variance`
-    :func:`cosh`                              :func:`map_entries`                       :func:`trail`
-    :func:`cosine_similarity`                 :func:`map_filter`                        :func:`transform`
-    :func:`crc32`                             :func:`map_from_entries`                  :func:`transform_keys`
-    :func:`current_date`                      :func:`map_key_exists`                    :func:`transform_values`
-    :func:`date`                              :func:`map_keys`                          :func:`trim`
-    :func:`date_add`                          :func:`map_normalize`                     :func:`trim_array`
-    :func:`date_diff`                         :func:`map_remove_null_values`            :func:`truncate`
-    :func:`date_format`                       :func:`map_subset`                        :func:`typeof`
-    :func:`date_parse`                        :func:`map_top_n`                         :func:`upper`
-    :func:`date_trunc`                        :func:`map_top_n_keys`                    :func:`url_decode`
-    :func:`day`                               :func:`map_values`                        :func:`url_encode`
-    :func:`day_of_month`                      :func:`map_zip_with`                      :func:`url_extract_fragment`
-    :func:`day_of_week`                       :func:`md5`                               :func:`url_extract_host`
-    :func:`day_of_year`                       :func:`millisecond`                       :func:`url_extract_parameter`
-    :func:`degrees`                           :func:`minus`                             :func:`url_extract_path`
-    :func:`distinct_from`                     :func:`minute`                            :func:`url_extract_port`
-    :func:`divide`                            :func:`mod`                               :func:`url_extract_protocol`
-    :func:`dow`                               :func:`month`                             :func:`url_extract_query`
-    :func:`doy`                               :func:`multimap_from_entries`             :func:`uuid`
-    :func:`e`                                 :func:`multiply`                          :func:`week`
-    :func:`element_at`                        :func:`nan`                               :func:`week_of_year`
-    :func:`empty_approx_set`                  :func:`negate`                            :func:`weibull_cdf`
-    :func:`ends_with`                         :func:`neq`                               :func:`width_bucket`
-    :func:`eq`                                :func:`ngrams`                            :func:`wilson_interval_lower`
-    :func:`exp`                               :func:`no_keys_match`                     :func:`wilson_interval_upper`
-    :func:`f_cdf`                             :func:`no_values_match`                   :func:`word_stem`
-    :func:`fail`                              :func:`none_match`                        :func:`xxhash64`
-    :func:`filter`                            :func:`normal_cdf`                        :func:`year`
-    :func:`find_first`                        :func:`normalize`                         :func:`year_of_week`
-    :func:`find_first_index`                  not                                       :func:`yow`
-    :func:`flatten`                           :func:`parse_datetime`                    :func:`zip`
-    :func:`floor`                             :func:`pi`                                :func:`zip_with`
-    ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
+    =================================================  =================================================  =================================================  ==  =================================================  ==  =================================================
+    Scalar Functions                                                                                                                                             Aggregate Functions                                    Window Functions
+    =======================================================================================================================================================  ==  =================================================  ==  =================================================
+    :func:`$internal$json_string_to_array_cast`        :func:`gt`                                         :func:`sequence`                                       :func:`any_value`                                      :func:`cume_dist`
+    :func:`$internal$json_string_to_map_cast`          :func:`gte`                                        :func:`sha1`                                           :func:`approx_distinct`                                :func:`dense_rank`
+    :func:`$internal$json_string_to_row_cast`          :func:`hamming_distance`                           :func:`sha256`                                         :func:`approx_most_frequent`                           :func:`first_value`
+    :func:`$internal$split_to_map`                     :func:`hmac_md5`                                   :func:`sha512`                                         :func:`approx_percentile`                              :func:`lag`
+    :func:`abs`                                        :func:`hmac_sha1`                                  :func:`shuffle`                                        :func:`approx_set`                                     :func:`last_value`
+    :func:`acos`                                       :func:`hmac_sha256`                                :func:`sign`                                           :func:`arbitrary`                                      :func:`lead`
+    :func:`all_keys_match`                             :func:`hmac_sha512`                                :func:`simplify_geometry`                              :func:`array_agg`                                      :func:`nth_value`
+    :func:`all_match`                                  :func:`hour`                                       :func:`sin`                                            :func:`avg`                                            :func:`ntile`
+    :func:`any_keys_match`                             in                                                 :func:`slice`                                          :func:`bitwise_and_agg`                                :func:`percent_rank`
+    :func:`any_match`                                  :func:`infinity`                                   :func:`split`                                          :func:`bitwise_or_agg`                                 :func:`rank`
+    :func:`any_values_match`                           :func:`inverse_beta_cdf`                           :func:`split_part`                                     :func:`bitwise_xor_agg`                                :func:`row_number`
+    :func:`array_average`                              :func:`inverse_binomial_cdf`                       :func:`split_to_map`                                   :func:`bool_and`
+    :func:`array_constructor`                          :func:`inverse_cauchy_cdf`                         :func:`split_to_multimap`                              :func:`bool_or`
+    :func:`array_cum_sum`                              :func:`inverse_chi_squared_cdf`                    :func:`spooky_hash_v2_32`                              :func:`checksum`
+    :func:`array_distinct`                             :func:`inverse_f_cdf`                              :func:`spooky_hash_v2_64`                              :func:`classification_fall_out`
+    :func:`array_duplicates`                           :func:`inverse_gamma_cdf`                          :func:`sqrt`                                           :func:`classification_miss_rate`
+    :func:`array_except`                               :func:`inverse_laplace_cdf`                        :func:`st_area`                                        :func:`classification_precision`
+    :func:`array_frequency`                            :func:`inverse_normal_cdf`                         :func:`st_asbinary`                                    :func:`classification_recall`
+    :func:`array_has_duplicates`                       :func:`inverse_poisson_cdf`                        :func:`st_astext`                                      :func:`classification_thresholds`
+    :func:`array_intersect`                            :func:`inverse_weibull_cdf`                        :func:`st_boundary`                                    :func:`corr`
+    :func:`array_join`                                 :func:`ip_prefix`                                  :func:`st_buffer`                                      :func:`count`
+    :func:`array_max`                                  :func:`ip_prefix_collapse`                         :func:`st_centroid`                                    :func:`count_if`
+    :func:`array_max_by`                               :func:`ip_prefix_subnets`                          :func:`st_contains`                                    :func:`covar_pop`
+    :func:`array_min`                                  :func:`ip_subnet_max`                              :func:`st_convexhull`                                  :func:`covar_samp`
+    :func:`array_min_by`                               :func:`ip_subnet_min`                              :func:`st_coorddim`                                    :func:`entropy`
+    :func:`array_normalize`                            :func:`ip_subnet_range`                            :func:`st_crosses`                                     :func:`every`
+    :func:`array_position`                             :func:`is_finite`                                  :func:`st_difference`                                  :func:`geometric_mean`
+    :func:`array_remove`                               :func:`is_infinite`                                :func:`st_dimension`                                   :func:`histogram`
+    :func:`array_sort`                                 :func:`is_json_scalar`                             :func:`st_disjoint`                                    :func:`kurtosis`
+    :func:`array_sort_desc`                            :func:`is_nan`                                     :func:`st_distance`                                    :func:`map_agg`
+    :func:`array_sum`                                  :func:`is_null`                                    :func:`st_endpoint`                                    :func:`map_union`
+    :func:`array_sum_propagate_element_null`           :func:`is_private_ip`                              :func:`st_envelope`                                    :func:`map_union_sum`
+    :func:`array_top_n`                                :func:`is_subnet_of`                               :func:`st_envelopeaspts`                               :func:`max`
+    :func:`array_union`                                :func:`json_array_contains`                        :func:`st_equals`                                      :func:`max_by`
+    :func:`arrays_overlap`                             :func:`json_array_get`                             :func:`st_exteriorring`                                :func:`max_data_size_for_stats`
+    :func:`asin`                                       :func:`json_array_length`                          :func:`st_geometries`                                  :func:`merge`
+    :func:`at_timezone`                                :func:`json_extract`                               :func:`st_geometryfromtext`                            :func:`min`
+    :func:`atan`                                       :func:`json_extract_scalar`                        :func:`st_geometryn`                                   :func:`min_by`
+    :func:`atan2`                                      :func:`json_format`                                :func:`st_geometrytype`                                :func:`multimap_agg`
+    :func:`beta_cdf`                                   :func:`json_parse`                                 :func:`st_geomfrombinary`                              :func:`noisy_approx_distinct_sfm`
+    :func:`between`                                    :func:`json_size`                                  :func:`st_interiorringn`                               :func:`noisy_approx_set_sfm`
+    :func:`bing_tile`                                  :func:`laplace_cdf`                                :func:`st_interiorrings`                               :func:`noisy_approx_set_sfm_from_index_and_zeros`
+    :func:`bing_tile_at`                               :func:`last_day_of_month`                          :func:`st_intersection`                                :func:`noisy_avg_gaussian`
+    :func:`bing_tile_children`                         :func:`least`                                      :func:`st_intersects`                                  :func:`noisy_count_gaussian`
+    :func:`bing_tile_coordinates`                      :func:`length`                                     :func:`st_isclosed`                                    :func:`noisy_count_if_gaussian`
+    :func:`bing_tile_parent`                           :func:`levenshtein_distance`                       :func:`st_isempty`                                     :func:`noisy_sum_gaussian`
+    :func:`bing_tile_quadkey`                          :func:`like`                                       :func:`st_isring`                                      :func:`numeric_histogram`
+    :func:`bing_tile_zoom_level`                       :func:`line_interpolate_point`                     :func:`st_issimple`                                    :func:`qdigest_agg`
+    :func:`bing_tiles_around`                          :func:`line_locate_point`                          :func:`st_isvalid`                                     :func:`reduce_agg`
+    :func:`binomial_cdf`                               :func:`ln`                                         :func:`st_length`                                      :func:`regr_avgx`
+    :func:`bit_count`                                  :func:`log10`                                      :func:`st_numgeometries`                               :func:`regr_avgy`
+    :func:`bitwise_and`                                :func:`log2`                                       :func:`st_numinteriorring`                             :func:`regr_count`
+    :func:`bitwise_arithmetic_shift_right`             :func:`lower`                                      :func:`st_numpoints`                                   :func:`regr_intercept`
+    :func:`bitwise_left_shift`                         :func:`lpad`                                       :func:`st_overlaps`                                    :func:`regr_r2`
+    :func:`bitwise_logical_shift_right`                :func:`lt`                                         :func:`st_point`                                       :func:`regr_slope`
+    :func:`bitwise_not`                                :func:`lte`                                        :func:`st_pointn`                                      :func:`regr_sxx`
+    :func:`bitwise_or`                                 :func:`ltrim`                                      :func:`st_points`                                      :func:`regr_sxy`
+    :func:`bitwise_right_shift`                        :func:`map`                                        :func:`st_polygon`                                     :func:`regr_syy`
+    :func:`bitwise_right_shift_arithmetic`             :func:`map_concat`                                 :func:`st_relate`                                      :func:`set_agg`
+    :func:`bitwise_shift_left`                         :func:`map_entries`                                :func:`st_startpoint`                                  :func:`set_union`
+    :func:`bitwise_xor`                                :func:`map_filter`                                 :func:`st_symdifference`                               :func:`skewness`
+    :func:`cardinality`                                :func:`map_from_entries`                           :func:`st_touches`                                     :func:`stddev`
+    :func:`cauchy_cdf`                                 :func:`map_key_exists`                             :func:`st_union`                                       :func:`stddev_pop`
+    :func:`cbrt`                                       :func:`map_keys`                                   :func:`st_within`                                      :func:`stddev_samp`
+    :func:`ceil`                                       :func:`map_keys_by_top_n_values`                   :func:`st_x`                                           :func:`sum`
+    :func:`ceiling`                                    :func:`map_normalize`                              :func:`st_xmax`                                        :func:`sum_data_size_for_stats`
+    :func:`chi_squared_cdf`                            :func:`map_remove_null_values`                     :func:`st_xmin`                                        :func:`tdigest_agg`
+    :func:`chr`                                        :func:`map_subset`                                 :func:`st_y`                                           :func:`var_pop`
+    :func:`clamp`                                      :func:`map_top_n`                                  :func:`st_ymax`                                        :func:`var_samp`
+    :func:`codepoint`                                  :func:`map_top_n_keys`                             :func:`st_ymin`                                        :func:`variance`
+    :func:`combinations`                               :func:`map_top_n_values`                           :func:`starts_with`
+    :func:`combine_hash_internal`                      :func:`map_values`                                 :func:`strpos`
+    :func:`concat`                                     :func:`map_zip_with`                               :func:`strrpos`
+    :func:`construct_tdigest`                          :func:`md5`                                        :func:`subscript`
+    :func:`contains`                                   :func:`merge_sfm`                                  :func:`substr`
+    :func:`cos`                                        :func:`merge_tdigest`                              :func:`substring`
+    :func:`cosh`                                       :func:`millisecond`                                :func:`tan`
+    :func:`cosine_similarity`                          :func:`minus`                                      :func:`tanh`
+    :func:`crc32`                                      :func:`minute`                                     :func:`timezone_hour`
+    :func:`current_date`                               :func:`mod`                                        :func:`timezone_minute`
+    :func:`date`                                       :func:`month`                                      :func:`to_base`
+    :func:`date_add`                                   :func:`multimap_from_entries`                      :func:`to_base64`
+    :func:`date_diff`                                  :func:`multiply`                                   :func:`to_base64url`
+    :func:`date_format`                                :func:`murmur3_x64_128`                            :func:`to_big_endian_32`
+    :func:`date_parse`                                 :func:`nan`                                        :func:`to_big_endian_64`
+    :func:`date_trunc`                                 :func:`negate`                                     :func:`to_hex`
+    :func:`day`                                        :func:`neq`                                        :func:`to_ieee754_32`
+    :func:`day_of_month`                               :func:`ngrams`                                     :func:`to_ieee754_64`
+    :func:`day_of_week`                                :func:`no_keys_match`                              :func:`to_iso8601`
+    :func:`day_of_year`                                :func:`no_values_match`                            :func:`to_milliseconds`
+    :func:`degrees`                                    :func:`noisy_empty_approx_set_sfm`                 :func:`to_unixtime`
+    :func:`destructure_tdigest`                        :func:`none_match`                                 :func:`to_utf8`
+    :func:`distinct_from`                              :func:`normal_cdf`                                 :func:`trail`
+    :func:`divide`                                     :func:`normalize`                                  :func:`transform`
+    :func:`dot_product`                                not                                                :func:`transform_keys`
+    :func:`dow`                                        :func:`parse_datetime`                             :func:`transform_values`
+    :func:`doy`                                        :func:`parse_duration`                             :func:`trim`
+    :func:`e`                                          :func:`parse_presto_data_size`                     :func:`trim_array`
+    :func:`element_at`                                 :func:`pi`                                         :func:`trimmed_mean`
+    :func:`empty_approx_set`                           :func:`plus`                                       :func:`truncate`
+    :func:`ends_with`                                  :func:`poisson_cdf`                                :func:`typeof`
+    :func:`eq`                                         :func:`pow`                                        :func:`upper`
+    :func:`exp`                                        :func:`power`                                      :func:`url_decode`
+    :func:`f_cdf`                                      :func:`quantile_at_value`                          :func:`url_encode`
+    :func:`fail`                                       :func:`quantiles_at_values`                        :func:`url_extract_fragment`
+    :func:`filter`                                     :func:`quarter`                                    :func:`url_extract_host`
+    :func:`find_first`                                 :func:`radians`                                    :func:`url_extract_parameter`
+    :func:`find_first_index`                           :func:`rand`                                       :func:`url_extract_path`
+    :func:`flatten`                                    :func:`random`                                     :func:`url_extract_port`
+    :func:`flatten_geometry_collections`               :func:`reduce`                                     :func:`url_extract_protocol`
+    :func:`floor`                                      :func:`regexp_extract`                             :func:`url_extract_query`
+    :func:`format_datetime`                            :func:`regexp_extract_all`                         :func:`uuid`
+    :func:`from_base`                                  :func:`regexp_like`                                :func:`value_at_quantile`
+    :func:`from_base64`                                :func:`regexp_replace`                             :func:`values_at_quantiles`
+    :func:`from_base64url`                             :func:`regexp_split`                               :func:`week`
+    :func:`from_big_endian_32`                         :func:`remove_nulls`                               :func:`week_of_year`
+    :func:`from_big_endian_64`                         :func:`repeat`                                     :func:`weibull_cdf`
+    :func:`from_hex`                                   :func:`replace`                                    :func:`width_bucket`
+    :func:`from_ieee754_32`                            :func:`replace_first`                              :func:`wilson_interval_lower`
+    :func:`from_ieee754_64`                            :func:`reverse`                                    :func:`wilson_interval_upper`
+    :func:`from_iso8601_date`                          :func:`round`                                      :func:`word_stem`
+    :func:`from_iso8601_timestamp`                     :func:`rpad`                                       :func:`xxhash64`
+    :func:`from_unixtime`                              :func:`rtrim`                                      :func:`xxhash64_internal`
+    :func:`from_utf8`                                  :func:`scale_qdigest`                              :func:`year`
+    :func:`gamma_cdf`                                  :func:`scale_tdigest`                              :func:`year_of_week`
+    :func:`geometry_invalid_reason`                    :func:`second`                                     :func:`yow`
+    :func:`geometry_nearest_points`                    :func:`secure_rand`                                :func:`zip`
+    :func:`greatest`                                   :func:`secure_random`                              :func:`zip_with`
+    =================================================  =================================================  =================================================  ==  =================================================  ==  =================================================

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -13,97 +13,123 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage td:nth-child(8) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(1) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(1) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(2) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(3) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(4) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(6) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(6) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(7) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(7) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(9) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(10) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(15) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(2) {background-color: #6BA81E;}
@@ -119,11 +145,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(22) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
@@ -132,12 +160,14 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
@@ -148,6 +178,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
@@ -169,21 +200,28 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(35) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(38) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(39) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(40) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(4) {background-color: #6BA81E;}
@@ -194,139 +232,201 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(41) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(43) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(43) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(44) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(44) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(45) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(48) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(48) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(51) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(51) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(52) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(52) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(54) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(56) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(57) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(61) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(62) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(67) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(68) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(69) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(69) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(69) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(70) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(70) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(70) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(71) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(73) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(73) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(73) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(77) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(5) {background-color: #6BA81E;}
     </style>
@@ -338,83 +438,83 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_diff`                         ip_subnet_range                           :func:`random`                            st_numgeometries                              :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_format`                       :func:`is_finite`                         :func:`reduce`                            st_numinteriorring                            :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_parse`                        :func:`is_infinite`                       :func:`regexp_extract`                    st_numpoints                                  :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_json_scalar`                    :func:`regexp_extract_all`                st_overlaps                                   :func:`approx_set`                            :func:`lag`
-    :func:`any_match`                         :func:`day`                               :func:`is_nan`                            :func:`regexp_like`                       st_point                                      :func:`arbitrary`                             :func:`last_value`
-    :func:`any_values_match`                  :func:`day_of_month`                      is_private_ip                             :func:`regexp_replace`                    st_pointn                                     :func:`array_agg`                             :func:`lead`
-    :func:`array_average`                     :func:`day_of_week`                       is_subnet_of                              :func:`regexp_split`                      st_points                                     :func:`avg`                                   :func:`nth_value`
-    :func:`array_cum_sum`                     :func:`day_of_year`                       jaccard_index                             regress                                   st_polygon                                    :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_contains`               reidentification_potential                st_relate                                     :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      st_startpoint                                 :func:`bool_and`                              :func:`rank`
-    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    st_symdifference                              :func:`bool_or`                               :func:`row_number`
-    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            st_touches                                    :func:`checksum`
-    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           st_union                                      :func:`classification_fall_out`
-    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     st_within                                     :func:`classification_miss_rate`
-    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           st_x                                          :func:`classification_precision`
-    array_least_frequent                      enum_key                                  :func:`json_size`                         rgb                                       st_xmax                                       :func:`classification_recall`
-    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             st_xmin                                       :func:`classification_thresholds`
-    array_max_by                              expand_envelope                           :func:`laplace_cdf`                       :func:`rpad`                              st_y                                          convex_hull_agg
-    :func:`array_min`                         :func:`f_cdf`                             :func:`last_day_of_month`                 :func:`rtrim`                             st_ymax                                       :func:`corr`
-    array_min_by                              features                                  :func:`least`                             scale_qdigest                             st_ymin                                       :func:`count`
+    :func:`abs`                               :func:`date_diff`                         :func:`ip_subnet_range`                   :func:`random`                            :func:`st_numgeometries`                      :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_format`                       :func:`is_finite`                         :func:`reduce`                            :func:`st_numinteriorring`                    :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`date_parse`                        :func:`is_infinite`                       :func:`regexp_extract`                    :func:`st_numpoints`                          :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_json_scalar`                    :func:`regexp_extract_all`                :func:`st_overlaps`                           :func:`approx_set`                            :func:`lag`
+    :func:`any_match`                         :func:`day`                               :func:`is_nan`                            :func:`regexp_like`                       :func:`st_point`                              :func:`arbitrary`                             :func:`last_value`
+    :func:`any_values_match`                  :func:`day_of_month`                      :func:`is_private_ip`                     :func:`regexp_replace`                    :func:`st_pointn`                             :func:`array_agg`                             :func:`lead`
+    :func:`array_average`                     :func:`day_of_week`                       :func:`is_subnet_of`                      :func:`regexp_split`                      :func:`st_points`                             :func:`avg`                                   :func:`nth_value`
+    :func:`array_cum_sum`                     :func:`day_of_year`                       jaccard_index                             regress                                   :func:`st_polygon`                            :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_contains`               reidentification_potential                :func:`st_relate`                             :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      :func:`st_startpoint`                         :func:`bool_and`                              :func:`rank`
+    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    :func:`st_symdifference`                      :func:`bool_or`                               :func:`row_number`
+    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            :func:`st_touches`                            :func:`checksum`
+    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           :func:`st_union`                              :func:`classification_fall_out`
+    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     :func:`st_within`                             :func:`classification_miss_rate`
+    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           :func:`st_x`                                  :func:`classification_precision`
+    array_least_frequent                      enum_key                                  :func:`json_size`                         rgb                                       :func:`st_xmax`                               :func:`classification_recall`
+    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             :func:`st_xmin`                               :func:`classification_thresholds`
+    :func:`array_max_by`                      expand_envelope                           :func:`laplace_cdf`                       :func:`rpad`                              :func:`st_y`                                  convex_hull_agg
+    :func:`array_min`                         :func:`f_cdf`                             :func:`last_day_of_month`                 :func:`rtrim`                             :func:`st_ymax`                               :func:`corr`
+    :func:`array_min_by`                      features                                  :func:`least`                             :func:`scale_qdigest`                     :func:`st_ymin`                               :func:`count`
     :func:`array_normalize`                   :func:`filter`                            :func:`length`                            :func:`second`                            :func:`starts_with`                           :func:`count_if`
     :func:`array_position`                    :func:`filter`                            :func:`levenshtein_distance`              :func:`secure_rand`                       :func:`strpos`                                :func:`covar_pop`
-    :func:`array_remove`                      :func:`find_first`                        line_interpolate_point                    :func:`secure_random`                     :func:`strrpos`                               :func:`covar_samp`
-    :func:`array_sort`                        :func:`find_first_index`                  line_locate_point                         :func:`sequence`                          :func:`substr`                                differential_entropy
+    :func:`array_remove`                      :func:`find_first`                        :func:`line_interpolate_point`            :func:`secure_random`                     :func:`strrpos`                               :func:`covar_samp`
+    :func:`array_sort`                        :func:`find_first_index`                  :func:`line_locate_point`                 :func:`sequence`                          :func:`substr`                                differential_entropy
     :func:`array_sort_desc`                   :func:`flatten`                           :func:`ln`                                :func:`sha1`                              :func:`tan`                                   :func:`entropy`
-    array_split_into_chunks                   flatten_geometry_collections              localtime                                 :func:`sha256`                            :func:`tanh`                                  evaluate_classifier_predictions
+    array_split_into_chunks                   :func:`flatten_geometry_collections`      localtime                                 :func:`sha256`                            :func:`tanh`                                  evaluate_classifier_predictions
     :func:`array_sum`                         :func:`floor`                             localtimestamp                            :func:`sha512`                            tdigest_agg                                   :func:`every`
-    array_top_n                               fnv1_32                                   :func:`log10`                             :func:`shuffle`                           :func:`timezone_hour`                         :func:`geometric_mean`
+    :func:`array_top_n`                       fnv1_32                                   :func:`log10`                             :func:`shuffle`                           :func:`timezone_hour`                         :func:`geometric_mean`
     :func:`array_union`                       fnv1_64                                   :func:`log2`                              :func:`sign`                              :func:`timezone_minute`                       geometry_union_agg
-    :func:`arrays_overlap`                    fnv1a_32                                  :func:`lower`                             simplify_geometry                         :func:`to_base`                               :func:`histogram`
+    :func:`arrays_overlap`                    fnv1a_32                                  :func:`lower`                             :func:`simplify_geometry`                 :func:`to_base`                               :func:`histogram`
     :func:`asin`                              fnv1a_64                                  :func:`lpad`                              :func:`sin`                               to_base32                                     khyperloglog_agg
     :func:`atan`                              :func:`format_datetime`                   :func:`ltrim`                             sketch_kll_quantile                       :func:`to_base64`                             :func:`kurtosis`
     :func:`atan2`                             :func:`from_base`                         :func:`map`                               sketch_kll_rank                           :func:`to_base64url`                          learn_classifier
     bar                                       from_base32                               :func:`map_concat`                        :func:`slice`                             :func:`to_big_endian_32`                      learn_libsvm_classifier
     :func:`beta_cdf`                          :func:`from_base64`                       :func:`map_entries`                       spatial_partitions                        :func:`to_big_endian_64`                      learn_libsvm_regressor
-    bing_tile                                 :func:`from_base64url`                    :func:`map_filter`                        :func:`split`                             to_geometry                                   learn_regressor
-    bing_tile_at                              :func:`from_big_endian_32`                :func:`map_from_entries`                  :func:`split_part`                        :func:`to_hex`                                make_set_digest
-    bing_tile_children                        :func:`from_big_endian_64`                :func:`map_keys`                          :func:`split_to_map`                      :func:`to_ieee754_32`                         :func:`map_agg`
-    bing_tile_coordinates                     :func:`from_hex`                          map_keys_by_top_n_values                  split_to_multimap                         :func:`to_ieee754_64`                         :func:`map_union`
-    bing_tile_parent                          :func:`from_ieee754_32`                   :func:`map_normalize`                     :func:`spooky_hash_v2_32`                 :func:`to_iso8601`                            :func:`map_union_sum`
+    :func:`bing_tile`                         :func:`from_base64url`                    :func:`map_filter`                        :func:`split`                             to_geometry                                   learn_regressor
+    :func:`bing_tile_at`                      :func:`from_big_endian_32`                :func:`map_from_entries`                  :func:`split_part`                        :func:`to_hex`                                make_set_digest
+    :func:`bing_tile_children`                :func:`from_big_endian_64`                :func:`map_keys`                          :func:`split_to_map`                      :func:`to_ieee754_32`                         :func:`map_agg`
+    :func:`bing_tile_coordinates`             :func:`from_hex`                          :func:`map_keys_by_top_n_values`          :func:`split_to_multimap`                 :func:`to_ieee754_64`                         :func:`map_union`
+    :func:`bing_tile_parent`                  :func:`from_ieee754_32`                   :func:`map_normalize`                     :func:`spooky_hash_v2_32`                 :func:`to_iso8601`                            :func:`map_union_sum`
     bing_tile_polygon                         :func:`from_ieee754_64`                   :func:`map_remove_null_values`            :func:`spooky_hash_v2_64`                 :func:`to_milliseconds`                       :func:`max`
-    bing_tile_quadkey                         :func:`from_iso8601_date`                 :func:`map_subset`                        :func:`sqrt`                              to_spherical_geography                        :func:`max_by`
-    bing_tile_zoom_level                      :func:`from_iso8601_timestamp`            :func:`map_top_n`                         st_area                                   :func:`to_unixtime`                           :func:`merge`
-    bing_tiles_around                         :func:`from_unixtime`                     :func:`map_top_n_keys`                    st_asbinary                               :func:`to_utf8`                               merge_set_digest
-    :func:`binomial_cdf`                      :func:`from_utf8`                         map_top_n_keys_by_value                   st_astext                                 :func:`trail`                                 :func:`min`
-    :func:`bit_count`                         :func:`gamma_cdf`                         map_top_n_values                          st_boundary                               :func:`transform`                             :func:`min_by`
-    :func:`bitwise_and`                       geometry_as_geojson                       :func:`map_values`                        st_buffer                                 :func:`transform_keys`                        :func:`multimap_agg`
-    :func:`bitwise_arithmetic_shift_right`    geometry_from_geojson                     :func:`map_zip_with`                      st_centroid                               :func:`transform_values`                      noisy_avg_gaussian
-    :func:`bitwise_left_shift`                geometry_invalid_reason                   :func:`md5`                               st_contains                               :func:`trim`                                  noisy_count_gaussian
-    :func:`bitwise_logical_shift_right`       geometry_nearest_points                   merge_hll                                 st_convexhull                             :func:`trim_array`                            noisy_count_if_gaussian
-    :func:`bitwise_not`                       geometry_to_bing_tiles                    merge_khll                                st_coorddim                               :func:`truncate`                              noisy_sum_gaussian
-    :func:`bitwise_or`                        geometry_to_dissolved_bing_tiles          :func:`millisecond`                       st_crosses                                :func:`typeof`                                numeric_histogram
-    :func:`bitwise_right_shift`               geometry_union                            :func:`minute`                            st_difference                             uniqueness_distribution                       qdigest_agg
-    :func:`bitwise_right_shift_arithmetic`    great_circle_distance                     :func:`mod`                               st_dimension                              :func:`upper`                                 :func:`reduce_agg`
-    :func:`bitwise_shift_left`                :func:`greatest`                          :func:`month`                             st_disjoint                               :func:`url_decode`                            :func:`regr_avgx`
-    :func:`bitwise_xor`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             st_distance                               :func:`url_encode`                            :func:`regr_avgy`
-    :func:`cardinality`                       hash_counts                               murmur3_x64_128                           st_endpoint                               :func:`url_extract_fragment`                  :func:`regr_count`
-    :func:`cauchy_cdf`                        :func:`hmac_md5`                          myanmar_font_encoding                     st_envelope                               :func:`url_extract_host`                      :func:`regr_intercept`
-    :func:`cbrt`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 st_envelopeaspts                          :func:`url_extract_parameter`                 :func:`regr_r2`
-    :func:`ceil`                              :func:`hmac_sha256`                       :func:`nan`                               st_equals                                 :func:`url_extract_path`                      :func:`regr_slope`
-    :func:`ceiling`                           :func:`hmac_sha512`                       :func:`ngrams`                            st_exteriorring                           :func:`url_extract_port`                      :func:`regr_sxx`
-    :func:`chi_squared_cdf`                   :func:`hour`                              :func:`no_keys_match`                     st_geometries                             :func:`url_extract_protocol`                  :func:`regr_sxy`
-    :func:`chr`                               :func:`infinity`                          :func:`no_values_match`                   st_geometryfromtext                       :func:`url_extract_query`                     :func:`regr_syy`
-    classify                                  intersection_cardinality                  :func:`none_match`                        st_geometryn                              :func:`uuid`                                  reservoir_sample
-    :func:`codepoint`                         :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        st_geometrytype                           value_at_quantile                             :func:`set_agg`
-    color                                     inverse_binomial_cdf                      :func:`normalize`                         st_geomfrombinary                         values_at_quantiles                           :func:`set_union`
-    :func:`combinations`                      :func:`inverse_cauchy_cdf`                now                                       st_interiorringn                          :func:`week`                                  sketch_kll
-    :func:`concat`                            inverse_chi_squared_cdf                   :func:`parse_datetime`                    st_interiorrings                          :func:`week_of_year`                          sketch_kll_with_k
-    :func:`contains`                          inverse_f_cdf                             parse_duration                            st_intersection                           :func:`weibull_cdf`                           :func:`skewness`
-    :func:`cos`                               inverse_gamma_cdf                         parse_presto_data_size                    st_intersects                             :func:`width_bucket`                          spatial_partitioning
-    :func:`cosh`                              :func:`inverse_laplace_cdf`               :func:`pi`                                st_isclosed                               :func:`wilson_interval_lower`                 :func:`stddev`
-    :func:`cosine_similarity`                 :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            st_isempty                                :func:`wilson_interval_upper`                 :func:`stddev_pop`
-    :func:`crc32`                             inverse_poisson_cdf                       :func:`poisson_cdf`                       st_isring                                 :func:`word_stem`                             :func:`stddev_samp`
-    :func:`current_date`                      :func:`inverse_weibull_cdf`               :func:`pow`                               st_issimple                               :func:`xxhash64`                              :func:`sum`
-    current_time                              :func:`ip_prefix`                         :func:`power`                             st_isvalid                                :func:`year`                                  tdigest_agg
-    current_timestamp                         ip_prefix_collapse                        quantile_at_value                         st_length                                 :func:`year_of_week`                          :func:`var_pop`
-    current_timezone                          ip_prefix_subnets                         :func:`quarter`                           st_linefromtext                           :func:`yow`                                   :func:`var_samp`
-    :func:`date`                              ip_subnet_max                             :func:`radians`                           st_linestring                             :func:`zip`                                   :func:`variance`
-    :func:`date_add`                          ip_subnet_min                             :func:`rand`                              st_multipoint                             :func:`zip_with`
+    :func:`bing_tile_quadkey`                 :func:`from_iso8601_date`                 :func:`map_subset`                        :func:`sqrt`                              to_spherical_geography                        :func:`max_by`
+    :func:`bing_tile_zoom_level`              :func:`from_iso8601_timestamp`            :func:`map_top_n`                         :func:`st_area`                           :func:`to_unixtime`                           :func:`merge`
+    :func:`bing_tiles_around`                 :func:`from_unixtime`                     :func:`map_top_n_keys`                    :func:`st_asbinary`                       :func:`to_utf8`                               merge_set_digest
+    :func:`binomial_cdf`                      :func:`from_utf8`                         map_top_n_keys_by_value                   :func:`st_astext`                         :func:`trail`                                 :func:`min`
+    :func:`bit_count`                         :func:`gamma_cdf`                         :func:`map_top_n_values`                  :func:`st_boundary`                       :func:`transform`                             :func:`min_by`
+    :func:`bitwise_and`                       geometry_as_geojson                       :func:`map_values`                        :func:`st_buffer`                         :func:`transform_keys`                        :func:`multimap_agg`
+    :func:`bitwise_arithmetic_shift_right`    geometry_from_geojson                     :func:`map_zip_with`                      :func:`st_centroid`                       :func:`transform_values`                      :func:`noisy_avg_gaussian`
+    :func:`bitwise_left_shift`                :func:`geometry_invalid_reason`           :func:`md5`                               :func:`st_contains`                       :func:`trim`                                  :func:`noisy_count_gaussian`
+    :func:`bitwise_logical_shift_right`       :func:`geometry_nearest_points`           merge_hll                                 :func:`st_convexhull`                     :func:`trim_array`                            :func:`noisy_count_if_gaussian`
+    :func:`bitwise_not`                       geometry_to_bing_tiles                    merge_khll                                :func:`st_coorddim`                       :func:`truncate`                              :func:`noisy_sum_gaussian`
+    :func:`bitwise_or`                        geometry_to_dissolved_bing_tiles          :func:`millisecond`                       :func:`st_crosses`                        :func:`typeof`                                :func:`numeric_histogram`
+    :func:`bitwise_right_shift`               geometry_union                            :func:`minute`                            :func:`st_difference`                     uniqueness_distribution                       :func:`qdigest_agg`
+    :func:`bitwise_right_shift_arithmetic`    great_circle_distance                     :func:`mod`                               :func:`st_dimension`                      :func:`upper`                                 :func:`reduce_agg`
+    :func:`bitwise_shift_left`                :func:`greatest`                          :func:`month`                             :func:`st_disjoint`                       :func:`url_decode`                            :func:`regr_avgx`
+    :func:`bitwise_xor`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             :func:`st_distance`                       :func:`url_encode`                            :func:`regr_avgy`
+    :func:`cardinality`                       hash_counts                               :func:`murmur3_x64_128`                   :func:`st_endpoint`                       :func:`url_extract_fragment`                  :func:`regr_count`
+    :func:`cauchy_cdf`                        :func:`hmac_md5`                          myanmar_font_encoding                     :func:`st_envelope`                       :func:`url_extract_host`                      :func:`regr_intercept`
+    :func:`cbrt`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 :func:`st_envelopeaspts`                  :func:`url_extract_parameter`                 :func:`regr_r2`
+    :func:`ceil`                              :func:`hmac_sha256`                       :func:`nan`                               :func:`st_equals`                         :func:`url_extract_path`                      :func:`regr_slope`
+    :func:`ceiling`                           :func:`hmac_sha512`                       :func:`ngrams`                            :func:`st_exteriorring`                   :func:`url_extract_port`                      :func:`regr_sxx`
+    :func:`chi_squared_cdf`                   :func:`hour`                              :func:`no_keys_match`                     :func:`st_geometries`                     :func:`url_extract_protocol`                  :func:`regr_sxy`
+    :func:`chr`                               :func:`infinity`                          :func:`no_values_match`                   :func:`st_geometryfromtext`               :func:`url_extract_query`                     :func:`regr_syy`
+    classify                                  intersection_cardinality                  :func:`none_match`                        :func:`st_geometryn`                      :func:`uuid`                                  reservoir_sample
+    :func:`codepoint`                         :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        :func:`st_geometrytype`                   :func:`value_at_quantile`                     :func:`set_agg`
+    color                                     :func:`inverse_binomial_cdf`              :func:`normalize`                         :func:`st_geomfrombinary`                 :func:`values_at_quantiles`                   :func:`set_union`
+    :func:`combinations`                      :func:`inverse_cauchy_cdf`                now                                       :func:`st_interiorringn`                  :func:`week`                                  sketch_kll
+    :func:`concat`                            :func:`inverse_chi_squared_cdf`           :func:`parse_datetime`                    :func:`st_interiorrings`                  :func:`week_of_year`                          sketch_kll_with_k
+    :func:`contains`                          :func:`inverse_f_cdf`                     :func:`parse_duration`                    :func:`st_intersection`                   :func:`weibull_cdf`                           :func:`skewness`
+    :func:`cos`                               :func:`inverse_gamma_cdf`                 :func:`parse_presto_data_size`            :func:`st_intersects`                     :func:`width_bucket`                          spatial_partitioning
+    :func:`cosh`                              :func:`inverse_laplace_cdf`               :func:`pi`                                :func:`st_isclosed`                       :func:`wilson_interval_lower`                 :func:`stddev`
+    :func:`cosine_similarity`                 :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            :func:`st_isempty`                        :func:`wilson_interval_upper`                 :func:`stddev_pop`
+    :func:`crc32`                             :func:`inverse_poisson_cdf`               :func:`poisson_cdf`                       :func:`st_isring`                         :func:`word_stem`                             :func:`stddev_samp`
+    :func:`current_date`                      :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_issimple`                       :func:`xxhash64`                              :func:`sum`
+    current_time                              :func:`ip_prefix`                         :func:`power`                             :func:`st_isvalid`                        :func:`year`                                  :func:`tdigest_agg`
+    current_timestamp                         :func:`ip_prefix_collapse`                :func:`quantile_at_value`                 :func:`st_length`                         :func:`year_of_week`                          :func:`var_pop`
+    current_timezone                          :func:`ip_prefix_subnets`                 :func:`quarter`                           st_linefromtext                           :func:`yow`                                   :func:`var_samp`
+    :func:`date`                              :func:`ip_subnet_max`                     :func:`radians`                           st_linestring                             :func:`zip`                                   :func:`variance`
+    :func:`date_add`                          :func:`ip_subnet_min`                     :func:`rand`                              st_multipoint                             :func:`zip_with`
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/docs/functions/presto/most_used_coverage.rst
+++ b/velox/docs/functions/presto/most_used_coverage.rst
@@ -54,6 +54,7 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage tr:nth-child(7) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(7) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(2) {background-color: #6BA81E;}
@@ -71,10 +72,13 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage tr:nth-child(10) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(10) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
@@ -100,6 +104,7 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     table.coverage tr:nth-child(16) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(2) {background-color: #6BA81E;}
@@ -126,16 +131,16 @@ Here is a list of most used scalar and aggregate Presto functions with functions
     :func:`upper`                :func:`transform_values`     :func:`map_filter`           :func:`map_zip_with`         :func:`xxhash64`                 :func:`array_agg`
     :func:`split`                :func:`map_entries`          :func:`regexp_extract`       :func:`year`                 :func:`to_hex`                   :func:`arbitrary`
     :func:`random`               :func:`concat`               :func:`map_values`           :func:`slice`                :func:`transform_keys`           :func:`min`
-    :func:`floor`                :func:`cardinality`          :func:`map_keys`             :func:`month`                bing_tile_quadkey                :func:`max_by`
+    :func:`floor`                :func:`cardinality`          :func:`map_keys`             :func:`month`                :func:`bing_tile_quadkey`        :func:`max_by`
     :func:`contains`             :func:`sequence`             :func:`reduce`               :func:`any_match`            :func:`to_utf8`                  :func:`approx_distinct`
     :func:`map_concat`           :func:`substr`               :func:`greatest`             :func:`bitwise_and`          :func:`crc32`                    :func:`count_if`
-    :func:`length`               :func:`date`                 :func:`date_trunc`           :func:`date_parse`           st_y                             :func:`approx_percentile`
-    :func:`from_unixtime`        :func:`is_nan`               :func:`date_diff`            bing_tile_at                 st_x                             :func:`avg`
+    :func:`length`               :func:`date`                 :func:`date_trunc`           :func:`date_parse`           :func:`st_y`                     :func:`approx_percentile`
+    :func:`from_unixtime`        :func:`is_nan`               :func:`date_diff`            :func:`bing_tile_at`         :func:`st_x`                     :func:`avg`
     :func:`transform`            :func:`rand`                 :func:`array_max`            :func:`array_union`          now                              :func:`map_agg`
     :func:`to_unixtime`          :func:`filter`               :func:`from_iso8601_date`    :func:`reverse`              :func:`truncate`                 :func:`min_by`
     :func:`regexp_like`          :func:`sqrt`                 :func:`json_extract`         :func:`array_intersect`                                       :func:`stddev`
     :func:`array_join`           :func:`least`                :func:`mod`                  :func:`repeat`                                                :func:`set_agg`
-    :func:`replace`              :func:`json_parse`           :func:`array_distinct`       st_geometryfromtext                                           :func:`histogram`
+    :func:`replace`              :func:`json_parse`           :func:`array_distinct`       :func:`st_geometryfromtext`                                   :func:`histogram`
     :func:`regexp_replace`       :func:`map_from_entries`     :func:`pow`                  :func:`split_part`                                            :func:`set_union`
     :func:`parse_datetime`       :func:`date_add`             :func:`power`                :func:`log10`                                                 :func:`merge`
     ===========================  ===========================  ===========================  ===========================  ===========================  ==  ===========================  ==  ===========================


### PR DESCRIPTION
Re-generated coverage maps with instructions from `velox/functions/prestosql/coverage/README.md`
URL: file:///Users/jacobkhaliqi/develop/fbvelox/velox/velox/docs/_build/html/functions/presto/coverage.html
<img width="1399" height="934" alt="Screenshot 2025-08-11 at 5 09 47 PM" src="https://github.com/user-attachments/assets/be54956a-6c5a-4e24-9b4c-1f63c32decb0" />

<img width="1283" height="994" alt="Screenshot 2025-08-11 at 5 09 59 PM" src="https://github.com/user-attachments/assets/d8aca4e6-6280-42d2-a527-ea62cd1f491c" />
