### PR TITLE
refactor: Replace folly::Optional with std::optional

### DIFF
--- a/velox/common/config/Config.cpp
+++ b/velox/common/config/Config.cpp
@@ -138,8 +138,8 @@ std::unordered_map<std::string, std::string> ConfigBase::rawConfigsCopy()
   return configs_;
 }
 
-folly::Optional<std::string> ConfigBase::get(const std::string& key) const {
-  folly::Optional<std::string> val;
+std::optional<std::string> ConfigBase::get(const std::string& key) const {
+  std::optional<std::string> val;
   std::shared_lock<std::shared_mutex> l(mutex_);
   auto it = configs_.find(key);
   if (it != configs_.end()) {

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -112,17 +112,17 @@ class ConfigBase {
   }
 
   template <typename T>
-  folly::Optional<T> get(
+  std::optional<T> get(
       const std::string& key,
       std::function<T(std::string, std::string)> toT = [](auto /* unused */,
                                                           auto value) {
         return folly::to<T>(value);
       }) const {
     auto val = get(key);
-    if (val.hasValue()) {
+    if (val.has_value()) {
       return toT(key, val.value());
     } else {
-      return folly::none;
+      return std::nullopt;
     }
   }
 
@@ -135,7 +135,7 @@ class ConfigBase {
         return folly::to<T>(value);
       }) const {
     auto val = get(key);
-    if (val.hasValue()) {
+    if (val.has_value()) {
       return toT(key, val.value());
     } else {
       return defaultValue;
@@ -153,7 +153,7 @@ class ConfigBase {
   std::unordered_map<std::string, std::string> configs_;
 
  private:
-  folly::Optional<std::string> get(const std::string& key) const;
+  std::optional<std::string> get(const std::string& key) const;
 
   const bool mutable_;
 };

--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -143,9 +143,9 @@ class ISerializable {
   template <
       typename T,
       std::enable_if_t<
-          std::is_same_v<T, folly::Optional<typename T::value_type>>>>
-  static folly::dynamic serialize(const folly::Optional<T>& val) {
-    if (!val.hasValue()) {
+          std::is_same_v<T, std::optional<typename T::value_type>>>>
+  static folly::dynamic serialize(const std::optional<T>& val) {
+    if (!val.has_value()) {
       return nullptr;
     }
 
@@ -250,16 +250,16 @@ class ISerializable {
   template <
       typename T,
       typename = std::enable_if_t<
-          std::is_same_v<T, folly::Optional<typename T::value_type>>>>
-  static folly::Optional<
+          std::is_same_v<T, std::optional<typename T::value_type>>>>
+  static std::optional<
       decltype(ISerializable::deserialize<typename T::value_type>(
           std::declval<folly::dynamic>()))>
   deserialize(const folly::dynamic& obj, void* context = nullptr) {
     if (obj.isNull()) {
-      return folly::none;
+      return std::nullopt;
     }
     auto val = deserialize<typename T::value_type>(obj);
-    return folly::Optional<
+    return std::optional<
         decltype(ISerializable::deserialize<typename T::value_type>(
             std::declval<folly::dynamic>()))>(move(val));
   }

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -129,11 +129,11 @@ HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(
     // Fall back to get a fixed endpoint from config.
     auto hdfsHost = config->get<std::string>("hive.hdfs.host");
     VELOX_CHECK(
-        hdfsHost.hasValue(),
+        hdfsHost.has_value(),
         "hdfsHost is empty, configuration missing for hdfs host");
     auto hdfsPort = config->get<std::string>("hive.hdfs.port");
     VELOX_CHECK(
-        hdfsPort.hasValue(),
+        hdfsPort.has_value(),
         "hdfsPort is empty, configuration missing for hdfs port");
     return HdfsServiceEndpoint{*hdfsHost, *hdfsPort};
   }

--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -53,7 +53,7 @@ class JsonExtractor {
     return *op;
   }
 
-  folly::Optional<folly::dynamic> extract(const folly::dynamic& json);
+  std::optional<folly::dynamic> extract(const folly::dynamic& json);
 
   // Shouldn't instantiate directly - use getInstance().
   explicit JsonExtractor(const std::string& path) {
@@ -139,7 +139,7 @@ void extractArray(
   }
 }
 
-folly::Optional<folly::dynamic> JsonExtractor::extract(
+std::optional<folly::dynamic> JsonExtractor::extract(
     const folly::dynamic& json) {
   JsonVector input;
   // Temporary extraction result holder, swap with input after
@@ -156,7 +156,7 @@ folly::Optional<folly::dynamic> JsonExtractor::extract(
       }
     }
     if (result.empty()) {
-      return folly::none;
+      return std::nullopt;
     }
     input.clear();
     result.swap(input);
@@ -164,7 +164,7 @@ folly::Optional<folly::dynamic> JsonExtractor::extract(
 
   auto len = input.size();
   if (0 == len) {
-    return folly::none;
+    return std::nullopt;
   } else if (1 == len) {
     return *input.front();
   } else {
@@ -176,20 +176,20 @@ folly::Optional<folly::dynamic> JsonExtractor::extract(
   }
 }
 
-bool isScalarType(const folly::Optional<folly::dynamic>& json) {
+bool isScalarType(const std::optional<folly::dynamic>& json) {
   return json.has_value() && !json->isObject() && !json->isArray() &&
       !json->isNull();
 }
 
 } // namespace
 
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     folly::StringPiece json,
     folly::StringPiece path) {
   try {
     // If extractor fails to parse the path, this will throw a VeloxUserError,
     // and we want to let this exception bubble up to the client. We only catch
-    // json parsing failures (in which cases we return folly::none instead of
+    // json parsing failures (in which cases we return std::nullopt instead of
     // throw).
     auto& extractor = JsonExtractor::getInstance(path);
     return extractor.extract(folly::parseJson(json));
@@ -198,26 +198,26 @@ folly::Optional<folly::dynamic> jsonExtract(
     // Folly might throw a conversion error while parsing the input json. In
     // this case, let it return null.
   }
-  return folly::none;
+  return std::nullopt;
 }
 
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     const std::string& json,
     const std::string& path) {
   return jsonExtract(folly::StringPiece(json), folly::StringPiece(path));
 }
 
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     const folly::dynamic& json,
     folly::StringPiece path) {
   try {
     return JsonExtractor::getInstance(path).extract(json);
   } catch (const folly::json::parse_error&) {
   }
-  return folly::none;
+  return std::nullopt;
 }
 
-folly::Optional<std::string> jsonExtractScalar(
+std::optional<std::string> jsonExtractScalar(
     folly::StringPiece json,
     folly::StringPiece path) {
   auto res = jsonExtract(json, path);
@@ -229,10 +229,10 @@ folly::Optional<std::string> jsonExtractScalar(
       return res->asString();
     }
   }
-  return folly::none;
+  return std::nullopt;
 }
 
-folly::Optional<std::string> jsonExtractScalar(
+std::optional<std::string> jsonExtractScalar(
     const std::string& json,
     const std::string& path) {
   folly::StringPiece jsonPiece{json};

--- a/velox/functions/prestosql/json/JsonExtractor.h
+++ b/velox/functions/prestosql/json/JsonExtractor.h
@@ -33,7 +33,7 @@ namespace facebook::velox::functions {
  *              "[]"     Subscript operator for array and map
  *              "*"      Wildcard for [], get all the elements of an array
  * @return Return json string object on success.
- *         On invalid json path, returns folly::none (not json null) value
+ *         On invalid json path, returns std::nullopt (not json null) value
  *         On non-json value, returns the original value.
  * Example:
  * For the following example: ,
@@ -51,23 +51,23 @@ namespace facebook::velox::functions {
  * jsonExtract(json, "$.non_exist_key") = NULL
  * jsonExtract(json, "$.store.fruit[*].type") = "[\"apple\", \"pear\"]"
  */
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     folly::StringPiece json,
     folly::StringPiece path);
 
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     const folly::dynamic& json,
     folly::StringPiece path);
 
-folly::Optional<std::string> jsonExtractScalar(
+std::optional<std::string> jsonExtractScalar(
     folly::StringPiece json,
     folly::StringPiece path);
 
-folly::Optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtract(
     const std::string& json,
     const std::string& path);
 
-folly::Optional<std::string> jsonExtractScalar(
+std::optional<std::string> jsonExtractScalar(
     const std::string& json,
     const std::string& path);
 

--- a/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -29,33 +29,33 @@ using namespace std::string_literals;
 #define EXPECT_SCALAR_VALUE_EQ(json, path, ret) \
   {                                             \
     auto val = jsonExtractScalar(json, path);   \
-    EXPECT_TRUE(val.hasValue());                \
+    EXPECT_TRUE(val.has_value());               \
     EXPECT_EQ(val.value(), ret);                \
   }
 
 #define EXPECT_SCALAR_VALUE_NULL(json, path) \
-  EXPECT_FALSE(jsonExtractScalar(json, path).hasValue())
+  EXPECT_FALSE(jsonExtractScalar(json, path).has_value())
 
 #define EXPECT_JSON_VALUE_EQ(json, path, ret)        \
   {                                                  \
     auto val = json_format(jsonExtract(json, path)); \
-    EXPECT_TRUE(val.hasValue());                     \
+    EXPECT_TRUE(val.has_value());                    \
     EXPECT_EQ(val.value(), ret);                     \
   }
 
 #define EXPECT_JSON_VALUE_NULL(json, path) \
-  EXPECT_FALSE(json_format(jsonExtract(json, path)).hasValue())
+  EXPECT_FALSE(json_format(jsonExtract(json, path)).has_value())
 
 #define EXPECT_THROW_INVALID_ARGUMENT(json, path) \
   EXPECT_THROW(jsonExtract(json, path), VeloxUserError)
 
 namespace {
-folly::Optional<std::string> json_format(
-    const folly::Optional<folly::dynamic>& json) {
+std::optional<std::string> json_format(
+    const std::optional<folly::dynamic>& json) {
   if (json.has_value()) {
     return folly::toJson(json.value());
   }
-  return folly::none;
+  return std::nullopt;
 }
 } // namespace
 
@@ -478,7 +478,7 @@ TEST(JsonExtractorTest, reextractJsonTest) {
   auto originalJsonObj = jsonExtract(json, "$");
   // extract the same json json by giving the root path
   auto reExtractedJsonObj = jsonExtract(originalJsonObj.value(), "$");
-  ASSERT_TRUE(reExtractedJsonObj.hasValue());
+  ASSERT_TRUE(reExtractedJsonObj.has_value());
   // expect the re-extracted json object to be the same as the original jsonObj
   EXPECT_EQ(originalJsonObj.value(), reExtractedJsonObj.value());
 }
@@ -514,8 +514,8 @@ TEST(JsonExtractorTest, jsonMultipleExtractsTest) {
         "e mail":"amy@only_for_json_udf_test.net",
         "owner":"amy"})DELIM";
   auto extract1 = jsonExtract(json, "$.store");
-  ASSERT_TRUE(extract1.hasValue());
+  ASSERT_TRUE(extract1.has_value());
   auto extract2 = jsonExtract(extract1.value(), "$.fruit");
-  ASSERT_TRUE(extract2.hasValue());
+  ASSERT_TRUE(extract2.has_value());
   EXPECT_EQ(jsonExtract(json, "$.store.fruit").value(), extract2.value());
 }

--- a/velox/vector/VectorUtil.h
+++ b/velox/vector/VectorUtil.h
@@ -26,7 +26,7 @@ template <typename T>
 static inline BufferPtr copyToBuffer(
     const T& values,
     velox::memory::MemoryPool* pool,
-    folly::Optional<int32_t> size = folly::none,
+    std::optional<int32_t> size = std::nullopt,
     bool returnsNullptr = false) {
   using Value = typename T::value_type;
   VELOX_CHECK(pool, "pool must be non-null");

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -29,7 +29,7 @@ namespace facebook::velox::test {
 template <typename T>
 class VectorUtilTest : public testing::Test {
  public:
-  void runTest(folly::Optional<int32_t> size = folly::none) {
+  void runTest(std::optional<int32_t> size = std::nullopt) {
     std::vector<T> vec;
     constexpr int32_t kSize = 3;
     for (size_t i = 1; i <= kSize; ++i) {
@@ -37,7 +37,7 @@ class VectorUtilTest : public testing::Test {
     }
     auto buffer = copyToBuffer(vec, pool_.get(), size);
     int32_t actualBufferSize =
-        size.hasValue() ? std::min(size.value(), kSize) : kSize;
+        size.has_value() ? std::min(size.value(), kSize) : kSize;
     ASSERT_EQ(actualBufferSize * sizeof(T), buffer->size());
   }
 
@@ -50,7 +50,7 @@ class VectorUtilTest : public testing::Test {
   void runTestWithEmptyVectorAndReturnsNullptr() {
     std::vector<T> vec;
     auto buffer = copyToBuffer(
-        vec, pool_.get(), folly::none /*size*/, true /*returnsNullptr*/);
+        vec, pool_.get(), std::nullopt /*size*/, true /*returnsNullptr*/);
     ASSERT_EQ(nullptr, buffer);
   }
 


### PR DESCRIPTION
It follows style guide and also avoids extra "velox depends on folly".

https://github.com/facebookincubator/velox/blob/09bc52ac56a4876385686cd26e6891fd7c2ca871/CODING_STYLE.md#L323-L324
