### PR TITLE
feat: Add tracing tool logic handling traceDir

### DIFF
--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -109,7 +109,13 @@ void createTraceDirectory(
 std::string getQueryTraceDirectory(
     const std::string& traceDir,
     const std::string& queryId) {
-  return fmt::format("{}/{}", traceDir, queryId);
+  // Remove trailing slash from traceDir if present
+  std::string normalizedTraceDir = traceDir;
+  if (!normalizedTraceDir.empty() && normalizedTraceDir.back() == '/') {
+    normalizedTraceDir.pop_back();
+  }
+
+  return fmt::format("{}/{}", normalizedTraceDir, queryId);
 }
 
 std::string getTaskTraceDirectory(
@@ -123,8 +129,9 @@ std::string getTaskTraceDirectory(
     const std::string& traceDir,
     const std::string& queryId,
     const std::string& taskId) {
-  return fmt::format(
-      "{}/{}", getQueryTraceDirectory(traceDir, queryId), taskId);
+  auto queryTraceDir = getQueryTraceDirectory(traceDir, queryId);
+
+  return fmt::format("{}/{}", queryTraceDir, taskId);
 }
 
 std::string getTaskTraceMetaFilePath(const std::string& taskTraceDir) {

--- a/velox/exec/tests/TraceUtilTest.cpp
+++ b/velox/exec/tests/TraceUtilTest.cpp
@@ -139,6 +139,29 @@ TEST_F(TraceUtilTest, traceDirectoryLayoutUtilities) {
       "/traceRoot/queryId/taskId/1/1/1/op_split_trace.split");
 }
 
+TEST_F(TraceUtilTest, traceDirectoryTrailingSlashHandling) {
+  const std::string queryId = "queryId";
+  const std::string taskId = "taskId";
+
+  const std::string expectedPath = "/traceRoot/queryId";
+  const std::string expectedTaskPath = "/traceRoot/queryId/taskId";
+
+  // Test with trailing slash
+  const std::string traceDirWithSlash = "/traceRoot/";
+  ASSERT_EQ(getQueryTraceDirectory(traceDirWithSlash, queryId), expectedPath);
+  ASSERT_EQ(
+      getTaskTraceDirectory(traceDirWithSlash, queryId, taskId),
+      expectedTaskPath);
+
+  // Test without trailing slash
+  const std::string traceDirWithoutSlash = "/traceRoot";
+  ASSERT_EQ(
+      getQueryTraceDirectory(traceDirWithoutSlash, queryId), expectedPath);
+  ASSERT_EQ(
+      getTaskTraceDirectory(traceDirWithoutSlash, queryId, taskId),
+      expectedTaskPath);
+}
+
 TEST_F(TraceUtilTest, getTaskIds) {
   const auto rootDir = TempDirectoryPath::create();
   const auto rootPath = rootDir->getPath();


### PR DESCRIPTION
Summary: Lots of time, users may not pay attention to pass in the trace dir, which means they could either pass in a/b/c or a/b/c, both semantically correct, but the original code only handles the former case. this change will pass both cases.

Differential Revision: D80056445


