### PR TITLE
fix: Respect output buffer size in merge with spill and improvements

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -264,7 +264,8 @@ class QueryConfig {
       "topn_row_number_spill_enabled";
 
   /// LocalMerge spilling flag, only applies if "spill_enabled" flag is set.
-  static constexpr const char* kLocalMergeSpillEnabled = "local_merge_enabled";
+  static constexpr const char* kLocalMergeSpillEnabled =
+      "local_merge_spill_enabled";
 
   /// Specify the max number of local sources to merge at a time.
   static constexpr const char* kLocalMergeMaxNumMergeSources =

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -315,7 +315,7 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether HashBuild and HashProbe operators can spill to disk under memory pressure.
-   * - local_merge_enabled
+   * - local_merge_spill_enabled
      - boolean
      - false
      - When `spill_enabled` is true, determines whether LocalMerge operators can spill to disk to cap memory usage.

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -193,6 +193,28 @@ These stats are reported only by IndexLookupJoin operator
      -
      - The number of lazy decoded result batches returned from the storage client.
 
+Merge
+-----
+These stats are reported only by Merge operator
+
+.. list-table::
+   :widths: 50 25 50
+   :header-rows: 1
+
+   * - Stats
+     - Unit
+     - Description
+   * - streamingSourceReadWallNanos
+     - nanos
+     - The number of a spillable operators that don't support spill because of
+       spill limitation. For instance, a window operator do not support spill
+       if there is no partitioning.
+   * - spilledSourceReadWallNanos
+     - nanos
+     - The running wall time of the merge operator reading from the spilled source to
+       produce the final output. This only applies when spilling is enabled for local
+       merge.
+
 Spilling
 --------
 These stats are reported by operators that support spilling.

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -885,7 +885,7 @@ TEST_P(MultiFragmentTest, mergeExchangeWithSpill) {
   core::PlanNodeId partitionNodeId;
   std::unordered_map<std::string, std::string> spillMergeConfigs{
       {"spill_enabled", "true"},
-      {"local_merge_enabled", "true"},
+      {"local_merge_spill_enabled", "true"},
       {"local_merge_max_num_merge_sources", "3"}};
   std::vector<core::PlanNodeId> localMergeNodeIds;
   for (int numPartialSortTasks = 0; numPartialSortTasks < 2;


### PR DESCRIPTION
Summary:
Current merge operator doesn't respect output batch byte size when read merged result from the streaming sources as well as the spilled sources. This cause memory increase when we do local spill as the number output rows could be large as the default is 1024. This PR fix this by respecting the output batch size in bytes by estimating row size from the merge source which use the averaged row size from the first batch from each streaming or spilled source as the estimation. This significantly reduce the peak memory of pyspark velox use case which leverage local spill to cap the memory usage.

This PR also add runtime stats to tell how much wall time spent in streaming sources read and spilled source reads plus some code refactor.

The followup is to add async spilled read error handling and consider to provide a separate config to tune the output batch size of local merge operator which is single threaded and might not necessary to follow the regular operator batch size. This is a tradeoff between memory and cpu efficiency though.

Differential Revision: D80068538


