### PR TITLE
feat(Velox): Collect DataSink Runtime Stats in TableWriter Operator

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -240,6 +240,10 @@ class DataSink {
 
   /// Returns the stats of this data sink.
   virtual Stats stats() const = 0;
+
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() const {
+    return {};
+  }
 };
 
 class DataSource {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -423,6 +423,7 @@ HiveDataSink::HiveDataSink(
           hiveConfig_,
           connectorQueryCtx->sessionProperties())),
       fileNameGenerator_(insertTableHandle_->fileNameGenerator()) {
+  fileSystemStats_ = std::make_shared<filesystems::File::IoStats>();
   if (isBucketed()) {
     VELOX_USER_CHECK_LT(
         bucketCount_,
@@ -589,6 +590,19 @@ DataSink::Stats HiveDataSink::stats() const {
     }
   }
   return stats;
+}
+
+std::unordered_map<std::string, RuntimeCounter> HiveDataSink::runtimeStats()
+    const {
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats;
+
+  const auto fsStatsMap = fileSystemStats_->stats();
+  for (const auto& [statName, statValue] : fsStatsMap) {
+    runtimeStats.emplace(
+        statName, RuntimeCounter(statValue.sum, statValue.unit));
+  }
+
+  return runtimeStats;
 }
 
 std::shared_ptr<memory::MemoryPool> HiveDataSink::createWriterPool(
@@ -761,6 +775,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
       std::move(sinkPool),
       std::move(sortPool)));
   ioStats_.emplace_back(std::make_shared<io::IoStatistics>());
+
   setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
 
   // Take the writer options provided by the user as a starting point, or
@@ -825,6 +840,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
               .pool = writerInfo_.back()->sinkPool.get(),
               .metricLogger = dwio::common::MetricsLog::voidLog(),
               .stats = ioStats_.back().get(),
+              .fileSystemStats = fileSystemStats_.get(),
           }),
       options);
   writer = maybeCreateBucketSortWriter(std::move(writer));

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -536,6 +536,8 @@ class HiveDataSink : public DataSink {
 
   Stats stats() const override;
 
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() const override;
+
   std::vector<std::string> close() override;
 
   void abort() override;
@@ -692,6 +694,8 @@ class HiveDataSink : public DataSink {
   std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
   // IO statistics collected for each writer.
   std::vector<std::shared_ptr<io::IoStatistics>> ioStats_;
+  // Generic filesystem stats, exposed as RuntimeStats
+  std::shared_ptr<filesystems::File::IoStats> fileSystemStats_;
 
   // Below are structures updated when processing current input. partitionIds_
   // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -46,6 +46,7 @@ class FileSink : public Closeable {
     memory::MemoryPool* pool{nullptr};
     MetricsLogPtr metricLogger{MetricsLog::voidLog()};
     IoStatistics* stats{nullptr};
+    filesystems::File::IoStats* fileSystemStats{nullptr};
   };
 
   FileSink(std::string name, const Options& options)
@@ -54,6 +55,7 @@ class FileSink : public Closeable {
         pool_(options.pool),
         metricLogger_{options.metricLogger},
         stats_{options.stats},
+        fileSystemStats_{options.fileSystemStats},
         size_{0} {}
 
   ~FileSink() override {
@@ -117,6 +119,7 @@ class FileSink : public Closeable {
   memory::MemoryPool* const pool_;
   const MetricsLogPtr metricLogger_;
   IoStatistics* const stats_;
+  filesystems::File::IoStats* const fileSystemStats_;
 
   uint64_t size_;
 };

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -136,6 +136,19 @@ class TableWriter : public Operator {
     // the table writer operator pool. So we report the memory usage from
     // 'connectorPool_'.
     stats.memoryStats = MemoryStats::memStatsFromPool(connectorPool_);
+
+    if (FOLLY_LIKELY(dataSink_ != nullptr)) {
+      try {
+        const auto connectorStats = dataSink_->runtimeStats();
+        for (const auto& [name, counter] : connectorStats) {
+          stats.runtimeStats[name] = RuntimeMetric(counter.value, counter.unit);
+        }
+      } catch (const std::exception& e) {
+        LOG(WARNING) << "Failed to collect DataSink runtime stats: "
+                     << e.what();
+      }
+    }
+
     return stats;
   }
 


### PR DESCRIPTION
Summary:
Expose Data Sink Runtime Stats as TableWriter Operator stats

## Context

The previous PRs:

a) Added a base method for exposing Runtime Stats of DataSinks
b) For the Hive Data Sink, exposes the Filesystem Stats (IoStats) as Runtime Stats

Therefore, with this PR, all Filesystem Stats for Hive Data Sinks will be exposed as TableWriter Operator stats.

Differential Revision: D80153412


