### PR TITLE
refactor(Velox): Expose RuntimeStats from DataSinks, allow passing IoStats to FileSink

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -240,6 +240,10 @@ class DataSink {
 
   /// Returns the stats of this data sink.
   virtual Stats stats() const = 0;
+
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() const {
+    return {};
+  }
 };
 
 class DataSource {

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -46,6 +46,7 @@ class FileSink : public Closeable {
     memory::MemoryPool* pool{nullptr};
     MetricsLogPtr metricLogger{MetricsLog::voidLog()};
     IoStatistics* stats{nullptr};
+    filesystems::File::IoStats* fileSystemStats{nullptr};
   };
 
   FileSink(std::string name, const Options& options)
@@ -54,6 +55,7 @@ class FileSink : public Closeable {
         pool_(options.pool),
         metricLogger_{options.metricLogger},
         stats_{options.stats},
+        fileSystemStats_{options.fileSystemStats},
         size_{0} {}
 
   ~FileSink() override {
@@ -117,6 +119,7 @@ class FileSink : public Closeable {
   memory::MemoryPool* const pool_;
   const MetricsLogPtr metricLogger_;
   IoStatistics* const stats_;
+  filesystems::File::IoStats* const fileSystemStats_;
 
   uint64_t size_;
 };


### PR DESCRIPTION
Summary:
Minor changes related to exposing IoStats as Runtime Stats for write operations. More specifically:

- Pass the filesystem stats into the the filesystem `mkdir` call
- Store the provided fileystem stats in `FileSink`
- Create base method exposing runtime stats for data sinks

None of these changes should have any effect for now. Instead, they prepare for the following diffs which expose the filesystem stats

## Context

Filesystem Stats (IOStats) is generic stats tracker which filesystems may add arbitrary stats to. This is intended to support tracking IO statistics which are specific to the filesystem implementation (as opposed to the generic IoStatistics, which are included in open-source Velox).

This was previously only supported for Read operations. These PRs add support for Write operations as well.

Differential Revision: D80153408


