### PR TITLE
fix: Clear the serializer buffers from stream arena to avoid excessive buffering in partition output to avoid query OOM

### DIFF
--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -62,6 +62,10 @@ class StreamArena {
   /// serilizers.
   virtual void clear();
 
+  memory::MachinePageCount testingAllocationQuantum() const {
+    return allocationQuantum_;
+  }
+
  private:
   memory::MemoryPool* const pool_;
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -467,7 +467,9 @@ class VectorStreamGroup : public StreamArena {
       const VectorSerde::Options* options);
 
   void clear() override {
+    serializer_->clear();
     StreamArena::clear();
+    // TODO: provide a separate method to initialize the serializer header.
     serializer_->clear();
   }
 

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(
   VectorPrinterTest.cpp
   VectorSaverTest.cpp
   VectorStreamTest.cpp
+  VectorStreamGroupTest.cpp
   VectorTest.cpp
   VectorTestUtils.cpp
   VectorToStringTest.cpp)

--- a/velox/vector/tests/VectorStreamGroupTest.cpp
+++ b/velox/vector/tests/VectorStreamGroupTest.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <cstdint>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
+#include "velox/vector/VectorStream.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox {
+namespace {
+class VectorStreamGroupTest
+    : public testing::Test,
+      public velox::test::VectorTestBase,
+      public testing::WithParamInterface<VectorSerde::Kind> {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+      deregisterNamedVectorSerde(VectorSerde::Kind::kPresto);
+    }
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+
+    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+      deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    }
+    serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+
+    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+      deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+    }
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+  }
+
+  std::unique_ptr<ByteInputStream> prepareInput(std::string& string) {
+    const int32_t size = string.size();
+    std::vector<ByteRange> ranges;
+    for (int32_t i = 0; i < 10; ++i) {
+      int32_t start = i * (size / 10);
+      int32_t end = (i == 9) ? size : (i + 1) * (size / 10);
+      ranges.emplace_back();
+      ranges.back().buffer = reinterpret_cast<uint8_t*>(&string[start]);
+      ranges.back().size = end - start;
+      ranges.back().position = 0;
+    }
+    return std::make_unique<BufferInputStream>(std::move(ranges));
+  }
+};
+
+TEST_P(VectorStreamGroupTest, clear) {
+  const auto dataType = ROW({BIGINT()});
+  const int numBatches = 10;
+  const int vectorSize = 100;
+  VectorFuzzer::Options opts;
+  opts.vectorSize = vectorSize;
+  VectorFuzzer fuzzer(opts, pool());
+  std::vector<RowVectorPtr> inputVectors;
+  inputVectors.reserve(10);
+  for (int i = 0; i < numBatches; ++i) {
+    inputVectors.push_back(fuzzer.fuzzInputRow(dataType));
+  }
+  VectorStreamGroup vectorGroup(pool(), getNamedVectorSerde(GetParam()));
+  vectorGroup.createStreamTree(dataType, numBatches * vectorSize);
+  for (int i = 0; i < numBatches; ++i) {
+    vectorGroup.append(inputVectors[i]);
+  }
+  std::stringstream output;
+  OStreamOutputStream outputStream(&output);
+  vectorGroup.flush(&outputStream);
+  vectorGroup.clear();
+  if (GetParam() == VectorSerde::Kind::kPresto) {
+    // We expect two pages for header after clear.
+    ASSERT_EQ(
+        vectorGroup.size(),
+        memory::AllocationTraits::pageBytes(
+            vectorGroup.testingAllocationQuantum()));
+  } else {
+    ASSERT_EQ(vectorGroup.size(), 0);
+  }
+  auto outputStr = output.str();
+  RowVectorPtr resultRow;
+  auto deserializeInput = prepareInput(outputStr);
+  VectorStreamGroup::read(
+      deserializeInput.get(),
+      pool(),
+      dataType,
+      getNamedVectorSerde(GetParam()),
+      &resultRow,
+      nullptr);
+  ASSERT_EQ(resultRow->size(), numBatches * vectorSize);
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    VectorStreamGroupTest,
+    VectorStreamGroupTest,
+    testing::ValuesIn(
+        {VectorSerde::Kind::kPresto,
+         VectorSerde::Kind::kCompactRow,
+         VectorSerde::Kind::kUnsafeRow}));
+} // namespace
+} // namespace facebook::velox

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -876,6 +876,17 @@ class VectorTest : public testing::Test, public velox::test::VectorTestBase {
     OStreamOutputStream oddOutputStream(&oddStream);
     even.flush(&evenOutputStream);
     odd.flush(&oddOutputStream);
+    ASSERT_GT(even.size(), 0);
+    even.clear();
+    // We expect two pages for header after clear.
+    ASSERT_EQ(
+        even.size(),
+        memory::AllocationTraits::pageBytes(even.testingAllocationQuantum()));
+    ASSERT_GT(odd.size(), 0);
+    odd.clear();
+    ASSERT_EQ(
+        odd.size(),
+        memory::AllocationTraits::pageBytes(odd.testingAllocationQuantum()));
 
     auto evenString = evenStream.str();
     checkSizes(source.get(), evenSizes, evenString);
@@ -4204,6 +4215,5 @@ TEST_F(VectorTest, estimateFlatSize) {
   // Test that the second call to prepareForReuse will not cause crash
   arrayVector->prepareForReuse();
 }
-
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary: The current VectorStreamGroup clear method first clear the stream arena and then clear the serializer which is incorrect and leads to query out of memory as we see in sequence storage index lookup. The serializer allocate memory from the stream arena so if we clear the stream arena first, and then we won't be able to free the buffered memory from the serializer which can cause excessive memory buffering in partition output and we see the partition output operator's memory keep accumulating up to 900MB (total 8GB with 10 partition output operators). It eventually caused the query OOM. To fix this query OOM pattern, we shall first clear the serializer and then clear the stream arena. Given VectorStream clear will reset the header which allocate the memory from the stream arena so we have to call serializer clear after the stream arena to make sure the header is initialized properly. We might want to add initialize header method in followup.

Differential Revision: D80067054


