### PR TITLE
fix: Fix unused-local-typedef issue in velox/dwio/dwrf/test/ColumnWriterTest.cpp +1

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1504,10 +1504,6 @@ void testFlatMapWriter(
 }
 
 TEST_F(ColumnWriterTest, TestFlatMapKeyNotInAllBatches) {
-  using keyType = StringView;
-  using valueType = StringView;
-  using b = MapBuilder<keyType, valueType>;
-
   VectorMaker maker(pool_.get());
   // Test the case where not all keys appear in all batches.
   const std::vector<RowVectorPtr> batches{
@@ -1522,10 +1518,6 @@ TEST_F(ColumnWriterTest, TestFlatMapKeyNotInAllBatches) {
 }
 
 TEST_F(ColumnWriterTest, TesFlatMapDuplicatedKey) {
-  using keyType = StringView;
-  using valueType = StringView;
-  using b = MapBuilder<keyType, valueType>;
-
   const size_t size = 3;
   const BufferPtr inMaps = AlignedBuffer::allocate<bool>(size, pool_.get());
   bits::fillBits(inMaps->asMutable<uint64_t>(), 1, size, pool_.get());


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunused-local-typedef` which we are enabling to remove unused code. This has the side-effect of making it easier to do refactors should as removing unnecessary includes.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D79968264


