### PR TITLE
fix: Update the config name and documentation of flatmap preserving option in hive connector

### DIFF
--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -190,9 +190,9 @@ class HiveConfig {
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
   static constexpr const char* kPreserveFlatMapsInMemory =
-      "preserve-flat-maps-in-memory";
+      "hive.preserve-flat-maps-in-memory";
   static constexpr const char* kPreserveFlatMapsInMemorySession =
-      "preserve_flat_maps_in_memory";
+      "hive.preserve_flat_maps_in_memory";
 
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const config::ConfigBase* session) const;

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -676,6 +676,12 @@ Each query can override the config by setting corresponding query session proper
      - bool
      - true
      - Reads timestamp partition value as local time if true. Otherwise, reads as UTC.
+   * - hive.preserve-flat-maps-in-memory
+     - hive.preserve_flat_maps_in_memory
+     - bool
+     - false
+     - Whether to preserve flat maps in memory as FlatMapVectors instead of converting them to MapVectors. This is only applied during data reading inside the DWRF and Nimble readers, not during downstream processing like expression evaluation etc.
+
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Summary:
1. Prefixed the config name with "hive.",  to be consistent with other options in hive connector
2. Added an entry in the documentation about this new option

Differential Revision: D80227719


