### PR TITLE
fix: Improve tzdb to be compatible with old tzdata.zi

### DIFF
--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -724,7 +724,8 @@ static void __parse_link(tzdb& __tzdb, std::istream& __input) {
   __tzdb.links.emplace_back(std::move(__name), std::move(__target));
 }
 
-static void __parse_tzdata(
+template <int recordType>
+static void __parse_tzdata_record_type(
     tzdb& __db,
     __rules_storage_type& __rules,
     std::istream& __input) {
@@ -745,24 +746,50 @@ static void __parse_tzdata(
         break;
 
       case 'r':
-        __skip(__input, "ule");
-        __parse_rule(__db, __rules, __input);
-        break;
-
-      case 'z':
-        __skip(__input, "one");
-        __parse_zone(__db, __rules, __input);
+        if constexpr (recordType == 'r') {
+          __skip(__input, "ule");
+          __parse_rule(__db, __rules, __input);
+        } else {
+          __skip_line(__input);
+        }
         break;
 
       case 'l':
-        __skip(__input, "ink");
-        __parse_link(__db, __input);
+        if constexpr (recordType == 'l') {
+          __skip(__input, "ink");
+          __parse_link(__db, __input);
+        } else {
+          __skip_line(__input);
+        }
+        break;
+
+      case 'z':
+        if constexpr (recordType == 'z') {
+          __skip(__input, "one");
+          __parse_zone(__db, __rules, __input);
+        } else {
+          __skip_line(__input);
+        }
         break;
 
       default:
-        std::__throw_runtime_error("corrupt tzdb: unexpected input");
+        if constexpr (recordType == 'z') {
+          std::__throw_runtime_error("corrupt tzdb: unexpected input");
+        } else {
+          __skip_line(__input);
+        }
     }
   }
+}
+
+static void __parse_tzdata(
+    tzdb& __db,
+    __rules_storage_type& __rules,
+    std::istream& __input) {
+  const std::string buf{std::istreambuf_iterator<char>(__input), {}};
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'r'>(__db, __rules, iss); }
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'z'>(__db, __rules, iss); }
+  { std::istringstream iss(buf); __parse_tzdata_record_type<'l'>(__db, __rules, iss); }
 }
 
 static void __parse_leap_seconds(


### PR DESCRIPTION
Current tzdata.zi file parsing assumes `Rule`, `Zone`, and `Link` records appear in that order. Older tzdata versions may place `Zone` records before `Rule`. This PR relaxes that assumption to support parsing older tzdata.zi file.