### PR TITLE
feat(expr): Support non-ANSI Spark semantics for cast failures in complex types

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -309,7 +309,7 @@ class CastExpr : public SpecialForm {
   }
 
   bool setNullInResultAtError() const {
-    return isTryCast() && inTopLevel;
+    return isTryCast() && (inTopLevel || hooks_->applyTryCastRecursively());
   }
 
   CastOperatorPtr getCastOperator(const TypePtr& type);

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -50,26 +50,31 @@ class CastHooks {
   virtual Expected<int32_t> castStringToDate(
       const StringView& dateString) const = 0;
 
-  // 'data' is guaranteed to be non-empty and has been processed by
-  // removeWhiteSpaces.
+  /// 'data' is guaranteed to be non-empty and has been processed by
+  /// removeWhiteSpaces.
   virtual Expected<float> castStringToReal(const StringView& data) const = 0;
 
-  // 'data' is guaranteed to be non-empty and has been processed by
-  // removeWhiteSpaces.
+  /// 'data' is guaranteed to be non-empty and has been processed by
+  /// removeWhiteSpaces.
   virtual Expected<double> castStringToDouble(const StringView& data) const = 0;
 
-  // Trims all leading and trailing UTF8 whitespaces.
+  /// Trims all leading and trailing UTF8 whitespaces.
   virtual StringView removeWhiteSpaces(const StringView& view) const = 0;
 
-  // Returns the options to cast from timestamp to string.
+  /// Returns the options to cast from timestamp to string.
   virtual const TimestampToStringOptions& timestampToStringOptions() const = 0;
 
-  // Returns whether to cast to int by truncate.
+  /// Returns whether to cast to int by truncate.
   virtual bool truncate() const = 0;
+
+  /// Returns whether to apply try_cast recursively rather than only at the top
+  /// level. E.g. if true, an element inside an array would be null rather than
+  /// the entire array if the cast of that element fails.
+  virtual bool applyTryCastRecursively() const = 0;
 
   virtual PolicyType getPolicy() const = 0;
 
-  // Converts boolean to timestamp type.
+  /// Converts boolean to timestamp type.
   virtual Expected<Timestamp> castBooleanToTimestamp(bool seconds) const = 0;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -61,6 +61,10 @@ class PrestoCastHooks : public CastHooks {
     return false;
   }
 
+  bool applyTryCastRecursively() const override {
+    return false;
+  }
+
   PolicyType getPolicy() const override;
 
  private:

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -72,6 +72,10 @@ class SparkCastHooks : public exec::CastHooks {
     return allowOverflow_;
   }
 
+  bool applyTryCastRecursively() const override {
+    return true;
+  }
+
   exec::PolicyType getPolicy() const override;
 
  private:


### PR DESCRIPTION
Summary:
In Spark with ANSI mode turned off, when casting the elements of a complex type from one
type to another, if the cast fails, that particularly element is null in the result.

This differs from the current semantics of Velox's CastExpr (with try cast enabled) which 
follows the ANSI standard, which is to return null as the result for the entire complex type.

E.g.
TRY_CAST(ARRAY('1', 'abc', '2') as ARRAY(BIGINT))

This currently returns NULL in Velox. In Spark this would return ARRAY(1, NULL, 2).  It's also 
worth noting Spark would return this whether it was a TRY_CAST or a CAST.

This change adds a setting in the CastHooks `applyTryCastRecursively` which when true
applies the Spark semantics where a failed cast only effects the value in a complex type that
caused the failure.  This is false in PrestoCastHooks and true in SparkCastHooks.

Differential Revision: D80135098


