### PR TITLE
fix: LocalRunner hang when last stage has multiple inputs

### DIFF
--- a/velox/runner/LocalRunner.h
+++ b/velox/runner/LocalRunner.h
@@ -83,8 +83,7 @@ class LocalRunner : public Runner,
  private:
   void start();
 
-  // Creates all stages except for the single worker final consumer stage.
-  std::vector<std::shared_ptr<exec::RemoteConnectorSplit>> makeStages();
+  void makeStages(const std::shared_ptr<exec::Task>& lastStageTask);
 
   std::shared_ptr<SplitSource> splitSourceForScan(
       const core::TableScanNode& scan);


### PR DESCRIPTION
Summary: LocalRunner used to assume that last stage has at most one source. When adding splits for the last stage, it was only adding splits for the first source. When there were more sources, the task hanged waiting for splits.

Differential Revision: D80056120


