### PR TITLE
fix: Set the task execution end time on terminate instead of split finish

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -776,6 +776,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// split.
   bool testingHasDriverWaitForSplit() const;
 
+  /// Returns true if all the splits have finished.
+  bool testingAllSplitsFinished();
+
  private:
   // Hook of system-wide running task list.
   struct TaskListEntry {


### PR DESCRIPTION
Summary: In PySpark-Velox, we notice that task execution end-time might reflect the actual task execution end time as merge and write operator might do extensive work if spilling has been triggered. The current task execution end time is set when all the splits have been processed at which point only table scans have finished all the processing. Instead, this PR only sets the task execution end time on task terminate call. Unit test added.

Differential Revision: D80051645


